### PR TITLE
introduces singularity for target notification types

### DIFF
--- a/Services/Awareness/classes/class.WidgetManager.php
+++ b/Services/Awareness/classes/class.WidgetManager.php
@@ -114,13 +114,6 @@ class WidgetManager
 
         $this->session_repo->setOnlineUsersTS(date("Y-m-d H:i:s", time()));
 
-        $handler = new ilNotificationOSDHandler();
-        foreach ($handler->getNotificationsForUser($this->user_id) as $osd) {
-            if ($osd->getType() === 'who_is_online') {
-                $handler->removeNotification($osd->getId());
-            }
-        }
-
         $notification->notifyByUsers(array($this->user_id));
     }
 

--- a/Services/Notifications/classes/Repository/ilNotificationOSDRepositoryInterface.php
+++ b/Services/Notifications/classes/Repository/ilNotificationOSDRepositoryInterface.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
-/******************************************************************************
- *
+/**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
  *
@@ -12,10 +11,10 @@
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *     https://www.ilias.de
- *     https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
 namespace ILIAS\Notifications\Repository;
 
@@ -43,5 +42,5 @@ interface ilNotificationOSDRepositoryInterface
      */
     public function getOSDNotificationsByUser(int $user_id) : array;
 
-    public function deleteNotificationById(int $id) : bool;
+    public function deleteOSDNotificationById(int $id) : bool;
 }

--- a/Services/Notifications/classes/ilNotificationOSDHandler.php
+++ b/Services/Notifications/classes/ilNotificationOSDHandler.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
-/******************************************************************************
- *
+/**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
  *
@@ -12,10 +11,10 @@
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *     https://www.ilias.de
- *     https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
 namespace ILIAS\Notifications;
 
@@ -68,7 +67,7 @@ class ilNotificationOSDHandler extends ilNotificationHandler
 
     public function removeNotification(int $notification_osd_id) : bool
     {
-        return $this->repo->deleteNotificationById($notification_osd_id);
+        return $this->repo->deleteOSDNotificationById($notification_osd_id);
     }
 
     private function appendParamToLink(string $link, string $param, int $value) : string

--- a/Services/Notifications/test/bootstrap.php
+++ b/Services/Notifications/test/bootstrap.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
-/******************************************************************************
- *
+/**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
  *
@@ -12,10 +11,10 @@
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *     https://www.ilias.de
- *     https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
 require_once 'libs/composer/vendor/autoload.php';
 require_once 'ilNotificationsBaseTest.php';

--- a/Services/Notifications/test/ilNotificationsBaseTest.php
+++ b/Services/Notifications/test/ilNotificationsBaseTest.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
-/******************************************************************************
- *
+/**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
  *
@@ -12,10 +11,10 @@
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *     https://www.ilias.de
- *     https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
 use PHPUnit\Framework\TestCase;
 

--- a/Services/Notifications/test/ilServicesNotificationsSuite.php
+++ b/Services/Notifications/test/ilServicesNotificationsSuite.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
-/******************************************************************************
- *
+/**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
  *
@@ -12,10 +11,10 @@
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *     https://www.ilias.de
- *     https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=32985

Fixes the possibility to have multiple notifications from a type, even if its inconvinient for that type, by introducing a register for notification type that are unique for their user. 