### PR TITLE
Remove permanent link input field of footer

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -5156,6 +5156,7 @@ common#:#pdfg_visible#:#PDF-Erstellungs ist sichtbar.
 common#:#pdfg_write#:#Einstellungen der PDF-Erstellung bearbeiten
 common#:#pd_items_news#:#Einschließlich Neuigkeiten der ausgewählten Objekte
 common#:#perma_link#:#Link zu dieser Seite
+common#:#copy_perma_link#:#Link zu dieser Seite kopieren
 common#:#permission_denied#:#Kein Zugriffsrecht
 common#:#permission#:#Recht
 common#:#permission_settings#:#Rechteeinstellungen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5136,6 +5136,7 @@ common#:#pdfg_visible#:#PDF Generation is visible
 common#:#pdfg_write#:#User can edit settings of PDF Generation
 common#:#pd_items_news#:#Include News of Personal Items
 common#:#perma_link#:#Permanent Link
+common#:#copy_perma_link#:#Copy Permanent Link
 common#:#permission_denied#:#Permission Denied
 common#:#permission#:#Permission
 common#:#permission_settings#:#Object Permission Settings

--- a/src/UI/templates/default/MainControls/tpl.footer.html
+++ b/src/UI/templates/default/MainControls/tpl.footer.html
@@ -3,8 +3,7 @@
 
 		<!-- BEGIN footer_perm_url -->
 		<div class="il-footer-permanent-url">
-			<label for="current_perma_link">{PERMA_LINK_LABEL}</label>
-			<input id="current_perma_link" type="text" value="{PERMANENT_URL}" readonly="readOnly">
+                    {PERMANENT}
 		</div>
 		<!-- END footer_perm_url -->
 

--- a/src/UI/templates/js/MainControls/footer.js
+++ b/src/UI/templates/js/MainControls/footer.js
@@ -1,9 +1,0 @@
-$(document).ready(function() {
-	$('.il-maincontrols-footer .il-footer-content .il-footer-permanent-url').click(
-		function() {
-			document.getElementById('current_perma_link').select();
-			document.execCommand('copy');
-			return false;
-		}
-	);
-});

--- a/tests/UI/Component/MainControls/FooterTest.php
+++ b/tests/UI/Component/MainControls/FooterTest.php
@@ -150,6 +150,11 @@ class FooterTest extends ILIAS_UI_TestBase
             {
                 return new I\Listing\Factory();
             }
+
+            public function button() :  C\Button\Factory
+            {
+                return new I\Button\Factory();
+            }
         };
     }
 
@@ -219,7 +224,7 @@ EOT;
         $expected = <<<EOT
         <div class="il-maincontrols-footer">
             <div class="il-footer-content">
-                <div class="il-footer-permanent-url"><label for="current_perma_link">perma_link</label><input id="current_perma_link" type="text" value="http://www.ilias.de/goto.php?target=xxx_123" readonly="readOnly">
+                <div class="il-footer-permanent-url"><button class="btn btn-link" data-action="http://www.ilias.de/goto.php?target=xxx_123" id="id_1">copy_perma_link</button>
                 </div>
 
                 <div class="il-footer-text">footer text</div>


### PR DESCRIPTION
This PR removes the input field in the footer with the permanent link to the current page. Instead one can click on the link to copy the permanent link to the clipboard.

Feature wiki: https://docu.ilias.de/goto.php?target=wiki_1357_Remove_the_input_field_of_Permanent_link_in_Footer

This request was originally proposed as a feature but in agreement (of Oliver Samoila) with the UI coordinators (Richard Klees and Timon Amstutz) this should be implemented as a PR.

#### Clipboard API
If the clipboard is not available the default behavior of the anchor is preserved.

#### Focus Highlight
Because the anchor is a normal anchor the highlighting of the link when one focuses the link e.g. with *tab* is the same as with `Legal Notice` and `Accessibility Control Concept` links.