### PR TITLE
Test: Fix manual scoring

### DIFF
--- a/Modules/Test/classes/class.ilTestScoringGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringGUI.php
@@ -314,12 +314,12 @@ class ilTestScoringGUI extends ilTestServiceGUI
             );
 
             $feedback = ilUtil::stripSlashes(
-                $form->getItemByPostVar("question__{$questionId}__feedback")->getValue(),
+                (string) $form->getItemByPostVar("question__{$questionId}__feedback")->getValue(),
                 false,
                 ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment")
             );
                     
-            $this->object->saveManualFeedback($activeId, $questionId, $pass, $feedback);
+            $this->object->saveManualFeedback($activeId, (int) $questionId, (int) $pass, $feedback);
 
             $notificationData[$questionId] = array(
                 'points' => $reachedPoints, 'feedback' => $feedback
@@ -460,7 +460,7 @@ class ilTestScoringGUI extends ilTestServiceGUI
             $area = new ilTextAreaInputGUI($lng->txt('set_manual_feedback'), "question__{$questionId}__feedback");
             $area->setUseRTE(true);
             if ($initValues) {
-                $area->setValue($this->object->getSingleManualFeedback($activeId, $questionId, $pass)['feedback'] ?? '');
+                $area->setValue(ilObjTest::getSingleManualFeedback((int) $activeId, (int) $questionId, (int) $pass)['feedback'] ?? '');
             }
             $form->addItem($area);
             if (strlen(trim($bestSolution))) {

--- a/Modules/Test/classes/class.ilTestServiceGUI.php
+++ b/Modules/Test/classes/class.ilTestServiceGUI.php
@@ -504,7 +504,7 @@ class ilTestServiceGUI
                     
                     $scoretemplate->setCurrentBlock("feedback");
                     $scoretemplate->setVariable("FEEDBACK_NAME_INPUT", $question);
-                    $feedback = $this->object->getSingleManualFeedback($active_id, $question, $pass)['feedback'];
+                    $feedback = ilObjTest::getSingleManualFeedback((int) $active_id, (int) $question, (int) $pass)['feedback'] ?? '';
                     $scoretemplate->setVariable(
                         "VALUE_FEEDBACK",
                         ilLegacyFormElementsUtil::prepareFormOutput(


### PR DESCRIPTION
<pre>
DEAR TESTER! AN ERROR OCCURRED... PLEASE INCLUDE THE FOLLOWING OUTPUT AS ADDITIONAL INFORMATION IN YOUR BUG REPORT.

Whoops\Exception\ErrorException thrown with message "Undefined array key "finalized_evaluation""

Stacktrace:
#12 Whoops\Exception\ErrorException in /srv/www/test8.ilias.de/html/ilias/Modules/Test/classes/class.ilObjTest.php:9481
#11 ilErrorHandling:handlePreWhoops in /srv/www/test8.ilias.de/html/ilias/Modules/Test/classes/class.ilObjTest.php:9481
#10 ilObjTest:saveManualFeedback in /srv/www/test8.ilias.de/html/ilias/Modules/Test/classes/class.ilTestScoringGUI.php:322
#9 ilTestScoringGUI:saveManScoringParticipantScreen in /srv/www/test8.ilias.de/html/ilias/Modules/Test/classes/class.ilTestScoringGUI.php:408
#8 ilTestScoringGUI:saveReturnManScoringParticipantScreen in /srv/www/test8.ilias.de/html/ilias/Modules/Test/classes/class.ilTestScoringGUI.php:151
#7 ilTestScoringGUI:executeCommand in /srv/www/test8.ilias.de/html/ilias/Services/UICore/classes/class.ilCtrl.php:196
#6 ilCtrl:forwardCommand in /srv/www/test8.ilias.de/html/ilias/Modules/Test/classes/class.ilObjTestGUI.php:381
#5 ilObjTestGUI:executeCommand in /srv/www/test8.ilias.de/html/ilias/Services/UICore/classes/class.ilCtrl.php:196
#4 ilCtrl:forwardCommand in /srv/www/test8.ilias.de/html/ilias/Services/Repository/classes/class.ilRepositoryGUI.php:243
#3 ilRepositoryGUI:show in /srv/www/test8.ilias.de/html/ilias/Services/Repository/classes/class.ilRepositoryGUI.php:223
#2 ilRepositoryGUI:executeCommand in /srv/www/test8.ilias.de/html/ilias/Services/UICore/classes/class.ilCtrl.php:196
#1 ilCtrl:forwardCommand in /srv/www/test8.ilias.de/html/ilias/Services/UICore/classes/class.ilCtrl.php:171
#0 ilCtrl:callBaseClass in /srv/www/test8.ilias.de/html/ilias/ilias.php:24
</pre>