### PR TITLE
bugfix: change datatypes for metrics 'port' and 'weight'

### DIFF
--- a/Services/GlobalCache/classes/Setup/class.ilGlobalCacheMetricsCollectedObjective.php
+++ b/Services/GlobalCache/classes/Setup/class.ilGlobalCacheMetricsCollectedObjective.php
@@ -79,12 +79,12 @@ class ilGlobalCacheMetricsCollectedObjective extends Setup\Metrics\CollectedObje
                 );
                 $port = new Setup\Metrics\Metric(
                     Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
+                    Setup\Metrics\Metric::TYPE_GAUGE,
                     $server->getPort()
                 );
                 $weight = new Setup\Metrics\Metric(
                     Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
+                    Setup\Metrics\Metric::TYPE_GAUGE,
                     $server->getWeight()
                 );
 


### PR DESCRIPTION
For cachetype 'memcache' the data types for the metrics 'port' and 'weight' must be TYPE_GAUGE not TYPE_TEXT,
otherwise a 'Failed Precondition Exception' is raised for command 'status':

$  sudo -u www-data php setup/cli.php status
In ObjectiveIterator.php line 139:

  Objective had failed preconditions.