### PR TITLE
Data type LanguageTag with parsing

### DIFF
--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -2,7 +2,21 @@
 
 declare(strict_types=1);
 
-/* Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Data;
 
@@ -201,5 +215,10 @@ class Factory
         }
 
         return $this->open_graph_metadata_factory;
+    }
+
+    public function languageTag(string $language_tag): LanguageTag
+    {
+        return LanguageTag::fromString($language_tag);
     }
 }

--- a/src/Data/LanguageTag.php
+++ b/src/Data/LanguageTag.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Data;
+
+use ILIAS\Data\LanguageTag\Standard;
+use ILIAS\Data\LanguageTag\Regular;
+use ILIAS\Data\LanguageTag\Irregular;
+use ILIAS\Data\LanguageTag\PrivateUse;
+use InvalidArgumentException;
+use ILIAS\Refinery\Custom\Transformation as Custom;
+use ILIAS\Refinery\Parser\ABNF\Brick;
+use ILIAS\Data\Result\Error;
+use Closure;
+
+/**
+ * This class represents a valid language tag that should be used instead of plain strings.
+ * The language tag is validated by the provided language tag definition.
+ *
+ * RFC 5646 compliant language tag definition (https://www.ietf.org/rfc/bcp/bcp47.txt).
+ */
+abstract class LanguageTag
+{
+    abstract public function value(): string;
+
+    public function __toString(): string
+    {
+        return $this->value();
+    }
+
+    public static function fromString(string $string): static
+    {
+        $brick = new Brick();
+        return $brick->apply(self::definition($brick), $string)->except(static fn (): Result => (
+            new Error('Given string is no valid language tag.')
+        ))->value();
+    }
+
+    /**
+     * This definition is directly translated from the ABNF definition on https://www.ietf.org/rfc/bcp/bcp47.txt.
+     */
+    private static function definition(Brick $brick): Closure
+    {
+        $extlang = $brick->sequence([
+            $brick->repeat(3, 3, $brick->alpha()),
+            $brick->repeat(0, 2, $brick->sequence(['-', $brick->repeat(3, 3, $brick->alpha())])),
+        ]);
+
+        $language = $brick->either([
+            $brick->sequence([
+                'lang' => $brick->repeat(2, 3, $brick->alpha()),
+                $brick->repeat(0, 1, $brick->sequence(['-', 'extlang' => $extlang])),
+            ]),
+            $brick->sequence(['lang' => $brick->repeat(4, 4, $brick->alpha())]),
+            $brick->sequence(['lang' => $brick->repeat(5, 8, $brick->alpha())]),
+        ]);
+
+        $script = $brick->repeat(4, 4, $brick->alpha());
+
+        $region = $brick->either([
+            $brick->repeat(2, 2, $brick->alpha()),
+            $brick->repeat(3, 3, $brick->digit()),
+        ]);
+
+        $alphanum = $brick->either([$brick->alpha(), $brick->digit()]);
+
+        $variant = $brick->either([
+            $brick->repeat(5, 8, $alphanum),
+            $brick->sequence([$brick->digit(), $brick->repeat(3, 3, $alphanum)])
+        ]);
+
+        $singleton = $brick->either([
+            $brick->digit(),
+            $brick->range(0x41, 0x57),
+            $brick->range(0x59, 0x5A),
+            $brick->range(0x61, 0x77),
+            $brick->range(0x79, 0x7A),
+        ]);
+
+        $extension = $brick->sequence([
+            $singleton,
+            $brick->repeat(1, null, $brick->sequence(['-', $brick->repeat(2, 8, $alphanum)])),
+        ]);
+
+        $privateuse = $brick->sequence([
+            'x',
+            $brick->repeat(1, null, $brick->sequence(['-', $brick->repeat(1, 8, $alphanum)]))
+        ]);
+
+        $new = static fn (string $class) => new Custom(static fn (string $arg) => new $class($arg));
+
+        $privateuse = $brick->transformation($new(PrivateUse::class), $privateuse);
+
+        $irregular = $brick->either([
+            'en-GB-oed',
+            'i-ami',
+            'i-bnn',
+            'i-default',
+            'i-enochian',
+            'i-hak',
+            'i-klingon',
+            'i-lux',
+            'i-mingo',
+            'i-navajo',
+            'i-pwn',
+            'i-tao',
+            'i-tay',
+            'i-tsu',
+            'sgn-BE-FR',
+            'sgn-BE-NL',
+            'sgn-CH-DE',
+        ]);
+
+        $regular = $brick->either([
+            'art-lojban',
+            'cel-gaulish',
+            'no-bok',
+            'no-nyn',
+            'zh-guoyu',
+            'zh-hakka',
+            'zh-min',
+            'zh-min-nan',
+            'zh-xiang',
+        ]);
+
+        $grandfathered = $brick->either([
+            $brick->transformation($new(Irregular::class), $irregular),
+            $brick->transformation($new(Regular::class), $regular)
+        ]);
+
+        $langtag = $brick->transformation(
+            new Custom(static fn (array $from): Standard => new Standard(
+                $from['language']['lang'],
+                $from['language']['extlang'] ?? null,
+                $from['script'] ?? null,
+                $from['region'] ?? null,
+                $from['variant'] ?? null,
+                $from['extension'] ?? null,
+                $from['privateuse'] ?? null,
+            )),
+            $brick->sequence([
+                'language' => $language,
+                $brick->repeat(0, 1, $brick->sequence(['-', 'script' => $script])),
+                $brick->repeat(0, 1, $brick->sequence(['-', 'region' => $region])),
+                $brick->repeat(0, null, $brick->sequence(['-', 'variant' => $variant])),
+                $brick->repeat(0, null, $brick->sequence(['-', 'extension' => $extension])),
+                $brick->repeat(0, 1, $brick->sequence(['-', 'privateuse' => $privateuse])),
+            ])
+        );
+
+        return $brick->either([$langtag, $privateuse, $grandfathered]);
+    }
+}

--- a/src/Data/LanguageTag/GrandFathered.php
+++ b/src/Data/LanguageTag/GrandFathered.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Data\LanguageTag;
+
+use ILIAS\Data\LanguageTag;
+use InvalidArgumentException;
+
+abstract class GrandFathered extends LanguageTag
+{
+}

--- a/src/Data/LanguageTag/Irregular.php
+++ b/src/Data/LanguageTag/Irregular.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Data\LanguageTag;
+
+class Irregular extends GrandFathered
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/LanguageTag/PrivateUse.php
+++ b/src/Data/LanguageTag/PrivateUse.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Data\LanguageTag;
+
+use ILIAS\Data\LanguageTag;
+
+class PrivateUse extends LanguageTag
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/LanguageTag/Regular.php
+++ b/src/Data/LanguageTag/Regular.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Data\LanguageTag;
+
+class Regular extends GrandFathered
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/LanguageTag/Standard.php
+++ b/src/Data/LanguageTag/Standard.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Data\LanguageTag;
+
+use ILIAS\Data\LanguageTag;
+
+class Standard extends LanguageTag
+{
+    private string $language;
+    private ?string $extlang;
+    private ?string $script;
+    private ?string $region;
+    private ?string $variant;
+    private ?string $extension;
+    private ?PrivateUse $privateuse;
+
+    public function __construct(
+        string $language,
+        ?string $extlang,
+        ?string $script,
+        ?string $region,
+        ?string $variant,
+        ?string $extension,
+        ?PrivateUse $privateuse
+    ) {
+        $this->language = $language;
+        $this->extlang = $extlang;
+        $this->script = $script;
+        $this->region = $region;
+        $this->variant = $variant;
+        $this->extension = $extension;
+        $this->privateuse = $privateuse;
+    }
+
+    public function language(): string
+    {
+        return $this->language;
+    }
+
+    public function extlang(): ?string
+    {
+        return $this->extlang;
+    }
+
+    public function script(): ?string
+    {
+        return $this->script;
+    }
+
+    public function region(): ?string
+    {
+        return $this->region;
+    }
+
+    public function variant(): ?string
+    {
+        return $this->variant;
+    }
+
+    public function extension(): ?string
+    {
+        return $this->extension;
+    }
+
+    public function privateuse(): ?PrivateUse
+    {
+        return $this->privateuse;
+    }
+
+    public function value(): string
+    {
+        $optional = array_filter([$this->script, $this->extlang, $this->region, $this->variant, $this->extension, $this->privateuse ? $this->privateuse->value() : null]);
+
+        return implode('-', array_merge([$this->language], $optional));
+    }
+}

--- a/src/Data/README.md
+++ b/src/Data/README.md
@@ -26,6 +26,7 @@ interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 * [Dataset](#dataset)
 * [HTML Metadata](#htmlmetadata)
 * [OpenGraph Metadata](#opengraphmetadata)
+* [LanguageTag](#languagetag)
 
 Other examples for data types that could (and maybe should) be added here:
 
@@ -655,3 +656,18 @@ function itIsTrueThat(bool $truth) {
 
 ?>
 ```
+
+## LanguageTag
+
+This represents a RFC 5646 compliant language tag.
+To create a language tag:
+
+```php
+(new \ILIAS\Data\Factory())->languageTag('de');
+```
+
+If the given string is no valid tag an exception is thrown.
+
+The language tag can have several different forms, which are represented with the classes: `Standard`, `Irregular`, `Regular` and `Privateuse`.
+
+The specific meaning of the different language tags can be found in the [RFC](https://www.ietf.org/rfc/bcp/bcp47.txt).

--- a/src/Refinery/Factory.php
+++ b/src/Refinery/Factory.php
@@ -24,6 +24,7 @@ use ILIAS\Refinery\In;
 use ILIAS\Refinery\To;
 use ILIAS\Refinery\Random\Group as RandomGroup;
 use ilLanguage;
+use ILIAS\Refinery\Parser\Group as Parser;
 
 class Factory
 {
@@ -174,5 +175,10 @@ class Factory
     public function always($value): Transformation
     {
         return new ConstantTransformation($value);
+    }
+
+    public function parser(): Parser
+    {
+        return new Parser($this);
     }
 }

--- a/src/Refinery/Parser/ABNF/Brick.php
+++ b/src/Refinery/Parser/ABNF/Brick.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Refinery\Parser\ABNF;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use Closure;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\Custom\Transformation as Custom;
+
+/**
+ * @phpstan-type Continuation Closure(Result<Intermediate>): Result<Intermediate>
+ * @phpstan-type Parser Closure(Intermediate, Continuation): Result<Intermediate>
+ */
+class Brick
+{
+    private Transform $transform;
+    private Primitives $primitives;
+
+    public function __construct()
+    {
+        $this->transform = new Transform();
+        $this->primitives = new Primitives();
+    }
+
+    public function apply(Closure $parse, string $input): Result
+    {
+        return $this->consume($parse, new Intermediate($input))->then(static fn (Intermediate $x): Result => (
+            $x->transform(static fn ($value): Result => (
+                new Ok(is_array($value) && !is_string(key($value)) ? current($value) : $value)
+            ))
+        ));
+    }
+
+    /**
+     * @param Parser $parse
+     * @return Transformation
+     */
+    public function toTransformation(Closure $parse): Transformation
+    {
+        return new Custom(fn ($input) => $this->apply($parse, $input)->value());
+    }
+
+    /**
+     * @param int $start
+     * @param int $end
+     * @return Parser
+     */
+    public function range(int $start, int $end): Closure
+    {
+        return static fn (Intermediate $x, Closure $cc): Result => $cc(
+            $x->value() >= $start && $x->value() <= $end ? $x->accept() : $x->reject()
+        );
+    }
+
+    /**
+     * @return Parser
+     */
+    public function alpha(): Closure
+    {
+        return $this->primitives->simpleEither([
+            $this->range(0x41, 0x5A),
+            $this->range(0x61, 0x7A),
+        ]);
+    }
+
+    /**
+     * @return Parser
+     */
+    public function digit(): Closure
+    {
+        return $this->range(0x30, 0x39);
+    }
+
+    public function either(array $parsers): Closure
+    {
+        return $this->primitives->simpleEither($this->namesFromKeys($parsers));
+    }
+
+    /**
+     * @param (Parser|string)[] $parse
+     * @return Parser
+     */
+    public function sequence(array $parsers): Closure
+    {
+        return $this->primitives->simpleSequence($this->namesFromKeys($parsers));
+    }
+
+    /**
+     * @param int $min
+     * @param null|int $max
+     * @param Parser|string $parse
+     * @return Parser
+     */
+    public function repeat(int $min, ?int $max, $parse): Closure
+    {
+        $min = max(0, $min);
+        $max = null === $max ? null : max($min, $max) - $min;
+
+        return $this->primitives->simpleSequence([
+            ...array_fill(0, $min, $parse),
+            $this->primitives->until($max, $parse)
+        ]);
+    }
+
+    /**
+     * @param Transformation $transformation
+     * @param Parser $parser
+     * @return Parser
+     */
+    public function transformation(Transformation $transformation, Closure $parse): Closure
+    {
+        return $this->transform->to($transformation, $parse);
+    }
+
+    /**
+     * @param array<(string|int), (string|Parser)> $array
+     * @return Parser[]
+     */
+    private function namesFromKeys(array $array): array
+    {
+        return array_map(
+            function ($key) use ($array): Closure {
+                $current = $this->primitives->parserFrom($array[$key]);
+                return is_string($key) ? $this->transform->as($key, $current) : $current;
+            },
+            array_keys($array)
+        );
+    }
+
+    /**
+     * It just checks if the given input is fully consumed after parsing and rejects the input otherwise.
+     *
+     * @param Parser $parse
+     * @param Intermediate $intermediate
+     * @return Result<Intermediate>
+     */
+    private function consume(Closure $parse, Intermediate $intermediate): Result
+    {
+        return $parse($intermediate, static fn (Result $x): Result => $x->then(
+            static fn (Intermediate $x): Result => $x->done() ? new Ok($x) : new Error('EOF not reached.')
+        ));
+    }
+}

--- a/src/Refinery/Parser/ABNF/Character.php
+++ b/src/Refinery/Parser/ABNF/Character.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Refinery\Parser\ABNF;
+
+/**
+ * Class for internal usage of Intermediate. Used to distinguish between already transformed characters and ones that are not.
+ */
+class Character
+{
+    private string $char;
+
+    public function __construct(string $char)
+    {
+        $this->char = $char;
+    }
+
+    public function value(): string
+    {
+        return $this->char;
+    }
+}

--- a/src/Refinery/Parser/ABNF/Intermediate.php
+++ b/src/Refinery/Parser/ABNF/Intermediate.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Refinery\Parser\ABNF;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use Closure;
+
+class Intermediate
+{
+    private string $todo;
+    private array $accepted;
+
+    public function __construct(string $todo, array $accepted = [])
+    {
+        $this->todo = $todo;
+        $this->accepted = $accepted;
+    }
+
+    public function value(): int
+    {
+        return ord($this->todo);
+    }
+
+    public function accept(): Result
+    {
+        return new Ok((new self(
+            substr($this->todo, 1),
+            $this->accepted()
+        ))->push([new Character(substr($this->todo, 0, 1))]));
+    }
+
+    public function push(array $values): self
+    {
+        return new self(
+            $this->todo,
+            array_merge($this->accepted, $values)
+        );
+    }
+
+    public function reject(): Result
+    {
+        return new Error('Rejected.');
+    }
+
+    public function accepted(): array
+    {
+        return $this->accepted;
+    }
+
+    public function done(): bool
+    {
+        return '' === $this->todo;
+    }
+
+    public function onlyTodo(): self
+    {
+        return new self($this->todo);
+    }
+
+    /**
+     * Calls the given closure with all accepted values. For convenience the $accepted values are transformed to a string when they are a Character[].
+     * Unprocessed characters are wrapped with the Character class to prevent the need for a conversion from a character list (e.g. ['a', 'b'] ) to a string ("ab"),
+     * because it's not nice to operate on single length string lists instead of strings.
+     *
+     * @template A
+     * @param Closure(string|A[]): Result<A> $transform
+     * @return Result<A>
+     */
+    public function transform(Closure $transform): Result
+    {
+        $string = '';
+        foreach ($this->accepted as $data) {
+            if (!$data instanceof Character) {
+                return $transform($this->accepted);
+            }
+            $string .= $data->value();
+        }
+
+        return $transform($string);
+    }
+}

--- a/src/Refinery/Parser/ABNF/Primitives.php
+++ b/src/Refinery/Parser/ABNF/Primitives.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Refinery\Parser\ABNF;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use Closure;
+
+/**
+ * @phpstan-type Continuation Closure(Result<Intermediate>): Result<Intermediate>
+ * @phpstan-type Parser Closure(Intermediate, Continuation): Result<Intermediate>
+ */
+class Primitives
+{
+    public function simpleEither(array $parse): Closure
+    {
+        return $this->variadic([$this, 'or2'], $parse);
+    }
+
+    public function simpleSequence(array $parse): Closure
+    {
+        return $this->variadic([$this, 'seq'], $parse);
+    }
+
+    /**
+     * @param null|int $max
+     * @param Parser|string $parse
+     * @return Parser
+     */
+    public function until(?int $max, $parse): Closure
+    {
+        if (0 === $max) {
+            return $this->nop();
+        }
+
+        $max = null === $max ? null : $max - 1;
+
+        return $this->simpleEither([
+            $this->nop(),
+            $this->simpleSequence([
+                $parse,
+                $this->lazy([$this, 'until'], $max, $parse)
+            ])
+        ]);
+    }
+
+    /**
+     * @param Parser|string $x
+     * @return Parser
+     */
+    public function parserFrom($x): Closure
+    {
+        return $x instanceof Closure ? $x : $this->mustEqual($x);
+    }
+
+    private function or2(Closure $f, Closure $g): Closure
+    {
+        return static fn (Intermediate $x, Closure $cc): Result => (
+            $f($x, $cc)->except(static fn (): Result => $g($x, $cc))
+        );
+    }
+
+    /**
+     * @param Parser $f
+     * @param Parser $g
+     * @return Parser
+     */
+    private function seq(Closure $f, Closure $g): Closure
+    {
+        return static fn (Intermediate $x, Closure $cc): Result => $f(
+            $x,
+            static fn (Result $x): Result => (
+                $x->then(static fn (Intermediate $x): Result => $g($x, $cc))
+                  ->except(static fn ($error): Result => $cc(new Error($error)))
+            )
+        );
+    }
+
+    /**
+     * @param int $atom
+     * @return Parser
+     */
+    private function eq(int $atom): Closure
+    {
+        return static fn (Intermediate $x, Closure $cc): Result => $cc(
+            $atom === $x->value() ? $x->accept() : $x->reject()
+        );
+    }
+
+    /**
+     * Makes a variadic function from a binary one (left associative and requires at leat 1 argument):
+     * f(f(a, b), c) === variadic(f, [a, b, c]);
+     *
+     * @param callable(Parser, Parser): Parser $call
+     * @param (Parser|string)[] $parse
+     * @return Parser
+     */
+    private function variadic(callable $call, array $parse): Closure
+    {
+        $parse = array_map([$this, 'parserFrom'], $parse);
+
+        return array_reduce(array_slice($parse, 1), $call, $parse[0]);
+    }
+
+    /**
+     * @param string $expected
+     * @return Parser
+     */
+    private function mustEqual(string $expected): Closure
+    {
+        if (strlen($expected) === 1) {
+            return $this->eq(ord($expected));
+        } elseif ('' === $expected) {
+            return $this->nop();
+        }
+
+        return $this->simpleSequence(str_split($expected));
+    }
+
+    /**
+     * @return Parser
+     */
+    private function nop(): Closure
+    {
+        return static fn (Intermediate $x, Closure $cc): Result => (
+            $cc(new Ok($x))
+        );
+    }
+
+    private function lazy(callable $call, ...$arguments): Closure
+    {
+        return static fn (Intermediate $x, Closure $cc): Result => (
+            ($call(...$arguments))($x, $cc)
+        );
+    }
+}

--- a/src/Refinery/Parser/ABNF/README.md
+++ b/src/Refinery/Parser/ABNF/README.md
@@ -1,0 +1,311 @@
+# ABNF Parser
+
+This service provides an API to create parser definitions with an ABNF like syntax.
+
+## Usage
+
+To use the ABNF parser the class `Brick` must be used.
+
+See [ABNF methods](#abnf-methods) for all implemented methods that directly correspond to an ABNF operator.
+
+## Brick
+
+This class can be used to write a parser definition.
+
+To keep this class as small as possible, please consider extracting parts of this class into new classes when adding / modifying code.
+
+See [Parser internals](#parser-internals) for more information.
+
+### Basic Example
+
+This example shows how ABNF code can be translated to an equivalent syntax with this API.
+
+Please note that this example does not create a parser but validates only. See Section [Parser Example](#parser-example) for a full and useful example.
+
+ABNF code (taken from https://datatracker.ietf.org/doc/html/rfc3339):
+
+```
+date-fullyear   = 4DIGIT
+date-month      = 2DIGIT  ; 01-12
+date-mday       = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on
+                          ; month/year
+time-hour       = 2DIGIT  ; 00-23
+time-minute     = 2DIGIT  ; 00-59
+time-second     = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second
+                          ; rules
+time-secfrac    = "." 1*DIGIT
+time-numoffset  = ("+" / "-") time-hour ":" time-minute
+time-offset     = "Z" / time-numoffset
+
+partial-time    = time-hour ":" time-minute ":" time-second
+                  [time-secfrac]
+full-date       = date-fullyear "-" date-month "-" date-mday
+full-time       = partial-time time-offset
+
+date-time       = full-date "T" full-time
+```
+
+```php
+use ILIAS\Refinery\Parser\ABNF\Brick;
+use ILIAS\Refinery\Parser\ABNF\Intermediate;
+
+$brick = new Brick();
+
+$two_digits = $brick->repeat(2, 2, $brick->digit());
+
+$date_fullyear   = $brick->repeat(4, 4, $brick->digit());
+$date_month      = $two_digits;
+$date_mday       = $two_digits;
+
+$time_hour       = $two_digits;
+$time_minute     = $two_digits;
+$time_second     = $two_digits;
+
+$time_secfrac    = $brick->sequence(['.', $brick->repeat(1, null, $brick->digit())]);
+$time_numoffset  = $brick->sequence([$brick->either(['+', '-']), $time_hour, ':', $time_minute]);
+$time_offset     = $brick->either(['Z', $time_numoffset]);
+
+$partial_time    = $brick->sequence([$time_hour, ':', $time_minute, ':', $time_second, $brick->repeat(0, 1, $time_secfrac)]);
+
+$full_date       = $brick->sequence([$date_fullyear, '-', $date_month, '-', $date_mday]);
+$full_time       = $brick->sequence([$partial_time, $time_offset]);
+
+$date_time       = $brick->sequence([$full_date, 'T', $full_time]);
+
+$result = $brick->apply($date_time, '2000-06-30T23:59:60Z');
+```
+
+## Parsing
+
+The previous example mirrors the ABNF syntax but doesn't parse any input (The structure is not touched).
+
+To extract the structure from a definition, this API provides two ways to achieve this:
+
+### Transformation
+
+The method `Brick::transformation(Transformation, Parser)` is used to create user defined values from a given parser definition.
+
+#### Example
+
+```php
+$brick = new Brick();
+global $DIC;
+
+$parser = $brick->sequence(['foo', 'bar']);
+
+$new_parser = $brick->transformation($DIC->refinery()->custom(function ($parsed) {
+    // $parsed === 'foobar'.
+    return 'My own value.'; // You can return anything here, it doesn't need to be a string.
+}), $parser);
+
+$brick->apply($new_parser, 'foobar'); // => new Ok('My own value.')
+```
+
+### Array keys with sequence and either
+
+Except from the functionality described by the ABNF definition of concatenation and alternatives, one can provide array keys, to give the parser a name in `Brick::transformation(Transformation, Parser)`.
+
+#### Example
+
+```php
+$brick = new Brick();
+global $DIC;
+
+$branch = $brick->either([
+    'number' => $brick->digit(),
+    'alpha' => $brick->alpha(),
+]);
+
+$parser = $brick->sequence([
+    'first' => $branch,
+    'second' => 'bar',
+]);
+
+$new_parser = $brick->transformation($DIC->refinery()->custom(function ($parsed) {
+    // In the case of Brick::either, only the taken path is available so: if isset($parsed['first']['numner']) then the 'numner' branch was taken.
+    // is_array($parsed) === true && $parsed['first']['number'] === '7' && $parsed['second'] === 'bar'.
+    return ['baz' => $parsed];
+}), $parser);
+
+$brick->apply($new_parser, '7bar'); // => new Ok(['baz' => ['first' => ['number' => '7'], 'second' => 'bar']])
+$brick->apply($new_parser, 'xbar'); // => new Ok(['baz' => ['first' => ['alpha' => 'x'], 'second' => 'bar']])
+```
+
+### Parser Example
+
+```php
+use ILIAS\Refinery\Parser\ABNF\Brick;
+
+class Time
+{
+    public function __construct(
+        private string $hour,
+        private string $minutes,
+        private string $seconds
+    ) {
+    }
+}
+
+class Date
+{
+    public function __construct(
+        private string $year,
+        private string $month,
+        private string $day
+    ) {
+    }
+}
+
+class DateAndTime
+{
+    public function __construct(
+        private Date $date,
+        private Time $time
+    ) {
+    }
+}
+
+$brick = new Brick();
+global $DIC;
+$custom = [$DIC->refinery()->custom(), 'transformation'];
+
+$two_digits = $brick->repeat(2, 2, $brick->digit());
+
+$date_fullyear   = $brick->repeat(4, 4, $brick->digit());
+$date_month      = $two_digits;
+$date_mday       = $two_digits;
+
+$time_hour       = $two_digits;
+$time_minute     = $two_digits;
+$time_second     = $two_digits;
+
+$time_secfrac    = $brick->sequence(['.', $brick->repeat(1, null, $brick->digit())]);
+$time_numoffset  = $brick->sequence([$brick->either(['+', '-']), $time_hour, ':', $time_minute]);
+$time_offset     = $brick->either(['Z', $time_numoffset]);
+
+$partial_time    = $brick->sequence(['hour' => $time_hour, ':', 'minutes' => $time_minute, ':', 'seconds' => $time_second, $brick->repeat(0, 1, $time_secfrac)]);
+
+$full_date       = $brick->sequence(['year' => $date_fullyear, '-', 'month' => $date_month, '-', 'day' => $date_mday]);
+$full_date       = $brick->transformation($custom(fn ($from) => new Date($from['year'], $from['month'], $from['day'])), $full_date);
+
+$full_time       = $brick->sequence([$partial_time, $time_offset]);
+$full_time       = $brick->transformation($custom(fn ($from) => new Time($from['hour'], $from['minutes'], $from['seconds'])), $full_time);
+
+$date_time       = $brick->sequence(['date' => $full_date, 'T', 'time' => $full_time]);
+$date_time       = $brick->transformation($custom(fn ($from) => new DateAndTime($from['date'], $from['time'])), $date_time);
+
+$result = $brick->apply($date_time, '2000-06-30T23:59:60Z');
+```
+
+## ABNF methods
+
+### Brick::range
+
+ABNF equivalent to value ranges:
+
+`fu = %x30-37` is equivalent to `$fu = $this->range(0x30, 0x37)`.
+
+### Brick::alpha
+
+ABNF equivalent to ALPHA:
+
+`fu = ALPHA` is equivalent to `$fu = $this->alpha()`.
+
+### Brick::digit
+
+ABNF equivalent to DIGIT:
+
+`fu = DIGIT` is equivalent to `$fu = $this->digit()`.
+
+### Brick::either
+
+ABNF equivalent to alternative:
+
+`fu = a / b` is equivalent to `$fu = $this->either([a, b])`.
+
+You can use `Brick::either(['foo', 'bar']);` to match a string directly.
+
+See [Array keys with sequence and either](#array-keys-with-sequence-and-either) for additional information features beyond the ABNF equivalence.
+
+### Brick::sequence
+
+ABNF equivalent to concatenation:
+
+`fu = a b` is equivalent to `$fu = $this->sequence([a, b])`.
+
+You can use `Brick::sequence(['foo']);` to match a string directly.
+
+See [Array keys with sequence and either](#array-keys-with-sequence-and-either) for additional information features beyond the ABNF equivalence.
+
+### Brick::repeat
+
+ABNF equivalent to variable repetition:
+
+`fu = <a>*<b>element` is equivalent to `$fu = $this->repeat(<a>, <b>, element)`.
+
+`fu = *<b>element` is equivalent to `$fu = $this->repeat(0, <b>, element)`.
+
+`fu = 1*element` is equivalent to `$fu = $this->repeat(1, null, element)`.
+
+`fu = *element` is equivalent to `$fu = $this->repeat(0, null, element)`.
+
+`fu = [element]` is equivalent to `0*1element and therefore equivalent to $fu = $this->repeat(0, 1, element)`.
+
+You can use `Brick::repeat(0, 1 'foo');` to match a string directly.
+
+## Parser internals
+
+The parser is an implementation of a parser compinator.
+
+To manipulate the execution of a parser chain [continuations](https://en.wikipedia.org/wiki/Call-with-current-continuation) or [CPS](https://en.wikipedia.org/wiki/Continuation-passing_style) are used.
+
+Type of Parser: (Intermediate, Continuation): Result
+
+Type of Continuation: (Result): Result
+
+Only immutable values are used.
+
+`$cc` stands for _current continuation_.
+
+This is used to be able to capture the next computation and run it again with different input in case of an error.
+
+The `$cc` is used for example in the `either` method to rerun the computation chain with the next branch if the current failed.
+
+`$x` holds the _state_. Everything that is parsed, the current value and the data that still needs to be parsed (Either `Result<Intermediate>` or `Intermediate`)
+
+To restart the whole computation (on error):
+
+```php
+$parser = function ($x, $cc) {
+    return some_parser($x, $cc)->except(fn () => parse_something_else($x, $cc));
+};
+```
+
+To get the result of the parsers "children" (in case of `either` these would be the branches):
+
+```php
+$parser = function (Intermediate $x, Closure $cc): Result {
+    return some_parser($x, fn($x): Result => (
+        $x->then(fn(Intermediate $x): Result => ( // $x is the successful value.
+            $cc(new Ok($x))
+        ))->except(fn($error) => (
+            $cc(new Error($error)) // This is necessary because the $cc MUST always be called when returning a value.
+        ))
+    ));
+};
+```
+
+To consume a value:
+
+```php
+$parser = function (Intermediate $x, Closure $cc): Result {
+    return $cc(some_predicate($x->value()) ? $x->accept() : $x->reject());
+};
+```
+
+The class `Primitives` is used for the basic composition and consumtion of the parser compinator basics.
+
+The class `Transform` does the actual transformations from the origin values to compound values.
+
+The class `Brick` bundles both classes together into a useful API.
+

--- a/src/Refinery/Parser/ABNF/Transform.php
+++ b/src/Refinery/Parser/ABNF/Transform.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Refinery\Parser\ABNF;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use Closure;
+use ILIAS\Refinery\Transformation;
+
+class Transform
+{
+    /**
+     * Transforms the value parsed by the given $parse parameter to the value returned by $transformation.
+     * Example:
+     * $brick = new Brick();
+     * $int = $DIC->refinery()->kindlyTo()->int();
+     * $brick->apply($this->to($int, $brick->digit()), '4') => new Ok(4);
+     */
+    public function to(Transformation $transformation, Closure $parse): Closure
+    {
+        return $this->from(static fn ($value): Result => $transformation->applyTo(new Ok($value))->map(
+            static fn ($value): array => [$value]
+        ), $parse);
+    }
+
+    /**
+     * The value parsed by the given $parse parameter will be stored under the key $key.
+     *
+     * Example:
+     * $brick = new Brick();
+     *
+     * $brick->apply($this->as('hej', $brick->alpha()), 'a') => new Ok(['hej' => 'a']);
+     *
+     * $brick->apply($brick->sequence([
+     *     $this->as('first', $brick->alpha()),
+     *     $this->as('second', $brick->alpha()),
+     *     $this->as('third', $brick->alpha()),
+     * ]), 'abc') => new Ok(['first' => 'a', 'second' => 'b', 'third' => 'c']);
+     *
+     * $brick->apply($this->as('foo', $this->as('bar', $brick->alpha())), 'a') => new Ok(['foo' => ['bar' => 'a']]);
+     */
+    public function as(string $key, Closure $parse): Closure
+    {
+        return $this->from(
+            fn ($value): Result => new Ok([$key => $this->removeArrayLevel($value)]),
+            $parse
+        );
+    }
+
+    /**
+     * self::to MUST add one array level, because it may be used in a context where more array levels are added,
+     * this method removes this level when it is known that it is and will be the only element in the array.
+     */
+    private function removeArrayLevel($value)
+    {
+        if (is_array($value) && count($value) === 1 && isset($value[0])) {
+            return $value[0];
+        }
+
+        return $value;
+    }
+
+    private function from(Closure $transform, Closure $parse): Closure
+    {
+        return fn (Intermediate $previous, Closure $cc): Result => $parse(
+            $previous->onlyTodo(),
+            fn (Result $child): Result => $child->then(
+                fn (Intermediate $child): Result =>
+                    $child->transform($transform)
+                          ->then($this->combine($previous, $child, $cc))
+                          ->except($this->error($cc))
+            )->except($this->error($cc))
+        );
+    }
+
+    private function combine(Intermediate $hasAccepted, Intermediate $hasTodos, Closure $cc): Closure
+    {
+        return static fn (array $values): Result => $cc(new Ok(
+            $hasTodos->onlyTodo()
+                     ->push($hasAccepted->accepted())
+                     ->push($values)
+        ));
+    }
+
+    private function error(Closure $cc): Closure
+    {
+        return static fn ($error): Result => $cc(new Error($error));
+    }
+}

--- a/tests/Data/DataFactoryTest.php
+++ b/tests/Data/DataFactoryTest.php
@@ -2,12 +2,28 @@
 
 declare(strict_types=1);
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 require_once("libs/composer/vendor/autoload.php");
 
 use ILIAS\Data;
 use PHPUnit\Framework\TestCase;
+use ILIAS\Data\LanguageTag;
+use ILIAS\Data\NotOKException;
 
 /**
  * Testing the faytory of result objects
@@ -78,5 +94,17 @@ class DataFactoryTest extends TestCase
         $this->assertEquals(Data\DataSize::GiB, $dataType->getUnit());
         $this->assertEquals(10 * Data\DataSize::GiB, $dataType->inBytes());
         $this->assertInstanceOf(Data\DataSize::class, $dataType);
+    }
+
+    public function testLanguageTag(): void
+    {
+        $tag = $this->f->languageTag('de');
+        $this->assertInstanceOf(LanguageTag::class, $tag);
+    }
+
+    public function testLanguageTagFailed(): void
+    {
+        $this->expectException(NotOKException::class);
+        $this->f->languageTag('d$');
     }
 }

--- a/tests/Data/LanguageTag/IrregularTest.php
+++ b/tests/Data/LanguageTag/IrregularTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Data\LanguageTag;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Data\LanguageTag\Irregular;
+
+class IrregularTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $irregular = new Irregular('foo');
+        $this->assertInstanceOf(Irregular::class, $irregular);
+    }
+
+    public function testValue(): void
+    {
+        $irregular = new Irregular('foo');
+        $this->assertEquals('foo', $irregular->value());
+    }
+}

--- a/tests/Data/LanguageTag/PrivateUseTest.php
+++ b/tests/Data/LanguageTag/PrivateUseTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Data\LanguageTag;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Data\LanguageTag\PrivateUse;
+
+class PrivateUseTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $privateuse = new PrivateUse('foo');
+        $this->assertInstanceOf(PrivateUse::class, $privateuse);
+    }
+
+    public function testValue(): void
+    {
+        $privateuse = new PrivateUse('foo');
+        $this->assertEquals('foo', $privateuse->value());
+    }
+}

--- a/tests/Data/LanguageTag/RegularTest.php
+++ b/tests/Data/LanguageTag/RegularTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Data\LanguageTag;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Data\LanguageTag\Regular;
+
+class RegularTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $regular = new Regular('foo');
+        $this->assertInstanceOf(Regular::class, $regular);
+    }
+
+    public function testValue(): void
+    {
+        $regular = new Regular('foo');
+        $this->assertEquals('foo', $regular->value());
+    }
+}

--- a/tests/Data/LanguageTag/StandardTest.php
+++ b/tests/Data/LanguageTag/StandardTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Data\LanguageTag;
+
+use ILIAS\Data\LanguageTag\Standard;
+use PHPUnit\Framework\TestCase;
+use InvalidArgumentException;
+use ILIAS\Data\LanguageTag\PrivateUse;
+
+class StandardTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(Standard::class, new Standard('hej', null, null, null, null, null, null));
+    }
+
+    public function testLanguage(): void
+    {
+        $this->assertEquals('hej', (new Standard('hej', null, null, null, null, null, null))->language());
+    }
+
+    public function testExtlang(): void
+    {
+        $this->assertEquals('hej', (new Standard('ho', 'hej', null, null, null, null, null))->extlang());
+    }
+
+    public function testScript(): void
+    {
+        $this->assertEquals('hej', (new Standard('ho', null, 'hej', null, null, null, null))->script());
+    }
+
+    public function testRegion(): void
+    {
+        $this->assertEquals('hej', (new Standard('ho', null, null, 'hej', null, null, null))->region());
+    }
+
+    public function testVariant(): void
+    {
+        $this->assertEquals('hej', (new Standard('ho', null, null, null, 'hej', null, null))->variant());
+    }
+
+    public function testExtension(): void
+    {
+        $this->assertEquals('hej', (new Standard('ho', null, null, null, null, 'hej', null))->extension());
+    }
+
+    public function testPrivateuse(): void
+    {
+        $privateuse = $this->getMockBuilder(PrivateUse::class)->disableOriginalConstructor()->getMock();
+        $privateuse->method('value')->willReturn('hej');
+
+        $this->assertEquals($privateuse, (new Standard('ho', null, null, null, null, null, $privateuse))->privateuse());
+    }
+
+    public function testValue(): void
+    {
+        $privateuse = $this->getMockBuilder(PrivateUse::class)->disableOriginalConstructor()->getMock();
+        $privateuse->method('value')->willReturn('hej');
+
+        $this->assertEquals('hej', (new Standard('hej', null, null, null, null, null, null))->value());
+        $this->assertEquals('hej-hej', (new Standard('hej', 'hej', null, null, null, null, null))->value());
+        $this->assertEquals('hej-hej', (new Standard('hej', null, 'hej', null, null, null, null))->value());
+        $this->assertEquals('hej-hej', (new Standard('hej', null, null, 'hej', null, null, null))->value());
+        $this->assertEquals('hej-hej', (new Standard('hej', null, null, null, 'hej', null, null))->value());
+        $this->assertEquals('hej-hej', (new Standard('hej', null, null, null, null, 'hej', null))->value());
+        $this->assertEquals('hej-hej', (new Standard('hej', null, null, null, null, null, $privateuse))->value());
+    }
+}

--- a/tests/Data/LanguageTagTest.php
+++ b/tests/Data/LanguageTagTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Data;
+
+use ILIAS\Data\LanguageTag;
+use PHPUnit\Framework\TestCase;
+use ILIAS\Data\NotOKException;
+
+class LanguageTagTest extends TestCase
+{
+    public function testFromString(): void
+    {
+        $tag = LanguageTag::fromString('de');
+        $this->assertInstanceOf(LanguageTag::class, $tag);
+    }
+
+        /**
+     * @dataProvider parseProvider
+     */
+    public function testParse(string $input, bool $isOk): void
+    {
+        if (!$isOk) {
+            $this->expectException(NotOKException::class);
+        }
+        $tag = LanguageTag::fromString($input);
+        $this->assertInstanceOf(LanguageTag::class, $tag);
+    }
+
+    public function parseProvider(): array
+    {
+        return [
+            ['de', true],
+            ['d$', false],
+            ['aa-111', true],
+            ['aa-7-123abc-abc-a-12', true],
+            ['aa-b1b1b-6a8b-cccccc', true],
+            ['aa-b1b1b', true],
+            ['aa-bb', true],
+            ['aa-bbb-ccc-1111-ccccc-b1b1b', true],
+            ['aa-bbb-ccc-ddd', true],
+            ['aa-bbb', true],
+            ['aa-bbbb-cc', true],
+            ['aa-bbbb', true],
+            ['aa-x-1234ab-d', true],
+            ['aa', true],
+            ['aaa-bbb-ccc-ddd-abcd-123-abc123-0abc-b-01-abc123-x-01ab-abc12', true],
+            ['aaa-bbb-ccc', true],
+            ['aaaa', true],
+            ['aaaaa', true],
+            ['aaaaaa', true],
+            ['aaaaaaa', true],
+            ['aaaaaaaa', true],
+            ['afb', true],
+            ['ar-afb', true],
+            ['art-lojban', true],
+            ['ast', true],
+            ['az-Arab-x-AZE-derbend', true],
+            ['az-Latn', true],
+            ['cel-gaulish', true],
+            ['cmn-Hans-CN', true],
+            ['de-CH-1901', true],
+            ['de-CH-x-phonebk', true],
+            ['de-DE-u-co-phonebk', true],
+            ['de-DE', true],
+            ['de-Qaaa', true],
+            ['de', true],
+            ['en-GB-oed', true],
+            ['en-US-u-islamcal', true],
+            ['en-US-x-twain', true],
+            ['en-US', true],
+            ['en-a-myext-b-another', true],
+            ['en', true],
+            ['es-005', true],
+            ['es-419', true],
+            ['fr-CA', true],
+            ['fr', true],
+            ['hak', true],
+            ['hy-Latn-IT-arevela', true],
+            ['i-ami', true],
+            ['i-bnn', true],
+            ['i-default', true],
+            ['i-enochian', true],
+            ['i-hak', true],
+            ['i-klingon', true],
+            ['i-lux', true],
+            ['i-mingo', true],
+            ['i-navajo', true],
+            ['i-pwn', true],
+            ['i-tao', true],
+            ['i-tay', true],
+            ['i-tsu', true],
+            ['ja', true],
+            ['mas', true],
+            ['no-bok', true],
+            ['no-nyn', true],
+            ['qaa-Qaaa-QM-x-southern', true],
+            ['sgn-BE-FR', true],
+            ['sgn-BE-NL', true],
+            ['sgn-CH-DE', true],
+            ['sl-IT-nedis', true],
+            ['sl-nedis', true],
+            ['sl-rozaj-biske', true],
+            ['sl-rozaj', true],
+            ['sr-Cyrl', true],
+            ['sr-Latn-QM', true],
+            ['sr-Latn-RS', true],
+            ['sr-Latn', true],
+            ['sr-Qaaa-RS', true],
+            ['x-111-aaaaa-BBB', true],
+            ['x-whatever', true],
+            ['yue-HK', true],
+            ['zh-CN-a-myext-x-private', true],
+            ['zh-Hans-CN', true],
+            ['zh-Hans', true],
+            ['zh-Hant-HK', true],
+            ['zh-Hant', true],
+            ['zh-cmn-Hans-CN', true],
+            ['zh-guoyu', true],
+            ['zh-hakka', true],
+            ['zh-min-nan', true],
+            ['zh-min', true],
+            ['zh-xiang', true],
+            ['zh-yue-HK', true],
+            ['zh-yue', true],
+        ];
+    }
+}

--- a/tests/Refinery/Parser/ABNF/BrickTest.php
+++ b/tests/Refinery/Parser/ABNF/BrickTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Refinery\Parser\ABNF;
+
+use Closure;
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use ILIAS\Refinery\Parser\ABNF\Brick;
+use ILIAS\Refinery\Parser\ABNF\Intermediate;
+use ILIAS\Refinery\Transformation;
+use PHPUnit\Framework\TestCase;
+
+class BrickTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(Brick::class, new Brick());
+    }
+
+    public function testApply(): void
+    {
+        $expected = 'aloha';
+        $ok = $this->getMockBuilder(Result::class)->getMock();
+        $ok->method('isOk')->willReturn(true);
+        $ok->method('value')->willReturn($expected);
+        $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+        $intermediate->method('done')->willReturn(true);
+        $intermediate->method('transform')->willReturnCallback(fn () => $ok);
+        $brick = new Brick();
+        $result = $brick->apply(static fn (Intermediate $x, Closure $cc): Result => (
+            $cc(new Ok($intermediate))
+        ), 'abcde');
+
+        $this->assertTrue($result->isOk());
+        $this->assertEquals($expected, $result->value());
+    }
+
+    public function testThatAllInputMustBeConsumed(): void
+    {
+        $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+        $intermediate->expects(self::once())->method('done')->willReturn(false);
+        $intermediate->expects(self::never())->method('transform');
+
+        $brick = new Brick();
+        $result = $brick->apply(static fn (Intermediate $x, Closure $cc): Result => (
+            $cc(new Ok($intermediate))
+        ), 'abcde');
+
+        $this->assertFalse($result->isOk());
+    }
+
+    public function testAFailingParser(): void
+    {
+        $brick = new Brick();
+        $result = $brick->apply(static fn (Intermediate $x, Closure $cc): Result => (
+            $cc(new Error('something happened'))
+        ), 'abcde');
+
+        $this->assertFalse($result->isOk());
+    }
+
+    public function testToTransformation(): void
+    {
+        $brick = new Brick();
+        $parser = $brick->sequence(['foo']);
+        $transformation = $brick->toTransformation($parser);
+        $this->assertInstanceOf(Transformation::class, $transformation);
+        $result = $transformation->applyTo(new Ok('foo'));
+        $this->assertTrue($result->isOk());
+        $this->assertEquals('foo', $result->value());
+    }
+
+    public function testToTransformationFailed(): void
+    {
+        $brick = new Brick();
+        $parser = $brick->sequence(['foo']);
+        $transformation = $brick->toTransformation($parser);
+        $this->assertInstanceOf(Transformation::class, $transformation);
+        $result = $transformation->applyTo(new Ok('fox'));
+        $this->assertFalse($result->isOk());
+    }
+
+    public function testRange(): void
+    {
+        $brick = new Brick();
+
+        $parse = $brick->range(0, 0x14);
+
+        foreach (array_fill(0, 0x14 + 1, null) as $i => $_) {
+            $result = $brick->apply($parse, chr($i));
+            $this->assertTrue($result->isOk());
+            $this->assertEquals(chr($i), $result->value());
+        }
+    }
+
+    public function testOutOfRange(): void
+    {
+        $brick = new Brick();
+
+        $parse = $brick->range(1, 0x14);
+
+        $this->assertFalse($brick->apply($parse, "\x0")->isOk());
+        $this->assertFalse($brick->apply($parse, "\x15")->isOk());
+    }
+
+    public function testEither(): void
+    {
+        $brick = new Brick();
+
+        $parse = $brick->either([
+            'a' => $brick->range(0x10, 0x20), // False.
+            $brick->range(0x21, 0x30), // False without key.
+            'b' => $brick->range(0x0, 0x5), // True.
+        ]);
+
+        $result = $brick->apply($parse, "\x0");
+
+        $this->assertTrue($result->isOk());
+        $this->assertEquals("\x0", $result->value()['b']);
+    }
+
+    public function testSequence(): void
+    {
+        $brick = new Brick();
+
+        $parse = $brick->sequence([
+            'first' => $brick->range(ord('a'), ord('b')),
+            'second' => $brick->range(ord('c'), ord('d')),
+        ]);
+
+        $result = $brick->apply($parse, 'ad');
+
+        $this->assertTrue($result->isOk());
+        $this->assertEquals('a', $result->value()['first']);
+        $this->assertEquals('d', $result->value()['second']);
+    }
+
+    /**
+     * @dataProvider repeatProvider
+     */
+    public function testRepeat(int $min, ?int $max, array $succeed, array $fail): void
+    {
+        $brick = new Brick();
+        $parse = $brick->repeat($min, $max, $brick->range(ord('a'), ord('z')));
+
+        foreach ($succeed as $input) {
+            $result = $brick->apply($parse, $input);
+
+            $this->assertTrue($result->isOk());
+            $this->assertEquals($input, $result->value());
+        }
+
+        foreach ($fail as $input) {
+            $result = $brick->apply($parse, $input);
+            $this->assertFalse($result->isOk());
+        }
+    }
+
+    public function repeatProvider(): array
+    {
+        return [
+            'Ranges are inclusive' => [3, 3, ['abc'], ['ab', 'abcd']],
+            'Null is used for infinity' => [0, null, ['', 'abcdefghijklmop'], []],
+            'Minimum is 0' => [-1, 3, ['', 'a', 'ab', 'abc'], ['abcd']],
+            'Minimum of the end range is the start range' => [3, 2, ['abc'], ['ab', 'abcd']],
+        ];
+    }
+
+    /**
+     * @dataProvider characterProvider
+     */
+    public function testCharacters(string $method, string $input, bool $isOk): void
+    {
+        $brick = new Brick();
+
+        $parse = $brick->either(str_split($input)); // No character is allowed to pass.
+        if ($isOk) {
+            $parse = $brick->repeat(0, null, $brick->$method()); // All characters must pass.
+        }
+
+        $result = $brick->apply($parse, $input);
+
+        $this->assertEquals($isOk, $result->isOk());
+        if ($isOk) {
+            $this->assertEquals($input, $result->value());
+        }
+    }
+
+    public function characterProvider(): array
+    {
+        $alpha = array_fill(ord('a'), ord('z') - ord('a') + 1, '');
+        array_walk($alpha, function (&$value, int $i) {
+            $value = chr($i);
+        });
+        $alpha = implode('', $alpha);
+        $alpha .= strtoupper($alpha);
+
+        $digits = '1234567890';
+
+        return [
+            'Accepts all digits.' => ['digit', $digits, true],
+            'Accepts no characters from a-z or A-Z.' => ['digit', $alpha, false],
+            'Accepts characters from a-z and A-Z.' => ['alpha', $alpha, true],
+            'Accepts no digits.' => ['alpha', $digits, false],
+        ];
+    }
+
+    /**
+     * @dataProvider emptyStringProvider
+     */
+    public function testEmptyString(string $input, bool $isOk): void
+    {
+        $brick = new Brick();
+
+        $parse = $brick->sequence(['']);
+        $result = $brick->apply($parse, $input);
+
+        $this->assertEquals($isOk, $result->isOk());
+    }
+
+    public function emptyStringProvider(): array
+    {
+        return [
+            'Test empty input' => ['', true],
+            'Test non empty input' => ['x', false],
+        ];
+    }
+
+    public function testTransfromation(): void
+    {
+        $brick = new Brick();
+
+        $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+        $intermediate->method('done')->willReturn(true);
+
+        $ok = $this->getMockBuilder(Result::class)->getMock();
+        $ok->method('isOk')->willReturn(true);
+        $ok->method('value')->willReturn($intermediate);
+        $ok->method('map')->willReturn($ok);
+        $ok->method('then')->willReturn($ok);
+        $ok->method('except')->willReturn($ok);
+
+        $transformation = $this->getMockBuilder(Transformation::class)->getMock();
+        $transformation->expects(self::once())->method('applyTo')->willReturn($ok);
+
+        $parser = $brick->transformation($transformation, fn ($x, $cc) => $cc(new Ok($x)));
+
+        $result = $brick->apply($parser, 'a');
+
+        $this->assertEquals($ok, $result);
+    }
+
+    private function string(): Closure
+    {
+        return static function (string $string): Ok {
+            return new Ok($string);
+        };
+    }
+}

--- a/tests/Refinery/Parser/ABNF/IntermediateTest.php
+++ b/tests/Refinery/Parser/ABNF/IntermediateTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Refinery\Parser\ABNF;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Refinery\Parser\ABNF\Intermediate;
+use ILIAS\Refinery\Parser\ABNF\Character;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class IntermediateTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $intermediate = new Intermediate('input');
+
+        $this->assertInstanceOf(Intermediate::class, $intermediate);
+    }
+
+    public function testValue(): void
+    {
+        $intermediate = new Intermediate('input');
+
+        $this->assertEquals(ord('i'), $intermediate->value());
+    }
+
+    /**
+     * @depends testValue
+     */
+    public function testAccept(): void
+    {
+        $intermediate = new Intermediate('input');
+
+        $this->assertEquals(ord('i'), $intermediate->value());
+
+        $next = $intermediate->accept();
+        $this->assertTrue($next->isOK());
+        $this->assertEquals(ord('n'), $next->value()->value());
+    }
+
+    public function testReject(): void
+    {
+        $intermediate = new Intermediate('input');
+
+        $next = $intermediate->reject();
+        $this->assertFalse($next->isOK());
+    }
+
+    /**
+     * @depends testValue
+     * @depends testAccept
+     */
+    public function testAccepted(): void
+    {
+        $expected = 'in';
+        $intermediate = new Intermediate('input');
+        $this->assertEquals([], $intermediate->accepted());
+        $accepted = $intermediate->accept()->value()->accept()->value()->accepted();
+        $this->assertTrue(is_array($accepted));
+        $actual = '';
+        foreach ($accepted as $character) {
+            $this->assertInstanceOf(Character::class, $character);
+            $actual .= $character->value();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @depends testAccept
+     */
+    public function testDone(): void
+    {
+        $intermediate = new Intermediate('ab');
+        $this->assertFalse($intermediate->done());
+        $this->assertTrue($intermediate->accept()->value()->accept()->value()->done());
+    }
+
+    /**
+     * @depends testAccepted
+     * @depends testAccepted
+     * @depends testValue
+     */
+    public function testOnlyTodo(): void
+    {
+        $intermediate = new Intermediate('ab');
+        $intermediate = $intermediate->accept()->value()->onlyTodo();
+        $this->assertEmpty($intermediate->accepted());
+        $this->assertEquals(ord('b'), $intermediate->value());
+    }
+
+    /**
+     * @depends testAccept
+     */
+    public function testTransformOnlyWithCharacters(): void
+    {
+        $intermediate = new Intermediate('hej');
+        $intermediate = $intermediate->accept()->value();
+
+        $ok = new Ok('transformed');
+
+        $result = $intermediate->transform(function (string $accepted) use ($ok): Result {
+            $this->assertEquals('h', $accepted);
+            return $ok;
+        });
+
+        $this->assertEquals($ok, $result);
+    }
+
+    /**
+     * @depends testAccepted
+     */
+    public function testPush(): void
+    {
+        $intermediate = new Intermediate('hej');
+        $value = new stdClass();
+        $this->assertEmpty($intermediate->accepted());
+        $this->assertEquals([$value], $intermediate->push([$value])->accepted());
+    }
+
+    /**
+     * @depends testPush
+     * @depends testAccept
+     */
+    public function testTransformWithTransformedValues(): void
+    {
+        $intermediate = new Intermediate('hej');
+        $intermediate = $intermediate->accept()->value();
+
+        $dummy = new stdClass();
+        $ok = new Ok('transformed');
+
+        $intermediate = $intermediate->push([$dummy]);
+
+        $result = $intermediate->transform(function (array $accepted) use ($dummy, $ok): Result {
+            $this->assertEquals(2, count($accepted));
+            $this->assertInstanceOf(Character::class, $accepted[0]);
+            $this->assertEquals('h', $accepted[0]->value());
+            $this->assertEquals($dummy, $accepted[1]);
+            return $ok;
+        });
+
+        $this->assertEquals($ok, $result);
+    }
+}

--- a/tests/Refinery/Parser/ABNF/PrimitivesTest.php
+++ b/tests/Refinery/Parser/ABNF/PrimitivesTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Refinery\Parser\ABNF;
+
+use Closure;
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use ILIAS\Refinery\Parser\ABNF\Brick;
+use ILIAS\Refinery\Parser\ABNF\Intermediate;
+use ILIAS\Refinery\Parser\ABNF\Primitives;
+use ILIAS\Refinery\Transformation;
+use PHPUnit\Framework\TestCase;
+use Exception;
+
+class PrimitivesTest extends TestCase
+{
+    public function testSimpleEither(): void
+    {
+        $primitives = new Primitives();
+
+        $parse = $primitives->simpleEither([
+            'a', // False.
+            "\x0", // True.
+        ]);
+
+        $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+        $intermediate->expects(self::exactly(2))->method('value')->willReturn(ord("\x0"));
+        $intermediate->method('accept')->willReturn(new Ok($intermediate));
+        $intermediate->method('reject')->willReturn(new Error('Failed'));
+
+        $result = $parse($intermediate, static fn (Result $x): Result => $x);
+
+        $this->assertTrue($result->isOk());
+        $this->assertEquals($intermediate, $result->value());
+    }
+
+    public function testSimpleSequence(): void
+    {
+        $primitives = new Primitives();
+
+        $parse = $primitives->simpleSequence(['a', 'd']);
+
+        $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+        $intermediate->expects(self::exactly(2))->method('value')->willReturnOnConsecutiveCalls(ord('a'), ord('d'));
+        $intermediate->method('accept')->willReturn(new Ok($intermediate));
+
+        $result = $parse($intermediate, static fn (Result $x): Result => $x);
+
+        $this->assertTrue($result->isOk());
+        $this->assertEquals($intermediate, $result->value());
+    }
+
+    public function testUntilZero(): void
+    {
+        $primitives = new Primitives();
+        $parser = $primitives->until(0, static function (): void {
+            throw new Exception('Should not be called.');
+        });
+
+        $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+
+        $result = $parser($intermediate, static fn (Result $x): Result => $x);
+        $this->assertTrue($result->isOk());
+        $this->assertEquals($intermediate, $result->value());
+    }
+
+    public function testUntilN(): void
+    {
+        $n = 8;
+        foreach (array_fill(0, $n + 1, null) as $i => $_) {
+            $primitives = new Primitives();
+            $called = 0;
+            $end_called = 0;
+            $parser = $primitives->until($n, static function (Intermediate $x, Closure $cc) use (&$called): Result {
+                $called++;
+                return $cc(new Ok($x));
+            });
+
+            $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+
+            $result = $parser($intermediate, static function (Result $x) use (&$end_called, $i): Result {
+                $end_called++;
+                return $end_called <= $i ? new Error('Failed') : $x;
+            });
+            if ($i > $n) {
+                $this->assertEquals($i, $n);
+                $this->assertFalse($result->isOk());
+            } else {
+                $this->assertEquals($i, $called);
+                $this->assertEquals($i + 1, $end_called);
+                $this->assertTrue($result->isOk());
+                $this->assertEquals($intermediate, $result->value());
+            }
+        }
+    }
+
+    public function testUntilSuccess(): void
+    {
+        $success_after = 300;
+        $primitives = new Primitives();
+        $called = 0;
+        $end_called = 0;
+        $parser = $primitives->until(null, static function (Intermediate $x, Closure $cc) use (&$called): Result {
+            $called++;
+            return $cc(new Ok($x));
+        });
+
+        $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+
+        $result = $parser($intermediate, static function (Result $x) use (&$end_called, $success_after): Result {
+            $end_called++;
+            return $end_called <= $success_after ? new Error('Failed') : $x;
+        });
+        $this->assertEquals($success_after, $called);
+        $this->assertEquals($success_after + 1, $end_called);
+        $this->assertTrue($result->isOk());
+        $this->assertEquals($intermediate, $result->value());
+    }
+
+    public function testUntilChildFails(): void
+    {
+        $fail_after = 134;
+        $primitives = new Primitives();
+        $called = 0;
+        $end_called = 0;
+        $parser = $primitives->until(null, static function (Intermediate $x, Closure $cc) use (&$called, $fail_after): Result {
+            $called++;
+            return $called <= $fail_after ? $cc(new Ok($x)) : $cc(new Error('Failed.'));
+        });
+
+        $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+
+        $result = $parser($intermediate, static function (Result $x) use (&$end_called): Result {
+            $end_called++;
+            return new Error('Failed.');
+        });
+        $this->assertEquals($fail_after + 1, $called);
+        $this->assertEquals(($fail_after + 1) * 2, $end_called);
+        $this->assertFalse($result->isOk());
+    }
+
+    public function testParserFromParser(): void
+    {
+        $primitives = new Primitives();
+
+        $parser = static function (): void {
+            throw new Exception('Should not be called.');
+        };
+
+        $this->assertEquals($parser, $primitives->parserFrom($parser));
+    }
+
+    public function testParserFromString(): void
+    {
+        $primitives = new Primitives();
+
+        $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+        $intermediate->method('value')->willReturnOnConsecutiveCalls(ord('h'), ord('e'), ord('l'), ord('l'), ord('o'));
+        $intermediate->method('accept')->willReturn(new Ok($intermediate));
+
+        $parser = $primitives->parserFrom('hello');
+
+        $result = $parser($intermediate, static fn (Result $x): Result => $x);
+        $this->assertTrue($result->isOk());
+    }
+
+    public function testParserFromEmptyString(): void
+    {
+        $primitives = new Primitives();
+
+        $intermediate = $this->getMockBuilder(Intermediate::class)->disableOriginalConstructor()->getMock();
+        $intermediate->expects(self::never())->method('value');
+        $intermediate->expects(self::never())->method('accept');
+        $intermediate->expects(self::never())->method('reject');
+
+        $parser = $primitives->parserFrom('');
+
+        $result = $parser($intermediate, fn ($x) => $x);
+        $this->assertTrue($result->isOk());
+        $this->assertEquals($intermediate, $result->value());
+    }
+}

--- a/tests/Refinery/Parser/ABNF/TransformTest.php
+++ b/tests/Refinery/Parser/ABNF/TransformTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\Refinery\Parser\ABNF;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use PHPUnit\Framework\TestCase;
+use ILIAS\Refinery\Parser\ABNF\Transform;
+use ILIAS\Refinery\Parser\ABNF\Intermediate;
+use ILIAS\Refinery\Transformation;
+use Closure;
+use stdClass;
+
+class TransformTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(Transform::class, new Transform());
+    }
+
+    /**
+     * @depends testConstruct
+     */
+    public function testTo(): void
+    {
+        $transform = new Transform();
+        $transformed = new stdClass();
+        $transformation = $this->getMockBuilder(Transformation::class)->getMock();
+        $transformation->method('applyTo')->willReturnCallback(function (Result $x) use ($transformed): Result {
+            $this->assertEquals('x', $x->value());
+            return new Ok($transformed);
+        });
+
+        $parse = $transform->to($transformation, function (Intermediate $x, Closure $cc): Result {
+            return $cc($x->accept());
+        });
+
+        $end = new stdClass();
+
+        $x = $parse(new Intermediate('x'), function (Result $x) use ($transformed, $end): Result {
+            $this->assertEquals([$transformed], $x->value()->accepted());
+            return new Ok($end);
+        });
+
+        $this->assertEquals($end, $x->value());
+    }
+
+    /**
+     * @depends testConstruct
+     */
+    public function testFailedToTransform(): void
+    {
+        $transform = new Transform();
+        $transformation = $this->getMockBuilder(Transformation::class)->getMock();
+        $transformation->method('applyTo')->willReturnCallback(function (Result $x): Result {
+            $this->assertEquals('x', $x->value());
+            return new Error('Sorryy.');
+        });
+
+        $parse = $transform->to($transformation, function (Intermediate $x, Closure $cc): Result {
+            return $cc($x->accept());
+        });
+
+        $end = new stdClass();
+
+        $x = $parse(new Intermediate('x'), function (Result $x) use ($end): Result {
+            $this->assertFalse($x->isOK());
+            return new Ok($end);
+        });
+
+        $this->assertEquals($end, $x->value());
+    }
+
+    /**
+     * @depends testConstruct
+     */
+    public function testFailedToParse(): void
+    {
+        $transform = new Transform();
+        $transformCalled = false;
+        $transformation = $this->getMockBuilder(Transformation::class)->getMock();
+        $transformation->method('applyTo')->willReturnCallback(function (Result $x) use (&$transformCalled): Result {
+            $transformCalled = true;
+            return $x;
+        });
+
+        $parse = $transform->to($transformation, function (Intermediate $x, Closure $cc): Result {
+            return $cc($x->reject());
+        });
+
+        $end = new stdClass();
+
+        $x = $parse(new Intermediate('x'), function (Result $x) use ($end): Result {
+            $this->assertFalse($x->isOK());
+            return new Ok($end);
+        });
+
+        $this->assertEquals($end, $x->value());
+        $this->assertFalse($transformCalled);
+    }
+
+    public function testAs(): void
+    {
+        $transform = new Transform();
+        $parse = $transform->as('hej', function (Intermediate $x, Closure $cc): Result {
+            return $cc($x->accept());
+        });
+
+        $result = $parse(new Intermediate('lorem'), static function (Result $x): Result {
+            return $x->map(static fn (Intermediate $x): array => $x->accepted());
+        });
+
+        $this->assertTrue($result->isOK());
+        $this->assertEquals(['hej' => 'l'], $result->value());
+    }
+}


### PR DESCRIPTION
This PR introduces a new data type LanguageTag.
The language tag is validated by the RFC as it is defined here: https://www.ietf.org/rfc/bcp/bcp47.txt.
This is the continuation of PR #4653.

This will be used in: https://github.com/ILIAS-eLearning/ILIAS/pull/4082