### PR TITLE
src/Data: Add `Enum` trait

### DIFF
--- a/src/Data/Enum.php
+++ b/src/Data/Enum.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data;
+
+use InvalidArgumentException;
+use ReflectionClass;
+
+trait Enum
+{
+    private static ?array $constantsCache = null;
+    private int|string $value;
+
+    public function __construct(int|string $value)
+    {
+        if (!in_array($value, static::constantValues())) {
+            throw new InvalidArgumentException(sprintf(
+                '%s is not a valid value for this enum.',
+                print_r($value, true)
+            ));
+        }
+
+        $this->value = $value;
+    }
+
+    public function value(): int|string
+    {
+        return $this->value;
+    }
+
+    public static function from(int|string $value): self
+    {
+        return new static($value);
+    }
+
+    public static function tryFrom(int|string $value): ?self
+    {
+        try {
+            return new static($value);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /**
+     * @return self[]
+     */
+    public static function cases(): array
+    {
+        return array_map(fn (string|int $value): self => new static($value), self::constantValues());
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        if (!in_array($name, static::constantKeys())) {
+            throw new InvalidArgumentException(sprintf(
+                '%s is an invalid value for this enum.',
+                print_r($name, true)
+            ));
+        }
+
+        return new static(constant(get_called_class() . '::' . $name));
+    }
+
+    public function equals($other): bool
+    {
+        if (!($other instanceof self)) {
+            return false;
+        }
+
+        return $other->value() === $this->value();
+    }
+
+    protected static function constants(): array
+    {
+        if (static::$constantsCache !== null) {
+            return static::$constantsCache;
+        }
+
+        $reflect = new ReflectionClass(get_called_class());
+        return static::$constantsCache = $reflect->getConstants();
+    }
+
+    /**
+     * @return int[]|string[]
+     */
+    protected static function constantValues(): array
+    {
+        return array_values(static::constants());
+    }
+
+    protected static function constantKeys(): array
+    {
+        return array_keys(static::constants());
+    }
+}

--- a/src/Data/README.md
+++ b/src/Data/README.md
@@ -24,6 +24,7 @@ interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 * [Clock](#clock)
 * [Dimension](#dimension)
 * [Dataset](#dataset)
+* [Enum Trait](#enum-trait)
 
 Other examples for data types that could (and maybe should) be added here:
 
@@ -563,3 +564,52 @@ function itIsTrueThat(bool $truth) {
 
 ?>
 ```
+
+## Enum Trait
+
+The `Enum` trait can be used to emulate an `Enum` type for PHP < 8.1. The `@method` docs will help
+`PhpStorm` (or other IDEs) for autocomplete/intellisense suggestions.
+
+```php
+/**
+ * @method self NOT_ATTEMPTED()
+ * @method self IN_PROGRESS()
+ * @method self COMPLETED()
+ * @method self FAILED()
+ */
+class LearningProgress
+{
+    use \ILIAS\Data\Enum;
+    
+    private const NOT_ATTEMPTED = 'not_attempted';
+    private const IN_PROGRESS = 'not_attempted';
+    private const COMPLETED = 'completed';
+    private const FAILED = 'failed';
+}
+
+$not_attempted = LearningProgress::NOT_ATTEMPTED();
+```
+
+In userland code, this can be used as shown here:
+
+```php
+$not_attempted = LearningProgress::NOT_ATTEMPTED();
+```
+
+Or, if you want to create a type from a persisted value:
+
+```php
+$not_attempted = LearningProgress::from('not_attempted');
+$value = $not_attempted->value();
+
+$will_throw_exception = LearningProgress::from('phpunit');
+$will_return_null_if_value_is_invalid = LearningProgress::tryFrom('phpunit');
+```
+
+What are the advantages of having this `trait`?
+
+- You can type hint the type, `LearningProgress` in this example.
+- An instance can only be created with valid values defined in the emulated `Enum`.
+
+*A word of warning*: The emulated approach uses introspection (`Reflections`), so obsessive use will
+potentially cause performance issues.

--- a/tests/Data/EnumIntSample.php
+++ b/tests/Data/EnumIntSample.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace Data;
+
+use ILIAS\Data\Enum;
+
+/**
+ * @method self CASE1()
+ * @method self CASE2()
+ * @method self CASE3()
+ */
+class EnumIntSample
+{
+    use Enum;
+
+    private const CASE1 = 1;
+    private const CASE2 = 2;
+    private const CASE3 = 3;
+}

--- a/tests/Data/EnumStringSample.php
+++ b/tests/Data/EnumStringSample.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace Data;
+
+use ILIAS\Data\Enum;
+
+/**
+ * @method self CASE1()
+ * @method self CASE2()
+ * @method self CASE3()
+ */
+class EnumStringSample
+{
+    use Enum;
+
+    private const CASE1 = 'case1';
+    private const CASE2 = 'case2';
+    private const CASE3 = 'case3';
+}

--- a/tests/Data/EnumTest.php
+++ b/tests/Data/EnumTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data;
+
+use Data\EnumIntSample;
+use Data\EnumStringSample;
+use InvalidArgumentException;
+use Generator;
+use PHPUnit\Framework\TestCase;
+
+class EnumTest extends TestCase
+{
+    public function backedEnumProvider(): Generator
+    {
+        require_once __DIR__ . '/EnumStringSample.php';
+        require_once __DIR__ . '/EnumIntSample.php';
+
+        yield 'Backed string enum' => [EnumStringSample::class, fn (int $case_id): string => 'case' . $case_id];
+        yield 'Backed int enum' => [EnumIntSample::class, fn (int $case_id): int => $case_id];
+    }
+
+    /**
+     * @param class-string<EnumStringSample|EnumIntSample> $enum_user
+     * @param callable(int $case_id): (int|string) $case_id_transformer
+     * @dataProvider backedEnumProvider
+     */
+    public function testBackedEnumTrait(string $enum_user, callable $case_id_transformer): void
+    {
+        $cases = $enum_user::cases();
+
+        foreach (range(1, count($cases)) as $case_id) {
+            $expected_value = $case_id_transformer($case_id);
+
+            $method = 'CASE' . $case_id;
+            $case = $enum_user::$method();
+            $this->assertSame($expected_value, $case->value());
+
+            $case_from = $enum_user::from($expected_value);
+            $this->assertSame($case->value(), $case_from->value());
+        }
+
+        foreach ($cases as $case) {
+            $this->assertInstanceOf($enum_user, $case);
+        }
+
+        $invalid_value = $case_id_transformer(count($cases) + 1);
+        try {
+            $enum_user::from($invalid_value);
+            $this->fail('Creating an Enum by calling "from" with an invalid case value should throw an exception');
+        } catch (InvalidArgumentException) {
+        }
+
+        $this->assertNull($enum_user::tryFrom($invalid_value));
+    }
+}


### PR DESCRIPTION
This PR suggests a `trait` to emulate an (backed) `Enum` type for PHP < 8.1.

@klees suggested to add this `trait` to `src/Data` after @thibsy, @klees and @mjansenDatabay discussed this approach in [`Discord`](https://discord.gg/H9v2v2Ar2T).

Of course it only makes sence if this `trait` is really used for `ILIAS 9`. I am confident that usages can be migrated to a native `Enum` with `rector` later on.

To discuss:
- The `value` property is `public`, so the state could be mutated. Unfortunately the `readonly` modifier, which would solve this issue, will be available with PHP 8.2, where we do not need this `trait` anymore. So to maintain the encapsulated state we could use a `value()` method instead.