### PR TITLE
Export: remove TargetRelese from exports

### DIFF
--- a/Services/Export/classes/class.ilExport.php
+++ b/Services/Export/classes/class.ilExport.php
@@ -1,18 +1,21 @@
 <?php declare(strict_types=1);
 
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 /**
  * Export
  * @author    Alex Killing <alex.killing@gmx.de>
@@ -347,7 +350,6 @@ class ilExport
             array(
                 "MainEntity" => $a_type,
                 "Title" => ilObject::_lookupTitle($a_id),
-                "TargetRelease" => $a_target_release,
                 "InstallationId" => IL_INST_ID,
                 "InstallationUrl" => ILIAS_HTTP_PATH
             )
@@ -442,7 +444,6 @@ class ilExport
             array(
                 "MainEntity" => $a_entity,
                 "Title" => $a_title,
-                "TargetRelease" => $a_target_release,
                 "InstallationId" => IL_INST_ID,
                 "InstallationUrl" => ILIAS_HTTP_PATH
             )
@@ -557,7 +558,6 @@ class ilExport
                          "InstallationUrl" => ILIAS_HTTP_PATH,
                          "Entity" => $a_entity,
                          "SchemaVersion" => $sv["schema_version"],
-                         "TargetRelease" => $a_target_release,
                          "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance",
                          "xmlns:exp" => "http://www.ilias.de/Services/Export/exp/4_1",
                          "xsi:schemaLocation" => "http://www.ilias.de/Services/Export/exp/4_1 " . ILIAS_HTTP_PATH . "/xml/ilias_export_4_1.xsd"

--- a/Services/Export/classes/class.ilExportContainer.php
+++ b/Services/Export/classes/class.ilExportContainer.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2021 ILIAS open source, GPLv3, see LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Export Container
@@ -46,17 +60,17 @@ class ilExportContainer extends ilExport
 
         $log->debug('Using base directory: ' . $this->export_run_dir);
 
-        $this->manifestWriterBegin($a_type, $a_id, $a_target_release);
+        $this->manifestWriterBegin($a_type, $a_id);
         $this->addContainer();
         $this->addSubitems($a_id, $a_type, $a_target_release);
-        $this->manifestWriterEnd($a_type, $a_id, $a_target_release);
+        $this->manifestWriterEnd($a_type, $a_id);
 
         ilFileUtils::zip($this->cont_export_dir, $this->cont_export_dir . '.zip');
         ilFileUtils::delDir($this->cont_export_dir);
         return [];
     }
 
-    protected function manifestWriterBegin(string $a_type, int $a_id, string $a_target_release) : void
+    protected function manifestWriterBegin(string $a_type, int $a_id) : void
     {
         $this->cont_manifest_writer = new ilXmlWriter();
         $this->cont_manifest_writer->xmlHeader();
@@ -65,7 +79,6 @@ class ilExportContainer extends ilExport
             array(
                 "MainEntity" => $a_type,
                 "Title" => ilObject::_lookupTitle($a_id),
-                "TargetRelease" => $a_target_release,
                 "InstallationId" => IL_INST_ID,
                 "InstallationUrl" => ILIAS_HTTP_PATH
             )
@@ -135,7 +148,7 @@ class ilExportContainer extends ilExport
         }
     }
 
-    protected function manifestWriterEnd(string $a_type, int $a_id, string $a_target_release) : void
+    protected function manifestWriterEnd(string $a_type, int $a_id) : void
     {
         $this->cont_manifest_writer->xmlEndTag('Manifest');
         $this->log->debug($this->cont_export_dir . DIRECTORY_SEPARATOR . 'manifest.xml');

--- a/Services/Export/classes/class.ilManifestParser.php
+++ b/Services/Export/classes/class.ilManifestParser.php
@@ -1,18 +1,21 @@
 <?php declare(strict_types=1);
 
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 /**
  * Manifest parser for ILIAS standard export files
  * @author Aleex Killing <alex.killing@gmx.de>
@@ -74,16 +77,6 @@ class ilManifestParser extends ilSaxParser
         return $this->title;
     }
 
-    public function setTargetRelease(string $a_val) : void
-    {
-        $this->target_release = $a_val;
-    }
-
-    public function getTargetRelease() : string
-    {
-        return $this->target_release;
-    }
-
     public function getExportFiles() : array
     {
         return $this->expfiles;
@@ -117,7 +110,6 @@ class ilManifestParser extends ilSaxParser
                 $this->setInstallId($a_attribs["InstallationId"]);
                 $this->setInstallUrl($a_attribs["InstallationUrl"]);
                 $this->setTitle($a_attribs["Title"]);
-                $this->setTargetRelease($a_attribs["TargetRelease"]);
                 $this->setMainEntity($a_attribs["MainEntity"]);
                 break;
 

--- a/xml/ilias_ds_4_1.xsd
+++ b/xml/ilias_ds_4_1.xsd
@@ -24,7 +24,7 @@
 			<element ref='t:FieldType' minOccurs='0' maxOccurs='unbounded'/>
 		</sequence>
 		<attribute name='Entity' type='string' use='required'/>
-		<attribute name='TargetRelease' type='string' use='required'/>
+		<attribute name='TargetRelease' type='string'/>
 		</complexType>
 	</element>
 

--- a/xml/ilias_export_4_1.xsd
+++ b/xml/ilias_export_4_1.xsd
@@ -13,7 +13,7 @@
 		<attribute name='InstallationId' type='string' use='required'/>
 		<attribute name='InstallationUrl' type='string' use='required'/>
 		<attribute name='Entity' type='string' use='required'/>
-		<attribute name='TargetRelease' type='string' use='required'/>
+		<attribute name='TargetRelease' type='string'/>
 		<attribute name='SchemaVersion' type='string' use='required'/>
 		</complexType>
 	</element>


### PR DESCRIPTION
Hi everyone,

basically, the field `TargetRelase` in the export seems to be of no use, hence we might as well remove it.

Best regards! 