### PR TITLE
Fix more Globals in test

### DIFF
--- a/Modules/Test/classes/class.ilAssQuestionPageCommandForwarder.php
+++ b/Modules/Test/classes/class.ilAssQuestionPageCommandForwarder.php
@@ -55,9 +55,6 @@ class ilAssQuestionPageCommandForwarder
             $ctrl->setParameter($this, 'prev_qid', $this->testrequest->raw('prev_qid'));
         }
         
-        //global $___test_express_mode;
-        //$___test_express_mode = true;
-        $_GET['calling_test'] = $this->getTestObj()->getRefId();
         $main_template->setCurrentBlock("ContentStyle");
         $main_template->setVariable(
             "LOCATION_CONTENT_STYLESHEET",

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -812,10 +812,6 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                         $this->ctrl->setParameterByClass($questionGuiClass, 'test_express_mode', 1);
                     }
 
-                    if (!$questionGui->isSaveCommand()) {
-                        $_GET['calling_test'] = $this->object->getRefId();
-                    }
-
                     $questionGui->setQuestionTabs();
 
                     $this->ctrl->forwardCommand($questionGui);

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -646,7 +646,6 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                 if ($cmd === 'edit' && !$ilAccess->checkAccess('write', '', $this->testrequest->getRefId())) {
                     $this->redirectAfterMissingWrite();
                 }
-                $_GET['q_id'] = $this->fetchAuthoringQuestionIdParameter();
                 $this->prepareOutput();
                 $forwarder = new ilAssQuestionPageCommandForwarder();
                 $forwarder->setTestObj($this->getTestObject());

--- a/Modules/Test/classes/class.ilTestParticipantList.php
+++ b/Modules/Test/classes/class.ilTestParticipantList.php
@@ -1,8 +1,20 @@
 <?php
 
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-require_once 'Modules/Test/classes/class.ilTestParticipant.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestParticipantList

--- a/Modules/Test/classes/class.ilTestParticipantList.php
+++ b/Modules/Test/classes/class.ilTestParticipantList.php
@@ -197,7 +197,7 @@ class ilTestParticipantList implements Iterator
             $participant->setFirstname($rowData['firstname']);
             $participant->setMatriculation($rowData['matriculation']);
             
-            $participant->setActiveStatus((bool) $rowData['active']);
+            $participant->setActiveStatus((bool) ($rowData['active'] ?? false));
             
             if (isset($rowData['clientip'])) {
                 $participant->setClientIp($rowData['clientip']);

--- a/Modules/Test/classes/class.ilTestParticipantsGUI.php
+++ b/Modules/Test/classes/class.ilTestParticipantsGUI.php
@@ -199,7 +199,7 @@ class ilTestParticipantsGUI
         if (is_array($a_user_ids)) {
             $i = 0;
             foreach ($a_user_ids as $user_id) {
-                $client_ip = $_POST["client_ip"][$i];
+                $client_ip = $_POST["client_ip"][$i] ?? '';
                 $this->getTestObj()->inviteUser($user_id, $client_ip);
                 $countusers++;
                 $i++;

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1,16 +1,25 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\Refinery\Transformation;
 use ILIAS\Refinery\Random\Seed\GivenSeed;
 use ILIAS\Refinery\Random\Group as RandomGroup;
 
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
-require_once './Modules/Test/classes/class.ilTestPlayerCommands.php';
-require_once './Modules/Test/classes/class.ilTestServiceGUI.php';
-require_once './Modules/TestQuestionPool/classes/class.assQuestion.php';
-require_once './Services/UIComponent/Button/classes/class.ilSubmitButton.php';
-require_once 'Modules/Test/classes/class.ilTestPlayerNavButton.php';
 
 /**
  * Output class for assessment test execution

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2332,12 +2332,6 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
         return $this->testSession->getLastSequence();
     }
-    
-    protected function resetSequenceElementParameter()
-    {
-        unset($_GET['sequence']);
-        $this->ctrl->setParameter($this, 'sequence', null);
-    }
 
     protected function getSequenceElementParameter()
     {

--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -1,10 +1,21 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-require_once './Modules/TestQuestionPool/classes/class.assQuestion.php';
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
-require_once './Modules/TestQuestionPool/interfaces/interface.ilObjQuestionScoringAdjustable.php';
-require_once './Modules/TestQuestionPool/interfaces/interface.ilObjFileHandlingQuestionType.php';
 
 /**
  * Class for file upload questions

--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -1037,7 +1037,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     */
     public function setMaxSize($a_value) : void
     {
-        $this->maxsize = $a_value;
+        $this->maxsize = (int) $a_value;
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -137,7 +137,12 @@ class ilAssQuestionPreviewGUI
                 );
                 if (($_GET["calling_test"] > 0) || ($_GET["test_ref_id"] > 0)) {
                     $ref_id = $_GET["calling_test"];
-                    if (strlen($ref_id) == 0) {
+                    if (strlen($ref_id) !== 0 && !is_numeric($ref_id)) {
+                        $ref_id_array = explode('_', $ref_id);
+                        $ref_id = array_pop($ref_id_array);
+                    }
+                    
+                    if (strlen($ref_id) === 0) {
                         $ref_id = $_GET["test_ref_id"];
                     }
 


### PR DESCRIPTION
This PR contains a few fixes for assignments to globals that blew up in my face when running more tests on test8. I simply removed two of them and changed the read out of a ref_id from "calling_test" as it might be a string. I also changed a few accesses to potentially undefined arrays and a wrong type.

I left the following assignment to $_GET/$_POST/$_REQUEST in: https://github.com/ILIAS-eLearning/ILIAS/blob/e150251c515f85cf0bf2464d20193a31e298f0d1/Modules/Test/classes/class.ilObjTestGUI.php#L955 . If this ever gets called on test8 test goes boom, but then at least we know, that we needed. If this doesn't happen during beta-testing I would strongly suggest to remove it.