### PR TITLE
LSO: Fix lost characters during XML import

### DIFF
--- a/Modules/LearningSequence/classes/Xml/class.ilLearningSequenceXMLParser.php
+++ b/Modules/LearningSequence/classes/Xml/class.ilLearningSequenceXMLParser.php
@@ -17,6 +17,9 @@ class ilLearningSequenceXMLParser extends ilSaxParser
      */
     protected $counter;
 
+    /** @var string */
+    private $cdata = '';
+
     public function __construct(ilObjLearningSequence $obj, string $xml)
     {
         parent::__construct();
@@ -75,6 +78,8 @@ class ilLearningSequenceXMLParser extends ilSaxParser
 
     public function handleEndTag($parser, string $name)
     {
+        $this->cdata = trim($this->cdata);
+
         switch ($name) {
             case "title":
                 $this->obj->setTitle(trim($this->cdata));
@@ -121,11 +126,13 @@ class ilLearningSequenceXMLParser extends ilSaxParser
             default:
                 break;
         }
+
+        $this->cdata = '';
     }
 
     public function handleCharacterData($parser, $data)
     {
-        $this->cdata = $data ?? "";
+        $this->cdata .= ($data ?? "");
         $this->storeData();
     }
 


### PR DESCRIPTION
This PR fixes the handling of text nodes in the XML import of `lso` repository objects. The assumption that all characters of an XML text node (character data) are completely passed in a call of `handleEndTag` was wrong.

Mantis Issues:
- https://mantis.ilias.de/view.php?id=31944
- https://mantis.ilias.de/view.php?id=31945