### PR TITLE
CSS: Fix Big in LPG of Learning Modules, see #34163 and #34163

### DIFF
--- a/Services/Tracking/classes/repository_statistics/class.ilLPCollectionSettingsTableGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilLPCollectionSettingsTableGUI.php
@@ -14,6 +14,9 @@ class ilLPCollectionSettingsTableGUI extends ilTable2GUI
 
     protected ilObjectDefinition $obj_definition;
 
+    protected \ILIAS\UI\Factory $ui_factory;
+    protected \ILIAS\UI\Renderer $renderer;
+
     public function __construct(
         ?object $a_parent_obj,
         string $a_parent_cmd,
@@ -21,6 +24,9 @@ class ilLPCollectionSettingsTableGUI extends ilTable2GUI
         int $a_mode
     ) {
         global $DIC;
+
+        $this->ui_factory = $DIC->ui()->factory();
+        $this->renderer = $DIC->ui()->renderer();
 
         $this->obj_definition = $DIC["objDefinition"];
         $this->node_id = $a_node_id;
@@ -81,23 +87,9 @@ class ilLPCollectionSettingsTableGUI extends ilTable2GUI
         $this->tpl->setVariable('COLL_TITLE', $a_set['title'] ?? "");
         $this->tpl->setVariable('COLL_DESC', $a_set['description'] ?? "");
 
-        if ($this->obj_definition->isPluginTypeName($a_set["type"])) {
-            $alt = ilObjectPlugin::lookupTxtById(
-                $a_set['type'],
-                "obj_" . $a_set['type']
-            );
-        } else {
-            $alt = $this->lng->txt('obj_' . $a_set['type']);
-        }
-        $this->tpl->setVariable('ALT_IMG', $alt);
-        $this->tpl->setVariable(
-            'TYPE_IMG',
-            ilObject::_getIcon(
-                (int) ($a_set['obj_id'] ?? 0),
-                'tiny',
-                $a_set['type']
-            )
-        );
+        $icon_path = ilObject::_getIcon((int) ($a_set['obj_id'] ?? 0), 'tiny', $a_set['type']);
+        $icon = $this->ui_factory->symbol()->icon()->custom($icon_path, "");
+        $this->tpl->setVariable("ICON", $this->renderer->render($icon));
 
         if (
             $this->getMode() != ilLPObjSettings::LP_MODE_COLLECTION_MANUAL &&

--- a/Services/Tracking/templates/default/tpl.lp_collection_row.html
+++ b/Services/Tracking/templates/default/tpl.lp_collection_row.html
@@ -5,7 +5,7 @@
 	<td class="std" valign="top">
 		<div>
 			<!-- BEGIN item_row -->
-			<img src="{TYPE_IMG}" alt="{ALT_IMG}" title="{ALT_IMG}" class="ilListItemIcon" /> <a href="{COLL_LINK}" target="{COLL_FRAME}">{COLL_TITLE}</a>
+			{ICON}<a href="{COLL_LINK}" target="{COLL_FRAME}">{COLL_TITLE}</a>
 			<!-- BEGIN description -->
 			<div class="il_Description_no_margin">{COLL_DESC}</div>
 			<!-- END description -->

--- a/Services/Tracking/templates/default/tpl.lp_collection_scorm_row.html
+++ b/Services/Tracking/templates/default/tpl.lp_collection_scorm_row.html
@@ -4,7 +4,7 @@
 	</td>
 	<td class="std" valign="top">
 		<!-- BEGIN item_row -->
-		<img src="{TYPE_IMG}" alt="{ALT_IMG}" title="{ALT_IMG}" /> {COLL_TITLE}
+		{ICON}{COLL_TITLE}
 		<!-- BEGIN description -->
 		<div class="il_Description_no_margin">{COLL_DESC}</div>
 		<!-- END description -->

--- a/Services/Tracking/templates/default/tpl.lp_collection_subitem_row.html
+++ b/Services/Tracking/templates/default/tpl.lp_collection_subitem_row.html
@@ -5,7 +5,7 @@
 	<td class="std" valign="top">
 		<div>
 			<!-- BEGIN item_row -->
-			<img src="{TYPE_IMG}" alt="{ALT_IMG}" title="{ALT_IMG}" /> <a href="{COLL_LINK}">{COLL_TITLE}</a>
+			{ICON}{COLL_TITLE}
 			<!-- END item_row -->
 		</div>		
 	</td>


### PR DESCRIPTION
Proposed fix for https://mantis.ilias.de/view.php?id=34163 and https://mantis.ilias.de/view.php?id=34161

Note that the alt text has been left empty, since we probably might consider the icons here as "decorative" since an title in plain text is given as well.