### PR TITLE
Fix/9/failing setup

### DIFF
--- a/Modules/EmployeeTalk/classes/Setup/class.ilEmployeeTalkDBUpdateSteps.php
+++ b/Modules/EmployeeTalk/classes/Setup/class.ilEmployeeTalkDBUpdateSteps.php
@@ -18,13 +18,11 @@
 
 namespace ILIAS\EmployeeTalk\Setup;
 
-use ilOrgUnitOperationContextQueries;
-use ilOrgUnitOperationContext;
-use ilOrgUnitOperationQueries;
-use ilOrgUnitOperation;
-use ilTree;
 use ILIAS\Modules\EmployeeTalk\TalkSeries\Entity\EmployeeTalkSerieSettings;
-use ilUtil;
+use ilOrgUnitOperation;
+use ilOrgUnitOperationContext;
+use ilOrgUnitOperationContextQueries;
+use ilOrgUnitOperationQueries;
 
 /**
  * @author Nicolas Schaefli <nick@fluxlabs.ch>
@@ -38,7 +36,7 @@ final class ilEmployeeTalkDBUpdateSteps implements \ilDatabaseUpdateSteps
         $this->db = $db;
     }
 
-    private function useTransaction(callable $updateStep): void
+    private function useTransaction(callable $updateStep) : void
     {
         try {
             if ($this->db->supportsTransactions()) {
@@ -100,28 +98,7 @@ final class ilEmployeeTalkDBUpdateSteps implements \ilDatabaseUpdateSteps
 
     public function step_1() : void
     {
-        $this->useTransaction(function (\ilDBInterface $db) {
-            // create object data entry
-            $id = $db->nextId("object_data");
-            $db->manipulateF(
-                "INSERT INTO object_data (obj_id, type, title, description, owner, create_date, last_update) " .
-                "VALUES (%s, %s, %s, %s, %s, %s, %s)",
-                array("integer", "text", "text", "text", "integer", "timestamp", "timestamp"),
-                array($id, "tala", "__TalkTemplateAdministration", "Talk Templates", -1, ilUtil::now(), ilUtil::now())
-            );
-
-            // create object reference entry
-            $ref_id = $db->nextId('object_reference');
-            $res = $db->manipulateF(
-                "INSERT INTO object_reference (ref_id, obj_id) VALUES (%s, %s)",
-                array("integer", "integer"),
-                array($ref_id, $id)
-            );
-
-            // put in tree
-            $tree = new ilTree(ROOT_FOLDER_ID);
-            $tree->insertNode($ref_id, SYSTEM_FOLDER_ID);
-        });
+        // removed this content in favour of a ilTreeAdminNodeAddedObjective
     }
 
     public function step_2() : void
@@ -195,7 +172,7 @@ final class ilEmployeeTalkDBUpdateSteps implements \ilDatabaseUpdateSteps
     public function step_5() : void
     {
         $this->useTransaction(function (\ilDBInterface $db) {
-            EmployeeTalkSerieSettings::updateDB();
+            EmployeeTalkSerieSettings::updateDB(); // Please do not use updateDB in core!
         });
     }
 }

--- a/Modules/EmployeeTalk/classes/Setup/class.ilEmployeeTalkDBUpdateSteps.php
+++ b/Modules/EmployeeTalk/classes/Setup/class.ilEmployeeTalkDBUpdateSteps.php
@@ -42,48 +42,7 @@ final class ilEmployeeTalkDBUpdateSteps implements \ilDatabaseUpdateSteps
             if ($this->db->supportsTransactions()) {
                 $this->db->beginTransaction();
             }
-
-            // ATTENTION: This is a total abomination. It only exists to allow the db-
-            // update to run. This is a memento to the fact, that dependency injection
-            // is something we want. Currently, every component could just service
-            // locate the whole world via the global $DIC.
-            /** @noRector  */
-            $DIC = $GLOBALS["DIC"] ?? [];
-            $GLOBALS["DIC"] = new \ILIAS\DI\Container();
-            $GLOBALS["DIC"]["ilDB"] = $this->db;
-            $GLOBALS["ilDB"] = $this->db;
-            $GLOBALS["DIC"]["ilLog"] = new class() {
-                public function write() : void
-                {
-                }
-                public function info() : void
-                {
-                }
-                public function warning($msg) : void
-                {
-                }
-                public function error($msg) : void
-                {
-                    throw new \ILIAS\Setup\UnachievableException(
-                        "Problem in DB-Update: $msg"
-                    );
-                }
-            };
-            $GLOBALS["ilLog"] = $GLOBALS["DIC"]["ilLog"];
-            $GLOBALS["DIC"]["ilLoggerFactory"] = new class() {
-                public function getRootLogger() : object
-                {
-                    return new class() {
-                        public function write() : void
-                        {
-                        }
-                    };
-                }
-            };
-
             $updateStep($this->db);
-
-            $GLOBALS["DIC"] = $DIC;
 
             if ($this->db->supportsTransactions()) {
                 $this->db->commit();

--- a/Modules/EmployeeTalk/classes/Setup/class.ilEmployeeTalkSetupAgent.php
+++ b/Modules/EmployeeTalk/classes/Setup/class.ilEmployeeTalkSetupAgent.php
@@ -18,15 +18,63 @@
 
 namespace ILIAS\EmployeeTalk\Setup;
 
+use ILIAS\Refinery\Transformation;
 use ILIAS\Setup;
+use ILIAS\Setup\Config;
+use ILIAS\Setup\Metrics;
+use ILIAS\Setup\Migration;
+use ILIAS\Setup\Objective;
 
 /**
  * @author Nicolas Schaefli <nick@fluxlabs.ch>
  */
-final class ilEmployeeTalkSetupAgent extends Setup\Agent\NullAgent
+final class ilEmployeeTalkSetupAgent implements Setup\Agent
 {
+    public function hasConfig() : bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation() : Transformation
+    {
+        throw new \LogicException(
+            self::class . " has no config."
+        );
+    }
+
+    public function getInstallObjective(Config $config = null) : Objective
+    {
+        return new \ilTreeAdminNodeAddedObjective('tala', '__TalkTemplateAdministration');
+    }
+
+    public function getBuildArtifactObjective() : Objective
+    {
+        return new Objective\NullObjective();
+    }
+
+    public function getStatusObjective(Metrics\Storage $storage) : Objective
+    {
+        return new Objective\NullObjective();
+    }
+
+    public function getMigrations() : array
+    {
+        return [];
+    }
+
+    public function getNamedObjectives(?Config $config = null) : array
+    {
+        return [];
+    }
+
+
     public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
     {
-        return new \ilDatabaseUpdateStepsExecutedObjective(new ilEmployeeTalkDBUpdateSteps());
+        return new Setup\ObjectiveCollection(
+            'Employee Talks',
+            true,
+            new \ilTreeAdminNodeAddedObjective('tala', '__TalkTemplateAdministration'),
+            new \ilDatabaseUpdateStepsExecutedObjective(new ilEmployeeTalkDBUpdateSteps())
+        );
     }
 }

--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -748,14 +748,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
     public function lockTables(array $tables) : void
     {
         assert(is_array($tables));
-
         $lock = $this->manager->getQueryUtils()->lock($tables);
-        global $DIC;
-        $ilLogger = $DIC->logger()->root();
-        if ($ilLogger instanceof ilLogger) {
-            $ilLogger->log('ilDB::lockTables(): ' . $lock);
-        }
-
         $this->pdo->exec($lock);
     }
 

--- a/Services/Tree/classes/class.ilTree.php
+++ b/Services/Tree/classes/class.ilTree.php
@@ -128,11 +128,14 @@ class ilTree
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(int $a_tree_id, int $a_root_id = 0)
-    {
+    public function __construct(
+        int $a_tree_id,
+        int $a_root_id = 0,
+        ilDBInterface $db = null
+    ) {
         global $DIC;
 
-        $this->db = $DIC->database();
+        $this->db = $db ?? $DIC->database();
         $this->logger = ilLoggerFactory::getLogger('tree');
         //$this->logger = $DIC->logger()->tree();
         if (isset($DIC['ilAppEventHandler'])) {
@@ -141,7 +144,7 @@ class ilTree
 
         $this->lang_code = self::DEFAULT_LANGUAGE;
 
-        if (func_num_args() > 2) {
+        if (func_num_args() > 3) {
             $this->logger->error("Wrong parameter count!");
             $this->logger->logStack(ilLogLevel::ERROR);
             throw new InvalidArgumentException("Wrong parameter count!");


### PR DESCRIPTION
@mstuder and @smeyer-ilias as mentioned in #4785 I opened a new PR which:
- introduce possibility to inject ilDBinterface to ilTree, @smeyer-ilias already gave his OK
- moving the action of "adding a Admin Node" out of DatabaseUpdates (where they should not be located) to a new ilTreeAdminNodeAddedObjective
- made a comment to not use ActiveRecord::updateDb in core

both commits should be cherry-picked to release_8 as well