### PR TITLE
[FIX] 0033654: Failed test: Übung exportieren - Invalid path supplied

### DIFF
--- a/Modules/Exercise/Assignment/class.ilExAssignment.php
+++ b/Modules/Exercise/Assignment/class.ilExAssignment.php
@@ -939,8 +939,8 @@ class ilExAssignment
             $old_web_storage = new ilFSWebStorageExercise($a_old_exc_id, $d->getId());
             $new_web_storage = new ilFSWebStorageExercise($a_new_exc_id, $new_ass->getId());
             $new_web_storage->create();
-            if (is_dir($old_web_storage->getPath())) {
-                ilFileUtils::rCopy($old_web_storage->getPath(), $new_web_storage->getPath());
+            if (is_dir($old_web_storage->getAbsolutePath())) {
+                ilFileUtils::rCopy($old_web_storage->getAbsolutePath(), $new_web_storage->getAbsolutePath());
             }
             $order = $d->getInstructionFilesOrder();
             foreach ($order as $file) {

--- a/Modules/Exercise/classes/class.ilExerciseDataSet.php
+++ b/Modules/Exercise/classes/class.ilExerciseDataSet.php
@@ -436,14 +436,14 @@ class ilExerciseDataSet extends ilDataSet
             }
 
             $fstorage = new ilFSStorageExercise($a_set["ExerciseId"], $a_set["Id"]);
-            $a_set["Dir"] = $fstorage->getPath();
+            $a_set["Dir"] = $fstorage->getAbsolutePath();
 
             $fstorage = new ilFSStorageExercise($a_set["ExerciseId"], $a_set["Id"]);
             $a_set["FeedbackDir"] = $fstorage->getGlobalFeedbackPath();
 
             //now the instruction files inside the root directory
             $fswebstorage = new ilFSWebStorageExercise($a_set['ExerciseId'], $a_set['Id']);
-            $a_set['WebDataDir'] = $fswebstorage->getPath();
+            $a_set['WebDataDir'] = $fswebstorage->getAbsolutePath();
         }
 
         //Discuss if necessary when working with timestamps.
@@ -605,9 +605,9 @@ class ilExerciseDataSet extends ilDataSet
                         $deadline = new ilDateTime($a_rec["Deadline2"], IL_CAL_DATETIME, "UTC");
                         $ass->setExtendedDeadline($deadline->get(IL_CAL_UNIX));
                     }
-                    $ass->setMaxFile($a_rec["MaxFile"]);
+                    $ass->setMaxFile((int)$a_rec["MaxFile"]);
                     $ass->setTeamTutor($a_rec["TeamTutor"]);
-                    $ass->setPeerReviewChars($a_rec["PeerChar"]);
+                    $ass->setPeerReviewChars((int)$a_rec["PeerChar"]);
                     $ass->setPeerReviewSimpleUnlock($a_rec["PeerUnlock"]);
                     $ass->setPeerReviewValid($a_rec["PeerValid"]);
                     $ass->setPeerReviewText($a_rec["PeerText"]);
@@ -633,7 +633,7 @@ class ilExerciseDataSet extends ilDataSet
                     $dir = str_replace("..", "", $a_rec["Dir"]);
                     if ($dir != "" && $this->getImportDirectory() != "") {
                         $source_dir = $this->getImportDirectory() . "/" . $dir;
-                        $target_dir = $fstorage->getPath();
+                        $target_dir = $fstorage->getAbsolutePath();
                         ilFileUtils::rCopy($source_dir, $target_dir);
                     }
 
@@ -651,7 +651,7 @@ class ilExerciseDataSet extends ilDataSet
                     $dir = str_replace("..", "", $a_rec["WebDataDir"]);
                     if ($dir != "" && $this->getImportDirectory() != "") {
                         $source_dir = $this->getImportDirectory() . "/" . $dir;
-                        $target_dir = $fwebstorage->getPath();
+                        $target_dir = $fwebstorage->getAbsolutePath();
                         ilFileUtils::rCopy($source_dir, $target_dir);
                     }
 


### PR DESCRIPTION
This fixes specific issues with legacy filesystem changes, but export/import still fails due to other bugs (e.g. in metadata).
https://mantis.ilias.de/view.php?id=33654