### PR TITLE
New env variable ILIAS_HTTP_PATH can override ilias path

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -376,6 +376,11 @@ class ilInitialisation
      */
     protected static function buildHTTPPath() : bool
     {
+        $ilias_http_path_from_env = getenv('ILIAS_HTTP_PATH');
+        if (isset($ilias_http_path_from_env)) {
+            return define('ILIAS_HTTP_PATH', $ilias_http_path_from_env);
+        }
+
         global $DIC;
 
         if ($DIC['https']->isDetected()) {


### PR DESCRIPTION
As a Sysadmin I want to create Ilias instance under `https://MYHOSTNAME/ilias/`.

I am using Traefik as a reverse-proxy, it means that:
- I route all incoming requests to `MYHOSTNAME/ilias/` directly to Ilias-instance and I can strip path-postfix (`/ilias`). (My ilias-instance runs as docker container in a docker network)

**Current situation**
- My ilias instance accepts the original request but most of response-redirects which it sends, it's doing to `https://MYHOSTNAME/`.
- Example:
1. In user-browser (user is not logged in), first request to `https://MYHOSTNAME/ilias/` is accepted by Traefik because it has path `/ilias`
2. Traefik transforms request to http://INTERNAL-ILIAS-IP/
3. Ilias on INTERNAL-ILIAS-IP processes it and sends a response: `HTTP 302 REDIRECT to https://MYHOSTNAME/login.php?...`

**Should be**
- Ilias response should be `HTTP 302 REDIRECT to https://MYHOSTNAME/ilias/login.php?...`.

**Tech description of the problem in the code**
- Ilias can correctly guess the hostname, but fails at guessing its own **path**. It always "thinks" that his path is `/`.

**How it can be solved without coding**
- Only if you have a reverse proxy which can rewrite redirect responses. Then proxy can rewrite (edit) response `HTTP 302 REDIRECT to https://MYHOSTNAME/login.php` to `HTTP 302 REDIRECT to https://MYHOSTNAME/ilias/login.php`. **Currently Traefik cannot do it. Many popular reverse-proxies cannot do it.**

**How other apps are doing it and how I solved it here**
- I provide an additional env variable `ILIAS_HTTP_PATH` with "external" URL (including HTTP/HTTPS, domain name and path of the app in "external internet").
- if this env variable is not set, then behaviour is the same as before
- if it's set, then Ilias just picks it and not trying to ***guess*** ILIAS_HTTP_PATH.
