### PR TITLE
Fix Removal of < in KPrim-Question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
@@ -310,7 +310,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         }
         
         foreach ($answers as $key => $answer) {
-            $answer->setAnswerText(ilUtil::secureString($answer->getAnswerText()));
+            $answer->setAnswerText(ilUtil::secureString(htmlspecialchars($answer->getAnswerText())));
         }
         
         return $answers;

--- a/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -184,7 +184,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                 }
 
                 $tpl->setCurrentBlock("prop_text_propval");
-                $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getAnswertext()));
+                $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput(htmlspecialchars_decode($value->getAnswertext())));
                 $tpl->parseCurrentBlock();
 
                 $tpl->setCurrentBlock('singleline');


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=25428
So, this is not beautiful, but I don't find a better way to achieve this (if anyone sees one, I'm happy and will change it):
- I think the most correct way forward with the current infrastructure would be to change ilUtil::prepareFormOutput() to disallow double_encode, but I'm a little skeptical of side effects and ilUtil is on its way out anyways.
- The correct way on the middle run, is to completely replace the current way to build these forms in the test, but this is clearly out of scope here.
As always: If this is ok with you, I will provide the PR against 8.