### PR TITLE
#33003: Fix by introducing new ConstantTransformation and changing ArrayBasedRequestWrapper::retrieve

### DIFF
--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMembersGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMembersGUI.php
@@ -133,7 +133,8 @@ class ilIndividualAssessmentMembersGUI
 
     protected function addedUsers() : void
     {
-        if ($this->request_wrapper->retrieve('failure', $this->refinery->kindlyTo()->bool())) {
+        $r = $this->refinery;
+        if ($this->request_wrapper->retrieve('failure', $r->byTrying([$r->kindlyTo()->bool(), $r->always(false)]))) {
             $this->tpl->setOnScreenMessage("failure", $this->txt('iass_add_user_failure'));
         } else {
             $this->tpl->setOnScreenMessage("success", $this->txt('iass_add_user_success'));

--- a/Modules/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
+++ b/Modules/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
@@ -241,14 +241,29 @@ class ilObjLearningSequenceSettingsGUI
         $lso->setDescription($this->post_wrapper->retrieve(self::PROP_DESC, $this->refinery->kindlyTo()->string()));
 
         $settings = $this->settings
-            ->withMembersGallery($this->post_wrapper->retrieve(self::PROP_GALLERY, $this->refinery->kindlyTo()->bool()))
-        ;
+            ->withMembersGallery(
+                $this->post_wrapper->retrieve(
+                    self::PROP_GALLERY,
+                    $this->refinery->byTrying([
+                        $this->refinery->kindlyTo()->bool(),
+                        $this->refinery->always(false)
+                    ])
+                )
+            );
 
         $inpt = $form->getItemByPostVar(self::PROP_AVAIL_PERIOD);
         $start = $inpt->getStart();
         $end = $inpt->getEnd();
         $activation = $this->activation
-            ->withIsOnline($this->post_wrapper->retrieve(self::PROP_ONLINE, $this->refinery->kindlyTo()->bool()));
+            ->withIsOnline(
+                $this->post_wrapper->retrieve(
+                    self::PROP_ONLINE,
+                    $this->refinery->byTrying([
+                        $this->refinery->kindlyTo()->bool(),
+                        $this->refinery->always(false)
+                    ])
+                )
+            );
 
         if ($start) {
             $activation = $activation

--- a/src/HTTP/Wrapper/ArrayBasedRequestWrapper.php
+++ b/src/HTTP/Wrapper/ArrayBasedRequestWrapper.php
@@ -1,22 +1,25 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\HTTP\Wrapper;
 
 use ILIAS\Refinery\Transformation;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 /**
  * Class ArrayBasedRequestWrapper
  *

--- a/src/HTTP/Wrapper/ArrayBasedRequestWrapper.php
+++ b/src/HTTP/Wrapper/ArrayBasedRequestWrapper.php
@@ -42,11 +42,7 @@ class ArrayBasedRequestWrapper implements RequestWrapper
      */
     public function retrieve(string $key, Transformation $transformation)
     {
-        if (!$this->has($key)) {
-            throw new \OutOfBoundsException('unknown property demanded');
-        }
-
-        return $transformation->transform($this->raw_values[$key]);
+        return $transformation->transform($this->raw_values[$key] ?? null);
     }
 
 

--- a/src/Refinery/ConstantTransformation.php
+++ b/src/Refinery/ConstantTransformation.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Refinery;
+
+class ConstantTransformation implements Transformation
+{
+    use DeriveInvokeFromTransform;
+    use DeriveApplyToFromTransform;
+
+    protected $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function transform($from)
+    {
+        return $this->value;
+    }
+}

--- a/src/Refinery/Factory.php
+++ b/src/Refinery/Factory.php
@@ -168,4 +168,9 @@ class Factory
     {
         return new IdentityTransformation();
     }
+
+    public function always($value) : Transformation
+    {
+        return new ConstantTransformation($value);
+    }
 }

--- a/tests/Refinery/ConstantTransformationTest.php
+++ b/tests/Refinery/ConstantTransformationTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Refinery;
+
+use ILIAS\Refinery\ConstantTransformation;
+use PHPUnit\Framework\TestCase;
+
+class ConstantTransformationTest extends TestCase
+{
+    public function testTransform() : void
+    {
+        $value = 'hejaaa';
+
+        $actual = (new ConstantTransformation($value))->transform("foo");
+
+        $this->assertEquals($value, $actual);
+    }
+}


### PR DESCRIPTION
Hi everyone,

this is supposed to fix [#33003](https://mantis.ilias.de/view.php?id=33003). Basically, the current behaviour of `ArrayBasedRequestWrapper::retrieve` to throw exceptions on unknown keys already bothered me some times before, but now I've had enough =)

Currently, we need to guard almost every usage of `retrieve` with a `has`. I propose to make `retrieve` pass `null` to the supplied transformation on unknown keys. Reasoning is as follows:

* If someone wants to use the old `has` -> `retrieve` pattern, they still can. No existing and working code should be affected by the change.
* We now can also use a pattern where the handling of non existing keys is internalized in the transformation, as demonstrated in the fixed file. From my POV this is a lot more readable, since the intent is declared (instead of the execution being controlled).
* A quick research (Caching PSR 6) suggests that this also might be expected by some people.

I briefly discussed with @mjansenDatabay, maybe he wants to add some aspect here...

I kindly ask @chfsx to look into the changes in src/HTTP. I also added a new transformation that always returns a constant value. @mjansenDatabay, would you please review?

Best regards!