### PR TITLE
Test/TestQpl: Fix creating order question with (nested) terms/images (Mantis 33313)

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assOrderingQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingQuestion.php
@@ -1,14 +1,22 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once './Modules/TestQuestionPool/classes/class.assQuestion.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
-require_once './Modules/TestQuestionPool/interfaces/interface.ilObjQuestionScoringAdjustable.php';
-require_once './Modules/TestQuestionPool/interfaces/interface.ilObjAnswerScoringAdjustable.php';
-require_once './Modules/TestQuestionPool/interfaces/interface.iQuestionCondition.php';
-require_once './Modules/TestQuestionPool/classes/class.ilUserQuestionResult.php';
-
-require_once 'Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElementList.php';
 
 /**
  * Class for ordering questions
@@ -52,12 +60,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     */
     public $thumb_geometry = 100;
 
-    /**
-    * Minimum element height
-    *
-    * @var integer
-    */
-    public $element_height;
+    public ?int $element_height = null;
 
     public $old_ordering_depth = array();
     public $leveled_ordering = array();
@@ -169,7 +172,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
             $this->setQuestion(ilRTE::_replaceMediaObjectImageSrc((string) $data["question_text"], 1));
             $this->ordering_type = strlen($data["ordering_type"]) ? $data["ordering_type"] : OQ_TERMS;
             $this->thumb_geometry = $data["thumb_geometry"];
-            $this->element_height = $data["element_height"];
+            $this->element_height = $data["element_height"] ? (int) $data['element_height'] : null;
             $this->setEstimatedWorkingTime(substr($data["working_time"], 0, 2), substr($data["working_time"], 3, 2), substr($data["working_time"], 6, 2));
             
             try {
@@ -1077,24 +1080,14 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         $this->thumb_geometry = ($a_geometry < 1) ? 100 : $a_geometry;
     }
 
-    /*
-    * Get the minimum element height
-    *
-    * @return integer Height
-    */
-    public function getElementHeight() : int
+    public function getElementHeight() : ?int
     {
         return $this->element_height;
     }
-    
-    /*
-    * Set the minimum element height
-    *
-    * @param integer $a_height Height
-    */
-    public function setElementHeight($a_height) : void
+
+    public function setElementHeight(?int $a_height) : void
     {
-        $this->element_height = ($a_height < 20) ? "" : $a_height;
+        $this->element_height = ($a_height < 20) ? null : $a_height;
     }
 
     /*

--- a/Modules/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
@@ -1,9 +1,21 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once './Modules/TestQuestionPool/classes/class.assQuestionGUI.php';
-require_once './Modules/TestQuestionPool/interfaces/interface.ilGuiQuestionScoringAdjustable.php';
-require_once './Modules/TestQuestionPool/interfaces/interface.ilGuiAnswerScoringAdjustable.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
 
 /**

--- a/Modules/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
@@ -189,7 +189,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->object->setThumbGeometry($_POST["thumb_geometry"]);
         // $this->object->setElementHeight($_POST["element_height"]);
         //$this->object->setOrderingType( $_POST["ordering_type"] );
-        $this->object->setPoints($_POST["points"]);
+        $this->object->setPoints((float) ($_POST["points"] ?? 0.0));
     }
 
     public function writeAnswerSpecificPostData(ilPropertyFormGUI $form) : void

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingFormValuesObjectsConverter.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingFormValuesObjectsConverter.php
@@ -1,7 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Services/Form/interfaces/interface.ilFormValuesManipulator.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -357,7 +370,12 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
         
         return $_FILES[$this->getPostVar()];
     }
-    
+
+    /**
+     * TODO: Instead of accessing post, the complete ilFormValuesManipulator should be aware of a server request or the corresponding processed input values.
+     * @param $identifier
+     * @return bool
+     */
     protected function wasImageRemovalRequested($identifier) : bool
     {
         if (!$this->getImageRemovalCommand()) {
@@ -381,7 +399,14 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
         }
         
         $identifierArr = $fieldArr[$this->getPostVar()];
-    
-        return key($identifierArr) == $identifier;
+
+        $requested_identfier = key($identifierArr);
+
+        // The code actually relied on a manipulation of $_POST by ilIdentifiedMultiValuesJsPositionIndexRemover
+        return (string) str_replace(
+            ilIdentifiedMultiValuesJsPositionIndexRemover::IDENTIFIER_INDICATOR_PREFIX,
+            '',
+            (string) $requested_identfier
+        ) === (string) $identifier;
     }
 }

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingTextsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssOrderingTextsInputGUI.php
@@ -1,5 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -56,12 +71,11 @@ class ilAssOrderingTextsInputGUI extends ilMultipleTextsInputGUI
      */
     public function getElementList($questionId) : ilAssOrderingElementList
     {
-        require_once 'Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElementList.php';
         return ilAssOrderingElementList::buildInstance($questionId, $this->getIdentifiedMultiValues());
     }
     
     /**
-     * @param $value
+     * @param mixed $value
      * @return bool
      */
     protected function valueHasContentText($value) : bool
@@ -69,8 +83,8 @@ class ilAssOrderingTextsInputGUI extends ilMultipleTextsInputGUI
         if ($value === null || is_array($value)) {
             return false;
         }
-        
-        if (is_object($value) && $value instanceof ilAssOrderingElement) {
+
+        if ($value instanceof ilAssOrderingElement) {
             return (bool) strlen((string) $value);
         }
         

--- a/Modules/TestQuestionPool/classes/forms/class.ilIdentifiedMultiValuesInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilIdentifiedMultiValuesInputGUI.php
@@ -1,6 +1,20 @@
 <?php
 
-/* Copyright (c) 1998-2021 ILIAS open source, GPLv3, see LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author		Björn Heyser <bheyser@databay.de>
@@ -200,7 +214,7 @@ abstract class ilIdentifiedMultiValuesInputGUI extends ilTextInputGUI implements
     final public function setValueByArray(array $a_values) : void
     {
         if (!is_array($a_values[$this->getPostVar()])) {
-            $a_values[$this->getPostVar()] = array();
+            $a_values[$this->getPostVar()] = [];
         }
         
         $a_values[$this->getPostVar()] = $this->prepareMultiValuesSubmit(
@@ -214,18 +228,19 @@ abstract class ilIdentifiedMultiValuesInputGUI extends ilTextInputGUI implements
     {
         $this->identified_multi_values = $a_values[$this->getPostVar()];
     }
+
+    /**
+     * @return string[]
+     */
+    public function getInput() : array
+    {
+        $values = $this->arrayArray($this->getPostVar());
+
+        return $this->prepareMultiValuesSubmit($values);
+    }
     
     final public function checkInput() : bool
     {
-        /*
-        if (!is_array($_POST[$this->getPostVar()])) {
-            $_POST[$this->getPostVar()] = array();
-        }
-
-        $_POST[$this->getPostVar()] = $this->prepareMultiValuesSubmit(
-            $_POST[$this->getPostVar()]
-        );
-        */
         return $this->onCheckInput();
     }
     

--- a/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesFileSubmissionDataCompletion.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesFileSubmissionDataCompletion.php
@@ -1,24 +1,33 @@
 <?php
 
-/* Copyright (c) 1998-2021 ILIAS open source, GPLv3, see LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
  */
 class ilMultipleImagesFileSubmissionDataCompletion implements ilFormValuesManipulator
 {
-    protected $postVar;
-    
-    public function getPostVar()
+    protected stdClass $dodging_files;
+
+    public function __construct(stdClass $dodging_files)
     {
-        return $this->postVar;
+        $this->dodging_files = $dodging_files;
     }
-    
-    public function setPostVar($postVar) : void
-    {
-        $this->postVar = $postVar;
-    }
-    
+
     public function manipulateFormInputValues(array $inputValues) : array
     {
         return $inputValues;
@@ -26,24 +35,15 @@ class ilMultipleImagesFileSubmissionDataCompletion implements ilFormValuesManipu
     
     public function manipulateFormSubmitValues(array $submitValues) : array
     {
-        global $DIC;
-
-        $_REQUEST[$this->getPostVar()] = $this->populateStoredFileCustomUploadProperty(
-            $_REQUEST[$this->getPostVar()],
-            $submitValues
-        );
+        $this->populateStoredFileCustomUploadProperty($submitValues);
 
         return $submitValues;
     }
-    
-    protected function populateStoredFileCustomUploadProperty($submitFiles, $submitValues)
+
+    protected function populateStoredFileCustomUploadProperty(array $submitValues) : void
     {
-        $submitFiles['dodging_file'] = array();
-        
         foreach ($submitValues as $identifier => $storedFilename) {
-            $submitFiles['dodging_file'][$identifier] = $storedFilename;
+            $this->dodging_files->{$identifier} = $storedFilename;
         }
-        
-        return $submitFiles;
     }
 }

--- a/Modules/TestQuestionPool/classes/forms/class.ilMultipleTextsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultipleTextsInputGUI.php
@@ -1,7 +1,20 @@
 <?php
 
-/* Copyright (c) 1998-2021 ILIAS open source, GPLv3, see LICENSE */
-
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author		Björn Heyser <bheyser@databay.de>
@@ -73,24 +86,24 @@ abstract class ilMultipleTextsInputGUI extends ilIdentifiedMultiValuesInputGUI
     public function onCheckInput() : bool
     {
         $lng = $this->lng;
-        
-        $submittedElements = $_POST[$this->getPostVar()];
-        
-        if (!is_array($submittedElements) && $this->getRequired()) {
+
+        $submittedElements = $this->getInput();
+
+        if ($submittedElements === [] && $this->getRequired()) {
             $this->setAlert($lng->txt("msg_input_is_required"));
             return false;
         }
         
         foreach ($submittedElements as $submittedValue) {
             $submittedContentText = $this->fetchContentTextFromValue($submittedValue);
-            
-            if ($this->getRequired() && trim($submittedContentText) == "") {
+
+            if ($this->getRequired() && trim((string) $submittedContentText) === "") {
                 $this->setAlert($lng->txt('msg_input_is_required'));
                 return false;
             }
             
-            if (strlen($this->getValidationRegexp())) {
-                if (!preg_match($this->getValidationRegexp(), $submittedContentText)) {
+            if ($this->getValidationRegexp() !== '') {
+                if (!preg_match($this->getValidationRegexp(), (string) $submittedContentText)) {
                     $this->setAlert($lng->txt('msg_wrong_format'));
                     return false;
                 }
@@ -174,10 +187,10 @@ abstract class ilMultipleTextsInputGUI extends ilIdentifiedMultiValuesInputGUI
     }
     
     /**
-     * @param $value
-     * @return string
+     * @param mixed $value
+     * @return string|ilAssOrderingElement|null
      */
-    protected function fetchContentTextFromValue($value) : ?string
+    protected function fetchContentTextFromValue($value)
     {
         if ($this->valueHasContentText($value)) {
             return $value;

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php
@@ -1,7 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once "./Modules/TestQuestionPool/classes/import/qti12/class.assQuestionImport.php";
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
 * Class for ordering question imports
@@ -192,7 +205,7 @@ class assOrderingQuestionImport extends assQuestionImport
         $this->object->setOrderingType($type);
         $this->object->setObjId($questionpool_id);
         $this->object->setThumbGeometry($item->getMetadataEntry("thumb_geometry"));
-        $this->object->setElementHeight($item->getMetadataEntry("element_height"));
+        $this->object->setElementHeight($item->getMetadataEntry("element_height") ? (int) $item->getMetadataEntry("element_height") : null);
         $this->object->setEstimatedWorkingTime($duration["h"], $duration["m"], $duration["s"]);
         $this->object->setShuffle($shuffle);
         $points = 0;

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElement.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElement.php
@@ -1,5 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
 * Class represents an ordering element for assOrderingQuestion
@@ -145,7 +160,7 @@ class ilAssOrderingElement
      */
     public function getRandomIdentifier() : ?int
     {
-        return $this->randomIdentifier;
+        return $this->randomIdentifier ? (int) $this->randomIdentifier : null;
     }
     
     /**

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElementList.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElementList.php
@@ -1,7 +1,20 @@
 <?php
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-require_once 'Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElement.php';
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -518,10 +531,10 @@ class ilAssOrderingElementList implements Iterator
     /**
      * @param ilAssOrderingElement $element
      * @param string $identifierType
-     * @return int
+     * @return null|int
      * @throws ilTestQuestionPoolException
      */
-    protected function fetchIdentifier(ilAssOrderingElement $element, $identifierType) : int
+    protected function fetchIdentifier(ilAssOrderingElement $element, $identifierType) : ?int
     {
         if ($identifierType == self::IDENTIFIER_TYPE_SOLUTION) {
             return $element->getSolutionIdentifier();

--- a/Services/Form/js/ServiceFormMultiTextInputInit.js
+++ b/Services/Form/js/ServiceFormMultiTextInputInit.js
@@ -1,4 +1,4 @@
-function($){
+(function($){
     $(document).ready(function() {
         $.extend({}, ilWizardInput, ilIdentifiedWizardInputExtend).init({
             fieldContainerSelector: '.ilWzdContainerText',


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=33313

Maybe https://github.com/ILIAS-eLearning/ILIAS/pull/4017/ should be taken into consideration together with this PR here.

The following modes seem to work (for the happy path):

- Terms
- Nested Terms
- Images
- Nested Images

If the form is invalid and you try to upload new images, there will be an error which also occurs in ILIAS 7.

<pre>
Error thrown with message "Call to undefined method ilAssOrderingImagesInputGUI::setPending()"

Stacktrace:
#12 Error in /var/www/ilias/trunk/Services/Form/classes/class.ilPropertyFormGUI.php:862
#11 ilPropertyFormGUI:keepFileUpload in /var/www/ilias/trunk/Services/Form/classes/class.ilPropertyFormGUI.php:390
#10 ilPropertyFormGUI:checkInput in /var/www/ilias/trunk/Modules/TestQuestionPool/classes/class.assOrderingQuestionGUI.php:342
#9 assOrderingQuestionGUI:writePostData in /var/www/ilias/trunk/Modules/TestQuestionPool/classes/class.assQuestionGUI.php:699
#8 assQuestionGUI:save in /var/www/ilias/trunk/Modules/TestQuestionPool/classes/class.assQuestionGUI.php:203
#7 assQuestionGUI:executeCommand in /var/www/ilias/trunk/Services/UICore/classes/class.ilCtrl.php:196
#6 ilCtrl:forwardCommand in /var/www/ilias/trunk/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php:455
#5 ilObjQuestionPoolGUI:executeCommand in /var/www/ilias/trunk/Services/UICore/classes/class.ilCtrl.php:196
#4 ilCtrl:forwardCommand in /var/www/ilias/trunk/Services/Repository/classes/class.ilRepositoryGUI.php:243
#3 ilRepositoryGUI:show in /var/www/ilias/trunk/Services/Repository/classes/class.ilRepositoryGUI.php:223
#2 ilRepositoryGUI:executeCommand in /var/www/ilias/trunk/Services/UICore/classes/class.ilCtrl.php:196
#1 ilCtrl:forwardCommand in /var/www/ilias/trunk/Services/UICore/classes/class.ilCtrl.php:171
#0 ilCtrl:callBaseClass in /var/www/ilias/trunk/ilias.php:24
</pre>