### PR TITLE
DEBUG: Remove global constant

### DIFF
--- a/Modules/File/test/ilModulesFileTest.php
+++ b/Modules/File/test/ilModulesFileTest.php
@@ -15,7 +15,7 @@
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
- 
+
 use PHPUnit\Framework\TestCase;
 use ILIAS\Filesystem\Stream\Streams;
 use ILIAS\DI\Container;
@@ -71,9 +71,6 @@ class ilModulesFileTest extends TestCase
         
         if (!defined('ILIAS_LOG_ENABLED')) {
             define('ILIAS_LOG_ENABLED', false);
-        }
-        if (!defined('DEBUG')) {
-            define('DEBUG', false);
         }
     }
     

--- a/Modules/Forum/test/ilObjForumAdministrationTest.php
+++ b/Modules/Forum/test/ilObjForumAdministrationTest.php
@@ -28,10 +28,6 @@ class ilObjForumAdministrationTest extends TestCase
 
     public function testConstruct() : void
     {
-        if (!defined('DEBUG')) {
-            define('DEBUG', false);
-        }
-
         $this->mockLanguage->expects(self::once())->method('loadLanguageModule')->with('forum');
         $instance = new ilObjForumAdministration();
     }

--- a/Modules/OrgUnit/test/ilModulesOrgUnitTest.php
+++ b/Modules/OrgUnit/test/ilModulesOrgUnitTest.php
@@ -69,9 +69,6 @@ class ilModulesOrgUnitTest extends TestCase
         if (!defined('ILIAS_LOG_ENABLED')) {
             define('ILIAS_LOG_ENABLED', false);
         }
-        if (!defined('DEBUG')) {
-            define('DEBUG', false);
-        }
     }
     
     protected function tearDown() : void

--- a/Modules/Scorm2004/test/ilModulesScorm2004Suite.php
+++ b/Modules/Scorm2004/test/ilModulesScorm2004Suite.php
@@ -34,10 +34,6 @@ class ilModulesScorm2004Suite extends TestSuite
             define("ILIAS_HTTP_PATH", "http://localhost");
         }
 
-        if (!defined("DEBUG")) {
-            define("DEBUG", false);
-        }
-
         if (!defined("ILIAS_LOG_ENABLED")) {
             define("ILIAS_LOG_ENABLED", false);
         }

--- a/Modules/Test/test/ilModulesTestSuite.php
+++ b/Modules/Test/test/ilModulesTestSuite.php
@@ -29,10 +29,6 @@ class ilModulesTestSuite extends TestSuite
             define("ILIAS_HTTP_PATH", "http://localhost");
         }
 
-        if (!defined("DEBUG")) {
-            define("DEBUG", false);
-        }
-
         if (!defined("ILIAS_LOG_ENABLED")) {
             define("ILIAS_LOG_ENABLED", false);
         }

--- a/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
@@ -1,7 +1,20 @@
-<?php
-/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\Setup;
 use ILIAS\DI;

--- a/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
@@ -169,10 +169,6 @@ class ilComponentActivatePluginsObjective implements Setup\Objective
             }
         };
 
-        if (!defined('DEBUG')) {
-            define('DEBUG', false);
-        }
-
         if (!defined('SYSTEM_ROLE_ID')) {
             define('SYSTEM_ROLE_ID', '2');
         }

--- a/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
@@ -1,7 +1,20 @@
-<?php
-/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\Setup;
 use ILIAS\DI;

--- a/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
@@ -170,10 +170,6 @@ class ilComponentInstallPluginObjective implements Setup\Objective
             }
         };
 
-        if (!defined('DEBUG')) {
-            define('DEBUG', false);
-        }
-
         if (!defined('SYSTEM_ROLE_ID')) {
             define('SYSTEM_ROLE_ID', '2');
         }

--- a/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
@@ -1,7 +1,20 @@
-<?php
-/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\Setup;
 use ILIAS\DI;

--- a/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
@@ -247,10 +247,6 @@ class ilComponentUpdatePluginObjective implements Setup\Objective
             }
         };
 
-        if (!defined('DEBUG')) {
-            define('DEBUG', false);
-        }
-
         if (!defined("ILIAS_ABSOLUTE_PATH")) {
             define("ILIAS_ABSOLUTE_PATH", dirname(__FILE__, 5));
         }

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -512,7 +512,6 @@ class ilInitialisation
 
         self::initGlobal("ilClientIniFile", $ilClientIniFile);
         // set constants
-        define("DEBUG", (int) $ilClientIniFile->readVariable("system", "DEBUG"));
         define("DEVMODE", (int) $ilClientIniFile->readVariable("system", "DEVMODE"));
         define("SHOWNOTICES", (int) $ilClientIniFile->readVariable("system", "SHOWNOTICES"));
         if (!defined("ROOT_FOLDER_ID")) {

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1,5 +1,20 @@
 <?php
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 // TODO:
 use ILIAS\BackgroundTasks\Dependencies\DependencyMap\BaseDependencyMap;

--- a/Services/UICore/classes/class.ilTemplate.php
+++ b/Services/UICore/classes/class.ilTemplate.php
@@ -209,10 +209,6 @@ class ilTemplate extends HTML_Template_ITX
     {
         global $DIC;
 
-        if (DEBUG) {
-            echo "<br/>Template '" . $this->tplPath . "/" . $tplname . "'";
-        }
-
         $tplfile = $this->getTemplatePath($tplname, $in_module);
         if (file_exists($tplfile) === false) {
             echo "<br/>Template '" . $tplfile . "' doesn't exist! aborting...";

--- a/Services/UICore/classes/class.ilTemplate.php
+++ b/Services/UICore/classes/class.ilTemplate.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2022 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 require_once __DIR__ . '/../lib/html-it/IT.php';
 require_once __DIR__ . '/../lib/html-it/ITX.php';

--- a/setup/client.master.ini.php
+++ b/setup/client.master.ini.php
@@ -38,7 +38,6 @@ ROLE_FOLDER_ID = 8
 MAIL_SETTINGS_ID = 12
 MAXLENGTH_OBJ_TITLE = 65
 MAXLENGTH_OBJ_DESC = 123
-DEBUG = 0
 
 [cache]
 activate_global_cache = 0


### PR DESCRIPTION
This PR removes the global `DEBUG` constant and its usages. The effect and consequences of this DEBUG state are not documented (in contrast the `DEVMODE` is explained here: https://docu.ilias.de/goto_docu_pg_1082_42.html). It is unclear why (what's the purpose?) certain template file names are listed at the top of the rendered HTML page if the state evaluates to `true`.

The builds fail because of the wrong `License Header`, so no serious problems occur.