### PR TITLE
Fix: " Identifier 'ilDB' is not defined" when storing GlobalCache settings

### DIFF
--- a/Services/ActiveRecord/Connector/class.arConnectorDB.php
+++ b/Services/ActiveRecord/Connector/class.arConnectorDB.php
@@ -23,9 +23,7 @@ class arConnectorDB extends arConnector
 {
     protected function returnDB(): ilDBInterface
     {
-        global $DIC;
-
-        return $DIC['ilDB'];
+        return $GLOBALS['ilDB'];
     }
 
     public function checkConnection(ActiveRecord $ar): bool


### PR DESCRIPTION
When performing a setup-install or setup-update (with nominated config.json):
*Store configuration of Services/GlobalCache...                             [FAILED]*
*[ERROR] Identifier "ilDB" is not defined.*
is raised  (in this case, the 'config.json' defines a memchache daemon to be used) .

I'm not skilled enough to judge whether this PR has other negative effects, but for the use by setup "update" and "install" it works apparently.
So take my suggestion as a hint to a problem at least.

wbr