### PR TITLE
search: fixed dropzone issues

### DIFF
--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -2883,9 +2883,11 @@ class ilObjectListGUI
         }
 
         // if file upload is enabled the content is wrapped by a UI dropzone.
-        $file_upload_dropzone = new ilObjFileUploadDropzone($this->ref_id, $this->tpl->get());
-        if ($file_upload_dropzone->isUploadAllowed($this->type)) {
-            return $file_upload_dropzone->getDropzoneHtml();
+        if ($this->context === self::CONTEXT_REPOSITORY) {
+            $file_upload_dropzone = new ilObjFileUploadDropzone($this->ref_id, $this->tpl->get());
+            if ($file_upload_dropzone->isUploadAllowed($this->type)) {
+                return $file_upload_dropzone->getDropzoneHtml();
+            }
         }
 
         return $this->tpl->get();

--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -2883,7 +2883,7 @@ class ilObjectListGUI
         }
 
         // if file upload is enabled the content is wrapped by a UI dropzone.
-        if ($this->context === self::CONTEXT_REPOSITORY) {
+        if ($this->context !== self::CONTEXT_SEARCH) {
             $file_upload_dropzone = new ilObjFileUploadDropzone($this->ref_id, $this->tpl->get());
             if ($file_upload_dropzone->isUploadAllowed($this->type)) {
                 return $file_upload_dropzone->getDropzoneHtml();

--- a/Services/Search/classes/Lucene/class.ilLuceneSearchObjectListGUIFactory.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneSearchObjectListGUIFactory.php
@@ -58,7 +58,7 @@ class ilLuceneSearchObjectListGUIFactory
         $full_class = "ilObj" . $class . "ListGUI";
 
         include_once($location . "/class." . $full_class . ".php");
-        $item_list_gui = new $full_class();
+        $item_list_gui = new $full_class(ilObjectListGUI::CONTEXT_SEARCH);
 
         $item_list_gui->setDetailsLevel(ilObjectListGUI::DETAILS_SEARCH);
         $item_list_gui->enableDelete(true);

--- a/Services/Search/classes/class.ilSearchObjectListFactory.php
+++ b/Services/Search/classes/class.ilSearchObjectListFactory.php
@@ -55,7 +55,7 @@ class ilSearchObjectListFactory
         $full_class = "ilObj" . $class . "ListGUI";
 
         include_once($location . "/class." . $full_class . ".php");
-        $item_list_gui = new $full_class();
+        $item_list_gui = new $full_class(ilObjectListGUI::CONTEXT_SEARCH);
 
         $item_list_gui->enableDelete(false);
         $item_list_gui->enablePath(true);


### PR DESCRIPTION
This is one fix for https://mantis.ilias.de/view.php?id=32915

Without this fix ctrl errors like "ilCtrl cannot find a path for 'ilObjFileGUI' that reaches 'ilSearchGUI'" are thrown. 
I limited the dropzone presentation to context "repository" only. Maybe the dropzone is supported  in other contexts like "workspace". 