### PR TITLE
Fix `target=_blank` for dashboard items

### DIFF
--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -3794,7 +3794,7 @@ class ilObjectListGUI
 
         if ($def_command['link']) {
             $def_command['link'] = $this->modifySAHSlaunch($def_command['link'], $def_command['frame']);
-            $new_viewport = (bool) $this->getDefaultCommand()['frame']; // Cannot use $def_command['frame']. $this->default_command has been edited.
+            $new_viewport = !in_array($this->getDefaultCommand()['frame'], ['', '_top', '_self', '_parent'], true); // Cannot use $def_command['frame']. $this->default_command has been edited.
             $link = $this->ui->factory()
                              ->link()
                              ->standard($this->getTitle(), $def_command['link'])


### PR DESCRIPTION
Followup to the mantis Ticket https://mantis.ilias.de/view.php?id=31745 and to the PR #4622.
This only adds `target=_blank` if the frame option is not `_self`, `_top`, `_parent` or the empty string.