### PR TITLE
Add kitchen sink element: LightboxCardDetailPage

### DIFF
--- a/src/UI/Component/Modal/Factory.php
+++ b/src/UI/Component/Modal/Factory.php
@@ -20,6 +20,7 @@ namespace ILIAS\UI\Component\Modal;
 
 use ILIAS\UI\Component;
 use ILIAS\UI\Component\Image\Image;
+use ILIAS\UI\Component\Item\Item;
 
 /**
  * Interface Factory
@@ -224,4 +225,29 @@ interface Factory
      * @return \ILIAS\UI\Component\Modal\LightboxTextPage
      */
     public function lightboxTextPage(string $text, string $title) : LightboxTextPage;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     A Lightbox card detail page represents a detailed view of a card inside a Lightbox modal.
+     *   composition: >
+     *     The page consists of an image and an item and a title.
+     *   effect: >
+     *     The image and the item are displayed in the content section of the Lightbox modal and the title is used
+     *     as the modal title.
+     * rules:
+     *   usage:
+     *     1: >
+     *       A Lightbox card detail page MUST have an image and an item and a title.
+     *     2: >
+     *       A Lightbox card detail page SHOULD be used for further information.
+     * ---
+     *
+     * @param Image $image
+     * @param Item $item
+     * @param string $title
+     * @return \ILIAS\UI\Component\Modal\LightboxCardDetailPage
+     */
+    public function lightboxCardDetailPage(Image $image, Item $item, string $title) : LightboxCardDetailPage;
 }

--- a/src/UI/Component/Modal/LightboxCardDetailPage.php
+++ b/src/UI/Component/Modal/LightboxCardDetailPage.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Component\Modal;
+
+use ILIAS\UI\Component\Image\Image;
+
+/**
+ * A lightbox Card Detail page represents a page displaying an image and an item.
+ */
+interface LightboxCardDetailPage extends LightboxPage
+{
+    public function getImage() : Image;
+}

--- a/src/UI/Implementation/Component/Modal/Factory.php
+++ b/src/UI/Implementation/Component/Modal/Factory.php
@@ -21,6 +21,8 @@ namespace ILIAS\UI\Implementation\Component\Modal;
 use ILIAS\UI\Component\Modal as M;
 use ILIAS\UI\Component\Image\Image;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
+use ILIAS\UI\NotImplementedException;
+use ILIAS\UI\Component\Item\Item;
 
 /**
  * Implementation of factory for modals
@@ -86,5 +88,10 @@ class Factory implements M\Factory
     public function lightboxTextPage(string $text, string $title) : M\LightboxTextPage
     {
         return new LightboxTextPage($text, $title);
+    }
+
+    public function lightboxCardDetailPage(Image $image, Item $item, string $title) : M\LightboxCardDetailPage
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/UI/README.md
+++ b/src/UI/README.md
@@ -17,7 +17,7 @@ not a templating framework.
 
 In the ILIAS UI-Framework, GUIs are described by composing large chunks from
 smaller components. The available components and their possible compositions are
-described in the Kitchen Sink. The single components only have little  configuration,
+described in the Kitchen Sink. The single components only have little configuration,
 complex GUIs emerge from simple parts. You also won't need to modify existing
 components, just use them as provided.
 

--- a/src/UI/examples/Modal/LightboxCardDetailPage/show_modal_on_button_click.php
+++ b/src/UI/examples/Modal/LightboxCardDetailPage/show_modal_on_button_click.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\examples\Modal\LightboxCardDetailPage;
+
+function show_modal_on_button_click()
+{
+    global $DIC;
+
+    $image = $DIC->ui()->factory()->image()->standard('/', 'Dummy');
+    $item = $DIC->ui()->factory()->item()->standard('Hej');
+    $modal = $DIC->ui()->factory()->modal()->lightboxCardDetailPage($image, $item, 'Some title');
+
+    $button = $factory->button()
+                      ->standard('Show Modal', '')
+                      ->withOnClick($modal->getShowSignal());
+
+    return $DIC->ui()->renderer()->render([$button, $modal]);
+}


### PR DESCRIPTION
This PR adds a new element `LightboxCardDetailPage` to the UI Framework.
For the Feature Wiki: https://docu.ilias.de/goto_docu_wiki_wpage_5563_1357.html the currently available modal's do not satisfy the requirements for the proposed Feature. So this PR introduces a new lightbox modal which can be used to implement the feature in the future.

##### Why a new modal is needed:
The modal in the feature wiki **can** be implemented with existing modals like the `RoundTrip` or `Lightbox` + `LightboxTextPage`.
The issue with the `RoundTrip` is that there must be 2 buttons and that it is intended to be used for a sequence of steps. For the previously named feature a roundtrip with a `Close` and an `Add to profile` button and a sequence of `one` step does imo not respect the intention of the roundtrip modal.

For the `LightboxTextPage` the description and rules seem to loosely match the purpose of the modal that should be implemented in the feature but imo it misuses the `$text` parameter, which also accepts HTML and which would violate (among other things) the dependence of HTML as an output stream and hides the actual structure that one wants to implement.