### PR TITLE
UI item: move property key & value to same col

### DIFF
--- a/src/UI/templates/default/Item/item.less
+++ b/src/UI/templates/default/Item/item.less
@@ -45,6 +45,9 @@
 		font-size: @font-size-small;
 		color: @il-text-light-color;
 		overflow: hidden;
+		&:not(:empty):after {
+			content: ": "
+		}
 	}
 
 	.il-item-property-value {

--- a/src/UI/templates/default/Item/tpl.item_notification.html
+++ b/src/UI/templates/default/Item/tpl.item_notification.html
@@ -20,17 +20,11 @@
 				<hr class="il-item-divider">
 				<!-- BEGIN property_row -->
 				<div class="row il-item-properties">
-					<div class="col-md-12">
-						<div class="row">
-							<div class="col-sm-3 il-item-property-name">{PROP_NAME_A}</div>
-							<div class="col-sm-9 il-item-property-value il-multi-line-cap-3">{PROP_VAL_A}</div>
-						</div>
+					<div class="col-sm-12 il-multi-line-cap-3">
+						<span class="il-item-property-name">{PROP_NAME_A}</span><span class="il-item-property-value">{PROP_VAL_A}</span>
 					</div>
-					<div class="col-md-12">
-						<div class="row">
-							<div class="col-sm-3 il-item-property-name">{PROP_NAME_B}</div>
-							<div class="col-sm-9 il-item-property-value il-multi-line-cap-3">{PROP_VAL_B}</div>
-						</div>
+					<div class="col-sm-12 il-multi-line-cap-3">
+						<span class="il-item-property-name">{PROP_NAME_B}</span><span class="il-item-property-value">{PROP_VAL_B}</span>
 					</div>
 				</div>
 				<!-- END property_row -->

--- a/src/UI/templates/default/Item/tpl.item_standard.html
+++ b/src/UI/templates/default/Item/tpl.item_standard.html
@@ -25,17 +25,11 @@
 			<hr class="il-item-divider" />
 			<!-- BEGIN property_row -->
 			<div class="row">
-				<div class="col-md-6">
-					<div class="row">
-						<div class="col-sm-5 col-lg-4 il-item-property-name">{PROP_NAME_A}</div>
-						<div class="col-sm-7 col-lg-8 il-item-property-value il-multi-line-cap-3">{PROP_VAL_A}</div>
-					</div>
+				<div class="col-md-6 il-multi-line-cap-3">
+					<span class="il-item-property-name">{PROP_NAME_A}</span><span class="il-item-property-value">{PROP_VAL_A}</span>
 				</div>
-				<div class="col-md-6">
-					<div class="row">
-						<div class="col-sm-5 col-lg-4 il-item-property-name">{PROP_NAME_B}</div>
-						<div class="col-sm-7 col-lg-8 il-item-property-value il-multi-line-cap-3">{PROP_VAL_B}</div>
-					</div>
+				<div class="col-md-6 il-multi-line-cap-3">
+					<span class="il-item-property-name">{PROP_NAME_B}</span><span class="il-item-property-value">{PROP_VAL_B}</span>
 				</div>
 			</div>
 			<!-- END property_row -->

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7828,6 +7828,9 @@ ul.dropdown-menu > li > .btn:focus {
   color: #6f6f6f;
   overflow: hidden;
 }
+.il-item .il-item-property-name:not(:empty):after {
+  content: ": ";
+}
 .il-item .il-item-property-value {
   font-size: 12px;
   overflow: hidden;

--- a/tests/UI/Component/Item/ItemNotificationTest.php
+++ b/tests/UI/Component/Item/ItemNotificationTest.php
@@ -229,18 +229,12 @@ class ItemNotificationTest extends ILIAS_UI_TestBase
 				<div class="il-item-additional-content">someContent</div>
 				<hr class="il-item-divider">
 					<div class="row il-item-properties">
-						<div class="col-md-12">
-							<div class="row">
-								<div class="col-sm-3 il-item-property-name">prop1</div>
-								<div class="col-sm-9 il-item-property-value il-multi-line-cap-3">val1</div>
-							</div>
-						</div>
-						<div class="col-md-12">
-							<div class="row">
-								<div class="col-sm-3 il-item-property-name">prop2</div>
-								<div class="col-sm-9 il-item-property-value il-multi-line-cap-3">val2</div>
-							</div>
-						</div>
+                        <div class="col-sm-12 il-multi-line-cap-3">
+                            <span class="il-item-property-name">prop1</span><span class="il-item-property-value">val1</span>
+                        </div>
+                        <div class="col-sm-12 il-multi-line-cap-3">
+                            <span class="il-item-property-name">prop2</span><span class="il-item-property-value">val2</span>
+                        </div>
 					</div>
 					<div class="il-aggregate-notifications" data-aggregatedby="id">
 						<div class="il-maincontrols-slate il-maincontrols-slate-notification">

--- a/tests/UI/Component/Item/ItemTest.php
+++ b/tests/UI/Component/Item/ItemTest.php
@@ -154,31 +154,19 @@ class ItemTest extends ILIAS_UI_TestBase
 			<div class="il-item-description">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</div>
 			<hr class="il-item-divider" />
 			<div class="row">
-				<div class="col-md-6">
-					<div class="row">
-						<div class="col-sm-5 col-lg-4 il-item-property-name">Origin</div>
-						<div class="col-sm-7 col-lg-8 il-item-property-value il-multi-line-cap-3">Course Title 1</div>
-					</div>
+                <div class="col-md-6 il-multi-line-cap-3">
+					<span class="il-item-property-name">Origin</span><span class="il-item-property-value">Course Title 1</span>
 				</div>
-				<div class="col-md-6">
-					<div class="row">
-						<div class="col-sm-5 col-lg-4 il-item-property-name">Last Update</div>
-						<div class="col-sm-7 col-lg-8 il-item-property-value il-multi-line-cap-3">24.11.2011</div>
-					</div>
+				<div class="col-md-6 il-multi-line-cap-3">
+					<span class="il-item-property-name">Last Update</span><span class="il-item-property-value">24.11.2011</span>
 				</div>
 			</div>
 			<div class="row">
-				<div class="col-md-6">
-					<div class="row">
-						<div class="col-sm-5 col-lg-4 il-item-property-name">Location</div>
-						<div class="col-sm-7 col-lg-8 il-item-property-value il-multi-line-cap-3">Room 123, Main Street 44, 3012 Bern</div>
-					</div>
+                <div class="col-md-6 il-multi-line-cap-3">
+					<span class="il-item-property-name">Location</span><span class="il-item-property-value">Room 123, Main Street 44, 3012 Bern</span>
 				</div>
-				<div class="col-md-6">
-					<div class="row">
-						<div class="col-sm-5 col-lg-4 il-item-property-name"></div>
-						<div class="col-sm-7 col-lg-8 il-item-property-value il-multi-line-cap-3"></div>
-					</div>
+				<div class="col-md-6 il-multi-line-cap-3">
+					<span class="il-item-property-name"></span><span class="il-item-property-value"></span>
 				</div>
 			</div>
 </div>
@@ -297,18 +285,12 @@ EOT;
 
 			<hr class="il-item-divider" />
 			<div class="row">
-				<div class="col-md-6">
-					<div class="row">
-						<div class="col-sm-5 col-lg-4 il-item-property-name">test</div>
-						<div class="col-sm-7 col-lg-8 il-item-property-value il-multi-line-cap-3"><button class="btn btn-link" data-action="https://www.github.com" id="id_2"  >GitHub</button></div>
-					</div>
-				</div>
-				<div class="col-md-6">
-					<div class="row">
-						<div class="col-sm-5 col-lg-4 il-item-property-name"></div>
-						<div class="col-sm-7 col-lg-8 il-item-property-value il-multi-line-cap-3"></div>
-					</div>
-				</div>
+                <div class="col-md-6 il-multi-line-cap-3">
+                    <span class="il-item-property-name">test</span><span class="il-item-property-value"><button class="btn btn-link" data-action="https://www.github.com" id="id_2"  >GitHub</button></span>
+                </div>
+                <div class="col-md-6 il-multi-line-cap-3">
+                    <span class="il-item-property-name"></span><span class="il-item-property-value"></span>
+                </div>
 			</div>
 </div>
 EOT;


### PR DESCRIPTION
See Mantis Issue https://mantis.ilias.de/view.php?id=32750

This is a suggestion to move key and values to the same column inside the UI item, to make the connection between them unmistakably clear.

Before
![Bildschirmfoto 2022-05-24 um 15 07 40](https://user-images.githubusercontent.com/59924129/178224449-abd7656e-d051-4a0b-9b69-8c6657780c6e.png)

After
![2022-07-11 10_20_30-Window](https://user-images.githubusercontent.com/59924129/178224343-6acffedb-40b2-4e1e-a9da-39624dfce62d.png)

The colon and spacing ": " is being added as a :after pseudo element.

This is a fully functional minimal implementation, but there are some points left to discuss if there is an interest to commit to this concept:
* Line height could be more clear as well: The lines of long properties breaking to the next line could be closer together, vertical spacing to the next key-value pair could be larger.
* There is something off with shy buttons (btn-link in Bootstrap). They don't seem to be on the exact same base-line as normal text. I suspect that this is an issue beyond the UI item.
* I think Bootstrap recommends filling columns until they wrap to the next row automatically as best practice instead of actually opening up a multiple row divs in succession. Not sure if it's worth the hassle to change it, because in this case it visually gives the desired result.

All the best,
Ferdinand