### PR TITLE
Fix for https://mantis.ilias.de/view.php?id=32439

### DIFF
--- a/Modules/Test/templates/default/tpl.il_as_tst_output.html
+++ b/Modules/Test/templates/default/tpl.il_as_tst_output.html
@@ -100,12 +100,17 @@
 
     // fau: testNav - moved saving on time reached to ilTestPlayerQuestionEditControl.js .
 
-	function saveTextarea(editor)
-	{
-		document.forms["taForm"].submit();
-	}
-	
-<!-- fau: testNav - moved auto saver to ilTestPlayerQuestionEditControl.js -->
+    function saveTextarea(editor)
+    {
+        let form = document.forms['taForm'];
+        let input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'cmd[submitSolution]';
+        input.value = 'save';
+    
+        form.appendChild(input);
+        form.submit();
+    }
 
 	(function($){ $(document).ready( function()
 	{

--- a/Services/RTE/templates/default/tpl.usereditor.js
+++ b/Services/RTE/templates/default/tpl.usereditor.js
@@ -23,6 +23,7 @@ tinymce.init({
     content_style: 'html { overflow: initial; }',
     plugin_insertdate_dateFormat: "%d.%m.%Y",
     plugin_insertdate_timeFormat: "%H:%M:%S",
+    save_enablewhendirty: false,
     save_onsavecallback: "saveTextarea",
     resize: 'true',
     font_formats: "Arial=sans-serif;Courier=monospace;Times Roman=serif",


### PR DESCRIPTION
This is not the most beautiful of all fixes. But it keeps the footprint small.

It seems there is a bug in TinyMCE where the save_onsavecallback is not called if save_enablewhendirty is set to true (default).