### PR TITLE
Test/TestQPL: Fix dependency on `ilPluginAdmin`

### DIFF
--- a/Modules/LearningModule/classes/class.ilLMPageGUI.php
+++ b/Modules/LearningModule/classes/class.ilLMPageGUI.php
@@ -29,6 +29,7 @@ class ilLMPageGUI extends ilPageObjectGUI
 {
     protected ilDBInterface $db;
     protected PresentationGUIRequest $pres_request;
+    protected ilComponentRepository $component_repository;
 
     public function __construct(
         int $a_id = 0,
@@ -41,7 +42,8 @@ class ilLMPageGUI extends ilPageObjectGUI
         $this->lng = $DIC->language();
         $this->user = $DIC->user();
         $this->db = $DIC->database();
-        $this->plugin_admin = $DIC["ilPluginAdmin"];
+        $this->component_repository = $DIC['component.repository'];
+
         $this->log = $DIC["ilLog"];
         parent::__construct("lm", $a_id, $a_old_nr, $a_prevent_get_id, $a_lang);
         $this->pres_request = $DIC
@@ -78,7 +80,7 @@ class ilLMPageGUI extends ilPageObjectGUI
         $ilUser = $this->user;
         $ilDB = $this->db;
         $lng = $this->lng;
-        $ilPluginAdmin = $this->plugin_admin;
+        $component_repository = $this->component_repository;
 
         parent::processAnswer();
 
@@ -98,7 +100,7 @@ class ilLMPageGUI extends ilPageObjectGUI
 
             $as = ilPageQuestionProcessor::getAnswerStatus($id, $ilUser->getId());
             // get question information
-            $qlist = new ilAssQuestionList($ilDB, $lng, $ilPluginAdmin);
+            $qlist = new ilAssQuestionList($ilDB, $lng, $component_repository);
             $qlist->setParentObjId(0);
             $qlist->setJoinObjectData(false);
             $qlist->addFieldFilter("question_id", array($id));

--- a/Modules/LearningModule/classes/class.ilLMTracker.php
+++ b/Modules/LearningModule/classes/class.ilLMTracker.php
@@ -32,7 +32,7 @@ class ilLMTracker
 
     protected ilDBInterface $db;
     protected ilLanguage $lng;
-    protected ilPluginAdmin $plugin_admin;
+    protected ilComponentRepository $component_repository;
     protected ilObjUser $user;
     protected int $lm_ref_id;
     protected int $lm_obj_id;
@@ -60,9 +60,9 @@ class ilLMTracker
 
         $this->db = $DIC->database();
         $this->lng = $DIC->language();
-        $this->plugin_admin = $DIC["ilPluginAdmin"];
         $this->user = $DIC->user();
         $this->user_id = $a_user_id;
+        $this->component_repository = $DIC['component.repository'];
 
         if ($a_by_obj_id) {
             $this->lm_ref_id = 0;
@@ -531,7 +531,7 @@ class ilLMTracker
     {
         $ilDB = $this->db;
         $lng = $this->lng;
-        $ilPluginAdmin = $this->plugin_admin;
+        $component_repository = $this->component_repository;
 
         $blocked_users = array();
 
@@ -546,7 +546,7 @@ class ilLMTracker
             $page_for_question[$quest["question_id"]] = $quest["page_id"];
         }
         // get question information
-        $qlist = new ilAssQuestionList($ilDB, $lng, $ilPluginAdmin);
+        $qlist = new ilAssQuestionList($ilDB, $lng, $component_repository);
         $qlist->setParentObjId(0);
         $qlist->setJoinObjectData(false);
         $qlist->addFieldFilter("question_id", $this->all_questions);

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -477,7 +477,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         global $DIC;
         $tree = $DIC['tree'];
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
         $lng = $DIC['lng'];
 
         require_once 'Modules/Test/classes/class.ilTestParticipantData.php';
@@ -497,8 +497,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             array($this->getTestId())
         );
 
-        require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';
-        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $this);
+        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $this);
         $testQuestionSetConfigFactory->getQuestionSetConfig()->removeQuestionSetRelatedData();
 
         // delete export files
@@ -739,13 +738,12 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         global $DIC;
         $tree = $DIC['tree'];
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
-        
+        $component_repository = $DIC['component.repository'];
+
         $test = new ilObjTest($obj_id, false);
         $test->loadFromDb();
 
-        require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';
-        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $test);
+        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $test);
         
         return $test->isComplete($testQuestionSetConfigFactory->getQuestionSetConfig());
     }
@@ -832,15 +830,14 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         global $DIC;
         $tree = $DIC['tree'];
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
         
         // moved online_status to ilObjectActivation (see below)
 
         // cleanup RTE images
         $this->cleanupMediaobjectUsage();
 
-        require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';
-        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $this);
+        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $this);
         $testQuestionSetConfig = $testQuestionSetConfigFactory->getQuestionSetConfig();
         
         include_once("./Modules/Test/classes/class.ilObjAssessmentFolder.php");
@@ -2751,7 +2748,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $testSequenceFactory = new ilTestSequenceFactory(
             $DIC->database(),
             $DIC->language(),
-            $DIC['ilPluginAdmin'],
+            $DIC['component.repository'],
             $this
         );
         
@@ -3471,7 +3468,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $tree = $DIC['tree'];
         $ilDB = $DIC['ilDB'];
         $lng = $DIC['lng'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
 
         $results = $this->getResultsForActiveId($active_id);
         
@@ -3479,17 +3476,14 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             $pass = $results['pass'];
         }
 
-        require_once 'Modules/Test/classes/class.ilTestSessionFactory.php';
         $testSessionFactory = new ilTestSessionFactory($this);
         $testSession = $testSessionFactory->getSession($active_id);
         
-        require_once 'Modules/Test/classes/class.ilTestSequenceFactory.php';
-        $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $ilPluginAdmin, $this);
+        $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $component_repository, $this);
         $testSequence = $testSequenceFactory->getSequenceByActiveIdAndPass($active_id, $pass);
         
         if ($this->isDynamicTest()) {
-            require_once 'Modules/Test/classes/class.ilObjTestDynamicQuestionSetConfig.php';
-            $dynamicQuestionSetConfig = new ilObjTestDynamicQuestionSetConfig($tree, $ilDB, $ilPluginAdmin, $this);
+            $dynamicQuestionSetConfig = new ilObjTestDynamicQuestionSetConfig($tree, $ilDB, $component_repository, $this);
             $dynamicQuestionSetConfig->loadFromDb();
             
             $testSequence->loadFromDb($dynamicQuestionSetConfig);
@@ -4340,13 +4334,13 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     $dynamicQuestionSetConfig = new ilObjTestDynamicQuestionSetConfig(
                         $DIC->repositoryTree(),
                         $DIC->database(),
-                        $DIC['ilPluginAdmin'],
+                        $DIC['component.repository'],
                         $this
                     );
                     $dynamicQuestionSetConfig->loadFromDb();
 
                     require_once 'Modules/Test/classes/class.ilTestSequenceFactory.php';
-                    $testSequenceFactory = new ilTestSequenceFactory($DIC->database(), $DIC->language(), $DIC['ilPluginAdmin'], $this);
+                    $testSequenceFactory = new ilTestSequenceFactory($DIC->database(), $DIC->language(), $DIC['component.repository'], $this);
                     $testSequence = $testSequenceFactory->getSequenceByActiveIdAndPass($active_id, $testpass);
 
                     $testSequence->loadFromDb($dynamicQuestionSetConfig);
@@ -6292,15 +6286,14 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         /**
          * @var $tree          ilTree
          * @var $ilDB          ilDBInterface
-         * @var $ilPluginAdmin ilPluginAdmin
          */
         global $DIC;
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
         $tree = $DIC['tree'];
 
         require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';
-        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $this);
+        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $this);
         $this->saveCompleteStatus($testQuestionSetConfigFactory->getQuestionSetConfig());
         
         if ($this->participantDataExist()) {
@@ -6490,7 +6483,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $certificateLogger = $DIC->logger()->cert();
         $tree = $DIC['tree'];
         $ilDB = $DIC->database();
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
 
         $this->loadFromDb();
 
@@ -6598,7 +6591,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
 
         $cloneAction->cloneCertificate($this, $newObj);
 
-        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $this);
+        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $this);
         $testQuestionSetConfigFactory->getQuestionSetConfig()->cloneQuestionSetRelatedData($newObj);
 
         require_once 'Modules/Test/classes/class.ilTestSkillLevelThresholdList.php';
@@ -6625,12 +6618,12 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             global $DIC;
             $tree = $DIC['tree'];
             $ilDB = $DIC['ilDB'];
-            $ilPluginAdmin = $DIC['ilPluginAdmin'];
+            $component_repository = $DIC['component.repository'];
 
             $questionSetConfig = new ilTestRandomQuestionSetConfig(
                 $tree,
                 $ilDB,
-                $ilPluginAdmin,
+                $component_repository,
                 $this
             );
 
@@ -7581,18 +7574,16 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             $tree = $DIC['tree'];
             $ilDB = $DIC['ilDB'];
             $lng = $DIC['lng'];
-            $ilPluginAdmin = $DIC['ilPluginAdmin'];
+            $component_repository = $DIC['component.repository'];
             
             require_once 'Modules/Test/classes/class.ilTestSessionFactory.php';
             $testSessionFactory = new ilTestSessionFactory($this);
             $testSession = $testSessionFactory->getSession($active_id);
 
-            require_once 'Modules/Test/classes/class.ilTestSequenceFactory.php';
-            $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $ilPluginAdmin, $this);
+            $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $component_repository, $this);
             $testSequence = $testSequenceFactory->getSequenceByTestSession($testSession);
 
-            require_once 'Modules/Test/classes/class.ilObjTestDynamicQuestionSetConfig.php';
-            $dynamicQuestionSetConfig = new ilObjTestDynamicQuestionSetConfig($tree, $ilDB, $ilPluginAdmin, $this);
+            $dynamicQuestionSetConfig = new ilObjTestDynamicQuestionSetConfig($tree, $ilDB, $component_repository, $this);
             $dynamicQuestionSetConfig->loadFromDb();
             
             $testSequence->loadFromDb($dynamicQuestionSetConfig);
@@ -9691,12 +9682,19 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     public function isPluginActive($a_pname) : bool
     {
         global $DIC;
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
-        if ($ilPluginAdmin->isActive(ilComponentInfo::TYPE_MODULES, "TestQuestionPool", "qst", $a_pname)) {
-            return true;
-        } else {
-            return false;
-        }
+        $component_repository = $DIC['component.repository'];
+
+        return $component_repository
+            ->getComponentByTypeAndName(
+                ilComponentInfo::TYPE_MODULES,
+                'TestQuestionPool'
+            )
+            ->getPluginSlotById(
+                'qst'
+            )
+            ->getPluginByName(
+                $a_pname
+            )->isActive();
     }
     
     public function getPassed($active_id)
@@ -10207,10 +10205,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         global $DIC;
         $tree = $DIC['tree'];
         $db = $DIC['ilDB'];
-        $pluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
         
-        require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';
-        $qscFactory = new ilTestQuestionSetConfigFactory($tree, $db, $pluginAdmin, $this);
+        $qscFactory = new ilTestQuestionSetConfigFactory($tree, $db, $component_repository, $this);
         $questionSetConfig = $qscFactory->getQuestionSetConfig();
         
         /* @var ilTestFixedQuestionSetConfig $questionSetConfig */
@@ -11404,7 +11401,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         global $DIC;
         $ilDB = $DIC['ilDB'];
         $lng = $DIC['lng'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
 
         /* @var ilObjTest $testOBJ */
 
@@ -11412,11 +11409,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
 
         $activeId = $testOBJ->getActiveIdOfUser($userId);
 
-        require_once 'Modules/Test/classes/class.ilTestSessionFactory.php';
         $testSessionFactory = new ilTestSessionFactory($testOBJ);
 
-        require_once 'Modules/Test/classes/class.ilTestSequenceFactory.php';
-        $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $ilPluginAdmin, $testOBJ);
+        $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $component_repository, $testOBJ);
 
         $testSession = $testSessionFactory->getSession($activeId);
         $testSequence = $testSequenceFactory->getSequenceByActiveIdAndPass($activeId, $testSession->getPass());
@@ -11438,7 +11433,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         global $DIC;
         $ilDB = $DIC['ilDB'];
         $lng = $DIC['lng'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
 
         /* @var ilObjTest $testOBJ */
 
@@ -11447,13 +11442,11 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         
         $activeId = $testOBJ->getActiveIdOfUser($userId);
         
-        require_once 'Modules/Test/classes/class.ilTestSessionFactory.php';
         $testSessionFactory = new ilTestSessionFactory($testOBJ);
         // Added temporarily bugfix smeyer
         $testSessionFactory->reset();
 
-        require_once 'Modules/Test/classes/class.ilTestSequenceFactory.php';
-        $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $ilPluginAdmin, $testOBJ);
+        $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $component_repository, $testOBJ);
         
         $testSession = $testSessionFactory->getSession($activeId);
         $testSequence = $testSequenceFactory->getSequenceByActiveIdAndPass($activeId, $testSession->getPass());

--- a/Modules/Test/classes/class.ilObjTestDynamicQuestionSetConfigGUI.php
+++ b/Modules/Test/classes/class.ilObjTestDynamicQuestionSetConfigGUI.php
@@ -1,7 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/Test/classes/class.ilObjTestDynamicQuestionSetConfig.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * GUI class that manages the question set configuration for continues tests
@@ -15,84 +28,34 @@ require_once 'Modules/Test/classes/class.ilObjTestDynamicQuestionSetConfig.php';
  */
 class ilObjTestDynamicQuestionSetConfigGUI
 {
-    /**
-     * command constants
-     */
     const CMD_SHOW_FORM = 'showForm';
     const CMD_SAVE_FORM = 'saveForm';
     const CMD_GET_TAXONOMY_OPTIONS_ASYNC = 'getTaxonomyOptionsAsync';
-    
-    /**
-     * global $ilCtrl object
-     *
-     * @var ilCtrl
-     */
-    protected $ctrl = null;
-    
-    /**
-     * global $ilAccess object
-     *
-     * @var ilAccess
-     */
-    protected $access = null;
-    
-    /**
-     * global $ilTabs object
-     *
-     * @var ilTabsGUI
-     */
-    protected $tabs = null;
-    
-    /**
-     * global $lng object
-     *
-     * @var ilLanguage
-     */
-    protected $lng = null;
-    
-    /**
-     * global $tpl object
-     *
-     * @var ilGlobalTemplateInterface
-     */
-    protected $tpl = null;
-    
-    /**
-     * global $ilDB object
-     *
-     * @var ilDBInterface
-     */
-    protected $db = null;
-    
-    /**
-     * global $tree object
-     *
-     * @var ilTree
-     */
-    protected $tree = null;
-    
-    /**
-     * object instance for current test
-     *
-     * @var ilObjTest
-     */
-    protected $testOBJ = null;
-    
-    /**
-     * object instance managing the dynamic question set config
-     *
-     * @var ilObjTestDynamicQuestionSetConfig
-     */
-    protected $questionSetConfig = null;
-    
+
     const QUESTION_ORDERING_TYPE_UPDATE_DATE = 'ordering_by_date';
     const QUESTION_ORDERING_TYPE_TAXONOMY = 'ordering_by_tax';
-    
-    /**
-     * Constructor
-     */
-    public function __construct(ilCtrl $ctrl, ilAccessHandler $access, ilTabsGUI $tabs, ilLanguage $lng, ilGlobalTemplateInterface $tpl, ilDBInterface $db, ilTree $tree, ilPluginAdmin $pluginAdmin, ilObjTest $testOBJ)
-    {
+
+    protected ilCtrlInterface $ctrl;
+    protected ilAccessHandler $access;
+    protected ilTabsGUI $tabs;
+    protected ilLanguage $lng;
+    protected ilGlobalTemplateInterface $tpl;
+    protected ilDBInterface $db;
+    protected ilTree $tree;
+    protected ilObjTest $testOBJ;
+    protected ilObjTestDynamicQuestionSetConfig $questionSetConfig;
+
+    public function __construct(
+        ilCtrl $ctrl,
+        ilAccessHandler $access,
+        ilTabsGUI $tabs,
+        ilLanguage $lng,
+        ilGlobalTemplateInterface $tpl,
+        ilDBInterface $db,
+        ilTree $tree,
+        ilComponentRepository $component_repository,
+        ilObjTest $testOBJ
+    ) {
         $this->ctrl = $ctrl;
         $this->access = $access;
         $this->tabs = $tabs;
@@ -100,16 +63,16 @@ class ilObjTestDynamicQuestionSetConfigGUI
         $this->tpl = $tpl;
         $this->db = $db;
         $this->tree = $tree;
-        $this->pluginAdmin = $pluginAdmin;
-
         $this->testOBJ = $testOBJ;
-        
-        $this->questionSetConfig = new ilObjTestDynamicQuestionSetConfig($this->tree, $this->db, $this->pluginAdmin, $this->testOBJ);
+
+        $this->questionSetConfig = new ilObjTestDynamicQuestionSetConfig(
+            $this->tree,
+            $this->db,
+            $component_repository,
+            $this->testOBJ
+        );
     }
-    
-    /**
-     * Command Execution
-     */
+
     public function executeCommand()
     {
         // allow only write access

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -98,7 +98,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         $lng = $DIC['lng'];
         $ilCtrl = $DIC['ilCtrl'];
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
         $tree = $DIC['tree'];
         $lng->loadLanguageModule("assessment");
         $this->type = "tst";
@@ -112,7 +112,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         parent::__construct("", (int) $refId, true, false);
 
         if ($this->object instanceof ilObjTest) {
-            $this->testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $this->object);
+            $this->testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $this->object);
             $this->testSessionFactory = new ilTestSessionFactory($this->object);
             $this->setTestAccess(new ilTestAccess($this->ref_id, $this->object->getTestId()));
         } else {
@@ -147,7 +147,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         $tpl = $DIC['tpl'];
         $lng = $DIC['lng'];
         $ilTabs = $DIC['ilTabs'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
         $ilDB = $DIC['ilDB'];
         $tree = $DIC['tree'];
         $ilias = $DIC['ilias'];
@@ -418,7 +418,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                     $this->lng,
                     $this->tree,
                     $ilDB,
-                    $ilPluginAdmin,
+                    $component_repository,
                     $ilUser,
                     $this
                 );
@@ -437,7 +437,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                     $this->lng,
                     $this->tree,
                     $ilDB,
-                    $ilPluginAdmin,
+                    $component_repository,
                     $this
                 );
                 $this->ctrl->forwardCommand($gui);
@@ -449,7 +449,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                 }
                 $this->prepareOutput();
                 $this->addHeaderAction();
-                $gui = new ilObjTestDynamicQuestionSetConfigGUI($this->ctrl, $ilAccess, $ilTabs, $this->lng, $this->tpl, $ilDB, $tree, $ilPluginAdmin, $this->getTestObject());
+                $gui = new ilObjTestDynamicQuestionSetConfigGUI($this->ctrl, $ilAccess, $ilTabs, $this->lng, $this->tpl, $ilDB, $tree, $component_repository, $this->getTestObject());
                 $this->ctrl->forwardCommand($gui);
                 break;
             
@@ -467,7 +467,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                     $this->tpl,
                     $ilDB,
                     $tree,
-                    $ilPluginAdmin,
+                    $component_repository,
                     $this->getTestObject(),
                     (new ilTestProcessLockerFactory(
                         new ilSetting('assessment'),
@@ -483,7 +483,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                 }
                 $this->prepareOutput();
                 $this->addHeaderAction();
-                $gui = new ilObjTestDynamicQuestionSetConfigGUI($this->ctrl, $ilAccess, $ilTabs, $this->lng, $this->tpl, $ilDB, $tree, $ilPluginAdmin, $this->getTestObject());
+                $gui = new ilObjTestDynamicQuestionSetConfigGUI($this->ctrl, $ilAccess, $ilTabs, $this->lng, $this->tpl, $ilDB, $tree, $component_repository, $this->getTestObject());
                 $this->ctrl->forwardCommand($gui);
                 break;
             
@@ -500,7 +500,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                     $this->lng,
                     $tree,
                     $ilDB,
-                    $ilPluginAdmin,
+                    $component_repository,
                     $this->getTestObject(),
                     $ilAccess,
                     $DIC->http(),
@@ -517,7 +517,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                 }
                 $this->prepareOutput();
                 $this->addHeaderAction();
-                $gui = new ilTestSkillAdministrationGUI($ilias, $this->ctrl, $ilAccess, $ilTabs, $this->tpl, $this->lng, $ilDB, $tree, $ilPluginAdmin, $this->getTestObject(), $this->ref_id);
+                $gui = new ilTestSkillAdministrationGUI($ilias, $this->ctrl, $ilAccess, $ilTabs, $this->tpl, $this->lng, $ilDB, $tree, $component_repository, $this->getTestObject(), $this->ref_id);
                 $this->ctrl->forwardCommand($gui);
                 break;
             
@@ -909,7 +909,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
     private function testResultsGatewayObject()
     {
-        global $DIC, $ilPluginAdmin;
+        global $DIC;
         $this->tabs_gui->clearTargets();
 
         $this->prepareOutput();
@@ -922,7 +922,12 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         $gui = new ilParticipantsTestResultsGUI();
         $gui->setTestObj($this->object);
 
-        $factory = new ilTestQuestionSetConfigFactory($this->tree, $DIC->database(), $ilPluginAdmin, $this->object);
+        $factory = new ilTestQuestionSetConfigFactory(
+            $this->tree,
+            $DIC->database(),
+            $DIC['component.repository'],
+            $this->object
+        );
         $gui->setQuestionSetConfig($factory->getQuestionSetConfig());
         $gui->setObjectiveParent(new ilTestObjectiveOrientedContainer());
         $gui->setTestAccess($this->getTestAccess());

--- a/Modules/Test/classes/class.ilObjTestSettingsGeneralGUI.php
+++ b/Modules/Test/classes/class.ilObjTestSettingsGeneralGUI.php
@@ -47,53 +47,24 @@ class ilObjTestSettingsGeneralGUI extends ilTestSettingsGUI
     const INSTANT_FEEDBACK_TRIGGER_MANUAL = 0;
     const INSTANT_FEEDBACK_TRIGGER_FORCED = 1;
 
-    /** @var ilCtrl $ctrl */
-    protected $ctrl = null;
+    protected ilCtrlInterface $ctrl;
+    protected ilAccessHandler $access;
+    protected ilLanguage $lng;
+    protected ilGlobalTemplateInterface $tpl;
+    protected ilTree $tree;
+    protected ilDBInterface $db;
+    protected ilComponentRepository $component_repository;
+    protected ilObjUser $activeUser;
+    protected ilObjTestGUI $testGUI;
+    private ilTestQuestionSetConfigFactory $testQuestionSetConfigFactory;
 
-    /** @var ilAccessHandler $access */
-    protected $access = null;
-
-    /** @var ilLanguage $lng */
-    protected $lng = null;
-
-    /** @var ilGlobalTemplateInterface $tpl */
-    protected $tpl = null;
-
-    /** @var ilTree $tree */
-    protected $tree = null;
-
-    /** @var ilDBInterface $db */
-    protected $db = null;
-
-    /** @var ilPluginAdmin $pluginAdmin */
-    protected $pluginAdmin = null;
-
-    /** @var ilObjUser $activeUser */
-    protected $activeUser = null;
-
-    /** @var ilObjTestGUI $testGUI */
-    protected $testGUI = null;
-
-    /** @var ilTestQuestionSetConfigFactory $testQuestionSetConfigFactory Factory for question set config. */
-    private $testQuestionSetConfigFactory = null;
-
-    /**
-     * Constructor
-     *
-     * @param ilCtrl          $ctrl
-     * @param ilAccessHandler $access
-     * @param ilLanguage      $lng
-     * @param ilTemplate      $tpl
-     * @param ilDBInterface   $db
-     * @param ilObjTestGUI    $testGUI
-     */
     public function __construct(
-        ilCtrl $ctrl,
+        ilCtrlInterface $ctrl,
         ilAccessHandler $access,
         ilLanguage $lng,
         ilTree $tree,
         ilDBInterface $db,
-        ilPluginAdmin $pluginAdmin,
+        ilComponentRepository $component_repository,
         ilObjUser $activeUser,
         ilObjTestGUI $testGUI
     ) {
@@ -105,13 +76,17 @@ class ilObjTestSettingsGeneralGUI extends ilTestSettingsGUI
         $this->tpl = $DIC->ui()->mainTemplate();
         $this->tree = $tree;
         $this->db = $db;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->activeUser = $activeUser;
 
         $this->testGUI = $testGUI;
 
-        require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';
-        $this->testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($this->tree, $this->db, $this->pluginAdmin, $testGUI->getTestObject());
+        $this->testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory(
+            $this->tree,
+            $this->db,
+            $this->component_repository,
+            $testGUI->getTestObject()
+        );
 
         parent::__construct($testGUI->getTestObject());
     }

--- a/Modules/Test/classes/class.ilObjTestSettingsScoringResultsGUI.php
+++ b/Modules/Test/classes/class.ilObjTestSettingsScoringResultsGUI.php
@@ -1,20 +1,20 @@
 <?php
 
 /**
-* This file is part of ILIAS, a powerful learning management system
-* published by ILIAS open source e-Learning e.V.
-*
-* ILIAS is licensed with the GPL-3.0,
-* see https://www.gnu.org/licenses/gpl-3.0.en.html
-* You should have received a copy of said license along with the
-* source code, too.
-*
-* If this is not the case or you just want to try ILIAS, you'll find
-* us at:
-* https://www.ilias.de
-* https://github.com/ILIAS-eLearning
-*
-*********************************************************************/
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * GUI class that manages the editing of general test settings/properties
@@ -36,60 +36,23 @@ class ilObjTestSettingsScoringResultsGUI extends ilTestSettingsGUI
     const CMD_SAVE_FORM = 'saveForm';
     const CMD_CONFIRMED_SAVE_FORM = 'confirmedSaveForm';
 
-    /** @var ilCtrl $ctrl */
-    protected $ctrl = null;
-    
-    /** @var ilAccess $access */
-    protected $access = null;
-    
-    /** @var ilLanguage $lng */
-    protected $lng = null;
-    
-    /** @var ilGlobalTemplateInterface $tpl */
-    protected $tpl = null;
-    
-    /** @var ilTree $tree */
-    protected $tree = null;
-    
-    /** @var ilDBInterface $db */
-    protected $db = null;
+    protected ilCtrlInterface $ctrl;
+    protected ilAccessHandler $access;
+    protected ilLanguage $lng;
+    protected ilGlobalTemplateInterface $tpl;
+    protected ilTree $tree;
+    protected ilDBInterface $db;
+    protected ilComponentRepository $component_repository;
+    protected ilObjTestGUI $testGUI;
+    private ilTestQuestionSetConfigFactory $testQuestionSetConfigFactory;
 
-    /** @var ilPluginAdmin $pluginAdmin */
-    protected $pluginAdmin = null;
-
-    /** @var ilObjTest $testOBJ */
-    protected $testOBJ = null;
-
-    /** @var ilObjTestGUI $testGUI */
-    protected $testGUI = null;
-    
-    /** @var ilTestQuestionSetConfigFactory $testQuestionSetConfigFactory Factory for question set config. */
-    private $testQuestionSetConfigFactory = null;
-
-    /**
-     * object instance for currently active settings template
-     *
-     * @var $settingsTemplate ilSettingsTemplate
-     */
-    protected $settingsTemplate = null;
-
-    /**
-     * Constructor
-     *
-     * @param ilCtrl          $ctrl
-     * @param ilAccessHandler $access
-     * @param ilLanguage      $lng
-     * @param ilTemplate      $tpl
-     * @param ilDBInterface   $db
-     * @param ilObjTestGUI    $testGUI
-     */
     public function __construct(
-        ilCtrl $ctrl,
+        ilCtrlInterface $ctrl,
         ilAccessHandler $access,
         ilLanguage $lng,
         ilTree $tree,
         ilDBInterface $db,
-        ilPluginAdmin $pluginAdmin,
+        ilComponentRepository $component_repository,
         ilObjTestGUI $testGUI
     ) {
         global $DIC; /* @var ILIAS\DI\Container $DIC */
@@ -100,18 +63,21 @@ class ilObjTestSettingsScoringResultsGUI extends ilTestSettingsGUI
         $this->tpl = $DIC->ui()->mainTemplate();
         $this->tree = $tree;
         $this->db = $db;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
 
         $this->testGUI = $testGUI;
         $this->testOBJ = $testGUI->getObject();
 
-        require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';
-        $this->testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($this->tree, $this->db, $this->pluginAdmin, $this->testOBJ);
-        
+        $this->testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory(
+            $this->tree,
+            $this->db,
+            $this->component_repository,
+            $this->testOBJ
+        );
+
         $templateId = $this->testOBJ->getTemplate();
 
         if ($templateId) {
-            include_once "Services/Administration/classes/class.ilSettingsTemplate.php";
             $this->settingsTemplate = new ilSettingsTemplate($templateId, ilObjAssessmentFolderGUI::getSettingsTemplateConfig());
         }
     }

--- a/Modules/Test/classes/class.ilObjTestXMLParser.php
+++ b/Modules/Test/classes/class.ilObjTestXMLParser.php
@@ -1,17 +1,21 @@
 <?php
-/******************************************************************************
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 /**
  * @author        Björn Heyser <bheyser@databay.de>
  * @version        $Id$
@@ -183,8 +187,8 @@ class ilObjTestXMLParser extends ilSaxParser
         global $DIC;
         $tree = $DIC['tree'];
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
-        $questionSetConfig = new ilTestRandomQuestionSetConfig($tree, $ilDB, $ilPluginAdmin, $this->testOBJ);
+        $component_repository = $DIC['component.repository'];
+        $questionSetConfig = new ilTestRandomQuestionSetConfig($tree, $ilDB, $component_repository, $this->testOBJ);
 
         if (!$questionSetConfig->isValidQuestionAmountConfigurationMode($attr['amountMode'])) {
             throw new ilTestException(

--- a/Modules/Test/classes/class.ilTestDynamicQuestionSet.php
+++ b/Modules/Test/classes/class.ilTestDynamicQuestionSet.php
@@ -1,75 +1,49 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionList.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class manages access to the dynamic question set
  * provided for the current test
- *
  * @author		Björn Heyser <bheyser@databay.de>
- * @version		$Id$
- *
  * @package		Modules/Test
  */
 class ilTestDynamicQuestionSet
 {
-    /**
-     * @var ilDBInterface
-     */
-    private $db = null;
-    
-    /**
-     * @var ilLanguage
-     */
-    private $lng = null;
-    
-    /**
-     * @var ilPluginAdmin
-     */
-    private $pluginAdmin = null;
-    
-    /**
-     * @var ilObjTest
-     */
-    private $testOBJ = null;
-    
-    /**
-     * @var ilAssQuestionList
-     */
-    private $completeQuestionList = null;
-    
-    /**
-     * @var ilAssQuestionList
-     */
-    private $selectionQuestionList = null;
-    
-    /**
-     * @var ilAssQuestionList
-     */
-    private $filteredQuestionList = null;
-    
-    /**
-     * @var array
-     */
-    private $actualQuestionSequence = array();
-    
-    /**
-     * Constructor
-     *
-     * @param ilObjTest $testOBJ
-     */
-    public function __construct(ilDBInterface $db, ilLanguage $lng, ilPluginAdmin $pluginAdmin, ilObjTest $testOBJ)
+    private ilDBInterface $db;
+    private ilLanguage $lng;
+    private ilComponentRepository $component_repository;
+    private ilObjTest $testOBJ;
+    private ?ilAssQuestionList $completeQuestionList = null;
+    private ?ilAssQuestionList $selectionQuestionList = null;
+    private ?ilAssQuestionList $filteredQuestionList = null;
+    private array $actualQuestionSequence = [];
+
+    public function __construct(ilDBInterface $db, ilLanguage $lng, ilComponentRepository $component_repository, ilObjTest $testOBJ)
     {
         $this->db = $db;
         $this->lng = $lng;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->testOBJ = $testOBJ;
     }
     
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     
-    public function load(ilObjTestDynamicQuestionSetConfig $dynamicQuestionSetConfig, ilTestDynamicQuestionSetFilterSelection $filterSelection)
+    public function load(ilObjTestDynamicQuestionSetConfig $dynamicQuestionSetConfig, ilTestDynamicQuestionSetFilterSelection $filterSelection) : void
     {
         $this->completeQuestionList = $this->initCompleteQuestionList(
             $dynamicQuestionSetConfig,
@@ -315,7 +289,7 @@ class ilTestDynamicQuestionSet
      */
     private function buildQuestionList($sourceQuestionPoolId, $answerStatusActiveId) : ilAssQuestionList
     {
-        $questionList = new ilAssQuestionList($this->db, $this->lng, $this->pluginAdmin);
+        $questionList = new ilAssQuestionList($this->db, $this->lng, $this->component_repository);
         $questionList->setParentObjId($sourceQuestionPoolId);
         $questionList->setAnswerStatusActiveId($answerStatusActiveId);
         return $questionList;

--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -1,10 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once './Modules/Test/classes/class.ilTestServiceGUI.php';
-require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionHintTracking.php';
-require_once 'Modules/Test/classes/class.ilTestPassFinishTasks.php';
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Output class for assessment test evaluation
@@ -2046,7 +2056,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
 
         $resultData = $this->object->getTestResult($active_id, $pass, false, $considerHiddenQuestions);
         $questionIds = array();
@@ -2061,8 +2071,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         $table_gui = $this->buildPassDetailsOverviewTableGUI($this, 'outUserPassDetails');
         $table_gui->initFilter();
 
-        require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionList.php';
-        $questionList = new ilAssQuestionList($ilDB, $this->lng, $ilPluginAdmin);
+        $questionList = new ilAssQuestionList($ilDB, $this->lng, $component_repository);
 
         $questionList->setIncludeQuestionIdsFilter($questionIds);
         $questionList->setQuestionInstanceTypeFilter(null);

--- a/Modules/Test/classes/class.ilTestExportRandomQuestionSet.php
+++ b/Modules/Test/classes/class.ilTestExportRandomQuestionSet.php
@@ -1,7 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/Test/classes/class.ilTestExport.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -25,7 +38,7 @@ class ilTestExportRandomQuestionSet extends ilTestExport
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
 
         require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetSourcePoolDefinitionFactory.php';
         $srcPoolDefFactory = new ilTestRandomQuestionSetSourcePoolDefinitionFactory(
@@ -66,10 +79,9 @@ class ilTestExportRandomQuestionSet extends ilTestExport
         global $DIC;
         $tree = $DIC['tree'];
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
         
-        require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetConfig.php';
-        $questionSetConfig = new ilTestRandomQuestionSetConfig($tree, $ilDB, $ilPluginAdmin, $this->test_obj);
+        $questionSetConfig = new ilTestRandomQuestionSetConfig($tree, $ilDB, $component_repository, $this->test_obj);
         $questionSetConfig->loadFromDb();
 
         $xmlWriter->xmlElement('RandomQuestionSetSettings', array(
@@ -166,9 +178,9 @@ class ilTestExportRandomQuestionSet extends ilTestExport
         if (!isset($this->stagingPoolQuestionListByPoolId[$poolId])) {
             global $DIC;
             $ilDB = $DIC['ilDB'];
-            $ilPluginAdmin = $DIC['ilPluginAdmin'];
+            $component_repository = $DIC['component.repository'];
             
-            $questionList = new ilTestRandomQuestionSetStagingPoolQuestionList($ilDB, $ilPluginAdmin);
+            $questionList = new ilTestRandomQuestionSetStagingPoolQuestionList($ilDB, $component_repository);
             $questionList->setTestId($this->test_obj->getTestId());
             $questionList->setPoolId($poolId);
             $questionList->loadQuestions();

--- a/Modules/Test/classes/class.ilTestExpressPageObjectGUI.php
+++ b/Modules/Test/classes/class.ilTestExpressPageObjectGUI.php
@@ -1,8 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once "./Modules/TestQuestionPool/classes/class.ilAssQuestionPageGUI.php";
-include_once 'Modules/Test/classes/class.ilTestExpressPage.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @ilCtrl_Calls ilTestExpressPageObjectGUI: assMultipleChoiceGUI, assClozeTestGUI, assMatchingQuestionGUI
@@ -500,10 +512,9 @@ class ilTestExpressPageObjectGUI extends ilAssQuestionPageGUI
             global $DIC;
             $tree = $DIC['tree'];
             $ilDB = $DIC['ilDB'];
-            $ilPluginAdmin = $DIC['ilPluginAdmin'];
+            $component_repository = $DIC['component.repository'];
 
-            require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';
-            $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $this->test_object);
+            $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $this->test_object);
             $testQuestionSetConfig = $testQuestionSetConfigFactory->getQuestionSetConfig();
 
             foreach ($selected_array as $key => $value) {

--- a/Modules/Test/classes/class.ilTestFixedQuestionSetConfigGUI.php
+++ b/Modules/Test/classes/class.ilTestFixedQuestionSetConfigGUI.php
@@ -1,5 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * GUI class that manages the question set configuration for tests
@@ -51,10 +66,7 @@ class ilTestFixedQuestionSetConfigGUI
      */
     public $tree = null;
     
-    /**
-     * @var ilPluginAdmin
-     */
-    public $pluginAdmin = null;
+    public ?ilComponentRepository $component_repository;
     
     /**
      * @var ilObjectDefinition

--- a/Modules/Test/classes/class.ilTestInfoScreenToolbarFactory.php
+++ b/Modules/Test/classes/class.ilTestInfoScreenToolbarFactory.php
@@ -1,12 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';
-require_once 'Modules/Test/classes/class.ilTestPlayerFactory.php';
-require_once 'Modules/Test/classes/class.ilTestSessionFactory.php';
-require_once 'Modules/Test/classes/class.ilTestSequenceFactory.php';
-require_once 'Modules/Test/classes/class.ilTestDynamicQuestionSetFilterSelection.php';
-require_once 'Modules/Test/classes/toolbars/class.ilTestInfoScreenToolbarGUI.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -87,7 +95,7 @@ class ilTestInfoScreenToolbarFactory
         $this->testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory(
             $d['tree'],
             $d['ilDB'],
-            $d['ilPluginAdmin'],
+            $d['component.repository'],
             $this->getTestOBJ()
         );
         
@@ -97,7 +105,7 @@ class ilTestInfoScreenToolbarFactory
         $this->testSequenceFactory = new ilTestSequenceFactory(
             $d['ilDB'],
             $d['lng'],
-            $d['ilPluginAdmin'],
+            $d['component.repository'],
             $this->getTestOBJ()
         );
     }
@@ -115,7 +123,7 @@ class ilTestInfoScreenToolbarFactory
         
         $d = $GLOBALS['DIC'];
         
-        $toolbar = new ilTestInfoScreenToolbarGUI($d['ilDB'], $d['ilAccess'], $d['ilCtrl'], $d['lng'], $d['ilPluginAdmin']);
+        $toolbar = new ilTestInfoScreenToolbarGUI($d['ilDB'], $d['ilAccess'], $d['ilCtrl'], $d['lng'], $d['component.repository']);
         
         $toolbar->setTestOBJ($this->getTestOBJ());
         $toolbar->setTestPlayerGUI($this->testPlayerFactory->getPlayerGUI());

--- a/Modules/Test/classes/class.ilTestOutputGUI.php
+++ b/Modules/Test/classes/class.ilTestOutputGUI.php
@@ -44,7 +44,7 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
         $lng = $DIC['lng'];
         $ilTabs = $DIC['ilTabs'];
 
@@ -74,7 +74,7 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
         
         $this->initProcessLocker($this->testSession->getActiveId());
         
-        $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $ilPluginAdmin, $this->object);
+        $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $component_repository, $this->object);
         $this->testSequence = $testSequenceFactory->getSequenceByTestSession($this->testSession);
         $this->testSequence->loadFromDb();
         $this->testSequence->loadQuestions();
@@ -781,25 +781,20 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
         global $DIC;
         $tree = $DIC['tree'];
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
 
-        require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetConfig.php';
-        $questionSetConfig = new ilTestRandomQuestionSetConfig($tree, $ilDB, $ilPluginAdmin, $this->object);
+        $questionSetConfig = new ilTestRandomQuestionSetConfig($tree, $ilDB, $component_repository, $this->object);
         $questionSetConfig->loadFromDb();
 
-        require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetSourcePoolDefinitionFactory.php';
         $sourcePoolDefinitionFactory = new ilTestRandomQuestionSetSourcePoolDefinitionFactory($ilDB, $this->object);
 
-        require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetSourcePoolDefinitionList.php';
         $sourcePoolDefinitionList = new ilTestRandomQuestionSetSourcePoolDefinitionList($ilDB, $this->object, $sourcePoolDefinitionFactory);
         $sourcePoolDefinitionList->loadDefinitions();
 
-        $this->processLocker->executeRandomPassBuildOperation(function () use ($ilDB, $ilPluginAdmin, $questionSetConfig, $sourcePoolDefinitionList) {
+        $this->processLocker->executeRandomPassBuildOperation(function () use ($ilDB, $component_repository, $questionSetConfig, $sourcePoolDefinitionList) {
             if (!$this->performTearsAndAngerBrokenConfessionChecks()) {
-                require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetStagingPoolQuestionList.php';
-                $stagingPoolQuestionList = new ilTestRandomQuestionSetStagingPoolQuestionList($ilDB, $ilPluginAdmin);
+                $stagingPoolQuestionList = new ilTestRandomQuestionSetStagingPoolQuestionList($ilDB, $component_repository);
 
-                require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetBuilder.php';
                 $questionSetBuilder = ilTestRandomQuestionSetBuilder::getInstance($ilDB, $this->object, $questionSetConfig, $sourcePoolDefinitionList, $stagingPoolQuestionList);
 
                 $questionSetBuilder->performBuild($this->testSession);

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -898,7 +898,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         }
 
         global $DIC;
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        /** @var ilComponentRepository $component_repository */
         $component_repository = $DIC["component.repository"];
         return $component_repository->getPluginSlotById("tsig")->hasActivePlugins();
     }

--- a/Modules/Test/classes/class.ilTestPlayerFixedQuestionSetGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerFixedQuestionSetGUI.php
@@ -1,14 +1,24 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/Test/classes/class.ilTestOutputGUI.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author		Björn Heyser <bheyser@databay.de>
- * @version		$Id$
- *
  * @package     Modules/Test
- *
  * @ilCtrl_Calls ilTestPlayerFixedQuestionSetGUI: ilAssGenFeedbackPageGUI
  * @ilCtrl_Calls ilTestPlayerFixedQuestionSetGUI: ilAssSpecFeedbackPageGUI
  * @ilCtrl_Calls ilTestPlayerFixedQuestionSetGUI: ilAssQuestionHintRequestGUI
@@ -24,10 +34,9 @@ class ilTestPlayerFixedQuestionSetGUI extends ilTestOutputGUI
     protected function buildTestPassQuestionList() : ilAssQuestionList
     {
         global $DIC;
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
-        
-        require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionList.php';
-        $questionList = new ilAssQuestionList($this->db, $this->lng, $ilPluginAdmin);
+        $component_repository = $DIC['component.repository'];
+
+        $questionList = new ilAssQuestionList($this->db, $this->lng, $component_repository);
         
         $questionList->setParentObjId($this->object->getId());
 

--- a/Modules/Test/classes/class.ilTestPlayerRandomQuestionSetGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerRandomQuestionSetGUI.php
@@ -1,14 +1,24 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/Test/classes/class.ilTestOutputGUI.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author		Björn Heyser <bheyser@databay.de>
- * @version		$Id$
- *
  * @package     Modules/Test
- *
  * @ilCtrl_Calls ilTestPlayerRandomQuestionSetGUI: ilAssGenFeedbackPageGUI
  * @ilCtrl_Calls ilTestPlayerRandomQuestionSetGUI: ilAssSpecFeedbackPageGUI
  * @ilCtrl_Calls ilTestPlayerRandomQuestionSetGUI: ilAssQuestionHintRequestGUI
@@ -24,10 +34,9 @@ class ilTestPlayerRandomQuestionSetGUI extends ilTestOutputGUI
     protected function buildTestPassQuestionList() : ilAssQuestionList
     {
         global $DIC;
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
 
-        require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionList.php';
-        $questionList = new ilAssQuestionList($this->db, $this->lng, $ilPluginAdmin);
+        $questionList = new ilAssQuestionList($this->db, $this->lng, $component_repository);
         
         $questionList->setParentObjId($this->object->getId());
 

--- a/Modules/Test/classes/class.ilTestQuestionSetConfig.php
+++ b/Modules/Test/classes/class.ilTestQuestionSetConfig.php
@@ -18,53 +18,25 @@
 
 /**
  * abstract parent class that manages/holds the data for a question set configuration
- *
  * @author		Björn Heyser <bheyser@databay.de>
- * @version		$Id$
- *
  * @package		Modules/Test
  */
 abstract class ilTestQuestionSetConfig
 {
-    /**
-     * global $tree object instance
-     *
-     * @var ilTree
-     */
-    protected $tree = null;
-    
-    /**
-     * global $ilDB object instance
-     *
-     * @var ilDBInterface
-     */
-    protected $db = null;
+    protected ilTree $tree;
+    protected ilDBInterface $db;
+    protected ilComponentRepository $component_repository;
+    protected ilObjTest $testOBJ;
 
-    /**
-     * global $pluginAdmin object instance
-     *
-     * @var ilPluginAdmin
-     */
-    protected $pluginAdmin = null;
-
-    /**
-     * object instance of current test
-     *
-     * @var ilObjTest
-     */
-    protected $testOBJ = null;
-
-    /**
-     * @param ilTree $tree
-     * @param ilDBInterface $db
-     * @param ilPluginAdmin $pluginAdmin
-     * @param ilObjTest $testOBJ
-     */
-    public function __construct(ilTree $tree, ilDBInterface $db, ilPluginAdmin $pluginAdmin, ilObjTest $testOBJ)
-    {
+    public function __construct(
+        ilTree $tree,
+        ilDBInterface $db,
+        ilComponentRepository $component_repository,
+        ilObjTest $testOBJ
+    ) {
         $this->tree = $tree;
         $this->db = $db;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->testOBJ = $testOBJ;
     }
     

--- a/Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php
+++ b/Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php
@@ -1,5 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Factory for test question set config
@@ -11,46 +26,21 @@
  */
 class ilTestQuestionSetConfigFactory
 {
-    /**
-     * singleton instance of test question set config
-     *
-     * @var ilTestQuestionSetConfig
-     */
-    private $testQuestionSetConfig = null;
-    
-    /**
-     * global $tree object instance
-     *
-     * @var ilTree
-     */
-    private $tree = null;
-    
-    /**
-     * object instance of $ilDB
-     *
-     * @var ilDBInterface
-     */
-    private $db = null;
+    private ilTree $tree;
+    private ilDBInterface $db;
+    private ilComponentRepository $component_repository;
+    private ilObjTest $testOBJ;
+    private ?ilTestQuestionSetConfig $testQuestionSetConfig = null;
 
-    /**
-     * object instance of $ilPluginAdmin
-     *
-     * @var ilPluginAdmin
-     */
-    private $pluginAdmin = null;
-
-    /**
-     * object instance of current test
-     *
-     * @var ilObjTest
-     */
-    private $testOBJ = null;
-    
-    public function __construct(ilTree $tree, ilDBInterface $db, ilPluginAdmin $pluginAdmin, ilObjTest $testOBJ)
-    {
+    public function __construct(
+        ilTree $tree,
+        ilDBInterface $db,
+        ilComponentRepository $component_repository,
+        ilObjTest $testOBJ
+    ) {
         $this->tree = $tree;
         $this->db = $db;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->testOBJ = $testOBJ;
     }
     
@@ -74,7 +64,7 @@ class ilTestQuestionSetConfigFactory
                 $this->testQuestionSetConfig = new ilTestFixedQuestionSetConfig(
                     $this->tree,
                     $this->db,
-                    $this->pluginAdmin,
+                    $this->component_repository,
                     $this->testOBJ
                 );
             }
@@ -82,7 +72,7 @@ class ilTestQuestionSetConfigFactory
                 $this->testQuestionSetConfig = new ilTestRandomQuestionSetConfig(
                     $this->tree,
                     $this->db,
-                    $this->pluginAdmin,
+                    $this->component_repository,
                     $this->testOBJ
                 );
             }
@@ -91,7 +81,7 @@ class ilTestQuestionSetConfigFactory
                 $this->testQuestionSetConfig = new ilObjTestDynamicQuestionSetConfig(
                     $this->tree,
                     $this->db,
-                    $this->pluginAdmin,
+                    $this->component_repository,
                     $this->testOBJ
                 );
             }

--- a/Modules/Test/classes/class.ilTestRandomQuestionSetConfig.php
+++ b/Modules/Test/classes/class.ilTestRandomQuestionSetConfig.php
@@ -55,17 +55,6 @@ class ilTestRandomQuestionSetConfig extends ilTestQuestionSetConfig
     // fau.
 
     /**
-     * @param ilTree $tree
-     * @param ilDBInterface $db
-     * @param ilPluginAdmin $pluginAdmin
-     * @param ilObjTest $testOBJ
-     */
-    public function __construct(ilTree $tree, ilDBInterface $db, ilPluginAdmin $pluginAdmin, ilObjTest $testOBJ)
-    {
-        parent::__construct($tree, $db, $pluginAdmin, $testOBJ);
-    }
-
-    /**
      * @param boolean $requirePoolsWithHomogeneousScoredQuestions
      */
     public function setPoolsWithHomogeneousScoredQuestionsRequired($requirePoolsWithHomogeneousScoredQuestions)
@@ -345,10 +334,8 @@ class ilTestRandomQuestionSetConfig extends ilTestQuestionSetConfig
         $sourcePoolDefinitionList = $this->buildSourcePoolDefinitionList($this->testOBJ);
         $sourcePoolDefinitionList->loadDefinitions();
 
-        require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetStagingPoolQuestionList.php';
-        $stagingPoolQuestionList = new ilTestRandomQuestionSetStagingPoolQuestionList($this->db, $this->pluginAdmin);
+        $stagingPoolQuestionList = new ilTestRandomQuestionSetStagingPoolQuestionList($this->db, $this->component_repository);
 
-        require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetBuilder.php';
         $questionSetBuilder = ilTestRandomQuestionSetBuilder::getInstance($this->db, $this->testOBJ, $this, $sourcePoolDefinitionList, $stagingPoolQuestionList);
         
         //fau: fixRandomTestBuildable - get messages if set is not buildable

--- a/Modules/Test/classes/class.ilTestRandomQuestionSetConfigGUI.php
+++ b/Modules/Test/classes/class.ilTestRandomQuestionSetConfigGUI.php
@@ -16,15 +16,6 @@
  *
  *********************************************************************/
 
-
-require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetConfig.php';
-require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetSourcePoolDefinitionList.php';
-require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetSourcePoolDefinitionFactory.php';
-require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetStagingPoolBuilder.php';
-require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetConfigStateMessageHandler.php';
-
-require_once 'Services/Taxonomy/classes/class.ilObjTaxonomy.php';
-
 /**
  * GUI class that manages the question set configuration for continues tests
  *
@@ -61,84 +52,23 @@ class ilTestRandomQuestionSetConfigGUI
     
     const HTTP_PARAM_AFTER_REBUILD_QUESTION_STAGE_CMD = 'afterRebuildQuestionStageCmd';
     private \ILIAS\Test\InternalRequestService $testrequest;
-    /**
-     * @var ilCtrl
-     */
-    public $ctrl = null;
-    
-    /**
-     * @var ilAccess
-     */
-    public $access = null;
-    
-    /**
-     * @var ilTabsGUI
-     */
-    public $tabs = null;
-    
-    /**
-     * @var ilLanguage
-     */
-    public $lng = null;
-    
-    /**
-     * @var ilGlobalTemplateInterface
-     */
-    public $tpl = null;
-    
-    /**
-     * @var ilDBInterface
-     */
-    public $db = null;
-    
-    /**
-     * @var ilTree
-     */
-    public $tree = null;
 
-    /**
-     * @var ilPluginAdmin
-     */
-    public $pluginAdmin = null;
-    
-    /**
-     * @var ilObjectDefinition
-     */
-    public $objDefinition = null;
-
-    /**
-     * @var ilObjTest
-     */
-    public $testOBJ = null;
-    
-    /**
-     * @var ilTestRandomQuestionSetConfig
-     */
-    protected $questionSetConfig = null;
-
-    /**
-     * @var ilTestRandomQuestionSetSourcePoolDefinitionFactory
-     */
-    protected $sourcePoolDefinitionFactory = null;
-
-    /**
-     * @var ilTestRandomQuestionSetSourcePoolDefinitionList
-     */
-    protected $sourcePoolDefinitionList = null;
-
-    /**
-     * @var ilTestRandomQuestionSetStagingPoolBuilder
-     */
-    protected $stagingPool = null;
-
-    /**
-     * @var ilTestRandomQuestionSetConfigStateMessageHandler
-     */
-    protected $configStateMessageHandler;
-    /**
-     * @var ilTestProcessLockerFactory
-     */
-    private $processLockerFactory;
+    public ilCtrlInterface $ctrl;
+    public ?ilAccessHandler $access;
+    public ilTabsGUI $tabs;
+    public ilLanguage $lng;
+    public ilGlobalTemplateInterface $tpl;
+    public ilDBInterface $db;
+    public ilTree $tree;
+    public ilComponentRepository $component_repository;
+    public ilObjectDefinition $objDefinition;
+    public ilObjTest $testOBJ;
+    protected ilTestRandomQuestionSetConfig $questionSetConfig;
+    protected ilTestRandomQuestionSetSourcePoolDefinitionFactory $sourcePoolDefinitionFactory;
+    protected ilTestRandomQuestionSetSourcePoolDefinitionList $sourcePoolDefinitionList;
+    protected ilTestRandomQuestionSetStagingPoolBuilder $stagingPool;
+    protected ilTestRandomQuestionSetConfigStateMessageHandler $configStateMessageHandler;
+    private ilTestProcessLockerFactory $processLockerFactory;
 
     /**
      * @var ArrayAccess
@@ -153,7 +83,7 @@ class ilTestRandomQuestionSetConfigGUI
         ilGlobalTemplateInterface $tpl,
         ilDBInterface $db,
         ilTree $tree,
-        ilPluginAdmin $pluginAdmin,
+        ilComponentRepository $component_repository,
         ilObjTest $testOBJ,
         ilTestProcessLockerFactory $processLockerFactory
     ) {
@@ -167,7 +97,7 @@ class ilTestRandomQuestionSetConfigGUI
         $this->tpl = $tpl;
         $this->db = $db;
         $this->tree = $tree;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->testOBJ = $testOBJ;
 
         $this->dic = $DIC;
@@ -176,7 +106,7 @@ class ilTestRandomQuestionSetConfigGUI
         $this->questionSetConfig = new ilTestRandomQuestionSetConfig(
             $this->tree,
             $this->db,
-            $this->pluginAdmin,
+            $this->component_repository,
             $this->testOBJ
         );
         $this->questionSetConfig->loadFromDb();
@@ -926,12 +856,10 @@ class ilTestRandomQuestionSetConfigGUI
         $targetRef = $this->fetchTargetRefParameter();
         
         if (count($poolIds)) {
-            require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetPoolDeriver.php';
-            
             foreach ($poolIds as $poolId) {
                 $lostPool = $this->sourcePoolDefinitionList->getLostPool($poolId);
-                
-                $deriver = new ilTestRandomQuestionSetPoolDeriver($this->db, $this->pluginAdmin, $this->testOBJ);
+
+                $deriver = new ilTestRandomQuestionSetPoolDeriver($this->db, $this->component_repository, $this->testOBJ);
                 $deriver->setSourcePoolDefinitionList($this->sourcePoolDefinitionList);
                 $deriver->setTargetContainerRef($targetRef);
                 $deriver->setOwnerId($this->dic['ilUser']->getId());

--- a/Modules/Test/classes/class.ilTestRandomQuestionSetPoolDeriver.php
+++ b/Modules/Test/classes/class.ilTestRandomQuestionSetPoolDeriver.php
@@ -1,10 +1,21 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/Test/classes/class.ilTestRandomQuestionSetStagingPoolQuestionList.php';
-require_once 'Modules/TestQuestionPool/classes/class.ilQuestionPoolFactory.php';
-require_once 'Modules/TestQuestionPool/classes/class.assQuestion.php';
-        
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 /**
  * @author        Björn Heyser <bheyser@databay.de>
  * @version        $Id$
@@ -13,45 +24,30 @@ require_once 'Modules/TestQuestionPool/classes/class.assQuestion.php';
  */
 class ilTestRandomQuestionSetPoolDeriver
 {
-    /**
-     * @var ilDBInterface
-     */
-    protected $db;
-    
-    /**
-     * @var ilPluginAdmin
-     */
-    protected $pluginAdmin;
-    
-    /**
-     * @var ilObjTest
-     */
-    protected $testOBJ;
-    
+    protected ilDBInterface $db;
+    protected ilComponentRepository $component_repository;
+    protected ilObjTest $testOBJ;
+    protected ilQuestionPoolFactory $poolFactory;
+
     /**
      * @var integer
      */
     protected $targetContainerRef;
-    
+
     /**
      * @var integer
      */
     protected $ownerId;
-    
-    /**
-     * @var ilQuestionPoolFactory
-     */
-    protected $poolFactory;
-    
+
     /**
      * @var ilTestRandomQuestionSetSourcePoolDefinitionList
      */
     protected $sourcePoolDefinitionList;
     
-    public function __construct(ilDBInterface $ilDB, ilPluginAdmin $pluginAdmin, ilObjTest $testOBJ)
+    public function __construct(ilDBInterface $ilDB, ilComponentRepository $component_repository, ilObjTest $testOBJ)
     {
         $this->db = $ilDB;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->testOBJ = $testOBJ;
         $this->poolFactory = new ilQuestionPoolFactory();
     }
@@ -108,7 +104,7 @@ class ilTestRandomQuestionSetPoolDeriver
     {
         $questionList = new ilTestRandomQuestionSetStagingPoolQuestionList(
             $this->db,
-            $this->pluginAdmin
+            $this->component_repository
         );
         
         $questionList->setTestObjId($this->testOBJ->getId());

--- a/Modules/Test/classes/class.ilTestRandomQuestionSetStagingPoolQuestionList.php
+++ b/Modules/Test/classes/class.ilTestRandomQuestionSetStagingPoolQuestionList.php
@@ -1,7 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/TestQuestionPool/classes/questions/class.ilAssQuestionType.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Handles a list of questions
@@ -14,15 +27,8 @@ require_once 'Modules/TestQuestionPool/classes/questions/class.ilAssQuestionType
  */
 class ilTestRandomQuestionSetStagingPoolQuestionList implements Iterator
 {
-    /**
-     * @var ilDBInterface
-     */
-    private $db = null;
-    
-    /**
-     * @var ilPluginAdmin
-     */
-    private $pluginAdmin = null;
+    private ilDBInterface $db;
+    private ilComponentRepository $component_repository;
 
     /**
      * @var integer
@@ -62,10 +68,10 @@ class ilTestRandomQuestionSetStagingPoolQuestionList implements Iterator
      */
     private $questions = array();
 
-    public function __construct(ilDBInterface $db, ilPluginAdmin $pluginAdmin)
+    public function __construct(ilDBInterface $db, ilComponentRepository $component_repository)
     {
         $this->db = $db;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
     }
 
     public function setTestObjId($testObjId)
@@ -253,7 +259,7 @@ class ilTestRandomQuestionSetStagingPoolQuestionList implements Iterator
     }
     // fau;
 
-    private function isActiveQuestionType($questionData) : bool
+    private function isActiveQuestionType(array $questionData) : bool
     {
         if (!isset($questionData['plugin'])) {
             return false;
@@ -262,8 +268,18 @@ class ilTestRandomQuestionSetStagingPoolQuestionList implements Iterator
         if (!$questionData['plugin']) {
             return true;
         }
-        
-        return $this->pluginAdmin->isActive(ilComponentInfo::TYPE_MODULES, 'TestQuestionPool', 'qst', $questionData['plugin_name']);
+
+        return $this->component_repository
+            ->getComponentByTypeAndName(
+                ilComponentInfo::TYPE_MODULES,
+                'TestQuestionPool'
+            )
+            ->getPluginSlotById(
+                'qst'
+            )
+            ->getPluginByName(
+                $questionData['plugin_name']
+            )->isActive();
     }
 
     public function resetQuestionList()

--- a/Modules/Test/classes/class.ilTestResultsGUI.php
+++ b/Modules/Test/classes/class.ilTestResultsGUI.php
@@ -1,6 +1,20 @@
 <?php
 
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestResultsGUI
@@ -259,15 +273,15 @@ class ilTestResultsGUI
                     $dynamicQuestionSetConfig = new ilObjTestDynamicQuestionSetConfig(
                         $DIC->repositoryTree(),
                         $DIC->database(),
-                        $DIC['ilPluginAdmin'],
+                        $DIC['component.repository'],
                         $this->getTestObj()
                     );
                     $dynamicQuestionSetConfig->loadFromDb();
-                    $questionList = new ilAssQuestionList($DIC->database(), $DIC->language(), $DIC['ilPluginAdmin']);
+                    $questionList = new ilAssQuestionList($DIC->database(), $DIC->language(), $DIC['component.repository']);
                     $questionList->setParentObjId($dynamicQuestionSetConfig->getSourceQuestionPoolId());
                     $questionList->setQuestionInstanceTypeFilter(ilAssQuestionList::QUESTION_INSTANCE_TYPE_ORIGINALS);
                 } else {
-                    $questionList = new ilAssQuestionList($DIC->database(), $DIC->language(), $DIC['ilPluginAdmin']);
+                    $questionList = new ilAssQuestionList($DIC->database(), $DIC->language(), $DIC['component.repository']);
                     $questionList->setParentObjId($this->getTestObj()->getId());
                     $questionList->setQuestionInstanceTypeFilter(ilAssQuestionList::QUESTION_INSTANCE_TYPE_DUPLICATES);
                 }

--- a/Modules/Test/classes/class.ilTestSequenceFactory.php
+++ b/Modules/Test/classes/class.ilTestSequenceFactory.php
@@ -1,61 +1,44 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Factory for test sequence
- *
  * @author		Björn Heyser <bheyser@databay.de>
- * @version		$Id$
- *
  * @package		Modules/Test
  */
 class ilTestSequenceFactory
 {
-    /**
-     * singleton instances of test sequences
-     *
-     * @var array
-     */
-    private $testSequences = array();
-    
-    /**
-     * global ilDBInterface object instance
-     *
-     * @var ilDBInterface
-     */
-    private $db = null;
-    
-    /**
-     * global ilLanguage object instance
-     *
-     * @var ilLanguage
-     */
-    private $lng = null;
-    
-    /**
-     * global ilPluginAdmin object instance
-     *
-     * @var ilPluginAdmin
-     */
-    private $pluginAdmin = null;
-    
-    /**
-     * object instance of current test
-     *
-     * @var ilObjTest
-     */
-    private $testOBJ = null;
-    
-    /**
-     * constructor
-     *
-     * @param ilObjTest $testOBJ
-     */
-    public function __construct(ilDBInterface $db, ilLanguage $lng, ilPluginAdmin $pluginAdmin, ilObjTest $testOBJ)
-    {
+    /** @var array<int, array<int, ilTestSequenceFixedQuestionSet|ilTestSequenceRandomQuestionSet|ilTestSequenceDynamicQuestionSet|ilTestSequenceSummaryProvider>> */
+    private array $testSequences = [];
+    private ilDBInterface $db;
+    private ilLanguage $lng;
+    private ilComponentRepository $component_repository;
+    private ilObjTest $testOBJ;
+
+    public function __construct(
+        ilDBInterface $db,
+        ilLanguage $lng,
+        ilComponentRepository $component_repository,
+        ilObjTest $testOBJ
+    ) {
         $this->db = $db;
         $this->lng = $lng;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->testOBJ = $testOBJ;
     }
     
@@ -77,7 +60,7 @@ class ilTestSequenceFactory
      *
      * @param integer $activeId
      * @param integer $pass
-     * @return ilTestSequenceFixedQuestionSet|ilTestSequenceRandomQuestionSet|ilTestSequenceDynamicQuestionSet
+     * @return ilTestSequenceFixedQuestionSet|ilTestSequenceRandomQuestionSet|ilTestSequenceDynamicQuestionSet|ilTestSequenceSummaryProvider
      */
     public function getSequenceByActiveIdAndPass($activeId, $pass)
     {
@@ -102,7 +85,7 @@ class ilTestSequenceFactory
                 $questionSet = new ilTestDynamicQuestionSet(
                     $this->db,
                     $this->lng,
-                    $this->pluginAdmin,
+                    $this->component_repository,
                     $this->testOBJ
                 );
                 $this->testSequences[$activeId][$pass] = new ilTestSequenceDynamicQuestionSet(

--- a/Modules/Test/classes/class.ilTestService.php
+++ b/Modules/Test/classes/class.ilTestService.php
@@ -1,5 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Service class for tests.
@@ -181,16 +196,13 @@ class ilTestService
         global $DIC;
         $ilDB = $DIC['ilDB'];
         $lng = $DIC['lng'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component_repository'];
 
-        require_once 'Modules/Test/classes/class.ilTestVirtualSequence.php';
-        $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $ilPluginAdmin, $this->object);
+        $testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $component_repository, $this->object);
 
         if ($this->object->isRandomTest()) {
-            require_once 'Modules/Test/classes/class.ilTestVirtualSequenceRandomQuestionSet.php';
             $virtualSequence = new ilTestVirtualSequenceRandomQuestionSet($ilDB, $this->object, $testSequenceFactory);
         } else {
-            require_once 'Modules/Test/classes/class.ilTestVirtualSequence.php';
             $virtualSequence = new ilTestVirtualSequence($ilDB, $this->object, $testSequenceFactory);
         }
 

--- a/Modules/Test/classes/class.ilTestServiceGUI.php
+++ b/Modules/Test/classes/class.ilTestServiceGUI.php
@@ -1,8 +1,22 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 include_once "./Modules/Test/classes/inc.AssessmentConstants.php";
-include_once 'Modules/Test/classes/class.ilTestService.php';
 
 /**
 * Service GUI class for tests. This class is the parent class for all
@@ -116,7 +130,7 @@ class ilTestServiceGUI
         $ilias = $DIC['ilias'];
         $tree = $DIC['tree'];
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
         $ilTabs = $DIC['ilTabs'];
         $ilObjDataCache = $DIC['ilObjDataCache'];
 
@@ -135,11 +149,9 @@ class ilTestServiceGUI
 
         $this->service = new ilTestService($a_object);
         $this->testrequest = $DIC->test()->internal()->request();
-        require_once 'Modules/Test/classes/class.ilTestSessionFactory.php';
         $this->testSessionFactory = new ilTestSessionFactory($this->object);
 
-        require_once 'Modules/Test/classes/class.ilTestSequenceFactory.php';
-        $this->testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $ilPluginAdmin, $this->object);
+        $this->testSequenceFactory = new ilTestSequenceFactory($ilDB, $lng, $component_repository, $this->object);
 
         $this->objectiveOrientedContainer = null;
     }
@@ -1033,13 +1045,12 @@ class ilTestServiceGUI
     {
         global $DIC;
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
 
         $table_gui = $this->buildPassDetailsOverviewTableGUI($this, 'outUserPassDetails');
         $table_gui->initFilter();
 
-        require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionList.php';
-        $questionList = new ilAssQuestionList($ilDB, $this->lng, $ilPluginAdmin);
+        $questionList = new ilAssQuestionList($ilDB, $this->lng, $component_repository);
 
         $questionList->setParentObjIdsFilter(array($this->object->getId()));
         $questionList->setQuestionInstanceTypeFilter(ilAssQuestionList::QUESTION_INSTANCE_TYPE_DUPLICATES);

--- a/Modules/Test/classes/class.ilTestSettingsGUI.php
+++ b/Modules/Test/classes/class.ilTestSettingsGUI.php
@@ -1,28 +1,31 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * GUI class that manages the editing of general test settings/properties
  * shown on "general" subtab
- *
  * @author		Björn Heyser <bheyser@databay.de>
- * @version		$Id: class.ilObjTestSettingsGeneralGUI.php 57702 2015-01-31 21:30:34Z bheyser $
- *
  * @package		Modules/Test
  */
 abstract class ilTestSettingsGUI
 {
-    /**
-     * @var ilObjTest $testOBJ
-     */
-    protected $testOBJ = null;
-
-    /**
-     * object instance for currently active settings template
-     *
-     * @var $settingsTemplate ilSettingsTemplate
-     */
-    protected $settingsTemplate = null;
+    protected ilObjTest $testOBJ;
+    protected ?ilSettingsTemplate $settingsTemplate = null;
 
     public function __construct(ilObjTest $testOBJ)
     {
@@ -31,7 +34,6 @@ abstract class ilTestSettingsGUI
         $templateId = $this->testOBJ->getTemplate();
 
         if ($templateId) {
-            include_once "Services/Administration/classes/class.ilSettingsTemplate.php";
             $this->settingsTemplate = new ilSettingsTemplate($templateId, ilObjAssessmentFolderGUI::getSettingsTemplateConfig());
         }
     }

--- a/Modules/Test/classes/class.ilTestSkillAdministrationGUI.php
+++ b/Modules/Test/classes/class.ilTestSkillAdministrationGUI.php
@@ -1,8 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php';
-require_once 'Modules/Test/classes/class.ilTestSkillLevelThresholdsGUI.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author		Björn Heyser <bheyser@databay.de>
@@ -15,59 +27,31 @@ require_once 'Modules/Test/classes/class.ilTestSkillLevelThresholdsGUI.php';
  */
 class ilTestSkillAdministrationGUI
 {
-    /**
-     * @var ILIAS
-     */
-    private $ilias;
-
-    /**
-     * @var ilCtrl
-     */
-    private $ctrl;
-
-    /**
-     * @var ilAccessHandler
-     */
-    private $access;
-
-    /**
-     * @var ilTabsGUI
-     */
-    private $tabs;
-
-    /**
-     * @var ilGlobalTemplateInterface
-     */
-    private $tpl;
-
-    /**
-     * @var ilLanguage
-     */
-    private $lng;
-
-    /**
-     * @var ilDBInterface
-     */
-    private $db;
-
-    /**
-     * @var ilTree
-     */
-    private $tree;
-
-    /**
-     * @var ilPluginAdmin
-     */
-    private $pluginAdmin;
-
-    /**
-     * @var ilObjTest
-     */
-    private $testOBJ;
+    private ILIAS $ilias;
+    private ilCtrlInterface $ctrl;
+    private ilAccessHandler $access;
+    private ilTabsGUI $tabs;
+    private ilGlobalTemplateInterface $tpl;
+    private ilLanguage $lng;
+    private ilDBInterface $db;
+    private ilTree $tree;
+    private ilComponentRepository $component_repository;
+    private ilObjTest $testOBJ;
     private $refId;
 
-    public function __construct(ILIAS $ilias, ilCtrl $ctrl, ilAccessHandler $access, ilTabsGUI $tabs, ilGlobalTemplateInterface $tpl, ilLanguage $lng, ilDBInterface $db, ilTree $tree, ilPluginAdmin $pluginAdmin, ilObjTest $testOBJ, $refId)
-    {
+    public function __construct(
+        ILIAS $ilias,
+        ilCtrl $ctrl,
+        ilAccessHandler $access,
+        ilTabsGUI $tabs,
+        ilGlobalTemplateInterface $tpl,
+        ilLanguage $lng,
+        ilDBInterface $db,
+        ilTree $tree,
+        ilComponentRepository $component_repository,
+        ilObjTest $testOBJ,
+        $refId
+    ) {
         $this->ilias = $ilias;
         $this->ctrl = $ctrl;
         $this->access = $access;
@@ -76,7 +60,7 @@ class ilTestSkillAdministrationGUI
         $this->lng = $lng;
         $this->db = $db;
         $this->tree = $tree;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->testOBJ = $testOBJ;
         $this->refId = $refId;
     }
@@ -96,8 +80,7 @@ class ilTestSkillAdministrationGUI
 
                 $questionContainerId = $this->getQuestionContainerId();
                 
-                require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionList.php';
-                $questionList = new ilAssQuestionList($this->db, $this->lng, $this->pluginAdmin);
+                $questionList = new ilAssQuestionList($this->db, $this->lng, $this->component_repository);
                 $questionList->setParentObjId($questionContainerId);
                 $questionList->setQuestionInstanceTypeFilter($this->getRequiredQuestionInstanceTypeFilter());
                 $questionList->load();
@@ -189,7 +172,7 @@ class ilTestSkillAdministrationGUI
             $questionSetConfigFactory = new ilTestQuestionSetConfigFactory(
                 $this->tree,
                 $this->db,
-                $this->pluginAdmin,
+                $this->component_repository,
                 $this->testOBJ
             );
 
@@ -219,7 +202,7 @@ class ilTestSkillAdministrationGUI
         $questionSetConfigFactory = new ilTestQuestionSetConfigFactory(
             $this->tree,
             $this->db,
-            $this->pluginAdmin,
+            $this->component_repository,
             $this->testOBJ
         );
         

--- a/Modules/Test/classes/tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestQuestionBrowserTableGUI.php
@@ -45,7 +45,7 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
     private ilTabsGUI $tabs;
     private ilTree $tree;
     private ilDBInterface $db;
-    private ilPluginAdmin $pluginAdmin;
+    private ilComponentRepository $component_repository;
     private ilObjTest $testOBJ;
     private ilAccessHandler $access;
 
@@ -59,7 +59,7 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
         ilLanguage $lng,
         ilTree $tree,
         ilDBInterface $db,
-        ilPluginAdmin $pluginAdmin,
+        ilComponentRepository $component_repository,
         ilObjTest $testOBJ,
         ilAccessHandler $access,
         ILIAS\HTTP\GlobalHttpState $httpState,
@@ -71,7 +71,7 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
         $this->lng = $lng;
         $this->tree = $tree;
         $this->db = $db;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->testOBJ = $testOBJ;
         $this->access = $access;
         $this->httpState = $httpState;
@@ -447,7 +447,7 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
         $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory(
             $this->tree,
             $this->db,
-            $this->pluginAdmin,
+            $this->component_repository,
             $this->testOBJ
         );
 
@@ -456,7 +456,7 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
 
     private function getQuestionsData() : array
     {
-        $questionList = new ilAssQuestionList($this->db, $this->lng, $this->pluginAdmin);
+        $questionList = new ilAssQuestionList($this->db, $this->lng, $this->component_repository);
 
         $questionList->setQuestionInstanceTypeFilter($this->getQuestionInstanceTypeFilter());
         $questionList->setExcludeQuestionIdsFilter($this->testOBJ->getExistingQuestions());

--- a/Modules/Test/classes/toolbars/class.ilTestInfoScreenToolbarGUI.php
+++ b/Modules/Test/classes/toolbars/class.ilTestInfoScreenToolbarGUI.php
@@ -1,11 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php';
-require_once 'Services/UIComponent/Button/classes/class.ilLinkButton.php';
-require_once 'Services/UIComponent/Button/classes/class.ilSubmitButton.php';
-require_once 'Services/Form/classes/class.ilFormPropertyGUI.php';
-require_once 'Services/Form/classes/class.ilHiddenInputGUI.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -23,7 +32,7 @@ class ilTestInfoScreenToolbarGUI extends ilToolbarGUI
     protected ilDBInterface $db;
     protected ilAccessHandler $access;
     protected ilCtrl $ctrl;
-    protected ilPluginAdmin $pluginAdmin;
+    protected ilComponentRepository $component_repository;
     private \ilGlobalTemplateInterface $main_tpl;
 
     protected ?ilObjTest $testOBJ = null;
@@ -43,8 +52,13 @@ class ilTestInfoScreenToolbarGUI extends ilToolbarGUI
     private array $infoMessages = array();
     private array $failureMessages = array();
 
-    public function __construct(ilDBInterface $db, ilAccessHandler $access, ilCtrl $ctrl, ilLanguage $lng, ilPluginAdmin $pluginAdmin)
-    {
+    public function __construct(
+        ilDBInterface $db,
+        ilAccessHandler $access,
+        ilCtrl $ctrl,
+        ilLanguage $lng,
+        ilComponentRepository $component_repository
+    ) {
         global $DIC;
         $this->main_tpl = $DIC->ui()->mainTemplate(); /* @var ILIAS\DI\Container $DIC */
         $this->DIC = $DIC;
@@ -52,7 +66,7 @@ class ilTestInfoScreenToolbarGUI extends ilToolbarGUI
         $this->access = $access;
         $this->ctrl = $ctrl;
         $this->lng = $lng;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
     }
 
     public function getGlobalToolbar() : ?ilToolbarGUI

--- a/Modules/Test/test/ilObjTestDynamicQuestionSetConfigGUITest.php
+++ b/Modules/Test/test/ilObjTestDynamicQuestionSetConfigGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilObjTestDynamicQuestionSetConfigGUITest
@@ -17,13 +31,13 @@ class ilObjTestDynamicQuestionSetConfigGUITest extends ilTestBaseTestCase
         $this->testObj = new ilObjTestDynamicQuestionSetConfigGUI(
             $this->createMock(ilCtrl::class),
             $this->createMock(ilAccessHandler::class),
-            $this->createMock(ilTabsGUI::class),
-            $this->createMock(ilLanguage::class),
+            $this->getMockBuilder(ilTabsGUI::class)->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock(),
             $this->createMock(ilGlobalPageTemplate::class),
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilTree::class),
-            $this->createMock(ilPluginAdmin::class),
-            $this->createMock(ilObjTest::class)
+            $this->getMockBuilder(ilTree::class)->disableOriginalConstructor()->getMock(),
+            $this->createMock(ilComponentRepository::class),
+            $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock()
         );
     }
 

--- a/Modules/Test/test/ilObjTestDynamicQuestionSetConfigTest.php
+++ b/Modules/Test/test/ilObjTestDynamicQuestionSetConfigTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilObjTestDynamicQuestionSetConfigTest
@@ -15,10 +29,10 @@ class ilObjTestDynamicQuestionSetConfigTest extends ilTestBaseTestCase
         parent::setUp();
 
         $this->testObj = new ilObjTestDynamicQuestionSetConfig(
-            $this->createMock(ilTree::class),
+            $this->getMockBuilder(ilTree::class)->disableOriginalConstructor()->getMock(),
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilPluginAdmin::class),
-            $this->createMock(ilObjTest::class)
+            $this->createMock(ilComponentRepository::class),
+            $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock()
         );
     }
 

--- a/Modules/Test/test/ilObjTestGUITest.php
+++ b/Modules/Test/test/ilObjTestGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilObjTestGUITest
@@ -19,7 +33,7 @@ class ilObjTestGUITest extends ilTestBaseTestCase
         $this->addGlobal_lng();
         $this->addGlobal_ilCtrl();
         $this->addGlobal_ilDB();
-        $this->addGlobal_ilPluginAdmin();
+        $this->addGlobal_ilComponentRepository();
         $this->addGlobal_tree();
         $this->addGlobal_http();
         $this->addGlobal_ilLocator();

--- a/Modules/Test/test/ilObjTestSettingsGeneralGUITest.php
+++ b/Modules/Test/test/ilObjTestSettingsGeneralGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilObjTestSettingsGeneralGUITest
@@ -22,18 +36,18 @@ class ilObjTestSettingsGeneralGUITest extends ilTestBaseTestCase
         $this->addGlobal_tree();
         $this->addGlobal_ilAppEventHandler();
         $this->addGlobal_objDefinition();
-        //$objTestGui_mock = $this->createMock(ilObjTestGUI::class);
+
         $objTestGui_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getTestObject'))->getMock();
-        $objTestGui_mock->expects($this->any())->method('getTestObject')->willReturn($this->createMock(ilObjTest::class));
+        $objTestGui_mock->method('getTestObject')->willReturn($this->createMock(ilObjTest::class));
 
         $this->testObj = new ilObjTestSettingsGeneralGUI(
             $this->createMock(ilCtrl::class),
             $this->createMock(ilAccessHandler::class),
-            $this->createMock(ilLanguage::class),
-            $this->createMock(ilTree::class),
+            $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(ilTree::class)->disableOriginalConstructor()->getMock(),
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilPluginAdmin::class),
-            $this->createMock(ilObjUser::class),
+            $this->createMock(ilComponentRepository::class),
+            $this->getMockBuilder(ilObjUser::class)->disableOriginalConstructor()->getMock(),
             $objTestGui_mock
         );
     }

--- a/Modules/Test/test/ilObjTestSettingsScoringResultsGUITest.php
+++ b/Modules/Test/test/ilObjTestSettingsScoringResultsGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilObjTestSettingsScoringResultsGUITest
@@ -21,10 +35,10 @@ class ilObjTestSettingsScoringResultsGUITest extends ilTestBaseTestCase
         $this->testObj = new ilObjTestSettingsScoringResultsGUI(
             $this->createMock(ilCtrl::class),
             $this->createMock(ilAccessHandler::class),
-            $this->createMock(ilLanguage::class),
-            $this->createMock(ilTree::class),
+            $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(ilTree::class)->disableOriginalConstructor()->getMock(),
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilPluginAdmin::class),
+            $this->createMock(ilComponentRepository::class),
             $objTestGui_mock
         );
     }

--- a/Modules/Test/test/ilTestBaseTestCase.php
+++ b/Modules/Test/test/ilTestBaseTestCase.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -201,9 +215,9 @@ class ilTestBaseTestCase extends TestCase
         $this->setGlobalVariable("tpl", $this->createMock(ilGlobalPageTemplate::class));
     }
 
-    protected function addGlobal_ilPluginAdmin() : void
+    protected function addGlobal_ilComponentRepository() : void
     {
-        $this->setGlobalVariable("ilPluginAdmin", $this->createMock(ilPluginAdmin::class));
+        $this->setGlobalVariable("component.repository", $this->createMock(ilComponentRepository::class));
     }
 
     protected function addGlobal_ilTabs() : void

--- a/Modules/Test/test/ilTestDynamicQuestionSetTest.php
+++ b/Modules/Test/test/ilTestDynamicQuestionSetTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestDynamicQuestionSetTest
@@ -16,9 +30,9 @@ class ilTestDynamicQuestionSetTest extends ilTestBaseTestCase
 
         $this->testObj = new ilTestDynamicQuestionSet(
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilLanguage::class),
-            $this->createMock(ilPluginAdmin::class),
-            $this->createMock(ilObjTest::class)
+            $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock(),
+            $this->createMock(ilComponentRepository::class),
+            $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock()
         );
     }
 

--- a/Modules/Test/test/ilTestEvalObjectiveOrientedGUITest.php
+++ b/Modules/Test/test/ilTestEvalObjectiveOrientedGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestEvalObjectiveOrientedGUITest
@@ -20,7 +34,7 @@ class ilTestEvalObjectiveOrientedGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilias();
         $this->addGlobal_tree();
         $this->addGlobal_ilDB();
-        $this->addGlobal_ilPluginAdmin();
+        $this->addGlobal_ilComponentRepository();
         $this->addGlobal_ilTabs();
         $this->addGlobal_ilObjDataCache();
 

--- a/Modules/Test/test/ilTestEvaluationGUITest.php
+++ b/Modules/Test/test/ilTestEvaluationGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestEvaluationGUITest
@@ -20,7 +34,7 @@ class ilTestEvaluationGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilias();
         $this->addGlobal_tree();
         $this->addGlobal_ilDB();
-        $this->addGlobal_ilPluginAdmin();
+        $this->addGlobal_ilComponentRepository();
         $this->addGlobal_ilTabs();
         $this->addGlobal_ilObjDataCache();
 

--- a/Modules/Test/test/ilTestFixedQuestionSetConfigTest.php
+++ b/Modules/Test/test/ilTestFixedQuestionSetConfigTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -23,9 +37,9 @@ class ilTestFixedQuestionSetConfigTest extends ilTestBaseTestCase
         $this->objTest_mock = $this->createMock(ilObjTest::class);
 
         $this->testObj = new ilTestFixedQuestionSetConfig(
-            $this->createMock(ilTree::class),
+            $this->getMockBuilder(ilTree::class)->disableOriginalConstructor()->getMock(),
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilPluginAdmin::class),
+            $this->createMock(ilComponentRepository::class),
             $this->objTest_mock
         );
     }

--- a/Modules/Test/test/ilTestPlayerFactoryTest.php
+++ b/Modules/Test/test/ilTestPlayerFactoryTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestPlayerFactoryTest
@@ -35,7 +49,7 @@ class ilTestPlayerFactoryTest extends ilTestBaseTestCase
         $this->addGlobal_objDefinition();
         $this->addGlobal_tpl();
         $this->addGlobal_ilCtrl();
-        $this->addGlobal_ilPluginAdmin();
+        $this->addGlobal_ilComponentRepository();
         $this->addGlobal_ilTabs();
         $this->addGlobal_ilObjDataCache();
         $this->addGlobal_rbacsystem();

--- a/Modules/Test/test/ilTestPlayerFixedQuestionSetGUITest.php
+++ b/Modules/Test/test/ilTestPlayerFixedQuestionSetGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestPlayerFixedQuestionSetGUITest
@@ -20,7 +34,7 @@ class ilTestPlayerFixedQuestionSetGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilias();
         $this->addGlobal_tree();
         $this->addGlobal_ilDB();
-        $this->addGlobal_ilPluginAdmin();
+        $this->addGlobal_ilComponentRepository();
         $this->addGlobal_ilTabs();
         $this->addGlobal_ilObjDataCache();
         $this->addGlobal_rbacsystem();

--- a/Modules/Test/test/ilTestPlayerRandomQuestionSetGUITest.php
+++ b/Modules/Test/test/ilTestPlayerRandomQuestionSetGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestPlayerRandomQuestionSetGUITest
@@ -20,7 +34,7 @@ class ilTestPlayerRandomQuestionSetGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilias();
         $this->addGlobal_tree();
         $this->addGlobal_ilDB();
-        $this->addGlobal_ilPluginAdmin();
+        $this->addGlobal_ilComponentRepository();
         $this->addGlobal_ilTabs();
         $this->addGlobal_ilObjDataCache();
         $this->addGlobal_rbacsystem();

--- a/Modules/Test/test/ilTestQuestionSetConfigFactoryTest.php
+++ b/Modules/Test/test/ilTestQuestionSetConfigFactoryTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestQuestionSetConfigFactoryTest
@@ -17,7 +31,7 @@ class ilTestQuestionSetConfigFactoryTest extends ilTestBaseTestCase
         $this->testObj = new ilTestQuestionSetConfigFactory(
             $this->createMock(ilTree::class),
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilPluginAdmin::class),
+            $this->createMock(ilComponentRepository::class),
             $this->createMock(ilObjTest::class),
         );
     }

--- a/Modules/Test/test/ilTestRandomQuestionSetConfigGUITest.php
+++ b/Modules/Test/test/ilTestRandomQuestionSetConfigGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestRandomQuestionSetConfigGUITest
@@ -24,7 +38,7 @@ class ilTestRandomQuestionSetConfigGUITest extends ilTestBaseTestCase
             $this->createMock(ilGlobalTemplateInterface::class),
             $this->createMock(ilDBInterface::class),
             $this->getMockBuilder(ilTree::class)->disableOriginalConstructor()->getMock(),
-            $this->getMockBuilder(ilPluginAdmin::class)->disableOriginalConstructor()->getMock(),
+            $this->createMock(ilComponentRepository::class),
             $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock(),
             $this->getMockBuilder(ilTestProcessLockerFactory::class)->disableOriginalConstructor()->getMock()
         );

--- a/Modules/Test/test/ilTestRandomQuestionSetConfigTest.php
+++ b/Modules/Test/test/ilTestRandomQuestionSetConfigTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestRandomQuestionSetConfigTest
@@ -15,10 +29,10 @@ class ilTestRandomQuestionSetConfigTest extends ilTestBaseTestCase
         parent::setUp();
 
         $this->testObj = new ilTestRandomQuestionSetConfig(
-            $this->createMock(ilTree::class),
+            $this->getMockBuilder(ilTree::class)->disableOriginalConstructor()->getMock(),
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilPluginAdmin::class),
-            $this->createMock(ilObjTest::class)
+            $this->createMock(ilComponentRepository::class),
+            $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock()
         );
     }
 

--- a/Modules/Test/test/ilTestRandomQuestionSetPoolDeriverTest.php
+++ b/Modules/Test/test/ilTestRandomQuestionSetPoolDeriverTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestRandomQuestionSetPoolDeriverTest
@@ -16,8 +30,8 @@ class ilTestRandomQuestionSetPoolDeriverTest extends ilTestBaseTestCase
 
         $this->testObj = new ilTestRandomQuestionSetPoolDeriver(
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilPluginAdmin::class),
-            $this->createMock(ilObjTest::class)
+            $this->createMock(ilComponentRepository::class),
+            $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock()
         );
     }
 

--- a/Modules/Test/test/ilTestRandomQuestionSetStagingPoolQuestionListTest.php
+++ b/Modules/Test/test/ilTestRandomQuestionSetStagingPoolQuestionListTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestRandomQuestionSetStagingPoolQuestionListTest
@@ -16,7 +30,7 @@ class ilTestRandomQuestionSetStagingPoolQuestionListTest extends ilTestBaseTestC
 
         $this->testObj = new ilTestRandomQuestionSetStagingPoolQuestionList(
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilPluginAdmin::class)
+            $this->createMock(ilComponentRepository::class)
         );
     }
 

--- a/Modules/Test/test/ilTestScoringByQuestionsGUITest.php
+++ b/Modules/Test/test/ilTestScoringByQuestionsGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestScoringByQuestionsGUITest
@@ -20,7 +34,7 @@ class ilTestScoringByQuestionsGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilias();
         $this->addGlobal_tree();
         $this->addGlobal_ilDB();
-        $this->addGlobal_ilPluginAdmin();
+        $this->addGlobal_ilComponentRepository();
         $this->addGlobal_ilTabs();
         $this->addGlobal_ilObjDataCache();
 

--- a/Modules/Test/test/ilTestScoringGUITest.php
+++ b/Modules/Test/test/ilTestScoringGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestScoringGUITest
@@ -20,7 +34,7 @@ class ilTestScoringGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilias();
         $this->addGlobal_tree();
         $this->addGlobal_ilDB();
-        $this->addGlobal_ilPluginAdmin();
+        $this->addGlobal_ilComponentRepository();
         $this->addGlobal_ilTabs();
         $this->addGlobal_ilObjDataCache();
 

--- a/Modules/Test/test/ilTestSequenceFactoryTest.php
+++ b/Modules/Test/test/ilTestSequenceFactoryTest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestSequenceFactoryTest
@@ -16,9 +30,9 @@ class ilTestSequenceFactoryTest extends ilTestBaseTestCase
 
         $this->testObj = new ilTestSequenceFactory(
             $this->createMock(ilDBInterface::class),
-            $this->createMock(ilLanguage::class),
-            $this->createMock(ilPluginAdmin::class),
-            $this->createMock(ilObjTest::class)
+            $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock(),
+            $this->createMock(ilComponentRepository::class),
+            $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock(),
         );
     }
 

--- a/Modules/Test/test/ilTestServiceGUITest.php
+++ b/Modules/Test/test/ilTestServiceGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestServiceGUITest
@@ -20,7 +34,7 @@ class ilTestServiceGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilias();
         $this->addGlobal_tree();
         $this->addGlobal_ilDB();
-        $this->addGlobal_ilPluginAdmin();
+        $this->addGlobal_ilComponentRepository();
         $this->addGlobal_ilTabs();
         $this->addGlobal_ilObjDataCache();
 

--- a/Modules/Test/test/ilTestSkillAdministrationGUITest.php
+++ b/Modules/Test/test/ilTestSkillAdministrationGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestSkillAdministrationGUITest
@@ -23,7 +37,7 @@ class ilTestSkillAdministrationGUITest extends ilTestBaseTestCase
             $this->createMock(ilLanguage::class),
             $this->createMock(ilDBInterface::class),
             $this->createMock(ilTree::class),
-            $this->createMock(ilPluginAdmin::class),
+            $this->createMock(ilComponentRepository::class),
             $this->createMock(ilObjTest::class),
             201
         );

--- a/Modules/Test/test/ilTestSubmissionReviewGUITest.php
+++ b/Modules/Test/test/ilTestSubmissionReviewGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestSubmissionReviewGUITest
@@ -20,7 +34,7 @@ class ilTestSubmissionReviewGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilias();
         $this->addGlobal_tree();
         $this->addGlobal_ilDB();
-        $this->addGlobal_ilPluginAdmin();
+        $this->addGlobal_ilComponentRepository();
         $this->addGlobal_ilTabs();
         $this->addGlobal_ilObjDataCache();
 

--- a/Modules/Test/test/tables/ilAssessmentFolderLogAdministrationTableGUITest.php
+++ b/Modules/Test/test/tables/ilAssessmentFolderLogAdministrationTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilAssessmentFolderLogAdministrationTableGUITest
@@ -30,7 +44,6 @@ class ilAssessmentFolderLogAdministrationTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
         $this->parentObj_mock = $this->getMockBuilder(ilObjAssessmentFolderGUI::class)->disableOriginalConstructor()->onlyMethods(['getObject'])->getMock();
         $this->parentObj_mock->method('getObject')->willReturn($this->createMock(ilObjTest::class));

--- a/Modules/Test/test/tables/ilAssessmentFolderLogTableGUITest.php
+++ b/Modules/Test/test/tables/ilAssessmentFolderLogTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilAssessmentFolderLogTableGUITest
@@ -30,7 +44,6 @@ class ilAssessmentFolderLogTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjAssessmentFolderGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilEvaluationAllTableGUITest.php
+++ b/Modules/Test/test/tables/ilEvaluationAllTableGUITest.php
@@ -1,5 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilEvaluationAllTableGUITest
@@ -35,7 +50,6 @@ class ilEvaluationAllTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
         $this->setGlobalVariable("ilSetting", $this->createMock(ilSetting::class));
         $this->setGlobalVariable("rbacreview", $this->createMock(ilRbacReview::class));

--- a/Modules/Test/test/tables/ilListOfQuestionsTableGUITest.php
+++ b/Modules/Test/test/tables/ilListOfQuestionsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilListOfQuestionsTableGUITest
@@ -30,7 +44,6 @@ class ilListOfQuestionsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilMarkSchemaTableGUITest.php
+++ b/Modules/Test/test/tables/ilMarkSchemaTableGUITest.php
@@ -1,5 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilMarkSchemaTableGUITest
@@ -29,7 +44,6 @@ class ilMarkSchemaTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
         $this->setGlobalVariable("ilToolbar", $this->createMock(ilToolbarGUI::class));
 

--- a/Modules/Test/test/tables/ilParticipantsTestResultsTableGUITest.php
+++ b/Modules/Test/test/tables/ilParticipantsTestResultsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilParticipantsTestResultsTableGUITest
@@ -30,7 +44,6 @@ class ilParticipantsTestResultsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->createMock(ilParticipantsTestResultsGUI::class);

--- a/Modules/Test/test/tables/ilResultsByQuestionTableGUITest.php
+++ b/Modules/Test/test/tables/ilResultsByQuestionTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilResultsByQuestionTableGUITest
@@ -30,7 +44,6 @@ class ilResultsByQuestionTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestAggregatedResultsTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestAggregatedResultsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestAggregatedResultsTableGUITest
@@ -30,7 +44,6 @@ class ilTestAggregatedResultsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestAverageReachedPointsTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestAverageReachedPointsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestAverageReachedPointsTableGUITest
@@ -30,7 +44,6 @@ class ilTestAverageReachedPointsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestDetailedEvaluationStatisticsTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestDetailedEvaluationStatisticsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestDetailedEvaluationStatisticsTableGUITest
@@ -30,7 +44,6 @@ class ilTestDetailedEvaluationStatisticsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestDynamicQuestionSetStatisticTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestDynamicQuestionSetStatisticTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestDynamicQuestionSetStatisticTableGUITest
@@ -35,7 +49,6 @@ class ilTestDynamicQuestionSetStatisticTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestExportTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestExportTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestExportTableGUITest
@@ -30,7 +44,6 @@ class ilTestExportTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
         $this->setGlobalVariable("ilAccess", $this->createMock(ilAccessHandler::class));
 

--- a/Modules/Test/test/tables/ilTestHistoryTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestHistoryTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestHistoryTableGUITest
@@ -30,7 +44,6 @@ class ilTestHistoryTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestInviteGroupsTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestInviteGroupsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestInviteGroupsTableGUITest
@@ -30,7 +44,6 @@ class ilTestInviteGroupsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestInviteRolesTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestInviteRolesTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestInviteRolesTableGUITest
@@ -30,7 +44,6 @@ class ilTestInviteRolesTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestInviteUsersTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestInviteUsersTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestInviteUsersTableGUITest
@@ -30,7 +44,6 @@ class ilTestInviteUsersTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestManScoringParticipantsBySelectedQuestionAndPassTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestManScoringParticipantsBySelectedQuestionAndPassTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestManScoringParticipantsBySelectedQuestionAndPassTableGUITest
@@ -48,7 +62,6 @@ class ilTestManScoringParticipantsBySelectedQuestionAndPassTableGUITest extends 
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestManScoringParticipantsTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestManScoringParticipantsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestManScoringParticipantsTableGUITest
@@ -36,7 +50,6 @@ class ilTestManScoringParticipantsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestParticipantsTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestParticipantsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestParticipantsTableGUITest
@@ -30,7 +44,6 @@ class ilTestParticipantsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->createMock(ilTestParticipantsGUI::class);

--- a/Modules/Test/test/tables/ilTestPassDetailsOverviewTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestPassDetailsOverviewTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestPassDetailsOverviewTableGUITest
@@ -30,7 +44,6 @@ class ilTestPassDetailsOverviewTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestPassManualScoringOverviewTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestPassManualScoringOverviewTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestPassManualScoringOverviewTableGUITest
@@ -30,7 +44,6 @@ class ilTestPassManualScoringOverviewTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestPassOverviewTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestPassOverviewTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestPassOverviewTableGUITest
@@ -30,7 +44,6 @@ class ilTestPassOverviewTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestPersonalDefaultSettingsTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestPersonalDefaultSettingsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestPersonalDefaultSettingsTableGUITest
@@ -30,7 +44,6 @@ class ilTestPersonalDefaultSettingsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestQuestionBrowserTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestQuestionBrowserTableGUITest.php
@@ -53,12 +53,12 @@ class ilTestQuestionBrowserTableGUITest extends ilTestBaseTestCase
         $this->setGlobalVariable("ilDB", $db_mock);
         $this->setGlobalVariable("ilUser", $this->createMock(ilObjUser::class));
         $this->setGlobalVariable("ilObjDataCache", $this->createMock(ilObjectDataCache::class));
-        $this->setGlobalVariable("component.repository", $this->createMock(ilComponentRepository::class));
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $pluginAdmin = new ilPluginAdmin($this->createMock(ilComponentRepository::class));
-        $this->setGlobalVariable("ilPluginAdmin", $pluginAdmin);
+
+        $component_repository = $this->createMock(ilComponentRepository::class);
+        $this->setGlobalVariable("component.repository", $component_repository);
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();
         $this->parentObj_mock->method('getObject')->willReturn($this->createMock(ilObjTest::class));
@@ -69,7 +69,7 @@ class ilTestQuestionBrowserTableGUITest extends ilTestBaseTestCase
             $lng_mock,
             $tree_mock,
             $db_mock,
-            $pluginAdmin,
+            $component_repository,
             $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock(),
             $this->createMock(ilAccessHandler::class),
             $this->createMock(\ILIAS\HTTP\GlobalHttpState::class),

--- a/Modules/Test/test/tables/ilTestQuestionsTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestQuestionsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestQuestionsTableGUITest
@@ -30,7 +44,6 @@ class ilTestQuestionsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestRandomQuestionSelectionTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestRandomQuestionSelectionTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestRandomQuestionSelectionTableGUITest
@@ -30,7 +44,6 @@ class ilTestRandomQuestionSelectionTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestRandomQuestionSetNonAvailablePoolsTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestRandomQuestionSetNonAvailablePoolsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestRandomQuestionSetNonAvailablePoolsTableGUITest
@@ -30,7 +44,6 @@ class ilTestRandomQuestionSetNonAvailablePoolsTableGUITest extends ilTestBaseTes
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestRandomQuestionSetSourcePoolDefinitionListTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestRandomQuestionSetSourcePoolDefinitionListTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestRandomQuestionSetSourcePoolDefinitionListTableGUITest
@@ -30,7 +44,6 @@ class ilTestRandomQuestionSetSourcePoolDefinitionListTableGUITest extends ilTest
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestSkillLevelThresholdsTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestSkillLevelThresholdsTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestSkillLevelThresholdsTableGUITest
@@ -30,7 +44,6 @@ class ilTestSkillLevelThresholdsTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/tables/ilTestTopListTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestTopListTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestTopListTableGUITest
@@ -30,7 +44,6 @@ class ilTestTopListTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
         $this->parentObj_mock = $this->createMock(ilTestToplistGUI::class);

--- a/Modules/Test/test/tables/ilTestVerificationTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestVerificationTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestVerificationTableGUITest
@@ -27,7 +41,6 @@ class ilTestVerificationTableGUITest extends ilTestBaseTestCase
         $this->setGlobalVariable("tpl", $this->createMock(ilGlobalPageTemplate::class));
         $this->setGlobalVariable("component.repository", $this->createMock(ilComponentRepository::class));
         $this->setGlobalVariable("component.factory", $this->createMock(ilComponentFactory::class));
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
         $this->setGlobalVariable("ilUser", $this->createMock(ilObjUser::class));
 

--- a/Modules/Test/test/tables/ilTimingOverviewTableGUITest.php
+++ b/Modules/Test/test/tables/ilTimingOverviewTableGUITest.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTimingOverviewTableGUITest
@@ -30,7 +44,6 @@ class ilTimingOverviewTableGUITest extends ilTestBaseTestCase
         $component_factory = $this->createMock(ilComponentFactory::class);
         $component_factory->method("getActivePluginsInSlot")->willReturn(new ArrayIterator());
         $this->setGlobalVariable("component.factory", $component_factory);
-        $this->setGlobalVariable("ilPluginAdmin", new ilPluginAdmin($this->createMock(ilComponentRepository::class)));
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
         //$this->addGlobal_http();
         $this->parentObj_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();

--- a/Modules/Test/test/toolbars/ilTestInfoScreenToolbarGUITest.php
+++ b/Modules/Test/test/toolbars/ilTestInfoScreenToolbarGUITest.php
@@ -1,5 +1,20 @@
 <?php declare(strict_types=1);
-/* Copyright (c) 1998-2020 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilTestInfoScreenToolbarGUITest
@@ -27,14 +42,13 @@ class ilTestInfoScreenToolbarGUITest extends ilTestBaseTestCase
         $access_mock = $this->createMock(ilAccessHandler::class);
         $ctrl_mock = $this->createMock(ilCtrl::class);
         $lng_mock = $this->createMock(ilLanguage::class);
-        $pluginAdmin_mock = $this->createMock(ilPluginAdmin::class);
     
         $this->testInfoScreenToolbarGUI = new ilTestInfoScreenToolbarGUI(
             $db_mock,
             $access_mock,
             $ctrl_mock,
             $lng_mock,
-            $pluginAdmin_mock
+            $this->createMock(ilComponentRepository::class)
         );
     }
     

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -827,14 +827,12 @@ class assFormulaQuestionGUI extends assQuestionGUI
                     global $DIC;
                     $tree = $DIC['tree'];
                     $ilDB = $DIC['ilDB'];
-                    $ilPluginAdmin = $DIC['ilPluginAdmin'];
+                    $component_repository = $DIC['component.repository'];
 
-                    include_once("./Modules/Test/classes/class.ilObjTest.php");
                     $_GET["ref_id"] = $this->request->raw("calling_test");
                     $test = new ilObjTest($this->request->raw("calling_test"), true);
 
-                    require_once 'Modules/Test/classes/class.ilTestQuestionSetConfigFactory.php';
-                    $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $test);
+                    $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $test);
 
                     $new_id = $test->insertQuestion(
                         $testQuestionSetConfigFactory->getQuestionSetConfig(),

--- a/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -668,12 +668,12 @@ abstract class assQuestionGUI
                 global $DIC;
                 $tree = $DIC['tree'];
                 $ilDB = $DIC['ilDB'];
-                $ilPluginAdmin = $DIC['ilPluginAdmin'];
+                $component_repository = $DIC['component.repository'];
                 // TODO: Courier Antipattern!
                 $_GET["ref_id"] = $this->request->raw("test_ref_id");
                 $test = new ilObjTest($this->request->raw("test_ref_id"), true);
 
-                $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $test);
+                $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $test);
 
                 $test->insertQuestion($testQuestionSetConfigFactory->getQuestionSetConfig(), $this->object->getId());
                 
@@ -722,13 +722,13 @@ abstract class assQuestionGUI
                     global $DIC;
                     $tree = $DIC['tree'];
                     $ilDB = $DIC['ilDB'];
-                    $ilPluginAdmin = $DIC['ilPluginAdmin'];
+                    $component_repository = $DIC['component.repository'];
 
                     // TODO: Courier Antipattern!
                     //$_GET["ref_id"] = $this->request->raw("calling_test");
 
                     $test = new ilObjTest($this->request->raw("calling_test"), true);
-                    $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $test);
+                    $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $test);
 
                     $new_id = $test->insertQuestion(
                         $testQuestionSetConfigFactory->getQuestionSetConfig(),
@@ -767,10 +767,10 @@ abstract class assQuestionGUI
                         global $DIC;
                         $tree = $DIC['tree'];
                         $ilDB = $DIC['ilDB'];
-                        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+                        $component_repository = $DIC['component.repository'];
                         // TODO: Courier Antipattern!
                         $test = new ilObjTest($this->request->getRefId(), true);
-                        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $test);
+                        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $test);
                         $test->insertQuestion(
                             $testQuestionSetConfigFactory->getQuestionSetConfig(),
                             $this->object->getId()
@@ -820,12 +820,12 @@ abstract class assQuestionGUI
                     global $DIC;
                     $tree = $DIC['tree'];
                     $ilDB = $DIC['ilDB'];
-                    $ilPluginAdmin = $DIC['ilPluginAdmin'];
+                    $component_repository = $DIC['component.repository'];
                     // TODO: Courier Antipattern!
                     //$_GET["ref_id"] = $this->request->raw("calling_test");
                     $test = new ilObjTest($this->request->raw("calling_test"), true);
 
-                    $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $ilPluginAdmin, $test);
+                    $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory($tree, $ilDB, $component_repository, $test);
 
                     $new_id = $test->insertQuestion(
                         $testQuestionSetConfigFactory->getQuestionSetConfig(),

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -1,40 +1,32 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Taxonomy/interfaces/interface.ilTaxAssignedItemInfo.php';
-require_once 'Modules/TestQuestionPool/classes/questions/class.ilAssQuestionType.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Handles a list of questions
- *
  * @author		Björn Heyser <bheyser@databay.de>
- * @version		$Id$
- *
  * @package		Modules/TestQuestionPool
  *
  */
 class ilAssQuestionList implements ilTaxAssignedItemInfo
 {
-    /**
-     * global ilDBInterface object instance
-     *
-     * @var ilDBInterface
-     */
-    protected $db = null;
-    
-    /**
-     * global ilLanguage object instance
-     *
-     * @var ilLanguage
-     */
-    private $lng = null;
-    
-    /**
-     * global ilPluginAdmin object instance
-     *
-     * @var ilPluginAdmin
-     */
-    private $pluginAdmin = null;
+    private ilDBInterface $db;
+    private ilLanguage $lng;
+    private ilComponentRepository $component_repository;
 
     /**
      * object ids of parent question containers
@@ -151,18 +143,11 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
      */
     protected $questions = array();
     
-    /**
-     * Constructor
-     *
-     * @param ilDBInterface $db
-     * @param ilLanguage $lng
-     * @param ilPluginAdmin $pluginAdmin
-     */
-    public function __construct(ilDBInterface $db, ilLanguage $lng, ilPluginAdmin $pluginAdmin)
+    public function __construct(ilDBInterface $db, ilLanguage $lng, ilComponentRepository $component_repository)
     {
         $this->db = $db;
         $this->lng = $lng;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
     }
 
     public function getParentObjId() : ?int
@@ -690,8 +675,8 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         
         return $taxAssignmentData;
     }
-    
-    private function isActiveQuestionType($questionData) : bool
+
+    private function isActiveQuestionType(array $questionData) : bool
     {
         if (!isset($questionData['plugin'])) {
             return false;
@@ -700,8 +685,18 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         if (!$questionData['plugin']) {
             return true;
         }
-        
-        return $this->pluginAdmin->isActive(ilComponentInfo::TYPE_MODULES, 'TestQuestionPool', 'qst', $questionData['plugin_name']);
+
+        return $this->component_repository
+            ->getComponentByTypeAndName(
+                ilComponentInfo::TYPE_MODULES,
+                'TestQuestionPool'
+            )
+            ->getPluginSlotById(
+                'qst'
+            )
+            ->getPluginByName(
+                $questionData['plugin_name']
+            )->isActive();
     }
 
     public function getDataArrayForQuestionId($questionId)

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php
@@ -1,18 +1,20 @@
 <?php
 
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
 include_once "./Modules/Test/classes/inc.AssessmentConstants.php";
 
@@ -1531,22 +1533,21 @@ class ilObjQuestionPool extends ilObject
     */
     public function isPluginActive($questionType) : bool
     {
-        /* @var ilPluginAdmin $ilPluginAdmin */
         global $DIC;
+        /** @var ilComponentRepository $component_factory */
         $component_factory = $DIC['component.factory'];
 
-        foreach ($component_factory->getActivePluginsInSlot("qst") as $plugin) {
-            if ($plugin->getPluginName() == $questionType) { // plugins having pname == qtype
-                return true;
-            }
-
-            /* @var ilQuestionsPlugin $plugin */
-            if ($plugin->getQuestionType() == $questionType) { // plugins havin an independent name
-                return true;
-            }
-        }
-
-        return false;
+        return  $component_factory
+            ->getComponentByTypeAndName(
+                ilComponentInfo::TYPE_MODULES,
+                'TestQuestionPool'
+            )
+            ->getPluginSlotById(
+                'qst'
+            )
+            ->getPluginByName(
+                $questionType
+            )->isActive();
     }
 
     /*

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -124,7 +124,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $ilTabs = $DIC['ilTabs'];
         $lng = $DIC['lng'];
         $ilDB = $DIC['ilDB'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
         $ilias = $DIC['ilias'];
         $randomGroup = $DIC->refinery()->random();
 
@@ -379,7 +379,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 $forwarder = new ilObjQuestionPoolTaxonomyEditingCommandForwarder(
                     $obj,
                     $ilDB,
-                    $ilPluginAdmin,
+                    $component_repository,
                     $ilCtrl,
                     $ilTabs,
                     $lng
@@ -401,7 +401,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                     $tpl,
                     $lng,
                     $ilDB,
-                    $ilPluginAdmin,
+                    $component_repository,
                     $obj,
                     $this->ref_id
                 );
@@ -1038,7 +1038,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $ilCtrl = $DIC['ilCtrl'];
         $ilDB = $DIC['ilDB'];
         $lng = $DIC['lng'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        $component_repository = $DIC['component.repository'];
 
         if (get_class($this->object) == "ilObjTest") {
             if ($this->qplrequest->raw("calling_test") > 0) {
@@ -1700,7 +1700,6 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
      * @global ilRbacSystem  $rbacsystem
      * @global ilDBInterface $ilDB
      * @global ilLanguage $lng
-     * @global ilPluginAdmin $ilPluginAdmin
      * @return ilQuestionBrowserTableGUI
      */
     private function buildQuestionBrowserTableGUI($taxIds) : ilQuestionBrowserTableGUI
@@ -1709,7 +1708,8 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $rbacsystem = $DIC['rbacsystem'];
         $ilDB = $DIC['ilDB'];
         $lng = $DIC['lng'];
-        $ilPluginAdmin = $DIC['ilPluginAdmin'];
+        /* @var ilComponentRepository $component_repository */
+        $component_repository = $DIC['component.repository'];
 
         $writeAccess = (bool) $rbacsystem->checkAccess('write', $this->qplrequest->getRefId());
         $enableCommenting = $writeAccess;
@@ -1724,7 +1724,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         );
 
         $table_gui->setEditable($writeAccess);
-        $questionList = new ilAssQuestionList($ilDB, $lng, $ilPluginAdmin);
+        $questionList = new ilAssQuestionList($ilDB, $lng, $component_repository);
         $questionList->setParentObjId($this->object->getId());
 
         foreach ($table_gui->getFilterItems() as $item) {

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolTaxonomyEditingCommandForwarder.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolTaxonomyEditingCommandForwarder.php
@@ -1,94 +1,62 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * class can be used as forwarder for taxonomy editing context
- *
  * @author		Björn Heyser <bheyser@databay.de>
- * @version		$Id$
- *
  * @package		Modules/TestQuestionPool
  */
 class ilObjQuestionPoolTaxonomyEditingCommandForwarder
 {
-    /**
-     * object instance of current question
-     *
-     * @var ilObjQuestionPool
-     */
-    protected $poolOBJ = null;
-    
-    /**
-     * global $db
-     *
-     * @var ilDBInterface
-     */
-    protected $db = null;
-    
-    /**
-     * global $pluginAdmin
-     *
-     * @var ilPluginAdmin
-     */
-    protected $pluginAdmin = null;
-    
-    /**
-     * global $ilCtrl
-     *
-     * @var ilCtrl
-     */
-    protected $ctrl = null;
+    protected ilObjQuestionPool $poolOBJ;
+    protected ilDBInterface $db;
+    protected ilComponentRepository $component_repository;
+    protected ilCtrlInterface $ctrl;
+    protected ilTabsGUI $tabs ;
+    protected ilLanguage $lng;
 
-    /**
-     * global $ilCtrl
-     *
-     * @var ilCtrl
-     */
-    protected $tabs = null;
-
-    /**
-     * global $ilCtrl
-     *
-     * @var ilCtrl
-     */
-    protected $lng = null;
-    
-    /**
-     * Constructor
-     *
-     * @param ilObjQuestionPool $poolOBJ
-     * @param ilDBInterface $db
-     * @param ilPluginAdmin $pluginAdmin
-     * @param ilCtrl $ctrl
-     * @param ilTabsGUI $tabs
-     * @param ilLanguage $lng
-     */
-    public function __construct(ilObjQuestionPool $poolOBJ, ilDBInterface $db, ilPluginAdmin $pluginAdmin, ilCtrl $ctrl, ilTabsGUI $tabs, ilLanguage $lng)
-    {
+    public function __construct(
+        ilObjQuestionPool $poolOBJ,
+        ilDBInterface $db,
+        ilComponentRepository $component_repository,
+        ilCtrl $ctrl,
+        ilTabsGUI $tabs,
+        ilLanguage $lng
+    ) {
         $this->poolOBJ = $poolOBJ;
         $this->db = $db;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->ctrl = $ctrl;
         $this->tabs = $tabs;
         $this->lng = $lng;
     }
-    
-    /**
-     * forward method
-     */
+
     public function forward() : void
     {
         $this->tabs->setTabActive('settings');
         $this->lng->loadLanguageModule('tax');
 
-        require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionList.php';
-        $questionList = new ilAssQuestionList($this->db, $this->lng, $this->pluginAdmin);
+        $questionList = new ilAssQuestionList($this->db, $this->lng, $this->component_repository);
 
         $questionList->setParentObjId($this->poolOBJ->getId());
 
         $questionList->load();
 
-        require_once 'Services/Taxonomy/classes/class.ilObjTaxonomyGUI.php';
         $taxGUI = new ilObjTaxonomyGUI();
         
         $taxGUI->setAssignedObject($this->poolOBJ->getId());

--- a/Modules/TestQuestionPool/classes/class.ilQuestionPoolSkillAdministrationGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilQuestionPoolSkillAdministrationGUI.php
@@ -1,8 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php';
-require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionSkillUsagesTableGUI.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author		Björn Heyser <bheyser@databay.de>
@@ -50,10 +62,7 @@ class ilQuestionPoolSkillAdministrationGUI
      */
     private $db;
 
-    /**
-     * @var ilPluginAdmin
-     */
-    private $pluginAdmin;
+    private ilComponentRepository $component_repository;
 
     /**
      * @var ilObjQuestionPool
@@ -62,9 +71,19 @@ class ilQuestionPoolSkillAdministrationGUI
     
     /** @var string|int|null  */
     private $refId;
-    
-    public function __construct(ILIAS $ilias, ilCtrl $ctrl, ilAccessHandler $access, ilTabsGUI $tabs, ilGlobalTemplateInterface $tpl, ilLanguage $lng, ilDBInterface $db, ilPluginAdmin $pluginAdmin, ilObjQuestionPool $poolOBJ, $refId)
-    {
+
+    public function __construct(
+        ILIAS $ilias,
+        ilCtrl $ctrl,
+        ilAccessHandler $access,
+        ilTabsGUI $tabs,
+        ilGlobalTemplateInterface $tpl,
+        ilLanguage $lng,
+        ilDBInterface $db,
+        ilComponentRepository $component_repository,
+        ilObjQuestionPool $poolOBJ,
+        $refId
+    ) {
         $this->ilias = $ilias;
         $this->ctrl = $ctrl;
         $this->access = $access;
@@ -72,7 +91,7 @@ class ilQuestionPoolSkillAdministrationGUI
         $this->tpl = $tpl;
         $this->lng = $lng;
         $this->db = $db;
-        $this->pluginAdmin = $pluginAdmin;
+        $this->component_repository = $component_repository;
         $this->poolOBJ = $poolOBJ;
         $this->refId = $refId;
     }
@@ -132,9 +151,7 @@ class ilQuestionPoolSkillAdministrationGUI
 
         switch ($nextClass) {
             case 'ilassquestionskillassignmentsgui':
-
-                require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionList.php';
-                $questionList = new ilAssQuestionList($this->db, $this->lng, $this->pluginAdmin);
+                $questionList = new ilAssQuestionList($this->db, $this->lng, $this->component_repository);
                 $questionList->setParentObjId($this->poolOBJ->getId());
                 $questionList->setQuestionInstanceTypeFilter(ilAssQuestionList::QUESTION_INSTANCE_TYPE_ORIGINALS);
                 $questionList->load();

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionType.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionType.php
@@ -1,5 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -9,10 +24,7 @@
  */
 class ilAssQuestionType
 {
-    /**
-     * @var ilPluginAdmin
-     */
-    protected $pluginAdmin;
+    protected ilComponentRepository $component_repository;
     
     /**
      * @var integer
@@ -40,7 +52,7 @@ class ilAssQuestionType
     public function __construct()
     {
         global $DIC; /* @var ILIAS\DI\Container $DIC */
-        $this->pluginAdmin = $DIC['ilPluginAdmin'];
+        $this->component_repository = $DIC['component.repository'];
     }
     
     /**
@@ -115,17 +127,19 @@ class ilAssQuestionType
         if (!$this->isPlugin()) {
             return true;
         }
-        return false;
 
-        /* Plugins MUST overwrite this method an report back their activation status
-        require_once 'Modules/TestQuestionPool/classes/class.ilQuestionsPlugin.php';
-        return $this->pluginAdmin->isActive(
-            ilComponentInfo::TYPE_MODULES,
-            ilQuestionsPlugin::COMP_NAME,
-            ilQuestionsPlugin::SLOT_ID,
-            $this->getPluginName()
-        );
-        */
+        // Plugins MAY overwrite this method an report back their activation status
+        return $this->component_repository
+            ->getComponentByTypeAndName(
+                ilComponentInfo::TYPE_MODULES,
+                'TestQuestionPool'
+            )
+            ->getPluginSlotById(
+                'qst'
+            )
+            ->getPluginByName(
+                $this->getPluginName()
+            )->isActive();
     }
     
     /**

--- a/Services/AssessmentQuestion/classes/class.ilAsqFactory.php
+++ b/Services/AssessmentQuestion/classes/class.ilAsqFactory.php
@@ -1,13 +1,24 @@
 <?php
 
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilAsqQuestionAuthoringFactory
- *
  * @author    Björn Heyser <info@bjoernheyser.de>
- * @version    $Id$
- *
  * @package    Services/AssessmentQuestion
  */
 class ilAsqFactory
@@ -27,10 +38,12 @@ class ilAsqFactory
     public function getQuestionDataArray($parentObjectId) : array
     {
         global $DIC; /* @var ILIAS\DI\Container $DIC */
-        global $ilPluginAdmin; /* @var ilPluginAdmin $ilPluginAdmin */
 
-        $list = new ilAssQuestionList($DIC->database(), $DIC->language(), $ilPluginAdmin);
-        $list->setParentObjIdsFilter(array($parentObjectId));
+        /* @var ilComponentRepository $component_repository */
+        $component_repository = $DIC['component.repository'];
+
+        $list = new ilAssQuestionList($DIC->database(), $DIC->language(), $component_repository);
+        $list->setParentObjIdsFilter([$parentObjectId]);
         $list->load();
 
         return $list->getQuestionDataArray(); // returns an array of arrays containing the question data
@@ -48,9 +61,11 @@ class ilAsqFactory
     public function getQuestionInstances($parentObjectId) : array
     {
         global $DIC; /* @var ILIAS\DI\Container $DIC */
-        global $ilPluginAdmin; /* @var ilPluginAdmin $ilPluginAdmin */
-        
-        $list = new ilAssQuestionList($DIC->database(), $DIC->language(), $ilPluginAdmin);
+
+        /* @var ilComponentRepository $component_repository */
+        $component_repository = $DIC['component.repository'];
+
+        $list = new ilAssQuestionList($DIC->database(), $DIC->language(), $component_repository);
         $list->setParentObjIdsFilter(array($parentObjectId));
         $list->load();
         

--- a/Services/COPage/classes/class.ilCopySelfAssQuestionTableGUI.php
+++ b/Services/COPage/classes/class.ilCopySelfAssQuestionTableGUI.php
@@ -79,7 +79,7 @@ class ilCopySelfAssQuestionTableGUI extends ilTable2GUI
             $questionList = new ilAssQuestionList(
                 $DIC->database(),
                 $DIC->language(),
-                $DIC["ilPluginAdmin"]
+                $DIC["component.repository"]
             );
             $questionList->setParentObjId($this->pool_obj_id);
             $questionList->load();


### PR DESCRIPTION
This PR removes the dependency on `ilPluginAdmin` from the `Test` and `TestQuestionPool` components. According to the deprecation declaration of @klees the `ilComponentRepository` has to be used in the future. The triggered error resulted in failing ILIAS 8 tests, so we had to get rid of the dependency now.

Mantis Issue: https://mantis.ilias.de/view.php?id=33298

Because I touched many files (~100) of the T&A code base this should be tested thoroughly (e.g. by checking out this branch locally).