### PR TITLE
Data: Proposal for improved HTML metadata

### DIFF
--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -8,6 +8,7 @@ namespace ILIAS\Data;
 
 use ILIAS\Data\Clock\ClockFactory;
 use ILIAS\Data\Clock\ClockFactoryImpl;
+use ILIAS\Data\Meta;
 
 /**
  * Builds data types.
@@ -24,6 +25,7 @@ class Factory
      */
     private ?Color\Factory $colorfactory = null;
     private ?Dimension\Factory $dimensionfactory = null;
+    private ?Meta\Html\Factory $html_metadata_factory = null;
 
     /**
      * Get an ok result.
@@ -180,5 +182,10 @@ class Factory
     public function dataset(array $dimensions): Chart\Dataset
     {
         return new Chart\Dataset($dimensions);
+    }
+
+    public function htmlMetadata(): Meta\Html\Factory
+    {
+        return $this->html_metadata_factory;
     }
 }

--- a/src/Data/Factory.php
+++ b/src/Data/Factory.php
@@ -26,6 +26,7 @@ class Factory
     private ?Color\Factory $colorfactory = null;
     private ?Dimension\Factory $dimensionfactory = null;
     private ?Meta\Html\Factory $html_metadata_factory = null;
+    private ?Meta\Html\OpenGraph\Factory $open_graph_metadata_factory = null;
 
     /**
      * Get an ok result.
@@ -186,6 +187,19 @@ class Factory
 
     public function htmlMetadata(): Meta\Html\Factory
     {
+        if (null === $this->html_metadata_factory) {
+            $this->html_metadata_factory = new Meta\Html\Factory();
+        }
+
         return $this->html_metadata_factory;
+    }
+
+    public function openGraphMetadata(): Meta\Html\OpenGraph\Factory
+    {
+        if (null === $this->open_graph_metadata_factory) {
+            $this->open_graph_metadata_factory = new Meta\Html\OpenGraph\Factory();
+        }
+
+        return $this->open_graph_metadata_factory;
     }
 }

--- a/src/Data/Meta/Html/Factory.php
+++ b/src/Data/Meta/Html/Factory.php
@@ -19,30 +19,26 @@ declare(strict_types=1);
 
 namespace ILIAS\Data\Meta\Html;
 
-use ILIAS\Data\Meta\Html\OpenGraph\Factory as OGFactory;
-
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
 class Factory
 {
-    public function __construct(
-        protected OGFactory $og_factory,
-    ) {
-    }
-
     public function userDefined(string $key, string $value): Tag
     {
         return new UserDefined($key, $value);
     }
 
-    public function undefined(): Tag
+    /**
+     * @param Tag[] $tags
+     */
+    public function collection(array $tags): TagCollection
     {
-        return new Undefined();
+        return new TagCollection(...$tags);
     }
 
-    public function openGraph(): OGFactory
+    public function nullTag(): Tag
     {
-        return $this->og_factory;
+        return new NullTag();
     }
 }

--- a/src/Data/Meta/Html/Factory.php
+++ b/src/Data/Meta/Html/Factory.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html;
+
+use ILIAS\Data\Meta\Html\OpenGraph\Factory as OGFactory;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class Factory
+{
+    public function __construct(
+        protected OGFactory $og_factory,
+    ) {
+    }
+
+    public function userDefined(string $key, string $value): Tag
+    {
+        return new UserDefined($key, $value);
+    }
+
+    public function undefined(): Tag
+    {
+        return new Undefined();
+    }
+
+    public function openGraph(): OGFactory
+    {
+        return $this->og_factory;
+    }
+}

--- a/src/Data/Meta/Html/NullTag.php
+++ b/src/Data/Meta/Html/NullTag.php
@@ -19,20 +19,16 @@ declare(strict_types=1);
 
 namespace ILIAS\Data\Meta\Html;
 
-use Generator;
-
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
-abstract class Tag
+class NullTag extends Tag
 {
     /**
-     * This method MUST return the valid HTML markup for this tag.
-     *
-     * It's possible that several meta-tags must be returned, but please comply
-     * with MDNs documentation.
-     *
-     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
+     * @inheritDoc
      */
-    abstract public function toHtml(): string;
+    public function toHtml(): string
+    {
+        return '';
+    }
 }

--- a/src/Data/Meta/Html/OpenGraph/Audio.php
+++ b/src/Data/Meta/Html/OpenGraph/Audio.php
@@ -17,18 +17,18 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\Data\Meta\Html;
+namespace ILIAS\Data\Meta\Html\OpenGraph;
+
+use ILIAS\Data\Meta\Html\TagCollection;
+use ILIAS\Data\URI;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
-class Undefined extends Tag
+class Audio extends Resource
 {
-    /**
-     * @inheritDoc
-     */
-    public function toHtml(): string
+    protected function getPropertyName(): string
     {
-        return '';
+        return 'og:audio';
     }
 }

--- a/src/Data/Meta/Html/OpenGraph/Factory.php
+++ b/src/Data/Meta/Html/OpenGraph/Factory.php
@@ -23,7 +23,6 @@ use ILIAS\Data\Meta\Html\TagCollection;
 use ILIAS\Data\Meta\Html\Tag as HTMLTag;
 use ILIAS\Data\Meta\Html\Undefined;
 use ILIAS\Data\URI;
-use org\bovigo\vfs\vfsStreamWrapperUnregisterTestCase;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>

--- a/src/Data/Meta/Html/OpenGraph/Factory.php
+++ b/src/Data/Meta/Html/OpenGraph/Factory.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html\OpenGraph;
+
+use ILIAS\Data\Meta\Html\TagCollection;
+use ILIAS\Data\Meta\Html\Tag as HTMLTag;
+use ILIAS\Data\Meta\Html\Undefined;
+use ILIAS\Data\URI;
+use org\bovigo\vfs\vfsStreamWrapperUnregisterTestCase;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class Factory
+{
+    public function website(
+        string $title,
+        URI $link,
+        ?string $description = null,
+        ?URI $image_url = null,
+    ): TagCollection {
+        return new TagCollection(
+            new Text('og:title', $title),
+            new Text('og:type', 'website'),
+            new Link('og:url', $link),
+            (null !== $description) ? new Text('og:description', $description) : new Undefined(),
+            (null !== $description) ? new Text('og:description', $description) : new Undefined(),
+        );
+    }
+}

--- a/src/Data/Meta/Html/OpenGraph/Factory.php
+++ b/src/Data/Meta/Html/OpenGraph/Factory.php
@@ -19,28 +19,103 @@ declare(strict_types=1);
 
 namespace ILIAS\Data\Meta\Html\OpenGraph;
 
-use ILIAS\Data\Meta\Html\TagCollection;
-use ILIAS\Data\Meta\Html\Tag as HTMLTag;
-use ILIAS\Data\Meta\Html\Undefined;
 use ILIAS\Data\URI;
+use ILIAS\Data\Meta\Html\OpenGraph\Resource;
+use ILIAS\Data\Meta\Html\TagCollection;
+use ILIAS\Data\Meta\Html\NullTag;
+use ILIAS\Data\Meta\Html\Tag as HTMLTag;
+use DateTimeImmutable;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
 class Factory
 {
+    public function audio(URI $audio_url, string $mime_type): Audio
+    {
+        return new Audio($audio_url, $mime_type);
+    }
+
+    public function image(
+        URI $image_url,
+        string $mime_type,
+        ?string $aria_label = null,
+        ?int $width = null,
+        ?int $height = null,
+    ): Image {
+        return new Image($image_url, $mime_type, $aria_label, $width, $height);
+    }
+
+    public function video(
+        URI $video_url,
+        string $mime_type,
+        ?int $width = null,
+        ?int $height = null,
+    ): Video {
+        return new Video($video_url, $mime_type, $width, $height);
+    }
+
+    /**
+     * @param string|null $default_locale defaults to en_US
+     * @param string[]    $alternative_locales
+     * @param Resource[]  $additional_resources
+     */
     public function website(
-        string $title,
-        URI $link,
+        URI $canonical_url,
+        Image $image,
+        string $object_title,
+        ?string $website_name = null,
         ?string $description = null,
-        ?URI $image_url = null,
+        ?string $default_locale = null,
+        array $alternative_locales = [],
+        array $additional_resources = [],
     ): TagCollection {
         return new TagCollection(
-            new Text('og:title', $title),
             new Text('og:type', 'website'),
-            new Link('og:url', $link),
-            (null !== $description) ? new Text('og:description', $description) : new Undefined(),
-            (null !== $description) ? new Text('og:description', $description) : new Undefined(),
+            new Text('og:title', $object_title),
+            new Link('og:url', $canonical_url),
+            $image,
+            (null !== $website_name) ? new Text('og:site_title', $website_name) : new NullTag(),
+            (null !== $description) ? new Text('og:description', $description) : new NullTag(),
+            (null !== $default_locale) ? new Text('og:locale', $default_locale) : new NullTag(),
+            $this->getAlternativeLocalesTag($alternative_locales),
+            ($this->checkAdditionalResources($additional_resources)) ? new TagCollection(
+                ...$additional_resources
+            ) : new NullTag(),
         );
+    }
+
+    /**
+     * @param string[] $locales
+     */
+    protected function getAlternativeLocalesTag(array $locales): HTMLTag
+    {
+        if (empty($locales)) {
+            return new NullTag();
+        }
+
+        $alternative_language_tags = [];
+        foreach ($locales as $locale) {
+            $alternative_language_tags[] = new Text('og:locale:alternative', $locale);
+        }
+
+        return new TagCollection(...$alternative_language_tags);
+    }
+
+    protected function checkAdditionalResources(array $resources): bool
+    {
+        foreach ($resources as $resource) {
+            if (!$resource instanceof Resource) {
+                throw new \LogicException(
+                    sprintf(
+                        "Expected array of %s but received %s.",
+                        Resource::class,
+                        get_class($resource)
+                    )
+                );
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Data/Meta/Html/OpenGraph/Image.php
+++ b/src/Data/Meta/Html/OpenGraph/Image.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html\OpenGraph;
+
+use ILIAS\Data\Meta\Html\TagCollection;
+use ILIAS\Data\Meta\Html\NullTag;
+use ILIAS\Data\URI;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class Image extends Resource
+{
+    public function __construct(
+        URI $image_url,
+        string $mime_type,
+        ?string $aria_label = null,
+        ?int $width = null,
+        ?int $height = null,
+    ) {
+        parent::__construct(
+            $image_url,
+            $mime_type,
+            (null !== $aria_label) ? new Text('og:image:alt', $aria_label) : new NullTag(),
+            (null !== $width) ? new Text('og:image:width', (string) $width) : new NullTag(),
+            (null !== $height) ? new Text('og:image:height', (string) $height) : new NullTag(),
+        );
+    }
+
+    protected function getPropertyName(): string
+    {
+        return 'og:image';
+    }
+}

--- a/src/Data/Meta/Html/OpenGraph/Link.php
+++ b/src/Data/Meta/Html/OpenGraph/Link.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html\OpenGraph;
+
+use ILIAS\Data\URI;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class Link extends Tag
+{
+    public function __construct(
+        string $property_name,
+        protected URI $uri,
+    ) {
+        parent::__construct($property_name);
+    }
+
+    protected function getValue(): string
+    {
+        return (string) $this->uri;
+    }
+}

--- a/src/Data/Meta/Html/OpenGraph/Resource.php
+++ b/src/Data/Meta/Html/OpenGraph/Resource.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html\OpenGraph;
+
+use ILIAS\Data\Meta\Html\TagCollection;
+use ILIAS\Data\Meta\Html\Tag as HTMLTag;
+use ILIAS\Data\URI;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+abstract class Resource extends TagCollection
+{
+    public function __construct(
+        URI $resource_url,
+        string $mime_type,
+        HTMLTag ...$additional_tags,
+    ) {
+        parent::__construct(
+            new Link($this->getPropertyName(), $resource_url),
+            new Text("{$this->getPropertyName()}:type", $mime_type),
+            ...$additional_tags
+        );
+    }
+
+    abstract protected function getPropertyName(): string;
+}

--- a/src/Data/Meta/Html/OpenGraph/Tag.php
+++ b/src/Data/Meta/Html/OpenGraph/Tag.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html\OpenGraph;
+
+use ILIAS\Data\Meta\Html\Tag as HTMLTag;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+abstract class Tag extends HTMLTag
+{
+    public function __construct(
+        protected string $property_name,
+    ) {
+    }
+
+    public function toHtml(): string
+    {
+        return "<meta property=\"$this->property_name\" content=\"{$this->getValue()}\" />";
+    }
+
+    abstract protected function getValue(): string;
+}

--- a/src/Data/Meta/Html/OpenGraph/Text.php
+++ b/src/Data/Meta/Html/OpenGraph/Text.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html\OpenGraph;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class Text extends Tag
+{
+    public function __construct(
+        string $property_name,
+        protected string $text,
+    ) {
+        parent::__construct($property_name);
+    }
+
+    protected function getValue(): string
+    {
+        return $this->text;
+    }
+}

--- a/src/Data/Meta/Html/OpenGraph/Video.php
+++ b/src/Data/Meta/Html/OpenGraph/Video.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html\OpenGraph;
+
+use ILIAS\Data\Meta\Html\TagCollection;
+use ILIAS\Data\Meta\Html\NullTag;
+use ILIAS\Data\URI;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class Video extends Resource
+{
+    public function __construct(
+        URI $video_url,
+        string $mime_type,
+        ?int $width = null,
+        ?int $height = null,
+    ) {
+        parent::__construct(
+            $video_url,
+            $mime_type,
+            (null !== $width) ? new Text('og:video:width', (string) $width) : new NullTag(),
+            (null !== $height) ? new Text('og:video:height', (string) $height) : new NullTag(),
+        );
+    }
+
+    protected function getPropertyName(): string
+    {
+        return 'og:video';
+    }
+}

--- a/src/Data/Meta/Html/Tag.php
+++ b/src/Data/Meta/Html/Tag.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+abstract class Tag
+{
+    /**
+     * This method MUST return the valid HTML markup for this tag.
+     *
+     * It's possible that several meta-tags must be returned, but please comply
+     * with MDNs documentation.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
+     */
+    abstract public function toHtml(): string;
+}

--- a/src/Data/Meta/Html/TagCollection.php
+++ b/src/Data/Meta/Html/TagCollection.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class TagCollection extends Tag
+{
+    /**
+     * @var Tag[]
+     */
+    protected array $tags;
+
+    public function __construct(Tag ...$tags)
+    {
+        $this->tags = $tags;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toHtml(): string
+    {
+        $html = '';
+        foreach ($this->tags as $tag) {
+            $html .= $tag->toHtml();
+        }
+
+        return $html;
+    }
+}

--- a/src/Data/Meta/Html/TagCollection.php
+++ b/src/Data/Meta/Html/TagCollection.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Data\Meta\Html;
 
+use Generator;
+
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
@@ -31,7 +33,7 @@ class TagCollection extends Tag
 
     public function __construct(Tag ...$tags)
     {
-        $this->tags = $tags;
+        $this->tags = $this->collapseTags($tags);
     }
 
     /**
@@ -40,10 +42,44 @@ class TagCollection extends Tag
     public function toHtml(): string
     {
         $html = '';
-        foreach ($this->tags as $tag) {
+        foreach ($this->getTags() as $tag) {
             $html .= $tag->toHtml();
+            $html .= PHP_EOL;
         }
 
         return $html;
+    }
+
+    /**
+     * @return Tag[]|Generator
+     */
+    public function getTags(): Generator
+    {
+        yield from $this->tags;
+    }
+
+    /**
+     * @param Tag[] $tags
+     * @return Tag[]
+     */
+    protected function collapseTags(array $tags): array
+    {
+        $collapsed_tags = [];
+        foreach ($tags as $tag) {
+            if ($tag instanceof NullTag) {
+                continue;
+            }
+
+            if (!$tag instanceof self) {
+                $collapsed_tags[] = $tag;
+                continue;
+            }
+
+            foreach ($tag->getTags() as $nested_tag) {
+                $collapsed_tags[] = $nested_tag;
+            }
+        }
+
+        return $collapsed_tags;
     }
 }

--- a/src/Data/Meta/Html/Undefined.php
+++ b/src/Data/Meta/Html/Undefined.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class Undefined extends Tag
+{
+    /**
+     * @inheritDoc
+     */
+    public function toHtml(): string
+    {
+        return '';
+    }
+}

--- a/src/Data/Meta/Html/UserDefined.php
+++ b/src/Data/Meta/Html/UserDefined.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Meta\Html;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class UserDefined extends Tag
+{
+    public function __construct(
+        protected string $key,
+        protected string $value
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toHtml(): string
+    {
+        return "<meta name=\"$this->key\" content=\"$this->value\" />";
+    }
+}

--- a/src/Data/README.md
+++ b/src/Data/README.md
@@ -24,6 +24,8 @@ interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 * [Clock](#clock)
 * [Dimension](#dimension)
 * [Dataset](#dataset)
+* [HTML Metadata](#htmlmetadata)
+* [OpenGraph Metadata](#opengraphmetadata)
 
 Other examples for data types that could (and maybe should) be added here:
 
@@ -548,6 +550,96 @@ itIsTrueThat($dataset->getMaxValueForDimension("Target") === 1.5);
 ?>
 ```
 
+## HTMLMetadata
+
+When working with HTML metadata, you MUST always type-hint `\ILIAS\Data\Meta\Html\Tag`, except in rare cases where you
+have to work with a collection of tags explicitly (`\ILIAS\Data\Meta\Html\TagCollection`).
+
+Currently the factory can only provide `UserDefined` metadata which accepts key => value pairs mapped to a
+HTML-meta-tags name and content attribute.
+
+If you have to use something more speficic like e.g. the pragma directive feel free to implement it, derrived from the
+abstract class `\ILIAS\Data\Meta\Html\Tag`.
+
+### Example
+
+```php
+<?php
+
+$f = new \ILIAS\Data\Factory;
+
+$viewport_metadata = $f->htmlMetadata()->userDefined('viewport', 'widht=device-width');
+
+class ExpectsHtmlMetadata {
+    public function __construct(
+        protected \ILIAS\Data\Meta\Html\Tag $html_metadata,
+    ) {
+    }
+    
+    public function getMetadata(): \ILIAS\Data\Meta\Html\Tag
+    {
+        return $this->html_metadata;
+    }
+}
+
+$class = new ExpectsHtmlMetadata(
+    $f->htmlMetadata()->collection(
+        $f->htmlMetadata()->userDefined('description', 'Lorem ipsum dolor sit amet.'),
+        $viewport_metadata
+    )
+);
+
+itIsTrueThat(is_string($viewport_metadata->toHtml()));
+itIsTrueThat(is_string($class->getMetadata()->toHtml()));
+?>
+```
+
+## OpenGraphMetadata
+
+OpenGraph metadata is HTML metadata as well, but it's more structured and follows the
+open-graph-protocol ([ogp.me](https://ogp.me)).
+
+The factory currently only provides the website-type (of all the possible object-types
+documented [here](https://ogp.me/#types)). If you ever need a more specific object-type for e.g. articles or books, feel
+free to implement it accordingly.
+
+The factory also provides resources (`\ILIAS\Data\Meta\Html\OpenGraph\Resource`), which MUST NOT be used in any other
+way than the factory itself. These resources are [structured properties](https://ogp.me/#structured) which cannot be
+used standalone and MUST belong to an object-type.
+
+### Example
+
+```php
+<?php
+
+$f = new \ILIAS\Data\Factory;
+
+$structured_image = $f->openGraphMetadata()->image($f->uri('https://picsum.photos/200/300'), 'image/jpeg');
+
+$minimal_website_graph = $basic_website_graph = $f->openGraphMetadata()->website(
+    $f->uri('https://docu.ilias.de/object/101'),
+    $structured_image,
+    'object title 101'
+);
+
+$full_website_graph = $f->openGraphMetadata()->website(
+    $f->uri('https://docu.ilias.de/object/101'),
+    $structured_image,
+    'object title 101',
+    'ILIAS',
+    'lorem ipsum dolor sit amet.',
+    'en_US',
+    ['de_DE', 'de_CH'],
+    [
+        $f->openGraphMetadata()->image($f->uri('https://picsum.photos/100/100'), 'image/jpeg'),
+    ]
+);
+
+itIsTrueThat(is_string($minimal_website_graph->toHtml()));
+itIsTrueThat(is_string($full_website_graph->toHtml()));
+?>
+```
+
 ## Helper
 
 To make this run, we need a little helper:
@@ -561,26 +653,5 @@ function itIsTrueThat(bool $truth) {
     }
 }
 
-?>
-```
-
-## HTML metadata
-
-will follow.
-
-### Example
-
-```php
-<?php
-
-$f = new \ILIAS\Data\Factory;
-
-$html_metadata = $f->htmlMetadata()->userDefined('viewport', 'widht=device-width');
-
-$og_html_metadata = $f->htmlMetadata()->openGraph()->website(
-    'ILIAS',
-    $f->uri('https://docu.ilias.de'),
-    'hello world!'
-);
 ?>
 ```

--- a/src/Data/README.md
+++ b/src/Data/README.md
@@ -582,4 +582,5 @@ $og_html_metadata = $f->htmlMetadata()->openGraph()->website(
     $f->uri('https://docu.ilias.de'),
     'hello world!'
 );
+?>
 ```

--- a/src/Data/README.md
+++ b/src/Data/README.md
@@ -563,3 +563,23 @@ function itIsTrueThat(bool $truth) {
 
 ?>
 ```
+
+## HTML metadata
+
+will follow.
+
+### Example
+
+```php
+<?php
+
+$f = new \ILIAS\Data\Factory;
+
+$html_metadata = $f->htmlMetadata()->userDefined('viewport', 'widht=device-width');
+
+$og_html_metadata = $f->htmlMetadata()->openGraph()->website(
+    'ILIAS',
+    $f->uri('https://docu.ilias.de'),
+    'hello world!'
+);
+```

--- a/tests/Data/HtmlMetadataTest.php
+++ b/tests/Data/HtmlMetadataTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Data\Meta\Html\Factory;
+use ILIAS\Data\Meta\Html\TagCollection;
+use ILIAS\Data\Meta\Html\UserDefined;
+use ILIAS\Data\Meta\Html\NullTag;
+use ILIAS\Data\Meta\Html\Tag;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class HtmlMetadataTest extends TestCase
+{
+    protected Factory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new Factory();
+    }
+
+    public function testNullTag(): void
+    {
+        $null_tag = $this->factory->nullTag();
+
+        $this->assertInstanceOf(NullTag::class, $null_tag);
+        $this->assertEmpty($null_tag->toHtml());
+    }
+
+    public function testTagCollection(): void
+    {
+        $test_tag_1_html = 'test_tag_1_html';
+        $test_tag_1 = $this->getMockedTag($test_tag_1_html);
+
+        $test_tag_2_html = 'test_tag_2_html';
+        $test_tag_2 = $this->getMockedTag($test_tag_2_html);
+
+        $expected_html = $test_tag_1_html . PHP_EOL . $test_tag_2_html . PHP_EOL;
+
+        $tag_collection = $this->factory->collection([$test_tag_1, $test_tag_2]);
+
+        $this->assertCount(2, iterator_to_array($tag_collection->getTags()));
+        $this->assertEquals($expected_html, $tag_collection->toHtml());
+    }
+
+    public function testEmptyTagCollection(): void
+    {
+        $tag_collection = $this->factory->collection([]);
+
+        $this->assertEmpty(iterator_to_array($tag_collection->getTags()));
+        $this->assertEmpty($tag_collection->toHtml());
+    }
+
+    public function testNestedTagCollection(): void
+    {
+        $test_tag_1_html = 'test_tag_1_html';
+        $test_tag_1 = $this->getMockedTag($test_tag_1_html);
+
+        $test_tag_2_html = 'test_tag_2_html';
+        $test_tag_2 = $this->getMockedTag($test_tag_2_html);
+
+        $test_tag_3_html = 'test_tag_3_html';
+        $test_tag_3 = $this->getMockedTag($test_tag_3_html);
+
+        $expected_html = $test_tag_1_html . PHP_EOL . $test_tag_2_html . PHP_EOL . $test_tag_3_html . PHP_EOL;
+
+        $tag_collection = $this->factory->collection([
+            $this->factory->collection([$test_tag_1, $test_tag_2]),
+            $test_tag_3,
+        ]);
+
+        $this->assertCount(3, iterator_to_array($tag_collection->getTags()));
+        $this->assertEquals($expected_html, $tag_collection->toHtml());
+    }
+
+    public function testUserDefinedTag(): void
+    {
+        $key = 'expected_key';
+        $val = 'expected_value';
+
+        $user_defined_tag = $this->factory->userDefined($key, $val);
+
+        $this->assertInstanceOf(UserDefined::class, $user_defined_tag);
+        $this->assertEquals(
+            "<meta name=\"$key\" content=\"$val\" />",
+            $user_defined_tag->toHtml()
+        );
+    }
+
+    public function getMockedTag(string $html): Tag
+    {
+        $tag_mock = $this->createMock(Tag::class);
+        $tag_mock->method('toHtml')->willReturn($html);
+
+        return $tag_mock;
+    }
+}

--- a/tests/Data/OpenGraphMetadataTest.php
+++ b/tests/Data/OpenGraphMetadataTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Data\URI;
+use ILIAS\Data\Meta\Html\OpenGraph\Factory;
+use ILIAS\Data\Meta\Html\OpenGraph\Link;
+use ILIAS\Data\Meta\Html\OpenGraph\Text;
+use ILIAS\Data\Meta\Html\OpenGraph\Resource;
+use ILIAS\Data\Meta\Html\OpenGraph\Image;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class OpenGraphMetadataTest extends TestCase
+{
+    protected Factory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new Factory();
+    }
+
+    public function testTextTag(): void
+    {
+        $property = 'test_property';
+        $value = 'test_value';
+
+        $link_tag = new Text($property, $value);
+
+        $this->assertEquals(
+            "<meta property=\"$property\" content=\"$value\" />",
+            $link_tag->toHtml()
+        );
+    }
+
+    public function testLinkTag(): void
+    {
+        $property = 'test_property';
+        $value = 'test_value';
+
+        $link_tag = new Link($property, $this->getMockedUrl($value));
+
+        $this->assertEquals(
+            "<meta property=\"$property\" content=\"$value\" />",
+            $link_tag->toHtml()
+        );
+    }
+
+    public function testAudioTag(): void
+    {
+        $expected_url = 'test_url';
+        $expected_mime = 'test_mime_type';
+        $expected_html =
+            "<meta property=\"og:audio\" content=\"$expected_url\" />" . PHP_EOL .
+            "<meta property=\"og:audio:type\" content=\"$expected_mime\" />" . PHP_EOL;
+
+        $audio_tag = $this->factory->audio($this->getMockedUrl($expected_url), $expected_mime);
+
+        $this->assertEquals($expected_html, $audio_tag->toHtml());
+    }
+
+    public function testImageTag(): void
+    {
+        $expected_url = 'test_url';
+        $expected_mime = 'test_mime_type';
+        $expected_alt = 'test_aria_label';
+        $expected_width = 200;
+        $expected_height = 100;
+        $expected_html =
+            "<meta property=\"og:image\" content=\"$expected_url\" />" . PHP_EOL .
+            "<meta property=\"og:image:type\" content=\"$expected_mime\" />" . PHP_EOL .
+            "<meta property=\"og:image:alt\" content=\"$expected_alt\" />" . PHP_EOL .
+            "<meta property=\"og:image:width\" content=\"$expected_width\" />" . PHP_EOL .
+            "<meta property=\"og:image:height\" content=\"$expected_height\" />" . PHP_EOL;
+
+        $image_tag = $this->factory->image(
+            $this->getMockedUrl($expected_url),
+            $expected_mime,
+            $expected_alt,
+            $expected_width,
+            $expected_height
+        );
+
+        $this->assertEquals($expected_html, $image_tag->toHtml());
+    }
+
+    public function testVideoTag(): void
+    {
+        $expected_url = 'test_url';
+        $expected_mime = 'test_mime_type';
+        $expected_width = 200;
+        $expected_height = 100;
+        $expected_html =
+            "<meta property=\"og:video\" content=\"$expected_url\" />" . PHP_EOL .
+            "<meta property=\"og:video:type\" content=\"$expected_mime\" />" . PHP_EOL .
+            "<meta property=\"og:video:width\" content=\"$expected_width\" />" . PHP_EOL .
+            "<meta property=\"og:video:height\" content=\"$expected_height\" />" . PHP_EOL;
+
+        $video_tag = $this->factory->video(
+            $this->getMockedUrl($expected_url),
+            $expected_mime,
+            $expected_width,
+            $expected_height
+        );
+
+        $this->assertEquals($expected_html, $video_tag->toHtml());
+    }
+
+    public function testWebsiteTag(): void
+    {
+        $expected_canonical_url = 'test_canonical_url';
+        $expected_image_html = 'test_image_html';
+        $expected_object_title = 'test_object_title';
+        $expected_website_name = 'test_website_name';
+        $expected_description = 'test_description';
+        $expected_locale = 'test_locale';
+        $expected_locale_alt_1 = 'test_locale_alt_1';
+        $expected_locale_alt_2 = 'test_locale_alt_2';
+        $expected_additional_resource_html_1 = 'test_additional_resource_html_1';
+        $expected_additional_resource_html_2 = 'test_additional_resource_html_2';
+
+        $expected_html =
+            "<meta property=\"og:type\" content=\"website\" />" . PHP_EOL .
+            "<meta property=\"og:title\" content=\"test_object_title\" />" . PHP_EOL .
+            "<meta property=\"og:url\" content=\"test_canonical_url\" />" . PHP_EOL .
+            $expected_image_html . PHP_EOL .
+            "<meta property=\"og:site_title\" content=\"test_website_name\" />" . PHP_EOL .
+            "<meta property=\"og:description\" content=\"test_description\" />" . PHP_EOL .
+            "<meta property=\"og:locale\" content=\"test_locale\" />" . PHP_EOL .
+            "<meta property=\"og:locale:alternative\" content=\"test_locale_alt_1\" />" . PHP_EOL .
+            "<meta property=\"og:locale:alternative\" content=\"test_locale_alt_2\" />" . PHP_EOL .
+            $expected_additional_resource_html_1 . PHP_EOL .
+            $expected_additional_resource_html_2 . PHP_EOL;
+
+        $website_tag = $this->factory->website(
+            $this->getMockedUrl($expected_canonical_url),
+            $this->getMockedImage($expected_image_html),
+            $expected_object_title,
+            $expected_website_name,
+            $expected_description,
+            $expected_locale,
+            [
+                $expected_locale_alt_1,
+                $expected_locale_alt_2,
+            ],
+            [
+                $this->getMockedResource($expected_additional_resource_html_1),
+                $this->getMockedResource($expected_additional_resource_html_2),
+            ]
+        );
+
+        $this->assertEquals($expected_html, $website_tag->toHtml());
+    }
+
+    protected function getMockedResource(string $html): Resource
+    {
+        $mock_resource = $this->createMock(Resource::class);
+        $mock_resource->method('toHtml')->willReturn($html);
+        $mock_resource->method('getTags')->willReturnCallback(
+            static function () use ($mock_resource): Generator {
+                yield $mock_resource;
+            }
+        );
+
+        return $mock_resource;
+    }
+
+    protected function getMockedImage(string $html): Image
+    {
+        $mock_image = $this->createMock(Image::class);
+        $mock_image->method('toHtml')->willReturn($html);
+        $mock_image->method('getTags')->willReturnCallback(
+            static function () use ($mock_image): Generator {
+                yield $mock_image;
+            }
+        );
+
+        return $mock_image;
+    }
+
+    protected function getMockedUrl(string $url): URI
+    {
+        $mock_url = $this->createMock(URI::class);
+        $mock_url->method('__toString')->willReturn($url);
+
+        return $mock_url;
+    }
+}


### PR DESCRIPTION
Hi @klees 

I'm sorry for the long delay, but this PR is an unfinalized follow-up of #4695. Let me explain my thoughts on this:

 - [ ] `Tag` I've decided to name this abstract representation of HTML metadata a "tag", since the namespace already tells us about what kind of data is stored inside it.
 - [ ] `Tag::toHtml` I didn't implement this in PHPs `__toString` method, because I thought there could be a need of other methods like `toJson` or even `toXml` in the future, and in this scenario `toHtml` would be more semantic.
 - [ ] `UserDefined` I only introduced this HTML metadata object because there is currently no need for further implementations except key => value pairs that are mapped to the meta tags name and content attribute.
 - [ ] `TagCollection` and `Undefined` were introduced, because I was inspired by your presentation on monoids at the DevConf =). The OpenGraph ([ogp.me](https://ogp.me)) protocol dictates a certain collection of HTML meta tags that differ depending on the OpenGraph [type](https://ogp.me#types). Therefore I thought, this looks monoid-ish because I add multiple tags to (again) a tag and I've tried to structure it similar to the FormInputs or Objectives.
 - [ ] I think there are far too many OpenGraph properties that would need to be implemented, so I've decided to be lazy and implement more generic properties like currently `Text` or `Link`. The properties are then grouped together properly in the `OpenGraph\Factory`.

To start-off I have a few questions:

- [ ] Do you think the OpenGraph metadata could benefit from such a monoid-ish structure? 
- [ ] Do you think we should implement more specific properties, like e.g. `OpenGraph\Title` or `OpenGraph\Image`?
- [ ] Do you think the namespace and name of `Tag` are fitting?
- [ ] Do you think the nesting of the `Html\Factory` and `OpenGraph\Factory` should already be separated in the main factory?

Best regards!