### PR TITLE
TA: Repo for ScoreSettings, UI Form

### DIFF
--- a/Modules/Test/classes/ScoreReporting/ScoreSettingsRepository.php
+++ b/Modules/Test/classes/ScoreReporting/ScoreSettingsRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+interface ScoreSettingsRepository
+{
+    public function getFor(int $test_id): ilObjTestScoreSettings;
+    public function store(ilObjTestScoreSettings $settings): void;
+}

--- a/Modules/Test/classes/ScoreReporting/TestSettings.php
+++ b/Modules/Test/classes/ScoreReporting/TestSettings.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
+use ILIAS\UI\Component\Input\Field\Input;
+use ILIAS\Refinery\Factory as Refinery;
+
+abstract class TestSettings
+{
+    protected int $test_id;
+
+    public function __construct(int $test_id)
+    {
+        $this->test_id = $test_id;
+    }
+
+    public function getTestId(): int
+    {
+        return $this->test_id;
+    }
+    public function withTestId(int $test_id): self
+    {
+        $clone = clone $this;
+        $clone->test_id = $test_id;
+        return $clone;
+    }
+
+    abstract public function toForm(
+        \ilLanguage $lng,
+        FieldFactory $f,
+        Refinery $refinery,
+        array $environment = null
+    ): Input;
+
+    abstract public function toStorage(): array;
+}

--- a/Modules/Test/classes/ScoreReporting/class.ilObjTestScoreSettings.php
+++ b/Modules/Test/classes/ScoreReporting/class.ilObjTestScoreSettings.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
+use ILIAS\UI\Component\Input\Field\Field;
+use ILIAS\Refinery\Factory as Refinery;
+
+use ILIAS\UI\Component\Input\Container\Form\Form;
+
+class ilObjTestScoreSettings
+{
+    protected int $test_id;
+    protected ilObjTestSettingsScoring $settings_scoring;
+    protected ilObjTestSettingsResultSummary $settings_result_summary;
+    protected ilObjTestSettingsResultDetails $settings_result_details;
+    protected ilObjTestSettingsGamification $settings_gamification;
+
+    public function __construct(
+        int $test_id,
+        ilObjTestSettingsScoring $settings_scoring,
+        ilObjTestSettingsResultSummary $settings_result_summary,
+        ilObjTestSettingsResultDetails $settings_result_details,
+        ilObjTestSettingsGamification $settings_gamification
+    ) {
+        $this->test_id = $test_id;
+
+        foreach ([
+            $settings_scoring,
+            $settings_result_summary,
+            $settings_result_details,
+            $settings_gamification
+        ] as $setting) {
+            $this->throwOnDifferentTestId($setting);
+        }
+
+        $settings_result_summary = $settings_result_summary
+            ->withShowPassDetails($settings_result_details->getShowPassDetails());
+
+        $this->settings_scoring = $settings_scoring;
+        $this->settings_result_summary = $settings_result_summary;
+        $this->settings_result_details = $settings_result_details;
+        $this->settings_gamification = $settings_gamification;
+    }
+
+    protected function throwOnDifferentTestId(TestSettings $setting)
+    {
+        if ($setting->getTestId() !== $this->getTestId()) {
+            throw new \LogicException('TestId mismatch in ' . get_class($setting));
+        }
+    }
+
+    public function getTestId(): int
+    {
+        return $this->test_id;
+    }
+    public function withTestId(int $test_id): self
+    {
+        $clone = clone $this;
+        $clone->test_id = $test_id;
+        $clone->settings_scoring = $clone->settings_scoring->withTestId($test_id);
+        $clone->settings_result_summary = $clone->settings_result_summary->withTestId($test_id);
+        $clone->settings_result_details = $clone->settings_result_details->withTestId($test_id);
+        $clone->settings_gamification = $clone->settings_gamification->withTestId($test_id);
+        return $clone;
+    }
+
+
+    public function getScoringSettings(): ilObjTestSettingsScoring
+    {
+        return $this->settings_scoring;
+    }
+    public function withScoringSettings(ilObjTestSettingsScoring $settings): self
+    {
+        $this->throwOnDifferentTestId($settings);
+        $clone = clone $this;
+        $clone->settings_scoring = $settings;
+        return $clone;
+    }
+
+    public function getResultSummarySettings(): ilObjTestSettingsResultSummary
+    {
+        return $this->settings_result_summary;
+    }
+    public function withResultSummarySettings(ilObjTestSettingsResultSummary $settings): self
+    {
+        $this->throwOnDifferentTestId($settings);
+        $clone = clone $this;
+        $clone->settings_result_summary = $settings;
+        return $clone;
+    }
+
+    public function getResultDetailsSettings(): ilObjTestSettingsResultDetails
+    {
+        return $this->settings_result_details;
+    }
+    public function withResultDetailsSettings(ilObjTestSettingsResultDetails $settings): self
+    {
+        $this->throwOnDifferentTestId($settings);
+        $clone = clone $this;
+        $clone->settings_result_details = $settings;
+        return $clone;
+    }
+
+    public function getGamificationSettings(): ilObjTestSettingsGamification
+    {
+        return $this->settings_gamification;
+    }
+    public function withGamificationSettings(ilObjTestSettingsGamification $settings): self
+    {
+        $this->throwOnDifferentTestId($settings);
+        $clone = clone $this;
+        $clone->settings_gamification = $settings;
+        return $clone;
+    }
+}

--- a/Modules/Test/classes/ScoreReporting/class.ilObjTestScoreSettingsDatabaseRepository.php
+++ b/Modules/Test/classes/ScoreReporting/class.ilObjTestScoreSettingsDatabaseRepository.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+class ilObjTestScoreSettingsDatabaseRepository implements ScoreSettingsRepository
+{
+    public const TABLE_NAME = 'tst_tests';
+    public const STORAGE_DATE_FORMAT = 'YmdHis';
+
+    protected ilDBInterface $db;
+
+    public function __construct(ilDBInterface $db)
+    {
+        $this->db = $db;
+    }
+
+    public function getForObjFi(int $obj_fi): ilObjTestScoreSettings
+    {
+        $where_part = 'WHERE obj_fi = ' . $this->db->quote($obj_fi, 'integer');
+        return $this->doSelect($where_part);
+    }
+
+    public function getFor(int $test_id): ilObjTestScoreSettings
+    {
+        $where_part = 'WHERE test_id = ' . $this->db->quote($test_id, 'integer');
+        return $this->doSelect($where_part);
+    }
+
+    protected function doSelect(string $where_part): ilObjTestScoreSettings
+    {
+        $query = 'SELECT ' . PHP_EOL
+            . 'test_id,' . PHP_EOL
+            . 'count_system, score_cutting, pass_scoring,' . PHP_EOL
+            . 'score_reporting, reporting_date,' . PHP_EOL
+            . 'show_grading_status, show_grading_mark, pass_deletion_allowed,' . PHP_EOL
+            . 'print_bs_with_res,' . PHP_EOL //print_bs_with_res_sp
+            . 'examid_in_test_res,' . PHP_EOL
+            . 'results_presentation,' . PHP_EOL
+            . 'exportsettings,' . PHP_EOL
+            . 'highscore_enabled, highscore_anon, highscore_achieved_ts, highscore_score, highscore_percentage, highscore_hints, highscore_wtime, highscore_own_table, highscore_top_table, highscore_top_num,' . PHP_EOL
+            . 'result_tax_filters' . PHP_EOL
+            . 'FROM ' . self::TABLE_NAME . PHP_EOL
+            . $where_part;
+
+        $res = $this->db->query($query);
+
+        if ($this->db->numRows($res) == 0) {
+            throw new \Exception('no score settings: ' . $where_part);
+        }
+
+        $row = $this->db->fetchAssoc($res);
+
+        $reporting_date = $row['reporting_date'];
+        if ($reporting_date) {
+            $reporting_date = \DateTimeImmutable::createFromFormat(
+                self::STORAGE_DATE_FORMAT,
+                $reporting_date
+            );
+        } else {
+            $reporting_date = null;
+        }
+
+        $test_id = (int) $row['test_id'];
+        $results_presentation = $row['results_presentation'];
+
+        $settings = new ilObjTestScoreSettings(
+            $test_id,
+            (new ilObjTestSettingsScoring($test_id))
+                ->withCountSystem((int) $row['count_system'])
+                ->withScoreCutting((int) $row['score_cutting'])
+                ->withPassScoring((int) $row['pass_scoring']),
+            (new ilObjTestSettingsResultSummary($test_id))
+                ->withScoreReporting((int) $row['score_reporting'])
+                ->withReportingDate($reporting_date)
+                ->withShowGradingStatusEnabled((bool) $row['show_grading_status'])
+                ->withShowGradingMarkEnabled((bool) $row['show_grading_mark'])
+                ->withPassDeletionAllowed((bool) $row['pass_deletion_allowed']),
+                //->withShowPassDetails derived from results_presentation with bit RESULTPRES_BIT_PASS_DETAILS
+            (new ilObjTestSettingsResultDetails($test_id))
+                ->withResultsPresentation((int)$row['results_presentation'])
+                ->withPrintBestSolutionWithResult((bool) $row['print_bs_with_res'])
+                ->withShowExamIdInTestResults((bool) $row['examid_in_test_res'])
+                ->withExportSettings((int) $row['exportsettings'])
+                ->withTaxonomyFilterIds(unserialize($row['result_tax_filters'])),
+            (new ilObjTestSettingsGamification($test_id))
+                ->withHighscoreEnabled((bool) $row['highscore_enabled'])
+                ->withHighscoreAnon((bool) $row['highscore_anon'])
+                ->withHighscoreAchievedTS((bool) $row['highscore_achieved_ts'])
+                ->withHighscoreScore((bool) $row['highscore_score'])
+                ->withHighscorePercentage((bool) $row['highscore_percentage'])
+                ->withHighscoreHints((bool) $row['highscore_hints'])
+                ->withHighscoreWTime((bool) $row['highscore_wtime'])
+                ->withHighscoreOwnTable((bool) $row['highscore_own_table'])
+                ->withHighscoreTopTable((bool) $row['highscore_top_table'])
+                ->withHighscoreTopNum((int) $row['highscore_top_num'])
+        );
+
+        return $settings;
+    }
+
+    public function store(ilObjTestScoreSettings $settings): void
+    {
+        $values = array_merge(
+            $settings->getScoringSettings()->toStorage(),
+            $settings->getResultSummarySettings()->toStorage(),
+            $settings->getResultDetailsSettings()
+            ->withShowPassDetails($settings->getResultSummarySettings()->getShowPassDetails())
+            ->toStorage(),
+            $settings->getGamificationSettings()->toStorage()
+        );
+
+        $this->db->update(
+            self::TABLE_NAME,
+            $values,
+            ['test_id' => ['integer', $settings->getTestId()]]
+        );
+    }
+}

--- a/Modules/Test/classes/ScoreReporting/ilObjTestSettingsGamification.php
+++ b/Modules/Test/classes/ScoreReporting/ilObjTestSettingsGamification.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
+use ILIAS\UI\Component\Input\Field\Input;
+use ILIAS\Refinery\Factory as Refinery;
+
+class ilObjTestSettingsGamification extends TestSettings
+{
+    public const HIGHSCORE_SHOW_OWN_TABLE = 1;
+    public const HIGHSCORE_SHOW_TOP_TABLE = 2;
+    public const HIGHSCORE_SHOW_ALL_TABLES = 3;
+
+    protected bool $highscore_enabled = false;
+    protected bool $highscore_anon = true;
+    protected bool $highscore_achieved_ts = true;
+    protected bool $highscore_score = true;
+    protected bool $highscore_percentage = true;
+    protected bool $highscore_hints = true;
+    protected bool $highscore_wtime = true;
+    protected bool $highscore_own_table = true;
+    protected bool $highscore_top_table = true;
+    protected int $highscore_top_num = 10;
+
+
+    public function __construct(int $test_id)
+    {
+        parent::__construct($test_id);
+    }
+
+    public function toForm(
+        \ilLanguage $lng,
+        FieldFactory $f,
+        Refinery $refinery,
+        array $environment = null
+    ): Input {
+        $optional_group = $f->optionalGroup(
+            [
+                'highscore_mode' => $f->radio($lng->txt('tst_highscore_mode'), "")
+                    ->withOption((string) self::HIGHSCORE_SHOW_OWN_TABLE, $lng->txt('tst_highscore_own_table'), $lng->txt('tst_highscore_own_table_description'))
+                    ->withOption((string) self::HIGHSCORE_SHOW_TOP_TABLE, $lng->txt('tst_highscore_top_table'), $lng->txt('tst_highscore_top_table_description'))
+                    ->withOption((string) self::HIGHSCORE_SHOW_ALL_TABLES, $lng->txt('tst_highscore_all_tables'), $lng->txt('tst_highscore_all_tables_description'))
+                    ->withValue($this->getHighScoreMode() > 0 ? (string) $this->getHighScoreMode() : '')
+                    ->withRequired(true)
+                    ,
+                'highscore_top_num' => $f->numeric($lng->txt('tst_highscore_top_num'), $lng->txt('tst_highscore_top_num_description'))
+                    ->withRequired(true)
+                    ->withValue($this->getHighscoreTopNum()),
+                'highscore_anon' => $f->checkbox(
+                    $lng->txt('tst_highscore_anon'),
+                    $lng->txt('tst_highscore_anon_description')
+                )->withValue($this->getHighscoreAnon()),
+                'highscore_achieved_ts' => $f->checkbox(
+                    $lng->txt('tst_highscore_achieved_ts'),
+                    $lng->txt('tst_highscore_achieved_ts_description')
+                )->withValue($this->getHighscoreAchievedTS()),
+                'highscore_score' => $f->checkbox(
+                    $lng->txt('tst_highscore_score'),
+                    $lng->txt('tst_highscore_score_description')
+                )->withValue($this->getHighscoreScore()),
+                'highscore_percentage' => $f->checkbox(
+                    $lng->txt('tst_highscore_percentage'),
+                    $lng->txt('tst_highscore_percentage_description')
+                )->withValue($this->getHighscorePercentage()),
+                'highscore_hints' => $f->checkbox(
+                    $lng->txt('tst_highscore_hints'),
+                    $lng->txt('tst_highscore_hints_description')
+                )->withValue($this->getHighscoreHints()),
+                'highscore_wtime' => $f->checkbox(
+                    $lng->txt('tst_highscore_wtime'),
+                    $lng->txt('tst_highscore_wtime_description')
+                )->withValue($this->getHighscoreWTime())
+
+            ],
+            $lng->txt('tst_highscore_enabled'),
+            $lng->txt('tst_highscore_description')
+        );
+
+        if (!$this->getHighscoreEnabled()) {
+            $optional_group = $optional_group->withValue(null);
+        }
+
+        $fields = ['highscore' => $optional_group];
+        return $f->section($fields, $lng->txt('tst_results_gamification'))
+            ->withAdditionalTransformation(
+                $refinery->custom()->transformation(
+                    function ($v) {
+                        $settings = clone $this;
+
+                        if (! $v['highscore']) {
+                            return $settings->withHighscoreEnabled(false);
+                        }
+
+                        return $settings
+                            ->withHighscoreEnabled(true)
+                            ->withHighscoreOwnTable(
+                                (int) $v['highscore']['highscore_mode'] == self::HIGHSCORE_SHOW_OWN_TABLE ||
+                                (int) $v['highscore']['highscore_mode'] == self::HIGHSCORE_SHOW_ALL_TABLES
+                            )
+                            ->withHighscoreTopTable(
+                                (int) $v['highscore']['highscore_mode'] == self::HIGHSCORE_SHOW_TOP_TABLE ||
+                                (int) $v['highscore']['highscore_mode'] == self::HIGHSCORE_SHOW_ALL_TABLES
+                            )
+                            ->withHighscoreTopNum($v['highscore']['highscore_top_num'])
+                            ->withHighscoreAnon($v['highscore']['highscore_anon'])
+                            ->withHighscoreAchievedTS($v['highscore']['highscore_achieved_ts'])
+                            ->withHighscoreScore($v['highscore']['highscore_score'])
+                            ->withHighscorePercentage($v['highscore']['highscore_percentage'])
+                            ->withHighscoreHints($v['highscore']['highscore_hints'])
+                            ->withHighscoreWTime($v['highscore']['highscore_wtime']);
+                    }
+                )
+            );
+    }
+
+    public function toStorage(): array
+    {
+        return [
+            'highscore_enabled' => ['integer', (int) $this->getHighscoreEnabled()],
+            'highscore_anon' => ['integer', (int) $this->getHighscoreAnon()],
+            'highscore_achieved_ts' => ['integer', (int) $this->getHighscoreAchievedTS()],
+            'highscore_score' => ['integer', (int) $this->getHighscoreScore()],
+            'highscore_percentage' => ['integer', (int) $this->getHighscorePercentage()],
+            'highscore_hints' => ['integer', (int) $this->getHighscoreHints()],
+            'highscore_wtime' => ['integer', (int) $this->getHighscoreWTime()],
+            'highscore_own_table' => ['integer', (int) $this->getHighscoreOwnTable()],
+            'highscore_top_table' => ['integer', (int) $this->getHighscoreTopTable()],
+            'highscore_top_num' => ['integer', $this->getHighscoreTopNum()]
+        ];
+    }
+
+    public function getHighscoreEnabled(): bool
+    {
+        return $this->highscore_enabled;
+    }
+    public function withHighscoreEnabled(bool $highscore_enabled): self
+    {
+        $clone = clone $this;
+        $clone->highscore_enabled = $highscore_enabled;
+        return $clone;
+    }
+
+    public function getHighscoreOwnTable(): bool
+    {
+        return $this->highscore_own_table;
+    }
+    public function withHighscoreOwnTable(bool $highscore_own_table): self
+    {
+        $clone = clone $this;
+        $clone->highscore_own_table = $highscore_own_table;
+        return $clone;
+    }
+    public function getHighscoreTopTable(): bool
+    {
+        return $this->highscore_top_table;
+    }
+    public function withHighscoreTopTable(bool $highscore_top_table): self
+    {
+        $clone = clone $this;
+        $clone->highscore_top_table = $highscore_top_table;
+        return $clone;
+    }
+
+    public function getHighScoreMode(): int
+    {
+        if ($this->getHighscoreTopTable() && $this->getHighscoreOwnTable()) {
+            return self::HIGHSCORE_SHOW_ALL_TABLES;
+        }
+
+        if ($this->getHighscoreTopTable()) {
+            return self::HIGHSCORE_SHOW_TOP_TABLE;
+        }
+
+        if ($this->getHighscoreOwnTable()) {
+            return self::HIGHSCORE_SHOW_OWN_TABLE;
+        }
+
+        return 0;
+    }
+
+    public function getHighscoreTopNum(): int
+    {
+        return $this->highscore_top_num;
+    }
+    public function withHighscoreTopNum(int $highscore_top_num): self
+    {
+        $clone = clone $this;
+        $clone->highscore_top_num = $highscore_top_num;
+        return $clone;
+    }
+
+    public function getHighscoreAnon(): bool
+    {
+        return $this->highscore_anon;
+    }
+    public function withHighscoreAnon(bool $highscore_anon): self
+    {
+        $clone = clone $this;
+        $clone->highscore_anon = $highscore_anon;
+        return $clone;
+    }
+
+    public function getHighscoreAchievedTS(): bool
+    {
+        return $this->highscore_achieved_ts;
+    }
+    public function withHighscoreAchievedTS(bool $highscore_achieved_ts): self
+    {
+        $clone = clone $this;
+        $clone->highscore_achieved_ts = $highscore_achieved_ts;
+        return $clone;
+    }
+
+    public function getHighscoreScore(): bool
+    {
+        return $this->highscore_score;
+    }
+    public function withHighscoreScore(bool $highscore_score): self
+    {
+        $clone = clone $this;
+        $clone->highscore_score = $highscore_score;
+        return $clone;
+    }
+
+    public function getHighscorePercentage(): bool
+    {
+        return $this->highscore_percentage;
+    }
+    public function withHighscorePercentage(bool $highscore_percentage): self
+    {
+        $clone = clone $this;
+        $clone->highscore_percentage = $highscore_percentage;
+        return $clone;
+    }
+
+    public function getHighscoreHints(): bool
+    {
+        return $this->highscore_hints;
+    }
+    public function withHighscoreHints(bool $highscore_hints): self
+    {
+        $clone = clone $this;
+        $clone->highscore_hints = $highscore_hints;
+        return $clone;
+    }
+
+    public function getHighscoreWTime(): bool
+    {
+        return $this->highscore_wtime;
+    }
+    public function withHighscoreWTime(bool $highscore_wtime): self
+    {
+        $clone = clone $this;
+        $clone->highscore_wtime = $highscore_wtime;
+        return $clone;
+    }
+}

--- a/Modules/Test/classes/ScoreReporting/ilObjTestSettingsResultDetails.php
+++ b/Modules/Test/classes/ScoreReporting/ilObjTestSettingsResultDetails.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
+use ILIAS\UI\Component\Input\Field\Input;
+use ILIAS\Refinery\Factory as Refinery;
+
+class ilObjTestSettingsResultDetails extends TestSettings
+{
+    public const RESULTPRES_BIT_PASS_DETAILS = 1;
+    public const RESULTPRES_BIT_SOLUTION_DETAILS = 2;
+    public const RESULTPRES_BIT_SOLUTION_PRINTVIEW = 4;
+    public const RESULTPRES_BIT_SOLUTION_FEEDBACK = 8;
+    public const RESULTPRES_BIT_SOLUTION_ANSWERS_ONLY = 16;
+    public const RESULTPRES_BIT_SOLUTION_SIGNATURE = 32;
+    public const RESULTPRES_BIT_SOLUTION_SUGGESTED = 64;
+    public const RESULTPRES_BIT_SOLUTION_LISTCOMPARE = 128;
+    public const RESULTPRES_BIT_SOLUTION_LISTOWNANSWERS = 256;
+
+    public const EXPORT_BIT_SINGLECHOICE_SHORT = 1;
+
+    protected bool $print_bs_with_res = true;
+    protected bool $examid_in_test_res = true;
+    protected int $exportsettings = 0;
+    protected int $results_presentation = 0;
+    protected array $taxonomy_filter_ids = [];
+
+
+    public function __construct(int $test_id)
+    {
+        parent::__construct($test_id);
+    }
+
+    public function toForm(
+        \ilLanguage $lng,
+        FieldFactory $f,
+        Refinery $refinery,
+        array $environment = null
+    ): Input {
+        $bool_with_optional_addition = $refinery->custom()->transformation(
+            function ($v) {
+                if (!$v) {
+                    return [false, false]; //[enabled, show_best_solution]
+                }
+                return [true, array_shift($v)];
+            }
+        );
+
+        $optgroup_lists = $f->optionalGroup(
+            [
+                $f->checkbox(
+                    $lng->txt('tst_results_print_best_solution'),
+                    $lng->txt('tst_results_print_best_solution_info')
+                )->withValue($this->getShowSolutionListComparison())
+            ],
+            $lng->txt('tst_show_solution_details'),
+            $lng->txt('tst_show_solution_details_desc')
+        )->withAdditionalTransformation($bool_with_optional_addition);
+
+        if (!$this->getShowSolutionListOwnAnswers()) {
+            $optgroup_lists = $optgroup_lists->withValue(null);
+        }
+
+        $optgroup_singlepage = $f->optionalGroup(
+            [
+                $f->checkbox(
+                    $lng->txt('tst_results_print_best_solution_singlepage'),
+                    $lng->txt('tst_results_print_best_solution_singlepage_info')
+                )->withValue($this->getPrintBestSolutionWithResult())
+            ],
+            $lng->txt('tst_show_solution_details_singlepage'),
+            $lng->txt('tst_show_solution_details_singlepage_desc')
+        )->withAdditionalTransformation($bool_with_optional_addition);
+        if (!$this->getShowSolutionDetails()) {
+            $optgroup_singlepage = $optgroup_singlepage->withValue(null);
+        }
+
+
+        $taxonomy_options = $environment['taxonomy_options'];
+        $taxonomy_ids = $f->multiselect(
+            $lng->txt('tst_results_tax_filters'),
+            $taxonomy_options,
+            ''
+        );
+
+        $fields = [
+            'solution_details' => $optgroup_lists,
+            'solution_details_singlepage' => $optgroup_singlepage,
+
+            'solution_feedback' => $f->checkbox(
+                $lng->txt('tst_show_solution_feedback'),
+                $lng->txt('tst_show_solution_feedback_desc')
+            )->withValue($this->getShowSolutionFeedback()),
+            'solution_suggested' => $f->checkbox(
+                $lng->txt('tst_show_solution_suggested'),
+                $lng->txt('tst_show_solution_suggested_desc')
+            )->withValue($this->getShowSolutionSuggested()),
+            'solution_printview' => $f->checkbox(
+                $lng->txt('tst_show_solution_printview'),
+                $lng->txt('tst_show_solution_printview_desc')
+            )->withValue($this->getShowSolutionPrintview()),
+            'solution_hide_page' => $f->checkbox(
+                $lng->txt('tst_hide_pagecontents'),
+                $lng->txt('tst_hide_pagecontents_desc')
+            )->withValue($this->getShowSolutionAnswersOnly()),
+
+            'solution_signature' => $f->checkbox(
+                $lng->txt('tst_show_solution_signature'),
+                $lng->txt('tst_show_solution_signature_desc')
+            )
+            ->withValue($this->getShowSolutionSignature())
+            //TODO ?->withDisabled($anonymity)
+            ,
+            'examid_in_test_res' => $f->checkbox(
+                $lng->txt('examid_in_test_res'),
+                $lng->txt('examid_in_test_res_desc')
+            )->withValue($this->getShowExamIdInTestResults()),
+            'exp_sc_short' => $f->checkbox(
+                $lng->txt('tst_exp_sc_short'),
+                $lng->txt('tst_exp_sc_short_desc')
+            )->withValue($this->getExportSettingsSingleChoiceShort()),
+            'result_tax_filters' => $taxonomy_ids
+                ->withValue($this->getTaxonomyFilterIds())
+        ];
+
+        return $f->section($fields, $lng->txt('tst_results_details_options'))
+            ->withAdditionalTransformation(
+                $refinery->custom()->transformation(
+                    function ($v) {
+                        list($solution_list_details, $solution_list_best_solution) = $v['solution_details'];
+                        list($solution_sp_details, $solution_sp_best_solution) = $v['solution_details_singlepage'];
+                        return (clone $this)
+                            ->withShowSolutionListOwnAnswers($solution_list_details)
+                            ->withShowSolutionListComparison($solution_list_best_solution)
+                            ->withShowSolutionDetails($solution_sp_details)
+                            ->withPrintBestSolutionWithResult($solution_sp_best_solution)
+                            ->withShowSolutionFeedback($v['solution_feedback'])
+                            ->withShowSolutionSuggested($v['solution_suggested'])
+                            ->withShowSolutionPrintview($v['solution_printview'])
+                            ->withShowSolutionAnswersOnly($v['solution_hide_page'])
+                            ->withShowSolutionSignature($v['solution_signature'])
+                            ->withShowExamIdInTestResults($v["examid_in_test_res"])
+                            ->withExportSettingsSingleChoiceShort($v["exp_sc_short"])
+                            ->withTaxonomyFilterIds($v["result_tax_filters"] ?? []);
+                    }
+                )
+            );
+    }
+
+    public function toStorage(): array
+    {
+        return [
+            'print_bs_with_res' => ['integer', (int) $this->getPrintBestSolutionWithResult()],
+            'results_presentation' => ['integer', $this->getResultsPresentation()],
+            'examid_in_test_res' => ['integer', (int) $this->getShowExamIdInTestResults()],
+            'exportsettings' => ['integer', (int) $this->getExportSettings()],
+            'results_presentation' => ['integer', (int) $this->getResultsPresentation()],
+            'result_tax_filters' => ['string', serialize($this->getTaxonomyFilterIds())]
+        ];
+    }
+
+
+    public function getPrintBestSolutionWithResult(): bool
+    {
+        return $this->print_bs_with_res;
+    }
+    public function withPrintBestSolutionWithResult(bool $print_bs_with_res): self
+    {
+        $clone = clone $this;
+        $clone->print_bs_with_res = $print_bs_with_res;
+        return $clone;
+    }
+
+    public function getResultsPresentation(): int
+    {
+        return $this->results_presentation;
+    }
+    public function withResultsPresentation(int $results_presentation): self
+    {
+        $clone = clone $this;
+        $clone->results_presentation = $results_presentation;
+        return $clone;
+    }
+
+    public function getShowExamIdInTestResults(): bool
+    {
+        return $this->examid_in_test_res;
+    }
+    public function withShowExamIdInTestResults(bool $examid_in_test_res): self
+    {
+        $clone = clone $this;
+        $clone->examid_in_test_res = $examid_in_test_res;
+        return $clone;
+    }
+
+    protected function compareResultPresentation(int $bit): bool
+    {
+        return ($this->results_presentation & $bit) > 0;
+    }
+    protected function modifyResultPresentation(int $bit, bool $flag): self
+    {
+        $clone = clone $this;
+        $v = $clone->results_presentation;
+
+        if ($flag) {
+            $v = $v | $bit;
+        } else {
+            if ($this->compareResultPresentation($bit)) {
+                $v = $v ^ $bit;
+            }
+        }
+        $clone->results_presentation = $v;
+        return $clone;
+    }
+
+    public function getShowPassDetails(): bool
+    {
+        return $this->compareResultPresentation(self::RESULTPRES_BIT_PASS_DETAILS);
+    }
+    public function withShowPassDetails(bool $flag): self
+    {
+        return $this->modifyResultPresentation(self::RESULTPRES_BIT_PASS_DETAILS, $flag);
+    }
+
+    public function getShowSolutionDetails(): bool
+    {
+        return $this->compareResultPresentation(self::RESULTPRES_BIT_SOLUTION_DETAILS);
+    }
+    public function withShowSolutionDetails(bool $flag): self
+    {
+        return $this->modifyResultPresentation(self::RESULTPRES_BIT_SOLUTION_DETAILS, $flag);
+    }
+
+    public function getShowSolutionPrintview(): bool
+    {
+        return $this->compareResultPresentation(self::RESULTPRES_BIT_SOLUTION_PRINTVIEW);
+    }
+    public function withShowSolutionPrintview(bool $flag): self
+    {
+        return $this->modifyResultPresentation(self::RESULTPRES_BIT_SOLUTION_PRINTVIEW, $flag);
+    }
+
+    public function getShowSolutionFeedback(): bool
+    {
+        return $this->compareResultPresentation(self::RESULTPRES_BIT_SOLUTION_FEEDBACK);
+    }
+    public function withShowSolutionFeedback(bool $flag): self
+    {
+        return $this->modifyResultPresentation(self::RESULTPRES_BIT_SOLUTION_FEEDBACK, $flag);
+    }
+
+    public function getShowSolutionAnswersOnly(): bool
+    {
+        return $this->compareResultPresentation(self::RESULTPRES_BIT_SOLUTION_ANSWERS_ONLY);
+    }
+    public function withShowSolutionAnswersOnly(bool $flag): self
+    {
+        return $this->modifyResultPresentation(self::RESULTPRES_BIT_SOLUTION_ANSWERS_ONLY, $flag);
+    }
+
+    public function getShowSolutionSignature(): bool
+    {
+        return $this->compareResultPresentation(self::RESULTPRES_BIT_SOLUTION_SIGNATURE);
+    }
+    public function withShowSolutionSignature(bool $flag): self
+    {
+        return $this->modifyResultPresentation(self::RESULTPRES_BIT_SOLUTION_SIGNATURE, $flag);
+    }
+
+    public function getShowSolutionSuggested(): bool
+    {
+        return $this->compareResultPresentation(self::RESULTPRES_BIT_SOLUTION_SUGGESTED);
+    }
+    public function withShowSolutionSuggested(bool $flag): self
+    {
+        return $this->modifyResultPresentation(self::RESULTPRES_BIT_SOLUTION_SUGGESTED, $flag);
+    }
+
+    public function getShowSolutionListComparison(): bool
+    {
+        return $this->compareResultPresentation(self::RESULTPRES_BIT_SOLUTION_LISTCOMPARE);
+    }
+    public function withShowSolutionListComparison(bool $flag): self
+    {
+        return $this->modifyResultPresentation(self::RESULTPRES_BIT_SOLUTION_LISTCOMPARE, $flag);
+    }
+
+    public function getShowSolutionListOwnAnswers(): bool
+    {
+        return $this->compareResultPresentation(self::RESULTPRES_BIT_SOLUTION_LISTOWNANSWERS);
+    }
+    public function withShowSolutionListOwnAnswers(bool $flag): self
+    {
+        return $this->modifyResultPresentation(self::RESULTPRES_BIT_SOLUTION_LISTOWNANSWERS, $flag);
+    }
+
+    public function getExportSettings(): int
+    {
+        return $this->exportsettings;
+    }
+    public function withExportSettings(int $exportsettings): self
+    {
+        $clone = clone $this;
+        $clone->exportsettings = $exportsettings;
+        return $clone;
+    }
+    protected function compareExportSetting(int $bit): bool
+    {
+        return ($this->exportsettings & $bit) > 0;
+    }
+    protected function modifyExportSetting(int $bit, bool $flag): self
+    {
+        $clone = clone $this;
+        $v = $clone->exportsettings;
+
+        if ($flag) {
+            $v = $v | $bit;
+        } else {
+            if ($this->compareExportSetting($bit)) {
+                $v = $v ^ $bit;
+            }
+        }
+        $clone->exportsettings = $v;
+        return $clone;
+    }
+    public function getExportSettingsSingleChoiceShort(): bool
+    {
+        return $this->compareExportSetting(self::EXPORT_BIT_SINGLECHOICE_SHORT);
+    }
+    public function withExportSettingsSingleChoiceShort(bool $flag): self
+    {
+        return $this->modifyExportSetting(self::EXPORT_BIT_SINGLECHOICE_SHORT, $flag);
+    }
+
+    public function getTaxonomyFilterIds(): array
+    {
+        return $this->taxonomy_filter_ids;
+    }
+    public function withTaxonomyFilterIds(array $taxonomy_filter_ids): self
+    {
+        $clone = clone $this;
+        $clone->taxonomy_filter_ids = $taxonomy_filter_ids;
+        return $clone;
+    }
+}

--- a/Modules/Test/classes/ScoreReporting/ilObjTestSettingsResultSummary.php
+++ b/Modules/Test/classes/ScoreReporting/ilObjTestSettingsResultSummary.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
+use ILIAS\UI\Component\Input\Field\Input;
+use ILIAS\Refinery\Factory as Refinery;
+
+class ilObjTestSettingsResultSummary extends TestSettings
+{
+    public const SCORE_REPORTING_DISABLED = 0;
+    public const SCORE_REPORTING_FINISHED = 1;
+    public const SCORE_REPORTING_IMMIDIATLY = 2;
+    public const SCORE_REPORTING_DATE = 3;
+    public const SCORE_REPORTING_AFTER_PASSED = 4;
+
+    protected int $score_reporting = 0;
+    protected ?\DateTimeImmutable $reporting_date = null;
+    protected bool $pass_deletion_allowed = false;
+    /**
+     * this is derived from results_presentation with RESULTPRES_BIT_PASS_DETAILS;
+     * see ilObjTestSettingsResultDetails
+     */
+    protected bool $show_pass_details = false;
+
+    public function __construct(int $test_id)
+    {
+        parent::__construct($test_id);
+    }
+
+    public function toForm(
+        \ilLanguage $lng,
+        FieldFactory $f,
+        Refinery $refinery,
+        array $environment = null
+    ): Input {
+        $trafo = $refinery->custom()->transformation(
+            function ($v) {
+                list($mode, $date) = $v;
+                if (count($date) < 1) {
+                    $date = null;
+                } else {
+                    $date = array_shift($date);
+                }
+                return [(int) $mode, $date];
+            }
+        );
+
+        $results_time_group = $f->switchableGroup(
+            [
+                self::SCORE_REPORTING_IMMIDIATLY => $f->group([], $lng->txt('tst_results_access_always'), $lng->txt('tst_results_access_always_desc')),
+                self::SCORE_REPORTING_FINISHED => $f->group([], $lng->txt('tst_results_access_finished'), $lng->txt('tst_results_access_finished_desc')),
+                self::SCORE_REPORTING_AFTER_PASSED => $f->group([], $lng->txt('tst_results_access_passed'), $lng->txt('tst_results_access_passed_desc')),
+                self::SCORE_REPORTING_DATE => $f->group(
+                    [
+                    $f->dateTime($lng->txt('tst_reporting_date'), "")
+                        ->withUseTime(true)
+                        ->withValue($this->getReportingDate())
+                        ->withRequired(true)
+                    ],
+                    $lng->txt('tst_results_access_date'),
+                    $lng->txt('tst_results_access_date_desc')
+                )
+            ],
+            $lng->txt('tst_results_access_setting'),
+            ""
+        )
+        ->withRequired(true)
+        ->withAdditionalTransformation($trafo);
+
+        if ($this->getScoreReporting() > 0) {
+            $results_time_group = $results_time_group->withValue($this->getScoreReporting());
+        }
+
+
+        $optional_group = $f->optionalGroup(
+            [
+                'score_reporting_mode' => $results_time_group,
+                'show_grading_status' => $f->checkbox(
+                    $lng->txt('tst_results_grading_opt_show_status'),
+                    $lng->txt('tst_results_grading_opt_show_status_desc')
+                ),
+                'show_grading_mark' => $f->checkbox(
+                    $lng->txt('tst_results_grading_opt_show_mark'),
+                    $lng->txt('tst_results_grading_opt_show_mark_desc')
+                ),
+                'show_pass_details' => $f->checkbox(
+                    $lng->txt('tst_results_grading_opt_show_details'),
+                    $lng->txt('tst_results_grading_opt_show_details_desc')
+                ),
+                'pass_deletion_allowed' => $f->checkbox(
+                    $lng->txt('tst_pass_deletion'),
+                    $lng->txt('tst_pass_deletion_allowed')
+                )
+            ],
+            $lng->txt('tst_results_access_enabled'),
+            $lng->txt('tst_results_access_enabled_desc')
+        );
+
+        if ($this->getScoreReportingEnabled()) {
+            $optional_group = $optional_group->withValue(
+                [
+                    "score_reporting_mode" => $this->getScoreReporting(),
+                    "show_grading_status" => $this->getShowGradingStatusEnabled(),
+                    "show_grading_mark" => $this->getShowGradingMarkEnabled(),
+                    "show_pass_details" => $this->getShowPassDetails(),
+                    "pass_deletion_allowed" => $this->getPassDeletionAllowed()
+                ]
+            );
+        } else {
+            $optional_group = $optional_group->withValue(null);
+        }
+
+        $fields = ['score_reporting' => $optional_group];
+        return $f->section($fields, $lng->txt('test_results'))
+            ->withAdditionalTransformation(
+                $refinery->custom()->transformation(
+                    function ($v) {
+                        $settings = clone $this;
+                        $mode = 0;
+                        $date = null;
+                        if ($v['score_reporting']) {
+                            list($mode, $date) = $v['score_reporting']['score_reporting_mode'];
+                            $settings = $settings
+                                ->withShowGradingStatusEnabled($v['score_reporting']['show_grading_status'])
+                                ->withShowGradingMarkEnabled($v['score_reporting']['show_grading_mark'])
+                                ->withShowPassDetails($v['score_reporting']['show_pass_details'])
+                                ->withPassDeletionAllowed($v['score_reporting']['pass_deletion_allowed'])
+                            ;
+                        }
+                        return $settings
+                            ->withScoreReporting((int) $mode)
+                            ->withReportingDate($date);
+                    }
+                )
+            );
+    }
+
+    public function toStorage(): array
+    {
+        $dat = $this->getReportingDate();
+        if ($dat) {
+            $dat = $dat->format(ilObjTestScoreSettingsDatabaseRepository::STORAGE_DATE_FORMAT);
+        }
+        return [
+            'pass_deletion_allowed' => ['integer', (int) $this->getPassDeletionAllowed()],
+            'score_reporting' => ['integer', $this->getScoreReporting()],
+            'reporting_date' => ['text', (string) $dat],
+            'show_grading_status' => ['integer', (int) $this->getShowGradingStatusEnabled()],
+            'show_grading_mark' => ['integer', (int) $this->getShowGradingMarkEnabled()]
+            //show_pass_details
+        ];
+    }
+
+
+    public function getScoreReporting(): int
+    {
+        return $this->score_reporting;
+    }
+    public function withScoreReporting(int $score_reporting): self
+    {
+        $clone = clone $this;
+        $clone->score_reporting = $score_reporting;
+        return $clone;
+    }
+
+    public function getScoreReportingEnabled(): bool
+    {
+        return $this->score_reporting !== self::SCORE_REPORTING_DISABLED;
+    }
+
+    public function getReportingDate(): ?\DateTimeImmutable
+    {
+        return $this->reporting_date;
+    }
+    public function withReportingDate(?\DateTimeImmutable $reporting_date): self
+    {
+        $clone = clone $this;
+        $clone->reporting_date = $reporting_date;
+        return $clone;
+    }
+
+    public function getShowGradingStatusEnabled(): bool
+    {
+        return $this->show_grading_status;
+    }
+    public function withShowGradingStatusEnabled(bool $show_grading_status): self
+    {
+        $clone = clone $this;
+        $clone->show_grading_status = $show_grading_status;
+        return $clone;
+    }
+
+    public function getShowGradingMarkEnabled(): bool
+    {
+        return $this->show_grading_mark;
+    }
+    public function withShowGradingMarkEnabled(bool $show_grading_mark): self
+    {
+        $clone = clone $this;
+        $clone->show_grading_mark = $show_grading_mark;
+        return $clone;
+    }
+
+    public function getPassDeletionAllowed(): bool
+    {
+        return $this->pass_deletion_allowed;
+    }
+    public function withPassDeletionAllowed(bool $pass_deletion_allowed): self
+    {
+        $clone = clone $this;
+        $clone->pass_deletion_allowed = $pass_deletion_allowed;
+        return $clone;
+    }
+
+    public function getShowPassDetails(): bool
+    {
+        return $this->show_pass_details;
+    }
+    public function withShowPassDetails(bool $flag): self
+    {
+        $clone = clone $this;
+        $clone->show_pass_details = $flag;
+        return $clone;
+    }
+}

--- a/Modules/Test/classes/ScoreReporting/ilObjTestSettingsScoring.php
+++ b/Modules/Test/classes/ScoreReporting/ilObjTestSettingsScoring.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
+use ILIAS\UI\Component\Input\Field\Input;
+use ILIAS\Refinery\Factory as Refinery;
+
+class ilObjTestSettingsScoring extends TestSettings
+{
+    protected int $count_system = 0;
+    protected int $score_cutting = 0;
+    protected int $pass_scoring = 0;
+
+
+    public function __construct(int $test_id)
+    {
+        parent::__construct($test_id);
+    }
+
+    public function toForm(
+        \ilLanguage $lng,
+        FieldFactory $f,
+        Refinery $refinery,
+        array $environment = null
+    ): Input {
+        $trafo = $refinery->kindlyTo()->Int();
+        $fields = [
+            'count_system' => $f->radio($lng->txt('tst_text_count_system'), "")
+                ->withOption('0', $lng->txt('tst_count_partial_solutions'), $lng->txt('tst_count_partial_solutions_desc'))
+                ->withOption('1', $lng->txt('tst_count_correct_solutions'), $lng->txt('tst_count_correct_solutions_desc'))
+                ->withValue($this->getCountSystem())
+                ->withAdditionalTransformation($trafo),
+            'score_cutting' => $f->radio($lng->txt('tst_score_cutting'), "")
+                ->withOption('0', $lng->txt('tst_score_cut_question'), $lng->txt('tst_score_cut_question_desc'))
+                ->withOption('1', $lng->txt('tst_score_cut_test'), $lng->txt('tst_score_cut_test_desc'))
+                ->withValue($this->getScoreCutting())
+                ->withAdditionalTransformation($trafo),
+            'pass_scoring' => $f->radio($lng->txt('tst_pass_scoring'), "")
+                ->withOption('0', $lng->txt('tst_pass_last_pass'), $lng->txt('tst_pass_last_pass_desc'))
+                ->withOption('1', $lng->txt('tst_pass_best_pass'), $lng->txt('tst_pass_best_pass_desc'))
+                ->withValue($this->getPassScoring())
+                ->withAdditionalTransformation($trafo)
+        ];
+        return $f->section($fields, $lng->txt('test_scoring'))
+            ->withAdditionalTransformation(
+                $refinery->custom()->transformation(
+                    function ($v) {
+                        return (clone $this)
+                            ->withCountSystem($v['count_system'])
+                            ->withScoreCutting($v['score_cutting'])
+                            ->withPassScoring($v['pass_scoring']);
+                    }
+                )
+            );
+    }
+
+    public function toStorage(): array
+    {
+        return [
+            'count_system' => ['text', $this->getCountSystem()],
+            'score_cutting' => ['text', $this->getScoreCutting()],
+            'pass_scoring' => ['text', $this->getPassScoring()]
+        ];
+    }
+
+
+    public function getCountSystem(): int
+    {
+        return $this->count_system;
+    }
+    public function withCountSystem(int $count_system): self
+    {
+        $clone = clone $this;
+        $clone->count_system = $count_system;
+        return $clone;
+    }
+
+    public function getScoreCutting(): int
+    {
+        return $this->score_cutting;
+    }
+    public function withScoreCutting(int $score_cutting): self
+    {
+        $clone = clone $this;
+        $clone->score_cutting = $score_cutting;
+        return $clone;
+    }
+
+    public function getPassScoring(): int
+    {
+        return $this->pass_scoring;
+    }
+    public function withPassScoring(int $pass_scoring): self
+    {
+        $clone = clone $this;
+        $clone->pass_scoring = $pass_scoring;
+        return $clone;
+    }
+}

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -350,7 +350,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->redirection_mode = 0;
         $this->redirection_url = null;
         $this->show_exam_id_in_test_pass_enabled = false;
-        $this->show_exam_id_in_test_results_enabled = false;
+        //$this->show_exam_id_in_test_results_enabled = false;
         $this->sign_submission = false;
         $this->char_selector_availability = 0;
         $this->char_selector_definition = null;
@@ -10550,7 +10550,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
      */
     public function isShowExamIdInTestResultsEnabled(): bool
     {
-        return $this->show_exam_id_in_test_results_enabled;
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowExamIdInTestResults();
     }
 
     /**

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -10751,7 +10751,10 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
 
     public function getResultFilterTaxIds(): array
     {
-        return $this->getScoreSettings()->getResultDetailsSettings()->getTaxonomyFilterIds();
+        if ($this->getTestId() != -1) {
+            return $this->getScoreSettings()->getResultDetailsSettings()->getTaxonomyFilterIds();
+        }
+        return [];
     }
 
     public function isSkillServiceToBeConsidered(): bool

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -37,10 +37,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     public const QUESTION_SET_TYPE_RANDOM = 'RANDOM_QUEST_SET';
     private const QUESTION_SET_TYPE_DYNAMIC = 'DYNAMIC_QUEST_SET';
 
-    public const HIGHSCORE_SHOW_OWN_TABLE = 1;
-    public const HIGHSCORE_SHOW_TOP_TABLE = 2;
-    public const HIGHSCORE_SHOW_ALL_TABLES = 3;
-
     private string $questionSetType = self::QUESTION_SET_TYPE_FIXED;
     private bool $skillServiceEnabled = false;
     private array $resultFilterTaxIds = array();
@@ -113,28 +109,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     protected array $ects_grades = array();
 
     protected $enabled_view_mode;
-    protected $_highscore_enabled;
-    protected $_highscore_anon;
-    protected $_highscore_achieved_ts;
-    protected $_highscore_score;
-    protected $_highscore_percentage;
-    protected $_highscore_hints;
-    protected $_highscore_wtime;
-    protected $_highscore_own_table;
-    protected $_highscore_top_table;
-    protected $_highscore_top_num;
-
-    public int $count_system;
-    public int $mc_scoring;
-    public int $pass_scoring;
     public bool $shuffle_questions;
-
-    /**
-     * Contains the presentation settings for the test results
-     *
-     * @var bool|int|null
-     */
-    public $results_presentation;
 
     /**
      * Determines wheather or not a question summary is shown to the users
@@ -142,13 +117,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
      * @var bool|int
      */
     public $show_summary;
-
-    /**
-     * Determines if the score of every question should be cut at 0 points or the score of the complete test
-     *
-     * @var bool|int
-     */
-    public $score_cutting;
 
     /**
      * bool?
@@ -291,6 +259,8 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     protected $pass_waiting = "00:000:00:00:00";
     #endregion
 
+    protected ilDBInterface $db;
+
     /**
      * Constructor
      *
@@ -318,6 +288,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             1
         );
 
+        $this->score_settings = null;
         $this->test_id = -1;
         $this->author = $ilUser->fullname;
         $this->introductionEnabled = false;
@@ -341,11 +312,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->ects_fx = null;
         $this->shuffle_questions = false;
         $this->mailnottype = 0;
-        $this->exportsettings = 0;
         $this->show_summary = 8;
-        $this->count_system = COUNT_PARTIAL_SOLUTIONS;
-        $this->score_cutting = SCORE_CUT_QUESTION;
-        $this->pass_scoring = SCORE_LAST_PASS;
         $this->answer_feedback = 0;
         $this->password = "";
         $this->allowedUsers = "";
@@ -359,10 +326,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->show_cancel = 0;
         $this->show_marker = 0;
         $this->fixed_participants = 0;
-        $this->setShowPassDetails(true);
-        $this->setShowSolutionDetails(true);
-        $this->setShowSolutionAnswersOnly(false);
-        $this->setShowSolutionSignature(false);
         $this->testSession = false;
         $this->testSequence = false;
         $this->mailnotification = 0;
@@ -401,6 +364,8 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->testFinalBroken = false;
 
         $this->tmpCopyWizardCopyId = null;
+
+        $this->db = $DIC['ilDB'];
 
         parent::__construct($a_id, $a_call_by_reference);
     }
@@ -856,7 +821,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                 'processing_time' => array('text', $this->getProcessingTime()),
                 'enable_processing_time' => array('text', $this->getEnableProcessingTime()),
                 'reset_processing_time' => array('integer', $this->getResetProcessingTime()),
-                'reporting_date' => array('text', $this->getReportingDate()),
                 'starting_time_enabled' => array('integer', $this->isStartingTimeEnabled()),
                 'starting_time' => array('integer', $this->getStartingTime()),
                 'ending_time_enabled' => array('integer', $this->isEndingTimeEnabled()),
@@ -869,11 +833,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                 'ects_d' => array('float', strlen($this->ects_grades["D"]) ? $this->ects_grades["D"] : 10),
                 'ects_e' => array('float', strlen($this->ects_grades["E"]) ? $this->ects_grades["E"] : 0),
                 'ects_fx' => array('float', $this->getECTSFX()),
-                'count_system' => array('text', $this->getCountSystem()),
-                'score_cutting' => array('text', $this->getScoreCutting()),
-                'pass_scoring' => array('text', $this->getPassScoring()),
                 'shuffle_questions' => array('text', $this->getShuffleQuestions()),
-                'results_presentation' => array('integer', $this->getResultsPresentation()),
                 'show_summary' => array('integer', $this->getListOfQuestionsSettings()),
                 'password_enabled' => array('integer', (int) $this->isPasswordEnabled()),
                 'password' => array('text', $this->getPassword()),
@@ -881,29 +841,16 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                 'allowedusers' => array('integer', $this->getAllowedUsers()),
                 'alloweduserstimegap' => array('integer', $this->getAllowedUsersTimeGap()),
                 'mailnottype' => array('integer', $this->getMailNotificationType()),
-                'exportsettings' => array('integer', $this->getExportSettings()),
                 'mailnotification' => array('integer', $this->getMailNotification()),
                 'created' => array('integer', time()),
                 'tstamp' => array('integer', time()),
                 'enabled_view_mode' => array('text', $this->getEnabledViewMode()),
                 'template_id' => array('integer', $this->getTemplate()),
-                'print_bs_with_res' => array('integer', (int) $this->isBestSolutionPrintedWithResult()),
                 'obligations_enabled' => array('integer', (int) $this->areObligationsEnabled()),
                 'offer_question_hints' => array('integer', (int) $this->isOfferingQuestionHintsEnabled()),
-                'highscore_enabled' => array('integer', (int) $this->getHighscoreEnabled()),
-                'highscore_anon' => array('integer', (int) $this->getHighscoreAnon()),
-                'highscore_achieved_ts' => array('integer', (int) $this->getHighscoreAchievedTS()),
-                'highscore_score' => array('integer', (int) $this->getHighscoreScore()),
-                'highscore_percentage' => array('integer', (int) $this->getHighscorePercentage()),
-                'highscore_hints' => array('integer', (int) $this->getHighscoreHints()),
-                'highscore_wtime' => array('integer', (int) $this->getHighscoreWTime()),
-                'highscore_own_table' => array('integer', (int) $this->getHighscoreOwnTable()),
-                'highscore_top_table' => array('integer', (int) $this->getHighscoreTopTable()),
-                'highscore_top_num' => array('integer', $this->getHighscoreTopNum()),
                 'specific_feedback' => array('integer', $this->getSpecificAnswerFeedback()),
                 'autosave' => array('integer', (int) $this->getAutosave()),
                 'autosave_ival' => array('integer', $this->getAutosaveIval()),
-                'pass_deletion_allowed' => array('integer', (int) $this->isPassDeletionAllowed()),
                 'enable_examview' => array('integer', (int) $this->getEnableExamview()),
                 'show_examview_html' => array('integer', (int) $this->getShowExamviewHtml()),
                 'show_examview_pdf' => array('integer', (int) $this->getShowExamviewPdf()),
@@ -911,15 +858,12 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                 'redirection_url' => array('text', (string) $this->getRedirectionUrl()),
                 'enable_archiving' => array('integer', (int) $this->getEnableArchiving()),
                 'examid_in_test_pass' => array('integer', (int) $this->isShowExamIdInTestPassEnabled()),
-                'examid_in_test_res' => array('integer', (int) $this->isShowExamIdInTestResultsEnabled()),
                 'sign_submission' => array('integer', (int) $this->getSignSubmission()),
                 'question_set_type' => array('text', $this->getQuestionSetType()),
                 'char_selector_availability' => array('integer', $this->getCharSelectorAvailability()),
                 'char_selector_definition' => array('text', (string) $this->getCharSelectorDefinition()),
                 'skill_service' => array('integer', (int) $this->isSkillServiceEnabled()),
                 'result_tax_filters' => array('text', serialize($this->getResultFilterTaxIds())),
-                'show_grading_status' => array('integer', (int) $this->isShowGradingStatusEnabled()),
-                'show_grading_mark' => array('integer', (int) $this->isShowGradingMarkEnabled()),
                 'follow_qst_answer_fixation' => array('integer', (int) $this->isFollowupQuestionAnswerFixationEnabled()),
                 'inst_fb_answer_fixation' => array('integer', (int) $this->isInstantFeedbackAnswerFixationEnabled()),
                 'force_inst_fb' => array('integer', (int) $this->isForceInstantFeedbackEnabled()),
@@ -974,7 +918,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     'processing_time' => array('text', $this->getProcessingTime()),
                     'enable_processing_time' => array('text', $this->getEnableProcessingTime()),
                     'reset_processing_time' => array('integer', $this->getResetProcessingTime()),
-                    'reporting_date' => array('text', $this->getReportingDate()),
                     'starting_time_enabled' => array('integer', $this->isStartingTimeEnabled()),
                     'starting_time' => array('integer', $this->getStartingTime()),
                     'ending_time_enabled' => array('integer', $this->isEndingTimeEnabled()),
@@ -987,11 +930,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     'ects_d' => array('float', strlen($this->ects_grades["D"]) ? $this->ects_grades["D"] : null),
                     'ects_e' => array('float', strlen($this->ects_grades["E"]) ? $this->ects_grades["E"] : null),
                     'ects_fx' => array('float', $this->getECTSFX()),
-                    'count_system' => array('text', $this->getCountSystem()),
-                    'score_cutting' => array('text', $this->getScoreCutting()),
-                    'pass_scoring' => array('text', $this->getPassScoring()),
                     'shuffle_questions' => array('text', $this->getShuffleQuestions()),
-                    'results_presentation' => array('integer', $this->getResultsPresentation()),
                     'show_summary' => array('integer', $this->getListOfQuestionsSettings()),
                     'password_enabled' => array('integer', (int) $this->isPasswordEnabled()),
                     'password' => array('text', $this->getPassword()),
@@ -1004,23 +943,11 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     'tstamp' => array('integer', time()),
                     'enabled_view_mode' => array('text', $this->getEnabledViewMode()),
                     'template_id' => array('integer', $this->getTemplate()),
-                    'print_bs_with_res' => array('integer', (int) $this->isBestSolutionPrintedWithResult()),
                     'obligations_enabled' => array('integer', (int) $this->areObligationsEnabled()),
                     'offer_question_hints' => array('integer', (int) $this->isOfferingQuestionHintsEnabled()),
-                    'highscore_enabled' => array('integer', (int) $this->getHighscoreEnabled()),
-                    'highscore_anon' => array('integer', (int) $this->getHighscoreAnon()),
-                    'highscore_achieved_ts' => array('integer', (int) $this->getHighscoreAchievedTS()),
-                    'highscore_score' => array('integer', (int) $this->getHighscoreScore()),
-                    'highscore_percentage' => array('integer', (int) $this->getHighscorePercentage()),
-                    'highscore_hints' => array('integer', (int) $this->getHighscoreHints()),
-                    'highscore_wtime' => array('integer', (int) $this->getHighscoreWTime()),
-                    'highscore_own_table' => array('integer', (int) $this->getHighscoreOwnTable()),
-                    'highscore_top_table' => array('integer', (int) $this->getHighscoreTopTable()),
-                    'highscore_top_num' => array('integer', $this->getHighscoreTopNum()),
                     'specific_feedback' => array('integer', $this->getSpecificAnswerFeedback()),
                     'autosave' => array('integer', (int) $this->getAutosave()),
                     'autosave_ival' => array('integer', $this->getAutosaveIval()),
-                    'pass_deletion_allowed' => array('integer', (int) $this->isPassDeletionAllowed()),
                     'enable_examview' => array('integer', (int) $this->getEnableExamview()),
                     'show_examview_html' => array('integer', (int) $this->getShowExamviewHtml()),
                     'show_examview_pdf' => array('integer', (int) $this->getShowExamviewPdf()),
@@ -1028,7 +955,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     'redirection_url' => array('text', (string) $this->getRedirectionUrl()),
                     'enable_archiving' => array('integer', (int) $this->getEnableArchiving()),
                     'examid_in_test_pass' => array('integer', (int) $this->isShowExamIdInTestPassEnabled()),
-                    'examid_in_test_res' => array('integer', (int) $this->isShowExamIdInTestResultsEnabled()),
                     'sign_submission' => array('integer', (int) $this->getSignSubmission()),
                     'question_set_type' => array('text', $this->getQuestionSetType()),
                     'char_selector_availability' => array('integer', $this->getCharSelectorAvailability()),
@@ -1455,49 +1381,31 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             $this->setECTSFX($data->ects_fx);
             $this->mark_schema->flush();
             $this->mark_schema->loadFromDb($this->getTestId());
-            $this->setCountSystem($data->count_system);
             $this->setMailNotification($data->mailnotification);
             $this->setMailNotificationType($data->mailnottype);
-            $this->setExportSettings($data->exportsettings);
-            $this->setScoreCutting($data->score_cutting);
             $this->setPasswordEnabled($data->password_enabled);
             $this->setPassword($data->password);
             $this->setLimitUsersEnabled($data->limit_users_enabled);
             $this->setAllowedUsers($data->allowedusers);
             $this->setAllowedUsersTimeGap($data->alloweduserstimegap);
-            $this->setPassScoring($data->pass_scoring);
             $this->setObligationsEnabled($data->obligations_enabled);
             $this->setOfferingQuestionHintsEnabled($data->offer_question_hints);
             $this->setEnabledViewMode($data->enabled_view_mode);
             $this->setTemplate($data->template_id);
-            $this->setPrintBestSolutionWithResult((bool) $data->print_bs_with_res);
-            $this->setHighscoreEnabled((bool) $data->highscore_enabled);
-            $this->setHighscoreAnon((bool) $data->highscore_anon);
-            $this->setHighscoreAchievedTS((bool) $data->highscore_achieved_ts);
-            $this->setHighscoreScore((bool) $data->highscore_score);
-            $this->setHighscorePercentage((bool) $data->highscore_percentage);
-            $this->setHighscoreHints((bool) $data->highscore_hints);
-            $this->setHighscoreWTime((bool) $data->highscore_wtime);
-            $this->setHighscoreOwnTable((bool) $data->highscore_own_table);
-            $this->setHighscoreTopTable((bool) $data->highscore_top_table);
-            $this->setHighscoreTopNum((int) $data->highscore_top_num);
             $this->setOldOnlineStatus(!$this->getOfflineStatus());
             $this->setSpecificAnswerFeedback((int) $data->specific_feedback);
             $this->setAutosave((bool) $data->autosave);
             $this->setAutosaveIval((int) $data->autosave_ival);
-            $this->setPassDeletionAllowed($data->pass_deletion_allowed);
             $this->setEnableExamview((bool) $data->enable_examview);
             $this->setShowExamviewHtml((bool) $data->show_examview_html);
             $this->setShowExamviewPdf((bool) $data->show_examview_pdf);
             $this->setEnableArchiving((bool) $data->enable_archiving);
             $this->setShowExamIdInTestPassEnabled((bool) $data->examid_in_test_pass);
-            $this->setShowExamIdInTestResultsEnabled((bool) $data->examid_in_test_res);
             $this->setSignSubmission((bool) $data->sign_submission);
             $this->setQuestionSetType($data->question_set_type);
             $this->setCharSelectorAvailability((int) $data->char_selector_availability);
             $this->setCharSelectorDefinition($data->char_selector_definition);
             $this->setSkillServiceEnabled((bool) $data->skill_service);
-            $this->setResultFilterTaxIds(strlen($data->result_tax_filters) ? unserialize($data->result_tax_filters) : array());
             $this->setShowGradingStatusEnabled((bool) $data->show_grading_status);
             $this->setShowGradingMarkEnabled((bool) $data->show_grading_mark);
             $this->setFollowupQuestionAnswerFixationEnabled((bool) $data->follow_qst_answer_fixation);
@@ -1781,6 +1689,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
      *
      * @param int|string $score_reporting The score reporting
      * @see $score_reporting
+     * @deprecated
      */
     public function setScoreReporting($score_reporting = 0): void
     {
@@ -1959,7 +1868,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     */
     public function getCountSystem(): int
     {
-        return ($this->count_system) ? $this->count_system : 0;
+        return $this->getScoreSettings()->getScoringSettings()->getCountSystem();
     }
 
     /**
@@ -1992,9 +1901,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     * @access public
     * @see $score_cutting
     */
-    public function getScoreCutting()
+    public function getScoreCutting(): int
     {
-        return ($this->score_cutting) ? $this->score_cutting : 0;
+        return $this->getScoreSettings()->getScoringSettings()->getScoreCutting();
     }
 
     /**
@@ -2006,7 +1915,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     */
     public function getPassScoring(): int
     {
-        return ($this->pass_scoring) ? $this->pass_scoring : 0;
+        return $this->getScoreSettings()->getScoringSettings()->getPassScoring();
     }
 
     /**
@@ -2064,7 +1973,11 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     */
     public function getReportingDate(): ?string
     {
-        return (strlen($this->reporting_date)) ? $this->reporting_date : null;
+        $date = $this->getScoreSettings()->getResultSummarySettings()->getReportingDate();
+        if ($date) {
+            $date = $date->format('YmdHis'); //legacy-reasons ;(
+        }
+        return $date;
     }
 
     /**
@@ -2584,18 +2497,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     }
 
     /**
-    * Sets the count system for the calculation of points
-    *
-    * @param integer $a_count_system The count system for the calculation of points.
-    * @access public
-    * @see $count_system
-    */
-    public function setCountSystem($a_count_system = COUNT_PARTIAL_SOLUTIONS)
-    {
-        $this->count_system = $a_count_system;
-    }
-
-    /**
      * @return boolean
      */
     public function isPasswordEnabled(): ?bool
@@ -2626,37 +2527,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     public function setPassword($a_password = null): void
     {
         $this->password = $a_password;
-    }
-
-    /**
-    * Sets the type of score cutting
-    *
-    * @param integer $a_score_cutting The type of score cutting. 0 for cut questions, 1 for cut tests
-    * @access public
-    * @see $score_cutting
-    */
-    public function setScoreCutting($a_score_cutting = SCORE_CUT_QUESTION): void
-    {
-        $this->score_cutting = $a_score_cutting;
-    }
-
-    /**
-    * Sets the pass scoring
-    *
-    * @param integer $a_pass_scoring The pass scoring type
-    * @access public
-    * @see $pass_scoring
-    */
-    public function setPassScoring($a_pass_scoring = SCORE_LAST_PASS)
-    {
-        switch ($a_pass_scoring) {
-            case SCORE_BEST_PASS:
-                $this->pass_scoring = SCORE_BEST_PASS;
-                break;
-            default:
-                $this->pass_scoring = SCORE_LAST_PASS;
-                break;
-        }
     }
 
     /**
@@ -5048,6 +4918,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->setPasswordEnabled(false);
         $this->setLimitUsersEnabled(false);
 
+        $this->saveToDb();
+        $score_settings = $this->getScoreSettings();
+
         foreach ($assessment->qtimetadata as $metadata) {
             switch ($metadata["label"]) {
                 case "test_type":
@@ -5079,7 +4952,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     $this->setShowSolutionDetails((int) $metadata["entry"]);
                     break;
                 case "print_bs_with_res":
-                    $this->setPrintBestSolutionWithResult((int) $metadata["entry"]);
+                    $score_settings = $score_settings->withPrintBestSolutionWithResult((bool)$metadata["entry"]);
                     break;
                 case "author":
                     $this->setAuthor($metadata["entry"]);
@@ -5110,43 +4983,43 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     break;
 
                 case "highscore_enabled":
-                    $this->setHighscoreEnabled($metadata["entry"]);
+                    $score_settings = $score_settings->withHighscoreEnabled((bool)$metadata["entry"]);
                     break;
 
                 case "highscore_anon":
-                    $this->setHighscoreAnon($metadata["entry"]);
+                    $score_settings = $score_settings->withHighscoreAnon((bool)$metadata["entry"]);
                     break;
 
                 case "highscore_achieved_ts":
-                    $this->setHighscoreAchievedTS($metadata["entry"]);
+                    $score_settings = $score_settings->withHighscoreAchievedTS((bool)$metadata["entry"]);
                     break;
 
                 case "highscore_score":
-                    $this->setHighscoreScore($metadata["entry"]);
+                    $score_settings = $score_settings->withHighscoreScore((bool)$metadata["entry"]);
                     break;
 
                 case "highscore_percentage":
-                    $this->setHighscorePercentage($metadata["entry"]);
+                    $score_settings = $score_settings->withHighscorePercentage((bool)$metadata["entry"]);
                     break;
 
                 case "highscore_hints":
-                    $this->setHighscoreHints($metadata["entry"]);
+                    $score_settings = $score_settings->withHighscoreHints((bool)$metadata["entry"]);
                     break;
 
                 case "highscore_wtime":
-                    $this->setHighscoreWTime($metadata["entry"]);
+                    $score_settings = $score_settings->withHighscoreWTime((bool)$metadata["entry"]);
                     break;
 
                 case "highscore_own_table":
-                    $this->setHighscoreOwnTable($metadata["entry"]);
+                    $score_settings = $score_settings->withHighscoreOwnTable((bool)$metadata["entry"]);
                     break;
 
                 case "highscore_top_table":
-                    $this->setHighscoreTopTable($metadata["entry"]);
+                    $score_settings = $score_settings->withHighscoreTopTable((bool)$metadata["entry"]);
                     break;
 
                 case "highscore_top_num":
-                    $this->setHighscoreTopNum($metadata["entry"]);
+                    $score_settings = $score_settings->withHighscoreTopNum((int)$metadata["entry"]);
                     break;
 
                 case "hide_previous_results":
@@ -5216,7 +5089,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     $this->setShuffleQuestions($metadata["entry"]);
                     break;
                 case "count_system":
-                    $this->setCountSystem($metadata["entry"]);
+                    $score_settings = $score_settings->withCountSystem((int)$metadata["entry"]);
                     break;
                 case "mailnotification":
                     $this->setMailNotification($metadata["entry"]);
@@ -5225,10 +5098,10 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     $this->setMailNotificationType($metadata["entry"]);
                     break;
                 case "exportsettings":
-                    $this->setExportSettings($metadata['entry']);
+                    $score_settings = $score_settings->withExportSettings((int)$metadata["entry"]);
                     break;
                 case "score_cutting":
-                    $this->setScoreCutting($metadata["entry"]);
+                    $score_settings = $score_settings->withScoreCutting((int)$metadata["entry"]);
                     break;
                 case "password":
                     $this->setPassword($metadata["entry"]);
@@ -5242,10 +5115,10 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     $this->setAllowedUsersTimeGap($metadata["entry"]);
                     break;
                 case "pass_scoring":
-                    $this->setPassScoring($metadata["entry"]);
+                    $score_settings = $score_settings->withPassScoring((int)$metadata["entry"]);
                     break;
                 case 'pass_deletion_allowed':
-                    $this->setPassDeletionAllowed((int) $metadata['entry']);
+                    $score_settings = $score_settings->withPassDeletionAllowed((bool)$metadata["entry"]);
                     break;
                 case "show_summary":
                     $this->setListOfQuestionsSettings($metadata["entry"]);
@@ -5299,7 +5172,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     break;
                 case 'show_exam_id':
                 case 'examid_in_test_res':
-                    $this->setShowExamIdInTestResultsEnabled($metadata['entry']);
+                    $score_settings = $score_settings->withShowExamIdInTestResults((bool)$metadata["entry"]);
                     break;
                 case 'enable_archiving':
                     $this->setEnableArchiving($metadata['entry']);
@@ -5317,13 +5190,14 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                     $this->setSkillServiceEnabled((bool) $metadata['entry']);
                     break;
                 case 'result_tax_filters':
-                    $this->setResultFilterTaxIds(strlen($metadata['entry']) ? unserialize($metadata['entry']) : array());
+                    $tax_ids = strlen($metadata['entry']) ? unserialize($metadata['entry']) : [];
+                    $score_settings = $score_settings->withTaxonomyFilterIds($tax_ids);
                     break;
                 case 'show_grading_status':
-                    $this->setShowGradingStatusEnabled((bool) $metadata['entry']);
+                    $score_settings = $score_settings->withShowGradingStatusEnabled((bool)$metadata["entry"]);
                     break;
                 case 'show_grading_mark':
-                    $this->setShowGradingMarkEnabled((bool) $metadata['entry']);
+                    $score_settings = $score_settings->withShowGradingMarkEnabled((bool)$metadata["entry"]);
                     break;
                 case 'activation_limited':
                     $this->setActivationLimited($metadata['entry']);
@@ -5382,6 +5256,8 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                 }
             }
             $this->saveToDb();
+
+            $this->getScoreSettingsRepository()->store($score_settings);
         }
     }
 
@@ -6412,7 +6288,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $newObj->setLimitUsersEnabled($this->isLimitUsersEnabled());
         $newObj->setAllowedUsers($this->getAllowedUsers());
         $newObj->setAllowedUsersTimeGap($this->getAllowedUsersTimeGap());
-        $newObj->setCountSystem($this->getCountSystem());
         $newObj->setECTSFX($this->getECTSFX());
         $newObj->setECTSGrades($this->getECTSGrades());
         $newObj->setECTSOutput($this->getECTSOutput());
@@ -6434,16 +6309,12 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $newObj->setMailNotificationType($this->getMailNotificationType());
         $newObj->setNrOfTries($this->getNrOfTries());
         $newObj->setBlockPassesAfterPassedEnabled($this->isBlockPassesAfterPassedEnabled());
-        $newObj->setPassScoring($this->getPassScoring());
         $newObj->setPasswordEnabled($this->isPasswordEnabled());
         $newObj->setPassword($this->getPassword());
         $newObj->setProcessingTime($this->getProcessingTime());
         $newObj->setQuestionSetType($this->getQuestionSetType());
         $newObj->setReportingDate($this->getReportingDate());
         $newObj->setResetProcessingTime($this->getResetProcessingTime());
-        $newObj->setResultsPresentation($this->getResultsPresentation());
-        $newObj->setScoreCutting($this->getScoreCutting());
-        $newObj->setScoreReporting($this->getScoreReporting());
         $newObj->setShowGradingStatusEnabled($this->isShowGradingStatusEnabled());
         $newObj->setShowGradingMarkEnabled($this->isShowGradingMarkEnabled());
         $newObj->setSequenceSettings($this->getSequenceSettings());
@@ -6459,9 +6330,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $newObj->mark_schema = clone $this->mark_schema;
         $newObj->setEnabledViewMode($this->getEnabledViewMode());
         $newObj->setTemplate($this->getTemplate());
-        $newObj->setPrintBestSolutionWithResult($this->isBestSolutionPrintedWithResult());
         $newObj->setShowExamIdInTestPassEnabled($this->isShowExamIdInTestPassEnabled());
-        $newObj->setShowExamIdInTestResultsEnabled($this->isShowExamIdInTestResultsEnabled());
         $newObj->setEnableExamView($this->getEnableExamview());
         $newObj->setShowExamViewHtml($this->getShowExamviewHtml());
         $newObj->setShowExamViewPdf($this->getShowExamviewPdf());
@@ -6470,8 +6339,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $newObj->setCharSelectorAvailability($this->getCharSelectorAvailability());
         $newObj->setCharSelectorDefinition($this->getCharSelectorDefinition());
         $newObj->setSkillServiceEnabled($this->isSkillServiceEnabled());
-        $newObj->setResultFilterTaxIds($this->getResultFilterTaxIds());
-        $newObj->setPassDeletionAllowed($this->isPassDeletionAllowed());
         $newObj->setFollowupQuestionAnswerFixationEnabled($this->isFollowupQuestionAnswerFixationEnabled());
         $newObj->setInstantFeedbackAnswerFixationEnabled($this->isInstantFeedbackAnswerFixationEnabled());
         $newObj->setForceInstantFeedbackEnabled($this->isForceInstantFeedbackEnabled());
@@ -6512,6 +6379,12 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $newObj->saveToDb();
         $newObj->updateMetaData();// #14467
 
+        $score_settings = $this->getScoreSettingsRepository()->getForObjFi($this->getId());
+        $this->getScoreSettingsRepository()->store(
+            $score_settings->withTestId($newObj->getTestId())
+        );
+
+        include_once('./Services/Tracking/classes/class.ilLPObjSettings.php');
         $obj_settings = new ilLPObjSettings($this->getId());
         $obj_settings->cloneSettings($newObj->getId());
 
@@ -8019,9 +7892,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
 
     /**
     * Returns TRUE if the list of questions should be presented with the question descriptions
-    *
-    * @return boolean TRUE if the list of questions is shown with the question descriptions, FALSE otherwise
-    * @access public
     */
     public function getListOfQuestionsDescription(): bool
     {
@@ -8063,105 +7933,65 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
 
     /**
     * Returns if the pass details should be shown when a test is not finished
-    *
-    * @return boolean TRUE if the pass details should be shown, FALSE otherwise
-    * @access public
     */
     public function getShowPassDetails(): bool
     {
-        if (($this->results_presentation & 1) > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowPassDetails();
     }
 
     /**
     * Returns if the solution details should be presented to the user or not
-    *
-    * @return boolean TRUE if the solution details should be presented, FALSE otherwise
-    * @access public
     */
     public function getShowSolutionDetails(): bool
     {
-        if (($this->results_presentation & 2) > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowSolutionDetails();
     }
 
     /**
     * Returns if the solution printview should be presented to the user or not
-    *
-    * @return boolean TRUE if the solution printview should be presented, FALSE otherwise
-    * @access public
     */
     public function getShowSolutionPrintview(): bool
     {
-        if (($this->results_presentation & 4) > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowSolutionPrintview();
+    }
+    /**
+     * @deprecated
+     */
+    public function canShowSolutionPrintview($user_id = null): bool
+    {
+        return $this->getShowSolutionPrintview();
     }
 
     /**
     * Returns if the feedback should be presented to the solution or not
-    *
-    * @return boolean TRUE if the feedback should be presented in the solution, FALSE otherwise
-    * @access public
     */
     public function getShowSolutionFeedback(): bool
     {
-        if (($this->results_presentation & 8) > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowSolutionFeedback();
     }
 
     /**
     * Returns if the full solution (including ILIAS content) should be presented to the solution or not
-    *
-    * @return boolean TRUE if the full solution should be presented in the solution output, FALSE otherwise
-    * @access public
     */
     public function getShowSolutionAnswersOnly(): bool
     {
-        if (($this->results_presentation & 16) > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowSolutionAnswersOnly();
     }
 
     /**
     * Returns if the signature field should be shown in the test results
-    *
-    * @return boolean TRUE if the signature field should be shown, FALSE otherwise
-    * @access public
     */
     public function getShowSolutionSignature(): bool
     {
-        if (($this->results_presentation & 32) > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowSolutionSignature();
     }
 
     /**
     * @return boolean TRUE if the suggested solutions should be shown, FALSE otherwise
-    * @access public
     */
     public function getShowSolutionSuggested(): bool
     {
-        if (($this->results_presentation & 64) > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowSolutionSuggested();
     }
 
     /**
@@ -8170,11 +8000,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
      */
     public function getShowSolutionListComparison(): bool
     {
-        if (($this->results_presentation & 128) > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowSolutionListComparison();
     }
 
     /**
@@ -8182,6 +8008,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     *
     * @param integer $a_results_presentation The combined results presentation value
     * @access public
+    * @deprecated
     */
     public function setResultsPresentation($a_results_presentation = 3)
     {
@@ -8191,10 +8018,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     /**
     * Sets if the pass details should be shown when a test is not finished
     *
-    * Sets if the pass details should be shown when a test is not finished
-    *
     * @param boolean $a_details TRUE if the pass details should be shown, FALSE otherwise
     * @access public
+    * @deprecated
     */
     public function setShowPassDetails($a_details = 1)
     {
@@ -8212,6 +8038,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     *
     * @param integer $a_details 1 if the solution details should be presented, 0 otherwise
     * @access public
+    * @deprecated
     */
     public function setShowSolutionDetails($a_details = 1)
     {
@@ -8224,22 +8051,20 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         }
     }
 
-    /**
-    * Calculates if a user may see the solution printview of his/her test results
-    *
-    * @return boolean TRUE if the user may see the printview, FALSE otherwise
-    * @access public
-    */
-    public function canShowSolutionPrintview($user_id = null): bool
+    public function getShowSolutionListOwnAnswers($user_id = null): bool
     {
-        return $this->getShowSolutionPrintview();
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowSolutionListOwnAnswers();
     }
+
+
+    //--------------------------------
 
     /**
     * Sets if the the solution printview should be presented to the user or not
     *
     * @param boolean $a_details TRUE if the solution printview should be presented, FALSE otherwise
     * @access public
+    * @deprecated
     */
     public function setShowSolutionPrintview($a_printview = 1)
     {
@@ -8257,6 +8082,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     *
     * @param boolean $a_feedback TRUE if the feedback should be presented in the solution, FALSE otherwise
     * @access public
+    * @deprecated
     */
     public function setShowSolutionFeedback($a_feedback = true)
     {
@@ -8274,6 +8100,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     *
     * @param boolean $a_full TRUE if the full solution should be shown in the solution output, FALSE otherwise
     * @access public
+    * @deprecated
     */
     public function setShowSolutionAnswersOnly($a_full = true)
     {
@@ -8291,6 +8118,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     *
     * @param boolean $a_signature TRUE if the signature field should be shown, FALSE otherwise
     * @access public
+    * @deprecated
     */
     public function setShowSolutionSignature($a_signature = false)
     {
@@ -8308,6 +8136,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     *
     * @param boolean $a_solution TRUE if the suggested solution should be shown, FALSE otherwise
     * @access public
+    * @deprecated
     */
     public function setShowSolutionSuggested($a_solution = false)
     {
@@ -8324,6 +8153,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
      * Set to TRUE, if the list of answers should be shown prior to finish the test
      *
      * @param boolean $a_comparison TRUE if the list of answers should be shown prior to finish the test, FALSE otherwise
+     * @deprecated
      */
     public function setShowSolutionListComparison($a_comparison = false)
     {
@@ -9012,7 +8842,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->mark_schema = unserialize($test_defaults["marks"]);
 
         $this->setTitleOutput($testsettings["TitleOutput"]);
-        $this->setPassScoring($testsettings["PassScoring"]);
         $this->setIntroductionEnabled($testsettings["IntroEnabled"]);
         $this->setIntroduction($testsettings["Introduction"] ?? '');
         $this->setFinalStatement($testsettings["FinalStatement"] ?? '');
@@ -9022,9 +8851,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->setShowFinalStatement($testsettings["ShowFinalStatement"]);
         $this->setSequenceSettings($testsettings["SequenceSettings"]);
         $this->setScoreReporting($testsettings["ScoreReporting"]);
-        $this->setScoreCutting($testsettings['ScoreCutting']);
         $this->setSpecificAnswerFeedback($testsettings['SpecificAnswerFeedback']);
-        $this->setPrintBestSolutionWithResult((bool) $testsettings['PrintBsWithRes']);
         $this->setInstantFeedbackSolution($testsettings["InstantFeedbackSolution"]);
         $this->setAnswerFeedback($testsettings["AnswerFeedback"]);
         $this->setAnswerFeedbackPoints($testsettings["AnswerFeedbackPoints"]);
@@ -9059,34 +8886,20 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         } elseif (isset($testsettings["questionSetType"])) {
             $this->setQuestionSetType($testsettings["questionSetType"]);
         }
-        $this->setCountSystem($testsettings["CountSystem"]);
+
         $this->setMailNotification($testsettings["mailnotification"]);
         $this->setMailNotificationType($testsettings["mailnottype"]);
         $this->setExportSettings($testsettings['exportsettings']);
         $this->setListOfQuestionsSettings($testsettings["ListOfQuestionsSettings"]);
         $this->setObligationsEnabled($testsettings["obligations_enabled"]);
         $this->setOfferingQuestionHintsEnabled($testsettings["offer_question_hints"]);
-        $this->setHighscoreEnabled($testsettings['highscore_enabled']);
-        $this->setHighscoreAnon($testsettings['highscore_anon']);
-        $this->setHighscoreAchievedTS($testsettings['highscore_achieved_ts']);
-        $this->setHighscoreScore($testsettings['highscore_score']);
-        $this->setHighscorePercentage($testsettings['highscore_percentage']);
-        $this->setHighscoreHints($testsettings['highscore_hints']);
-        $this->setHighscoreWTime($testsettings['highscore_wtime']);
-        $this->setHighscoreOwnTable($testsettings['highscore_own_table']);
-        $this->setHighscoreTopTable($testsettings['highscore_top_table']);
-        $this->setHighscoreTopNum($testsettings['highscore_top_num']);
-        $this->setPassDeletionAllowed($testsettings['pass_deletion_allowed']);
+
         if (isset($testsettings['examid_in_kiosk'])) {
             $this->setShowExamIdInTestPassEnabled($testsettings['examid_in_kiosk']);
         } else {
             $this->setShowExamIdInTestPassEnabled($testsettings['examid_in_test_pass']);
         }
-        if (isset($testsettings['show_exam_id'])) {
-            $this->setShowExamIdInTestResultsEnabled($testsettings['show_exam_id']);
-        } else {
-            $this->setShowExamIdInTestResultsEnabled($testsettings['examid_in_test_res']);
-        }
+
         $this->setEnableExamview($testsettings['enable_examview']);
         $this->setShowExamviewHtml($testsettings['show_examview_html']);
         $this->setShowExamviewPdf($testsettings['show_examview_pdf']);
@@ -9095,19 +8908,15 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->setCharSelectorAvailability($testsettings['char_selector_availability']);
         $this->setCharSelectorDefinition($testsettings['char_selector_definition']);
         $this->setSkillServiceEnabled((bool) $testsettings['skill_service']);
-        $this->setResultFilterTaxIds((array) $testsettings['result_tax_filters']);
         $this->setShowGradingStatusEnabled((bool) $testsettings['show_grading_status']);
         $this->setShowGradingMarkEnabled((bool) $testsettings['show_grading_mark']);
-
         $this->setFollowupQuestionAnswerFixationEnabled($testsettings['follow_qst_answer_fixation']);
         $this->setInstantFeedbackAnswerFixationEnabled($testsettings['inst_fb_answer_fixation']);
         $this->setForceInstantFeedbackEnabled($testsettings['force_inst_fb']);
         $this->setRedirectionMode($testsettings['redirection_mode']);
         $this->setRedirectionUrl($testsettings['redirection_url']);
-
         $this->setAutosave($testsettings['autosave']);
         $this->setAutosaveIval($testsettings['autosave_ival']);
-        $this->setShowExamIdInTestResultsEnabled((int) $testsettings['examid_in_test_res']);
         $this->setPasswordEnabled($testsettings['password_enabled']);
         $this->setPassword($testsettings['password']);
         $this->setFixedParticipants($testsettings['fixed_participants']);
@@ -9121,6 +8930,46 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->setActivationVisibility($testsettings['activation_visibility']);
         $this->setPassWaiting($testsettings['pass_waiting']);
 
+        $settings = $this->getScoreSettings();
+        $exam_id_in_results = false;
+        if (array_key_exists('show_exam_id', $testsettings)) {
+            $exam_id_in_results = (bool) $testsettings['show_exam_id'];
+        } elseif (array_key_exists('examid_in_test_res', $testsettings)) {
+            $exam_id_in_results = (bool) $testsettings['examid_in_test_res'];
+        }
+
+        $settings = $settings
+            ->withScoringSettings(
+                $settings->getScoringSettings()
+                ->withPassScoring((bool)$testsettings["PassScoring"])
+                ->withScoreCutting((bool)$testsettings['ScoreCutting'])
+                ->withCountSystem((bool)$testsettings["CountSystem"])
+            )
+            ->withResultSummarySettings(
+                $settings->getResultSummarySettings()
+                ->withPassDeletionAllowed($testsettings['pass_deletion_allowed'])
+            )
+            ->withResultDetailsSettings(
+                $settings->getResultDetailsSettings()
+                ->withPrintBestSolutionWithResult((bool) $testsettings['PrintBsWithRes'])
+                ->withShowExamIdInTestResults($exam_id_in_results)
+                ->withResultFilterTaxIds((array) $testsettings['result_tax_filters'])
+            )
+            ->withGamificationSettings(
+                $settings->getGamificationSettings()
+                ->withHighscoreEnabled($testsettings['highscore_enabled'])
+                ->withHighscoreAnon($testsettings['highscore_anon'])
+                ->withHighscoreAchievedTS($testsettings['highscore_achieved_ts'])
+                ->withHighscoreScore($testsettings['highscore_score'])
+                ->withHighscorePercentage($testsettings['highscore_percentage'])
+                ->withHighscoreHints($testsettings['highscore_hints'])
+                ->withHighscoreWTime($testsettings['highscore_wtime'])
+                ->withHighscoreOwnTable($testsettings['highscore_own_table'])
+                ->withHighscoreTopTable($testsettings['highscore_top_table'])
+                ->withHighscoreTopNum($testsettings['highscore_top_num'])
+            )
+        ;
+        $this->getScoreSettingsRepository()->store($settings);
         $this->saveToDb();
 
         return true;
@@ -9811,11 +9660,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
 
     public function getExportSettings(): int
     {
-        if ($this->exportsettings) {
-            return $this->exportsettings;
-        } else {
-            return 0;
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getExportSettings();
     }
 
     public function setExportSettings($a_settings)
@@ -9829,11 +9674,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
 
     public function getExportSettingsSingleChoiceShort(): bool
     {
-        if (($this->exportsettings & 1) > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getExportSettingsSingleChoiceShort();
     }
 
     public function setExportSettingsSingleChoiceShort($a_settings)
@@ -9952,26 +9793,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             $this->setSpecificAnswerFeedback(0);
             $this->setAnswerFeedbackPoints(0);
             $this->setInstantFeedbackSolution(0);
-        }
-    }
-
-    public function setResultsPresentationOptionsByArray($options)
-    {
-        $setter = array(
-                'pass_details' => 'setShowPassDetails',
-                'solution_details' => 'setShowSolutionDetails',
-                'solution_printview' => 'setShowSolutionPrintview',
-                'solution_feedback' => 'setShowSolutionFeedback',
-                'solution_answers_only' => 'setShowSolutionAnswersOnly',
-                'solution_signature' => 'setShowSolutionSignature',
-                'solution_suggested' => 'setShowSolutionSuggested',
-                );
-        foreach ($setter as $key => $method) {
-            if (in_array($key, $options)) {
-                $this->$method(1);
-            } else {
-                $this->$method(0);
-            }
         }
     }
 
@@ -10194,32 +10015,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     }
 
     /* GET/SET for highscore feature */
-
-    /**
-     * Sets if the highscore feature should be enabled.
-     *
-     * @param bool $a_enabled
-     */
-    public function setHighscoreEnabled($a_enabled)
+    public function getHighscoreEnabled(): bool
     {
-        $this->_highscore_enabled = (bool) $a_enabled;
-    }
-
-    public function getHighscoreEnabled(): ?bool
-    {
-        return $this->_highscore_enabled;
-    }
-
-    /**
-     * Sets if the highscores should be anonymized.
-     *
-     * Note: This setting will be overriden, if the test is globally anonymized.
-     *
-     * @param bool $a_anon
-     */
-    public function setHighscoreAnon($a_anon)
-    {
-        $this->_highscore_anon = (bool) $a_anon;
+        return $this->getScoreSettings()->getGamificationSettings()->getHighscoreEnabled();
     }
 
     /**
@@ -10231,9 +10029,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
      *
      * @return bool True, if setting is to anonymize highscores.
      */
-    public function getHighscoreAnon(): ?bool
+    public function getHighscoreAnon(): bool
     {
-        return $this->_highscore_anon;
+        return $this->getScoreSettings()->getGamificationSettings()->getHighscoreAnon();
     }
 
     /**
@@ -10244,196 +10042,79 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
      *
      * @return boolean True, if output is anonymized.
      */
-    public function isHighscoreAnon(): ?bool
+    public function isHighscoreAnon(): bool
     {
-        if ($this->getAnonymity() == 1) {
-            return true;
-        } else {
-            return $this->getHighscoreAnon();
-        }
-    }
-
-    /**
-     * Sets if the date and time of the scores achievement should be displayed.
-     */
-    public function setHighscoreAchievedTS($a_achieved_ts): void
-    {
-        $this->_highscore_achieved_ts = (bool) $a_achieved_ts;
+        return $this->getAnonymity() == 1 || $this->getHighscoreAnon();
     }
 
     /**
      * Returns if date and time of the scores achievement should be displayed.
      */
-    public function getHighscoreAchievedTS(): ?bool
+    public function getHighscoreAchievedTS(): bool
     {
-        return $this->_highscore_achieved_ts;
-    }
-
-    /**
-     * Sets if the actual score should be displayed.
-     *
-     * @param bool $a_score
-     */
-    public function setHighscoreScore($a_score): void
-    {
-        $this->_highscore_score = (bool) $a_score;
+        return $this->getScoreSettings()->getGamificationSettings()->getHighscoreAchievedTS();
     }
 
     /**
      * Gets if the score column should be shown.
      */
-    public function getHighscoreScore(): ?bool
+    public function getHighscoreScore(): bool
     {
-        return $this->_highscore_score;
-    }
-
-    /**
-     * Sets if the percentages of the scores pass should be shown.
-     */
-    public function setHighscorePercentage($a_percentage): void
-    {
-        $this->_highscore_percentage = (bool) $a_percentage;
+        return $this->getScoreSettings()->getGamificationSettings()->getHighscoreScore();
     }
 
     /**
      * Gets if the percentage column should be shown.
      */
-    public function getHighscorePercentage(): ?bool
+    public function getHighscorePercentage(): bool
     {
-        return $this->_highscore_percentage;
-    }
-
-    /**
-     * Sets if the number of requested hints should be shown.
-     */
-    public function setHighscoreHints($a_hints): void
-    {
-        $this->_highscore_hints = (bool) $a_hints;
+        return $this->getScoreSettings()->getGamificationSettings()->getHighscorePercentage();
     }
 
     /**
      * Gets, if the column with the number of requested hints should be shown.
      */
-    public function getHighscoreHints(): ?bool
+    public function getHighscoreHints(): bool
     {
-        return $this->_highscore_hints;
-    }
-
-    /**
-     * Sets if the workingtime of the scores should be shown.
-     */
-    public function setHighscoreWTime($a_wtime): void
-    {
-        $this->_highscore_wtime = (bool) $a_wtime;
+        return $this->getScoreSettings()->getGamificationSettings()->getHighscoreHints();
     }
 
     /**
      * Gets if the column with the workingtime should be shown.
      */
-    public function getHighscoreWTime(): ?bool
+    public function getHighscoreWTime(): bool
     {
-        return $this->_highscore_wtime;
-    }
-
-    /**
-     * Sets if the table with the own ranking should be shown.
-     */
-    public function setHighscoreOwnTable($a_own_table): void
-    {
-        $this->_highscore_own_table = (bool) $a_own_table;
+        return $this->getScoreSettings()->getGamificationSettings()->getHighscoreWTime();
     }
 
     /**
      * Gets if the own rankings table should be shown.
      */
-    public function getHighscoreOwnTable(): ?bool
+    public function getHighscoreOwnTable(): bool
     {
-        return $this->_highscore_own_table;
-    }
-
-    /**
-     * Sets if the top-rankings table should be shown.
-     */
-    public function setHighscoreTopTable($a_top_table): void
-    {
-        $this->_highscore_top_table = (bool) $a_top_table;
+        return $this->getScoreSettings()->getGamificationSettings()->getHighscoreOwnTable();
     }
 
     /**
      * Gets, if the top-rankings table should be shown.
      */
-    public function getHighscoreTopTable(): ?bool
+    public function getHighscoreTopTable(): bool
     {
-        return $this->_highscore_top_table;
-    }
-
-    /**
-     * Sets the number of entries which are to be shown in the top-rankings
-     * table.
-     */
-    public function setHighscoreTopNum($a_top_num): void
-    {
-        $this->_highscore_top_num = (int) $a_top_num;
+        return $this->getScoreSettings()->getGamificationSettings()->getHighscoreTopTable();
     }
 
     /**
      * Gets the number of entries which are to be shown in the top-rankings table.
-     * Default: 10 entries
-     *
-     * @param integer $a_retval Optional return value if nothing is set, defaults to 10.
-     *
      * @return integer Number of entries to be shown in the top-rankings table.
      */
-    public function getHighscoreTopNum($a_retval = 10): int
+    public function getHighscoreTopNum(int $a_retval = 10): int
     {
-        $retval = $a_retval;
-        if ($this->_highscore_top_num != 0) {
-            $retval = $this->_highscore_top_num;
-        }
-
-        return $retval;
+        return $this->getScoreSettings()->getGamificationSettings()->getHighscoreTopNum();
     }
 
     public function getHighscoreMode(): int
     {
-        switch (true) {
-            case $this->getHighscoreOwnTable() && $this->getHighscoreTopTable():
-                return self::HIGHSCORE_SHOW_ALL_TABLES;
-                break;
-
-            case $this->getHighscoreTopTable():
-                return self::HIGHSCORE_SHOW_TOP_TABLE;
-                break;
-
-            case $this->getHighscoreOwnTable():
-            default:
-                return self::HIGHSCORE_SHOW_OWN_TABLE;
-                break;
-        }
-    }
-
-    /**
-     * @param $mode int
-     */
-    public function setHighscoreMode($mode)
-    {
-        switch ($mode) {
-            case self::HIGHSCORE_SHOW_ALL_TABLES:
-                $this->setHighscoreTopTable(1);
-                $this->setHighscoreOwnTable(1);
-                break;
-
-            case self::HIGHSCORE_SHOW_TOP_TABLE:
-                $this->setHighscoreTopTable(1);
-                $this->setHighscoreOwnTable(0);
-                break;
-
-            case self::HIGHSCORE_SHOW_OWN_TABLE:
-            default:
-                $this->setHighscoreTopTable(0);
-                $this->setHighscoreOwnTable(1);
-                break;
-        }
+        return $this->getScoreSettings()->getGamificationSettings()->getHighScoreMode();
     }
     /* End GET/SET for highscore feature*/
 
@@ -10592,15 +10273,14 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         return $this->autosave_ival;
     }
 
-    /**
-     * getter for the test setting passDeletionAllowed
-     * @return bool|null
-     */
-    public function isPassDeletionAllowed(): ?bool
+    public function isPassDeletionAllowed(): bool
     {
-        return $this->passDeletionAllowed;
+        return $this->getScoreSettings()->getResultSummarySettings()->getPassDeletionAllowed();
     }
 
+    /**
+     * @deprecated ?
+     */
     public function setPassDeletionAllowed($passDeletionAllowed): void
     {
         $this->passDeletionAllowed = (bool) $passDeletionAllowed;
@@ -10866,14 +10546,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     }
 
     /**
-     * @param boolean $show_exam_id
-     */
-    public function setShowExamIdInTestResultsEnabled($show_exam_id_in_test_results_enabled)
-    {
-        $this->show_exam_id_in_test_results_enabled = $show_exam_id_in_test_results_enabled;
-    }
-
-    /**
      * @return boolean
      */
     public function isShowExamIdInTestResultsEnabled(): bool
@@ -11077,14 +10749,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         return $this->skillServiceEnabled;
     }
 
-    public function setResultFilterTaxIds($resultFilterTaxIds)
-    {
-        $this->resultFilterTaxIds = $resultFilterTaxIds;
-    }
-
     public function getResultFilterTaxIds(): array
     {
-        return $this->resultFilterTaxIds;
+        return $this->getScoreSettings()->getResultDetailsSettings()->getTaxonomyFilterIds();
     }
 
     public function isSkillServiceToBeConsidered(): bool
@@ -11330,11 +10997,31 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         }
     }
 
+<<<<<<< HEAD
     /**
      * @return ilHtmlPurifierInterface|ilAssHtmlUserSolutionPurifier
      */
     protected function getHtmlQuestionContentPurifier(): ilHtmlPurifierInterface
     {
         return ilHtmlPurifierFactory::getInstanceByType('qpl_usersolution');
+=======
+    protected ?ilObjTestScoreSettings $score_settings = null;
+    protected ?ScoreSettingsRepository $score_settings_repo = null;
+    public function getScoreSettings(): ilObjTestScoreSettings
+    {
+        if (!$this->score_settings) {
+            $this->score_settings = $this->getScoreSettingsRepository()
+                ->getFor($this->getTestId());
+        }
+        return $this->score_settings;
+    }
+
+    public function getScoreSettingsRepository(): ScoreSettingsRepository
+    {
+        if (!$this->score_settings_repo) {
+            $this->score_settings_repo = new ilObjTestScoreSettingsDatabaseRepository($this->db);
+        }
+        return $this->score_settings_repo;
+>>>>>>> 4f95b82746 (TA: Repo for ScoreSettings, UI Form, tests)
     }
 }

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -260,6 +260,8 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     #endregion
 
     protected ilDBInterface $db;
+    protected ?ilObjTestScoreSettings $score_settings = null;
+    protected ?ScoreSettingsRepository $score_settings_repo = null;
 
     /**
      * Constructor
@@ -10995,16 +10997,14 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         }
     }
 
-<<<<<<< HEAD
     /**
      * @return ilHtmlPurifierInterface|ilAssHtmlUserSolutionPurifier
      */
     protected function getHtmlQuestionContentPurifier(): ilHtmlPurifierInterface
     {
         return ilHtmlPurifierFactory::getInstanceByType('qpl_usersolution');
-=======
-    protected ?ilObjTestScoreSettings $score_settings = null;
-    protected ?ScoreSettingsRepository $score_settings_repo = null;
+    }
+
     public function getScoreSettings(): ilObjTestScoreSettings
     {
         if (!$this->score_settings) {
@@ -11020,6 +11020,5 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             $this->score_settings_repo = new ilObjTestScoreSettingsDatabaseRepository($this->db);
         }
         return $this->score_settings_repo;
->>>>>>> 4f95b82746 (TA: Repo for ScoreSettings, UI Form, tests)
     }
 }

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -353,7 +353,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->redirection_mode = 0;
         $this->redirection_url = null;
         $this->show_exam_id_in_test_pass_enabled = false;
-        //$this->show_exam_id_in_test_results_enabled = false;
         $this->sign_submission = false;
         $this->char_selector_availability = 0;
         $this->char_selector_definition = null;
@@ -6385,7 +6384,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             $score_settings->withTestId($newObj->getTestId())
         );
 
-        include_once('./Services/Tracking/classes/class.ilLPObjSettings.php');
         $obj_settings = new ilLPObjSettings($this->getId());
         $obj_settings->cloneSettings($newObj->getId());
 
@@ -8016,23 +8014,20 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->results_presentation = $a_results_presentation;
     }
 
-    /**
-    * Sets if the pass details should be shown when a test is not finished
-    *
-    * @param boolean $a_details TRUE if the pass details should be shown, FALSE otherwise
-    * @access public
-    * @deprecated
-    */
-    public function setShowPassDetails($a_details = 1)
+    public function getShowSolutionListOwnAnswers($user_id = null): bool
     {
-        if ($a_details) {
-            $this->results_presentation = $this->results_presentation | 1;
-        } else {
-            if ($this->getShowPassDetails()) {
-                $this->results_presentation = $this->results_presentation ^ 1;
-            }
-        }
+        return $this->getScoreSettings()->getResultDetailsSettings()->getShowSolutionListOwnAnswers();
     }
+
+    /**
+     * -------------------------------------------------------------------------
+     * Those setters are @deprecated!
+     * They modify $results_presentation based on some parameter and fall back to
+     * repo-settings when called without.
+     * Calls are a.o. in class.ilObjTestGUI.php and here during import;
+     * I left it in place to not to break too many things now, but they should go.
+     * Soon.
+     **/
 
     /**
     * Sets if the the solution details should be presented to the user or not
@@ -8051,14 +8046,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             }
         }
     }
-
-    public function getShowSolutionListOwnAnswers($user_id = null): bool
-    {
-        return $this->getScoreSettings()->getResultDetailsSettings()->getShowSolutionListOwnAnswers();
-    }
-
-
-    //--------------------------------
 
     /**
     * Sets if the the solution printview should be presented to the user or not
@@ -8079,93 +8066,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     }
 
     /**
-    * Sets if the the feedback should be presented to the user in the solution or not
-    *
-    * @param boolean $a_feedback TRUE if the feedback should be presented in the solution, FALSE otherwise
-    * @access public
-    * @deprecated
-    */
-    public function setShowSolutionFeedback($a_feedback = true)
-    {
-        if ($a_feedback) {
-            $this->results_presentation = $this->results_presentation | 8;
-        } else {
-            if ($this->getShowSolutionFeedback()) {
-                $this->results_presentation = $this->results_presentation ^ 8;
-            }
-        }
-    }
-
-    /**
-    * Set to true, if the full solution (including the ILIAS content pages) should be shown in the solution output
-    *
-    * @param boolean $a_full TRUE if the full solution should be shown in the solution output, FALSE otherwise
-    * @access public
-    * @deprecated
-    */
-    public function setShowSolutionAnswersOnly($a_full = true)
-    {
-        if ($a_full) {
-            $this->results_presentation = $this->results_presentation | 16;
-        } else {
-            if ($this->getShowSolutionAnswersOnly()) {
-                $this->results_presentation = $this->results_presentation ^ 16;
-            }
-        }
-    }
-
-    /**
-    * Set to TRUE, if the signature field should be shown in the solution
-    *
-    * @param boolean $a_signature TRUE if the signature field should be shown, FALSE otherwise
-    * @access public
-    * @deprecated
-    */
-    public function setShowSolutionSignature($a_signature = false)
-    {
-        if ($a_signature) {
-            $this->results_presentation = $this->results_presentation | 32;
-        } else {
-            if ($this->getShowSolutionSignature()) {
-                $this->results_presentation = $this->results_presentation ^ 32;
-            }
-        }
-    }
-
-    /**
-    * Set to TRUE, if the suggested solution should be shown in the solution
-    *
-    * @param boolean $a_solution TRUE if the suggested solution should be shown, FALSE otherwise
-    * @access public
-    * @deprecated
-    */
-    public function setShowSolutionSuggested($a_solution = false)
-    {
-        if ($a_solution) {
-            $this->results_presentation = $this->results_presentation | 64;
-        } else {
-            if ($this->getShowSolutionSuggested()) {
-                $this->results_presentation = $this->results_presentation ^ 64;
-            }
-        }
-    }
-
-    /**
-     * Set to TRUE, if the list of answers should be shown prior to finish the test
-     *
-     * @param boolean $a_comparison TRUE if the list of answers should be shown prior to finish the test, FALSE otherwise
-     * @deprecated
+     * -------------------------------------------------------------------------
      */
-    public function setShowSolutionListComparison($a_comparison = false)
-    {
-        if ($a_comparison) {
-            $this->results_presentation = $this->results_presentation | 128;
-        } else {
-            if ($this->getShowSolutionListComparison()) {
-                $this->results_presentation = $this->results_presentation ^ 128;
-            }
-        }
-    }
+
 
     /**
      * @deprecated: use ilTestParticipantData instead
@@ -10272,14 +10175,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     public function isPassDeletionAllowed(): bool
     {
         return $this->getScoreSettings()->getResultSummarySettings()->getPassDeletionAllowed();
-    }
-
-    /**
-     * @deprecated ?
-     */
-    public function setPassDeletionAllowed($passDeletionAllowed): void
-    {
-        $this->passDeletionAllowed = (bool) $passDeletionAllowed;
     }
 
     #region Examview / PDF Examview

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -9964,14 +9964,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->oldOnlineStatus = $oldOnlineStatus;
     }
 
-    public function setPrintBestSolutionWithResult($status)
-    {
-        $this->print_best_solution_with_result = (bool) $status;
-    }
-
     public function isBestSolutionPrintedWithResult(): bool
     {
-        return $this->print_best_solution_with_result;
+        return $this->getScoreSettings()->getResultDetailsSettings()->getPrintBestSolutionWithResult();
     }
 
     /**

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -272,6 +272,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     public function __construct($a_id = 0, bool $a_call_by_reference = true)
     {
         global $DIC;
+        $this->db = $DIC['ilDB'];
         $ilUser = $DIC['ilUser'];
         $lng = $DIC['lng'];
         $this->type = "tst";
@@ -366,8 +367,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $this->testFinalBroken = false;
 
         $this->tmpCopyWizardCopyId = null;
-
-        $this->db = $DIC['ilDB'];
 
         parent::__construct($a_id, $a_call_by_reference);
     }

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -89,6 +89,8 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
     protected \ILIAS\Test\InternalRequestService $testrequest;
 
+    protected array $ui;
+
     /**
      * Constructor
      * @access public
@@ -103,6 +105,14 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         $component_repository = $DIC['component.repository'];
         $tree = $DIC['tree'];
         $lng->loadLanguageModule("assessment");
+
+        $this->ui = [
+            $DIC['ui.factory'],
+            $DIC['ui.renderer'],
+            $DIC['refinery'],
+            $DIC['http']->request()
+        ];
+
         $this->type = "tst";
         $this->error = $DIC['ilErr'];
         $this->ctrl = $ilCtrl;
@@ -439,8 +449,14 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                     $this->tree,
                     $ilDB,
                     $component_repository,
-                    $this
+                    $this,
+                    $DIC->ui()->mainTemplate(),
+                    $ilTabs,
+                    $this->getTestObject()->getScoreSettingsRepository(),
+                    $this->getTestObject()->getTestId(),
+                    ...$this->ui
                 );
+
                 $this->ctrl->forwardCommand($gui);
                 break;
 
@@ -1059,6 +1075,8 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
     */
     public function afterSave(ilObject $new_object): void
     {
+        $new_object->saveToDb();
+
         $tstdef = $this->getDidacticTemplateVar("tstdef");
         if ($tstdef) {
             $testDefaultsId = $tstdef;
@@ -3340,9 +3358,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         return $form;
     }
 
-    // begin-patch lok
     public function applyTemplate($templateData, ilObjTest $object)
-    // end-patch lok
     {
         // map formFieldName => setterName
         $simpleSetters = array(
@@ -3393,25 +3409,28 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
             'mailnotification' => 'setMailNotification',
 
             // scoring options properties
-            'count_system' => 'setCountSystem',
-            'score_cutting' => 'setScoreCutting',
-            'pass_scoring' => 'setPassScoring',
-            'pass_deletion_allowed' => 'setPassDeletionAllowed',
+            'count_system' => 'withCountSystem',
+            'score_cutting' => 'withScoreCutting',
+            'pass_scoring' => 'withPassScoring',
 
             // result summary properties
-            'results_access_enabled' => 'setScoreReporting',
-            'grading_status' => 'setShowGradingStatusEnabled',
-            'grading_mark' => 'setShowGradingMarkEnabled',
+            'grading_status' => 'withShowGradingStatusEnabled',
+            'grading_mark' => 'withShowGradingMarkEnabled',
+            'pass_deletion_allowed' => 'withPassDeletionAllowed',
+            'results_access_enabled' => 'withScoreReporting',
 
             // result details properties
-            'solution_details' => 'setShowSolutionDetails',
-            'solution_feedback' => 'setShowSolutionFeedback',
-            'solution_suggested' => 'setShowSolutionSuggested',
+            'solution_details' => 'withShowSolutionDetails',
+            'solution_feedback' => 'withShowSolutionFeedback',
+            'solution_suggested' => 'withShowSolutionSuggested',
             'solution_printview' => 'setShowSolutionPrintview',
-            'highscore_enabled' => 'setHighscoreEnabled',
-            'solution_signature' => 'setShowSolutionSignature',
-            'examid_in_test_res' => 'setShowExamIdInTestResultsEnabled',
-            'exp_sc_short' => 'setExportSettingsSingleChoiceShort',
+            'solution_signature' => 'withShowSolutionSignature',
+            'examid_in_test_res' => 'withShowExamIdInTestResults',
+            'exp_sc_short' => 'withExportSettingsSingleChoiceShort',
+
+
+            // result gamification properties
+            'highscore_enabled' => 'withHighscoreEnabled',
 
             // misc scoring & result properties
             'anonymity' => 'setAnonymity',
@@ -3422,13 +3441,65 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
             $templateData['results_presentation']['value'] = array();
         }
 
+
+
+        $settings = $object->getScoreSettings();
         foreach ($simpleSetters as $field => $setter) {
-            if ($templateData[$field] && strlen($setter)) {
-                $object->$setter($templateData[$field]['value']);
+            if (! array_key_exists($field, $templateData)) {
                 continue;
             }
 
             switch ($field) {
+
+                case 'count_system':
+                case 'count_system':
+                case 'pass_scoring':
+                    $settings = $settings->withScoringSettings(
+                        $settings->getScoringSettings()->$setter(
+                            (int) $templateData[$field]['value']
+                        )
+                    );
+                    break;
+
+                case 'pass_deletion_allowed':
+                case 'grading_status':
+                case 'grading_mark':
+                    $settings = $settings->withResultSummarySettings(
+                        $settings->getResultSummarySettings()->$setter(
+                            (bool) $templateData[$field]['value']
+                        )
+                    );
+                    break;
+                case 'results_access_enabled':
+                    $settings = $settings->withResultSummarySettings(
+                        $settings->getResultSummarySettings()->$setter(
+                            (int) $templateData[$field]['value']
+                        )
+                    );
+                    break;
+
+                case 'solution_details':
+                case 'solution_feedback':
+                case 'solution_suggested':
+                case 'solution_printview':
+                case 'solution_signature':
+                case 'examid_in_test_res':
+                case 'exp_sc_short':
+                    $settings = $settings->withResultDetailsSettings(
+                        $settings->getResultDetailsSettings()->$setter(
+                            (bool) $templateData[$field]['value']
+                        )
+                    );
+                    break;
+
+                case 'highscore_enabled':
+                    $settings = $settings->withGamificationSettings(
+                        $settings->getGamificationSettings()->$setter(
+                            (bool) $templateData[$field]['value']
+                        )
+                    );
+                    break;
+
                 case 'autosave':
                     if ($templateData[$field]['value'] > 0) {
                         $object->setAutosave(true);
@@ -3479,8 +3550,14 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                             break;
                     }
                     break;
+
+                default:
+                    if (strlen($setter)) {
+                        $object->$setter($templateData[$field]['value']);
+                    }
             }
         }
+        $object->getScoreSettingsRepository()->store($settings);
     }
 
     public function saveOrderAndObligationsObject()

--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -970,7 +970,16 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 
         $result_array = $this->getFilteredTestResult($active_id, $pass, false, !$this->getObjectiveOrientedContainer()->isObjectiveOrientedPresentationRequired());
 
-        $overviewTableGUI = $this->getPassDetailsOverviewTableGUI($result_array, $active_id, $pass, $this, "outParticipantsPassDetails", '', true, $objectivesList);
+        $overviewTableGUI = $this->getPassDetailsOverviewTableGUI(
+            $result_array,
+            $active_id,
+            $pass,
+            $this,
+            "outParticipantsPassDetails",
+            '',
+            true,
+            $objectivesList
+        );
         $overviewTableGUI->setTitle($testResultHeaderLabelBuilder->getPassDetailsHeaderLabel($pass + 1));
         $user_data = $this->getAdditionalUsrDataHtmlAndPopulateWindowTitle($testSession, $active_id, false);
         $user_id = $this->object->_getUserIdFromActiveId($active_id);
@@ -1273,7 +1282,11 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         if ($this->object->getShowSolutionDetails()) {
             $command_solution_details = "outCorrectSolution";
         }
-        $questionAnchorNav = $this->object->canShowSolutionPrintview();
+
+        //$questionAnchorNav = $this->object->canShowSolutionPrintview();
+        $questionAnchorNav =
+            $this->object->getShowSolutionListOwnAnswers() &&
+            $this->object->getShowSolutionDetails() ;
 
         $tpl = new ilTemplate('tpl.il_as_tst_pass_details_overview_participants.html', true, true, "Modules/Test");
 

--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -1348,7 +1348,6 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         $tpl->setVariable("TOTAL_RESULT", $result);
         $tpl->parseCurrentBlock();
 
-        //if ($this->object->canShowSolutionPrintview()) {
         if ($this->object->getShowSolutionListOwnAnswers()) {
             $list_of_answers = $this->getPassListOfAnswers(
                 $result_array,
@@ -1552,9 +1551,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 
         $template->setVariable("TEXT_RESULTS", $this->lng->txt("tst_passes"));
 
-        global $DIC; /* @var ILIAS\DI\Container $DIC */
-        require_once 'Modules/Test/classes/class.ilTestPassesSelector.php';
-        $testPassesSelector = new ilTestPassesSelector($DIC['ilDB'], $this->object);
+        $testPassesSelector = new ilTestPassesSelector($this->dic['ilDB'], $this->object);
         $testPassesSelector->setActiveId($testSession->getActiveId());
         $testPassesSelector->setLastFinishedPass($testSession->getLastFinishedPass());
 
@@ -1568,7 +1565,6 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 
         $signature = "";
         if (strlen($pass)) {
-            require_once 'Modules/Test/classes/class.ilTestResultHeaderLabelBuilder.php';
             $testResultHeaderLabelBuilder = new ilTestResultHeaderLabelBuilder($this->lng, $ilObjDataCache);
 
             $objectivesList = null;
@@ -1578,7 +1574,6 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
                 $testSequence->loadFromDb();
                 $testSequence->loadQuestions();
 
-                require_once 'Modules/Course/classes/Objectives/class.ilLOTestQuestionAdapter.php';
                 $objectivesAdapter = ilLOTestQuestionAdapter::getInstance($testSession);
 
                 $objectivesList = $this->buildQuestionRelatedObjectivesList($objectivesAdapter, $testSequence);

--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -37,15 +37,9 @@
  */
 class ilTestEvaluationGUI extends ilTestServiceGUI
 {
-    /**
-     * @var ilTestAccess
-     */
-    protected $testAccess;
-
-    /**
-     * @var ilTestProcessLockerFactory
-     */
-    protected $processLockerFactory;
+    protected ilTestAccess $testAccess;
+    protected ilTestProcessLockerFactory $processLockerFactory;
+    protected ilObjUser $current_user;
 
     /**
      * ilTestEvaluationGUI constructor
@@ -59,12 +53,12 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
     {
         parent::__construct($a_object);
 
-        global $DIC; /* @var ILIAS\DI\Container $DIC */
-        $this->dic = $DIC;
+        global $DIC;
+        $this->current_user = $DIC['ilUser'];
 
         $this->processLockerFactory = new ilTestProcessLockerFactory(
             new ilSetting('assessment'),
-            $this->dic->database()
+            $this->db
         );
     }
 
@@ -1224,7 +1218,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
     {
         $ilTabs = $this->tabs;
         $ilObjDataCache = $this->objCache;
-        $ilUser = $this->dic['ilUser'];
+        $ilUser = $this->current_user;
 
         $ilTabs->clearSubTabs();
         $ilTabs->setBackTarget($this->lng->txt('tst_results_back_overview'), $this->ctrl->getLinkTarget($this));
@@ -1549,7 +1543,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 
         $template->setVariable("TEXT_RESULTS", $this->lng->txt("tst_passes"));
 
-        $testPassesSelector = new ilTestPassesSelector($this->dic['ilDB'], $this->object);
+        $testPassesSelector = new ilTestPassesSelector($this->db, $this->object);
         $testPassesSelector->setActiveId($testSession->getActiveId());
         $testPassesSelector->setLastFinishedPass($testSession->getLastFinishedPass());
 

--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -1311,13 +1311,11 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
             $tpl->parseCurrentBlock();
 
             if ($this->object->isShowExamIdInTestResultsEnabled()) {
-                $tpl->setCurrentBlock('exam_id');
                 $tpl->setVariable('EXAM_ID', ilObjTest::lookupExamId(
                     $testSession->getActiveId(),
                     $pass
                 ));
                 $tpl->setVariable('EXAM_ID_TXT', $this->lng->txt('exam_id'));
-                $tpl->parseCurrentBlock();
             }
         }
 

--- a/Modules/Test/classes/class.ilTestRandomQuestionSetStagingPoolBuilder.php
+++ b/Modules/Test/classes/class.ilTestRandomQuestionSetStagingPoolBuilder.php
@@ -56,10 +56,7 @@ class ilTestRandomQuestionSetStagingPoolBuilder
     public function reset()
     {
         $this->removeMirroredTaxonomies();
-
         $this->removeStagedQuestions();
-
-        $this->cleanupTestSettings();
     }
 
     private function removeMirroredTaxonomies()
@@ -284,12 +281,4 @@ class ilTestRandomQuestionSetStagingPoolBuilder
             }
         }
     }
-
-    private function cleanupTestSettings()
-    {
-        $this->testOBJ->setResultFilterTaxIds(array());
-        $this->testOBJ->saveToDb(true);
-    }
-
-    // =================================================================================================================
 }

--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -217,8 +217,9 @@ class ilTestScoring
 
     public function addRecalculatedPassByActive($activeId, $pass)
     {
-        if (!array_key_exists($activeId, $this->recalculatedPasses) ||
-            !is_array($this->recalculatedPasses[$activeId])) {
+        if (! array_key_exists($activeId, $this->recalculatedPasses)
+            || !is_array($this->recalculatedPasses[$activeId])
+        ) {
             $this->recalculatedPasses[$activeId] = array();
         }
 

--- a/Modules/Test/classes/class.ilTestServiceGUI.php
+++ b/Modules/Test/classes/class.ilTestServiceGUI.php
@@ -362,8 +362,18 @@ class ilTestServiceGUI
      * @return string HTML code of the list of answers
      * @access public
      */
-    public function getPassListOfAnswers(&$result_array, $active_id, $pass, $show_solutions = false, $only_answered_questions = false, $show_question_only = false, $show_reached_points = false, $anchorNav = false, ilTestQuestionRelatedObjectivesList $objectivesList = null, ilTestResultHeaderLabelBuilder $testResultHeaderLabelBuilder = null): string
-    {
+    public function getPassListOfAnswers(
+        &$result_array,
+        $active_id,
+        $pass,
+        $show_solutions = false,
+        $only_answered_questions = false,
+        $show_question_only = false,
+        $show_reached_points = false,
+        $anchorNav = false,
+        ilTestQuestionRelatedObjectivesList $objectivesList = null,
+        ilTestResultHeaderLabelBuilder $testResultHeaderLabelBuilder = null
+    ): string {
         $maintemplate = new ilTemplate("tpl.il_as_tst_list_of_answers.html", true, true, "Modules/Test");
 
         $counter = 1;

--- a/Modules/Test/classes/class.ilTestServiceGUI.php
+++ b/Modules/Test/classes/class.ilTestServiceGUI.php
@@ -439,7 +439,9 @@ class ilTestServiceGUI
                             $compare_template->setVariable('SOLUTION', $best_output);
                             $template->setVariable('SOLUTION_OUTPUT', $compare_template->get());
                         } else {
-                            $result_output = $question_gui->getSolutionOutput($active_id, $pass, $show_solutions, false, $show_question_only, $showFeedback);
+                            $graphical_output = true;
+                            $show_correct_solution = false;
+                            $result_output = $question_gui->getSolutionOutput($active_id, $pass, $graphical_output, false, $show_question_only, $showFeedback, $show_correct_solution);
                             $template->setVariable('SOLUTION_OUTPUT', $result_output);
                         }
 
@@ -507,11 +509,7 @@ class ilTestServiceGUI
      */
     public function getPassListOfAnswersWithScoring(&$result_array, $active_id, $pass, $show_solutions = false): string
     {
-        include_once "./Modules/TestQuestionPool/classes/class.assQuestion.php";
-
         $maintemplate = new ilTemplate("tpl.il_as_tst_list_of_answers.html", true, true, "Modules/Test");
-
-        include_once "./Modules/Test/classes/class.ilObjAssessmentFolder.php";
         $scoring = ilObjAssessmentFolder::_getManualScoring();
 
         $counter = 1;

--- a/Modules/Test/classes/class.ilTestServiceGUI.php
+++ b/Modules/Test/classes/class.ilTestServiceGUI.php
@@ -440,7 +440,7 @@ class ilTestServiceGUI
                             $template->setVariable('SOLUTION_OUTPUT', $compare_template->get());
                         } else {
                             $graphical_output = true;
-                            $show_correct_solution = false;
+                            $show_correct_solution = true;
                             $result_output = $question_gui->getSolutionOutput($active_id, $pass, $graphical_output, false, $show_question_only, $showFeedback, $show_correct_solution);
                             $template->setVariable('SOLUTION_OUTPUT', $result_output);
                         }

--- a/Modules/Test/classes/class.ilTestServiceGUI.php
+++ b/Modules/Test/classes/class.ilTestServiceGUI.php
@@ -208,7 +208,7 @@ class ilTestServiceGUI
 
         foreach ($passes as $pass) {
             $row = [
-                'scored' => null,
+                'scored' => false,
                 'pass' => $pass,
                 'date' => ilObjTest::lookupLastTestPassAccess($testSession->getActiveId(), $pass)
             ];
@@ -585,8 +585,17 @@ class ilTestServiceGUI
         return $maintemplate->get();
     }
 
-    protected function getPassDetailsOverviewTableGUI($result_array, $active_id, $pass, $targetGUI, $targetCMD, $questionDetailsCMD, $questionAnchorNav, ilTestQuestionRelatedObjectivesList $objectivesList = null, $multipleObjectivesInvolved = true): ilTestPassDetailsOverviewTableGUI
-    {
+    protected function getPassDetailsOverviewTableGUI(
+        $result_array,
+        $active_id,
+        $pass,
+        $targetGUI,
+        $targetCMD,
+        $questionDetailsCMD,
+        $questionAnchorNav,
+        ilTestQuestionRelatedObjectivesList $objectivesList = null,
+        $multipleObjectivesInvolved = true
+    ): ilTestPassDetailsOverviewTableGUI {
         $this->ctrl->setParameter($targetGUI, 'active_id', $active_id);
         $this->ctrl->setParameter($targetGUI, 'pass', $pass);
 
@@ -877,7 +886,16 @@ class ilTestServiceGUI
             }
 
             if ($show_pass_details) {
-                $overviewTableGUI = $this->getPassDetailsOverviewTableGUI($result_array, $active_id, $pass, $targetGUI, "getResultsOfUserOutput", '', $show_answers, $objectivesList);
+                $overviewTableGUI = $this->getPassDetailsOverviewTableGUI(
+                    $result_array,
+                    $active_id,
+                    $pass,
+                    $targetGUI,
+                    "getResultsOfUserOutput",
+                    '',
+                    $show_answers,
+                    $objectivesList
+                );
                 $overviewTableGUI->setTitle($testResultHeaderLabelBuilder->getPassDetailsHeaderLabel($pass + 1));
                 $template->setVariable("PASS_DETAILS", $overviewTableGUI->getHTML());
             }
@@ -1032,7 +1050,6 @@ class ilTestServiceGUI
             $targetGUI->object = $targetGUI->getTestObj();
         }
 
-        require_once 'Modules/Test/classes/tables/class.ilTestPassDetailsOverviewTableGUI.php';
         $tableGUI = new ilTestPassDetailsOverviewTableGUI($this->ctrl, $targetGUI, $targetCMD);
         $tableGUI->setIsPdfGenerationRequest($this->isPdfDeliveryRequest());
         return $tableGUI;

--- a/Modules/Test/classes/class.ilTestToplistGUI.php
+++ b/Modules/Test/classes/class.ilTestToplistGUI.php
@@ -209,15 +209,7 @@ class ilTestToplistGUI
      */
     protected function isTopTenRankingTableRequired(): bool
     {
-        if ($this->object->getHighscoreMode() == ilObjTest::HIGHSCORE_SHOW_TOP_TABLE) {
-            return true;
-        }
-
-        if ($this->object->getHighscoreMode() == ilObjTest::HIGHSCORE_SHOW_ALL_TABLES) {
-            return true;
-        }
-
-        return false;
+        return $this->object->getHighscoreTopTable();
     }
 
     /**
@@ -225,14 +217,6 @@ class ilTestToplistGUI
      */
     protected function isOwnRankingTableRequired(): bool
     {
-        if ($this->object->getHighscoreMode() == ilObjTest::HIGHSCORE_SHOW_OWN_TABLE) {
-            return true;
-        }
-
-        if ($this->object->getHighscoreMode() == ilObjTest::HIGHSCORE_SHOW_ALL_TABLES) {
-            return true;
-        }
-
-        return false;
+        return $this->object->getHighscoreOwnTable();
     }
 }

--- a/Modules/Test/test/ScoreSettingsTest.php
+++ b/Modules/Test/test/ScoreSettingsTest.php
@@ -1,0 +1,636 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+
+use ILIAS\UI\Implementation\Component as I;
+use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component\SignalGenerator;
+use ILIAS\UI\Implementation\Component\Symbol as S;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data;
+use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
+
+class ScoreSettingsTest extends ILIAS_UI_TestBase
+{
+    public function testScoreSettingsBuild(): void
+    {
+        $id = -666;
+        $s = new ilObjTestScoreSettings(
+            $id,
+            new ilObjTestSettingsScoring($id),
+            new ilObjTestSettingsResultSummary($id),
+            new ilObjTestSettingsResultDetails($id),
+            new ilObjTestSettingsGamification($id)
+        );
+        $this->assertInstanceOf(ilObjTestScoreSettings::class, $s);
+        $this->assertEquals($id, $s->getTestId());
+        $this->assertInstanceOf(ilObjTestSettingsScoring::class, $s->getScoringSettings());
+        $this->assertInstanceOf(ilObjTestSettingsResultSummary::class, $s->getResultSummarySettings());
+        $this->assertInstanceOf(ilObjTestSettingsResultDetails::class, $s->getResultDetailsSettings());
+        $this->assertInstanceOf(ilObjTestSettingsGamification::class, $s->getGamificationSettings());
+    }
+
+    public function testScoreSettingsScoring(): void
+    {
+        $s = new ilObjTestSettingsScoring(-666);
+        $this->assertEquals(-667, $s->withTestId(-667)->getTestId());
+        $this->assertEquals(2, $s->withCountSystem(2)->getCountSystem());
+        $this->assertEquals(4, $s->withScoreCutting(4)->getScoreCutting());
+        $this->assertEquals(5, $s->withPassScoring(5)->getPassScoring());
+    }
+
+    public function testScoreSettingsSummary(): void
+    {
+        $dat = new \DateTimeImmutable();
+        $s = new ilObjTestSettingsResultSummary(-666);
+        $this->assertEquals(5, $s->withScoreReporting(5)->getScoreReporting());
+        $this->assertTrue($s->withScoreReporting(1)->getScoreReportingEnabled());
+        $this->assertFalse($s->withScoreReporting(0)->getScoreReportingEnabled());
+        $this->assertEquals($dat, $s->withReportingDate($dat)->getReportingDate());
+        $this->assertTrue($s->withShowGradingStatusEnabled(true)->getShowGradingStatusEnabled());
+        $this->assertFalse($s->withShowGradingStatusEnabled(false)->getShowGradingStatusEnabled());
+        $this->assertTrue($s->withShowGradingMarkEnabled(true)->getShowGradingMarkEnabled());
+        $this->assertFalse($s->withShowGradingMarkEnabled(false)->getShowGradingMarkEnabled());
+        $this->assertTrue($s->withPassDeletionAllowed(true)->getPassDeletionAllowed());
+        $this->assertFalse($s->withPassDeletionAllowed(false)->getPassDeletionAllowed());
+        $this->assertTrue($s->withShowPassDetails(true)->getShowPassDetails());
+        $this->assertFalse($s->withShowPassDetails(false)->getShowPassDetails());
+    }
+
+    public function testScoreSettingsDetails(): void
+    {
+        $s = new ilObjTestSettingsResultDetails(-666);
+        $this->assertTrue($s->withPrintBestSolutionWithResult(true)->getPrintBestSolutionWithResult());
+        $this->assertEquals(192, $s->withResultsPresentation(192)->getResultsPresentation(192));
+        $this->assertTrue($s->withShowExamIdInTestResults(true)->getShowExamIdInTestResults());
+        $this->assertTrue($s->withShowPassDetails(true)->getShowPassDetails());
+        $this->assertFalse($s->withShowPassDetails(false)->getShowPassDetails());
+        $this->assertTrue($s->withShowSolutionDetails(true)->getShowSolutionDetails());
+        $this->assertFalse($s->withShowSolutionDetails(false)->getShowSolutionDetails());
+        $this->assertTrue($s->withShowSolutionPrintview(true)->getShowSolutionPrintview());
+        $this->assertFalse($s->withShowSolutionPrintview(false)->getShowSolutionPrintview());
+        $this->assertTrue($s->withShowSolutionFeedback(true)->getShowSolutionFeedback());
+        $this->assertFalse($s->withShowSolutionFeedback(false)->getShowSolutionFeedback());
+        $this->assertTrue($s->withShowSolutionAnswersOnly(true)->getShowSolutionAnswersOnly());
+        $this->assertFalse($s->withShowSolutionAnswersOnly(false)->getShowSolutionAnswersOnly());
+        $this->assertTrue($s->withShowSolutionSignature(true)->getShowSolutionSignature());
+        $this->assertFalse($s->withShowSolutionSignature(false)->getShowSolutionSignature());
+        $this->assertTrue($s->withShowSolutionSuggested(true)->getShowSolutionSuggested());
+        $this->assertFalse($s->withShowSolutionSuggested(false)->getShowSolutionSuggested());
+        $this->assertTrue($s->withShowSolutionListComparison(true)->getShowSolutionListComparison());
+        $this->assertFalse($s->withShowSolutionListComparison(false)->getShowSolutionListComparison());
+        $this->assertTrue($s->withExportSettingsSingleChoiceShort(true)->getExportSettingsSingleChoiceShort());
+        $this->assertFalse($s->withExportSettingsSingleChoiceShort(false)->getExportSettingsSingleChoiceShort());
+        $this->assertTrue($s->withShowPassDetails(true)->getShowPassDetails());
+        $tax_ids = [1,3,5,17];
+        $this->assertEquals($tax_ids, $s->withTaxonomyFilterIds($tax_ids)->getTaxonomyFilterIds());
+    }
+
+    public function testScoreSettingsGamification(): void
+    {
+        $s = new ilObjTestSettingsGamification(-666);
+        $this->assertTrue($s->withHighscoreEnabled(true)->getHighscoreEnabled());
+        $this->assertFalse($s->withHighscoreEnabled(false)->getHighscoreEnabled());
+        $this->assertTrue($s->withHighscoreAnon(true)->getHighscoreAnon());
+        $this->assertFalse($s->withHighscoreAnon(false)->getHighscoreAnon());
+        $this->assertTrue($s->withHighscoreAchievedTS(true)->getHighscoreAchievedTS());
+        $this->assertFalse($s->withHighscoreAchievedTS(false)->getHighscoreAchievedTS());
+        $this->assertTrue($s->withHighscoreScore(true)->getHighscoreScore());
+        $this->assertFalse($s->withHighscoreScore(false)->getHighscoreScore());
+        $this->assertTrue($s->withHighscorePercentage(true)->getHighscorePercentage());
+        $this->assertFalse($s->withHighscorePercentage(false)->getHighscorePercentage());
+        $this->assertTrue($s->withHighscoreHints(true)->getHighscoreHints());
+        $this->assertFalse($s->withHighscoreHints(false)->getHighscoreHints());
+        $this->assertTrue($s->withHighscoreWTime(true)->getHighscoreWTime());
+        $this->assertFalse($s->withHighscoreWTime(false)->getHighscoreWTime());
+        $this->assertTrue($s->withHighscoreOwnTable(true)->getHighscoreOwnTable());
+        $this->assertFalse($s->withHighscoreOwnTable(false)->getHighscoreOwnTable());
+        $this->assertTrue($s->withHighscoreTopTable(true)->getHighscoreTopTable());
+        $this->assertFalse($s->withHighscoreTopTable(false)->getHighscoreTopTable());
+        $this->assertEquals(15, $s->withHighscoreTopNum(15)->getHighscoreTopNum());
+    }
+
+
+
+    protected function getFieldFactory()
+    {
+        $factory = new I\Input\Field\Factory(
+            $this->createMock(I\Input\UploadLimitResolver::class),
+            new IncrementalSignalGenerator(),
+            new Data\Factory(),
+            $this->getRefinery(),
+            $this->getLanguage()
+        );
+        return $factory;
+    }
+
+    protected function getUIPack()
+    {
+        return [
+            $this->getLanguage(),
+            $this->getFieldFactory(),
+            $this->getRefinery()
+        ];
+    }
+
+    public function testScoreSettingsSectionScoring(): void
+    {
+        $s = new ilObjTestSettingsScoring(666);
+        $actual = $this->getDefaultRenderer()->render(
+            $s->toForm(...$this->getUIPack())
+        );
+
+        $expected = <<<EOT
+<div class="il-section-input">
+    <div class="il-section-input-header"><h2>test_scoring</h2></div>
+    
+    <div class="form-group row">
+        <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_text_count_system</label>
+        <div class="col-sm-8 col-md-9 col-lg-10">
+            <div id="id_1" class="il-input-radio">
+
+                <div class="form-control form-control-sm il-input-radiooption">
+                    <input type="radio" id="id_1_0_opt" name="" value="0" checked="checked" />
+                    <label for="id_1_0_opt">tst_count_partial_solutions</label>
+                    <div class="help-block">tst_count_partial_solutions_desc</div>
+                </div>
+                <div class="form-control form-control-sm il-input-radiooption">
+                    <input type="radio" id="id_1_1_opt" name="" value="1" />
+                    <label for="id_1_1_opt">tst_count_correct_solutions</label>
+                    <div class="help-block">tst_count_correct_solutions_desc</div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_score_cutting</label>
+        <div class="col-sm-8 col-md-9 col-lg-10">
+            <div id="id_2" class="il-input-radio">
+            
+                <div class="form-control form-control-sm il-input-radiooption">
+                    <input type="radio" id="id_2_0_opt" name="" value="0" checked="checked" />
+                    <label for="id_2_0_opt">tst_score_cut_question</label>
+                    <div class="help-block">tst_score_cut_question_desc</div>
+                </div>
+                <div class="form-control form-control-sm il-input-radiooption">
+                    <input type="radio" id="id_2_1_opt" name="" value="1" />
+                    <label for="id_2_1_opt">tst_score_cut_test</label>
+                    <div class="help-block">tst_score_cut_test_desc</div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_pass_scoring</label>
+        <div class="col-sm-8 col-md-9 col-lg-10">
+            <div id="id_3" class="il-input-radio">
+                <div class="form-control form-control-sm il-input-radiooption">
+                    <input type="radio" id="id_3_0_opt" name="" value="0" checked="checked" />
+                    <label for="id_3_0_opt">tst_pass_last_pass</label>
+                    <div class="help-block">tst_pass_last_pass_desc</div>
+                </div>
+                <div class="form-control form-control-sm il-input-radiooption">
+                    <input type="radio" id="id_3_1_opt" name="" value="1" />
+                    <label for="id_3_1_opt">tst_pass_best_pass</label>
+                    <div class="help-block">tst_pass_best_pass_desc</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+EOT;
+
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($this->brutallyTrimSignals($actual))
+        );
+    }
+
+
+    public function getUIFactory(): NoUIFactory
+    {
+        return new class () extends NoUIFactory {
+            public function symbol(): C\Symbol\Factory
+            {
+                return new S\Factory(
+                    new S\Icon\Factory(),
+                    new S\Glyph\Factory(),
+                    new S\Avatar\Factory()
+                );
+            }
+        };
+    }
+
+    public function testScoreSettingsSectionSummary(): void
+    {
+        $data_factory = new \ILIAS\Data\Factory();
+        $language = $this->getLanguage();
+        $refinery = new \ILIAS\Refinery\Factory($data_factory, $language);
+
+        $field_factory = new ILIAS\UI\Implementation\Component\Input\Field\Factory(
+            $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
+            new \ILIAS\UI\Implementation\Component\SignalGenerator(),
+            $data_factory,
+            $refinery,
+            $language
+        );
+        $ui = [$language, $field_factory, $refinery];
+
+        $s = new ilObjTestSettingsResultSummary(666);
+        $actual = $this->getDefaultRenderer()->render(
+            $s->toForm(...$ui)
+        );
+
+        $expected = <<<EOT
+<div class="il-section-input">
+    <div class="il-section-input-header"><h2>test_results</h2></div>
+        <div class="form-group row">
+            <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_access_enabled</label>
+            <div class="col-sm-8 col-md-9 col-lg-10">
+                <input type="checkbox" id="id_1" value="checked" name="" class="form-control form-control-sm" />
+                <div class="help-block">tst_results_access_enabled_desc</div>
+                <div class="form-group row">
+                    <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_access_setting<span class="asterisk">*</span></label>
+                    <div class="col-sm-8 col-md-9 col-lg-10">
+                        <div id="id_2" class="il-input-radio">
+                            <div class="form-control form-control-sm il-input-radiooption">
+                                <input type="radio" id="id_2_2_opt" name="" value="2" />
+                                <label for="id_2_2_opt">tst_results_access_always</label>
+                                <div class="help-block">tst_results_access_always_desc</div>
+                            </div>
+                            <div class="form-control form-control-sm il-input-radiooption">
+                                <input type="radio" id="id_2_1_opt" name="" value="1" />
+                                <label for="id_2_1_opt">tst_results_access_finished</label>
+                                <div class="help-block">tst_results_access_finished_desc</div>
+                            </div>
+                            <div class="form-control form-control-sm il-input-radiooption">
+                                <input type="radio" id="id_2_4_opt" name="" value="4" />
+                                <label for="id_2_4_opt">tst_results_access_passed</label>
+                                <div class="help-block">tst_results_access_passed_desc</div>
+                            </div>
+
+                            <div class="form-control form-control-sm il-input-radiooption">
+                                <input type="radio" id="id_2_3_opt" name="" value="3" />
+                                <label for="id_2_3_opt">tst_results_access_date</label>
+                                <div class="form-group row">
+                                    <label for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">tst_reporting_date<span class="asterisk">*</span></label>
+                                    <div class="col-sm-8 col-md-9 col-lg-10">
+                                        <div class="input-group date il-input-datetime" id="id_3">
+                                            <input type="text" name="" placeholder="YYYY-MM-DD HH:mm" class="form-control form-control-sm" />
+                                            <span class="input-group-addon"><a class="glyph" href="#" aria-label="calendar"><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span></a></span>
+                                        </div>
+                                    </div>
+                                </div>
+                            <div class="help-block">tst_results_access_date_desc</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        
+            <div class="form-group row">
+                <label for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_grading_opt_show_status</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_4" value="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_results_grading_opt_show_status_desc</div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="id_5" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_grading_opt_show_mark</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_5" value="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_results_grading_opt_show_mark_desc</div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="id_6" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_grading_opt_show_details</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_6" value="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_results_grading_opt_show_details_desc</div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="id_7" class="control-label col-sm-4 col-md-3 col-lg-2">tst_pass_deletion</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_7" value="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_pass_deletion_allowed</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+EOT;
+
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($this->brutallyTrimSignals($actual))
+        );
+    }
+
+
+
+
+    public function testScoreSettingsSectionDetails(): void
+    {
+        $s = new ilObjTestSettingsResultDetails(666);
+        $tax_ids = [1,2];
+        $actual = $this->getDefaultRenderer()->render(
+            $s->toForm(
+                ...array_merge(
+                    $this->getUIPack(),
+                    [['taxonomy_options' => $tax_ids]]
+                )
+            )
+        );
+
+        $expected = <<<EOT
+<div class="il-section-input">
+    <div class="il-section-input-header"><h2>tst_results_details_options</h2></div>
+    <div class="form-group row">
+        <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_details</label>
+        <div class="col-sm-8 col-md-9 col-lg-10">
+            <input type="checkbox" id="id_1" value="checked" name="" class="form-control form-control-sm" />
+            <div class="help-block">tst_show_solution_details_desc</div>
+            <div class="form-group row">
+                <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_print_best_solution</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_2" value="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_results_print_best_solution_info</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_details_singlepage</label>
+        <div class="col-sm-8 col-md-9 col-lg-10">
+            <input type="checkbox" id="id_3" value="checked" name="" class="form-control form-control-sm" />
+            <div class="help-block">tst_show_solution_details_singlepage_desc</div>
+            <div class="form-group row">
+                <label for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_print_best_solution_singlepage</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_4" value="checked" checked="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_results_print_best_solution_singlepage_info</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label for="id_5" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_feedback</label>
+        <div class="col-sm-8 col-md-9 col-lg-10">
+            <input type="checkbox" id="id_5" value="checked" name="" class="form-control form-control-sm" /><div class="help-block">tst_show_solution_feedback_desc</div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label for="id_6" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_suggested</label><div class="col-sm-8 col-md-9 col-lg-10">
+            <input type="checkbox" id="id_6" value="checked" name="" class="form-control form-control-sm" /><div class="help-block">tst_show_solution_suggested_desc</div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label for="id_7" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_printview</label><div class="col-sm-8 col-md-9 col-lg-10">
+            <input type="checkbox" id="id_7" value="checked" name="" class="form-control form-control-sm" /><div class="help-block">tst_show_solution_printview_desc</div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label for="id_8" class="control-label col-sm-4 col-md-3 col-lg-2">tst_hide_pagecontents</label><div class="col-sm-8 col-md-9 col-lg-10">
+            <input type="checkbox" id="id_8" value="checked" name="" class="form-control form-control-sm" /><div class="help-block">tst_hide_pagecontents_desc</div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label for="id_9" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_signature</label><div class="col-sm-8 col-md-9 col-lg-10">
+            <input type="checkbox" id="id_9" value="checked" name="" class="form-control form-control-sm" /><div class="help-block">tst_show_solution_signature_desc</div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label for="id_10" class="control-label col-sm-4 col-md-3 col-lg-2">examid_in_test_res</label><div class="col-sm-8 col-md-9 col-lg-10">
+            <input type="checkbox" id="id_10" value="checked" checked="checked" name="" class="form-control form-control-sm" /><div class="help-block">examid_in_test_res_desc</div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label for="id_11" class="control-label col-sm-4 col-md-3 col-lg-2">tst_exp_sc_short</label><div class="col-sm-8 col-md-9 col-lg-10">
+            <input type="checkbox" id="id_11" value="checked" name="" class="form-control form-control-sm" /><div class="help-block">tst_exp_sc_short_desc</div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_tax_filters</label>
+        <div class="col-sm-8 col-md-9 col-lg-10">
+            <ul class="il-input-multiselect" id="id_12">
+                <li>
+                    <input type="checkbox" name="[]" value="0" /><span>1</span>
+                </li>
+                <li>
+                    <input type="checkbox" name="[]" value="1" /><span>2</span>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+</div>
+EOT;
+
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($this->brutallyTrimSignals($actual))
+        );
+    }
+
+
+    public function testScoreSettingsSectionGamification(): void
+    {
+        $s = new ilObjTestSettingsGamification(666);
+        $actual = $this->getDefaultRenderer()->render(
+            $s->toForm(...$this->getUIPack())
+        );
+
+        $expected = <<<EOT
+<div class="il-section-input">
+
+    <div class="il-section-input-header"><h2>tst_results_gamification</h2></div>
+    
+    <div class="form-group row">
+        <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_enabled</label>
+        <div class="col-sm-8 col-md-9 col-lg-10">
+            <input type="checkbox" id="id_1" value="checked" name="" class="form-control form-control-sm" />
+            <div class="help-block">tst_highscore_description</div>
+    
+            <div class="form-group row">
+                <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_mode<span class="asterisk">*</span></label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <div id="id_2" class="il-input-radio">
+                        <div class="form-control form-control-sm il-input-radiooption">
+                            <input type="radio" id="id_2_1_opt" name="" value="1" />
+                            <label for="id_2_1_opt">tst_highscore_own_table</label>
+                            <div class="help-block">tst_highscore_own_table_description</div>
+                        </div>
+
+                        <div class="form-control form-control-sm il-input-radiooption">
+                            <input type="radio" id="id_2_2_opt" name="" value="2" />
+                            <label for="id_2_2_opt">tst_highscore_top_table</label>
+                            <div class="help-block">tst_highscore_top_table_description</div>
+                        </div>
+
+                        <div class="form-control form-control-sm il-input-radiooption">
+                            <input type="radio" id="id_2_3_opt" name="" value="3" checked="checked" />
+                            <label for="id_2_3_opt">tst_highscore_all_tables</label>
+                            <div class="help-block">tst_highscore_all_tables_description</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-group row">
+                <label for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_top_num<span class="asterisk">*</span></label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input id="id_3" type="number" value="10" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_highscore_top_num_description</div>
+                </div>
+            </div>
+            
+            <div class="form-group row">
+                <label for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_anon</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_4" value="checked" checked="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_highscore_anon_description</div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="id_5" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_achieved_ts</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_5" value="checked" checked="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_highscore_achieved_ts_description</div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="id_6" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_score</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_6" value="checked" checked="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_highscore_score_description</div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="id_7" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_percentage</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_7" value="checked" checked="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_highscore_percentage_description</div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="id_8" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_hints</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_8" value="checked" checked="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_highscore_hints_description</div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="id_9" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_wtime</label>
+                <div class="col-sm-8 col-md-9 col-lg-10">
+                    <input type="checkbox" id="id_9" value="checked" checked="checked" name="" class="form-control form-control-sm" />
+                    <div class="help-block">tst_highscore_wtime_description</div>
+                </div>
+            </div>
+        
+        </div>
+
+    </div>
+</div>
+EOT;
+
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected),
+            $this->brutallyTrimHTML($this->brutallyTrimSignals($actual))
+        );
+    }
+
+    public function testScoreSettingsDirectlyAccessedByTestObj(): void
+    {
+        $id = -666;
+        $s = new ilObjTestScoreSettings(
+            $id,
+            new ilObjTestSettingsScoring($id),
+            new ilObjTestSettingsResultSummary($id),
+            new ilObjTestSettingsResultDetails($id),
+            new ilObjTestSettingsGamification($id)
+        );
+
+        $t = new class ($s) extends ilObjTest {
+            public function __construct($s)
+            {
+                $this->score_settings = $s;
+            }
+        };
+
+        $this->assertIsInt($t->getCountSystem());
+        $this->assertIsInt($t->getScoreCutting());
+        $this->assertIsInt($t->getPassScoring());
+        $this->assertNull($t->getReportingDate());
+        $this->assertIsBool($t->getShowPassDetails());
+        $this->assertIsBool($t->getShowSolutionDetails());
+        $this->assertIsBool($t->getShowSolutionAnswersOnly());
+        $this->assertIsBool($t->getShowSolutionSignature());
+        $this->assertIsBool($t->getShowSolutionSuggested());
+        $this->assertIsBool($t->getShowSolutionListComparison());
+        $this->assertIsBool($t->getShowSolutionListOwnAnswers());
+        $this->assertIsBool($t->isPassDeletionAllowed());
+        $this->assertIsInt($t->getExportSettings());
+        $this->assertIsBool($t->getExportSettingsSingleChoiceShort());
+        $this->assertIsBool($t->getHighscoreEnabled());
+        $this->assertIsBool($t->getHighscoreAnon());
+        $this->assertIsBool($t->getHighscoreAchievedTS());
+        $this->assertIsBool($t->getHighscoreScore());
+        $this->assertIsBool($t->getHighscorePercentage());
+        $this->assertIsBool($t->getHighscoreHints());
+        $this->assertIsBool($t->getHighscoreWTime());
+        $this->assertIsBool($t->getHighscoreOwnTable());
+        $this->assertIsBool($t->getHighscoreTopTable());
+        $this->assertIsInt($t->getHighscoreTopNum());
+        $this->assertIsInt($t->getHighscoreMode());
+    }
+
+    public function testScoreSettingsRelayingTestId(): void
+    {
+        $id = -666;
+        $s = new ilObjTestScoreSettings(
+            $id,
+            new ilObjTestSettingsScoring($id),
+            new ilObjTestSettingsResultSummary($id),
+            new ilObjTestSettingsResultDetails($id),
+            new ilObjTestSettingsGamification($id)
+        );
+
+        $nu_id =  1234;
+        $s = $s->withTestId($nu_id);
+        $this->assertEquals($nu_id, $s->getTestId());
+        $this->assertEquals($nu_id, $s->getScoringSettings()->getTestId());
+        $this->assertEquals($nu_id, $s->getResultSummarySettings()->getTestId());
+        $this->assertEquals($nu_id, $s->getResultDetailsSettings()->getTestId());
+        $this->assertEquals($nu_id, $s->getGamificationSettings()->getTestId());
+    }
+}

--- a/Modules/Test/test/ilObjTestSettingsScoringResultsGUITest.php
+++ b/Modules/Test/test/ilObjTestSettingsScoringResultsGUITest.php
@@ -18,21 +18,52 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
 /**
  * Class ilObjTestSettingsScoringResultsGUITest
  * @author Marvin Beym <mbeym@databay.de>
+ * @author Nils Haagen <nhaagen@concepts-and-training.de>
  */
-class ilObjTestSettingsScoringResultsGUITest extends ilTestBaseTestCase
+class ilObjTestSettingsScoringResultsGUITest extends TestCase
 {
-    private ilObjTestSettingsScoringResultsGUI $testObj;
-
-    protected function setUp(): void
+    protected function getUIComponents(): array
     {
-        parent::setUp();
+        $test_helper = new UITestHelper();
+
+        $ui_factory = $test_helper->factory();
+        $ui_renderer = $test_helper->renderer();
+        $refinery = $this->getMockBuilder(\ILIAS\Refinery\Factory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request = $this->createMock(ServerRequestInterface::class);
+
+        $main_template = $test_helper->mainTemplate();
+        $tabs_gui = $this->createMock(ilTabsGUI::class);
+
+        return [
+            $ui_factory,
+            $ui_renderer,
+            $refinery,
+            $request,
+            $main_template,
+            $tabs_gui
+        ];
+    }
 
 
+    public function testScoringResultsGUIConstruct(): void
+    {
         $objTestGui_mock = $this->getMockBuilder(ilObjTestGUI::class)->disableOriginalConstructor()->onlyMethods(array('getObject'))->getMock();
-        $objTestGui_mock->expects($this->any())->method('getObject')->willReturn($this->createMock(ilObjTest::class));
+        $objTestGui_mock->expects(
+            $this->any()
+        )->method('getObject')->willReturn(
+            $this->createMock(ilObjTest::class)
+        );
+
+        list($ui_factory, $ui_renderer, $refinery, $request, $main_template, $tabs_gui) = $this->getUIComponents();
 
         $this->testObj = new ilObjTestSettingsScoringResultsGUI(
             $this->createMock(ilCtrl::class),
@@ -41,12 +72,17 @@ class ilObjTestSettingsScoringResultsGUITest extends ilTestBaseTestCase
             $this->getMockBuilder(ilTree::class)->disableOriginalConstructor()->getMock(),
             $this->createMock(ilDBInterface::class),
             $this->createMock(ilComponentRepository::class),
-            $objTestGui_mock
+            $objTestGui_mock,
+            $main_template,
+            $tabs_gui,
+            $this->createMock(ScoreSettingsRepository::class),
+            -123,
+            $ui_factory,
+            $ui_renderer,
+            $refinery,
+            $request
         );
-    }
 
-    public function test_instantiateObject_shouldReturnInstance(): void
-    {
         $this->assertInstanceOf(ilObjTestSettingsScoringResultsGUI::class, $this->testObj);
     }
 }

--- a/Modules/Test/test/ilTestEvaluationGUITest.php
+++ b/Modules/Test/test/ilTestEvaluationGUITest.php
@@ -39,6 +39,7 @@ class ilTestEvaluationGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilComponentRepository();
         $this->addGlobal_ilTabs();
         $this->addGlobal_ilObjDataCache();
+        $this->addGlobal_ilUser();
 
         $this->testObj = new ilTestEvaluationGUI($this->createMock(ilObjTest::class));
     }

--- a/Modules/TestQuestionPool/classes/class.ilQuestionPoolTaxonomiesDuplicator.php
+++ b/Modules/TestQuestionPool/classes/class.ilQuestionPoolTaxonomiesDuplicator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -112,19 +114,25 @@ class ilQuestionPoolTaxonomiesDuplicator
     private function duplicateTaxonomyFromPoolToTest($poolTaxonomyId): void
     {
         $poolTaxonomy = new ilObjTaxonomy($poolTaxonomyId);
-        $testTaxonomy = $poolTaxonomy->cloneObject(0, 0, true);
+        $testTaxonomy = new ilObjTaxonomy();
+        $testTaxonomy->create();
+        $testTaxonomy->setTitle($poolTaxonomy->getTitle());
+        $testTaxonomy->setDescription($poolTaxonomy->getDescription());
+        $testTaxonomy->setSortingMode($poolTaxonomy->getSortingMode());
 
-        if($testTaxonomy instanceof ilObjTaxonomy) {
-            $poolTaxonomy->getTree()->readRootId();
-            $testTaxonomy->getTree()->readRootId();
+        $this->node_mapping = array();
 
-            $testTaxonomy->update();
+        $poolTaxonomy->cloneNodes(
+            $testTaxonomy,
+            $testTaxonomy->getTree()->readRootId(),
+            $poolTaxonomy->getTree()->readRootId()
+        );
 
-            ilObjTaxonomy::saveUsage($testTaxonomy->getId(), $this->getTargetObjId());
+        $testTaxonomy->update();
 
-            $this->duplicatedTaxonomiesKeysMap->addDuplicatedTaxonomy($poolTaxonomy, $testTaxonomy);
-        }
+        ilObjTaxonomy::saveUsage($testTaxonomy->getId(), $this->getTargetObjId());
 
+        $this->duplicatedTaxonomiesKeysMap->addDuplicatedTaxonomy($poolTaxonomy, $testTaxonomy);
     }
 
     private function transferAssignmentsFromOriginalToDuplicatedTaxonomy($originalTaxonomyId, $mappedTaxonomyId): void

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -738,7 +738,7 @@ assessment#:#exam_id_label#:#ILIAS-Prüfungsnummer
 assessment#:#examid_in_test_pass#:#ILIAS-Prüfungsnummer anzeigen
 assessment#:#examid_in_test_pass_desc#:#Im Test wird eine ILIAS-Prüfungsnummer angezeigt. Für jeden Testdurchlauf wird eine eigene Nummer erzeugt.
 assessment#:#examid_in_test_res#:#ILIAS-Prüfungsnummer anzeigen
-assessment#:#examid_in_test_res_desc#:#In den Testergebnissen wird die ILIAS-Prüfungsnummer dargestellt.
+assessment#:#examid_in_test_res_desc#:#In den Testergebnissen, der Statistik und dem Excel-Export wird die ILIAS-Prüfungsnummer dargestellt.
 assessment#:#exp_eval_data#:#Evaluationsdaten exportieren als
 assessment#:#exp_file_created#:#Exportdatei erzeugt.
 assessment#:#exp_type_certificate#:#Zertifikat (PDF)
@@ -1417,7 +1417,7 @@ assessment#:#tst_eval_total_passed_average_points#:#Durchschnittliche Punktezahl
 assessment#:#tst_eval_total_passed_average_time#:#Mittlere Bearbeitungsdauer aller bestandenen Tests
 assessment#:#tst_eval_total_persons#:#Gesamtzahl der Personen, die den Test gestartet haben
 assessment#:#tst_exp_sc_short#:#Item-Statistik-Export für reinen Single Choice-Test
-assessment#:#tst_exp_sc_short_desc#:#Im Reiter 'Statistik' kann eine Export-Option 'MS Excel' ausgewählt werden. Sie erzeugt ein zusätzliches Datenblatt für eine Item-Statistik außerhalb von ILIAS. Diese Option funktioniert nur für reine Single Choice-Tests.
+assessment#:#tst_exp_sc_short_desc#:#Im Reiter „Statistik“ kann eine Export-Option „MS Excel“ ausgewählt werden. Das erzeugte Datenblatt kann außerhalb von ILIAS für eine Item-Statistik ausgewertet werden. Diese Option funktioniert nur für reine Single Choice-Tests.
 assessment#:#tst_extratime_added#:#Die Bearbeitungszeit des Teilnehmers wurde um %s Minuten verlängert.
 assessment#:#tst_extratime_info#:#Falls die Bearbeitungszeit eines Testteilnehmers mehrmals verlängert wird, geben Sie hier bitte die Summe aller seiner Zeitverlängerungen an.
 assessment#:#tst_extratime_notavailable#:#Zeitverlängerungen können nur für Tests mit einem Durchlauf und einer vorgegebenen Bearbeitungszeit durchgeführt werden.
@@ -1447,20 +1447,22 @@ assessment#:#tst_general_properties#:#Einstellungen des Tests
 assessment#:#tst_header_participant#:#Ihre Antwort:
 assessment#:#tst_header_solution#:#Bestmögliche Lösung:
 assessment#:#tst_heading_scoring#:#Bewertung
+assessment#:#tst_hide_pagecontents#:#Seiteninhalte ausblenden
+assessment#:#tst_hide_pagecontents_desc#:#ILIAS-Inhalte, die über den Button "Seite bearbeiten" vor und hinter dem eigentlichen Fragentext platziert wurden, werden in den Ergebnisansichten und der Druckausgabe nicht angezeigt.
 assessment#:#tst_hide_side_list#:#Fragenliste aus
 assessment#:#tst_highscore_achieved_ts#:#Datum
 assessment#:#tst_highscore_achieved_ts_description#:#Es wird eine zusätzliche Spalte mit dem Zeitpunkt des Tests eingeblendet.
 assessment#:#tst_highscore_all_tables#:#Eigener Rang und Bestenliste
 assessment#:#tst_highscore_all_tables_description#:#Zeigt sowohl eine Tabelle mit der eigenen Platzierung als auch eine Tabelle mit den besten Platzierungen.
 assessment#:#tst_highscore_anon#:#Keine Namen anzeigen
-assessment#:#tst_highscore_anon_description#:#Die Platzierungen anderer Teilnehmer werden ohne Angabe der Namen angezeigt.  Dies geschieht ohnehin bei anonymisierten Tests.
-assessment#:#tst_highscore_description#:#Im Reiter 'Ergebnisse' wird Teilnehmern ein Unterreiter 'Platzierung' angezeigt. Teilnehmern wird nach dem Anklicken eine Tabelle über das Abschneiden der verschiedenen Teilnehmer im Test  angezeigt. Sie müssen die Option 'Teilnehmer sehen Testergebnisse' aktivieren, um diese Funktion zu nutzen.
+assessment#:#tst_highscore_anon_description#:#Die Platzierungen anderer Teilnehmerinnen und Teilnehmer werden ohne Angabe der Namen angezeigt. Dies geschieht automatisch bei anonymisierten Tests.
+assessment#:#tst_highscore_description#:#Im Reiter 'Ergebnisse' wird ein zusätzlicher Unterreiter 'Platzierung' angezeigt. Es wird eine Tabelle über das Abschneiden der verschiedenen Personen im Test angezeigt. Sie müssen die Option „Eigenes Testergebnis einsehen“ aktivieren, um diese Funktion zu nutzen.
 assessment#:#tst_highscore_enabled#:#Platzierungen
 assessment#:#tst_highscore_hints#:#Lösungshinweise
 assessment#:#tst_highscore_hints_description#:#Es wird einen zusätzliche Spalte eingeblendet, in welcher angezeigt wird, wie viele Lösungshinweise angefordert wurden.
 assessment#:#tst_highscore_mode#:#Modus
 assessment#:#tst_highscore_own_table#:#Eigenen Rang anzeigen
-assessment#:#tst_highscore_own_table_description#:#Teilnehmern wird eine Tabelle mit ihrem Rang innerhalb aller Platzierungen angezeigt.
+assessment#:#tst_highscore_own_table_description#:#Teilnehmerinnen und Teilnehmern wird eine Tabelle mit ihrem Rang innerhalb aller Platzierungen angezeigt.
 assessment#:#tst_highscore_percentage#:#Prozentwert
 assessment#:#tst_highscore_percentage_description#:#Es wird einen zusätzliche Spalte mit der Angabe des erreichten Prozentwerts eingeblendet.
 assessment#:#tst_highscore_score#:#Punkte
@@ -1469,7 +1471,7 @@ assessment#:#tst_highscore_top_num#:#Länge der Bestenliste
 assessment#:#tst_highscore_top_num_description#:#Bestimmt, wie viele Einträge in der Bestenliste angezeigt werden.
 assessment#:#tst_highscore_top_num_unit#:#Platzierungen
 assessment#:#tst_highscore_top_table#:#Bestenliste
-assessment#:#tst_highscore_top_table_description#:#Teilnehmern wird eine Tabelle mit den besten Platzierungen angezeigt.
+assessment#:#tst_highscore_top_table_description#:#Teilnehmerinnen und Teilnehmern wird eine Tabelle mit den besten Platzierungen angezeigt.
 assessment#:#tst_highscore_wtime#:#Bearbeitungsdauer
 assessment#:#tst_highscore_wtime_description#:#Es wird einen zusätzliche Spalte mit der Bearbeitungsdauer eingeblendet.
 assessment#:#tst_imap_qst_mode#:#Antwortmodus
@@ -1625,25 +1627,24 @@ assessment#:#tst_participant#:#Teilnehmer
 assessment#:#tst_participant_fullname_pattern#:#%2$s, %1$s
 assessment#:#tst_participant_status#:#Teilnehmerstatus
 assessment#:#tst_participating_users#:#Teilnehmende Benutzer
-assessment#:#tst_pass_best_pass#:#Besten Testdurchlauf bewerten
-assessment#:#tst_pass_best_pass_desc#:#Es wird der Testdurchlauf bewertet, bei dem der Teilnehmer die höchste Punktezahl erreicht hat. Diese Einstellungen greift nur, wenn mehrere Testdurchläufe durchgeführt werden können.
+assessment#:#tst_pass_best_pass#:#Besten Durchlauf des Tests bewerten
+assessment#:#tst_pass_best_pass_desc#:#Es wird der Durchlauf bewertet, bei dem die höchste Punktezahl erreicht wurde.
 assessment#:#tst_pass_deletion#:#Durchläufe löschen
 assessment#:#tst_pass_deletion_allowed#:#Die Löschung von vorherigen Durchläufen ist erlaubt
-assessment#:#tst_pass_deletion_not_allowed#:#Die Löschung von vorherigen Durchläufen ist NICHT erlaubt
 assessment#:#tst_pass_details#:#Detaillierte Ergebnisse
 assessment#:#tst_pass_details_header_lo_initial#:#Einstiegsergebnisse zu den Lernzielen<br />%s - %s
 assessment#:#tst_pass_details_header_lo_qualifying#:#Qualifizierende Ergebnisse zu den Lernzielen<br />%s - %s
 assessment#:#tst_pass_details_overview_table_title#:#Detaillierte Testergebnisse für Testdurchlauf %s
 assessment#:#tst_pass_finished#:#Testdurchlauf wurde beendet
 assessment#:#tst_pass_finished_on#:#Testdurchlauf beendet am
-assessment#:#tst_pass_last_pass#:#Letzten Testdurchlauf bewerten
-assessment#:#tst_pass_last_pass_desc#:#Es wird immer der letzte Testdurchlauf eines Teilnehmers bewertet.
+assessment#:#tst_pass_last_pass#:#Letzten Durchlauf des Tests bewerten
+assessment#:#tst_pass_last_pass_desc#:#Es wird nur der letzte Durchlauf des Tests bewertet.
 assessment#:#tst_pass_overview_for_participant#:#Testdurchläufe für Teilnehmer: %s
 assessment#:#tst_pass_overview_header_lo_initial_all_objectives#:#Einstiegstestergebnisse<br />zu den Lernzielen im Kurs %s
 assessment#:#tst_pass_overview_header_lo_initial_per_objective#:#Einstiegstestergebnisse<br />zum Lernziel %s im Kurs %s
 assessment#:#tst_pass_overview_header_lo_qualifying_all_objectives#:#Qualifizierende Testergebnisse<br />zu den Lernzielen im Kurs %s
 assessment#:#tst_pass_overview_header_lo_qualifying_per_objective#:#Qualifizierende Testergebnisse<br />zum Lernziel %s im Kurs %s
-assessment#:#tst_pass_scoring#:#Bewertung bei mehreren Testdurchläufen
+assessment#:#tst_pass_scoring#:#Bewertung bei mehreren Durchläufen
 assessment#:#tst_pass_waiting_enabled#:#Wartezeit zwischen Durchläufen erzwingen
 assessment#:#tst_pass_waiting_info#:#Mit dieser Option können erneute Durchläufe erst gestartet werden, wenn die definierte Zeitspanne seit dem vorherigen Durchlauf abgelaufen ist.
 assessment#:#tst_pass_waiting_time#:#Wartezeit
@@ -1783,27 +1784,32 @@ assessment#:#tst_result_user_name#:#Testergebnisse für %s
 assessment#:#tst_result_user_name_pass#:#Ergebnisse von Testdurchlauf %s für %s
 assessment#:#tst_results#:#Testergebnisse
 assessment#:#tst_results_access_always#:#Sofort
-assessment#:#tst_results_access_always_desc#:#Teilnehmer können ihre Ergebnisse schon während eines Testdurchlaufs über den 'Ergebnisse'-Reiter einsehen. Zu dem werden sie direkt nach Abschluss des Testdurchlaufs dort hin geleitet.
+assessment#:#tst_results_access_always_desc#:#Schon während eines Testdurchlaufs kann ein Zwischenergebnis über den Reiter "Ergebnisse" eingesehen werden. Nach Abschluss des Durchlaufs wird automatisch das Testergebnis angezeigt.
 assessment#:#tst_results_access_date#:#Ab definiertem Datum
-assessment#:#tst_results_access_date_desc#:#Erst ab dem gewählten Datum können Teilnehmer Ihre Ergebnisse im 'Ergebnis'-Reiter einsehen.
-assessment#:#tst_results_access_enabled#:#Teilnehmer sehen Testergebnisse
-assessment#:#tst_results_access_enabled_desc#:#Teilnehmer erhalten Zugriff auf Ihre Testergebnisse über einen Reiter 'Ergebnisse'.
-assessment#:#tst_results_access_finished#:#Nach Testdurchlauf
-assessment#:#tst_results_access_finished_desc#:#Teilnehmer sehen ihre Ergebnisse direkt nach Abschluss eines Testdurchlaufs. Sie können ihre Ergebnisse danach jederzeit im 'Ergebnisse'-Reiter einsehen.
+assessment#:#tst_results_access_date_desc#:#Erst ab dem gewählten Datum werden Ergebnisse im Reiter "Ergebnisse" anzeigt.
+assessment#:#tst_results_access_enabled#:#Eigenes Testergebnis einsehen
+assessment#:#tst_results_access_enabled_desc#:#Teilnehmerinnen und Teilnehmer erhalten Zugriff auf Ihre Testergebnisse über den Reiter "Ergebnisse".
+assessment#:#tst_results_access_finished#:#Nach Durchlauf des Tests
+assessment#:#tst_results_access_finished_desc#:#Nach Abschluss eines Testdurchlaufs werden die Ergebnisse automatisch im Reiter "Ergebnisse" angezeigt.
 assessment#:#tst_results_access_passed#:#Nach Bestehen des Tests
-assessment#:#tst_results_access_passed_desc#:#Teilnehmer sehen ihre Ergebnisse nachdem sie den Test bestanden haben. Sie können ihre Ergebnisse dann jederzeit im 'Ergebnisse'-Reiter einsehen.
+assessment#:#tst_results_access_passed_desc#:#Erst wenn der Test bestanden wurde, werden die Ergebnisse angezeigt. Teilnehmerinnen und Teilnehmern, die den Test nicht bestehen, wird kein Ergebnis angezeigt.
 assessment#:#tst_results_access_setting#:#Zeitpunkt
 assessment#:#tst_results_aggregated#:#Aggregierte Testergebnisse
 assessment#:#tst_results_back_introduction#:#Zurück zur Startseite
 assessment#:#tst_results_back_overview#:#Zurück zur Ergebnisübersicht
-assessment#:#tst_results_details_options#:#Details Testergebnisse
-assessment#:#tst_results_grading_opt_show_mark#:#Resultierende Note anzeigen
-assessment#:#tst_results_grading_opt_show_mark_desc#:#Die resultierende Note wird in der Übersicht der Testergebnisse angezeigt. Teilnehmer können die Testergebnisse über den Reiter 'Ergebnisse' einsehen.
+assessment#:#tst_results_details_options#:#Weitere Optionen
+assessment#:#tst_results_gamification#:#Gamification
+assessment#:#tst_results_grading_opt_show_details#:#Detaillierte Testergebnisse anzeigen
+assessment#:#tst_results_grading_opt_show_details_desc#:#Zusätzlich zum zusammenfassenden Testergebnis wird eine Aktion "Detaillierte Ergebnisse" angeboten. Die Tabelle "Detaillierte Testergebnisse" zeigt für jeden Durchlauf die Titel der Fragen und die erreichten Punkte an. Der Inhalt der Tabelle kann im Abschnitt "Weitere Optionen" weiter ergänzt werden.
+assessment#:#tst_results_grading_opt_show_mark#:#Note anzeigen
+assessment#:#tst_results_grading_opt_show_mark_desc#:#Eine Meldung im Reiter "Ergebnisse" informiert Teilnehmerinnen und Teilnehmer, welche Note sie erzielt haben.
 assessment#:#tst_results_grading_opt_show_status#:#"Bestanden" / "Nicht bestanden" anzeigen
-assessment#:#tst_results_grading_opt_show_status_desc#:#Der Status "Bestanden" / "Nicht bestanden" wird in der Übersicht der Testergebnisse angezeigt. Teilnehmer können die Testergebnisse über den Reiter 'Ergebnisse' einsehen.
+assessment#:#tst_results_grading_opt_show_status_desc#:#Eine Meldung im Reiter "Ergebnisse" informiert Teilnehmerinnen und Teilnehmer, ob sie bestanden haben oder nicht.
 assessment#:#tst_results_overview#:#Übersicht der Testdurchläufe
 assessment#:#tst_results_print_best_solution#:#Bestmögliche Lösung
-assessment#:#tst_results_print_best_solution_info#:#Zusätzlich wird für jede Frage die bestmögliche Lösung angezeigt.
+assessment#:#tst_results_print_best_solution_info#:#Den eigenen Antworten werden die bestmöglichen Lösungen gegenübergestellt.
+assessment#:#tst_results_print_best_solution_singlepage#:#Bestmögliche Lösung
+assessment#:#tst_results_print_best_solution_singlepage_info#:#Zusätzlich wird für jede Frage die bestmögliche Lösung angezeigt.
 assessment#:#tst_results_tax_filters#:#Ergebnisfilter
 assessment#:#tst_resume_dyn_test_with_cur_quest_sel#:#Test mit aktueller Fragenauswahl fortsetzen
 assessment#:#tst_resume_test#:#Test fortsetzen
@@ -1848,24 +1854,24 @@ assessment#:#tst_show_answer_sheet#:#Antwortenübersicht anzeigen
 assessment#:#tst_show_cancel#:#"Test unterbrechen" anzeigen
 assessment#:#tst_show_cancel_description#:#Zeigt während der Durchführung des Tests einen Button an, mit der der Test unterbrochen werden kann. Achtung: Das Unterbrechen des Tests hält nicht die unter 'Maximale Bearbeitungsdauer' festgelegte Bearbeitungszeit an.
 assessment#:#tst_show_comp_results#:#Kompetenz-Ergebnisse
-assessment#:#tst_show_pass_details#:#'Tabelle mit detaillierten Testergebnissen' pro Durchlauf zum gewählten Zeitpunkt anzeigen
-assessment#:#tst_show_pass_details_desc#:#Zum oben gewählten Zeitpunkt wird die Bekanntgabe des Ergebnisses um eine weitere Tabelle ergänzt. <br>In dieser Tabelle werden für jeden Durchlauf die Titel der Fragen und die erreichten Punkte angezeigt. <br> Andernfalls erscheint diese Tabelle nur nach dem letzten erlaubten Testdurchlauf (einzustellen im Unterreiter 'Allgemeine Einstellungen', Option  'Anzahl von Testdurchläufen begrenzen') oder nach dem Ende des Tests (einzustellen im Unterreiter 'Allgemeine Einstellungen', Abschnitt  'Ende'). <br>Der Inhalt der Tabelle kann im Abschnitt 'Details Testergebnisse' weiter ergänzt werden.
 assessment#:#tst_show_results#:#Testergebnisse
 assessment#:#tst_show_side_list#:#Fragenliste an
 assessment#:#tst_show_solution_answers_only#:#Druckausgabe der Ergebnisse (nur Antworten)
 assessment#:#tst_show_solution_answers_only_desc#:#Wenn "Druckausgabe der Ergebnisse (nur Antworten)" ausgewählt ist, werden ILIAS-Inhalte, die Sie über den "Inhalt bearbeiten"-Reiter der Fragen vor und hinter dem eigentlichen Fragentext platzieren können, in einem Ausdruck nicht angezeigt.
 assessment#:#tst_show_solution_compare#:#Zeige bestmögliche Lösung in 'Tabelle mit detaillierten Testergebnissen'
 assessment#:#tst_show_solution_compare_desc#:#Teilnehmern wird als Teil der 'Tabelle mit detaillierten Testergebnissen' eine Übersicht präsentiert, welche ihre eigenen Antworten und die bestmögliche Lösung gegenüberstellt. <br> Diese Übersicht wird nicht im Unterreiter 'Bewertete Antworten' des 'Ergebnisse'-Reiters angezeigt, auch wenn diese Einstellung hier vorgenommen wird.
-assessment#:#tst_show_solution_details#:#Bewertete Teilnehmerantworten
-assessment#:#tst_show_solution_details_desc#:#Teilnehmer bekommen zusätzlich zur 'Tabelle mit detaillierten Testergebnissen' auf einer neuen Seite für jede einzelne Frage angezeigt, welche Antworten sie gegeben haben, ob diese Antworten richtig waren und wie viele Punkte sie mit diesen Antworten erreicht haben.
+assessment#:#tst_show_solution_details#:#Bewertete Antworten als Liste
+assessment#:#tst_show_solution_details_desc#:#Die Tabelle "Detallierte Testergebnisse" wird um eine Liste der eigenen Antworten ergänzt.
+assessment#:#tst_show_solution_details_singlepage#:#Bewertete Antworten auf Einzelseiten
+assessment#:#tst_show_solution_details_singlepage_desc#:#Teilnehmerinnen und Teilnehmer können jede Frage einzeln aufrufen und sehen, ob ihre Antworten richtig waren und wie viele Punkte sie damit erreicht haben.
 assessment#:#tst_show_solution_feedback#:#Rückmeldungen
-assessment#:#tst_show_solution_feedback_desc#:#Falls Rückmeldungen zu den gegebenen Antworten bei der Frage hinterlegt worden sind, werden diese angezeigt. Sie müssen die Option 'Bewertete Teilnehmerantworten‘ und/oder 'Druckbare Liste der Antworten' aktivieren, um diese Funktion zu nutzen.
+assessment#:#tst_show_solution_feedback_desc#:#Falls Rückmeldungen zu den gegebenen Antworten bei der Frage hinterlegt worden sind, werden diese angezeigt. Sie müssen die Option "Bewertete Antworten als Liste" und/oder "Bewertete Antworten auf Einzelseiten" aktivieren, um diese Funktion zu nutzen.
 assessment#:#tst_show_solution_printview#:#Druckbare Liste der Antworten
-assessment#:#tst_show_solution_printview_desc#:#Teilnehmern wird eine Übersicht mit ihren Antworten zu den einzelnen Testfragen angezeigt. Diese Übersicht wird nach Beendigung innerhalb des 'Ergebnisse'-Reiters in einem Unterreiter 'Bewertete Antworten' angeboten.
+assessment#:#tst_show_solution_printview_desc#:#Nach dem Klick auf "Test beenden" wird im Reiter "Ergebnisse" ein zusätzlicher Reiter "Bewertete Antworten" eingeblendet. Den Teilnehmerinnen und Teilnehmern werden hier ihre Antworten zu den einzelnen Testfragen angezeigt.
 assessment#:#tst_show_solution_signature#:#Platzhalter für Unterschrift
-assessment#:#tst_show_solution_signature_desc#:#Es wird im Ausdruck ein Platzhalter für die Unterschrift des Testteilnehmers angezeigt. Sie müssen, um diese Funktion zu nutzen, zusätzlich die Option 'Tabelle mit detaillierten Testergebnissen' aktivieren.
+assessment#:#tst_show_solution_signature_desc#:#Ist die Option „Detaillierte Testergebnisse anzeigen“ oder „Druckbare Liste der Antworten“ aktiviert, fügt ILIAS zusätzlich ein Unterschriftenfeld in den Ausdruck ein. In diesem kann die Person, die den Test durchgeführt hat, unterschreiben.
 assessment#:#tst_show_solution_suggested#:#Inhalte zur Wiederholung
-assessment#:#tst_show_solution_suggested_desc#:#Falls den Fragen im Test Inhalte zur Wiederholung des Stoffs zugeordnet wurden, werden diese in der 'Tabelle mit detaillierten Testergebnissen' angezeigt. Teilnehmer können so etwaige Wissenslücken schließen. Sie müssen, um diese Funktion zu nutzen, zusätzlich die Option 'Tabelle mit detaillierten Testergebnissen'  aktivieren.
+assessment#:#tst_show_solution_suggested_desc#:#Falls den Fragen im Test Inhalte zur Wiederholung des Stoffs zugeordnet wurden, werden diese angezeigt. Sie müssen die Option "Detaillierte Testergebnissen anzeigen" aktivieren, um diese Funktion zu nutzen. Teilnehmerinnen und Teilnehmer können so etwaige Wissenslücken schließen.
 assessment#:#tst_show_summary#:#Fragenliste und Bearbeitungstand anzeigen
 assessment#:#tst_show_summary_description#:#Teilnehmer können sich links neben den Testfragen eine Fragenliste anzeigen lassen. Mit dem Button 'Bearbeitungsstand' rufen die Teilnehmer eine Übersicht auf, die zeigt, welche Fragen sie jeweils bereits bearbeitet oder markiert haben. Das Verhalten der Übersicht 'Bearbeitungsstand' können Sie noch weiter konfigurieren:
 assessment#:#tst_show_toplist#:#Platzierung


### PR DESCRIPTION
This adjusts the ResultSettings form of TestObject according to a suggestion from the ILIAS-NRW group.
I still need some clarification concerning the exact mapping of some former options to new fields, but this should be a rather non-tech issue.
Also, UI-forms are used as well as a repo-adaption to maybe devide the big number of settings into smaller units.
I'll still have to look into export/import and the template-funtionality.

Comments are most welcome already, though.
