### PR TITLE
Bugfix 31495 FileInfo Error with no file

### DIFF
--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
@@ -212,7 +212,9 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
 
         if ($grading->getFile() == '') {
             $storage = $this->getUserFileStorage();
-            $storage->deleteCurrentFile();
+            if (!$storage->isEmpty()) {
+                $storage->deleteCurrentFile();
+            }
         }
 
         if ($grading->isFinalized()) {

--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
@@ -455,16 +455,6 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
     {
         $filename = $this->getFileName();
 
-        if (empty($filename)) {
-            return new BasicFileInfoResult(
-                $this->getFileIdentifierParameterName(),
-                'unknown',
-                'unknown',
-                0,
-                'unknown'
-            );
-        }
-
         if ($filename != $identifier) {
             throw new LogicException("Wrong filename $identifier");
         }

--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
@@ -454,7 +454,6 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
     protected function getInfoResult(string $identifier) : FileInfoResult
     {
         $filename = $this->getFileName();
-
         if ($filename != $identifier) {
             throw new LogicException("Wrong filename $identifier");
         }

--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
@@ -212,9 +212,7 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
 
         if ($grading->getFile() == '') {
             $storage = $this->getUserFileStorage();
-            if (!$storage->isEmpty()) {
-                $storage->deleteCurrentFile();
-            }
+            $storage->deleteCurrentFile();
         }
 
         if ($grading->isFinalized()) {
@@ -456,6 +454,17 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
     protected function getInfoResult(string $identifier) : FileInfoResult
     {
         $filename = $this->getFileName();
+
+        if (empty($filename)) {
+            return new BasicFileInfoResult(
+                $this->getFileIdentifierParameterName(),
+                'unknown',
+                'unknown',
+                0,
+                'unknown'
+            );
+        }
+
         if ($filename != $identifier) {
             throw new LogicException("Wrong filename $identifier");
         }

--- a/Modules/IndividualAssessment/classes/ilIndividualAssessmentUserGrading.php
+++ b/Modules/IndividualAssessment/classes/ilIndividualAssessmentUserGrading.php
@@ -103,6 +103,11 @@ class ilIndividualAssessmentUserGrading
         return $this->file;
     }
 
+    public function hasFile() : bool
+    {
+        return !empty($this->file);
+    }
+
     public function isFileVisible() : bool
     {
         return $this->is_file_visible;
@@ -178,7 +183,7 @@ class ilIndividualAssessmentUserGrading
 
         $file = $input
             ->file($file_handler, $lng->txt('iass_upload_file'), $lng->txt('iass_file_dropzone'))
-            ->withValue([$this->getFile()])
+            ->withValue($this->hasFile() ? [$this->getFile()] : null)
         ;
 
         $file_visible = $input


### PR DESCRIPTION
#bugfix
Target: release_7
Mantis issue: 31495
https://mantis.ilias.de/view.php?id=31495

The error was triggered every time the assessment form for a user in an individual assessment was loaded without a file having been added to it. The parent class calls the abstract function getInfoResult (which should return file information) and the current implementation in the ilIndividualAssessmentMemberGUI class could not handle an empty identifier.

This fix leans on the implementation as in the ilMMUploadHandlerGUI class which inherits from the same parent class.

An alternative solution would be to avoid calling the function in the first place by modifying the parent class AbstractCtrlAwareUploadHandler:100. I chose this safer approach to avoid unforeseen effects in other parts of the code, but I am of course open for discussion on that point :).