### PR TITLE
Container: make the GUI base class respect that sub object does not support page editor

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
@@ -744,4 +744,9 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI
     {
         ilExplorerBaseGUI::init();
     }
+
+    protected function supportsPageEditor() : bool
+    {
+        return false;
+    }
 }

--- a/Services/Container/classes/class.ilContainerGUI.php
+++ b/Services/Container/classes/class.ilContainerGUI.php
@@ -401,7 +401,8 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
             ) {
                 if ($ilSetting->get("enable_cat_page_edit")) {
                     if (!$this->isActiveAdministrationPanel() &&
-                        !$this->isActiveOrdering()) {
+                        !$this->isActiveOrdering() &&
+                        $this->supportsPageEditor()) {
                         $toolbar->addButton(
                             $lng->txt("cntr_text_media_editor"),
                             $ilCtrl->getLinkTarget($this, "editPageFrame")
@@ -419,6 +420,11 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
         if ($this->requested_ref_id > 1 && $ilSetting->get("rep_tree_synchronize")) {
             $ilCtrl->setParameter($this, "active_node", $this->requested_ref_id);
         }
+    }
+
+    protected function supportsPageEditor() : bool
+    {
+        return true;
     }
 
     /**


### PR DESCRIPTION
Hi @alex40724,

this fixes [Mantis 30959](https://mantis.ilias.de/view.php?id=30959). Unfortunatly I could not find another way to make the `ContainerGUI` respect the fact, that the Page Editor is not supported by the Study Programme without copying the method from the class verbatim. If you have a prefered way to implement this or if I have just missed some way to fix the issue, please let me know.

Best regards!