### PR TITLE
fixed #29983: Test run of user is already shown as finished but user …

### DIFF
--- a/Modules/Test/classes/class.ilTestEvaluationData.php
+++ b/Modules/Test/classes/class.ilTestEvaluationData.php
@@ -123,7 +123,8 @@ class ilTestEvaluationData
 							usr_data.title,
 							usr_data.login,
 							tst_pass_result.*,
-							tst_active.submitted
+							tst_active.submitted,
+							tst_active.last_finished_pass
 			FROM			tst_pass_result, tst_active
 			LEFT JOIN		usr_data
 			ON				tst_active.user_fi = usr_data.usr_id
@@ -183,6 +184,8 @@ class ilTestEvaluationData
                 $this->getParticipant($row["active_fi"])->setUserID($row["usr_id"]);
                 
                 $this->getParticipant($row["active_fi"])->setSubmitted($row['submitted']);
+
+                $this->getParticipant($row["active_fi"])->setLastFinishedPass($row['last_finished_pass']);
             }
             
             if (!is_object($this->getParticipant($row["active_fi"])->getPass($row["pass"]))) {

--- a/Modules/Test/classes/class.ilTestEvaluationUserData.php
+++ b/Modules/Test/classes/class.ilTestEvaluationUserData.php
@@ -127,6 +127,13 @@ class ilTestEvaluationUserData
     */
     public $passes;
 
+
+    /**
+     * Number of the last finished pass
+     * @var int|null
+     */
+    public $lastFinishedPass;
+
     /**
     * Questions
     *
@@ -376,7 +383,12 @@ class ilTestEvaluationUserData
             return $this->getLastPass();
         }
     }
-    
+
+    /**
+     * todo: this is used in the export and the scored pass differs from the result cache if the best pass is scored
+     * here: the last one of equal passes wins. In tst_result_cache the first one of equal passes wins
+     * @see \DBUpdateTestResultCalculator::_getBestPass
+    */
     public function getBestPass()
     {
         $bestpoints = 0;
@@ -386,7 +398,8 @@ class ilTestEvaluationUserData
         
         foreach ($this->passes as $pass) {
             $reached = $this->getReachedPointsInPercentForPass($pass->getPass());
-            
+
+            // todo: use > instead of >=
             if ($reached >= $bestpoints && ($pass->areObligationsAnswered() || !$obligationsAnsweredPassExists)) {
                 $bestpoints = $reached;
                 $bestpass = $pass->getPass();
@@ -406,7 +419,31 @@ class ilTestEvaluationUserData
         }
         return $lastpass;
     }
-    
+
+    /**
+     * @return int
+     */
+    public function getFinishedPasses()
+    {
+        return $this->getLastFinishedPass() === null ? 0 : $this->getLastFinishedPass() + 1;
+    }
+
+    /**
+     * @return ?int
+     */
+    public function getLastFinishedPass()
+    {
+        return $this->lastFinishedPass;
+    }
+
+    /**
+     * @param ?int $pass
+     */
+    public function setLastFinishedPass($pass = null)
+    {
+        $this->lastFinishedPass = $pass;
+    }
+
     public function addQuestionTitle($question_id, $question_title)
     {
         $this->questionTitles[$question_id] = $question_title;

--- a/Modules/Test/classes/class.ilTestExport.php
+++ b/Modules/Test/classes/class.ilTestExport.php
@@ -382,6 +382,8 @@ abstract class ilTestExport
         $worksheet->setFormattedExcelTitle($worksheet->getColumnCoord($col++) . $row, $this->lng->txt('tst_stat_result_rank_median'));
         $worksheet->setFormattedExcelTitle($worksheet->getColumnCoord($col++) . $row, $this->lng->txt('tst_stat_result_total_participants'));
         $worksheet->setFormattedExcelTitle($worksheet->getColumnCoord($col++) . $row, $this->lng->txt('tst_stat_result_median'));
+        $worksheet->setFormattedExcelTitle($worksheet->getColumnCoord($col++) . $row, $this->lng->txt('tst_tbl_col_started_passes'));
+        $worksheet->setFormattedExcelTitle($worksheet->getColumnCoord($col++) . $row, $this->lng->txt('tst_tbl_col_finished_passes'));
         $worksheet->setFormattedExcelTitle($worksheet->getColumnCoord($col++) . $row, $this->lng->txt('scored_pass'));
         $worksheet->setFormattedExcelTitle($worksheet->getColumnCoord($col++) . $row, $this->lng->txt('pass'));
 
@@ -466,7 +468,8 @@ abstract class ilTestExport
             $worksheet->setCell($row, $col++, $data->getStatistics()->getStatistics()->rank_median());
             $worksheet->setCell($row, $col++, $data->getStatistics()->getStatistics()->count());
             $worksheet->setCell($row, $col++, $median);
-
+            $worksheet->setCell($row, $col++, $data->getParticipant($active_id)->getPassCount());
+            $worksheet->setCell($row, $col++, $data->getParticipant($active_id)->getFinishedPasses());
             if ($this->test_obj->getPassScoring() == SCORE_BEST_PASS) {
                 $worksheet->setCell($row, $col++, $data->getParticipant($active_id)->getBestPass() + 1);
             } else {
@@ -834,6 +837,11 @@ abstract class ilTestExport
         $col++;
         array_push($datarow, $this->lng->txt("tst_stat_result_median"));
         $col++;
+        array_push($datarow, $this->lng->txt("tst_tbl_col_started_passes"));
+        $col++;
+        array_push($datarow, $this->lng->txt("tst_tbl_col_finished_passes"));
+        $col++;
+
         array_push($datarow, $this->lng->txt("scored_pass"));
         $col++;
 
@@ -918,6 +926,9 @@ abstract class ilTestExport
                 array_push($datarow2, $data->getStatistics()->getStatistics()->rank_median());
                 array_push($datarow2, $data->getStatistics()->getStatistics()->count());
                 array_push($datarow2, $median);
+
+                array_push($datarow2, $data->getParticipant($active_id)->getPassCount());
+                array_push($datarow2, $data->getParticipant($active_id)->getFinishedPasses());
                 if ($this->test_obj->getPassScoring() == SCORE_BEST_PASS) {
                     array_push($datarow2, $data->getParticipant($active_id)->getBestPass() + 1);
                 } else {

--- a/Modules/Test/classes/class.ilTestParticipantList.php
+++ b/Modules/Test/classes/class.ilTestParticipantList.php
@@ -340,11 +340,12 @@ class ilTestParticipantList implements Iterator
                 $row['percent_result'] = $participant->getScoring()->getPercentResult();
                 $row['passed_status'] = $participant->getScoring()->isPassed();
                 $row['final_mark'] = $participant->getScoring()->getFinalMark();
-
-                $row['pass_finished'] = ilObjTest::lookupLastTestPassAccess(
+                $row['last_scored_access'] = ilObjTest::lookupLastTestPassAccess(
                     $participant->getActiveId(),
                     $participant->getScoring()->getScoredPass()
                 );
+                $row['finished_passes'] = $participant->getFinishedTries();
+                $row['has_unfinished_passes'] = $participant->hasUnfinishedPasses();
             }
             
             $rows[] = $row;

--- a/Modules/Test/classes/tables/class.ilParticipantsTestResultsTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilParticipantsTestResultsTableGUI.php
@@ -123,9 +123,11 @@ class ilParticipantsTestResultsTableGUI extends ilTable2GUI
         
         $this->addColumn($this->lng->txt("name"), 'name');
         $this->addColumn($this->lng->txt("login"), 'login');
+
+        $this->addColumn($this->lng->txt("tst_tbl_col_finished_passes"), 'finished_passes');
         
         $this->addColumn($this->lng->txt("tst_tbl_col_scored_pass"), 'scored_pass');
-        $this->addColumn($this->lng->txt("tst_tbl_col_pass_finished"), 'pass_finished');
+        $this->addColumn($this->lng->txt("tst_tbl_col_last_scored_access"), 'last_scored_access');
         
         $this->addColumn($this->lng->txt("tst_tbl_col_answered_questions"), 'answered_questions');
         $this->addColumn($this->lng->txt("tst_tbl_col_reached_points"), 'reached_points');
@@ -179,9 +181,10 @@ class ilParticipantsTestResultsTableGUI extends ilTable2GUI
         $this->tpl->setVariable("ROW_KEY", $data['active_id']);
         $this->tpl->setVariable("LOGIN", $data['login']);
         $this->tpl->setVariable("FULLNAME", $data['name']);
-        
+
+        $this->tpl->setVariable("FINISHED_PASSES", $this->buildFinishedPassesString($data));
         $this->tpl->setVariable("SCORED_PASS", $this->buildScoredPassString($data));
-        $this->tpl->setVariable("PASS_FINISHED", $this->buildPassFinishedString($data));
+        $this->tpl->setVariable("LAST_SCORED_ACCESS", $this->buildPassFinishedString($data));
 
         $this->tpl->setVariable("ANSWERED_QUESTIONS", $this->buildAnsweredQuestionsString($data));
         $this->tpl->setVariable("REACHED_POINTS", $this->buildReachedPointsString($data));
@@ -297,8 +300,26 @@ class ilParticipantsTestResultsTableGUI extends ilTable2GUI
      */
     protected function buildPassFinishedString($data)
     {
-        return ilDatePresentation::formatDate(new ilDateTime($data['pass_finished'], IL_CAL_UNIX));
+        return ilDatePresentation::formatDate(new ilDateTime($data['last_scored_access'], IL_CAL_UNIX));
     }
+
+
+    /**
+     * @param array $data
+     * @return string
+     */
+    protected function buildFinishedPassesString($data)
+    {
+        $finished = $data['finished_passes'] ?? 0;
+        $started = (isset($data['has_unfinished_passes']) && $data['has_unfinished_passes']) ? $finished + 1 : $finished;
+
+        return sprintf(
+            $this->lng->txt('tst_tbl_col_finished_passes_num_of'),
+            $finished,
+            $started
+        );
+    }
+
 
     /**
      * @param array $data

--- a/Modules/Test/templates/default/tpl.il_as_tst_scorings_row.html
+++ b/Modules/Test/templates/default/tpl.il_as_tst_scorings_row.html
@@ -6,8 +6,9 @@
     <!-- END checkbox_column -->
     <td class="std" style="vertical-align: top"><label for="cb_{ROW_KEY}">{FULLNAME}</label></td>
     <td class="std" style="vertical-align: top"><label for="cb_{ROW_KEY}">{LOGIN}</label></td>
+    <td class="std" style="vertical-align: top">{FINISHED_PASSES}</td>
     <td class="std" style="vertical-align: top">{SCORED_PASS}</td>
-    <td class="std" style="vertical-align: top">{PASS_FINISHED}</td>
+    <td class="std" style="vertical-align: top">{LAST_SCORED_ACCESS}</td>
     <td class="std" style="vertical-align: top">{ANSWERED_QUESTIONS}</td>
     <td class="std" style="vertical-align: top">{REACHED_POINTS}</td>
     <td class="std" style="vertical-align: top">{PERCENT_RESULT}</td>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1473,6 +1473,10 @@ assessment#:#tst_finish_notification_content#:#Inhalt der Benachrichtigung
 assessment#:#tst_finish_notification_simple#:#Nur Benutzername und Datum des Beendens
 assessment#:#tst_finish_notification_no#:#Keine Benachrichtigung
 assessment#:#tst_finished#:#Beendet
+assessment#:#tst_tbl_col_started_passes#:#Gestartete Durchläufe
+assessment#:#tst_tbl_col_finished_passes#:#Beendete Durchläufe
+assessment#:#tst_tbl_col_finished_passes_num_of#:#%s von %s
+assessment#:#tst_tbl_col_last_scored_access#:#Letzter bewerteter Zugriff
 assessment#:#unfinished_passes#:#Unbeendeter Testdurchlauf
 assessment#:#finish_pass_for_user_confirmation#:#Wollen Sie den Test Durchlauf für den Teilnehmer "%s" wirklich beenden?
 assessment#:#finish_pass_for_user_in_processing_time#:#WARNUNG: die Bearbeitungszeit für diesen Benutzer ist noch nicht vorbei! Sie sollten den Testlauf nur bei zwingendem Grund (z.B. Ausschluss vom Test) beenden.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1398,6 +1398,10 @@ assessment#:#tst_finish_notification_no#:#No e-mail
 assessment#:#tst_finish_notification#:#Notification
 assessment#:#tst_finish_notification_desc#:#Sends an e-mail to the test owner for every user that has completed the test.
 assessment#:#tst_finished#:#Finished
+assessment#:#tst_tbl_col_started_passes#:#Started Passes
+assessment#:#tst_tbl_col_finished_passes#:#Finished Passes
+assessment#:#tst_tbl_col_finished_passes_num_of#:#%s of %s
+assessment#:#tst_tbl_col_last_scored_access#:#Last Scored Access
 assessment#:#unfinished_passes#:#Unfinished Passes
 assessment#:#finish_pass_for_user_confirmation#:#Are you sure you want to finish this test pass for the participant "%s"?
 assessment#:#finish_pass_for_user_in_processing_time#:#WARNING: the processing time for this user is not over yet! You should only end the test run if there is a compelling reason (e.g. exclusion from the test).


### PR DESCRIPTION
…is still browsing test

Please have also a look at this comment:
https://github.com/ILIAS-eLearning/ILIAS/compare/release_7...fneumann:fix7-mantis29983?expand=1#diff-50b17c076996ac620ec5be4fbfbea3a88cdf025ae4ce386cae11ea1712958ddbR386

I found a difference between the selection of the best pass here and in the test result cache. This results in different output of the best pass in the gui and in the result export.