### PR TITLE
[FIX] #33944: form-action of `ilTrObjectUsersPropsTableGUI`

### DIFF
--- a/Services/Tracking/classes/repository_statistics/class.ilTrObjectUsersPropsTableGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilTrObjectUsersPropsTableGUI.php
@@ -116,7 +116,7 @@ class ilTrObjectUsersPropsTableGUI extends ilLPTableBaseGUI
         $this->setExternalSegmentation(true);
         $this->setEnableHeader(true);
         $this->setFormAction(
-            $this->ctrl->getFormActionByClass(get_class($this))
+            $this->ctrl->getFormActionByClass([ilLPListOfObjectsGUI::class, get_class($this)])
         );
         $this->setRowTemplate(
             "tpl.object_users_props_row.html",


### PR DESCRIPTION
Hi all

@mjansenDatabay asked me to look into https://mantis.ilias.de/view.php?id=33944 since it's an ilCtrl related issue which would be solved by this PR.

To briefly explain the behaviour:

`ilTrObjectUsersPropsTableGUI` tried to generate a link target to itself. It is a child-class of `ilLPListOfObjectsGUI` but not a direct child-class of `ilLearningProgressGUI`, which is the last command-class in the ilCtrl context at this point. Therefore `ilTrObjectUsersPropsTableGUI` could not have been appended to it because it isn't a direct child-class. As proposed by this PR, we could tell ilCtrl that there is a command-class in between by providing an array of classes where the first one is applicable to the current one. We could also make `ilTrObjectUsersPropsTableGUI` a direct child-class of `ilLearningProgressGUI ` by adding an according `@ilCtrl_isCalledBy`-statement to `ilTrObjectUsersPropsTableGUI` (if there are multiple cases where this issue might occur).

I'm not entirely sure, but it might be possible that ilCtrl in the past searched for indirect children to a certain depth. If that's the case I would consider this an ilCtrl issue and we can close this PR.

Kind regards!