### PR TITLE
Container: read needs to respect target_id = null (#33052)

### DIFF
--- a/Services/ContainerReference/classes/class.ilContainerReference.php
+++ b/Services/ContainerReference/classes/class.ilContainerReference.php
@@ -184,11 +184,13 @@ class ilContainerReference extends ilObject
             $this->setTargetId((int) $row->target_obj_id);
             $this->setTitleType((int) $row->title_type);
         }
-        $ref_ids = ilObject::_getAllReferences($this->getTargetId());
-        $this->setTargetRefId(current($ref_ids));
+        if ($this->getTargetId()) {// might be null...
+            $ref_ids = ilObject::_getAllReferences($this->getTargetId());
+            $this->setTargetRefId(current($ref_ids));
         
-        if ($this->getTitleType() === self::TITLE_TYPE_REUSE) {
-            $this->title = ilObject::_lookupTitle($this->getTargetId());
+            if ($this->getTitleType() === self::TITLE_TYPE_REUSE) {
+                $this->title = ilObject::_lookupTitle($this->getTargetId());
+            }
         }
     }
 


### PR DESCRIPTION
Hi @alex40724,

this will fix [#33052](https://mantis.ilias.de/view.php?id=33052). I looked into other locations in the original stack trace to fix the problem. My conclusion was: since `getTargetId` might return `null`, `read` will have to deal with that possibility anyway. This might also happen in other circumstances.

Best regards!