### PR TITLE
centered login form

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -11127,7 +11127,7 @@ footer {
   grid-template-areas: "icon title close" "none description description" "none actions actions";
   grid-template-columns: 20px 1fr 20px;
   grid-gap: 9px;
-  box-shadow: 3px 9px 9px 0 #000000;
+  box-shadow: 3px 9px 9px 0 rgba(0, 0, 0, 0.3);
   transform: translateX(150%);
   transition: all 0.25s ease-in-out;
 }
@@ -16944,7 +16944,10 @@ body.ilBodyPrint {
   }
 }
 .ilStartupSection {
-  padding-top: 25px;
+  padding-top: 50px;
+  width: max-content;
+  margin-left: auto;
+  margin-right: auto;
 }
 .ilStartupSection .control-label {
   width: 33.33%;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -11127,7 +11127,7 @@ footer {
   grid-template-areas: "icon title close" "none description description" "none actions actions";
   grid-template-columns: 20px 1fr 20px;
   grid-gap: 9px;
-  box-shadow: 3px 9px 9px 0 rgba(0, 0, 0, 0.3);
+  box-shadow: 3px 9px 9px 0 #000000;
   transform: translateX(150%);
   transition: all 0.25s ease-in-out;
 }

--- a/templates/default/less/Services/Init/delos.less
+++ b/templates/default/less/Services/Init/delos.less
@@ -15,7 +15,10 @@ div.ilStartupFrame {
 		}
 	}
 
-	padding-top: 25px;
+	padding-top: 50px;
+	width: fit-content;
+	margin-left: auto;
+	margin-right: auto;
 	@media only screen and (max-width: @grid-float-breakpoint-max) {
 		padding-top: 15px;
 	}


### PR DESCRIPTION
we have discussed the following issue in the css squad. 

0033557 Loginform zentrieren - https://mantis.ilias.de/view.php?id=33557

I support the proposal. This customization only affects the default login form. If the login page is designed using the Page Editor, it will not be affected. The Page Editor content will remain. 

Since all authentication methods are displayed within the dic .ilStartupsection, the forms of all authentication methods are centered. 

However, I'm not sure if the div should be centered this way. If there is another/better way, discuss the CSS adjustments in the comments of this PR. 

![Screenshot 2022-07-27 at 13-10-27 ILIAS Bei ILIAS anmelden](https://user-images.githubusercontent.com/42470261/181234265-e276fd95-6637-401a-88a9-7baf50981053.png)
