### PR TITLE
Rule Change for the usage of Standard Forms

### DIFF
--- a/src/UI/Component/Input/Container/Form/Factory.php
+++ b/src/UI/Component/Input/Container/Form/Factory.php
@@ -40,7 +40,7 @@ interface Factory
      * rules:
      *   usage:
      *     1: Standard Forms MUST NOT be used on the same page as tables.
-     *     2: Standard Forms MUST NOT be used on the same page as toolbars.
+     *     2: Standard Forms SHOULD NOT be used on the same page as toolbars.
      *   composition:
      *     1: Each form SHOULD contain at least one section displaying a title.
      *     2: >


### PR DESCRIPTION
Today in the JF, @schmitz-ilias showed a use case in the feature https://docu.ilias.de/goto.php?target=wiki_1357_Revision_of_LOM_Metadata_Editor where a Toolbar and a form is much superior option, than e.g. placing the Action Button in the Toolbar in the form itself. 

I would therefore recommend to downgrade the usage rules somewhat to allow Toolbars along with forms if one can provide some valid reason, such as given today by @schmitz-ilias .