### PR TITLE
Prevent Invalidating Random Test

### DIFF
--- a/Modules/Test/classes/class.ilTestRandomQuestionSetConfigGUI.php
+++ b/Modules/Test/classes/class.ilTestRandomQuestionSetConfigGUI.php
@@ -973,7 +973,8 @@ class ilTestRandomQuestionSetConfigGUI
     {
         $return = false;
         $last_sync = $this->questionSetConfig->getLastQuestionSyncTimestamp();
-        if ($last_sync != 0) {
+        if ($last_sync != 0 &&
+            !$this->isFrozenConfigRequired()) {
             $return = true;
             
             $sync_date = new ilDateTime($last_sync, IL_CAL_UNIX);

--- a/Modules/Test/classes/class.ilTestRandomQuestionSetConfigStateMessageHandler.php
+++ b/Modules/Test/classes/class.ilTestRandomQuestionSetConfigStateMessageHandler.php
@@ -248,7 +248,7 @@ class ilTestRandomQuestionSetConfigStateMessageHandler
             );
             
             $message .= sprintf(
-                $this->lng->txt('tst_msg_rand_quest_set_stage_pool_last_sync'),
+                ' ' . $this->lng->txt('tst_msg_rand_quest_set_stage_pool_last_sync'),
                 ilDatePresentation::formatDate($syncDate)
             );
             


### PR DESCRIPTION
I don't see this directly as a bug and maybe it has been discussed already, but at least for us this caused troubles:
See: https://mantis.ilias.de/view.php?id=34334

This PR also adds a space where one is missing in the UI. I can move this elsewhere, if it bothers.