### PR TITLE
UI: handle required select with no selection gracefully (#32959)

### DIFF
--- a/src/Refinery/Logical/Sequential.php
+++ b/src/Refinery/Logical/Sequential.php
@@ -18,11 +18,12 @@
 
 namespace ILIAS\Refinery\Logical;
 
-use ILIAS\Refinery\Custom\Constraint;
+use ILIAS\Refinery\Custom\Constraint as CustomConstraint;
+use ILIAS\Refinery\Constraint;
 use ILIAS\Data;
 use ilLanguage;
 
-class Sequential extends Constraint
+class Sequential extends CustomConstraint
 {
     /**
      * There's a test to show this state will never be visible

--- a/src/UI/Implementation/Component/Input/Field/Select.php
+++ b/src/UI/Implementation/Component/Input/Field/Select.php
@@ -69,7 +69,10 @@ class Select extends Input implements C\Input\Field\Select
      */
     protected function getConstraintForRequirement() : ?Constraint
     {
-        return $this->refinery->string()->hasMinLength(1);
+        return $this->refinery->logical()->sequential([
+            $this->refinery->to()->string(),
+            $this->refinery->string()->hasMinLength(1)
+        ]);
     }
 
     /**

--- a/tests/UI/Component/Input/Field/SelectTest.php
+++ b/tests/UI/Component/Input/Field/SelectTest.php
@@ -21,6 +21,7 @@ require_once(__DIR__ . "/../../../Base.php");
 use ILIAS\Data;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Implementation\Component as I;
+use ILIAS\UI\Implementation\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 
 class SelectForTest extends ILIAS\UI\Implementation\Component\Input\Field\Select
@@ -81,6 +82,28 @@ class SelectInputTest extends ILIAS_UI_TestBase
         );
 
         $this->assertTrue($select->_isClientSideValueOk(""));
+    }
+
+    public function testEmptyStringCreatesErrorIfSelectIsRequired() : void
+    {
+        $options = [];
+        $select = $this->buildFactory()->select(
+            "",
+            $options,
+            ""
+        )
+        ->withRequired(true)
+        ->withNameFrom($this->name_source);
+
+        $data = $this->createMock(InputData::class);
+        $data->expects($this->once())
+            ->method("getOr")
+            ->willReturn(null);
+        $select = $select->withInput(
+            $data
+        );
+
+        $this->assertNotEquals(null, $select->getError());
     }
 
     public function testEmptyStringIsAnAcceptableClientSideValueEvenIfSelectIsRequired() : void


### PR DESCRIPTION
Hello everyone,

this fixes [#32959](https://mantis.ilias.de/view.php?id=32959) by correcting the constraint that is used to make the Select Input Field required. This revealed an error in `Refinery\Logical\Sequential`.

Best regards!