### PR TITLE
Test: `passed` column for the `getTestResults` soap call 

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -7951,7 +7951,8 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             "max_points" => $this->lng->txt("tst_maximum_points"),
             "percent_value" => $this->lng->txt("tst_percent_solved"),
             "mark" => $this->lng->txt("tst_mark"),
-            "ects" => $this->lng->txt("ects_grade")
+            "ects" => $this->lng->txt("ects_grade"),
+            "passed" => $this->lng->txt("tst_mark_passed"),
         );
         $results[] = $row;
         if (count($participants)) {
@@ -8000,7 +8001,8 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     "max_points" => $max_points,
                     "percent_value" => $percentvalue,
                     "mark" => $mark,
-                    "ects" => $ects_mark
+                    "ects" => $ects_mark,
+                    "passed" => $user_rec['passed'] ? '1' : '0',
                 );
                 $results[] = $prepareForCSV ? $this->processCSVRow($row, true) : $row;
             }
@@ -10281,7 +10283,8 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                             "question_id" => $question->getId(),
                             "question_title" => $question->getTitle(),
                             "reached_points" => $reached_points,
-                            "max_points" => $max_points
+                            "max_points" => $max_points,
+                            "passed" => $user_rec['passed'] ? '1' : '0',
                         );
                         $results[] = $row;
                     }

--- a/webservice/soap/classes/class.ilSoapTestAdministration.php
+++ b/webservice/soap/classes/class.ilSoapTestAdministration.php
@@ -713,8 +713,10 @@ class ilSoapTestAdministration extends ilSoapAdministration
         $participantList = new ilTestParticipantList($test_obj);
         $participantList->initializeFromDbRows($participants);
         $participantList = $participantList->getAccessFilteredList($accessFilter);
+        $participantList = $participantList->getScoredParticipantList();
         foreach ($participants as $activeId => $part) {
             if ($participantList->isActiveIdInList($activeId)) {
+                $participants[$activeId]['passed'] = $participantList->getParticipantByActiveId($activeId)->getScoring()->isPassed();
                 continue;
             }
             
@@ -726,6 +728,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
             // create xml
             $xmlResultSet->addColumn("maximum_points");
             $xmlResultSet->addColumn("received_points");
+            $xmlResultSet->addColumn("passed");
             // skip titles
             $titles = array_shift($data);
             foreach ($data as $row) {
@@ -737,6 +740,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
                 $xmlRow->setValue(4, $row["matriculation"]);
                 $xmlRow->setValue(5, $row["max_points"]);
                 $xmlRow->setValue(6, $row["reached_points"]);
+                $xmlRow->setValue(7, $row["passed"]);
                 $xmlResultSet->addRow($xmlRow);
             }
         } else {
@@ -746,6 +750,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
             $xmlResultSet->addColumn("question_title");
             $xmlResultSet->addColumn("maximum_points");
             $xmlResultSet->addColumn("received_points");
+            $xmlResultSet->addColumn("passed");
             foreach ($data as $row) {
                 $xmlRow = new ilXMLResultSetRow();
                 $xmlRow->setValue(0, $row["user_id"]);
@@ -757,6 +762,7 @@ class ilSoapTestAdministration extends ilSoapAdministration
                 $xmlRow->setValue(6, $row["question_title"]);
                 $xmlRow->setValue(7, $row["max_points"]);
                 $xmlRow->setValue(8, $row["reached_points"]);
+                $xmlRow->setValue(9, $row["passed"]);
                 $xmlResultSet->addRow($xmlRow);
             }
         }


### PR DESCRIPTION
Mantis ticket: https://mantis.ilias.de/view.php?id=14311

Add a new column `passed` for the `getTestResults` soap call. Please cherry-pick this to `trunk` as well.