### PR TITLE
Allows custom positions to be imported. (#3113)

### DIFF
--- a/Modules/OrgUnit/classes/SimpleUserImport/class.ilOrgUnitSimpleUserImport.php
+++ b/Modules/OrgUnit/classes/SimpleUserImport/class.ilOrgUnitSimpleUserImport.php
@@ -67,9 +67,14 @@ class ilOrgUnitSimpleUserImport extends ilOrgUnitImporter
         } elseif ($role === 'superior') {
             $position_id =  ilOrgUnitPosition::CORE_POSITION_SUPERIOR;
         } else {
-            $this->addError('not_a_valid_role', $user_id);
-
-            return;
+            //if passed a custom position.
+            $position = ilOrgUnitPosition::where(['title' => $role])->first();
+            if ($position instanceof ilOrgUnitPosition) {
+                $position_id = $position->getId();
+            } else {
+                $this->addError('not_a_valid_role', $user_id);
+                return;
+            }
         }
 
         if ($action == 'add') {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=32454


* Allows custom positions to be imported.

Noticed that you could not import custom positioned users using the XML import, Unsure if this is the proper procedure or there should be a lookup in ilOrgUnitPosition to lookup by title but this is tested working on my development site.

* Update class.ilOrgUnitSimpleUserImport.php