### PR TITLE
Fix string in goto of forum

### DIFF
--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -1524,6 +1524,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
         $ilErr = $DIC['ilErr'];
 
         $a_target = is_numeric($a_target) ? (int) $a_target : 0;
+        $a_thread = is_numeric($a_thread) ? (int) $a_thread : 0;
         if ($ilAccess->checkAccess('read', '', $a_target)) {
             if ($a_thread !== 0) {
                 $objTopic = new ilForumTopic($a_thread);


### PR DESCRIPTION
This fixes an error, when thread is a string (which it always is, as far as I can see).
You can see the behavior on this link: https://test8.ilias.de/goto.php?target=frm_68831_4042&client_id=test8