### PR TITLE
Move Statistics Tab to Preview

### DIFF
--- a/Modules/Test/classes/tables/class.ilTestQuestionsTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestQuestionsTableGUI.php
@@ -268,6 +268,12 @@ class ilTestQuestionsTableGUI extends ilTable2GUI
             $this->getEditLink($data, get_class($this->getParentObject()), $this->getParentCmd())
         );
         
+        $actions->addItem(
+            $this->lng->txt('statistics'),
+            '',
+            $this->getEditLink($data, 'ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_STATISTICS)
+        );
+        
         if ($this->isQuestionManagingEnabled()) {
             $editHref = $this->getEditLink($data, $data['type_tag'] . 'GUI', 'editQuestion');
             $actions->addItem($this->lng->txt('edit_question'), '', $editHref);

--- a/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -482,11 +482,8 @@ abstract class assQuestionGUI
          */
         global $DIC;
         $tpl = $DIC['tpl'];
-
-        require_once 'Modules/TestQuestionPool/classes/tables/class.ilQuestionCumulatedStatisticsTableGUI.php';
+        
         $stats_table = new ilQuestionCumulatedStatisticsTableGUI($this, 'assessment', '', $this->object);
-
-        require_once 'Modules/TestQuestionPool/classes/tables/class.ilQuestionUsagesTableGUI.php';
         $usage_table = new ilQuestionUsagesTableGUI($this, 'assessment', '', $this->object);
 
         $tpl->setContent(implode('<br />', array(

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -19,6 +19,7 @@ class ilAssQuestionPreviewGUI
 {
     const CMD_SHOW = 'show';
     const CMD_RESET = 'reset';
+    const CMD_STATISTICS = 'assessment';
     const CMD_INSTANT_RESPONSE = 'instantResponse';
     const CMD_HANDLE_QUESTION_ACTION = 'handleQuestionAction';
     const CMD_GATEWAY_CONFIRM_HINT_REQUEST = 'gatewayConfirmHintRequest';
@@ -102,7 +103,7 @@ class ilAssQuestionPreviewGUI
 
         $this->questionOBJ->setObjId($parentObjId);
 
-        if($this->ctrl->getCmd() == 'editQuestion') {
+        if ($this->ctrl->getCmd() == 'editQuestion') {
             $this->questionGUI->setQuestionTabs();
         } else {
             if ($_GET["q_id"]) {
@@ -113,6 +114,16 @@ class ilAssQuestionPreviewGUI
                     array(),
                     array('ilAssQuestionPreviewGUI')
                 );
+                // Assessment of questions sub menu entry
+                $q_type = $this->questionOBJ->getQuestionType();
+                $classname = $q_type . "GUI";
+                $this->tabs->addTarget(
+                    "statistics",
+                    $this->ctrl->getLinkTargetByClass('ilAssQuestionPreviewGUI', "assessment"),
+                    array("assessment"),
+                    $classname,
+                    ""
+                );
                 if (($_GET["calling_test"] > 0) || ($_GET["test_ref_id"] > 0)) {
                     $ref_id = $_GET["calling_test"];
                     if (strlen($ref_id) == 0) {
@@ -120,28 +131,33 @@ class ilAssQuestionPreviewGUI
                     }
 
                     if (!$_GET['test_express_mode'] && !$GLOBALS['___test_express_mode']) {
-                        $this->tabs->setBackTarget($this->lng->txt("backtocallingtest"),
-                            "ilias.php?baseClass=ilObjTestGUI&cmd=questions&ref_id=$ref_id");
-                        //BACK FROM Question Page to Test
+                        $this->tabs->setBackTarget(
+                            $this->lng->txt("backtocallingtest"),
+                            "ilias.php?baseClass=ilObjTestGUI&cmd=questions&ref_id=$ref_id"
+                        );
+                    //BACK FROM Question Page to Test
                     } else {
                         $link = ilTestExpressPage::getReturnToPageLink();
                         //$this->tabs->setBackTarget($this->lng->txt("backtocallingtest"), $link);
-                        $this->tabs->setBackTarget($this->lng->txt("backtocallingtest"),
-                            "ilias.php?baseClass=ilObjTestGUI&cmd=questions&ref_id=$ref_id");
+                        $this->tabs->setBackTarget(
+                            $this->lng->txt("backtocallingtest"),
+                            "ilias.php?baseClass=ilObjTestGUI&cmd=questions&ref_id=$ref_id"
+                        );
                     }
                 } elseif (isset($_GET['calling_consumer']) && (int) $_GET['calling_consumer']) {
                     $ref_id = (int) $_GET['calling_consumer'];
                     $consumer = ilObjectFactory::getInstanceByRefId($ref_id);
                     if ($consumer instanceof ilQuestionEditingFormConsumer) {
-                        $this->tabs->setBackTarget($consumer->getQuestionEditingFormBackTargetLabel(),
-                            $consumer->getQuestionEditingFormBackTarget($_GET['consumer_context']));
+                        $this->tabs->setBackTarget(
+                            $consumer->getQuestionEditingFormBackTargetLabel(),
+                            $consumer->getQuestionEditingFormBackTarget($_GET['consumer_context'])
+                        );
                     } else {
                         require_once 'Services/Link/classes/class.ilLink.php';
                         $this->tabs->setBackTarget($this->lng->txt("qpl"), ilLink::_getLink($ref_id));
                     }
-                //} elseif (true) {
+                    //} elseif (true) {
                     // We're in the underworld and want to go back to the question page
-
                 } else {
                     $this->tabs->setBackTarget($this->lng->txt("backtocallingpool"), $this->ctrl->getLinkTargetByClass("ilobjquestionpoolgui", "questions"));
                     //BACK FROM Question Page to Pool
@@ -279,6 +295,12 @@ class ilAssQuestionPreviewGUI
         $this->tpl->setContent($tpl->get());
     }
     
+    private function assessmentCmd()
+    {
+        $this->tabs->activateTab('statistics');
+        $this->questionGUI->assessment();
+    }
+    
     protected function handleInstantResponseRendering(ilTemplate $tpl)
     {
         $renderHeader = false;
@@ -355,13 +377,14 @@ class ilAssQuestionPreviewGUI
         $toolbarGUI->setFormAction($this->ctrl->getFormAction($this, self::CMD_SHOW));
         $toolbarGUI->setResetPreviewCmd(self::CMD_RESET);
         $toolbarGUI->setEditPageCmd(
-            $this->ctrl->getLinkTargetByClass('ilAssQuestionPageGUI','edit')
+            $this->ctrl->getLinkTargetByClass('ilAssQuestionPageGUI', 'edit')
         );
 
         $toolbarGUI->setEditQuestionCmd(
             $this->ctrl->getLinkTargetByClass(
                 array('ilrepositorygui','ilobjquestionpoolgui', get_class($this->questionGUI)),
-                'editQuestion')
+                'editQuestion'
+            )
         );
         $toolbarGUI->build();
         

--- a/Modules/TestQuestionPool/classes/tables/class.ilQuestionBrowserTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilQuestionBrowserTableGUI.php
@@ -451,7 +451,16 @@ class ilQuestionBrowserTableGUI extends ilTable2GUI
                 }
             }
 
-            $actions->addItem($this->lng->txt('preview'), '', $this->ctrl->getLinkTargetByClass('ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_SHOW));
+            $actions->addItem(
+                $this->lng->txt('preview'),
+                '',
+                $this->ctrl->getLinkTargetByClass('ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_SHOW)
+            );
+            $actions->addItem(
+                $this->lng->txt('statistics'),
+                '',
+                $this->ctrl->getLinkTargetByClass('ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_STATISTICS)
+            );
             if ($this->getEditable()) {
                 $editHref = $this->ctrl->getLinkTargetByClass($data['type_tag'] . 'GUI', 'editQuestion');
                 $actions->addItem($this->lng->txt('edit_question'), '', $editHref);


### PR DESCRIPTION
This PR only has an effect if first #4814 is merged.

It moves the statistics-tab to the QuestionPreviewGUI. The functionality in itself is kept in the question though as it seems the right place until we clean up routing in this part of the T&A.

As is pointed out in https://mantis.ilias.de/view.php?id=33391 right now the use of the tab is very limited.

This PR, from my point of view has two parts:
1. The conceptual one: Do we want to move this Information to a place where it can be accessed after a test is started? Personally I would suggest to attach the JF-label to this and see if we can reach a conclusion.
2. The implementation: I'm glad for any feedback or better ideas and would spend a little more time to make sure that the statistics shown here are as specified. I would also provide a PR against trunk