### PR TITLE
Fix for creating repository objects with long titles or descriptions

### DIFF
--- a/Services/Utilities/classes/class.ilStr.php
+++ b/Services/Utilities/classes/class.ilStr.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -189,6 +189,9 @@ class ilStr
         bool $a_next_blank = false,
         bool $a_keep_extension = false
     ) : string {
+        if ($a_dots) {
+            $a_len--;
+        }
         if (ilStr::strLen($a_str) > $a_len) {
             if ($a_next_blank) {
                 $len = ilStr::strPos($a_str, " ", $a_len);

--- a/Services/Utilities/classes/class.ilStr.php
+++ b/Services/Utilities/classes/class.ilStr.php
@@ -189,10 +189,10 @@ class ilStr
         bool $a_next_blank = false,
         bool $a_keep_extension = false
     ) : string {
-        if ($a_dots) {
-            $a_len--;
-        }
         if (ilStr::strLen($a_str) > $a_len) {
+            if ($a_dots) {
+                $a_len--;
+            }
             if ($a_next_blank) {
                 $len = ilStr::strPos($a_str, " ", $a_len);
             } else {

--- a/Services/Utilities/classes/class.ilStr.php
+++ b/Services/Utilities/classes/class.ilStr.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -190,6 +190,11 @@ class ilStr
         bool $a_keep_extension = false
     ) : string {
         if (ilStr::strLen($a_str) > $a_len) {
+            /*
+             * When adding dots, the dots have to be included in the length such
+             * that the total length of the resulting string does not exceed
+             * the given maximum length (see BT 33865).
+             */
             if ($a_dots) {
                 $a_len--;
             }


### PR DESCRIPTION
This PR fixes the creation of repository objects with titles and/or descriptions longer than object_data allows, see [33865](https://mantis.ilias.de/view.php?id=33865).