### PR TITLE
Fix Issue When Saving New LongMenu Question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assLongMenu.php
+++ b/Modules/TestQuestionPool/classes/class.assLongMenu.php
@@ -175,7 +175,11 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable
         return false;
     }
 
-    public function saveToDb($original_id = ""): void
+    /**
+     *
+     * @param int $original_id
+     */
+    public function saveToDb($original_id = -1): void
     {
         $this->saveQuestionDataToDb($original_id);
         $this->saveAdditionalQuestionDataToDb();


### PR DESCRIPTION
This Fixes an Issue when creating a new longmenu question. As original_id is null it will be set to an empty string and thus fail.