### PR TITLE
Dashboard Administration: Save form without write right

### DIFF
--- a/Services/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php
+++ b/Services/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\UI\Component\Input\Field\FormInput;
+
 /**
  * Dashboard settings
  *
@@ -172,7 +174,6 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
 
         $side_panel = $this->side_panel_settings;
 
-
         $fields["enable_favourites"] = $f->input()->field()->checkbox($lng->txt("dash_enable_favourites"))
             ->withValue($this->viewSettings->enabledSelectedItems());
         $info_text = ($this->viewSettings->enabledMemberships())
@@ -188,7 +189,7 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
             ->withValue($this->viewSettings->enabledMemberships());
 
         // main panel
-        $section1 = $f->input()->field()->section($fields, $lng->txt("dash_main_panel"));
+        $section1 = $f->input()->field()->section($this->maybeDisable($fields), $lng->txt("dash_main_panel"));
 
         $sp_fields = [];
         foreach ($side_panel->getValidModules() as $mod) {
@@ -197,7 +198,7 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
         }
 
         // side panel
-        $section2 = $f->input()->field()->section($sp_fields, $lng->txt("dash_side_panel"));
+        $section2 = $f->input()->field()->section($this->maybeDisable($sp_fields), $lng->txt("dash_side_panel"));
 
         $form_action = $ctrl->getLinkTarget($this, "saveSettings");
         return $f->input()->container()->form()->standard(
@@ -215,7 +216,8 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
         $ilAccess = $this->access;
         $side_panel = $this->side_panel_settings;
         
-        if (!$ilAccess->checkAccess('write', '', $this->object->getRefId())) {
+        if (!$this->canWrite()) {
+            ilUtil::sendFailure($this->lng->txt('no_permission'), true);
             $ilCtrl->redirect($this, "editSettings");
         }
 
@@ -325,7 +327,7 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
             ->withOption('tile', $lng->txt("dash_tile"));
         $default_pres = $default_pres->withValue((string) $this->viewSettings->getDefaultPresentationByView($view));
         $sec_presentation = $ui_factory->input()->field()->section(
-            ["avail_pres" => $avail_pres, "default_pres" => $default_pres],
+            $this->maybeDisable(["avail_pres" => $avail_pres, "default_pres" => $default_pres]),
             $lng->txt("dash_presentation")
         );
 
@@ -342,7 +344,7 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
         }
         $default_sort = $default_sort->withValue((string) $this->viewSettings->getDefaultSortingByView($view));
         $sec_sortation = $ui_factory->input()->field()->section(
-            ["avail_sort" => $avail_sort, "default_sort" => $default_sort],
+            $this->maybeDisable(["avail_sort" => $avail_sort, "default_sort" => $default_sort]),
             $lng->txt("dash_sortation")
         );
 
@@ -405,6 +407,11 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
         $lng = $this->lng;
         $ctrl = $this->ctrl;
 
+        if (!$this->canWrite()) {
+            ilUtil::sendFailure($this->lng->txt('no_permission'), true);
+            $ctrl->redirect($this, $redirect_cmd);
+        }
+
         $form = $this->getViewSettingsForm($view);
         $form = $form->withRequest($request);
         $form_data = $form->getData();
@@ -421,5 +428,25 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
 
         ilUtil::sendSuccess($lng->txt("msg_obj_modified"), true);
         $ctrl->redirect($this, $redirect_cmd);
+    }
+
+    /**
+     * @param FormInput[] $fields
+     * @return FormInput[]
+     */
+    private function maybeDisable(array $fields) : array
+    {
+        if ($this->canWrite()) {
+            return $fields;
+        }
+
+        return array_map(static function (FormInput $field) : FormInput {
+            return $field->withDisabled(true);
+        }, $fields);
+    }
+
+    private function canWrite() : bool
+    {
+        return $this->rbacsystem->checkAccess('write', $this->object->getRefId());
     }
 }


### PR DESCRIPTION
Mantis Bug: https://mantis.ilias.de/view.php?id=29592
When the user has visible and read rights but no write rights for the dashboard administration:
- all form fields will be disabled.
- an error message is shown when the user is trying to save the forms.