### PR TITLE
T&A: use short form of grade in test results table (Mantis #31209) (release_6)

### DIFF
--- a/Modules/Test/classes/class.ilTestParticipantList.php
+++ b/Modules/Test/classes/class.ilTestParticipantList.php
@@ -239,7 +239,7 @@ class ilTestParticipantList implements Iterator
             $scoring->setMaxPoints((float) $row['max_points']);
             
             $scoring->setPassed((bool) $row['passed']);
-            $scoring->setFinalMark((string) $row['mark_official']);
+            $scoring->setFinalMark((string) $row['mark_short']);
             
             $this->getParticipantByActiveId($row['active_fi'])->setScoring($scoring);
             


### PR DESCRIPTION
Change the “Results and Grades” table in the test results tab so that it shows the short form of grades instead of the official form.

This has side effects. Please see the commit message and the issue report [Mantis#31209](https://mantis.ilias.de/view.php?id=31209 "Mantis#31209: Column \"Mark\": Input sometimes from \"Short Form\", sometimes from \"Official Form\"") for details.

This is the pull request for the `release_6` branch.