### PR TITLE
Add ability to override filename of exported file

### DIFF
--- a/Services/Table/classes/class.ilTable2GUI.php
+++ b/Services/Table/classes/class.ilTable2GUI.php
@@ -2627,7 +2627,7 @@ class ilTable2GUI extends ilTableGUI
                 );
             }
 
-            $filename = "export";
+            $filename = $this->getExportFileName((int) $format);
 
             switch ($format) {
                 case self::EXPORT_EXCEL:
@@ -2827,5 +2827,10 @@ class ilTable2GUI extends ilTableGUI
             $this->limit_determined) {
             $this->rows_selector_off = true;
         }
+    }
+
+    protected function getExportFileName(int $format) : string
+    {
+        return 'export';
     }
 }


### PR DESCRIPTION
adds ability to override the filename of a table export by defining the **`getExportFileName`** function  
in a table class extending from **`ilTable2GUI`**