### PR TITLE
Fix clickthrough issues on PHP8

### DIFF
--- a/Modules/Test/classes/class.ilObjTestSettingsGeneralGUI.php
+++ b/Modules/Test/classes/class.ilObjTestSettingsGeneralGUI.php
@@ -1,8 +1,19 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-require_once 'Modules/Test/classes/class.ilTestSettingsGUI.php';
-require_once 'Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * GUI class that manages the editing of general test settings/properties
@@ -614,27 +625,28 @@ class ilObjTestSettingsGeneralGUI extends ilTestSettingsGUI
      */
     private function saveGeneralProperties(ilPropertyFormGUI $form)
     {
-        include_once 'Services/MetaData/classes/class.ilMD.php';
         $md_obj = new ilMD($this->testOBJ->getId(), 0, "tst");
         $md_section = $md_obj->getGeneral();
-
-        // title
-        if ($md_section !== null) {
-            $md_section->setTitle(ilUtil::stripSlashes($form->getItemByPostVar('title')->getValue()));
-            $md_section->update();
-
-            // Description
-            $md_desc_ids = $md_section->getDescriptionIds();
-            if ($md_desc_ids) {
-                $md_desc = $md_section->getDescription(array_pop($md_desc_ids));
-                $md_desc->setDescription(ilUtil::stripSlashes($form->getItemByPostVar('description')->getValue()));
-                $md_desc->update();
-            } else {
-                $md_desc = $md_section->addDescription();
-                $md_desc->setDescription(ilUtil::stripSlashes($form->getItemByPostVar('description')->getValue()));
-                $md_desc->save();
-            }
+        
+        if ($md_section === null) {
+            $md_section = $md_obj->addGeneral();
+            $md_section->save();
         }
+        
+        $md_section->setTitle(ilUtil::stripSlashes($form->getItemByPostVar('title')->getValue()));
+        $md_section->update();
+        
+        $md_desc_ids = $md_section->getDescriptionIds();
+        if ($md_desc_ids) {
+            $md_desc = $md_section->getDescription(array_pop($md_desc_ids));
+            $md_desc->setDescription(ilUtil::stripSlashes($form->getItemByPostVar('description')->getValue()));
+            $md_desc->update();
+        } else {
+            $md_desc = $md_section->addDescription();
+            $md_desc->setDescription(ilUtil::stripSlashes($form->getItemByPostVar('description')->getValue()));
+            $md_desc->save();
+        }
+        
         $this->testOBJ->setTitle(ilUtil::stripSlashes($form->getItemByPostVar('title')->getValue()));
         $this->testOBJ->setDescription(ilUtil::stripSlashes($form->getItemByPostVar('description')->getValue()));
         $this->testOBJ->setOfflineStatus(!$form->getItemByPostVar('online')->getChecked());

--- a/Modules/Test/classes/class.ilTestParticipantsGUI.php
+++ b/Modules/Test/classes/class.ilTestParticipantsGUI.php
@@ -1,6 +1,20 @@
 <?php
 
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestParticipantsGUI
@@ -305,7 +319,13 @@ class ilTestParticipantsGUI
     {
         global $DIC; /* @var ILIAS\DI\Container $DIC */
         
-        $sess_filter = ilSession::get('form_tst_participants_' . $this->getTestObj()->getRefId())['selection'];
+        $selected_pax = ilSession::get('form_tst_participants_' . $this->getTestObj()->getRefId());
+        
+        if ($selected_pax === null || !isset($selected_pax['selection'])) {
+            return $in_rows;
+        }
+        
+        $sess_filter = $selected_pax['selection'];
         $sess_filter = str_replace('"', '', $sess_filter);
         $sess_filter = explode(':', $sess_filter);
         $filter = substr($sess_filter[2], 0, strlen($sess_filter[2]) - 1);

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -124,7 +124,7 @@ class ilAssQuestionPreviewGUI
 
         $this->questionOBJ->setObjId($parentObjId);
 
-        if($this->ctrl->getCmd() == 'editQuestion') {
+        if ($this->ctrl->getCmd() == 'editQuestion') {
             $this->questionGUI->setQuestionTabs();
         } else {
             if ($_GET["q_id"]) {
@@ -141,29 +141,36 @@ class ilAssQuestionPreviewGUI
                         $ref_id = $_GET["test_ref_id"];
                     }
 
-                    if (!$_GET['test_express_mode'] && !$GLOBALS['___test_express_mode']) {
-                        $this->tabs->setBackTarget($this->lng->txt("backtocallingtest"),
-                            "ilias.php?baseClass=ilObjTestGUI&cmd=questions&ref_id=$ref_id");
-                        //BACK FROM Question Page to Test
+                    if (!$_GET['test_express_mode'] &&
+                        (array_key_exists('___test_express_mode', $GLOBALS) && !$GLOBALS['___test_express_mode'])
+                        ) {
+                        $this->tabs->setBackTarget(
+                            $this->lng->txt("backtocallingtest"),
+                            "ilias.php?baseClass=ilObjTestGUI&cmd=questions&ref_id=$ref_id"
+                        );
+                    //BACK FROM Question Page to Test
                     } else {
                         $link = ilTestExpressPage::getReturnToPageLink();
                         //$this->tabs->setBackTarget($this->lng->txt("backtocallingtest"), $link);
-                        $this->tabs->setBackTarget($this->lng->txt("backtocallingtest"),
-                            "ilias.php?baseClass=ilObjTestGUI&cmd=questions&ref_id=$ref_id");
+                        $this->tabs->setBackTarget(
+                            $this->lng->txt("backtocallingtest"),
+                            "ilias.php?baseClass=ilObjTestGUI&cmd=questions&ref_id=$ref_id"
+                        );
                     }
                 } elseif (isset($_GET['calling_consumer']) && (int) $_GET['calling_consumer']) {
                     $ref_id = (int) $_GET['calling_consumer'];
                     $consumer = ilObjectFactory::getInstanceByRefId($ref_id);
                     if ($consumer instanceof ilQuestionEditingFormConsumer) {
-                        $this->tabs->setBackTarget($consumer->getQuestionEditingFormBackTargetLabel(),
-                            $consumer->getQuestionEditingFormBackTarget($_GET['consumer_context']));
+                        $this->tabs->setBackTarget(
+                            $consumer->getQuestionEditingFormBackTargetLabel(),
+                            $consumer->getQuestionEditingFormBackTarget($_GET['consumer_context'])
+                        );
                     } else {
                         require_once 'Services/Link/classes/class.ilLink.php';
                         $this->tabs->setBackTarget($this->lng->txt("qpl"), ilLink::_getLink($ref_id));
                     }
-                //} elseif (true) {
+                    //} elseif (true) {
                     // We're in the underworld and want to go back to the question page
-
                 } else {
                     $this->tabs->setBackTarget($this->lng->txt("backtocallingpool"), $this->ctrl->getLinkTargetByClass("ilobjquestionpoolgui", "questions"));
                     //BACK FROM Question Page to Pool
@@ -380,13 +387,14 @@ class ilAssQuestionPreviewGUI
         $toolbarGUI->setFormAction($this->ctrl->getFormAction($this, self::CMD_SHOW));
         $toolbarGUI->setResetPreviewCmd(self::CMD_RESET);
         $toolbarGUI->setEditPageCmd(
-            $this->ctrl->getLinkTargetByClass('ilAssQuestionPageGUI','edit')
+            $this->ctrl->getLinkTargetByClass('ilAssQuestionPageGUI', 'edit')
         );
 
         $toolbarGUI->setEditQuestionCmd(
             $this->ctrl->getLinkTargetByClass(
                 array('ilrepositorygui','ilobjquestionpoolgui', get_class($this->questionGUI)),
-                'editQuestion')
+                'editQuestion'
+            )
         );
         $toolbarGUI->build();
         

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -300,7 +300,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 }
                 // set return target
                 $this->ctrl->setReturn($this, "questions");
-                $questionGUI = assQuestionGUI::_getQuestionGUI($q_type, $this->fetchAuthoringQuestionIdParamater());
+                $questionGUI = assQuestionGUI::_getQuestionGUI($q_type ?? '', $this->fetchAuthoringQuestionIdParamater());
                 $questionGUI->object->setObjId($this->object->getId());
                 $questionGUI->setQuestionTabs();
 


### PR DESCRIPTION
I clicked through the first level of the test and fixed the issues I found:
- Title and description missing in Settings.
- Dashboard could not be opened.
- Access to undefined array key.