### PR TITLE
Fix length for Mime Type Recognition

### DIFF
--- a/src/ResourceStorage/Resource/InfoResolver/StreamInfoResolver.php
+++ b/src/ResourceStorage/Resource/InfoResolver/StreamInfoResolver.php
@@ -63,7 +63,7 @@ class StreamInfoResolver extends AbstractInfoResolver implements InfoResolver
         if (class_exists('finfo')) {
             $finfo = finfo_open(FILEINFO_MIME_TYPE);
             //We only need the first few bytes to determine the mime-type this helps to reduce RAM-Usage
-            $this->mime_type = finfo_buffer($finfo, $this->file_stream->read(100));
+            $this->mime_type = finfo_buffer($finfo, $this->file_stream->read(255));
             if ($this->file_stream->isSeekable()) {
                 $this->file_stream->rewind();
             }


### PR DESCRIPTION
Sorry this is a fix for a previous error I committed: We need a few more bytes to be sure mime-type recognition works. 255 Bytes should be enough though. I couldn't find any resources on it, so the number is completely magical, it is the equivalent of the max-length of the full mime-type name. I will provide a pr back to ILIAS7 together with the MS-Office-Type fix. Let me know if you would prefer another number.

Thanks!