### PR TITLE
[FIX] PhpCsFixer will leave `declare(strict_types=1)` on the first line again.

### DIFF
--- a/CI/PHP-CS-Fixer/code-format.php_cs
+++ b/CI/PHP-CS-Fixer/code-format.php_cs
@@ -23,6 +23,7 @@ return (new PhpCsFixer\Config())
         '@PSR12' => true,
         'strict_param' => false,
         'concat_space' => ['spacing' => 'one'],
-        'function_typehint_space' => true
+        'function_typehint_space' => true,
+        'blank_line_after_opening_tag' => false,
 	])
 	->setFinder($finder);


### PR DESCRIPTION
Hi @mjansenDatabay 

I've noticed that my PhpCsFixer would put the strict-types declaration on the third line of the file again (similar as to the file generation with PHPStorm as mentioned in #4967). This PR introduces this rule to the code format config for the PhpCsFixer as well.

Kind regards!