### PR TITLE
More fixes for edit question

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -671,8 +671,7 @@ class ilObjTestGUI extends ilObjectGUI
                 $this->prepareOutput();
 
                 $this->ctrl->saveParameter($this, "q_id");
-
-                require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php';
+                
                 $gui = new ilAssQuestionPreviewGUI($this->ctrl, $this->tabs_gui, $this->tpl, $this->lng, $ilDB, $ilUser);
 
                 $gui->initQuestion($this->fetchAuthoringQuestionIdParameter(), $this->object->getId());
@@ -686,6 +685,10 @@ class ilObjTestGUI extends ilObjectGUI
                 break;
 
             case 'ilassquestionpagegui':
+                if ($cmd == 'finishEditing') {
+                    $this->ctrl->redirectByClass('ilassquestionpreviewgui', 'show');
+                    break;
+                }
                 if ((!$ilAccess->checkAccess("read", "", $_GET["ref_id"]))) {
                     $ilias->raiseError($this->lng->txt("permission_denied"), $ilias->error_obj->MESSAGE);
                 }

--- a/Modules/Test/classes/tables/class.ilTestQuestionsTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestQuestionsTableGUI.php
@@ -262,37 +262,32 @@ class ilTestQuestionsTableGUI extends ilTable2GUI
         $actions->setId('qst' . $data["question_id"]);
         $actions->setListTitle($this->lng->txt('actions'));
 
-        $actions->addItem($this->lng->txt('preview'), '', $this->ctrl->getLinkTargetByClass('ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_SHOW));
+        $actions->addItem(
+            $this->lng->txt('preview'),
+            '',
+            $this->getEditLink($data, get_class($this->getParentObject()), $this->getParentCmd())
+        );
+        
         if ($this->isQuestionManagingEnabled()) {
-            $editHref = $this->ctrl->getLinkTargetByClass($data['type_tag'] . 'GUI', 'editQuestion');
+            $editHref = $this->getEditLink($data, $data['type_tag'] . 'GUI', 'editQuestion');
             $actions->addItem($this->lng->txt('edit_question'), '', $editHref);
 
-            $editPageHref = $this->ctrl->getLinkTargetByClass('ilAssQuestionPageGUI', 'edit');
+            $editPageHref = $this->getEditLink($data, 'ilAssQuestionPageGUI', 'edit');
             $actions->addItem($this->lng->txt('edit_page'), '', $editPageHref);
-
-            $this->ctrl->setParameter($this->parent_obj, 'q_id', $data['question_id']);
-            $moveHref = $this->ctrl->getLinkTarget($this->parent_obj, 'moveQuestions');
-            $this->ctrl->setParameter($this->parent_obj, 'q_id', null);
+            
+            $moveHref = $this->getEditLink($data, get_class($this->getParentObject()), 'moveQuestions');
             $actions->addItem($this->lng->txt('move'), '', $moveHref);
-
-            $this->ctrl->setParameter($this->parent_obj, 'q_id', $data['question_id']);
-            $copyHref = $this->ctrl->getLinkTarget($this->parent_obj, 'copyQuestion');
-            $this->ctrl->setParameter($this->parent_obj, 'q_id', null);
+            
+            $copyHref = $this->getEditLink($data, get_class($this->getParentObject()), 'copyQuestion');
             $actions->addItem($this->lng->txt('copy'), '', $copyHref);
-
-            $this->ctrl->setParameter($this->parent_obj, 'q_id', $data['question_id']);
-            $deleteHref = $this->ctrl->getLinkTarget($this->parent_obj, 'removeQuestions');
-            $this->ctrl->setParameter($this->parent_obj, 'q_id', null);
+            
+            $deleteHref = $this->getEditLink($data, get_class($this->getParentObject()), 'removeQuestions');
             $actions->addItem($this->lng->txt('delete'), '', $deleteHref);
             
-            $this->ctrl->setParameterByClass('ilAssQuestionFeedbackEditingGUI', 'q_id', $data['question_id']);
-            $feedbackHref = $this->ctrl->getLinkTargetByClass('ilAssQuestionFeedbackEditingGUI', ilAssQuestionFeedbackEditingGUI::CMD_SHOW);
-            $this->ctrl->setParameterByClass('ilAssQuestionFeedbackEditingGUI', 'q_id', null);
+            $feedbackHref = $this->getEditLink($data, 'ilAssQuestionFeedbackEditingGUI', ilAssQuestionFeedbackEditingGUI::CMD_SHOW);
             $actions->addItem($this->lng->txt('tst_feedback'), '', $feedbackHref);
-
-            $this->ctrl->setParameterByClass('ilAssQuestionHintsGUI', 'q_id', $data['question_id']);
-            $hintsHref = $this->ctrl->getLinkTargetByClass('ilAssQuestionHintsGUI', ilAssQuestionHintsGUI::CMD_SHOW_LIST);
-            $this->ctrl->setParameterByClass('ilAssQuestionHintsGUI', 'q_id', null);
+            
+            $hintsHref = $this->getEditLink($data, 'ilAssQuestionHintsGUI', ilAssQuestionHintsGUI::CMD_SHOW_LIST);
             $actions->addItem($this->lng->txt('tst_question_hints_tab'), '', $hintsHref);
         }
         $this->tpl->setVariable('ROW_ACTIONS', $actions->getHTML());
@@ -301,10 +296,6 @@ class ilTestQuestionsTableGUI extends ilTable2GUI
         }
     }
     
-    /**
-     * @param array $rowData
-     * @return string
-     */
     protected function buildQuestionRemoveButton(array $rowData) : string
     {
         $this->ctrl->setParameter($this->getParentObject(), 'removeQid', $rowData['question_id']);
@@ -318,30 +309,45 @@ class ilTestQuestionsTableGUI extends ilTable2GUI
         return $button->render();
     }
     
-    /**
-     * @param array $rowData
-     * @return string
-     */
     protected function buildQuestionTitleLink(array $rowData) : string
     {
-        $this->ctrl->setParameter(
-            $this->getParentObject(),
+        $questionHref = $this->getEditLink($rowData, get_class($this->getParentObject()), $this->getParentCmd());
+        
+        return '<a href="' . $questionHref . '">' . $rowData["title"] . '</a>';
+    }
+    
+    protected function getEditLink(array $rowData, string $target_class, string $cmd) : string
+    {
+        $this->ctrl->setParameterByClass(
+            $target_class,
             'eqpl',
             current(ilObject::_getAllReferences($rowData['obj_fi']))
         );
         
-        $this->ctrl->setParameter(
-            $this->getParentObject(),
+        $this->ctrl->setParameterByClass(
+            $target_class,
             'eqid',
             $rowData['question_id']
         );
         
-        $questionHref = $this->ctrl->getLinkTarget($this->getParentObject(), $this->getParentCmd());
+        $this->ctrl->setParameterByClass(
+            $target_class,
+            'q_id',
+            $rowData['question_id']
+        );
+        $this->ctrl->setParameterByClass(
+            $target_class,
+            'calling_test',
+            $_GET['ref_id']
+        );
         
-        $this->ctrl->setParameter($this->getParentObject(), 'eqpl', '');
-        $this->ctrl->setParameter($this->getParentObject(), 'eqid', '');
+        $link = $this->ctrl->getLinkTargetByClass($target_class, $cmd);
         
-        return '<a href="' . $questionHref . '">' . $rowData["title"] . '</a>';
+        $this->ctrl->setParameterByClass($target_class, 'eqpl', '');
+        $this->ctrl->setParameterByClass($target_class, 'eqid', '');
+        $this->ctrl->setParameterByClass($target_class, 'q_id', '');
+        
+        return $link;
     }
     
     /**


### PR DESCRIPTION
This finalizes the work started in the following PR : https://github.com/ILIAS-eLearning/ILIAS/pull/4642

- It makes sure that the "Finish Editing"-Link in the Question Page always leads to the right page.
- It also makes sure that the "Back"-Links always points to the test and not suddenly to a none existent question pool

I opted for shortness of the implementation and thus added the same parameters to all calls. Not all of them are always necessary, but I would suggest to let this slide and fix it when we tackle the rather wonky command-flow.