### PR TITLE
Fixes Shown Preview Page when Locking is Enabled

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPageGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPageGUI.php
@@ -68,6 +68,11 @@ class ilAssQuestionPageGUI extends ilPageObjectGUI
         // fau.
         return parent::showPage();
     }
+    
+    public function finishEditing()
+    {
+        $this->ctrl->redirectByClass('ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_SHOW);
+    }
 
     public function postOutputProcessing($output)
     {


### PR DESCRIPTION
This fixes one more flow in the new question editing flow:
Currently when we finish editing and we have locking enabled in the Page Editor we still get to the "old" editor view. This fixes the redirect and leads it straight back to ilAssQuestionPreviewGUI.