### PR TITLE
Fixed char counter init for text question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -556,7 +556,8 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         $tpl->setCurrentBlock('counter_js');
         $tpl->setVariable("QID", $this->object->getId());
         $tpl->parseCurrentBlock();
-        
+
+        $this->tpl->addOnLoadCode('testQuestionInit();');
         return $tpl->get();
     }
 

--- a/Modules/TestQuestionPool/templates/default/tpl.charcounter.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.charcounter.html
@@ -23,11 +23,8 @@ var charCounter = function(e) // default handler hard coded to tinymce config
         updateAssTextQuestionWordCounter();
     }
 };
-
+let testQuestionInit = function() {
 <!-- END tinymce_handler -->
-
-(function($)
-{
 
     var qId = {QID};
 
@@ -132,5 +129,5 @@ var charCounter = function(e) // default handler hard coded to tinymce config
 
 <!-- END counter_js -->
 
-})(jQuery);
+}
 </script>


### PR DESCRIPTION
The inclusion of javascript seems to be broken in ILIAS 8, this PR fixes main part of this problem, for the preview and test view of the text question.