### PR TITLE
LoginPage: Remove 'focus' JavaScript from login template

### DIFF
--- a/Services/Init/templates/default/tpl.login.html
+++ b/Services/Init/templates/default/tpl.login.html
@@ -38,12 +38,3 @@
 	</p>
 	<!-- END agreement -->
 </div>
-<script>
-<!--
-if (document.formlogin.username && document.formlogin.password)
-{
-	if(document.formlogin.username.value!="") document.formlogin.password.focus();
-	else document.formlogin.username.focus();
-}
-//-->
-</script>


### PR DESCRIPTION
The JavaScript used in `tpl.login.html` to focus either the username or password field does not have any effect.

The focus is handled by `src/UI/templates/js/Page/stdpage.js`, so this PR removes the obsolete JS code from the login template.