### PR TITLE
TA 26290, block forms if pool-sync is currently in place

### DIFF
--- a/Modules/Test/classes/class.ilTestRandomQuestionSetConfig.php
+++ b/Modules/Test/classes/class.ilTestRandomQuestionSetConfig.php
@@ -290,27 +290,14 @@ class ilTestRandomQuestionSetConfig extends ilTestQuestionSetConfig
 
     // -----------------------------------------------------------------------------------------------------------------
 
-    public function isQuestionSetConfigured()
+    public function isQuestionSetConfigured() : bool
     {
-        // fau: delayCopyRandomQuestions - question set is not configured if date of last synchronisation is empty
-        if ($this->getLastQuestionSyncTimestamp() == 0) {
-            return false;
-        }
-        // fau.
-        
-        if (!$this->isQuestionAmountConfigComplete()) {
-            return false;
-        }
-
-        if (!$this->hasSourcePoolDefinitions()) {
-            return false;
-        }
-
-        if (!$this->isQuestionSetBuildable()) {
-            return false;
-        }
-
-        return true;
+        return (
+            $this->getLastQuestionSyncTimestamp() != 0
+            && $this->isQuestionAmountConfigComplete()
+            && $this->hasSourcePoolDefinitions()
+            && $this->isQuestionSetBuildable()
+        );
     }
 
     public function isQuestionAmountConfigComplete()

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1152,6 +1152,7 @@ assessment#:#tst_msg_random_qsc_modified_add_new_rule#:#Die Konfiguration für d
 assessment#:#tst_msg_random_question_set_config_modified#:#Die Konfiguration für den Test mit zufälliger Fragenauswahl wurde erfolgreich geändert.
 assessment#:#tst_msg_random_question_set_synced#:#Die Fragen zur aktuellen Konfiguration des Tests mit zufälliger Fragenauswahl wurde erfolgreich synchronisiert.
 assessment#:#tst_btn_rebuild_random_question_stage#:#Synchronisiere Fragen aus den Pools
+assessment#:#tst_btn_reset_pool_sync#:#Bearbeiten/Synchronisation aufheben
 assessment#:#tst_msg_rand_quest_set_stage_pool_last_sync#:#Zeitpunkt der letzten Synchronisierung der Fragen aus den ausgewählten Fragenpools: %s
 assessment#:#tst_msg_rand_quest_set_pass_buildable#:#Ein Test mit zufälliger Fragenauswahl ist mit der aktuellen Konfiguration möglich.
 assessment#:#tst_msg_rand_quest_set_pass_not_buildable#:#<b>Mit der aktuellen Auswahl an Fragenpools und der Fragenanzahl kann kein Test mit zufälliger Fragenauswahl erzeugt werden.</b><br />

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1108,6 +1108,7 @@ assessment#:#tst_msg_random_qsc_modified_add_new_rule#:#The configuration for th
 assessment#:#tst_msg_random_question_set_config_modified#:#The configuration for the random set of questions has been modified successfully.
 assessment#:#tst_msg_random_question_set_synced#:#The questions for the current configuration has been synchronized successfully.
 assessment#:#tst_btn_rebuild_random_question_stage#:#Synchronize Questions from Pool
+assessment#:#tst_btn_reset_pool_sync#:#Edit/Cancel Synchronisation
 assessment#:#tst_msg_rand_quest_set_stage_pool_last_sync#:#Date of last synchronisation of selected question pools: %s
 assessment#:#tst_msg_rand_quest_set_pass_buildable#:#A test with a random set of questions is possible with the current configuration.
 assessment#:#tst_msg_rand_quest_set_pass_not_buildable#:#<b>A test with a random set of questions is not possible with the current selection of question pools and the amount of questions.</b><br />


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=26290

You can sync the pool, and the action is being confirmed.
Before editing/saving, you have to "unsync" first.

![Screenshot from 2022-05-30 14-44-49](https://user-images.githubusercontent.com/3328364/170995389-ccf892b9-533f-44fb-bcd1-f595dd1638e7.png)
![Screenshot from 2022-05-30 14-45-13](https://user-images.githubusercontent.com/3328364/170995392-5a49e59c-0c60-4144-b338-1a97ad4ce566.png)
![Screenshot from 2022-05-30 14-45-34](https://user-images.githubusercontent.com/3328364/170995394-9fcd79e8-8571-4d07-9014-d99aa9f646e1.png)

