### PR TITLE
Setup: show nic status and id in status command

### DIFF
--- a/setup/classes/class.ilSetupMetricsCollectedObjective.php
+++ b/setup/classes/class.ilSetupMetricsCollectedObjective.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2019 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\Setup;
 
@@ -14,7 +28,8 @@ class ilSetupMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
     protected function getTentativePreconditions(Setup\Environment $environment) : array
     {
         return [
-            new ilIniFilesLoadedObjective()
+            new ilIniFilesLoadedObjective(),
+            new \ilSettingsFactoryExistsObjective()
         ];
     }
 
@@ -34,6 +49,23 @@ class ilSetupMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
                 $client_id,
                 "Id of the ILIAS client."
             );
+        }
+        $settings_factory  = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
+        if ($settings_factory) {
+            $common_settings = $settings_factory->settingsFor("common");
+            $nic_enabled = $common_settings->get("nic_enabled") == "1";
+            $storage->storeStableBool(
+                "nic_enabled",
+                $nic_enabled,
+                "Is the installation registered at the ILIAS NIC server?"
+            );
+            if ($nic_enabled) {
+                $storage->storeConfigText(
+                    "inst_id",
+                    $common_settings->get("inst_id"),
+                    "The id of the installation as provided by the ILIAS NIC server."
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Hi folks,

this improves the mechanism for registering NIC ids as provided in #3586 by an output of the status and id in the `status` command, as requested by @utesche in [Mantis 30554](https://mantis.ilias.de/view.php?id=30554).

@utesche Would you do the honor and review this PR?

Best regards!