### PR TITLE
bugfix: passed 'rule_id' MUST be of type int

### DIFF
--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentRules.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentRules.php
@@ -100,7 +100,7 @@ class ilLDAPRoleAssignmentRules
         $res = $ilDB->query($query);
         $roles = [];
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $rule = ilLDAPRoleAssignmentRule::_getInstanceByRuleId($row->rule_id);
+            $rule = ilLDAPRoleAssignmentRule::_getInstanceByRuleId((int) $row->rule_id);
 
             $matches = $rule->matches($a_usr_data);
             if ($matches && $row->add_on_update) {


### PR DESCRIPTION
otherwise a TypeError Exception is raised:

TypeError thrown with message "Argument 1 passed to ilLDAPRoleAssignmentRule::_getInstanceByRuleId() must be of the type int, string given, called in /.../Services/LDAP/classes/class.ilLDAPRoleAssignmentRules.php on line 103"

Stacktrace:
#14 TypeError in /.../Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php:62
#13 ilLDAPRoleAssignmentRule:_getInstanceByRuleId in /.../Services/LDAP/classes/class.ilLDAPRoleAssignmentRules.php:103
#12 ilLDAPRoleAssignmentRules:getAssignmentsForUpdate in /.../Services/LDAP/classes/class.ilLDAPAttributeToUser.php:140