### PR TITLE
Tree: Add missing tree impl. switch (sponsored by Mrs. Jansen)

### DIFF
--- a/Services/Tree/classes/Setup/class.ilTreeImplementationSwitch.php
+++ b/Services/Tree/classes/Setup/class.ilTreeImplementationSwitch.php
@@ -1,0 +1,147 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\UnachievableException;
+use ILIAS\Setup\NullConfig;
+
+class ilTreeImplementationSwitch extends ilSetupObjective
+{
+    public const NESTED_SET_TO_MATERIALIZED_PATH = 'nested_set_to_materialized_path';
+    public const MATERIALIZED_PATH_TO_NESTED_SET = 'materialized_path_to_nested_set';
+
+    private string $mode;
+
+    public function __construct(string $mode)
+    {
+        parent::__construct(new NullConfig());
+        $this->mode = $mode;
+    }
+
+    public function getHash() : string
+    {
+        return hash('sha256', self::class);
+    }
+
+    public function getLabel() : string
+    {
+        if ($this->mode === self::MATERIALIZED_PATH_TO_NESTED_SET) {
+            return 'The tree implementation is switched to nested set';
+        }
+
+        return 'The tree implementation is switched to materialized path';
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilSettingsFactoryExistsObjective(),
+            new ilDatabaseInitializedObjective(),
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+        $settings_factory = $environment->getResource(Environment::RESOURCE_SETTINGS_FACTORY);
+
+        $is_nested_set = $settings_factory->settingsFor('common')->get('main_tree_impl', 'ns') === 'ns';
+
+        if ($this->mode === self::NESTED_SET_TO_MATERIALIZED_PATH && $is_nested_set) {
+            ilMaterializedPathTree::createFromParentRelation($db);
+
+            $db->dropIndexByFields('tree', ['lft']);
+            $db->dropIndexByFields('tree', ['path']);
+            $db->addIndex('tree', ['path'], 'i4');
+
+            $settings_factory->settingsFor('common')->set('main_tree_impl', 'mp');
+        } elseif ($this->mode === self::MATERIALIZED_PATH_TO_NESTED_SET && !$is_nested_set) {
+            $renumber_callable = function (ilDBInterface $db) {
+                $this->renumberNestedSet($db, 1, 1);
+            };
+            $ilAtomQuery = $db->buildAtomQuery();
+            $ilAtomQuery->addTableLock('tree');
+
+            $ilAtomQuery->addQueryCallable($renumber_callable);
+            $ilAtomQuery->run();
+
+            $db->dropIndexByFields('tree', ['lft']);
+            $db->dropIndexByFields('tree', ['path']);
+            $db->addIndex('tree', ['lft'], 'i4');
+
+            $settings_factory->settingsFor('common')->set('main_tree_impl', 'ns');
+        } else {
+            throw new UnachievableException('The tree implementation switch does already equal the requested mode');
+        }
+
+        return $environment;
+    }
+    
+    private function renumberNestedSet(ilDBInterface $db, int $node_id, int $i) : int
+    {
+        $db->manipulateF(
+            'UPDATE tree SET lft = %s WHERE child = %s',
+            [ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER],
+            [$node_id, $i]
+        );
+
+        $query = 'SELECT child FROM tree WHERE parent = ' . $db->quote($node_id, ilDBConstants::T_INTEGER) . ' ORDER BY lft';
+        $res = $db->query($query);
+
+        $children = [];
+        while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+            $children[] = (int) $row->child;
+        }
+
+        foreach ($children as $child) {
+            $i = $this->renumberNestedSet($db, $child, $i + 1);
+        }
+        $i++;
+
+        if (count($children) > 0) {
+            $i += 100;
+        }
+
+        $query = 'UPDATE tree SET rgt = %s WHERE child = %s';
+        $db->manipulateF(
+            $query,
+            [ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER],
+            [$i, $node_id]
+        );
+
+        return $i;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        $settings_factory = $environment->getResource(Environment::RESOURCE_SETTINGS_FACTORY);
+
+        $is_nested_set = $settings_factory->settingsFor('common')->get('main_tree_impl', 'ns') === 'ns';
+
+        if ($this->mode === self::MATERIALIZED_PATH_TO_NESTED_SET) {
+            return !$is_nested_set;
+        }
+
+        return $is_nested_set;
+    }
+}

--- a/Services/Tree/classes/Setup/class.ilTreeMetricsCollectedObjective.php
+++ b/Services/Tree/classes/Setup/class.ilTreeMetricsCollectedObjective.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup\Metrics\CollectedObjective;
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Metrics\Storage;
+
+class ilTreeMetricsCollectedObjective extends CollectedObjective
+{
+    protected function getTentativePreconditions(Environment $environment) : array
+    {
+        return [
+            new ilSettingsFactoryExistsObjective(),
+            new ilDatabaseInitializedObjective(),
+        ];
+    }
+
+    protected function collectFrom(Environment $environment, Storage $storage) : void
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+        $settings_factory = $environment->getResource(Environment::RESOURCE_SETTINGS_FACTORY);
+
+        if (!$settings_factory || !$db) {
+            return;
+        }
+
+        $settings = $settings_factory->settingsFor('common');
+
+        $storage->storeConfigText(
+            'Tree Implementation',
+            $settings->get('main_tree_impl', 'ns') === 'ns' ? 'Nested Set' : 'Materialized Path',
+            'The database implementation of the ILIAS repository tree.'
+        );
+    }
+}

--- a/Services/Tree/classes/Setup/class.ilTreeSetupAgent.php
+++ b/Services/Tree/classes/Setup/class.ilTreeSetupAgent.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup\Agent;
+use ILIAS\Setup\Objective;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Setup\Metrics;
+use ILIAS\Setup\Config;
+use ILIAS\Setup\ObjectiveConstructor;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Setup\NullConfig;
+
+class ilTreeSetupAgent implements Agent
+{
+    protected Refinery $refinery;
+
+    public function __construct(Refinery $refinery)
+    {
+        $this->refinery = $refinery;
+    }
+
+    public function hasConfig() : bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation() : Transformation
+    {
+        return $this->refinery->custom()->transformation(static function ($data) : Config {
+            return new NullConfig();
+        });
+    }
+
+    public function getInstallObjective(Config $config = null) : Objective
+    {
+        return new Objective\NullObjective();
+    }
+
+    public function getUpdateObjective(Config $config = null) : Objective
+    {
+        return new Objective\NullObjective();
+    }
+
+    public function getBuildArtifactObjective() : Objective
+    {
+        return new Objective\NullObjective();
+    }
+
+    public function getStatusObjective(Metrics\Storage $storage) : Objective
+    {
+        return new ilTreeMetricsCollectedObjective($storage);
+    }
+
+    public function getMigrations() : array
+    {
+        return [];
+    }
+
+    public function getNamedObjectives(?Config $config = null) : array
+    {
+        return [
+            'mp-to-ns' => new ObjectiveConstructor(
+                'Migrate the ILIAS repository tree from Materialized Path to Nested Set',
+                static function () : Objective {
+                    return new ilTreeImplementationSwitch(
+                        ilTreeImplementationSwitch::MATERIALIZED_PATH_TO_NESTED_SET
+                    );
+                }
+            ),
+            'ns-to-mp' => new ObjectiveConstructor(
+                'Migrate the ILIAS repository tree from Nested to Materialized Path',
+                static function () : Objective {
+                    return new ilTreeImplementationSwitch(
+                        ilTreeImplementationSwitch::NESTED_SET_TO_MATERIALIZED_PATH
+                    );
+                }
+            )
+        ];
+    }
+}

--- a/Services/Tree/classes/SystemCheck/class.ilSCTreeTasksGUI.php
+++ b/Services/Tree/classes/SystemCheck/class.ilSCTreeTasksGUI.php
@@ -1,6 +1,20 @@
 <?php declare(strict_types=1);
 
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;
@@ -21,6 +35,7 @@ class ilSCTreeTasksGUI extends ilSCComponentTaskGUI
     protected ilTree $tree;
     protected GlobalHttpState $http;
     protected Factory $refinery;
+    private ilDBInterface $db;
 
     public function __construct(ilSCTask $task = null)
     {
@@ -30,6 +45,7 @@ class ilSCTreeTasksGUI extends ilSCComponentTaskGUI
         $this->tree = $DIC->repositoryTree();
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
+        $this->db = $DIC->database();
     }
 
     protected function getDuplicateIdFromRequest() : int
@@ -212,7 +228,7 @@ class ilSCTreeTasksGUI extends ilSCComponentTaskGUI
         $tasks = new ilSCTreeTasks($this->getTask());
 
         if ($this->tree->getTreeImplementation() instanceof ilMaterializedPathTree) {
-            ilMaterializedPathTree::createFromParentReleation();
+            ilMaterializedPathTree::createFromParentReleation($this->db);
         } elseif ($this->tree->getTreeImplementation() instanceof ilNestedSetTree) {
             $this->tree->renumber(ROOT_FOLDER_ID);
         }

--- a/setup/sql/dbupdate_05.php
+++ b/setup/sql/dbupdate_05.php
@@ -2910,7 +2910,7 @@ switch ($tree_type) {
                 break;
 
         case \ilTree::TREE_TYPE_MATERIALIZED_PATH:
-                \ilMaterializedPathTree::createFromParentReleation();
+                \ilMaterializedPathTree::createFromParentRelation($ilDB);
                 break;
 
 


### PR DESCRIPTION
This PR adds an `Achievable Setup Objective` to let administrators switch the `Tree Implementation` of the repository tree from a `Nested Set` implementation to a `Materialized Path` implementation and vice versa.

Debatable: Should we stick with the suggested objective class or should we segregate this into two separate objectives?

Using `ilTree` to migrate to `Nested Set` was not possible because of massive global scope usage, so I had to duplicate a few lines of code.

---

Furthermore this PR adds a `Metrics Collected Objective` to report the current tree implementation when executing the `status` command of the ILIAS setup.

---

- The builds fail because of the missing license header in `dbupdate_05.php`.
- If approved, this should be picked to `release_8` as well.

Mantis Issue: https://mantis.ilias.de/view.php?id=32277