### PR TITLE
Test/TestQuestionPool: Remove `strftime`

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -1,5 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 require_once 'Services/Object/classes/class.ilObject.php';
 require_once 'Modules/Test/classes/inc.AssessmentConstants.php';
@@ -3308,7 +3323,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $affectedRows = $ilDB->manipulateF(
             "INSERT INTO tst_times (times_id, active_fi, started, finished, pass, tstamp) VALUES (%s, %s, %s, %s, %s, %s)",
             array('integer', 'integer', 'timestamp', 'timestamp', 'integer', 'integer'),
-            array($next_id, $active_id, strftime("%Y-%m-%d %H:%M:%S"), strftime("%Y-%m-%d %H:%M:%S"), $pass, time())
+            array($next_id, $active_id, date("Y-m-d H:i:s"), date("Y-m-d H:i:s"), $pass, time())
         );
         return $next_id;
     }
@@ -3327,7 +3342,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $affectedRows = $ilDB->manipulateF(
             "UPDATE tst_times SET finished = %s, tstamp = %s WHERE times_id = %s",
             array('timestamp', 'integer', 'integer'),
-            array(strftime("%Y-%m-%d %H:%M:%S"), time(), $times_id)
+            array(date('Y-m-d H:i:s'), time(), $times_id)
         );
     }
 
@@ -8593,7 +8608,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         if (($nr_of_users > 0) && ($time_gap > 0)) {
             $now = time();
             $time_border = $now - $time_gap;
-            $str_time_border = strftime("%Y%m%d%H%M%S", $time_border);
+            $str_time_border = date("YmdHis", $time_border);
             $query = "
 				SELECT DISTINCT tst_times.active_fi
 				FROM tst_times

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -2367,10 +2367,12 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         $template->setVariable("TITLE", ilLegacyFormElementsUtil::prepareFormOutput($this->object->getTitle()));
         $template->setVariable("PRINT_TEST", ilLegacyFormElementsUtil::prepareFormOutput($this->lng->txt("tst_print")));
         $template->setVariable("TXT_PRINT_DATE", ilLegacyFormElementsUtil::prepareFormOutput($this->lng->txt("date")));
+        $used_relative_dates = ilDatePresentation::useRelativeDates();
         $template->setVariable(
             "VALUE_PRINT_DATE",
-            ilLegacyFormElementsUtil::prepareFormOutput(strftime("%c", $print_date))
+            ilDatePresentation::formatDate(new ilDateTime($print_date, IL_CAL_UNIX))
         );
+        $use = ilDatePresentation::setUseRelativeDates($used_relative_dates);
         $template->setVariable(
             "TXT_MAXIMUM_POINTS",
             ilLegacyFormElementsUtil::prepareFormOutput($this->lng->txt("tst_maximum_points"))

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assKprimChoiceImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assKprimChoiceImport.php
@@ -1,5 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 require_once 'Modules/TestQuestionPool/classes/import/qti12/class.assQuestionImport.php';
 require_once 'Modules/TestQuestionPool/classes/class.ilAssKprimChoiceAnswer.php';
@@ -315,6 +330,5 @@ class assKprimChoiceImport extends assQuestionImport
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
-        //$ilLog->write(strftime("%D %T") . ": finished import multiple choice question (single response)");
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assMultipleChoiceImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assMultipleChoiceImport.php
@@ -313,6 +313,5 @@ class assMultipleChoiceImport extends assQuestionImport
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
-        //$ilLog->write(strftime("%D %T") . ": finished import multiple choice question (single response)");
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assMultipleChoiceImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assMultipleChoiceImport.php
@@ -1,5 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 include_once "./Modules/TestQuestionPool/classes/import/qti12/class.assQuestionImport.php";
 


### PR DESCRIPTION
See: https://php.watch/versions/8.1/strftime-gmstrftime-deprecated

IMO there is no reason to use `local-dependant` functions for the found occurances, so I used `date` to replace the usages of `strftime` (except one HTML output case where I used `ilDatePresentation` / Impact: The date presentation will **not** look like this `Mon May 30 12:51:34 2022` anymore in the affected view).