### PR TITLE
[FIX] declare(strict_types=1); is now on the first line again.

### DIFF
--- a/docs/development/code-style-configs/php-storm.xml
+++ b/docs/development/code-style-configs/php-storm.xml
@@ -12,7 +12,6 @@
     <option name="KEEP_RPAREN_AND_LBRACE_ON_ONE_LINE" value="true" />
     <option name="BLANK_LINES_AFTER_OPENING_TAG" value="1" />
     <option name="KEEP_BLANK_LINES_AFTER_LBRACE" value="0" />
-    <option name="NEW_LINE_AFTER_PHP_OPENING_TAG" value="true" />
     <option name="ATTRIBUTES_WRAP" value="2" />
     <option name="PARAMETERS_ATTRIBUTES_WRAP" value="2" />
   </PHPCodeStyleSettings>


### PR DESCRIPTION
Hi @mjansenDatabay

I noticed that when generating PHP files with PHPStorm and the new coding style, the `declare(strict_types=1);` will be on the second line of the file due to the `NEW_LINE_AFTER_PHP_OPENING_TAG`. Up until now, the code-styles did not have this option enabled and the strict-types declaration was put on the first line with the PHP opening tag. If this was entirely intended though you can close this PR and I'll accept that the statement must be on the second line as of now :).

Kind regards!