### PR TITLE
Administration/Settings: Add missing database type switch for `settin…

### DIFF
--- a/Services/Administration/classes/Setup/class.ilSettingsMetricsCollectedObjective.php
+++ b/Services/Administration/classes/Setup/class.ilSettingsMetricsCollectedObjective.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Metrics\CollectedObjective;
+use ILIAS\Setup\Metrics\Storage;
+
+class ilSettingsMetricsCollectedObjective extends CollectedObjective
+{
+    protected function getTentativePreconditions(Environment $environment) : array
+    {
+        return [
+            new ilSettingsFactoryExistsObjective(),
+            new ilDatabaseInitializedObjective(),
+        ];
+    }
+
+    protected function collectFrom(Environment $environment, Storage $storage) : void
+    {
+        $db = $environment->getResource(Environment::RESOURCE_DATABASE);
+        $settings_factory = $environment->getResource(Environment::RESOURCE_SETTINGS_FACTORY);
+
+        if (!$settings_factory || !$db) {
+            return;
+        }
+
+        /** @var ilSetting $settings */
+        $settings = $settings_factory->settingsFor('common');
+
+        $storage->storeConfigText(
+            'Field type of settings::value',
+            $settings->getValueDbType() === 'clob' ? 'CLOB' : 'VARCHAR',
+            "The current database type of field 'value' in table 'settings'."
+        );
+    }
+}

--- a/Services/Administration/classes/Setup/class.ilSettingsSetupAgent.php
+++ b/Services/Administration/classes/Setup/class.ilSettingsSetupAgent.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup\Agent;
+use ILIAS\Setup\Objective;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Setup\Metrics;
+use ILIAS\Setup\Config;
+use ILIAS\Setup\ObjectiveConstructor;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Setup\NullConfig;
+
+class ilSettingsSetupAgent implements Agent
+{
+    protected Refinery $refinery;
+
+    public function __construct(Refinery $refinery)
+    {
+        $this->refinery = $refinery;
+    }
+
+    public function hasConfig() : bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation() : Transformation
+    {
+        return $this->refinery->custom()->transformation(static function ($data) : Config {
+            return new NullConfig();
+        });
+    }
+
+    public function getInstallObjective(Config $config = null) : Objective
+    {
+        return new Objective\NullObjective();
+    }
+
+    public function getUpdateObjective(Config $config = null) : Objective
+    {
+        return new Objective\NullObjective();
+    }
+
+    public function getBuildArtifactObjective() : Objective
+    {
+        return new Objective\NullObjective();
+    }
+
+    public function getStatusObjective(Metrics\Storage $storage) : Objective
+    {
+        return new ilSettingsMetricsCollectedObjective($storage);
+    }
+
+    public function getMigrations() : array
+    {
+        return [];
+    }
+
+    public function getNamedObjectives(?Config $config = null) : array
+    {
+        return [
+            'varchar-to-clob' => new ObjectiveConstructor(
+                "Migrate the 'value' field of table 'settings' to a CLOB type",
+                static function () : Objective {
+                    return new ilSettingsValueDatabaseTypeSwitch(
+                        ilSettingsValueDatabaseTypeSwitch::VARCHAR_TO_CLOB
+                    );
+                }
+            ),
+            'clob-to-varchar' => new ObjectiveConstructor(
+                "Migrate the 'value' field of table 'settings' to a VARCHAR type",
+                static function () : Objective {
+                    return new ilSettingsValueDatabaseTypeSwitch(
+                        ilSettingsValueDatabaseTypeSwitch::CLOB_TO_VARCHAR
+                    );
+                }
+            )
+        ];
+    }
+}

--- a/Services/Administration/classes/Setup/class.ilSettingsValueDatabaseTypeSwitch.php
+++ b/Services/Administration/classes/Setup/class.ilSettingsValueDatabaseTypeSwitch.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\UnachievableException;
+
+class ilSettingsValueDatabaseTypeSwitch extends ilSetupObjective
+{
+    public const VARCHAR_TO_CLOB = 'varchar-to-clob';
+    public const CLOB_TO_VARCHAR = 'clob-to-varchar';
+
+    private string $mode;
+
+    public function __construct(string $mode)
+    {
+        parent::__construct(new \ILIAS\Setup\NullConfig());
+        $this->mode = $mode;
+    }
+
+    public function getHash() : string
+    {
+        return hash('sha256', self::class);
+    }
+
+    public function getLabel() : string
+    {
+        if ($this->mode === self::CLOB_TO_VARCHAR) {
+            return 'The field type of settings:value type is switched to VARCHAR';
+        }
+
+        return 'The field type of settings:value is switched to CLOB';
+    }
+
+    public function isNotable() : bool
+    {
+        return true;
+    }
+
+    public function getPreconditions(Environment $environment) : array
+    {
+        return [
+            new ilSettingsFactoryExistsObjective(),
+            new ilDatabaseInitializedObjective(),
+        ];
+    }
+
+    public function achieve(Environment $environment) : Environment
+    {
+        $settings_factory = $environment->getResource(Environment::RESOURCE_SETTINGS_FACTORY);
+
+        /** @var ilSetting $settings */
+        $settings = $settings_factory->settingsFor('common');
+
+        $is_clob = $settings->getValueDbType() === 'clob';
+
+        if ($this->mode === self::CLOB_TO_VARCHAR && $is_clob) {
+            $settings->changeValueDbType('text');
+        } elseif ($this->mode === self::VARCHAR_TO_CLOB && !$is_clob) {
+            $settings->changeValueDbType('clob');
+        } else {
+            throw new UnachievableException('The database field type does already match the desired field type');
+        }
+
+        return $environment;
+    }
+
+    public function isApplicable(Environment $environment) : bool
+    {
+        $settings_factory = $environment->getResource(Environment::RESOURCE_SETTINGS_FACTORY);
+
+        /** @var ilSetting $settings */
+        $settings = $settings_factory->settingsFor('common');
+
+        $is_clob = $settings->getValueDbType() === 'clob';
+
+        if ($this->mode === self::VARCHAR_TO_CLOB) {
+            return !$is_clob;
+        }
+
+        return $is_clob && $settings->getLimitExceedingValues() === [];
+    }
+}


### PR DESCRIPTION
…gs:value`

This PR adds an `Achievable Setup Objective` to let administrators switch the database field type of `settings:value` from `VARCHAR` to `CLOB` and vice versa.

Debatable: Should we stick with the suggested objective class or should we segregate this into two separate objectives?

---

Furthermore this PR adds a `Metrics Collected Objective` to report the current database field type when executing the `status` command of the ILIAS setup.

---

- If approved, this should be picked to `release_8` as well.

---

Mantis Issue: https://mantis.ilias.de/view.php?id=33860