### PR TITLE
BF 0033595: section-input-header should use @il-font-weight-bold

### DIFF
--- a/src/UI/templates/default/Input/input.less
+++ b/src/UI/templates/default/Input/input.less
@@ -41,6 +41,7 @@
 
   .il-standard-form-header h2, .il-section-input-header h2{
     font-size: @il-standard-form-header-font-size;
+    font-weight: @il-font-weight-bold;
     padding-top: 2*@il-padding-large-vertical;
     padding-bottom: @il-padding-small-vertical;
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -16827,7 +16827,7 @@ div.ilBlockHeaderBig,
 td.ilBlockHeader,
 td.ilBlockHeaderBig {
   /* font-family: 'Open Sans Semibold';  deactivated, since it affects drop downs in the header */
-  font-weight: 600;
+  font-weight: 400;
   padding: 3px 0;
   margin: 0 9px;
   text-align: left;
@@ -16946,7 +16946,7 @@ body.ilBodyPrint {
 }
 .ilStartupSection {
   padding-top: 50px;
-  width: fit-content;
+  width: max-content;
   margin-left: auto;
   margin-right: auto;
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8188,6 +8188,7 @@ ul.dropdown-menu > li > .btn:focus {
 .il-standard-form .il-standard-form-header h2,
 .il-standard-form .il-section-input-header h2 {
   font-size: 1.115rem;
+  font-weight: 600;
   padding-top: 12px;
   padding-bottom: 3px;
 }
@@ -16826,7 +16827,7 @@ div.ilBlockHeaderBig,
 td.ilBlockHeader,
 td.ilBlockHeaderBig {
   /* font-family: 'Open Sans Semibold';  deactivated, since it affects drop downs in the header */
-  font-weight: 400;
+  font-weight: 600;
   padding: 3px 0;
   margin: 0 9px;
   text-align: left;
@@ -16945,7 +16946,7 @@ body.ilBodyPrint {
 }
 .ilStartupSection {
   padding-top: 50px;
-  width: max-content;
+  width: fit-content;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
Hi @all,

as discussed in the css squad, headings in forms should use the variable @il-font-weight-bold. For legacy forms we have already adjusted this. This PR is used to adjust the headings of KS forms.

0033595: section-input-header should use @il-font-weight-bold - https://mantis.ilias.de/view.php?id=33595

Many Greetings, 
Enrico
![Screenshot 2022-08-03 at 08-56-10 ILIAS Study Programme](https://user-images.githubusercontent.com/42470261/182543988-32b4d972-8cd2-48c9-89d0-eaec903b5f2b.png)
