### PR TITLE
OrgUnits/ActiveRecord, 32989: allow null for primary

### DIFF
--- a/Modules/OrgUnit/classes/PathStorage/class.ilOrgUnitPathStorage.php
+++ b/Modules/OrgUnit/classes/PathStorage/class.ilOrgUnitPathStorage.php
@@ -35,7 +35,7 @@ class ilOrgUnitPathStorage extends ActiveRecord
      * @con_fieldtype  integer
      * @con_length     8
      */
-    protected int $ref_id = 0;
+    protected ?int $ref_id = 0;
     /**
      * @var int
      * @con_has_field  true
@@ -92,9 +92,14 @@ class ilOrgUnitPathStorage extends ActiveRecord
             $ilDB = $DIC['ilDB'];
             ilObjOrgUnitTree::_getInstance()->buildTempTableWithUsrAssignements();
 
-            $res = $ilDB->queryF("SELECT " . $ilDB->groupConcat("path",
-                    $separator) . " AS orgus FROM orgu_usr_assignements WHERE user_id = %s GROUP BY user_id;",
-                array('integer'), array($user_id));
+            $res = $ilDB->queryF(
+                "SELECT " . $ilDB->groupConcat(
+                    "path",
+                    $separator
+                ) . " AS orgus FROM orgu_usr_assignements WHERE user_id = %s GROUP BY user_id;",
+                array('integer'),
+                array($user_id)
+            );
             $dat = $ilDB->fetchObject($res);
 
             return (isset($dat->orgus) && $dat->orgus) ? $dat->orgus : '-';
@@ -115,13 +120,12 @@ class ilOrgUnitPathStorage extends ActiveRecord
      * @param bool $sort_by_title
      * @return array
      */
-    public static function getTextRepresentationOfOrgUnits(bool $sort_by_title = true)
+    public static function getTextRepresentationOfOrgUnits(bool $sort_by_title = true) : array
     {
         if ($sort_by_title) {
             return ilOrgUnitPathStorage::orderBy('path')->getArray('ref_id', 'path');
-        } else {
-            return ilOrgUnitPathStorage::getArray('ref_id', 'path');
         }
+        return ilOrgUnitPathStorage::getArray('ref_id', 'path');
     }
 
     public static function writePathByRefId(string $ref_id) : void

--- a/Services/Object/classes/class.ilObjectAddNewItemGUI.php
+++ b/Services/Object/classes/class.ilObjectAddNewItemGUI.php
@@ -205,7 +205,10 @@ class ilObjectAddNewItemGUI
                     if ($ilAccess->checkAccess("create_" . $type, "", $this->parent_ref_id, $parent_type)) {
                         // if only assigned - do not add groups
                         if (sizeof($pos_group_map) > 1) {
-                            $obj_grp_id = (int) $grp_map[$type];
+                            $obj_grp_id = 0;
+                            if (array_key_exists($type, $grp_map)) {
+                                $obj_grp_id = (int) $grp_map[$type];
+                            }
                             if ($obj_grp_id !== $current_grp) {
                                 // add seperator after last group?
                                 $sdone = false;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=32989
I figure, the active record should enfoce primary_key=0 (when actually null), but this here is minimal invasive.
ilObjectAddNewItemGUI is a mere accident I had to bypass in order to test in GUI.