### PR TITLE
New UI-component "Launcher" proposal for JF decision

### DIFF
--- a/src/UI/Component/Launcher/Factory.php
+++ b/src/UI/Component/Launcher/Factory.php
@@ -31,21 +31,15 @@ interface Factory
      *     The Inline Launcher is meant to be used nested within Components (e.g. Cards or Panels).
      *     It provides description and status information at a glance.
      *   effect: >
-     *     Clicking the Primary Button starts an object or a process.
-     *     If the Component is configured with inputs, this will be communicated
-     *     to the user with an appropriate icon.
      *     The Form will be shown in an Interruptive Modal when clicking the Primary Button.
      *     On Submitting the modal, either a message is being displayed (in case of error)
      *     or the process/object is launched.
      *   rivals:
      *     Modal Launcher: >
-     *       The Modal Launcher will inform the user about a process after the basic
-     *       identification of the respective object was made or will further specify 
-     *       the initially chosen action.
-     * rules:
-     *   usage:
-     *     1: The Launcher SHOULD be nested in other Components like e.g. Panels or Cards.
-     *
+     *       Modal Launcher is visually only present via a Button and provides the required
+     *       information in a modal when the Button is clicked. Hence it is useful for
+     *       workflows where multiple launchable objects or workflows are presented and
+     *       the user choses among them.
      * ---
      * @return \ILIAS\UI\Component\Launcher\Inline
      */
@@ -55,25 +49,24 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *     For further specification of a process or to avoid another view change,
-     *     the Modal Launcher can be used to show its contents wrapped within a Modal.
+     *     The Modal Launcher is presented via a Button, where the other information
+     *     are presented in a Modal that opens one the button is clicked. Hence it can
+     *     be used in cases, where multiple workflows and objects are presented and the
+     *     the user is expected to chose among them. The Modal Launcher allows to do
+     *     so without changing views.
      *   effect: >
-     *     Upon Signal, the Modal Launcher will open an Interruptive Modal and
-     *     displays a title, a desription, status information and a Primary Button.
-     *     If Inputs are configured with the Launcher, the resulting Form replaces
-     *     the contents of the Modal when the Primary Button is clicked.
-     *     Submitting the Form starts the object or process.
+     *     Upon click on the button, the Modal Launcher will open an Interruptive Modal
+     *     and display title, desription and status information and, if configured, the
+     *     inputs.
      *   rivals:
      *     Inline Launcher: >
      *       The Inline Launcher also identifies an object/process. The Modal Launcher
-     *       is a reaction to an interaction with another Component (e.g. item)
+     *       is only presented via a Button and hence requires other means to be identified
+     *       by the user correctly, such as Items or Cards.
      *     Interruptive Modal: >
      *       The Interruptive Modal is meant to display objects affected by a critical action. 
      *       The Modal Launcher presents relevant information to identify an object/process to launch
      *       or communicates that the intended launching action is permitted.
-     * context:
-     *   - List of launchable items
-     *
      * ---
      * @return \ILIAS\UI\Component\Launcher\Modal
      */

--- a/src/UI/Component/Launcher/Factory.php
+++ b/src/UI/Component/Launcher/Factory.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Component\Launcher;
+
+use ILIAS\Data\Link;
+
+interface Factory
+{
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     The Inline Launcher is meant to be used nested within Components (e.g. Cards or Panels).
+     *     It provides description and status information at a glance.
+     *   effect: >
+     *     Clicking the Primary Button starts an object or a process.
+     *     If the Component is configured with inputs, this will be communicated
+     *     to the user with an appropriate icon.
+     *     The Form will be shown in an Interruptive Modal when clicking the Primary Button.
+     *     On Submitting the modal, either a message is being displayed (in case of error)
+     *     or the process/object is launched.
+     *   rivals:
+     *     Modal Launcher: >
+     *       The Modal Launcher will inform the user about a process after the basic
+     *       identification of the respective object was made or will further specify 
+     *       the initially chosen action.
+     * rules:
+     *   usage:
+     *     1: The Launcher SHOULD be nested in other Components like e.g. Panels or Cards.
+     *
+     * ---
+     * @return \ILIAS\UI\Component\Launcher\Inline
+     */
+    public function inline(Link $target): Inline;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     For further specification of a process or to avoid another view change,
+     *     the Modal Launcher can be used to show its contents wrapped within a Modal.
+     *   effect: >
+     *     Upon Signal, the Modal Launcher will open an Interruptive Modal and
+     *     displays a title, a desription, status information and a Primary Button.
+     *     If Inputs are configured with the Launcher, the resulting Form replaces
+     *     the contents of the Modal when the Primary Button is clicked.
+     *     Submitting the Form starts the object or process.
+     *   rivals:
+     *     Inline Launcher: >
+     *       The Inline Launcher also identifies an object/process. The Modal Launcher
+     *       is a reaction to an interaction with another Component (e.g. item)
+     *     Interruptive Modal: >
+     *       The Interruptive Modal is meant to display objects affected by a critical action. 
+     *       The Modal Launcher presents relevant information to identify an object/process to launch
+     *       or communicates that the intended launching action is permitted.
+     * context:
+     *   - List of launchable items
+     *
+     * ---
+     * @return \ILIAS\UI\Component\Launcher\Modal
+     */
+    public function modal(Link $target): Modal;
+}

--- a/src/UI/Component/Launcher/Inline.php
+++ b/src/UI/Component/Launcher/Inline.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Component\Launcher;
+
+use ILIAS\UI\Component\Component;
+
+interface Inline extends Launcher
+{
+}

--- a/src/UI/Component/Launcher/Launcher.php
+++ b/src/UI/Component/Launcher/Launcher.php
@@ -23,17 +23,25 @@ namespace ILIAS\UI\Component\Launcher;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Chart\ProgressMeter;
 use ILIAS\UI\Component\Symbol\Icon;
+use ILIAS\UI\Component\Input\Container\Form\Form;
 
-interface Launcher extends Component
+interface Launcher extends Component, Form
 {
-    public function withDescription(string $description) : self
+    public function withDescription(string $description) : self;
 
-    public function withInputs(Field $fields) : self
+    public function withInputs(Field $fields) : self;
 
     /**
      * @param Icon | ProgressMeter $status
      */
-    public function withStatus(Component $status) : self
+    public function withStatus(Component $status): self;
 
-    public function withButtonLabel(string $label, bool $launchable = true) : self
+    public function withButtonLabel(string $label, bool $launchable = true): self;
+
+    /**
+     * @inheritdoc
+     *
+     * If not Inputs have been configured, the method will always return true.
+     */
+    public function getData();
 }

--- a/src/UI/Component/Launcher/Launcher.php
+++ b/src/UI/Component/Launcher/Launcher.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Component\Launcher;
+
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Chart\ProgressMeter;
+use ILIAS\UI\Component\Symbol\Icon;
+
+interface Launcher extends Component
+{
+    public function withDescription(string $description) : self
+
+    public function withInputs(Field $fields) : self
+
+    /**
+     * @param Icon | ProgressMeter $status
+     */
+    public function withStatus(Component $status) : self
+
+    public function withButtonLabel(string $label, bool $launchable = true) : self
+}

--- a/src/UI/Component/Launcher/Modal.php
+++ b/src/UI/Component/Launcher/Modal.php
@@ -20,10 +20,9 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Launcher;
 
-use ILIAS\UI\Component\Component;
-use ILIAS\UI\Component\Signal;
+use ILIAS\UI\Component\Button\Button;
 
 interface Modal extends Launcher
 {
-    public function getShowSignal(): Signal;
+    public function getButton(): Button;
 }

--- a/src/UI/Component/Launcher/Modal.php
+++ b/src/UI/Component/Launcher/Modal.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Component\Launcher;
+
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Signal;
+
+interface Modal extends Launcher
+{
+    public function getShowSignal(): Signal;
+}

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -901,11 +901,12 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *     The Launcher Component is used to launch an object or a process.
-     *     From a users' perspective the main goal of the Launcher component is to present 
-     *     just relevant information for a quick decision to launch a certain object or process and 
-     *     if all preconditions for launching are fullfilled. For a clear guidance of the users' intent it  
-     *     can present a title and a descriptive text and offers a mandatory Primary Button for launching.
+     *     The Launcher Component is used to launch an object, process or workflow. From a
+     *     users' perspective the main goal of the Launcher component is to present just
+     *     relevant information for a quick decision to launch a certain object, process or
+     *     workflow and if all preconditions for launching are fullfilled. For a clear
+     *     guidance of the users' intent it  can present a title and a descriptive text and
+     *     offers a mandatory Primary Button for launching.
      *     If necessary, the component can be enriched with status information about the users'
      *     progress and optional inputs (e.g. access code field) if launching is restricted.
      *   composition: >
@@ -914,13 +915,14 @@ interface Factory
      *     inputs (e.g.: for access code input) and, finally, a Primary Button that
      *     executes an action.
      *   effect: >
-     *     Clicking the Primary Button starts the object or process.
-     *     If the Component is configured with inputs, the Form will be shown and
-     *     submitted asynchronously. With a successful response, the user is redirected to
-     *     the specified location. Otherwise, a message is being displayed.
+     *     Clicking the Primary Button starts the object, process or workflow. If the
+     *     Component is configured with inputs, they will be provided to make the user
+     *     fill them before the object can be launched. If the provided data is sufficient
+     *     the user is redirected to the target. Otherwise, a message is being displayed.
      *     If the user cannot launch the object at all (precondition, unavailability etc.),
      *     the primary button is disabled with unavailable action.
-     *     The label of the Primary Button may change, e.g. in relation to the status of the progress.
+     *     The label of the Primary Button may change, e.g. in relation to the statusu
+     *     of the progress.
      *   rivals:
      *     Item: >
      *       Other than an item, the Launcher's focus is on an action rather than
@@ -930,17 +932,21 @@ interface Factory
      *     1: The Launcher MUST contain a primary button.
      *     2: If the user cannot launch the process, the Primary Button MUST be disabled.
      *     3: >
-     *      The Launcher SHOULD NOT be used to collect larger sets of
-     *      information (e.g. a full user registration) - that would be a process in itself. 
-     *      It SHOULD support the users' intent to make a quick choice if it is the desired  
-     *      object/process to launch or not. Just relevant information SHOULD guide this decision.
+     *       The Launcher SHOULD NOT be used to collect larger sets of information (e.g. a
+     *       full user registration) - that would be a process in itself. 
+     *     4: >
+     *       The launcher SHOULD support the users' intent to make a quick choice if it is
+     *       the desired object/process/workflow to launch or not. Just relevant information
+     *       SHOULD guide this decision.
      *   interaction:
      *     1: The Launcher MUST start the object/progress when the Primary Button is clicked.
      *     2: >
      *      The Launcher MUST provide ample inputs if the object is configured
      *      with restricted access or the process needs further user decisions.
      *   accessibility:
-     *     1: All interactions offered by a Launcher MUST be accessible by only using the keyboard.
+     *     1: >
+     *       All interactions offered by a Launcher MUST be accessible by only using
+     *       the keyboard.
      *     2: >
      *       All information required before launching the object MUST be placed
      *       before the Primary Button launching the object/process, so users working

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -896,4 +896,58 @@ interface Factory
      * @return \ILIAS\UI\Component\Toast\Factory
      */
     public function toast(): C\Toast\Factory;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     The Launcher Component is used to launch an object or a process.
+     *     From a users' perspective the main goal of the Launcher component is to present 
+     *     just relevant information for a quick decision to launch a certain object or process and 
+     *     if all preconditions for launching are fullfilled. For a clear guidance of the users' intent it  
+     *     can present a title and a descriptive text and offers a mandatory Primary Button for launching.
+     *     If necessary, the component can be enriched with status information about the users'
+     *     progress and optional inputs (e.g. access code field) if launching is restricted.
+     *   composition: >
+     *     The Launcher consists of receptive elements, i.e. title, text, status information
+     *     about progress, such as Icons or Progress Meter. It also contains optional
+     *     inputs (e.g.: for access code input) and, finally, a Primary Button that
+     *     executes an action.
+     *   effect: >
+     *     Clicking the Primary Button starts the object or process.
+     *     If the Component is configured with inputs, the Form will be shown and
+     *     submitted asynchronously. With a successful response, the user is redirected to
+     *     the specified location. Otherwise, a message is being displayed.
+     *     If the user cannot launch the object at all (precondition, unavailability etc.),
+     *     the primary button is disabled with unavailable action.
+     *     The label of the Primary Button may change, e.g. in relation to the status of the progress.
+     *   rivals:
+     *     Item: >
+     *       Other than an item, the Launcher's focus is on an action rather than
+     *       the representation of an entity.
+     * rules:
+     *   usage:
+     *     1: The Launcher MUST contain a primary button.
+     *     2: If the user cannot launch the process, the Primary Button MUST be disabled.
+     *     3: >
+     *      The Launcher SHOULD NOT be used to collect larger sets of
+     *      information (e.g. a full user registration) - that would be a process in itself. 
+     *      It SHOULD support the users' intent to make a quick choice if it is the desired  
+     *      object/process to launch or not. Just relevant information SHOULD guide this decision.
+     *   interaction:
+     *     1: The Launcher MUST start the object/progress when the Primary Button is clicked.
+     *     2: >
+     *      The Launcher MUST provide ample inputs if the object is configured
+     *      with restricted access or the process needs further user decisions.
+     *   accessibility:
+     *     1: All interactions offered by a Launcher MUST be accessible by only using the keyboard.
+     *     2: >
+     *       All information required before launching the object MUST be placed
+     *       before the Primary Button launching the object/process, so users working
+     *       with screen readers will not miss it.
+     *
+     * ---
+     * @return \ILIAS\UI\Component\Launcher\Factory
+     */
+    public function launcher(): C\Launcher\Factory;
 }

--- a/src/UI/Implementation/Component/Launcher/Factory.php
+++ b/src/UI/Implementation/Component/Launcher/Factory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Implementation\Component\Launcher;
+
+use ILIAS\UI\Component\Launcher;
+
+class Factory implements Launcher\Factory
+{
+    /**
+     * @inheritdoc
+     */
+    public function inline(): Launcher\Inline
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function modal(): Launcher\Modal
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
+}

--- a/src/UI/Implementation/Factory.php
+++ b/src/UI/Implementation/Factory.php
@@ -325,4 +325,9 @@ class Factory implements \ILIAS\UI\Factory
     {
         return $this->toast_factory;
     }
+
+    public function launcher(): C\Launcher\Factory
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
 }


### PR DESCRIPTION
The newly proposed top-level component "Launcher" should be used for launching a  object or a process. It can display general and status information, can contain inputs and consists of a primary button to execute an action.

It may substitute e.g. the info-tab when starting a test or a survey. 

Following the basic concept of UI-components in general, it can be used nested in other components or wrapped inside a modal depending on the intended purpose.

As a starting point we propose two derivations of the Launcher: an "Inline Launcher" and a  "Modal Launcher". But when it comes to other areas of application, more derivations are conceivable ...

Sceenshot(s) will follow and we would like to discuss this proposal at the next Jour Fix.

Hier ein erstes Mockup zum "Modal Launcher" am Beispiel "Test":

![UI-Launcher-mockup](https://user-images.githubusercontent.com/25820780/192533816-31ede7a2-b866-4f3e-8815-3a134d9f6e02.png)

