### PR TITLE
Deprecate SOAP::distributeMails

### DIFF
--- a/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
+++ b/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
@@ -819,7 +819,7 @@ class ilNusoapUserAdministrationAdapter
             SERVICE_NAMESPACE . '#sendMail',
             SERVICE_STYLE,
             SERVICE_USE,
-            'ILIAS distributeMails(): Distribute ILIAS mails according according to the mail setting of the recipients as ' .
+            'DEPRECATED ILIAS distributeMails(): Distribute ILIAS mails according according to the mail setting of the recipients as ' .
             'ILIAS internal mail or as e-mail.'
         );
 

--- a/webservice/soap/classes/class.ilSoapUtils.php
+++ b/webservice/soap/classes/class.ilSoapUtils.php
@@ -40,6 +40,7 @@ class ilSoapUtils extends ilSoapAdministration
     }
 
     /**
+     * @deprecated
      * @return bool|soap_fault|SoapFault|null
      */
     public function distributeMails(string $sid, string $a_mail_xml)

--- a/webservice/soap/include/inc.soap_functions.php
+++ b/webservice/soap/include/inc.soap_functions.php
@@ -442,6 +442,7 @@ class ilSoapFunctions
     }
 
     /**
+     * @deprecated
      * @return bool|soap_fault|SoapFault|null
      */
     public static function distributeMails(string $sid, string $mail_xml)


### PR DESCRIPTION
Added deprecation notice to SOAP::distributeMails()

Feature Wiki: https://docu.ilias.de/goto_docu_wiki_wpage_7563_1357.html