### PR TITLE
GlobalScreen/NotificationCenter: Fix 404 error when closing contact request notification

### DIFF
--- a/src/GlobalScreen/Client/Notifications.php
+++ b/src/GlobalScreen/Client/Notifications.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -67,7 +68,7 @@ class Notifications
     /**
      * Location of the endpoint handling async notification requests
      */
-    public const NOTIFY_ENDPOINT = ILIAS_HTTP_PATH . "/src/GlobalScreen/Client/notify.php";
+    public const NOTIFY_ENDPOINT = "./src/GlobalScreen/Client/notify.php";
     protected array $identifiers_to_handle = [];
     protected ?string $single_identifier_to_handle;
     protected array $administrative_notifications = [];

--- a/tests/GlobalScreen/Notification/Collector/Renderer/StandardNotificationRendererTest.php
+++ b/tests/GlobalScreen/Notification/Collector/Renderer/StandardNotificationRendererTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Renderer\Hasher;
 use ILIAS\GlobalScreen\Scope\Notification\Collector\Renderer\StandardNotificationRenderer;
 
@@ -51,7 +67,7 @@ class StandardNotificationRendererTest extends BaseNotificationSetUp
             ->withClosedCallable(function () {
             });
 
-        $item = $item->withCloseAction("http://localhost/src/GlobalScreen/Client/notify.php?mode=closed&item_id=" . $this->hash($this->id->serialize()));
+        $item = $item->withCloseAction("./src/GlobalScreen/Client/notify.php?mode=closed&item_id=" . $this->hash($this->id->serialize()));
         $this->assertEquals($item, $renderer->getNotificationComponentForItem($standard_notification));
     }
 }


### PR DESCRIPTION
Mantis Ticket: https://mantis.ilias.de/view.php?id=34212
When clicking on the "x" for new contact request the AJAX requests now the correct URL.