### PR TITLE
UI: introduction of a markdown input

### DIFF
--- a/src/UI/Component/Input/Field/Factory.php
+++ b/src/UI/Component/Input/Field/Factory.php
@@ -673,4 +673,44 @@ interface Factory
      * @return \ILIAS\UI\Component\Input\Field\Hidden
      */
     public function hidden() : Hidden;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      Markdown inputs are used when formatted text should be submitted by using markdown-syntax.
+     *      The input does support a user in writing markdown by providing action-buttons that insert the corresponding
+     *      characters. It also provides a preview section where the already formatted text will be displayed.
+     *   composition: >
+     *      The Markdown input consists of two tabs (edit and preview) which will be implemented as buttons (ViewControl).
+     *      The action-buttons either consist of a button or a Glyph, to better illustrate its intention. The editable
+     *      area will be a simple textarea. If a limit is set, a byline about limitation is automatically set.
+     *   effect: >
+     *      Markdown inputs will render a textarea HTML tag which is decorated with action-buttons. Markdown inputs are
+     *      NOT restricted to one line of text and counts the amount of character input by user and displays the number.
+     *   rivals:
+     *      Text input: use a text-input if the content should not be formatted one line only.
+     *      Textarea input: use a text-input if the content should not be formatted and on multiple lines.
+     *
+     * formatting options:
+     *   - Headings (# text)
+     *   - Links ([text](url))
+     *   - Bold (**text**)
+     *   - Italic (_text_)
+     *   - Ordered list (1. text)
+     *   - Unordered list (- text)
+     *
+     * context:
+     *   - The Markdown input is used in UI-Forms.
+     *
+     * rules:
+     *   usage:
+     *      1: >
+     *        This input MUST be used whenever markdown-syntax is supported, e.g. if the user should be able to submit
+     *        formatted text.
+     *
+     * ---
+     * @return \ILIAS\UI\Component\Input\Field\Markdown
+     */
+    public function markdown() : Markdown;
 }

--- a/src/UI/Component/Input/Field/Factory.php
+++ b/src/UI/Component/Input/Field/Factory.php
@@ -688,17 +688,16 @@ interface Factory
      *   effect: >
      *      Markdown inputs will render a textarea HTML tag which is decorated with action-buttons. Markdown inputs are
      *      NOT restricted to one line of text and counts the amount of character input by user and displays the number.
+     *      The following formatting options will have a special effect on the input's preview:
+     *          - Headings (# text)
+     *          - Links ([text](url))
+     *          - Bold (**text**)
+     *          - Italic (_text_)
+     *          - Ordered list (1. text)
+     *          - Unordered list (- text)
      *   rivals:
      *      Text input: use a text-input if the content should not be formatted one line only.
      *      Textarea input: use a text-input if the content should not be formatted and on multiple lines.
-     *
-     * formatting options:
-     *   - Headings (# text)
-     *   - Links ([text](url))
-     *   - Bold (**text**)
-     *   - Italic (_text_)
-     *   - Ordered list (1. text)
-     *   - Unordered list (- text)
      *
      * context:
      *   - The Markdown input is used in UI-Forms.

--- a/src/UI/Component/Input/Field/Markdown.php
+++ b/src/UI/Component/Input/Field/Markdown.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+namespace ILIAS\UI\Component\Input\Field;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+interface Markdown extends Textarea
+{
+
+}


### PR DESCRIPTION
Hi @Amstutz and @klees

As discussed in our UI-Clinic meeting today (see https://docu.ilias.de/goto_docu_dcl_8186_166_7568.html), I hereby open the PR to kick-off and announce the introduction of a new UI input for markdown (structured text).

It might be possible that the description of the public interface is still incomplete or not quite detailed enough, let me know if and where that's the case. A more detailed explanation of our plan can be found at: https://docu.ilias.de/goto_docu_wiki_wpage_7404_1357.html#ilPageTocA216.

@chfsx and I discussed that an input like this would already benefit from better text-handling in ILIAS as proposed in #4901. During the implementation of this input we might as well tackle the implementation of the markdown-part of this project or at least maybe await it.

I noticed that @klees mentioned the distinction between formatting and structuring in the PR linked above. The KS documentation now currently uses the word "formatting" or "formatted text" - should I adjust this?

Kind regards!