### PR TITLE
[FIX] file.js can remove files manualy again.

### DIFF
--- a/src/UI/templates/js/Input/Field/file.js
+++ b/src/UI/templates/js/Input/Field/file.js
@@ -203,7 +203,7 @@ il.UI.Input = il.UI.Input || {};
 				return;
 			}
 
-			let file_entry = removal_glyph.closest(SELECTOR.file_list);
+			let file_entry = removal_glyph.closest(SELECTOR.file_list_entry);
 			let file_entry_input = getFileEntryInput(file_entry);
 
 			dropzone.options.current_file_count--;


### PR DESCRIPTION
Hi @Amstutz

Here's the other issue I've mentioned in #4981. The problem was when uploading two (or more) files and then removing one using the close-glyph, the form submission aborted because the corresponding dropzone instance couldn't be found. It was merely a mixe-up of the query-selectors though and hence a minor fix (but caused me a headache anyways =)).

Kind regards!