### PR TITLE
Streamline Questions-Tab in Test

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -968,7 +968,7 @@ class ilObjTestGUI extends ilObjectGUI
     {
         switch ($this->object->getQuestionSetType()) {
             case ilObjTest::QUESTION_SET_TYPE_FIXED:
-                $this->ctrl->redirectByClass('ilTestExpressPageObjectGUI', 'showPage');
+                $this->ctrl->redirectByClass('ilObjTestGUI', 'questions');
 
                 // no break
             case ilObjTest::QUESTION_SET_TYPE_RANDOM:


### PR DESCRIPTION
The 'editQuestions'-Link in the repository still led to the old questions-page. This makes it correctly point to the questions-tab.