### PR TITLE
Bugfix: no title/link for media used in snippets

### DIFF
--- a/Services/MediaObjects/classes/class.ilMediaObjectUsagesTableGUI.php
+++ b/Services/MediaObjects/classes/class.ilMediaObjectUsagesTableGUI.php
@@ -203,6 +203,23 @@ class ilMediaObjectUsagesTableGUI extends ilTable2GUI
                         }
                         break;
 
+                    case "mep":
+                        $item["obj_type_txt"] = $this->lng->txt("mep_page_type_mep");
+                        $item["sub_txt"] = $this->lng->txt("mep_page_type_mep");
+                        $item["sub_title"] = ilMediaPoolItem::lookupTitle($usage["id"]);
+
+                        $mep_pools = ilMediaPoolItem::getPoolForItemId($usage["id"]);
+                        foreach ($mep_pools as $mep_id) {
+                            $ref_ids = ilObject::_getAllReferences($mep_id);
+                            $item["obj_title"] = ilObject::_lookupTitle($mep_id);
+                            foreach ($ref_ids as $rid) {
+                                $item["obj_link"] = ilLink::_getStaticLink($rid , "mep");
+                                break;
+                            }
+                            break;
+                        }
+                        break;
+
                     default:
                         include_once("./Services/MediaObjects/classes/class.ilObjMediaObject.php");
                         $oid = ilObjMediaObject::getParentObjectIdForUsage($a_set);


### PR DESCRIPTION
In a mediapool, if a media object is used in a snippet page, the relative row in the usage tab is empty: no title, no link, no type...

Previous situation:

![Previous situation](https://user-images.githubusercontent.com/32195269/172011121-1c16f558-e827-4dfa-ac4a-1c066b21ed5f.png)

After fix:

![After fix](https://user-images.githubusercontent.com/32195269/172011138-e87bfc19-53c4-4fae-bb12-1f9f434dab12.png)