### PR TITLE
Fixed repository description limit 128 to be applied

### DIFF
--- a/Services/Container/classes/class.ilContainer.php
+++ b/Services/Container/classes/class.ilContainer.php
@@ -1102,37 +1102,11 @@ class ilContainer extends ilObject
     {
         global $DIC;
 
-        $ilSetting = $DIC->settings();
-        $ilObjDataCache = $DIC["ilObjDataCache"];
-        // using long descriptions?
-        $short_desc = $ilSetting->get("rep_shorten_description");
-        $short_desc_max_length = $ilSetting->get("rep_shorten_description_length");
-        if (!$short_desc || $short_desc_max_length != ilObject::DESC_LENGTH) {
-            // using (part of) shortened description
-            if ($short_desc && $short_desc_max_length && $short_desc_max_length < ilObject::DESC_LENGTH) {
-                foreach ($objects as $key => $object) {
-                    $objects[$key]["description"] = ilUtil::shortenText($object["description"], $short_desc_max_length, true);
-                }
-            }
-            // using (part of) long description
-            else {
-                $obj_ids = array();
-                foreach ($objects as $key => $object) {
-                    $obj_ids[] = $object["obj_id"];
-                }
-                if (sizeof($obj_ids)) {
-                    $long_desc = ilObject::getLongDescriptions($obj_ids);
-                    foreach ($objects as $key => $object) {
-                        // #12166 - keep translation, ignore long description
-                        if ($ilObjDataCache->isTranslatedDescription($object["obj_id"])) {
-                            $long_desc[$object["obj_id"]] = $object["description"];
-                        }
-                        if ($short_desc && $short_desc_max_length) {
-                            $long_desc[$object["obj_id"]] = ilUtil::shortenText($long_desc[$object["obj_id"]], $short_desc_max_length, true);
-                        }
-                        $objects[$key]["description"] = $long_desc[$object["obj_id"]];
-                    }
-                }
+        $short_desc = $DIC->settings()->get("rep_shorten_description");
+        $short_desc_max_length = $DIC->settings()->get("rep_shorten_description_length");
+        if ($short_desc && $short_desc_max_length !== false) {
+            foreach ($objects as $key => $object) {
+                $objects[$key]["description"] = ilUtil::shortenText($object["description"], $short_desc_max_length, true);
             }
         }
         return $objects;


### PR DESCRIPTION
Resolves https://mantis.ilias.de/view.php?id=32885 by removing deprecated parts

Also removes fetching of long descriptions because the loading of items already handles fetching of long descriptions since https://github.com/ILIAS-eLearning/ILIAS/pull/4656