### PR TITLE
Refinery/HTTP: Fix PHP types for PHP 8.1

### DIFF
--- a/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
+++ b/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
@@ -2,6 +2,22 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\HTTP\Wrapper;
 
 use ILIAS\Refinery\Factory;
@@ -9,19 +25,6 @@ use ILIAS\Refinery\KeyValueAccess;
 use LogicException;
 use OutOfBoundsException;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 /**
  * Class SuperGlobalDropInReplacement
  * This Class wraps SuperGlobals such as $_GET and $_POST to prevent modifying them in a future version.

--- a/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
+++ b/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
@@ -37,10 +37,7 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
         parent::__construct($raw_values, $factory->kindlyTo()->string());
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if ($this->throwOnValueAssignment) {
             throw new OutOfBoundsException("Modifying global Request-Array such as \$_GET is not allowed!");
@@ -49,10 +46,7 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
         parent::offsetSet($offset, $value);
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         throw new LogicException("Modifying global Request-Array such as \$_GET is not allowed!");
     }

--- a/src/Refinery/KeyValueAccess.php
+++ b/src/Refinery/KeyValueAccess.php
@@ -35,18 +35,12 @@ class KeyValueAccess implements ArrayAccess, Countable
         $this->raw_values = $raw_values;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->raw_values[$offset]);
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         if (!$this->offsetExists($offset)) {
             return null;
@@ -70,27 +64,18 @@ class KeyValueAccess implements ArrayAccess, Countable
         };
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->raw_values[$offset] = $value;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         if ($this->offsetExists($offset)) {
             unset($this->raw_values[$offset]);
         }
     }
 
-    /**
-     * @inheritDoc
-     */
     public function count(): int
     {
         return count($this->raw_values);


### PR DESCRIPTION
This PR fixes PHP 8.1 issues like ....

```bash
PHP Deprecated:  Return type of ILIAS\Refinery\KeyValueAccess::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/ILIAS/ILIAS/src/Refinery/KeyValueAccess.php on line 49
```
... for the `KeyValueAccess` (and derivate) type of the `Refinery` by using the types defined in the PHP core. This is one of the exceptions where we should accept `mixed` as a type.