### PR TITLE
Test: Fix Synchronization of Questions

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -9659,7 +9659,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             array($a_q_id)
         );
         $rec = $ilDB->fetchAssoc($result);
-        return $rec["obj_id"];
+        return $rec["obj_id"] ?? null;
     }
 
     /**


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=34426

@maxbecker : I spent some time trying to figure out if this is really enough, but actually this really simply restores the behavior found in ILIAS 7. I will simply merge this and cherry-pick it to trunk as I see it as trivial. This PR is just fyi.
The function is only used when updating MediaObjects in the question page. It does not feel right, but with the current structure relying on static calls, I would not spend time on finding a more logical solution right now.