### PR TITLE
bugfix: the Language to be set MUST not be NULL

### DIFF
--- a/Services/User/classes/class.ilUserImportParser.php
+++ b/Services/User/classes/class.ilUserImportParser.php
@@ -464,7 +464,7 @@ class ilUserImportParser extends ilSaxParser
                     $ilias->ini->readVariable("layout", "style")
                 );
 
-                $this->userObj->setLanguage($a_attribs["Language"]);
+                $this->userObj->setLanguage($a_attribs["Language"] ?? '');
                 $this->userObj->setImportId($a_attribs["Id"]);
                 $this->action = (is_null($a_attribs["Action"])) ? "Insert" : $a_attribs["Action"];
                 $this->currPassword = null;


### PR DESCRIPTION
otherwise a TypeError Exception is raised:

TypeError thrown with message "Argument 1 passed to ilObjUser::setLanguage() must be of the type string, null given, called in /.../Services/User/classes/class.ilUserImportParser.php on line 467"

Stacktrace:
#16 TypeError in /.../Services/User/classes/class.ilObjUser.php:1479
#15 ilObjUser:setLanguage in /.../Services/User/classes/class.ilUserImportParser.php:467
#14 ilUserImportParser:importBeginTag in /.../Services/User/classes/class.ilUserImportParser.php:364
#13 ilUserImportParser:handlerBeginTag in [internal]:0