### PR TITLE
bugfix: $controls MUST not be NULL when calling ldap_search()

### DIFF
--- a/Services/LDAP/classes/class.ilLDAPQuery.php
+++ b/Services/LDAP/classes/class.ilLDAPQuery.php
@@ -511,7 +511,7 @@ class ilLDAPQuery
      * @param array|null $controls LDAP Control to be passed on the the ldap functions
      * @return resource|null
      */
-    private function queryByScope(int $a_scope, string $a_base_dn, string $a_filter, array $a_attributes, array $controls = null)
+    private function queryByScope(int $a_scope, string $a_base_dn, string $a_filter, array $a_attributes, array $controls = [])
     {
         $a_filter = $a_filter ?: "(objectclass=*)";
 


### PR DESCRIPTION
otherwise a TypeError Exception is raised:

TypeError thrown with message "ldap_search() expects parameter 9 to be array, null given"

Stacktrace:
#10 TypeError in /.../Services/LDAP/classes/class.ilLDAPQuery.php:520
#9 ldap_search in /.../Services/LDAP/classes/class.ilLDAPQuery.php:520
#8 ilLDAPQuery:queryByScope in /.../Services/LDAP/classes/class.ilLDAPQuery.php:474
#7 ilLDAPQuery:readUserData in /.../Services/LDAP/classes/class.ilLDAPQuery.php:87
#6 ilLDAPQuery:fetchUser in /.../Services/LDAP/classes/class.ilAuthProviderLDAP.php:58