### PR TITLE
T&A fix 22130

### DIFF
--- a/Modules/Test/classes/class.ilTestExport.php
+++ b/Modules/Test/classes/class.ilTestExport.php
@@ -414,7 +414,7 @@ abstract class ilTestExport
                 $userfields = ilObjUser::_lookupFields($userdata->getUserId());
                 foreach ($additionalFields as $fieldname) {
                     if (strcmp($fieldname, 'gender') == 0) {
-                        $worksheet->setCell($row, $col++, $this->lng->txt('gender_' . $userfields[$fieldname]));
+                        $worksheet->setCell($row, $col++, strlen($userfields[$fieldname]) ? $this->lng->txt('gender_' . $userfields[$fieldname]) : '');
                     } elseif (strcmp($fieldname, "exam_id") == 0) {
                         $worksheet->setCell($row, $col++, $userdata->getExamIdFromScoredPass());
                     } else {
@@ -863,7 +863,7 @@ abstract class ilTestExport
                     $userfields = ilObjUser::_lookupFields($userdata->getUserID());
                     foreach ($additionalFields as $fieldname) {
                         if (strcmp($fieldname, "gender") == 0) {
-                            array_push($datarow2, $this->lng->txt("gender_" . $userfields[$fieldname]));
+                            array_push($datarow2, strlen($userfields[$fieldname]) ? $this->lng->txt('gender_' . $userfields[$fieldname]) : '');
                         } elseif (strcmp($fieldname, "exam_id") == 0) {
                             array_push($datarow2, $userdata->getExamIdFromScoredPass());
                         } else {

--- a/Modules/Test/classes/tables/class.ilEvaluationAllTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilEvaluationAllTableGUI.php
@@ -270,7 +270,7 @@ class ilEvaluationAllTableGUI extends ilTable2GUI
             if (!$this->anonymity) {
                 if (strcmp($c, 'gender') == 0) {
                     $this->tpl->setCurrentBlock('gender');
-                    $this->tpl->setVariable("GENDER", $this->lng->txt('gender_' . $data['gender']));
+                    $this->tpl->setVariable("GENDER", strlen($data['gender']) ? $this->lng->txt('gender_' . $data['gender']) : '&nbsp;');
                     $this->tpl->parseCurrentBlock();
                 }
                 if (strcmp($c, 'email') == 0) {


### PR DESCRIPTION
fixes https://mantis.ilias.de/view.php?id=22130
When a user has nothing selected for "Salutation", the field in the statistics and the exports will just show up empty.