### PR TITLE
Allow DateTimeImmutables as Value for DateTime Fields

### DIFF
--- a/src/Data/DateFormat/DateFormat.php
+++ b/src/Data/DateFormat/DateFormat.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2019 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Data\DateFormat;
 
@@ -77,5 +91,15 @@ class DateFormat
     public function toString() : string
     {
         return implode('', $this->format);
+    }
+
+    public function __toString() : string
+    {
+        return $this->toString();
+    }
+
+    public function applyTo(\DateTimeImmutable $datetime) : string
+    {
+        return $datetime->format($this->toString());
     }
 }

--- a/src/UI/Implementation/Component/Input/Field/DateTime.php
+++ b/src/UI/Implementation/Component/Input/Field/DateTime.php
@@ -95,9 +95,6 @@ class DateTime extends Input implements C\Input\Field\DateTime
         return $clone;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function withFormat(DateFormat $format) : C\Input\Field\DateTime
     {
         $clone = clone $this;
@@ -105,9 +102,6 @@ class DateTime extends Input implements C\Input\Field\DateTime
         return $clone;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getFormat() : DateFormat
     {
         return $this->format;
@@ -128,17 +122,11 @@ class DateTime extends Input implements C\Input\Field\DateTime
         return $clone;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getTimezone() : ?string
     {
         return $this->timezone;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function withMinValue(DateTimeImmutable $datetime) : C\Input\Field\DateTime
     {
         $clone = clone $this;
@@ -146,17 +134,11 @@ class DateTime extends Input implements C\Input\Field\DateTime
         return $clone;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getMinValue() : ?DateTimeImmutable
     {
         return $this->min_date;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function withMaxValue(DateTimeImmutable $datetime) : C\Input\Field\DateTime
     {
         $clone = clone $this;
@@ -164,17 +146,11 @@ class DateTime extends Input implements C\Input\Field\DateTime
         return $clone;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getMaxValue() : ?DateTimeImmutable
     {
         return $this->max_date;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function withUseTime(bool $with_time) : C\Input\Field\DateTime
     {
         $clone = clone $this;
@@ -182,17 +158,11 @@ class DateTime extends Input implements C\Input\Field\DateTime
         return $clone;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getUseTime() : bool
     {
         return $this->with_time;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function withTimeOnly(bool $time_only) : C\Input\Field\DateTime
     {
         $clone = clone $this;
@@ -200,25 +170,16 @@ class DateTime extends Input implements C\Input\Field\DateTime
         return $clone;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getTimeOnly() : bool
     {
         return $this->with_time_only;
     }
 
-    /**
-     * @inheritdoc
-     */
     protected function isClientSideValueOk($value) : bool
     {
         return is_string($value);
     }
 
-    /**
-     * @inheritdoc
-     */
     protected function getConstraintForRequirement() : ?Constraint
     {
         return $this->refinery->string()->hasMinLength(1)
@@ -245,9 +206,6 @@ class DateTime extends Input implements C\Input\Field\DateTime
         return $clone;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getUpdateOnLoadCode() : Closure
     {
         return fn ($id) => "$('#$id').on('input dp.change', function(event) {

--- a/src/UI/Implementation/Component/Input/Field/DateTime.php
+++ b/src/UI/Implementation/Component/Input/Field/DateTime.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2019 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -61,6 +75,24 @@ class DateTime extends Input implements C\Input\Field\DateTime
                 return $or_trafo->transform($v);
             }
         );
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Allows to pass a \DateTimeImmutable for consistencies sake.
+     */
+    public function withValue($value)
+    {
+        // TODO: It would be a lot nicer if the value would be held as DateTimeImmutable
+        // internally, but currently this is just to much. Added to the roadmap.
+        if ($value instanceof \DateTimeImmutable) {
+            $value = $this->format->applyTo($value);
+        }
+
+        $clone = clone $this;
+        $clone->value = $value;
+        return $clone;
     }
 
     /**

--- a/src/UI/Implementation/Component/Input/Field/Input.php
+++ b/src/UI/Implementation/Component/Input/Field/Input.php
@@ -173,7 +173,7 @@ abstract class Input implements C\Input\Field\Input, FormInputInternal
      * Get an input like this with another value displayed on the
      * client side.
      *
-     * @param   mixed
+     * @param   mixed $value
      * @throws  InvalidArgumentException    if value does not fit client side input
      */
     public function withValue($value)

--- a/src/UI/Implementation/Component/Input/Field/Input.php
+++ b/src/UI/Implementation/Component/Input/Field/Input.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -198,7 +198,7 @@ other files in src/GlobalScreen/Scope, an exception is being thrown for icons/gl
 configured with an empty (Aria-)Label.
 The components themselves should take care of this.
 
-### Get rid of < div > under < body > element in Standard Page template (beginner)
+### Get rid of `<div>` under `<body>` element in Standard Page template (beginner)
 In the template of the Standard Page, one level under the < body > element,
 a < div > element is used. This level seems redundant and not giving any advantages
 over just starting with < body >. We should remove the < div > element, but must
@@ -212,9 +212,9 @@ Add, where missing, and refine existing.
 Date/Time pickers are currently implemented using a third party library. The solution suffers from accessibility issues. Even native pickers seem not always to be easy accessible. See https://mantis.ilias.de/view.php?id=29816#bugnotes. We should evaluate different solutions to tackle this.
 
 ### Remove wrapping DIVs in Mainbar
-Top items in the mainbar are wrapped in a <div class="il-mainbar-triggers">;
-We should get rid of this wrapper and have <ol>/<li> only for "menu-items",
-directly under the <nav>-tag.
+Top items in the mainbar are wrapped in a `<div class="il-mainbar-triggers">`;
+We should get rid of this wrapper and have `<ol\>/<li>` only for "menu-items",
+directly under the `<nav>`-tag.
 
 ### Renovate Lightbox Modal (advanced, ~8h)
 The Lightbox Modal is a rather old component that does not follow current standards of
@@ -229,7 +229,7 @@ with modern CSS transformations.
 * The sizes of the various lightboxes do not align, which looks odd when clicking
 through the various pages.
 * The template file of the lightbox contains a script tag, which is not allowed as
-of Dicto Rule `IliasTemplateFiles cannot contain text: "<script"`.
+of Dicto Rule `IliasTemplateFiles cannot contain text: "\<script"`.
 
 ### Adjust FactoriesCrawler (beginner, 2h)
 

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -261,6 +261,14 @@ ILIAS 8 introduces an Audio Player component presenting an optional transcript t
 - Introduce a KS component for transcript presentation following the structure of the WebVTT format.
 - Add support for WebVTT files to the Audio Player component.
 
+### DateTime Input Field: use DateTimeImmutable for internal value (beginner, 2h)
+
+Currently the value of the DateTime Input Field is stored as a string internally.
+This will lead to problems when formatting or timezones are changed on the input
+field. Also, we already have a DateTimeImmutable on many occasions, why cast it
+down to string to later cast it up again? The change should be covered by a lot
+of tests, so little risk there only.
+
 ## Long Term
 
 ### Make Constraint in Tag Input Field work again

--- a/tests/Data/DateFormatTest.php
+++ b/tests/Data/DateFormatTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2019 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 require_once("libs/composer/vendor/autoload.php");
 
@@ -9,34 +23,26 @@ use PHPUnit\Framework\TestCase;
 
 class DateFormatTest extends TestCase
 {
-    public function testFactory() : \ILIAS\Data\DateFormat\Factory
+    public function setUp() : void
     {
         $f = new ILIAS\Data\Factory();
-        $df = $f->dateFormat();
-        $this->assertInstanceOf(DateFormat\Factory::class, $df);
-        return $df;
+        $this->df = $f->dateFormat();
     }
 
-    /**
-     * @depends testFactory
-     */
-    public function testDateFormatFactory(DateFormat\Factory $df) : void
+    public function testDateFormatFactory() : void
     {
-        $this->assertInstanceOf(DateFormat\DateFormat::class, $df->standard());
-        $this->assertInstanceOf(DateFormat\DateFormat::class, $df->germanShort());
-        $this->assertInstanceOf(DateFormat\DateFormat::class, $df->germanLong());
-        $this->assertInstanceOf(DateFormat\FormatBuilder::class, $df->custom());
+        $this->assertInstanceOf(DateFormat\DateFormat::class, $this->df->standard());
+        $this->assertInstanceOf(DateFormat\DateFormat::class, $this->df->germanShort());
+        $this->assertInstanceOf(DateFormat\DateFormat::class, $this->df->germanLong());
+        $this->assertInstanceOf(DateFormat\FormatBuilder::class, $this->df->custom());
     }
 
-    /**
-     * @depends testFactory
-     */
-    public function testDateFormatBuilderAndGetters(DateFormat\Factory $df) : void
+    public function testDateFormatBuilderAndGetters() : void
     {
         $expect = [
             '.', ',', '-', '/', ' ', 'd', 'jS', 'l', 'D', 'W', 'm', 'F', 'M', 'Y', 'y'
         ];
-        $format = $df->custom()
+        $format = $this->df->custom()
             ->dot()->comma()->dash()->slash()->space()
             ->day()->dayOrdinal()->weekday()->weekdayShort()
             ->week()->month()->monthSpelled()->monthSpelledShort()
@@ -52,11 +58,24 @@ class DateFormatTest extends TestCase
             implode('', $expect),
             $format->toString()
         );
+
+        $this->assertEquals(
+            $format->toString(),
+            (string) $format
+        );
     }
 
     public function testInvalidTokens() : void
     {
         $this->expectException(InvalidArgumentException::class);
         new DateFormat\DateFormat(['x', '2']);
+    }
+
+    public function test_applyTo() : void
+    {
+        $dt = new DateTimeImmutable("1985-04-05");
+        $format = $this->df->germanShort();
+        $this->assertEquals("05.04.1985", $format->applyTo($dt));
+        $this->assertEquals("05.04.1985", $dt->format((string) $format));
     }
 }

--- a/tests/UI/Component/Input/Field/DateTimeInputTest.php
+++ b/tests/UI/Component/Input/Field/DateTimeInputTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2018 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 require_once(__DIR__ . "/../../../../../libs/composer/vendor/autoload.php");
 require_once(__DIR__ . "/../../../Base.php");
@@ -146,5 +160,17 @@ class DateTimeInputTest extends ILIAS_UI_TestBase
 
         $onload_js = array_shift($js_binding->on_load_code);
         $this->assertEquals($expected, $onload_js);
+    }
+
+    public function test_withValueThatIsDateTimeImmutable() : void
+    {
+        $string_value = "1985-05-04";
+        $value = new \DateTimeImmutable($string_value);
+        $datetime = $this->factory->datetime('label', 'byline')
+            ->withValue($value);
+        $this->assertEquals(
+            $string_value,
+            $datetime->getValue()
+        );
     }
 }


### PR DESCRIPTION
Hoi zsämme,

currently the `DateTime Input Field` will only allow strings as input, which is irritating:

https://mantis.ilias.de/view.php?id=29267

This will allow to pass `DateTimeImmutable` as value as well. Also, this cleans up some stuff and adds a simplification for the `DateFormat`.

Best regards!