### PR TITLE
MyStaff: php8 review

### DIFF
--- a/Services/MyStaff/classes/ListCertificates/class.ilMStListCertificates.php
+++ b/Services/MyStaff/classes/ListCertificates/class.ilMStListCertificates.php
@@ -47,7 +47,7 @@ class ilMStListCertificates
 
         $data = [];
         $users_per_position = ilMyStaffAccess::getInstance()->getUsersForUserPerPosition($this->dic->user()->getId());
-        foreach ($users_per_position as $position_id => $users) {
+        foreach ($users_per_position as $users) {
             $usr_data_filter = new UserDataFilter();
             $usr_data_filter = $usr_data_filter->withUserIds($users);
             $usr_data_filter = $usr_data_filter->withObjIds(ilMyStaffAccess::getInstance()->getIdsForUserAndOperation($this->dic->user()->getId(),
@@ -65,6 +65,7 @@ class ilMStListCertificates
         }
 
         $unique_cert_data = [];
+        // TODO: php8_review: $data is always empty at this point
         foreach ($data as $cert_data) {
             assert($cert_data instanceof UserCertificateDto);
             $unique_cert_data[$cert_data->getCertificateId()] = $cert_data;

--- a/Services/MyStaff/classes/ListCertificates/class.ilMStListCertificatesGUI.php
+++ b/Services/MyStaff/classes/ListCertificates/class.ilMStListCertificatesGUI.php
@@ -18,7 +18,7 @@ class ilMStListCertificatesGUI
     const CMD_RESET_FILTER = 'resetFilter';
     protected ilTable2GUI $table;
     protected ilMyStaffAccess $access;
-    private \ilGlobalTemplateInterface $main_tpl;
+    private ilGlobalTemplateInterface $main_tpl;
 
     public function __construct()
     {

--- a/Services/MyStaff/classes/ListCertificates/class.ilMStListCertificatesTableGUI.php
+++ b/Services/MyStaff/classes/ListCertificates/class.ilMStListCertificatesTableGUI.php
@@ -79,6 +79,7 @@ class ilMStListCertificatesTableGUI extends ilTable2GUI
 
         $certificates_fetcher = new ilMStListCertificates($DIC);
         $data = $certificates_fetcher->getData($options);
+        // TODO: php8_review: $options['limit'] is never used; typecasts potentially redundant
         $options['limit'] = array(
             'start' => intval($this->getOffset()),
             'end' => intval($this->getLimit()),
@@ -206,6 +207,7 @@ class ilMStListCertificatesTableGUI extends ilTable2GUI
 
     final public function fillRow(array $a_set) : void
     {
+        // TODO: php8_review: $a_set is used as an object but declared as array
         global $DIC;
 
         $propGetter = Closure::bind(function ($prop) {
@@ -256,6 +258,7 @@ class ilMStListCertificatesTableGUI extends ilTable2GUI
     protected function fillRowExcel(ilExcel $a_excel, int &$a_row, array $a_set) : void
     {
         $col = 0;
+        // TODO: php8_review: Expected parameter of type '\Certificate\API\Data\UserCertificateDto', 'array' $a_set provided
         foreach ($this->getFieldValuesForExport($a_set) as $k => $v) {
             $a_excel->setCell($a_row, $col, $v);
             $col++;
@@ -264,6 +267,7 @@ class ilMStListCertificatesTableGUI extends ilTable2GUI
 
     protected function fillRowCSV(ilCSVWriter $a_csv, array $a_set) : void
     {
+        // TODO: php8_review: $a_set should be an object but declared as array
         foreach ($this->getFieldValuesForExport($a_set) as $k => $v) {
             $a_csv->addColumn($v);
         }

--- a/Services/MyStaff/classes/ListCompetences/Skills/class.ilMStListCompetencesSkills.php
+++ b/Services/MyStaff/classes/ListCompetences/Skills/class.ilMStListCompetencesSkills.php
@@ -26,6 +26,7 @@ class ilMStListCompetencesSkills
      */
     final public function getData(array $options)
     {
+        // TODO: php8_review: the function return int and ilMStListCompetencesSkill[]
         //Permission Filter
         $operation_access = ilOrgUnitOperation::OP_VIEW_COMPETENCES;
 

--- a/Services/MyStaff/classes/ListCompetences/Skills/class.ilMStListCompetencesSkillsTableGUI.php
+++ b/Services/MyStaff/classes/ListCompetences/Skills/class.ilMStListCompetencesSkillsTableGUI.php
@@ -28,7 +28,7 @@ class ilMStListCompetencesSkillsTableGUI extends ilTable2GUI
     protected ilMyStaffAccess $access;
     protected Container $dic;
 
-    public function __construct(\ilObjectGUI $parent_obj, string $parent_cmd, Container $dic)
+    public function __construct(\ilMStListCompetencesSkillsGUI $parent_obj, string $parent_cmd, Container $dic)
     {
         $this->dic = $dic;
         $this->access = ilMyStaffAccess::getInstance();
@@ -105,9 +105,14 @@ class ilMStListCompetencesSkillsTableGUI extends ilTable2GUI
         $this->filter['skill_level'] = $item->getValue();
 
         //user
-        $item = new ilTextInputGUI($this->dic->language()->txt("login") . "/" . $this->dic->language()->txt("email") . "/" . $this->dic->language()
-                                                                                                                                       ->txt("name"),
-            "user");
+        $item = new ilTextInputGUI(
+            $this->dic->language()->txt("login") .
+            "/" .
+            $this->dic->language()->txt("email") .
+            "/" .
+            $this->dic->language()->txt("name")
+            , "user"
+        );
 
         $this->addFilterItem($item);
         $item->readFromSession();

--- a/Services/MyStaff/classes/class.ilMyStaffGUI.php
+++ b/Services/MyStaff/classes/class.ilMyStaffGUI.php
@@ -10,6 +10,8 @@ use ILIAS\MyStaff\ListCourses\ilMStListCourse;
 class ilMyStaffGUI
 {
     public const CMD_INDEX = 'index';
+
+    // TODO: php8_review: remove unused constants
     public const TAB_LIST_USERS = 'list_users';
     public const TAB_LIST_COURSES = 'list_courses';
     public const TAB_LIST_CERTIFICATES = 'list_certificates';


### PR DESCRIPTION
# Must-Package
### What must be the agreed minimum goal from the community?  - Whether developers, operators or users.

## Goals
 * [ ] ILIAS can be used with PHP 8 without producing PHP-specific errors.
   * can't generally use gui
 * [x] Refactored code conforms to current coding styles
 * [ ] Elimination of all warnings and errors of the static code inspection (without weak | incl. undeclared variables)
   * 3 errors
   * 58 warnings
   * 48 weak warnings
 * [x] Transfer of GET params into Constructor
 * [x] Avoidance/reduction of POST accesses (e.g. through $form->getInput()) and switch to Request classes
 * [x] Use of SESSION (session object, alternative assignment of static session in constructor member variables)
 * [ ] Documentation of all existing typifications as typehints (of parameters, return values and properties)
   * missing void return type on many setters
 * [ ] Creation of a unit test infrastructure in the component
   * missing test suite

## Requirements and analysis criteria
* [ ] Preserve unit test coverage even in refactoring.
* [ ]  Simple call of all tabs/screens (without e.g. delete and move actions) and fixing of the corresponding bugs
  * * can't generally use gui
* [ ]  Checking of external libraries
* [x]  Basis of the refactoring and the reviews is, among others, ILIAS Development Documentation.

# Should-Package
### What do we need to do in the mid-term to catch recurring large code revisions and to refactor more than the minimum?

 * [ ] Expansion of the unit test coverage
  * General and structural improvements and optimisations to the code base. For example ...
   * [ ]  ... in static functions and by removing static methods
   * [ ]  ... by introducing return type declarations
   * ... by typification of all variables
     * [ ] Input/output typing of methods
       * 96%
     * [x] Typification of member variables
 * [ ]   Use of UI components from the UI framework "KitchenSink" that have been introduced and established in the meantime. Reduction of legacy UI and legacy code.

# Sustainability-Package
### he developer community has identified topics that would also improve the quality of ILIAS from the point of view of PHP and ILIAS in general. Ideally, these topics could be directly addressed in the process of systematic refactoring.

* [ ] Introduction and use of declarations of "strict_types" for data
* [ ]  Replace previous arrays with classes that enable ArrayAccess - in future also getter / setter
* [ ]  Switching previous arrays to generators/data objects

# Misc
* please have a deeper look at the warnings. There are type miss matches.
* remove unused use statememts
* unecassary comments
* many unecassary type casts with intval
* please also have a look at places marked with 'TODO: php8_review:' prefix