### PR TITLE
search: ctrl comment

### DIFF
--- a/Services/Search/classes/class.ilSearchControllerGUI.php
+++ b/Services/Search/classes/class.ilSearchControllerGUI.php
@@ -128,7 +128,7 @@ class ilSearchControllerGUI implements ilCtrlBaseClassInterface
                 // no break
             default:
                 $search_gui = new ilSearchGUI();
-                $this->ctrl->setCmdClass(ilSearchGUI::class);
+                $this->ctrl->setCmdClass(ilSearchGUI::class); // required to fix ctrl issues like ilCtrl cannot find a path for 'ilobjectcopygui' that reaches 'ilSearchControllerGUI'
                 $this->ctrl->forwardCommand($search_gui);
                 break;
         }


### PR DESCRIPTION
It is not necessary to merge this PR. 
I only created it to discuss changes in ilCtrl. 

The problem: 

- the main menu search creates a link to the "last search result" (./ilias.php?baseClass=ilSearchControllerGUI)
- ilSearchController forwards to the last search presentation class (e.g ilLuceneSearchGUI, ilSearchGUI,...)
- without the new (deprecated) call of setCmdClass() a ctrl error is triggered "ilCtrl cannot find a path for 'ilobjectcopygui' that reaches 'ilSearchControllerGUI'"

Prior releases of ilCtrl stored the "forward class" in ilCtrl->current_node, this seems to be not the case anymore.

I suspect that similar errors appear in other areas. E.g in the calendar service. 

How do we proceed here? 

