### PR TITLE
Mediacast: Remove old file upload on file update of a mediacast item

### DIFF
--- a/Modules/MediaCast/classes/class.ilObjMediaCastGUI.php
+++ b/Modules/MediaCast/classes/class.ilObjMediaCastGUI.php
@@ -2,6 +2,11 @@
 
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Filesystem\Exception\FileNotFoundException;
+use ILIAS\Filesystem\Exception\IOException;
+use ILIAS\Filesystem\Filesystem;
+use ILIAS\Filesystem\Util\LegacyPathHelper;
+
 require_once "./Services/Object/classes/class.ilObjectGUI.php";
 
 /**
@@ -37,6 +42,10 @@ class ilObjMediaCastGUI extends ilObjectGUI
      */
     protected $help;
 
+    /**
+     * @var FileSystem
+     */
+    protected $filesystem;
     
     private $additionalPurposes = array("VideoPortable", "AudioPortable");
     private $purposeSuffixes = array();
@@ -57,6 +66,7 @@ class ilObjMediaCastGUI extends ilObjectGUI
         $this->tpl = $DIC["tpl"];
         $this->access = $DIC->access();
         $this->toolbar = $DIC->toolbar();
+        $this->filesystem = $DIC->filesystem()->web();
         $this->log = $DIC["ilLog"];
         $this->error = $DIC["ilErr"];
         $this->help = $DIC["ilHelp"];
@@ -712,6 +722,8 @@ class ilObjMediaCastGUI extends ilObjectGUI
      * @param IlObjectMediaObject $mob
      * @param IlMediaItem $mediaItem
      * @return string file
+     * @throws FileNotFoundException
+     * @throws IOException
      */
     private function updateMediaItem($mob, &$mediaItem)
     {
@@ -730,6 +742,12 @@ class ilObjMediaCastGUI extends ilObjectGUI
             $mob_dir = ilObjMediaObject::_getDirectory($mob->getId());
             if (!is_dir($mob_dir)) {
                 $mob->createDirectory();
+            } else {
+                $dir = LegacyPathHelper::createRelativePath($mob_dir);
+                $old_files = $this->filesystem->finder()->in([$dir])->exclude([$dir . '/mob_vpreview.png'])->files();
+                foreach ($old_files as $file) {
+                    $this->filesystem->delete($file->getPath());
+                }
             }
             
             $file_name = ilUtil::getASCIIFilename($_FILES['file_' . $purpose]['name']);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=32131

This PR removes all files (excluding the preview file) of a mediacast-item when a new file is uploaded.