### PR TITLE
Load full descriptions within object cache

### DIFF
--- a/Services/Object/classes/class.ilObjectDataCache.php
+++ b/Services/Object/classes/class.ilObjectDataCache.php
@@ -180,12 +180,16 @@ class ilObjectDataCache
             $a_lang = $ilUser->getLanguage();
         }
 
-        $query = "SELECT * FROM object_data WHERE obj_id = " .
-            $ilDB->quote($a_obj_id, 'integer');
+        $query = "SELECT object_data.*, object_description.description as long_description " .
+            "FROM object_data LEFT JOIN object_description ON object_data.obj_id = object_description.obj_id " .
+            "WHERE object_data.obj_id = " . $ilDB->quote($a_obj_id, 'integer');
         $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
             $this->object_data_cache[$a_obj_id]['title'] = $row->title;
             $this->object_data_cache[$a_obj_id]['description'] = $row->description;
+            if ($row->long_description !== null) {
+                $this->object_data_cache[$a_obj_id]['description'] = $row->long_description;
+            }
             $this->object_data_cache[$a_obj_id]['type'] = $row->type;
             $this->object_data_cache[$a_obj_id]['owner'] = $row->owner;
             $this->object_data_cache[$a_obj_id]['last_update'] = $row->last_update;
@@ -247,10 +251,10 @@ class ilObjectDataCache
         if (count($a_obj_ids) == 0) {
             return;
         }
-        
-        
-        $query = "SELECT * FROM object_data " .
-            "WHERE " . $ilDB->in('obj_id', $a_obj_ids, false, 'integer');
+
+        $query = "SELECT object_data.*, object_description.description as long_description " .
+            "FROM object_data LEFT JOIN object_description ON object_data.obj_id = object_description.obj_id " .
+            "WHERE " . $ilDB->in('object_data.obj_id', $a_obj_ids, false, 'integer');
         $res = $ilDB->query($query);
         $db_trans = array();
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
@@ -259,6 +263,9 @@ class ilObjectDataCache
             if (!$this->trans_loaded[$row->obj_id]) {
                 $this->object_data_cache[$row->obj_id]['title'] = $row->title;
                 $this->object_data_cache[$row->obj_id]['description'] = $row->description;
+                if ($row->long_description !== null) {
+                    $this->object_data_cache[$row->obj_id]['description'] = $row->long_description;
+                }
             }
             $this->object_data_cache[$row->obj_id]['type'] = $row->type;
             $this->object_data_cache[$row->obj_id]['owner'] = $row->owner;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=32627

This enforces the loading off full decriptions (not just the cut offs o the object_data table) into the Object Data Cache