### PR TITLE
Notifications: Add JS toast API. Fix Bugs 34363, 34224

### DIFF
--- a/Services/Notifications/classes/Repository/ilNotificationOSDRepository.php
+++ b/Services/Notifications/classes/Repository/ilNotificationOSDRepository.php
@@ -90,7 +90,7 @@ class ilNotificationOSDRepository implements ilNotificationOSDRepositoryInterfac
         $query = 'SELECT count(*) AS count FROM ' . ilNotificationSetupHelper::$tbl_notification_osd_handler . ' WHERE notification_osd_id = %s';
         $result = $this->database->queryF($query, [ilDBConstants::T_INTEGER], [$id]);
         $row = $this->database->fetchAssoc($result);
-        return ($row['count'] ?? 0) === 1;
+        return ((int) ($row['count'] ?? 0)) === 1;
     }
 
     /**

--- a/Services/Notifications/classes/ToastsOfNotifications.php
+++ b/Services/Notifications/classes/ToastsOfNotifications.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Services\Notifications;
+
+use Closure;
+use ILIAS\UI\Factory as UIFactory;
+use ilSetting;
+use ILIAS\UI\Component\Toast\Toast;
+use ILIAS\Notifications\Model\OSD\ilOSDNotificationObject;
+
+class ToastsOfNotifications
+{
+    private UIFactory $factory;
+    private ilSetting $settings;
+
+    public function __construct(UIFactory $factory, ilSetting $settings)
+    {
+        $this->factory = $factory;
+        $this->settings = $settings;
+    }
+
+    public function create(array $notifications): array
+    {
+        return array_map([$this, 'toastFromNotification'], $notifications);
+    }
+
+    private function toastFromNotification(ilOSDNotificationObject $notification): Toast
+    {
+        $toast = $this->factory
+               ->toast()
+               ->standard(
+                   $notification->getObject()->title,
+                   $this->factory->symbol()->icon()->custom($notification->getObject()->iconPath, '')
+               )
+               ->withAction('ilias.php?' . http_build_query([
+                   'baseClass' => 'ilNotificationGUI',
+                   'cmd' => 'removeOSDNotifications',
+                   'cmdMode' => 'asynch',
+                   'notification_id' => $notification->getId()
+               ]))
+               ->withDescription($notification->getObject()->shortDescription)
+               ->withVanishTime($this->secondsToMS((int) $this->settings->get('osd_vanish')))
+               ->withDelayTime((int) $this->settings->get('osd_delay'));
+
+        foreach ($notification->getObject()->links as $link) {
+            $toast = $toast->withAdditionalLink($this->factory->link()->standard(
+                $link->getTitle(),
+                $link->getUrl()
+            ));
+        }
+
+        return $toast;
+    }
+
+    private function secondsToMS(int $seconds): int
+    {
+        return $seconds * 1000;
+    }
+}

--- a/Services/Notifications/classes/class.ilNotificationGUI.php
+++ b/Services/Notifications/classes/class.ilNotificationGUI.php
@@ -25,6 +25,7 @@ use ILIAS\Notifications\ilNotificationDatabaseHandler;
 use ILIAS\Notifications\ilNotificationHandler;
 use ILIAS\Notifications\ilNotificationOSDHandler;
 use ILIAS\Notifications\ilNotificationSettingsTable;
+use ILIAS\Services\Notifications\ToastsOfNotifications;
 
 /**
  * @author Ingmar Szmais <iszmais@databay.de>
@@ -108,40 +109,18 @@ class ilNotificationGUI implements ilCtrlBaseClassInterface
     public function getOSDNotificationsObject(): void
     {
         $settings = new ilSetting('notifications');
-
         ilSession::enableWebAccessWithoutSession(true);
-
         $notifications = (new ilNotificationOSDHandler())->getNotificationsForUser(
             $this->user->getId(),
             true,
             $this->dic->http()->wrapper()->query()->retrieve('max_age', $this->dic->refinery()->kindlyTo()->int())
         );
 
-        $result = new stdClass();
-        $result->notifications = $notifications;
-        $toasts = [];
-        foreach ($result->notifications as $notification) {
-            $toast = $this->dic->ui()->factory()->toast()->standard(
-                $notification->getObject()->title,
-                $this->dic->ui()->factory()->symbol()->icon()->custom($notification->getObject()->iconPath, '')
-            )
-            ->withAction('ilias.php?' . http_build_query([
-                    'baseClass' => 'ilNotificationGUI',
-                    'cmd' => 'removeOSDNotifications',
-                    'cmdMode' => 'asynch',
-                    'notification_id' => $notification->getId()
-            ]))
-            ->withDescription($notification->getObject()->shortDescription)
-            ->withVanishTime($settings->get('osd_vanish') * 1000)
-            ->withDelayTime((int) $settings->get('osd_delay'));
-            foreach ($notification->getObject()->links as $link) {
-                $toast = $toast->withAdditionalLink($this->dic->ui()->factory()->link()->standard(
-                    $link->getTitle(),
-                    $link->getUrl()
-                ));
-            }
-            $toasts[] = $toast;
-        }
+        $toasts = (new ToastsOfNotifications(
+            $this->dic->ui()->factory(),
+            $settings
+        ))->create($notifications);
+
         $this->dic->http()->saveResponse(
             $this->dic->http()->response()
                 ->withBody(Streams::ofString(

--- a/Services/Notifications/templates/default/notifications.js
+++ b/Services/Notifications/templates/default/notifications.js
@@ -1,83 +1,117 @@
-var OSDNotifier, OSDNotifications = (settings) => {
-	return (function () {
-		return new function () {
-			let	lastRequest = 0;
-			let osdNotificationContainer = il.UI.page.getOverlay().querySelector('.il-toast-container');
+var OSDNotifier, OSDNotifications = settings => {
+    const createThrottle = function(timeout){
+        let clear = function(){};
+        return function(callback){
+            clear();
+            clear = clearTimeout.bind(window, setTimeout(callback, timeout));
+        };
+    };
+    const evalInCleanEnv = codeAsString => new Function('', codeAsString).call();
+    const template = function(template, values){
+        return Object.entries(values).reduce(function(template, [key, value]){
+            return template.split('[' + key + ']').join(value);
+        }, template);
+    };
 
-			let playSound = () => {
-				let sound = document.createElement('audio');
+    const playSound = () => {
+	const sound = document.createElement('audio');
 
-				let mp3 = document.createElement('source');
-				mp3.src = 'Modules/Chatroom/sounds/receive.mp3';
-				mp3.type = 'audio/mp3';
-				sound.append(mp3);
+	const mp3 = document.createElement('source');
+	mp3.src = 'Modules/Chatroom/sounds/receive.mp3';
+	mp3.type = 'audio/mp3';
+	sound.append(mp3);
 
-				let ogg = document.createElement('source');
-				ogg.src = 'Modules/Chatroom/sounds/receive.ogg';
-				ogg.type = 'audio/ogg';
-				sound.append(ogg);
+	const ogg = document.createElement('source');
+	ogg.src = 'Modules/Chatroom/sounds/receive.ogg';
+	ogg.type = 'audio/ogg';
+	sound.append(ogg);
 
-				let attach = new Promise((resolve) => {
-					document.querySelector('body').append(sound);
-					resolve();
-				});
-				attach.then(
-					function() {
-						sound.play().then(() => {
-							console.log("Played sound successfully!");
-						}).catch((e) => {
-							console.log("Could not play sound, autoplay policy changes: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes");
-							console.log(e);
-						});
-					}
-				)
-			}
+	const attach = new Promise((resolve) => {
+	    document.querySelector('body').append(sound);
+	    resolve();
+	});
+	attach.then(
+	    function() {
+		sound.play().then(() => {
+		    console.log("Played sound successfully!");
+		}).catch((e) => {
+		    console.log("Could not play sound, autoplay policy changes: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes");
+		    console.log(e);
+		});
+	    }
+	);
+    };
 
-			let init = true;
-			let poll = () => {
-				let time = parseInt(new Date().getTime() / 1000);
-				let max_age = time - lastRequest;
-				let xhr = new XMLHttpRequest();
-				let updateCenter;
-				xhr.open('GET', 'ilias.php?baseClass=ilNotificationGUI&cmd=getOSDNotifications&cmdMode=asynch&max_age=' + max_age);
-				xhr.onload = () => {
-					if (xhr.status === 200) {
-						osdNotificationContainer.innerHTML = xhr.responseText;
-						osdNotificationContainer.querySelectorAll('script').forEach( element => {
-							eval(element.innerHTML);
-						})
-						osdNotificationContainer.querySelectorAll('.il-toast-wrapper').forEach(element => {
-							element.querySelectorAll('a').forEach(link => {
-								link.addEventListener('click', () => {
-									il.UI.toast.closeToast(element.querySelector('.il-toast'), true)
-								})
-							})
-							element.addEventListener('removeToast', () => {
-								if(updateCenter !== undefined) {
-									clearTimeout(updateCenter)
-								}
-								updateCenter = setTimeout(() => {document.dispatchEvent(new Event('rerenderNotificationCenter'))}, 500);
-							})
-						})
+    const createContentSetter = function(container){
+        const updateCenter = createThrottle(100);
 
-						if (!init && settings.playSound && xhr.responseText !== '') {
-							playSound();
-						}
+        return function(html){
+            container.innerHTML = html;
+	    container.querySelectorAll('script').forEach(element => {
+                evalInCleanEnv(element.innerHTML);
+	    });
+	    container.querySelectorAll('.il-toast-wrapper').forEach(element => {
+	        element.querySelectorAll('a').forEach(link => {
+		    link.addEventListener('click', () => {
+		        il.UI.toast.closeToast(element.querySelector('.il-toast'), true);
+		    });
+	        });
+	        element.addEventListener('removeToast', () => {
+                    updateCenter(() => document.dispatchEvent(new Event('rerenderNotificationCenter')));
+	        });
+	    });
+        };
+    };
 
-						lastRequest = time;
-					} else {
-						osdNotificationContainer.innerHTML = '';
-						console.error(xhr.status + ': ' + xhr.responseText);
-					}
-					init = false;
-				};
-				xhr.send();
-			};
+    const createPoll = function(lastRequest, container){
+        return () => {
+	    const time = parseInt(new Date().getTime() / 1000);
+	    const max_age = time - lastRequest;
+	    const xhr = new XMLHttpRequest();
+            const setContent = createContentSetter(container);
+	    xhr.open('GET', 'ilias.php?baseClass=ilNotificationGUI&cmd=getOSDNotifications&cmdMode=asynch&max_age=' + max_age);
+	    xhr.onload = () => {
+		if (xhr.status === 200) {
+		    setContent(xhr.responseText);
+                    if (settings.playSound && xhr.responseText !== '') {
+	                playSound();
+	            }
+		    lastRequest = time;
+		} else {
+		    container.innerHTML = '';
+		    console.error(xhr.status + ': ' + xhr.responseText);
+		}
+	    };
+	    xhr.send();
+	};
+    };
 
-			poll();
-			if (settings.pollingIntervall * 1000) {
-				window.setInterval(poll, settings.pollingIntervall * 1000);
-			}
-		};
-	})();
+    const toast = container => (title, options) => {
+        options = Object.assign({
+            icon: '',
+            action: '',
+            description: '',
+        }, options);
+
+        const setContent = createContentSetter(container);
+
+        setContent(template(settings.notificationPrototype, Object.assign(options, {title})));
+    };
+
+    const init = function(){
+        const container = il.UI.page.getOverlay().querySelector('.il-toast-container');
+        const interval = settings.pollingInterval * 1000;
+        if (interval) {
+	    window.setInterval(createPoll(settings.lastRequestedTime, container), interval);
+        }
+
+        const setContent = createContentSetter(container);
+        setContent(settings.initialNotifications);
+
+        return {
+            toast: toast(container)
+        };
+    };
+
+    return init();
 };

--- a/Services/Notifications/templates/default/tpl.osd_notifications.js
+++ b/Services/Notifications/templates/default/tpl.osd_notifications.js
@@ -1,4 +1,7 @@
 OSDNotifier = OSDNotifications({
-	pollingIntervall:     {OSD_INTERVAL},
-	playSound:            {OSD_PLAY_SOUND}
+    pollingInterval:     {OSD_INTERVAL},
+    playSound:            {OSD_PLAY_SOUND},
+    initialNotifications: {OSD_INITIAL_NOTIFICATIONS},
+    notificationPrototype: {OSD_PROTOTYPE},
+    lastRequestedTime: {OSD_REQUESTED_TIME},
 });


### PR DESCRIPTION
Fixed Bug: 34224: Strict comparison of `string` against `int` in: `ilNotificationOSDRepository::ifOSDNotificationExistsById(...)`
Fixed Bug 34363: The Notifications are rendered with the initial page load.

A toast can now be created on the client side only with:
`OSDNotifier.toast(title, {icon, description, action})`