### PR TITLE
UI Communication Item

### DIFF
--- a/src/UI/Component/Item/Communication.php
+++ b/src/UI/Component/Item/Communication.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Component\Item;
+
+use ILIAS\UI\Component\Symbol\Icon\Icon;
+use ILIAS\UI\Component\Symbol\Avatar\Avatar;
+
+/**
+ * Interface Notification
+ * @package ILIAS\UI\Component\Item
+ */
+interface Communication extends Item
+{
+    /**
+     * Set icon as lead
+     */
+    public function withLeadIcon(Icon $icon) : Communication;
+
+    /**
+     * Set avatar as lead
+     */
+    public function withLeadAvatar(Avatar $avatar) : Communication;
+
+    /**
+     * Get lead Icon or Avatar
+     * @return null|Icon|Avatar
+     */
+    public function getLead();
+}

--- a/src/UI/Component/Item/Factory.php
+++ b/src/UI/Component/Item/Factory.php
@@ -136,4 +136,42 @@ interface Factory
      * @return \ILIAS\UI\Component\Item\Notification
      */
     public function notification($title, Icon $lead) : Notification;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      The contextualisation of an item is prior to the content itself
+     *   composition: >
+     *      Communication items focus on a message to be communicated.
+     *      For a message, its context is of great relevance.
+     *      This context is given by information about the sender
+     *      and the receiver(s) of the message, as well as the time
+     *      at which the message was communicated.
+     *      This is followed by the main message content.
+     *      This can be supplemented by further information such as
+     *      attachments, references, ratings or status informations.
+     *   effect: >
+     *      Interactions can be present in the contextual information,
+     *      the content and metadata.
+     * context:
+     *     - Contexts can be single messages such as Mails, but also several related messages
+     *      such as in forums.
+     * rules:
+     *   usage:
+     *     1: Communincation Items SHOULD be used if it is a message.
+     *   ordering:
+     *     1: An lead icon or lead avatar can be used
+     *     2: Title
+     *     3: Context Informations
+     *     4: Message content
+     *     5: Metadata
+     *   accessibility:
+     *     1: All interactions offered by a notification item MUST be accessible
+     *      by only using the keyboard.
+     * ---
+     * @param $title
+     * @return \ILIAS\UI\Component\Item\Communication
+     */
+    public function communication($title) : Communication;
 }

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -541,8 +541,8 @@ interface Factory
      *      Items contain the name of the entity as a title. The title MAY be interactive by using
      *      a Shy Button. The item contains three
      *      sections, where one section contains important information about the item,
-     *      the second section shows the content of the item and another section shows
-     *      metadata about the entity.
+     *      a second section shows the content of the item and another section shows
+     *      metadata about the entity. The order of the sections may differ.
      *   effect: >
      *      Items may contain Interaction Triggers such as Glyphs, Buttons or Tags.
      *   rivals:

--- a/src/UI/Implementation/Component/Item/Factory.php
+++ b/src/UI/Implementation/Component/Item/Factory.php
@@ -54,4 +54,12 @@ class Factory implements Item\Factory
     {
         return new Notification($title, $icon);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function communication($title) : Item\Communication
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
 }

--- a/src/UI/examples/Item/Communication/open_communication.php
+++ b/src/UI/examples/Item/Communication/open_communication.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\examples\Item\Communication;
+
+function open_communication() : string
+{
+    // To be created after a feedback by the UI coordinators.
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $mail_icon = $f->symbol()->icon()->standard("mail", "mail");
+    $mail_title = $f->link()->standard("Inbox", "#");
+    $mail_communication_item = $f->item()->communication($mail_title)
+                                 ->withLeadIcon($mail_icon);
+
+
+    return $renderer->render($mail_communication_item);
+}

--- a/src/UI/examples/Item/Communication/personal_communication.php
+++ b/src/UI/examples/Item/Communication/personal_communication.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\examples\Item\Communication;
+
+function personal_communication() : string
+{
+    // To be created after a feedback by the UI coordinators.
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $mail_icon = $f->symbol()->icon()->standard("mail", "mail");
+    $mail_title = $f->link()->standard("Inbox", "#");
+    $mail_communication_item = $f->item()->communication($mail_title)
+                                ->withLeadIcon($mail_icon);
+
+
+    return $renderer->render($mail_communication_item);
+}


### PR DESCRIPTION
This PR proposes to introduce the UI-Component for implementing Communication Items
This item will initially be used for the new presentation of mails and forum postings


As discussed in https://docu.ilias.de/goto_docu_wiki_wpage_7421_1357.html mails should be represented in a view that is similar to standard item. 
Communication Items are introduced so that mails and forum postings can be presented in a view where contextual information is presented first.