### PR TITLE
Add isChild to class TopLinkItem

### DIFF
--- a/src/GlobalScreen/Scope/MainMenu/Factory/TopItem/TopLinkItem.php
+++ b/src/GlobalScreen/Scope/MainMenu/Factory/TopItem/TopLinkItem.php
@@ -9,12 +9,13 @@ use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isInterchangeableItem;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isInterchangeableItemTrait;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isTopItem;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\SymbolDecoratorTrait;
+use ILIAS\GlobalScreen\Scope\MainMenu\Factory\isChild;
 
 /**
  * Class TopLinkItem
  * @author Fabian Schmid <fs@studer-raimann.ch>
  */
-class TopLinkItem extends AbstractChildItem implements hasTitle, hasAction, isTopItem, hasSymbol, isInterchangeableItem
+class TopLinkItem extends AbstractChildItem implements hasTitle, hasAction, isTopItem, hasSymbol, isInterchangeableItem, isChild
 {
     use SymbolDecoratorTrait;
     use hasSymbolTrait;


### PR DESCRIPTION
I've got the following error after updating to the recent repo head:
```
TypeError thrown with message "Argument 1 passed to ILIAS\GlobalScreen\Scope\MainMenu\Factory\AbstractParentItem::removeChild() must implement interface ILIAS\GlobalScreen\Scope\MainMenu\Factory\isChild, instance of ILIAS\GlobalScreen\Scope\MainMenu\Factory\TopItem\TopLinkItem given, called in /srv/www/dev.digikos.de/html/ilias/src/GlobalScreen/Scope/MainMenu/Collector/MainMenuMainCollector.php on line 154"

Stacktrace:
#20 TypeError in /srv/www/dev.digikos.de/html/ilias/src/GlobalScreen/Scope/MainMenu/Factory/AbstractParentItem.php:55
#19 ILIAS\GlobalScreen\Scope\MainMenu\Factory\AbstractParentItem:removeChild in /srv/www/dev.digikos.de/html/ilias/src/GlobalScreen/Scope/MainMenu/Collector/MainMenuMainCollector.php:154
#18 ILIAS\GlobalScreen\Scope\MainMenu\Collector\MainMenuMainCollector:ILIAS\GlobalScreen\Scope\MainMenu\Collector\{closure} in [internal]:0
#17 array_walk in /srv/www/dev.digikos.de/html/ilias/src/GlobalScreen/Scope/MainMenu/Collector/Map/Map.php:162
#16 ILIAS\GlobalScreen\Scope\MainMenu\Collector\Map\Map:walk in /srv/www/dev.digikos.de/html/ilias/src/GlobalScreen/Scope/MainMenu/Collector/MainMenuMainCollector.php:159
#15 ILIAS\GlobalScreen\Scope\MainMenu\Collector\MainMenuMainCollector:cleanupItemsForUIRepresentation in /srv/www/dev.digikos.de/html/ilias/src/GlobalScreen/Collector/AbstractBaseCollector.php:40
#14 ILIAS\GlobalScreen\Collector\AbstractBaseCollector:collectOnce in /srv/www/dev.digikos.de/html/ilias/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php:89
```

I fixed it by adding isChild to src/GlobalScreen/Scope/MainMenu/Factory/TopItem/TopLinkItem.php