### PR TITLE
Allow using AUTO_INCREMENT for integer table columns

### DIFF
--- a/Services/Database/classes/PDO/FieldDefinition/class.ilDBPdoFieldDefinition.php
+++ b/Services/Database/classes/PDO/FieldDefinition/class.ilDBPdoFieldDefinition.php
@@ -58,7 +58,7 @@ abstract class ilDBPdoFieldDefinition
      */
     public array $allowed_attributes = [
         "text" => ["length", "notnull", "default", "fixed"],
-        "integer" => ["length", "notnull", "default", "unsigned"],
+        "integer" => ["length", "notnull", "default", "unsigned", "autoincrement"],
         "float" => ["notnull", "default"],
         "date" => ["notnull", "default"],
         "time" => ["notnull", "default"],

--- a/Services/Database/classes/PDO/class.ilDBPdoMySQL.php
+++ b/Services/Database/classes/PDO/class.ilDBPdoMySQL.php
@@ -147,6 +147,16 @@ abstract class ilDBPdoMySQL extends ilDBPdo
 
     public function nextId(string $table_name) : int
     {
+        $autoIncrementQueryResult = $this->queryF(
+            "SELECT `auto_increment` FROM INFORMATION_SCHEMA.TABLES WHERE table_name = %s",
+            ["text"],
+            [$table_name]
+        );
+        $autoIncrementValue = $this->fetchAssoc($autoIncrementQueryResult)["auto_increment"];
+        if ($autoIncrementValue && is_numeric($autoIncrementValue)) {
+            return (int) $autoIncrementValue;
+        }
+
         $sequence_name = $this->quoteIdentifier($this->getSequenceName($table_name), true);
         $seqcol_name = $this->quoteIdentifier('sequence');
         $query = "INSERT INTO $sequence_name ($seqcol_name) VALUES (NULL)";

--- a/Services/Database/interfaces/interface.ilDBInterface.php
+++ b/Services/Database/interfaces/interface.ilDBInterface.php
@@ -55,6 +55,11 @@ interface ilDBInterface
 
     public function addPrimaryKey(string $table_name, array $primary_keys) : bool;
 
+    /**
+     * @param $table_name
+     * @param int $start
+     * @deprecated use 'autoincrement' in $fields instead
+     */
     public function createSequence(string $table_name, int $start = 1) : bool;
 
     public function getSequenceName(string $table_name) : string;


### PR DESCRIPTION
- Allow the use of the MySQL/MariaDB AUTO_INCREMENT feature.
- The `nextId` method now returns the next AUTO_INCREMENT value if it's defined, otherwise for compatibility the previous sequence number
- deprecated `createSequence` method