### PR TITLE
Data type `LanguageTag`

### DIFF
--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -1,11 +1,28 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Data;
 
 use ILIAS\Data\Clock\ClockFactory;
 use ILIAS\Data\Clock\ClockFactoryImpl;
+use ILIAS\Data\LanguageTag;
+use ILIAS\Data\RFC\LanguageTagDefinition;
+use ILIAS\Data\RFC\Brick;
 
 /**
  * Builds data types.
@@ -178,5 +195,10 @@ class Factory
     public function dataset(array $dimensions) : Chart\Dataset
     {
         return new Chart\Dataset($dimensions);
+    }
+
+    public function languageTag(string $languageTag) : LanguageTag
+    {
+        return new LanguageTag(new LanguageTagDefinition(new Brick()), $languageTag);
     }
 }

--- a/src/Data/LanguageTag.php
+++ b/src/Data/LanguageTag.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Data;
+
+use ILIAS\Data\RFC\LanguageTagDefinition;
+
+/**
+ * This class represents a valid language tag that should be used instead of plain strings.
+ * The language tag is validated by the provided language tag definition.
+ * If an invalid language code is given an exception is thrown.
+ */
+class LanguageTag
+{
+    private string $value;
+
+    public function __construct(LanguageTagDefinition $definition, string $value)
+    {
+        $this->value = $definition->parse($value)->value();
+    }
+
+    public function value() : string
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/RFC/Brick.php
+++ b/src/Data/RFC/Brick.php
@@ -1,0 +1,301 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Data\RFC;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use Closure;
+
+/**
+ * @phpstan-type Continuation Closure(Result<Intermediate>): Result<Intermediate>
+ * @phpstan-type Parser Closure(Intermediate, Continuation): Result<Intermediate>
+ *
+ * If you want to use this class, please read the documentation above each (public) method.
+ *
+ * If you want to edit or add code in this class read below:
+ * Type of parser: (Intermediate, (Result): Result): Result
+ * Type of continuation: (Result): Result
+ * Only immutable values are used.
+ * $cc stands for "current continuation". https://en.wikipedia.org/wiki/Call-with-current-continuation
+ * This is used to be able to capture the next computation and run it again with different input in case of an error.
+ * The $cc is used for example in the `either` method to re run the computation chain with the next branch if the current failed.
+ * $x holds the "state". Everything that is parsed, the current value and the data that still needs to be parsed (Either Result<Intermediate> or Intermediate).
+ *
+ * To restart the whole computation (on error):
+ * $parse($x, $cc)->except(function () use ($x, $cc) {
+ *     return $parse_something_different($x, $cc);
+ * });
+ *
+ * To get the result of the parsers "children" (in case of `either` these would be the branches):
+ * $parse($x, function ($x) use ($cc) {
+ *    $x->then(function($x) use ($cc) {
+ *        // $x is the successful value.
+ *        return $cc(new Ok($x));
+ *    })->except(function ($error) use ($cc) {
+ *        return $cc(new Error($error)); // This is necessary because the $cc MUST always be called when returning a value.
+ *    });
+ * });
+ *
+ * To consume a value:
+ * return $cc(somePredicate($x->value()) ? $x->accept() : $x->reject());
+ */
+class Brick
+{
+    /**
+     * Used to invoke the created parser.
+     *
+     * It just checks if the given input is fully consumed after parsing and rejects the input otherwise.
+     *
+     * Example:
+     * $this->apply($this->either(['a', 'b']), new Intermediate('a')) => new Ok('a');
+     * $this->apply($this->either(['a', 'b']), new Intermediate('b')) => new Ok('b');
+     * $this->apply($this->either(['a', 'b']), new Intermediate('c')) => new Error();
+     * $this->apply($this->either(['a', 'b']), new Intermediate('ab')) => new Error();
+     *
+     * @param Parser $parse
+     * @param Intermediate $intermediate
+     * @return Result<Intermediate>
+     */
+    public function apply(Closure $parse, Intermediate $intermediate) : Result
+    {
+        return $parse($intermediate, static function (Result $x) : Result {
+            return $x->then(static function (Intermediate $x) : Result {
+                return $x->done() ? new Ok($x) : new Error('EOF not reached.');
+            });
+        });
+    }
+    
+    // Consumer methods.
+
+    /**
+     * ABNF equivalent to value ranges:
+     * fu = %x30-37 is equivalent to $fu = $this->range(0x30, 0x37).
+     *
+     * @param int $start
+     * @param int $end
+     * @return Parser
+     */
+    public function range(int $start, int $end) : Closure
+    {
+        return static function (Intermediate $x, Closure $cc) use ($start, $end) {
+            return $cc($x->value() >= $start && $x->value() <= $end ? $x->accept() : $x->reject());
+        };
+    }
+
+    /**
+     * ABNF equivalent to ALPHA:
+     * fu = ALPHA is equivalent to $fu = $this->alpha();
+     *
+     * @return Parser
+     */
+    public function alpha() : Closure
+    {
+        return $this->either([
+            $this->range(0x41, 0x5A),
+            $this->range(0x61, 0x7A),
+        ]);
+    }
+
+    /**
+     * ABNF equivalent to DIGIT:
+     * fu = DIGIT is equivalent to $fu = $this->digit();
+     *
+     * @return Parser
+     */
+    public function digit() : Closure
+    {
+        return $this->range(0x30, 0x39);
+    }
+
+    // Composition methods.
+
+    /**
+     * ABNF equivalent to alternative:
+     * fu = a / b is equivalent to $fu = $this->either([a, b]);
+     *
+     * @param (Parser|string)[] $parse
+     * @return Parser
+     */
+    public function either(array $parse) : Closure
+    {
+        return $this->tooMany([$this, 'or2'], $parse);
+    }
+
+    /**
+     * ABNF equivalent to concatenation:
+     * fu = a b is equivalent to $fu = $this->sequence([a, b]).
+     *
+     * @param (Parser|string)[] $parse
+     * @return Parser
+     */
+    public function sequence(array $parse) : Closure
+    {
+        return $this->tooMany([$this, 'seq'], $parse);
+    }
+
+    /**
+     * ABNF equivalent to variable repetition:
+     * fu = <a>*<b>element is equivalent to $fu = $this->repeat(<a>, <b>, element).
+     * fu = *<b>element is equivalent to $fu = $this->repeat(0, <b>, element).
+     * fu = 1*element is equivalent to $fu = $this->repeat(1, null, element).
+     * fu = *element is equivalent to $fu = $this->repeat(0, null, element).
+     * fu = [element] is equivalent to 0*1element and therefore equivalent to $fu = $this->repeat(0, 1, element).
+     *
+     * @param int $min
+     * @param null|int $max
+     * @param Parser|string $parse
+     * @return Parser
+     */
+    public function repeat(int $min, ?int $max, $parse) : Closure
+    {
+        $min = max(0, $min);
+        $max = null === $max ? null : max($min, $max) - $min;
+
+        return $this->sequence([
+            ...array_fill(0, $min, $parse),
+            $this->until($max, $parse)
+        ]);
+    }
+
+    /**
+     * @param null|int $max
+     * @param Parser|string $parse
+     * @return Parser
+     */
+    private function until(?int $max, $parse) : Closure
+    {
+        if (0 === $max) {
+            return $this->nop();
+        }
+        $max = null === $max ? null : $max - 1;
+
+        return ($this->either([
+            $this->nop(),
+            $this->sequence([
+                $parse,
+                $this->lazy([$this, 'until'], $max, $parse)
+            ])
+        ]));
+    }
+
+    /**
+     * @param Parser $f
+     * @param Parser $g
+     * @return Parser
+     */
+    private function or2(Closure $f, Closure $g) : Closure
+    {
+        return static function (Intermediate $x, Closure $cc) use ($f, $g) : Result {
+            return $f($x, $cc)->except(static function () use ($x, $g, $cc) : Result {
+                return $g($x, $cc);
+            });
+        };
+    }
+
+    /**
+     * @param int $atom
+     * @return Parser
+     */
+    private function eq(int $atom) : Closure
+    {
+        return static function (Intermediate $x, Closure $cc) use ($atom) : Result {
+            return $cc($atom === $x->value() ? $x->accept() : $x->reject());
+        };
+    }
+
+    /**
+     * @param Parser $f
+     * @param Parser $g
+     * @return Parser
+     */
+    private function seq(Closure $f, Closure $g) : Closure
+    {
+        return static function (Intermediate $x, Closure $cc) use ($f, $g) : Result {
+            return $f($x, static function (Result $x) use ($g, $cc) : Result {
+                return $x->then(static function (Intermediate $x) use ($g, $cc) : Result {
+                    return $g($x, $cc);
+                })->except(static function ($error) use ($cc) : Result {
+                    return $cc(new Error($error));
+                });
+            });
+        };
+    }
+
+    /**
+     * Makes a variadic function from a binary one (left associative and requires at leat 1 argument):
+     * f(f(a, b), c) === tooMany(f, [a, b, c]);
+     *
+     * @param callable(Parser, Parser): Parser $call
+     * @param (Parser|string)[] $parse
+     * @return Parser
+     */
+    private function tooMany(callable $call, array $parse) : Closure
+    {
+        $parse = array_map([$this, 'parserFrom'], $parse);
+
+        return array_reduce(array_slice($parse, 1), $call, $parse[0]);
+    }
+
+    /**
+     * If it is not a closure it will be transformed into a sequence of characters.
+     * This is for convenience so this is possible:
+     * $this->either(['ab', 'cd']) === $this->either([
+     *     $this->sequence([$this->eq('a'), $this->eq('b')])
+     *     $this->sequence([$this->eq('c'), $this->eq('d')])
+     * ]);
+     *
+     * @param Parser|string $x
+     * @return Parser
+     */
+    private function parserFrom($x) : Closure
+    {
+        return $x instanceof Closure ? $x : $this->mustEqual($x);
+    }
+
+    /**
+     * @param string $expected
+     * @return Parser
+     */
+    private function mustEqual(string $expected) : Closure
+    {
+        if (strlen($expected) === 1) {
+            return $this->eq(ord($expected));
+        } elseif ('' === $expected) {
+            return $this->nop();
+        }
+
+        return $this->sequence(str_split($expected));
+    }
+
+    /**
+     * @return Parser
+     */
+    private function nop() : Closure
+    {
+        return static function (Intermediate $x, Closure $cc) : Result {
+            return $cc(new Ok($x));
+        };
+    }
+
+    private function lazy(callable $call, ...$arguments) : Closure {
+        return static function (Intermediate $x, Closure $cc) use ($call, $arguments) : Result {
+            return ($call(...$arguments))($x, $cc);
+        };
+    }
+}

--- a/src/Data/RFC/Intermediate.php
+++ b/src/Data/RFC/Intermediate.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Data\RFC;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+
+class Intermediate
+{
+    private string $todo;
+    private string $accepted;
+
+    public function __construct(string $todo, string $accepted = '')
+    {
+        $this->todo = $todo;
+        $this->accepted = $accepted;
+    }
+
+    public function value() : int
+    {
+        return ord($this->todo);
+    }
+
+    public function accept() : Result
+    {
+        return new Ok(new self(
+            substr($this->todo, 1),
+            $this->accepted . substr($this->todo, 0, 1)
+        ));
+    }
+
+    public function reject() : Result
+    {
+        return new Error('Rejected.');
+    }
+
+    public function accepted() : string
+    {
+        return $this->accepted;
+    }
+
+    public function done() : bool
+    {
+        return '' === $this->todo;
+    }
+}

--- a/src/Data/RFC/LanguageTagDefinition.php
+++ b/src/Data/RFC/LanguageTagDefinition.php
@@ -1,0 +1,152 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Data\RFC;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use Closure;
+
+/**
+ * RFC 5646 compliant language tag definition (https://www.ietf.org/rfc/bcp/bcp47.txt).
+ */
+class LanguageTagDefinition
+{
+    private Brick $brick;
+
+    public function __construct(Brick $brick)
+    {
+        $this->brick = $brick;
+    }
+
+    /**
+     * @param Brick $brick
+     * @param string $input
+     * @return Result<string>
+     */
+    public function parse(string $input) : Result
+    {
+        return $this->brick->apply($this->definition($this->brick), new Intermediate($input))->map(static function (Intermediate $x) : string {
+            return $x->accepted();
+        })->except(static function () : Result {
+            return new Error('Given string is no valid language tag.');
+        });
+    }
+
+    /**
+     * This definition is directly translated from the ABNF definition on https://www.ietf.org/rfc/bcp/bcp47.txt.
+     */
+    public function definition(Brick $brick) : Closure
+    {
+        $extlang = $brick->sequence([
+            $brick->repeat(3, 3, $brick->alpha()),
+            $brick->repeat(0, 2, $brick->sequence(["-", $brick->repeat(3, 3, $brick->alpha())])),
+        ]);
+
+        $language = $brick->either([
+            $brick->sequence([
+                $brick->repeat(2, 3, $brick->alpha()),
+                $brick->repeat(0, 1, $brick->sequence(['-', $extlang])),
+            ]),
+            $brick->repeat(4, 4, $brick->alpha()),
+            $brick->repeat(5, 8, $brick->alpha()),
+        ]);
+
+        $script = $brick->repeat(4, 4, $brick->alpha());
+
+        $region = $brick->either([
+            $brick->repeat(2, 2, $brick->alpha()),
+            $brick->repeat(3, 3, $brick->digit()),
+        ]);
+
+        $alphanum = $brick->either([$brick->alpha(), $brick->digit()]);
+
+        $variant = $brick->either([
+            $brick->repeat(5, 8, $alphanum),
+            $brick->sequence([$brick->digit(), $brick->repeat(3, 3, $alphanum)])
+        ]);
+
+        $singleton = $brick->either([
+            $brick->digit(),
+            $brick->range(0x41, 0x57),
+            $brick->range(0x59, 0x5A),
+            $brick->range(0x61, 0x77),
+            $brick->range(0x79, 0x7A),
+        ]);
+
+        $extension = $brick->sequence([
+            $singleton,
+            $brick->repeat(1, null, $brick->sequence(['-', $brick->repeat(2, 8, $alphanum)])),
+        ]);
+
+        $privateuse = $brick->sequence([
+            'x',
+            $brick->repeat(1, null, $brick->sequence(['-', $brick->repeat(1, 8, $alphanum)]))
+        ]);
+
+        $irregular = $brick->either([
+            'en-GB-oed',
+            'i-ami',
+            'i-bnn',
+            'i-default',
+            'i-enochian',
+            'i-hak',
+            'i-klingon',
+            'i-lux',
+            'i-mingo',
+            'i-navajo',
+            'i-pwn',
+            'i-tao',
+            'i-tay',
+            'i-tsu',
+            'sgn-BE-FR',
+            'sgn-BE-NL',
+            'sgn-CH-DE',
+        ]);
+
+        $regular = $brick->either([
+            'art-lojban',
+            'cel-gaulish',
+            'no-bok',
+            'no-nyn',
+            'zh-guoyu',
+            'zh-hakka',
+            'zh-min',
+            'zh-min-nan',
+            'zh-xiang',
+        ]);
+
+        $grandfathered = $brick->either([$irregular, $regular]);
+
+        $langtag = $brick->sequence([
+            $language,
+            $brick->repeat(0, 1, $brick->sequence(['-', $script])),
+            $brick->repeat(0, 1, $brick->sequence(['-', $region])),
+            $brick->repeat(0, null, $brick->sequence(['-', $variant])),
+            $brick->repeat(0, null, $brick->sequence(['-', $extension])),
+            $brick->repeat(0, 1, $brick->sequence(['-', $privateuse])),
+        ]);
+
+        return $brick->either([
+            $langtag,
+            $privateuse,
+            $grandfathered,
+        ]);
+    }
+}

--- a/tests/Data/DataFactoryTest.php
+++ b/tests/Data/DataFactoryTest.php
@@ -1,11 +1,26 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 require_once("libs/composer/vendor/autoload.php");
 
 use ILIAS\Data;
 use PHPUnit\Framework\TestCase;
+use ILIAS\Data\LanguageTag;
 
 /**
  * Testing the faytory of result objects
@@ -77,5 +92,11 @@ class DataFactoryTest extends TestCase
         $this->assertEquals(Data\DataSize::GiB, $dataType->getUnit());
         $this->assertEquals(10 * Data\DataSize::GiB, $dataType->inBytes());
         $this->assertInstanceOf(Data\DataSize::class, $dataType);
+    }
+
+    public function testLanguageTag() : void
+    {
+        $this->assertInstanceOf(LanguageTag::class, $this->f->languageTag('de'));
+        $this->assertEquals('de', $this->f->languageTag('de')->value());
     }
 }

--- a/tests/Data/LanguageTagTest.php
+++ b/tests/Data/LanguageTagTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Data\RFC;
+
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use ILIAS\Data\LanguageTag;
+use ILIAS\Data\RFC\LanguageTagDefinition;
+use PHPUnit\Framework\TestCase;
+
+class LanguageTagTest extends TestCase
+{
+    public function testConstructSuccessful() : void
+    {
+        $definition = $this->getMockBuilder(LanguageTagDefinition::class)->disableOriginalConstructor()->getMock();
+        $definition->expects(self::once())->method('parse')->with('hej')->willReturn(new Ok('hej'));
+
+        $this->assertInstanceOf(LanguageTag::class, new LanguageTag($definition, 'hej'));
+    }
+
+    public function testConstructWithInvalidLanguageTag() : void
+    {
+        $this->expectExceptionMessage('Not valid.');
+
+        $definition = $this->getMockBuilder(LanguageTagDefinition::class)->disableOriginalConstructor()->getMock();
+        $definition->expects(self::once())->method('parse')->with('hej')->willReturn(new Error('Not valid.'));
+        new LanguageTag($definition, 'hej');
+    }
+
+    public function testValue() : void
+    {
+        $definition = $this->getMockBuilder(LanguageTagDefinition::class)->disableOriginalConstructor()->getMock();
+        $definition->expects(self::once())->method('parse')->with('hej')->willReturn(new Ok('ho'));
+
+        $this->assertEquals('ho', (new LanguageTag($definition, 'hej'))->value());
+    }
+}

--- a/tests/Data/RFC/BrickTest.php
+++ b/tests/Data/RFC/BrickTest.php
@@ -1,0 +1,183 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Data\RFC;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\RFC\Brick;
+use ILIAS\Data\RFC\Intermediate;
+use PHPUnit\Framework\TestCase;
+
+class BrickTest extends TestCase
+{
+    public function testConstruct() : void
+    {
+        $this->assertInstanceOf(Brick::class, new Brick());
+    }
+
+    public function testRange() : void
+    {
+        $intermediate = new Intermediate("\x0");
+
+        $brick = new Brick();
+
+        $parse = $brick->range(0, 20);
+
+        $result = $brick->apply($parse, $intermediate);
+
+        $this->assertTrue($result->isOk());
+        $this->assertInstanceOf(Intermediate::class, $result->value());
+        $this->assertEquals("\x0", $result->value()->accepted());
+        $this->assertTrue($result->value()->done());
+    }
+
+    public function testEither() : void
+    {
+        $intermediate = new Intermediate("\x0");
+
+        $brick = new Brick();
+
+        $parse = $brick->either([
+            $brick->range(0x10, 0x20), // False.
+            $brick->range(0x0, 0x5), // True.
+        ]);
+
+        $result = $brick->apply($parse, $intermediate);
+
+        $this->assertTrue($result->isOk());
+        $this->assertInstanceOf(Intermediate::class, $result->value());
+        $this->assertEquals("\x0", $result->value()->accepted());
+        $this->assertTrue($result->value()->done());
+    }
+
+    public function testSequence() : void
+    {
+        $intermediate = new Intermediate('ad');
+
+        $brick = new Brick();
+
+        $parse = $brick->sequence([
+            $brick->range(ord('a'), ord('b')),
+            $brick->range(ord('c'), ord('d')),
+        ]);
+
+        $result = $brick->apply($parse, $intermediate);
+
+        $this->assertTrue($result->isOk());
+        $this->assertInstanceOf(Intermediate::class, $result->value());
+        $this->assertEquals('ad', $result->value()->accepted());
+        $this->assertTrue($result->value()->done());
+    }
+
+    /**
+     * @dataProvider repeatProvider
+     */
+    public function testRepeat(int $min, ?int $max, array $succeed, array $fail) : void
+    {
+        $brick = new Brick();
+        $parse = $brick->repeat($min, $max, $brick->range(ord('a'), ord('z')));
+
+        foreach ($succeed as $input) {
+            $result = $brick->apply($parse, new Intermediate($input));
+
+            $this->assertTrue($result->isOk());
+            $this->assertInstanceOf(Intermediate::class, $result->value());
+            $this->assertEquals($input, $result->value()->accepted());
+            $this->assertTrue($result->value()->done());
+        }
+
+        foreach ($fail as $input) {
+            $result = $brick->apply($parse, new Intermediate($input));
+            $this->assertFalse($result->isOk());
+        }
+    }
+
+    public function repeatProvider() : array
+    {
+        return [
+            'Ranges are inclusive' => [3, 3, ['abc'], ['ab', 'abcd']],
+            'Null is used for infinity' => [0, null, ['', 'abcdefghijklmop'], []],
+            'Minimum is 0' => [-1, 3, ['', 'a', 'ab', 'abc'], ['abcd']],
+            'Minimum of the end range is the start range' => [3, 2, ['abc'], ['ab', 'abcd']],
+        ];
+    }
+
+    /**
+     * @dataProvider characterProvider
+     */
+    public function testCharacters(string $method, string $input, bool $isOk) : void
+    {
+        $intermediate = new Intermediate($input);
+        $brick = new Brick();
+
+        $parse = $brick->either(str_split($input)); // No character is allowed to pass.
+        if ($isOk) {
+            $parse = $brick->repeat(0, null, $brick->$method()); // All characters must pass.
+        }
+
+        $result = $brick->apply($parse, $intermediate);
+
+        $this->assertEquals($isOk, $result->isOk());
+        if ($isOk) {
+            $this->assertInstanceOf(Intermediate::class, $result->value());
+            $this->assertEquals($input, $result->value()->accepted());
+            $this->assertTrue($result->value()->done());
+        }
+    }
+
+    public function characterProvider() : array
+    {
+        $alpha = array_fill(ord('a'), ord('z') - ord('a') + 1, '');
+        array_walk($alpha, function (&$value, int $i) {
+            $value = chr($i);
+        });
+        $alpha = implode('', $alpha);
+        $alpha .= strtoupper($alpha);
+
+        $digits = '1234567890';
+
+        return [
+            'Accepts all digits.' => ['digit', $digits, true],
+            'Accepts no characters from a-z or A-Z.' => ['digit', $alpha, false],
+            'Accepts characters from a-z and A-Z.' => ['alpha', $alpha, true],
+            'Accepts no digits.' => ['alpha', $digits, false],
+        ];
+    }
+
+    /**
+     * @dataProvider emptyStringProvider
+     */
+    public function testEmptyString(string $input, bool $isOk) : void
+    {
+        $intermediate = new Intermediate($input);
+        $brick = new Brick();
+
+        $parse = $brick->sequence(['']);
+        $result = $brick->apply($parse, $intermediate);
+
+        $this->assertEquals($isOk, $result->isOk());
+    }
+
+    public function emptyStringProvider() : array
+    {
+        return [
+            'Test empty input' => ['', true],
+            'Test non empty input' => ['x', false],
+        ];
+    }
+}

--- a/tests/Data/RFC/IntermediateTest.php
+++ b/tests/Data/RFC/IntermediateTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Data\RFC;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\RFC\Intermediate;
+use PHPUnit\Framework\TestCase;
+
+class IntermediateTest extends TestCase
+{
+    public function testConstruct() : void
+    {
+        $intermediate = new Intermediate('input');
+
+        $this->assertInstanceOf(Intermediate::class, $intermediate);
+    }
+
+    public function testValue() : void
+    {
+        $intermediate = new Intermediate('input');
+
+        $this->assertEquals(ord('i'), $intermediate->value());
+    }
+
+    public function testAccept() : void
+    {
+        $intermediate = new Intermediate('input');
+
+        $this->assertEquals(ord('i'), $intermediate->value());
+
+        $next = $intermediate->accept();
+        $this->assertTrue($next->isOK());
+        $this->assertEquals(ord('n'), $next->value()->value());
+    }
+
+    public function testReject() : void
+    {
+        $intermediate = new Intermediate('input');
+
+        $next = $intermediate->reject();
+        $this->assertFalse($next->isOK());
+    }
+
+    public function testAccepted() : void
+    {
+        $intermediate = new Intermediate('input');
+        $this->assertEquals('', $intermediate->accepted());
+        $this->assertEquals('in', $intermediate->accept()->value()->accept()->value()->accepted());
+    }
+
+    public function testDone() : void
+    {
+        $intermediate = new Intermediate('ab');
+        $this->assertFalse($intermediate->done());
+        $this->assertTrue($intermediate->accept()->value()->accept()->value()->done());
+    }
+}

--- a/tests/Data/RFC/LanguageTagDefinitionTest.php
+++ b/tests/Data/RFC/LanguageTagDefinitionTest.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Data\RFC;
+
+use ILIAS\Data\RFC\LanguageTagDefinition;
+use ILIAS\Data\RFC\Brick;
+use PHPUnit\Framework\TestCase;
+
+class LanguageTagDefinitionTest extends TestCase
+{
+    public function testConstruct() : void
+    {
+        $this->assertInstanceOf(LanguageTagDefinition::class, new LanguageTagDefinition(new Brick()));
+    }
+
+    /**
+     * @dataProvider parseProvider
+     */
+    public function testParse(string $input, bool $isOk) : void
+    {
+        $tag = new LanguageTagDefinition(new Brick());
+
+        $result = $tag->parse($input);
+
+        $this->assertEquals($isOk, $result->isOK());
+        if ($isOk) {
+            $this->assertEquals($input, $result->value());
+        }
+    }
+
+    public function parseProvider() : array
+    {
+        return [
+            ['de', true],
+            ['d$', false],
+            ['aa-111', true],
+            ['aa-7-123abc-abc-a-12', true],
+            ['aa-b1b1b-6a8b-cccccc', true],
+            ['aa-b1b1b', true],
+            ['aa-bb', true],
+            ['aa-bbb-ccc-1111-ccccc-b1b1b', true],
+            ['aa-bbb-ccc-ddd', true],
+            ['aa-bbb', true],
+            ['aa-bbbb-cc', true],
+            ['aa-bbbb', true],
+            ['aa-x-1234ab-d', true],
+            ['aa', true],
+            ['aaa-bbb-ccc-ddd-abcd-123-abc123-0abc-b-01-abc123-x-01ab-abc12', true],
+            ['aaa-bbb-ccc', true],
+            ['aaaa', true],
+            ['aaaaa', true],
+            ['aaaaaa', true],
+            ['aaaaaaa', true],
+            ['aaaaaaaa', true],
+            ['afb', true],
+            ['ar-afb', true],
+            ['art-lojban', true],
+            ['ast', true],
+            ['az-Arab-x-AZE-derbend', true],
+            ['az-Latn', true],
+            ['cel-gaulish', true],
+            ['cmn-Hans-CN', true],
+            ['de-CH-1901', true],
+            ['de-CH-x-phonebk', true],
+            ['de-DE-u-co-phonebk', true],
+            ['de-DE', true],
+            ['de-Qaaa', true],
+            ['de', true],
+            ['en-GB-oed', true],
+            ['en-US-u-islamcal', true],
+            ['en-US-x-twain', true],
+            ['en-US', true],
+            ['en-a-myext-b-another', true],
+            ['en', true],
+            ['es-005', true],
+            ['es-419', true],
+            ['fr-CA', true],
+            ['fr', true],
+            ['hak', true],
+            ['hy-Latn-IT-arevela', true],
+            ['i-ami', true],
+            ['i-bnn', true],
+            ['i-default', true],
+            ['i-enochian', true],
+            ['i-hak', true],
+            ['i-klingon', true],
+            ['i-lux', true],
+            ['i-mingo', true],
+            ['i-navajo', true],
+            ['i-pwn', true],
+            ['i-tao', true],
+            ['i-tay', true],
+            ['i-tsu', true],
+            ['ja', true],
+            ['mas', true],
+            ['no-bok', true],
+            ['no-nyn', true],
+            ['qaa-Qaaa-QM-x-southern', true],
+            ['sgn-BE-FR', true],
+            ['sgn-BE-NL', true],
+            ['sgn-CH-DE', true],
+            ['sl-IT-nedis', true],
+            ['sl-nedis', true],
+            ['sl-rozaj-biske', true],
+            ['sl-rozaj', true],
+            ['sr-Cyrl', true],
+            ['sr-Latn-QM', true],
+            ['sr-Latn-RS', true],
+            ['sr-Latn', true],
+            ['sr-Qaaa-RS', true],
+            ['x-111-aaaaa-BBB', true],
+            ['x-whatever', true],
+            ['yue-HK', true],
+            ['zh-CN-a-myext-x-private', true],
+            ['zh-Hans-CN', true],
+            ['zh-Hans', true],
+            ['zh-Hant-HK', true],
+            ['zh-Hant', true],
+            ['zh-cmn-Hans-CN', true],
+            ['zh-guoyu', true],
+            ['zh-hakka', true],
+            ['zh-min-nan', true],
+            ['zh-min', true],
+            ['zh-xiang', true],
+            ['zh-yue-HK', true],
+            ['zh-yue', true],
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces a new data type `LanguageTag`.
The language tag is validated by the RFC as it is defined here: https://www.ietf.org/rfc/bcp/bcp47.txt.

This will be used in: https://github.com/ILIAS-eLearning/ILIAS/pull/4082