### PR TITLE
RoleTemplates: Bugfix 0033906 (ILIAS7): Updating internal templates no longer updates title 

### DIFF
--- a/Services/AccessControl/classes/class.ilObjRoleTemplateGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleTemplateGUI.php
@@ -203,7 +203,9 @@ class ilObjRoleTemplateGUI extends ilObjectGUI
         
         $form = $this->initFormRoleTemplate(self::FORM_MODE_EDIT);
         if ($form->checkInput()) {
-            $this->object->setTitle($form->getInput('title'));
+            if (!$this->object->isInternalTemplate()) {
+                $this->object->setTitle($form->getInput('title'));
+            }
             $this->object->setDescription($form->getInput('desc'));
             $rbacadmin->setProtected(
                 $this->rolf_ref_id,


### PR DESCRIPTION
Editing the desription of internal role templates resulted in them updating their title and no longer being internal
So for il_crs_member for example the new title in database would be "Kursmitglied" and when creating a course in Ilias this role would no longer be created inside the course, which resulted in not being able to add course members

Mantis: https://mantis.ilias.de/view.php?id=33906