### PR TITLE
Composer/CaptainHook: Install the `Cptn` when using `Composer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
 		"vendor-dir": "./libs/composer/vendor",
 		"allow-plugins": {
 			"simplesamlphp/composer-module-installer": true,
-			"cweagans/composer-patches": true
+			"cweagans/composer-patches": true,
+			"captainhook/plugin-composer": true
 		}
 	},
 	"scripts": {
@@ -75,7 +76,8 @@
 		"mockery/mockery": "^1.4",
 		"friendsofphp/php-cs-fixer": "^3.5",
 		"sebastian/environment": "^5.0",
-		"captainhook/captainhook": "^5.3",
+		"captainhook/captainhook": "^5.10",
+		"captainhook/plugin-composer": "^5.3",
 		"rector/rector": "^0.12.12",
 		"phpstan/phpstan": "^1.6"
 	},
@@ -485,6 +487,26 @@
 			"last_update_by" : "Per Pascal Seeland <pascal.seeland@tik.uni-stuttgart.de",
 			"approved-by" : "In Codebase since 2006",
 			"approved-date" : "YYYY-MM-DD"
+		},
+		"captainhook/captainhook": {
+			"source": "https://github.com/captainhookphp/captainhook",
+			"used_version": "5.10",
+			"added_by": "Michael Jansen <mjansen@databay.de>",
+			"wrapped_by": null,
+			"last_update": "2022-08-12",
+			"last_update_by": "",
+			"approved-by": "JF",
+			"approved-date": "2021-11-21"
+		},
+		"captainhook/plugin-composer": {
+			"source": "https://github.com/captainhookphp/plugin-composer",
+			"used_version": "5.3",
+			"added_by": "Michael Jansen <mjansen@databay.de>",
+			"wrapped_by": null,
+			"last_update": "2022-08-12",
+			"last_update_by": "",
+			"approved-by": "JF",
+			"approved-date": "2021-11-21"
 		},
 		"patches": {
 			"tecnickcom/tcpdf": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f42f13076b177ff7d47cb0e923f33acc",
+    "content-hash": "cdc88ef8b10b4bbebf174d24da6340f1",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -7865,6 +7865,61 @@
                 }
             ],
             "time": "2022-03-06T21:32:16+00:00"
+        },
+        {
+            "name": "captainhook/plugin-composer",
+            "version": "5.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/captainhookphp/plugin-composer.git",
+                "reference": "0a802aaf7742ef22b5cbccd586d99e16d9d23a39"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/captainhookphp/plugin-composer/zipball/0a802aaf7742ef22b5cbccd586d99e16d9d23a39",
+                "reference": "0a802aaf7742ef22b5cbccd586d99e16d9d23a39",
+                "shasum": ""
+            },
+            "require": {
+                "captainhook/captainhook": "^5.0",
+                "composer-plugin-api": "^1.1|^2.0",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "composer/composer": "*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "CaptainHook\\Plugin\\Composer\\ComposerPlugin",
+                "branch-alias": {
+                    "dev-fluffy_hedgehog": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CaptainHook\\Plugin\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Heigl",
+                    "email": "andreas@heigl.org"
+                },
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "Composer-Plugin handling your git-hooks",
+            "support": {
+                "issues": "https://github.com/captainhookphp/plugin-composer/issues",
+                "source": "https://github.com/captainhookphp/plugin-composer/tree/5.3.3"
+            },
+            "time": "2022-01-28T04:35:22+00:00"
         },
         {
             "name": "composer/pcre",


### PR DESCRIPTION
This commit adds the `captainhook/plugin-composer` to our development dependencies. With this we can ensure that every developer will install it and use our shared hooks. We tried to achieve this manually with https://github.com/ILIAS-eLearning/ILIAS/pull/3724 and https://github.com/ILIAS-eLearning/ILIAS/pull/3839, but relying on this plugin is the superior approach.