### PR TITLE
Readd Missing Function and Streamline Questions-Tab in Trunk

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -897,6 +897,15 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
         throw new ilTestException('question id does not relate to parent object!');
     }
+    
+    private function questionsTabGatewayObject()
+    {
+        if ($this->object->isRandomTest()) {
+            $this->ctrl->redirectByClass('ilTestRandomQuestionSetConfigGUI');
+        }
+        
+        $this->ctrl->redirectByClass('ilObjTestGUI', 'questions');
+    }
 
     private function userResultsGatewayObject()
     {


### PR DESCRIPTION
I think (I didn't investigate), I removed a function too many, when removing the dynamic test. Additional this streamlines the access to the question-tab from the repository.