### PR TITLE
Limit dashboard descriptions to repository setting

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeDashboardViewGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeDashboardViewGUI.php
@@ -368,11 +368,16 @@ class ilStudyProgrammeDashboardViewGUI
         $title = $prg->getTitle();
         $link = $this->getDefaultTargetUrl((int) $prg->getRefId());
         $title_btn = $this->factory->button()->shy($title, $link);
+        $description = $prg->getLongDescription() ?? "";
+        $max = $this->setting->get("rep_shorten_description_length");
+        if ($this->setting->get("rep_shorten_description") && $max) {
+            $description = ilUtil::shortenText($description, $max, true);
+        }
 
         $icon = $this->factory->symbol()->icon()->standard('prg', $title, 'medium');
         return $this->factory->item()->standard($title_btn)
             ->withProperties(array_merge(...$properties))
-            ->withDescription($prg->getDescription() ?? "")
+            ->withDescription($description)
             ->withLeadIcon($icon)
         ;
     }

--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockMembershipsProvider.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockMembershipsProvider.php
@@ -23,6 +23,11 @@ class ilPDSelectedItemsBlockMembershipsProvider implements ilPDSelectedItemsBloc
      */
     protected $access;
 
+    /**
+     * @var ilSetting
+     */
+    protected $settings;
+
     /** @var ilPDSelectedItemsBlockMembershipsObjectDatabaseRepository */
     private $repository;
 
@@ -37,6 +42,7 @@ class ilPDSelectedItemsBlockMembershipsProvider implements ilPDSelectedItemsBloc
         $this->actor = $actor;
         $this->tree = $DIC->repositoryTree();
         $this->access = $DIC->access();
+        $this->settings = $DIC->settings();
         $this->repository = new ilPDSelectedItemsBlockMembershipsObjectDatabaseRepository(
             $DIC->database(),
             RECOVERY_FOLDER_ID
@@ -50,6 +56,9 @@ class ilPDSelectedItemsBlockMembershipsProvider implements ilPDSelectedItemsBloc
      */
     protected function getObjectsByMembership(array $objTypes = []) : array
     {
+        $short_desc = $this->settings->get("rep_shorten_description");
+        $short_desc_max_length = $this->settings->get("rep_shorten_description_length");
+
         if (!is_array($objTypes) || $objTypes === []) {
             $objTypes = $this->repository->getValidObjectTypes();
         }
@@ -78,12 +87,17 @@ class ilPDSelectedItemsBlockMembershipsProvider implements ilPDSelectedItemsBloc
                 }
             }
 
+            $description = $item->getDescription();
+            if ($short_desc && $short_desc_max_length) {
+                $description = ilUtil::shortenText($description, $short_desc_max_length, true);
+            }
+
             $references[$parentTreeLftValue . $title . $refId] = [
                 'ref_id' => $refId,
                 'obj_id' => $objId,
                 'type' => $item->getType(),
                 'title' => $title,
-                'description' => $item->getDescription(),
+                'description' => $description,
                 'parent_ref' => $parentRefId,
                 'start' => $periodStart,
                 'end' => $periodEnd

--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockSelectedItemsProvider.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockSelectedItemsProvider.php
@@ -23,6 +23,11 @@ class ilPDSelectedItemsBlockSelectedItemsProvider implements ilPDSelectedItemsBl
     protected $access;
 
     /**
+     * @var ilSetting
+     */
+    protected $settings;
+
+    /**
      * ilPDSelectedItemsBlockSelectedItemsProvider constructor.
      * @param ilObjUser $actor
      */
@@ -33,6 +38,7 @@ class ilPDSelectedItemsBlockSelectedItemsProvider implements ilPDSelectedItemsBl
         $this->actor = $actor;
         $this->fav_manager = new ilFavouritesManager();
         $this->access = $DIC->access();
+        $this->settings = $DIC->settings();
     }
 
     /**
@@ -40,6 +46,9 @@ class ilPDSelectedItemsBlockSelectedItemsProvider implements ilPDSelectedItemsBl
      */
     public function getItems($object_type_white_list = array())
     {
+        $short_desc = $this->settings->get("rep_shorten_description");
+        $short_desc_max_length = $this->settings->get("rep_shorten_description_length");
+
         $favourites = $this->fav_manager->getFavouritesOfUser(
             $this->actor->getId(),
             count($object_type_white_list) > 0 ? $object_type_white_list : null
@@ -50,6 +59,11 @@ class ilPDSelectedItemsBlockSelectedItemsProvider implements ilPDSelectedItemsBl
             if (!$this->access->checkAccess('visible', '', $favourite['ref_id'])) {
                 continue;
             }
+
+            if ($short_desc && $short_desc_max_length) {
+                $favourite['description'] = ilUtil::shortenText($favourite['description'], $short_desc_max_length, true);
+            }
+
             $access_granted_favourites[$idx] = $favourite;
         }
         return $access_granted_favourites;

--- a/Services/Repository/RecommendedContent/classes/class.ilDashboardRecommendedContentGUI.php
+++ b/Services/Repository/RecommendedContent/classes/class.ilDashboardRecommendedContentGUI.php
@@ -10,12 +10,12 @@
 class ilDashboardRecommendedContentGUI
 {
     /**
-     * @var \ilObjUser
+     * @var ilObjUser
      */
     protected $user;
 
     /**
-     * @var \ilRecommendedContentManager
+     * @var ilRecommendedContentManager
      */
     protected $rec_manager;
 
@@ -36,14 +36,19 @@ class ilDashboardRecommendedContentGUI
     protected $ui;
 
     /**
-     * @var \ilLanguage
+     * @var ilLanguage
      */
     protected $lng;
 
     /**
-     * @var \ilCtrl
+     * @var ilCtrl
      */
     protected $ctrl;
+
+    /**
+     * @var ilSetting
+     */
+    protected $settings;
 
     /**
      * @var ilFavouritesManager
@@ -64,6 +69,7 @@ class ilDashboardRecommendedContentGUI
         $this->ui = $DIC->ui();
         $this->lng = $DIC->language();
         $this->ctrl = $DIC->ctrl();
+        $this->settings = $DIC->settings();
 
         $this->lng->loadLanguageModule("rep");
 
@@ -143,13 +149,17 @@ class ilDashboardRecommendedContentGUI
      */
     protected function getListItemForData($ref_id) : \ILIAS\UI\Component\Item\Item
     {
+        $short_desc = $this->settings->get("rep_shorten_description");
+        $short_desc_max_length = $this->settings->get("rep_shorten_description_length");
         $ctrl = $this->ctrl;
-        $lng = $this->lng;
 
         $obj_id = ilObject::_lookupObjectId($ref_id);
         $type = ilObject::_lookupType($obj_id);
         $title = ilObject::_lookupTitle($obj_id);
         $desc = ilObject::_lookupDescription($obj_id);
+        if ($short_desc && $short_desc_max_length) {
+            $desc = ilUtil::shortenText($desc, $short_desc_max_length, true);
+        }
         $item = [
             "ref_id" => $ref_id,
             "obj_id" => $obj_id,


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=32627

Limits the dashboard descriptions to the set limit inside the repository administration.
(And removes the predefined limit from StudyProgrameView).