### PR TITLE
Dashboard: Take SAHS display options into account

### DIFF
--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -3793,7 +3793,13 @@ class ilObjectListGUI
 
 
         if ($def_command['link']) {
-            $list_item = $ui->factory()->item()->standard($this->ui->factory()->link()->standard($this->getTitle(), $def_command['link']));
+            $def_command['link'] = $this->modifySAHSlaunch($def_command['link'], $def_command['frame']);
+            $new_viewport = (bool) $this->getDefaultCommand()['frame']; // Cannot use $def_command['frame']. $this->default_command has been edited.
+            $link = $this->ui->factory()
+                             ->link()
+                             ->standard($this->getTitle(), $def_command['link'])
+                             ->withOpenInNewViewport($new_viewport);
+            $list_item = $ui->factory()->item()->standard($link);
         } else {
             $list_item = $ui->factory()->item()->standard($this->getTitle());
         }


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=31745

The Dashboard uses the `ilObjectListGUI::getAsListItem` method to create a list item. 
The `ilObjectListGUI::getAsListItem` method does not use the `ilObjectListGUI::modifySAHSlaunch` and does not set the `target` attribute to the anchor when it is needed.
