### PR TITLE
[FIX] #32961: Input\File now uses default file-size and can render ex…

### DIFF
--- a/Modules/IndividualAssessment/test/Settings/ilIndividualAssessmentInfoSettingsTest.php
+++ b/Modules/IndividualAssessment/test/Settings/ilIndividualAssessmentInfoSettingsTest.php
@@ -1,6 +1,19 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
 
 use PHPUnit\Framework\TestCase;
 use ILIAS\UI\Component\Input\Field\Section;

--- a/Modules/IndividualAssessment/test/Settings/ilIndividualAssessmentInfoSettingsTest.php
+++ b/Modules/IndividualAssessment/test/Settings/ilIndividualAssessmentInfoSettingsTest.php
@@ -53,6 +53,7 @@ class ilIndividualAssessmentInfoSettingsTest extends TestCase
         $df = new ILIAS\Data\Factory();
         $refinery = new ILIAS\Refinery\Factory($df, $lng);
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
             $refinery,

--- a/Modules/IndividualAssessment/test/Settings/ilIndividualAssessmentSettingsTest.php
+++ b/Modules/IndividualAssessment/test/Settings/ilIndividualAssessmentSettingsTest.php
@@ -49,6 +49,7 @@ class ilIndividualAssessmentSettingsTest extends TestCase
         $df = new ILIAS\Data\Factory();
         $refinery = new ILIAS\Refinery\Factory($df, $lng);
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
             $refinery,

--- a/Modules/IndividualAssessment/test/Settings/ilIndividualAssessmentSettingsTest.php
+++ b/Modules/IndividualAssessment/test/Settings/ilIndividualAssessmentSettingsTest.php
@@ -1,6 +1,19 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 2021 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
 
 use PHPUnit\Framework\TestCase;
 use ILIAS\UI\Component\Input\Field\Section;

--- a/Modules/IndividualAssessment/test/ilIndividualAssessmentUserGradingTest.php
+++ b/Modules/IndividualAssessment/test/ilIndividualAssessmentUserGradingTest.php
@@ -1,5 +1,20 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
 use PHPUnit\Framework\TestCase;
 use ILIAS\UI\Component\Input\Field\Section;
 use ILIAS\FileUpload\Handler\AbstractCtrlAwareUploadHandler;

--- a/Modules/IndividualAssessment/test/ilIndividualAssessmentUserGradingTest.php
+++ b/Modules/IndividualAssessment/test/ilIndividualAssessmentUserGradingTest.php
@@ -110,6 +110,7 @@ class ilIndividualAssessmentUserGradingTest extends TestCase
         $df = new ILIAS\Data\Factory();
         $refinery = new ILIAS\Refinery\Factory($df, $lng);
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
             $refinery,

--- a/Modules/StudyProgramme/test/ilStudyProgrammeAssessmentSettingsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeAssessmentSettingsTest.php
@@ -119,6 +119,7 @@ class ilStudyProgrammeAssessmentSettingsTest extends TestCase
         $refinery = new ILIAS\Refinery\Factory($df, $lng);
 
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
             $refinery,

--- a/Modules/StudyProgramme/test/ilStudyProgrammeAutoMailSettingsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeAutoMailSettingsTest.php
@@ -193,6 +193,7 @@ class ilStudyProgrammeAutoMailSettingsTest extends TestCase
         $refinery = new ILIAS\Refinery\Factory($df, $lng);
 
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
             $refinery,

--- a/Modules/StudyProgramme/test/ilStudyProgrammeDeadlineSettingsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeDeadlineSettingsTest.php
@@ -86,6 +86,7 @@ class ilStudyProgrammeDeadlineSettingsTest extends TestCase
         $refinery = new ILIAS\Refinery\Factory($df, $lng);
 
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
             $refinery,

--- a/Modules/StudyProgramme/test/ilStudyProgrammeTypeSettingsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeTypeSettingsTest.php
@@ -47,6 +47,7 @@ class ilStudyProgrammeTypeSettingsTest extends TestCase
         $refinery = new ILIAS\Refinery\Factory($df, $lng);
 
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
             $refinery,

--- a/Modules/StudyProgramme/test/ilStudyProgrammeValidityOfAchievedQualificationSettingsTest.php
+++ b/Modules/StudyProgramme/test/ilStudyProgrammeValidityOfAchievedQualificationSettingsTest.php
@@ -139,6 +139,7 @@ class ilStudyProgrammeValidityOfAchievedQualificationSettingsTest extends TestCa
         $refinery = new ILIAS\Refinery\Factory($df, $lng);
 
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
             $refinery,

--- a/Modules/StudyProgramme/test/types/ilStudyProgrammeTypeInfoTest.php
+++ b/Modules/StudyProgramme/test/types/ilStudyProgrammeTypeInfoTest.php
@@ -124,6 +124,7 @@ class ilStudyProgrammeTypeInfoTest extends TestCase
         $refinery = new ILIAS\Refinery\Factory($df, $lng);
 
         $f = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new ILIAS\UI\Implementation\Component\SignalGenerator(),
             $df,
             $refinery,

--- a/Services/Init/classes/Dependencies/InitUIFramework.php
+++ b/Services/Init/classes/Dependencies/InitUIFramework.php
@@ -37,6 +37,11 @@ class InitUIFramework
                 $c["ui.factory.legacy"]
             );
         };
+        $c["ui.upload_limit_resolver"] = function ($c) {
+            return new \ILIAS\UI\Implementation\Component\Input\UploadLimitResolver(
+                (int) \ilFileUtils::getUploadSizeLimitBytes()
+            );
+        };
         $c["ui.signal_generator"] = function ($c) {
             return new ILIAS\UI\Implementation\Component\SignalGenerator();
         };
@@ -155,6 +160,7 @@ class InitUIFramework
             $refinery = new ILIAS\Refinery\Factory($data_factory, $c["lng"]);
 
             return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+                $c["ui.upload_limit_resolver"],
                 $c["ui.signal_generator"],
                 $data_factory,
                 $refinery,
@@ -187,6 +193,7 @@ class InitUIFramework
         };
         $c["ui.factory.dropzone.file"] = function ($c) {
             return new ILIAS\UI\Implementation\Component\Dropzone\File\Factory(
+                $c["ui.upload_limit_resolver"],
                 $c["ui.factory.input"],
                 $c["lng"]
             );

--- a/Services/Init/classes/Dependencies/InitUIFramework.php
+++ b/Services/Init/classes/Dependencies/InitUIFramework.php
@@ -1,6 +1,21 @@
 <?php
 
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+/**
  * Responsible for loading the UI Framework into the dependency injection container of ILIAS
  */
 class InitUIFramework

--- a/src/UI/Implementation/Component/Dropzone/File/Factory.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Factory.php
@@ -18,6 +18,7 @@
  
 namespace ILIAS\UI\Implementation\Component\Dropzone\File;
 
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 use ILIAS\UI\Component\Dropzone\File\Standard as StandardInterface;
 use ILIAS\UI\Component\Dropzone\File\Wrapper as WrapperInterface;
 use ILIAS\UI\Component\Dropzone\File\Factory as FactoryInterface;
@@ -31,11 +32,16 @@ use ilLanguage;
  */
 class Factory implements FactoryInterface
 {
+    protected UploadLimitResolver $upload_limit_resolver;
     protected InputFactory $factory;
     protected ilLanguage $language;
 
-    public function __construct(InputFactory $factory, ilLanguage $language)
-    {
+    public function __construct(
+        UploadLimitResolver $upload_limit_resolver,
+        InputFactory $factory,
+        ilLanguage $language
+    ) {
+        $this->upload_limit_resolver = $upload_limit_resolver;
         $this->factory = $factory;
         $this->language = $language;
     }
@@ -48,6 +54,7 @@ class Factory implements FactoryInterface
         return new Standard(
             $this->factory,
             $this->language,
+            $this->upload_limit_resolver,
             $upload_handler,
             $post_url,
             $metadata_input
@@ -66,6 +73,7 @@ class Factory implements FactoryInterface
         return new Wrapper(
             $this->factory,
             $this->language,
+            $this->upload_limit_resolver,
             $upload_handler,
             $post_url,
             $content,

--- a/src/UI/Implementation/Component/Dropzone/File/File.php
+++ b/src/UI/Implementation/Component/Dropzone/File/File.php
@@ -65,6 +65,7 @@ abstract class File implements FileInterface
         string $post_url,
         ?Input $metadata_input = null
     ) {
+        $this->max_file_size = $this->getMaxFileSizeDefault();
         $this->input_factory = $input_factory;
         $this->language = $language;
         $this->upload_handler = $upload_handler;

--- a/src/UI/Implementation/Component/Dropzone/File/File.php
+++ b/src/UI/Implementation/Component/Dropzone/File/File.php
@@ -31,6 +31,7 @@ use ILIAS\UI\Component\Signal;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\Refinery\Transformation;
 use ilLanguage;
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
@@ -61,11 +62,12 @@ abstract class File implements FileInterface
     public function __construct(
         InputFactory $input_factory,
         ilLanguage $language,
+        UploadLimitResolver $upload_limit_resolver,
         UploadHandler $upload_handler,
         string $post_url,
         ?Input $metadata_input = null
     ) {
-        $this->max_file_size = $this->getMaxFileSizeDefault();
+        $this->upload_limit_resolver = $upload_limit_resolver;
         $this->input_factory = $input_factory;
         $this->language = $language;
         $this->upload_handler = $upload_handler;

--- a/src/UI/Implementation/Component/Dropzone/File/Wrapper.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Wrapper.php
@@ -18,6 +18,7 @@
  
 namespace ILIAS\UI\Implementation\Component\Dropzone\File;
 
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 use ILIAS\UI\Component\Dropzone\File\Wrapper as WrapperInterface;
 use ILIAS\UI\Component\Input\Factory as InputFactory;
 use ILIAS\UI\Component\Input\Field\UploadHandler;
@@ -43,12 +44,13 @@ class Wrapper extends File implements WrapperInterface
     public function __construct(
         InputFactory $input_factory,
         ilLanguage $language,
+        UploadLimitResolver $upload_limit_resolver,
         UploadHandler $upload_handler,
         string $post_url,
         $content,
         ?Input $metadata_input
     ) {
-        parent::__construct($input_factory, $language, $upload_handler, $post_url, $metadata_input);
+        parent::__construct($input_factory, $language, $upload_limit_resolver, $upload_handler, $post_url, $metadata_input);
 
         $content = $this->toArray($content);
         $this->checkArgListElements('content', $content, [Component::class]);

--- a/src/UI/Implementation/Component/Input/Field/Factory.php
+++ b/src/UI/Implementation/Component/Input/Field/Factory.php
@@ -18,6 +18,7 @@
  
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 use ILIAS\Data;
 use ILIAS\UI\Component\Input\Field\Input;
 use ILIAS\UI\Component\Input\Field;
@@ -32,17 +33,20 @@ use ilLanguage;
  */
 class Factory implements Field\Factory
 {
+    protected UploadLimitResolver $upload_limit_resolver;
     protected Data\Factory $data_factory;
     protected SignalGeneratorInterface $signal_generator;
     private \ILIAS\Refinery\Factory $refinery;
     protected ilLanguage $lng;
 
     public function __construct(
+        UploadLimitResolver $upload_limit_resolver,
         SignalGeneratorInterface $signal_generator,
         Data\Factory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
         ilLanguage $lng
     ) {
+        $this->upload_limit_resolver = $upload_limit_resolver;
         $this->signal_generator = $signal_generator;
         $this->data_factory = $data_factory;
         $this->refinery = $refinery;
@@ -178,7 +182,7 @@ class Factory implements Field\Factory
         string $byline = null,
         Input $metadata_input = null
     ) : Field\File {
-        return new File($this->lng, $this->data_factory, $this->refinery, $handler, $label, $metadata_input, $byline);
+        return new File($this->lng, $this->data_factory, $this->refinery, $this->upload_limit_resolver, $handler, $label, $metadata_input, $byline);
     }
 
     /**

--- a/src/UI/Implementation/Component/Input/Field/File.php
+++ b/src/UI/Implementation/Component/Input/Field/File.php
@@ -25,6 +25,7 @@ use ILIAS\UI\Component as C;
 use ILIAS\Refinery\Constraint;
 use Closure;
 use ilLanguage;
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
  * Class File
@@ -44,12 +45,13 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
         ilLanguage $language,
         DataFactory $data_factory,
         Refinery $refinery,
+        UploadLimitResolver $upload_limit_resolver,
         C\Input\Field\UploadHandler $handler,
         string $label,
         ?InputInterface $metadata_input,
         ?string $byline
     ) {
-        $this->max_file_size = $this->getMaxFileSizeDefault();
+        $this->upload_limit_resolver = $upload_limit_resolver;
         $this->language = $language;
         $this->data_factory = $data_factory;
         $this->refinery = $refinery;

--- a/src/UI/Implementation/Component/Input/Field/File.php
+++ b/src/UI/Implementation/Component/Input/Field/File.php
@@ -15,7 +15,7 @@
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
- 
+
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\UI\Component\Input\Field\Input as InputInterface;
@@ -49,6 +49,7 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
         ?InputInterface $metadata_input,
         ?string $byline
     ) {
+        $this->max_file_size = $this->getMaxFileSizeDefault();
         $this->language = $language;
         $this->data_factory = $data_factory;
         $this->refinery = $refinery;

--- a/src/UI/Implementation/Component/Input/Field/FileUploadHelper.php
+++ b/src/UI/Implementation/Component/Input/Field/FileUploadHelper.php
@@ -30,7 +30,11 @@ trait FileUploadHelper
     protected array $accepted_mime_types = [];
     protected bool $has_metadata_inputs = false;
     protected int $max_file_amount = 1;
-    protected int $max_file_size = 2048;
+
+    /**
+     * @var int MUST be set manually because the file-size has to be gathered programatically.
+     */
+    protected int $max_file_size;
 
     public function getUploadHandler() : UploadHandler
     {
@@ -39,6 +43,10 @@ trait FileUploadHelper
 
     public function withMaxFileSize(int $size_in_bytes) : FileUpload
     {
+        if ($size_in_bytes > $this->getMaxFileSizeDefault()) {
+            throw new \InvalidArgumentException("Given file-size exceeds the limit of {$this->getMaxFileSizeDefault()} bytes.");
+        }
+
         $clone = clone $this;
         $clone->max_file_size = $size_in_bytes;
 
@@ -74,5 +82,10 @@ trait FileUploadHelper
     public function getAcceptedMimeTypes() : array
     {
         return $this->accepted_mime_types;
+    }
+
+    protected function getMaxFileSizeDefault() : int
+    {
+        return (int) \ilFileUtils::getUploadSizeLimitBytes();
     }
 }

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -670,7 +670,8 @@ class Renderer extends AbstractComponentRenderer
         foreach ($input->getDynamicInputs() as $metadata_input) {
             $file_info = null;
             if (null !== ($data = $metadata_input->getValue())) {
-                $file_id = $data[$input->getUploadHandler()->getFileIdentifierParameterName()] ?? null;
+                $file_id = (!$input->hasMetadataInputs()) ?
+                    $data : $data[$input->getUploadHandler()->getFileIdentifierParameterName()] ?? null;
 
                 if (null !== $file_id) {
                     $file_info = $input->getUploadHandler()->getInfoResult($file_id);

--- a/src/UI/Implementation/Component/Input/UploadLimitResolver.php
+++ b/src/UI/Implementation/Component/Input/UploadLimitResolver.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\UI\Implementation\Component\Input;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class UploadLimitResolver
+{
+    protected int $default_upload_size_limit;
+
+    public function __construct(int $default_upload_size_limit)
+    {
+        $this->default_upload_size_limit = $default_upload_size_limit;
+    }
+
+    public function checkUploadLimit(int $size_in_bytes) : void
+    {
+        if ($size_in_bytes > $this->default_upload_size_limit) {
+            throw new \InvalidArgumentException("File size exceeds $this->default_upload_size_limit bytest.");
+        }
+    }
+
+    public function getUploadLimit() : int
+    {
+        return $this->default_upload_size_limit;
+    }
+}

--- a/tests/UI/Component/Dropzone/File/FileTest.php
+++ b/tests/UI/Component/Dropzone/File/FileTest.php
@@ -15,7 +15,7 @@
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
- 
+
 namespace ILIAS\Tests\UI\Component\Dropzone\File;
 
 use ILIAS\UI\Implementation\Component\Dropzone\File\File;
@@ -29,7 +29,7 @@ class FileTest extends FileTestBase
 
     public function setUp() : void
     {
-        $this->dropzone = new class($this->getInputFactory(), $this->getLanguage(), $this->getUploadHandlerMock(), self::FILE_DROPZONE_POST_URL) extends File {
+        $this->dropzone = new class($this->getInputFactory(), $this->getLanguage(), $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class), $this->getUploadHandlerMock(), self::FILE_DROPZONE_POST_URL) extends File {
         };
 
         parent::setUp();
@@ -71,7 +71,7 @@ class FileTest extends FileTestBase
 
     public function testFormGenerationWithMetadataFields() : void
     {
-        $dropzone_form = (new class($this->getInputFactory(), $this->getLanguage(), $this->getUploadHandlerMock(), self::FILE_DROPZONE_POST_URL, $this->getFieldFactory()->text('test_input_1')) extends File {
+        $dropzone_form = (new class($this->getInputFactory(), $this->getLanguage(), $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class), $this->getUploadHandlerMock(), self::FILE_DROPZONE_POST_URL, $this->getFieldFactory()->text('test_input_1')) extends File {
         })->getForm();
 
         $this->assertEquals(self::FILE_DROPZONE_POST_URL, $dropzone_form->getPostURL());

--- a/tests/UI/Component/Dropzone/File/FileTestBase.php
+++ b/tests/UI/Component/Dropzone/File/FileTestBase.php
@@ -44,6 +44,7 @@ abstract class FileTestBase extends ILIAS_UI_TestBase
 
         $this->generator = new IncrementalSignalGenerator();
         $this->factory = new I\Component\Dropzone\File\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             $this->getInputFactory(),
             $this->getLanguage()
         );
@@ -139,8 +140,7 @@ abstract class FileTestBase extends ILIAS_UI_TestBase
             $this->getFieldFactory(),
             new I\Component\Input\Container\Factory(
                 new I\Component\Input\Container\Form\Factory(
-                    $this->getFieldFactory(),
-                    $this->getIncrementalNameSource()
+                    $this->getFieldFactory()
                 ),
                 $this->createMock(I\Component\Input\Container\Filter\Factory::class),
                 $this->createMock(I\Component\Input\Container\ViewControl\Factory::class)
@@ -152,6 +152,7 @@ abstract class FileTestBase extends ILIAS_UI_TestBase
     protected function getFieldFactory() : C\Input\Field\Factory
     {
         return new I\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             $this->generator,
             $this->createMock(\ILIAS\Data\Factory::class),
             $this->getRefinery(),

--- a/tests/UI/Component/Input/Container/Filter/FilterFactoryTest.php
+++ b/tests/UI/Component/Input/Container/Filter/FilterFactoryTest.php
@@ -41,6 +41,7 @@ class FilterFactoryTest extends AbstractFactoryTest
         return new Factory(
             new SignalGenerator(),
             new \ILIAS\UI\Implementation\Component\Input\Field\Factory(
+                $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
                 new SignalGenerator(),
                 $df,
                 new ILIAS\Refinery\Factory($df, $language),

--- a/tests/UI/Component/Input/Container/Filter/FilterTest.php
+++ b/tests/UI/Component/Input/Container/Filter/FilterTest.php
@@ -126,6 +126,7 @@ class FilterTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new ILIAS\Refinery\Factory($df, $language),

--- a/tests/UI/Component/Input/Container/Filter/StandardFilterTest.php
+++ b/tests/UI/Component/Input/Container/Filter/StandardFilterTest.php
@@ -90,6 +90,7 @@ class StandardFilterTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new I\SignalGenerator(),
             $df,
             new ILIAS\Refinery\Factory($df, $language),

--- a/tests/UI/Component/Input/Container/Form/FormFactoryTest.php
+++ b/tests/UI/Component/Input/Container/Form/FormFactoryTest.php
@@ -40,6 +40,7 @@ class FormFactoryTest extends AbstractFactoryTest
         $language = $this->createMock(ilLanguage::class);
         return new I\Container\Form\Factory(
             new I\Field\Factory(
+                $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
                 new SignalGenerator(),
                 $df,
                 new Factory($df, $language),

--- a/tests/UI/Component/Input/Container/Form/FormTest.php
+++ b/tests/UI/Component/Input/Container/Form/FormTest.php
@@ -98,6 +98,7 @@ class FormTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $this->language = $this->createMock(ilLanguage::class);
         return new Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $this->language),

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -71,6 +71,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new \ILIAS\Refinery\Factory($df, $language),
@@ -228,6 +229,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $refinery = new \ILIAS\Refinery\Factory($df, $language);
 
         $if = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             $refinery,
@@ -288,6 +290,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $refinery = new \ILIAS\Refinery\Factory($df, $language);
 
         $if = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             $refinery,

--- a/tests/UI/Component/Input/Field/CheckboxInputTest.php
+++ b/tests/UI/Component/Input/Field/CheckboxInputTest.php
@@ -43,6 +43,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/DateTimeInputTest.php
+++ b/tests/UI/Component/Input/Field/DateTimeInputTest.php
@@ -69,6 +69,7 @@ class DateTimeInputTest extends ILIAS_UI_TestBase
         $language = $this->createMock(ilLanguage::class);
 
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $this->data_factory,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/DurationInputTest.php
+++ b/tests/UI/Component/Input/Field/DurationInputTest.php
@@ -57,6 +57,7 @@ class DurationInputTest extends ILIAS_UI_TestBase
     protected function buildFactory() : I\Input\Field\Factory
     {
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $this->data_factory,
             $this->buildRefinery(),

--- a/tests/UI/Component/Input/Field/FieldFactoryTest.php
+++ b/tests/UI/Component/Input/Field/FieldFactoryTest.php
@@ -70,6 +70,7 @@ class FieldFactoryTest extends AbstractFactoryTest
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/FileInputTest.php
+++ b/tests/UI/Component/Input/Field/FileInputTest.php
@@ -74,6 +74,7 @@ class FileInputTest extends ILIAS_UI_TestBase
         $language = $this->createMock(ilLanguage::class);
 
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new ILIAS\Refinery\Factory($df, $language),

--- a/tests/UI/Component/Input/Field/GroupInputTest.php
+++ b/tests/UI/Component/Input/Field/GroupInputTest.php
@@ -364,6 +364,7 @@ class GroupInputTest extends ILIAS_UI_TestBase
     public function getFieldFactory() : Field\Factory
     {
         return new Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new IncrementalSignalGenerator(),
             new Data\Factory(),
             $this->getRefinery(),

--- a/tests/UI/Component/Input/Field/LinkInputTest.php
+++ b/tests/UI/Component/Input/Field/LinkInputTest.php
@@ -42,6 +42,7 @@ class LinkInputTest extends ILIAS_UI_TestBase
             ->will($this->returnArgument(0));
 
         return new Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $data_factory,
             new ILIAS\Refinery\Factory($data_factory, $language),

--- a/tests/UI/Component/Input/Field/MultiSelectInputTest.php
+++ b/tests/UI/Component/Input/Field/MultiSelectInputTest.php
@@ -41,6 +41,7 @@ class MultiSelectInputTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/NumericInputTest.php
+++ b/tests/UI/Component/Input/Field/NumericInputTest.php
@@ -40,6 +40,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->getLanguage();
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/PasswordInputTest.php
+++ b/tests/UI/Component/Input/Field/PasswordInputTest.php
@@ -61,6 +61,7 @@ class PasswordInputTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/RadioInputTest.php
+++ b/tests/UI/Component/Input/Field/RadioInputTest.php
@@ -39,6 +39,7 @@ class RadioInputTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(\ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/SectionInputTest.php
+++ b/tests/UI/Component/Input/Field/SectionInputTest.php
@@ -27,6 +27,7 @@ class SectionInputTest extends ILIAS_UI_TestBase
     public function getFieldFactory() : Field\Factory
     {
         $factory = new Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new IncrementalSignalGenerator(),
             new Data\Factory(),
             $this->getRefinery(),

--- a/tests/UI/Component/Input/Field/SelectTest.php
+++ b/tests/UI/Component/Input/Field/SelectTest.php
@@ -45,6 +45,7 @@ class SelectInputTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
@@ -102,6 +102,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
     protected function buildFactory() : I\Input\Field\Factory
     {
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $this->data_factory,
             $this->refinery,

--- a/tests/UI/Component/Input/Field/TagInputTest.php
+++ b/tests/UI/Component/Input/Field/TagInputTest.php
@@ -44,6 +44,7 @@ class TagInputTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/TextInputTest.php
+++ b/tests/UI/Component/Input/Field/TextInputTest.php
@@ -40,6 +40,7 @@ class TextInputTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/TextareaTest.php
+++ b/tests/UI/Component/Input/Field/TextareaTest.php
@@ -40,6 +40,7 @@ class TextareaTest extends ILIAS_UI_TestBase
         $df = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
             new Refinery($df, $language),

--- a/tests/UI/Component/Input/Field/UrlInputTest.php
+++ b/tests/UI/Component/Input/Field/UrlInputTest.php
@@ -40,6 +40,7 @@ class UrlInputTest extends ILIAS_UI_TestBase
         $data_factory = new Data\Factory();
         $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
             $data_factory,
             new Refinery($data_factory, $language),


### PR DESCRIPTION
Hi @Amstutz and @klees!

I have fixed an Issue in the ui-file-input I recently refactored, also see https://mantis.ilias.de/view.php?id=32961.

One thing I'm not quite fond of is the change to the `FileUploadHelper` trait, whose property $max_file_size must be set in the constructor programatically. Because the trait is used in both, inputs and dropzones, I cannot implement the constructor in the trait. Should I move the property completely out of the trait or is the current attempt readable enough?

Thanks for your opinion, best regards!