### PR TITLE
Fix Empty Headings in Results Table

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPageGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPageGUI.php
@@ -57,9 +57,10 @@ class ilAssQuestionPageGUI extends ilPageObjectGUI
     
     public function showPage()
     {
-        $this->setOriginalPresentationTitle($this->getPresentationTitle());
-        
-        $this->setPresentationTitle(self::TEMP_PRESENTATION_TITLE_PLACEHOLDER);
+        if ($this->getPresentationTitle() !== null) {
+            $this->setOriginalPresentationTitle($this->getPresentationTitle());
+            $this->setPresentationTitle(self::TEMP_PRESENTATION_TITLE_PLACEHOLDER);
+        }
         
         // fau: testNav - enable page toc as placeholder for info and actions block (see self::insertPageToc)
         $config = $this->getPageConfig();


### PR DESCRIPTION
This fixes: https://mantis.ilias.de/view.php?id=32258

An Empty Page-Heading coming from the ILIAS Page-Editor may force an Empty-Tag in certain circumstances. Maybe this is an overcautious fix as the whole if-statement might be unnecessary.

Should be cherry-picked to trunk if accepted.