### PR TITLE
Setup: Fix determination of plugin agents

### DIFF
--- a/src/Setup/ImplementationOfAgentFinder.php
+++ b/src/Setup/ImplementationOfAgentFinder.php
@@ -59,8 +59,7 @@ class ImplementationOfAgentFinder implements AgentFinder
         // Get a list of existing plugins in the system.
         $plugins = $this->getPluginNames();
 
-        foreach ($plugins as $plugin) {
-            $plugin_name = $plugin[3];
+        foreach ($plugins as $plugin_name) {
             $agents = $agents->withAdditionalAgent(
                 strtolower($plugin_name),
                 $this->getPluginAgent($plugin_name)
@@ -183,8 +182,8 @@ class ImplementationOfAgentFinder implements AgentFinder
             );
         foreach ($directories as $dir) {
             $groups = [];
-            if (preg_match("%^" . __DIR__ . "/[.][.]/[.][.]/Customizing/global/plugins/((Modules)|(Services))/(\\w+)/.$%", (string) $dir, $groups)) {
-                yield $groups[4];
+            if (preg_match("%^" . __DIR__ . "/[.][.]/[.][.]/Customizing/global/plugins/((Modules)|(Services))/((\\w+/){2})([^/\.]+)$%", (string) $dir, $groups)) {
+                yield $groups[6];
             }
         }
     }


### PR DESCRIPTION
This PR fixes the determination of plugin setup agents and the resulting exception:

`An agent with the name 'o' already exists.` (this error is thrown if two or more plugins are located below the `UIComponent` directory.

Issues:
- `\ILIAS\Setup\ImplementationOfAgentFinder::getPluginNames` yields strings, which should represent the plugin name (as far as I understand). But the regex seems to be wrong. There are **two** further directories to be skipped until we can check for the plugin base folder.
- `\ILIAS\Setup\ImplementationOfAgentFinder::getAgents` assumes that `$plugin` is an array and accesses the fourth element. But `\ILIAS\Setup\ImplementationOfAgentFinder::getPluginNames` returns a `Generator` yielding strings.

Mantis Issue: https://mantis.ilias.de/view.php?id=33513

If approved, this should be integrated into `release_7` (and maybe `release_8`) as well.