### PR TITLE
Page Layout: Sticky Breadcrumb Bar #32935

### DIFF
--- a/src/UI/templates/default/Layout/standardpage.less
+++ b/src/UI/templates/default/Layout/standardpage.less
@@ -235,16 +235,9 @@ main {
 	&:focus-visible {
 		outline: none;
 	}
-	display: grid;
-	grid-template-rows: 1fr auto;
-	grid-column: 2;
-	grid-row: 3;
+	display: flex;
+	flex-flow: column;
 	overflow: auto;
-	> div {
-		// contains breadcrumbs, mainspacekeeper of content
-		display: flex;
-		flex-flow: column;
-	}
 	#mainspacekeeper {
 	    flex-grow: 1; // stretches content from top to footer
     	width: 100%;

--- a/src/UI/templates/default/Layout/standardpage.less
+++ b/src/UI/templates/default/Layout/standardpage.less
@@ -113,6 +113,8 @@ header {
 
 //Breadcrumbs
 .breadcrumbs {
+	position: sticky;
+	top: 0;
 	align-items: center;
 	background-color: @il-standard-page-breadcrumbs-bg-color;
 	display: flex;

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -65,15 +65,13 @@
 
 		<!-- html5 main-tag is not supported in IE / div is needed -->
 		<main class="il-layout-page-content">
-			<div>
-				<!-- BEGIN content_breadcrumbs -->
-				<div class="breadcrumbs">
-					{BREADCRUMBS}
-				</div>
-				<!-- END content_breadcrumbs -->
-
-				{CONTENT}
+			<!-- BEGIN content_breadcrumbs -->
+			<div class="breadcrumbs">
+				{BREADCRUMBS}
 			</div>
+			<!-- END content_breadcrumbs -->
+
+			{CONTENT}
 
 			<!-- BEGIN pagefooter -->
 			<footer role="contentinfo">

--- a/src/UI/templates/default/MainControls/mode_info.less
+++ b/src/UI/templates/default/MainControls/mode_info.less
@@ -22,15 +22,6 @@
 }
 
 
-//
-// This is needed to break the current grid from the page
-//
-.il-layout-page-content > div {
-  display: grid;
-  grid-template-rows: auto 1fr
-}
-
-
 .il-mode-info span.il-mode-info-content {
   margin: auto;
   background-color: @il-mode-info-color;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9294,18 +9294,12 @@ main {
   display: block;
 }
 .il-layout-page-content {
-  display: grid;
-  grid-template-rows: 1fr auto;
-  grid-column: 2;
-  grid-row: 3;
+  display: flex;
+  flex-flow: column;
   overflow: auto;
 }
 .il-layout-page-content:focus-visible {
   outline: none;
-}
-.il-layout-page-content > div {
-  display: flex;
-  flex-flow: column;
 }
 .il-layout-page-content #mainspacekeeper {
   flex-grow: 1;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -10427,10 +10427,6 @@ footer {
     padding-top: 30px;
   }
 }
-.il-layout-page-content > div {
-  display: grid;
-  grid-template-rows: auto 1fr;
-}
 .il-mode-info span.il-mode-info-content {
   margin: auto;
   background-color: #B54F00;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9206,6 +9206,8 @@ header {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 .breadcrumbs {
+  position: sticky;
+  top: 0;
   align-items: center;
   background-color: white;
   display: flex;

--- a/templates/default/tpl.page_content.html
+++ b/templates/default/tpl.page_content.html
@@ -94,9 +94,6 @@
 		</div>
 	</div>
 </div>
-<!--<div id="minheight"></div>-->
-<!--<footer id="ilFooter" class="ilFooter hidden-print"><div class="container-fluid ilContainerWidth">-->
-<!--<div class="row"><div class="ilFooterContainer form-inline">{PRMLINK} {FOOTER}</div></div></div></footer>-->
 {LIGHTBOX}
 {WEBDAV_MODAL}
 <!-- END content -->

--- a/tests/UI/Component/Layout/Page/StandardPageTest.php
+++ b/tests/UI/Component/Layout/Page/StandardPageTest.php
@@ -270,9 +270,7 @@ class StandardPageTest extends ILIAS_UI_TestBase
         </header>
         <div class="il-system-infos"></div>
         <div class="nav il-maincontrols">MainBar Stub</div>
-        <main class="il-layout-page-content">
-            <div>some content</div>
-        </main>
+        <main class="il-layout-page-content">some content</main>
     </div>
     <script>il.Util.addOnLoad(function() {});</script>
 </body>
@@ -312,9 +310,7 @@ class StandardPageTest extends ILIAS_UI_TestBase
         </header>
         <div class="il-system-infos"></div>
         <div class="nav il-maincontrols">MainBar Stub</div>
-        <main class="il-layout-page-content">
-            <div>some content</div>
-        </main>
+        <main class="il-layout-page-content">some content</main>
     </div>
     <script>il.Util.addOnLoad(function() {});</script>
 </body>
@@ -357,9 +353,7 @@ class StandardPageTest extends ILIAS_UI_TestBase
         </header>
         <div class="il-system-infos"></div>
         <div class="nav il-maincontrols">MainBar Stub</div>
-        <main class="il-layout-page-content">
-            <div>some content</div>
-        </main>
+        <main class="il-layout-page-content">some content</main>
     </div>
     <script>il.Util.addOnLoad(function() {});</script>
 </body>
@@ -440,13 +434,11 @@ class StandardPageTest extends ILIAS_UI_TestBase
         <div class="il-system-infos"></div>
         <div class="nav il-maincontrols">MainBar Stub</div>
         <main class="il-layout-page-content">
-            <div>
                 <div class="breadcrumbs">
                     <nav aria-label="breadcrumbs_aria_label" class="breadcrumb_wrapper">
                         <div class="breadcrumb"><span class="crumb"><a href="#">label1</a></span><span class="crumb"><a href="#">label2</a></span><span class="crumb"><a href="#">label3</a></span></div>
                     </nav>
                 </div>some content
-            </div>
         </main>
     </div>
     <script>il.Util.addOnLoad(function() {});</script>


### PR DESCRIPTION
After the location of the breadcrumbs has been changed, the need for a sticky breadcrumb bar was reported in this Mantis issue: https://mantis.ilias.de/view.php?id=32935

## Sticky after scroll

To create the desired effect I used the CSS attribute position: sticky, no JS. Browser support is good (96% of all web users): https://caniuse.com/css-sticky

The breadcrumbs remain in the document flow until scrolling begins, so no padding under the breadcrumbs is necessary.

## Cleaner page structure

While implementing the sticky breadcrumbs I noticed a few leftovers from previous page structures that seem to be no longer in use (and in the worst case block simple solutions):

There was a commented out HTML Code of a legacy footer in tpl.page_content.html which I removed, because it could potentially mess up div spacekeeping, grid and flexbox behavior. If this is some sort of templating language that shouldn't be removed, please let me know.

Breadcrumbs, mainspacekeeper and footer were nested in a nameless div that once played a big role in pushing the footer down and anchoring the mode info. However, it seems to no longer serve both of these purposes. Removing this div makes the implementation of the breadcrumb bar (and any other objects) above the mainspacekeeper easier.

The footer is now being pushed down with flexbox instead of a nested CSS grid, which is a common practice for areas inside a CSS grid that only require a one directional column.

This approach should handle additional "unexpected" divs way more gracefully than the CSS grid which would "count" the divs to assign heights.

## Testing

This implementation of the breadcrumb bar can be tested on this dev server provided by CaT: https://dev.cate-tms.de/febreadcrumbs/ilias.php?baseClass=ilrepositorygui&reloadpublic=1&cmd=&ref_id=1

Some magazine pages are visible without login, where the sticky breadcrumb effect can be seen in actions. Let me know if you require personal login credentials for testing purposes.

I am happy to answer any questions! 🙂 