### PR TITLE
Fix Language Detection For WebDAV

### DIFF
--- a/Services/Language/classes/class.ilLanguageDetectorFactory.php
+++ b/Services/Language/classes/class.ilLanguageDetectorFactory.php
@@ -52,7 +52,8 @@ class ilLanguageDetectorFactory
         );
 
         if ($this->settings->get("lang_detection") &&
-            ilContext::usesHTTP()
+            ilContext::usesHTTP() &&
+            array_key_exists('HTTP_ACCEPT_LANGUAGE', $this->request_information)
         ) {
             $detectors[] = $this->createDetectorByType(self::HTTP_REQUEST_DETECTOR);
         }


### PR DESCRIPTION
WebDAV is an HTTP-Protocol, thus it has usesHTTP set to true. Not all clients deem it necessary though to send a ACCEPTS_LANGUAGE Header (Windows Explorer doesn't), so that we need this additional check.