### PR TITLE
[FIX] #33024: public profile link targets

### DIFF
--- a/Services/Contact/BuddySystem/classes/tables/class.ilBuddySystemRelationsTableGUI.php
+++ b/Services/Contact/BuddySystem/classes/tables/class.ilBuddySystemRelationsTableGUI.php
@@ -13,8 +13,7 @@
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
+ */
 
 /**
  * Class ilBuddyList

--- a/Services/Contact/BuddySystem/classes/tables/class.ilBuddySystemRelationsTableGUI.php
+++ b/Services/Contact/BuddySystem/classes/tables/class.ilBuddySystemRelationsTableGUI.php
@@ -218,7 +218,7 @@ class ilBuddySystemRelationsTableGUI extends ilTable2GUI
         if ((!$this->user->isAnonymous() && $public_profile === 'y') || $public_profile === 'g') {
             $this->ctrl->setParameterByClass(ilPublicUserProfileGUI::class, 'user', $a_set['usr_id']);
             $profile_target = $this->ctrl->getLinkTargetByClass(
-                ilPublicUserProfileGUI::class,
+                [ilContactGUI::class, ilPublicUserProfileGUI::class],
                 'getHTML'
             );
             $a_set['profile_link'] = $profile_target;

--- a/Services/UICore/classes/class.ilCtrlContext.php
+++ b/Services/UICore/classes/class.ilCtrlContext.php
@@ -296,7 +296,15 @@ class ilCtrlContext implements ilCtrlContextInterface
         // override the previously set path again.
         $cmd_class = $this->getQueryParam(ilCtrlInterface::PARAM_CMD_CLASS);
         if (null !== $cmd_class) {
-            $this->setCmdClass($cmd_class);
+            // DON'T use $this->setCmdClass because the path in should always
+            // be set in this method, but not in this case.
+            $this->cmd_class = $cmd_class;
+
+            // only set the path if the context doesn't yet determined one.
+            $path = $this->path_factory->find($this, $cmd_class);
+            if (null === $this->path->getCidPath()) {
+                $this->path = $path;
+            }
         }
     }
 

--- a/Services/UICore/classes/class.ilCtrlContext.php
+++ b/Services/UICore/classes/class.ilCtrlContext.php
@@ -1,6 +1,19 @@
 <?php declare(strict_types = 1);
 
-/* Copyright (c) 2021 Thibeau Fuhrer <thf@studer-raimann.ch> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
 
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\HTTP\Wrapper\RequestWrapper;
@@ -296,11 +309,14 @@ class ilCtrlContext implements ilCtrlContextInterface
         // override the previously set path again.
         $cmd_class = $this->getQueryParam(ilCtrlInterface::PARAM_CMD_CLASS);
         if (null !== $cmd_class) {
-            // DON'T use $this->setCmdClass because the path in should always
-            // be set in this method, but not in this case.
             $this->cmd_class = $cmd_class;
 
-            // only set the path if the context doesn't yet determined one.
+            // @see https://github.com/ILIAS-eLearning/ILIAS/pull/4696:
+            // there are rare cases where command-classes are also baseclasses. if the
+            // baseclass is provided as command-class, we cannot use the setCmdClass()
+            // method, because this would override the current path by one where the
+            // command-class is reached directly (since it's a baseclass) but should
+            // have been routed through different classes first.
             $path = $this->path_factory->find($this, $cmd_class);
             if (null === $this->path->getCidPath()) {
                 $this->path = $path;


### PR DESCRIPTION
Hi @mjansenDatabay, I think I might have found the issue with https://mantis.ilias.de/view.php?id=33024.

The link-target generation in `ilBuddySystemRelationsTableGUI::fillRow()` didn't route through `ilContactGUI` because it is a base class itself. I think previously the base classes were considered last when finding a path, whereas they are now considered first. Therefore the target got recognized as a base class right away instead of finding a way though parent classes. You can force ilCtrl to route through `ilContactGUI` by providing part of the path to the target class `ilPublicUserProfileGUI`. (Im not a fan of this but) ilCtrl will then automatically find a valid path that is connected to the first provided class and prepends the `ilDashboardGUI` node in this scenario. 

I also found a bug when adopting ilCtrlContext's parameters that occurred when the command-class is also a base class but shouldn't be treated as such. Therefore I left it within this PR too.

Kind regards!