### PR TITLE
UI: render byline for Groups, e.g. when used as option in an OptionalGroup

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Factory.php
+++ b/src/UI/Implementation/Component/Input/Field/Factory.php
@@ -72,9 +72,9 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function group(array $inputs, string $label = '') : Field\Group
+    public function group(array $inputs, string $label = '', $byline = '') : Field\Group
     {
-        return new Group($this->data_factory, $this->refinery, $this->lng, $inputs, $label, null);
+        return new Group($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
 
     /**

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -309,6 +309,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable("OPTIONID", $opt_id);
             $tpl->setVariable("VALUE", $key);
             $tpl->setVariable("LABEL", $group->getLabel());
+            $tpl->setVariable("BYLINE", $group->getByline());
 
             if ($component->getValue() !== null) {
                 list($index, ) = $component->getValue();

--- a/src/UI/examples/Input/Field/SwitchableGroup/base.php
+++ b/src/UI/examples/Input/Field/SwitchableGroup/base.php
@@ -1,5 +1,21 @@
 <?php declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\UI\examples\Input\Field\SwitchableGroup;
 
 /**
@@ -28,9 +44,10 @@ function base()
             "field_2_1" => $ui->input()->field()->text("Item 2", "Just another field")
                 ->withValue('some val')
         ],
-        "Switchable Group number two"
+        "Switchable Group number two",
+        "with byline"
     );
-    $group3 = $ui->input()->field()->group([], 'No items in this group');
+    $group3 = $ui->input()->field()->group([], 'No items in this group', 'but a byline');
 
     //Step 2: Switchable Group - one or the other:
     $sg = $ui->input()->field()->switchableGroup(

--- a/tests/UI/Component/Input/Field/GroupInputTest.php
+++ b/tests/UI/Component/Input/Field/GroupInputTest.php
@@ -402,4 +402,12 @@ EOT;
         $expected = $this->brutallyTrimHTML($expected);
         $this->assertEquals($expected, $actual);
     }
+
+    public function testBylineProperty() : void
+    {
+        $bl = 'some byline';
+        $f = $this->getFieldFactory();
+        $group = $f->group([],"LABEL",$bl);
+        $this->assertEquals($bl, $group->getByline());
+    }
 }

--- a/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
@@ -423,6 +423,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
                         <div class="help-block">some field</div>
                     </div>
                 </div>
+                <div class="help-block"></div>
             </div>
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_g2_opt" name="" value="g2" /><label for="id_1_g2_opt"></label>
@@ -433,6 +434,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
                         <div class="help-block">some other field</div>
                     </div>
                 </div>
+                <div class="help-block"></div>
             </div>
         </div>
         <div class="help-block">byline</div>
@@ -468,6 +470,7 @@ EOT;
                         <div class="help-block">some field</div>
                     </div>
                 </div>
+                <div class="help-block"></div>
             </div>
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_g2_opt" name="" value="g2" checked="checked" /><label for="id_1_g2_opt"></label>
@@ -478,6 +481,7 @@ EOT;
                         <div class="help-block">some other field</div>
                     </div>
                 </div>
+                <div class="help-block"></div>
             </div>
         </div>
         <div class="help-block">byline</div>
@@ -503,10 +507,11 @@ EOT;
         $group2 = $f->group([
             "field_2" => $f->text("f2", "some other field")
         ]);
+        $empty_group_title = 'empty group, the title';
+        $empty_group_byline =  'empty group, the byline';
+        $group3 = $f->group([], $empty_group_title, $empty_group_byline);
 
-        //construct without string-key:
-        $sg = $f->switchableGroup([$group1,$group2], $label, $byline);
-
+        $sg = $f->switchableGroup([$group1, $group2, $group3], $label, $byline);
         $r = $this->getDefaultRenderer();
         $html = $r->render($sg->withValue('1'));
 
@@ -524,6 +529,7 @@ EOT;
                         <div class="help-block">some field</div>
                     </div>
                 </div>
+                <div class="help-block"></div>
             </div>
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_1_opt" name="" value="1" checked="checked" /><label for="id_1_1_opt"></label>
@@ -534,6 +540,12 @@ EOT;
                         <div class="help-block">some other field</div>
                     </div>
                 </div>
+                <div class="help-block"></div>
+            </div>
+
+            <div class="form-control form-control-sm il-input-radiooption">
+                <input type="radio" id="id_1_2_opt" name="" value="2" /><label for="id_1_2_opt">empty group, the title</label>
+                <div class="help-block">empty group, the byline</div>
             </div>
         </div>
         <div class="help-block">byline</div>


### PR DESCRIPTION
Hi,
when translating some form into UI Framework, I found the switchableGroup (the one with the radios...) not to render bylines; this is especially missing if a group w/o any further input is used to just express an option.
Please consider including bylines ;)
Best regards,
Nils