### PR TITLE
Services/Exception: shorten testing error handler

### DIFF
--- a/Services/Exceptions/classes/class.ilTestingHandler.php
+++ b/Services/Exceptions/classes/class.ilTestingHandler.php
@@ -31,4 +31,13 @@ class ilTestingHandler extends ilPlainTextHandler
     {
         return "DEAR TESTER! AN ERROR OCCURRED... PLEASE INCLUDE THE FOLLOWING OUTPUT AS ADDITIONAL INFORMATION IN YOUR BUG REPORT.\n\n";
     }
+
+    /**
+     * Assemble the output for this handler.
+     */
+    protected function content() : string
+    {
+        return $this->pageHeader()
+            . $this->exceptionContent();
+    }
 }


### PR DESCRIPTION
Hi all,

as requested by @alex40724 and @matthiaskunkel via Fabian K, this removes everything but the stack trace from the exception handler used when testing ILIAS.

I hand this to @smeyer-ilias as implicit maintainer of the service...

Best regards!