### PR TITLE
Bugfix/0030763 iass store title and description in metadata

### DIFF
--- a/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessment.php
+++ b/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessment.php
@@ -66,12 +66,11 @@ class ilObjIndividualAssessment extends ilObject
     /**
      * @inheritdoc
      */
-    public function create($a_upload = false)
+    public function create()
     {
         parent::create();
-        if (!$a_upload) {
-            $this->createMetaData();
-        }
+        $this->createMetaData();
+
         $this->settings = new ilIndividualAssessmentSettings(
             (int) $this->getId(),
             '',

--- a/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessment.php
+++ b/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessment.php
@@ -66,9 +66,12 @@ class ilObjIndividualAssessment extends ilObject
     /**
      * @inheritdoc
      */
-    public function create()
+    public function create($a_upload = false)
     {
         parent::create();
+        if (!$a_upload) {
+            $this->createMetaData();
+        }
         $this->settings = new ilIndividualAssessmentSettings(
             (int) $this->getId(),
             '',
@@ -173,6 +176,7 @@ class ilObjIndividualAssessment extends ilObject
      */
     public function delete()
     {
+        $this->deleteMetaData();
         $this->settings_storage->deleteSettings($this);
         $this->members_storage->deleteMembers($this);
         parent::delete();
@@ -184,6 +188,8 @@ class ilObjIndividualAssessment extends ilObject
     public function update()
     {
         parent::update();
+        $this->updateMetaData();
+
         $this->settings_storage->updateSettings($this->settings);
     }
 


### PR DESCRIPTION
#bugfix
Mantis issue: 0030763
https://mantis.ilias.de/view.php?id=30763

Title and description were not stored in metadata. The missing method calls were added in the ilObjIndividualAssessment class.
The ilObjSurvey class served as a template for this fix. In this class the create method is called with „a_upload = false“ as a parameter. That didn't open up to me for the individual assessment class, so I left it out. But if the parameter is needed somewhere, I can add it to the function.
