### PR TITLE
[FIX] phpstorm code-style config

### DIFF
--- a/docs/development/code-style-configs/php-storm.xml
+++ b/docs/development/code-style-configs/php-storm.xml
@@ -12,6 +12,8 @@
     <option name="KEEP_RPAREN_AND_LBRACE_ON_ONE_LINE" value="true" />
     <option name="BLANK_LINES_AFTER_OPENING_TAG" value="1" />
     <option name="KEEP_BLANK_LINES_AFTER_LBRACE" value="0" />
+    <option name="SPACE_BEFORE_COLON_IN_RETURN_TYPE" value="true" />
+    <option name="SPACE_BEFORE_COLON_IN_ENUM_BACKED_TYPE" value="true" />
     <option name="ATTRIBUTES_WRAP" value="2" />
     <option name="PARAMETERS_ATTRIBUTES_WRAP" value="2" />
   </PHPCodeStyleSettings>


### PR DESCRIPTION
Hi @mjansenDatabay

I've noticed another small issue with the new code-style config for PHPStorm. Up until now the declaration of return-types was like `function foo() : int` instead of `function bar(): int`, which would be fixed by this PR.

Since we would want to keep things consistent I also assumed this would fit in case of enums, therefore I adjusted this setting as well from `enum a: int` to `enum b : int`. If that's not the case though, you can just adopt the `SPACE_BEFORE_COLON_IN_RETURN_TYPE` option.

Kind regards!