### PR TITLE
[FIX] 0034523: Failed test: Datei hochladen

### DIFF
--- a/Services/Init/classes/Dependencies/InitUIFramework.php
+++ b/Services/Init/classes/Dependencies/InitUIFramework.php
@@ -13,7 +13,8 @@
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
 /**
  * Responsible for loading the UI Framework into the dependency injection container of ILIAS
@@ -208,6 +209,7 @@ class InitUIFramework
         };
         $c["ui.factory.dropzone.file"] = function ($c) {
             return new ILIAS\UI\Implementation\Component\Dropzone\File\Factory(
+                $c["ui.signal_generator"],
                 $c["ui.upload_limit_resolver"],
                 $c["ui.factory.input"],
                 $c["lng"]

--- a/src/UI/Component/Closable.php
+++ b/src/UI/Component/Closable.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Component;
+
+/**
+ * Interface Closacle
+ *
+ * Describes a component that can trigger signals of other components on close.
+ *
+ * @package ILIAS\UI\Component
+ */
+interface Closable extends Triggerer
+{
+    /**
+     * Get a component like this, triggering a signal of another component on close.
+     * Note: Any previous signals registered on close are replaced.
+     *
+     * @param Signal $signal A signal of another component
+     * @return static
+     */
+    public function withOnClose(Signal $signal): self;
+
+    /**
+     * Get a component like this, triggering a signal of another component on close.
+     * In contrast to withOnClose, the signal is appended to existing signals for the close event.
+     *
+     * @return static
+     */
+    public function appendOnClose(Signal $signal): self;
+}

--- a/src/UI/Component/Dropzone/File/File.php
+++ b/src/UI/Component/Dropzone/File/File.php
@@ -23,6 +23,7 @@ namespace ILIAS\UI\Component\Dropzone\File;
 use ILIAS\UI\Component\Input\Container\Form\Form;
 use ILIAS\UI\Component\Input\Field\FileUpload;
 use ILIAS\UI\Component\Droppable;
+use ILIAS\UI\Component\Triggerable;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>

--- a/src/UI/Component/Dropzone/File/Wrapper.php
+++ b/src/UI/Component/Dropzone/File/Wrapper.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 namespace ILIAS\UI\Component\Dropzone\File;
 
 use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Triggerable;
+use ILIAS\UI\Implementation\Component\Signal;
 
 /**
  * A wrapper file dropzone wraps around any other component from the UI framework, e.g. a calendar entry.
@@ -28,7 +30,7 @@ use ILIAS\UI\Component\Component;
  * Dropping the files opens a modal where the user can start the upload process.
  * @author  nmaerchy <nm@studer-raimann.ch>
  */
-interface Wrapper extends File
+interface Wrapper extends File, Triggerable
 {
     /**
      * Get the components being wrapped by this dropzone.
@@ -36,4 +38,9 @@ interface Wrapper extends File
      * @return Component[]
      */
     public function getContent(): array;
+
+    /**
+     * gets the Signal to clear the file-list in the modal of a wrapper dropzone.
+     */
+    public function getClearSignal(): Signal;
 }

--- a/src/UI/Component/Modal/Modal.php
+++ b/src/UI/Component/Modal/Modal.php
@@ -25,11 +25,13 @@ use ILIAS\UI\Component\JavaScriptBindable;
 use ILIAS\UI\Component\Onloadable;
 use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Component\Triggerable;
+use ILIAS\UI\Component\Triggerer;
+use ILIAS\UI\Component\Closable;
 
 /**
  * This describes commonalities between the different modals
  */
-interface Modal extends Component, JavaScriptBindable, Triggerable, Onloadable
+interface Modal extends Component, JavaScriptBindable, Triggerable, Onloadable, Closable
 {
     /**
      * Get the url returning the rendered modal, if the modals content should be rendered via ajax

--- a/src/UI/Implementation/Component/Dropzone/File/Factory.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Factory.php
@@ -28,17 +28,20 @@ use ILIAS\UI\Component\Input\Factory as InputFactory;
 use ILIAS\UI\Component\Input\Field\UploadHandler;
 use ILIAS\UI\Component\Input\Field\Input;
 use ilLanguage;
+use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
 class Factory implements FactoryInterface
 {
+    protected SignalGeneratorInterface $signal_generator;
     protected UploadLimitResolver $upload_limit_resolver;
     protected InputFactory $factory;
     protected ilLanguage $language;
 
     public function __construct(
+        SignalGeneratorInterface $signal_generator,
         UploadLimitResolver $upload_limit_resolver,
         InputFactory $factory,
         ilLanguage $language
@@ -46,6 +49,7 @@ class Factory implements FactoryInterface
         $this->upload_limit_resolver = $upload_limit_resolver;
         $this->factory = $factory;
         $this->language = $language;
+        $this->signal_generator = $signal_generator;
     }
 
     public function standard(
@@ -73,6 +77,7 @@ class Factory implements FactoryInterface
         ?Input $metadata_input = null
     ): WrapperInterface {
         return new Wrapper(
+            $this->signal_generator,
             $this->factory,
             $this->language,
             $this->upload_limit_resolver,

--- a/src/UI/Implementation/Component/Dropzone/File/Renderer.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Renderer.php
@@ -56,10 +56,12 @@ class Renderer extends AbstractComponentRenderer
 
     protected function renderWrapper(Wrapper $dropzone, RenderInterface $default_renderer): string
     {
+        $clear_signal = $dropzone->getClearSignal();
+
         $modal = $this->getUIFactory()->modal()->roundtrip(
             $dropzone->getTitle(),
             [$dropzone->getForm()]
-        );
+        )->withOnClose($clear_signal);
 
         $template = $this->getTemplate("tpl.dropzone.html", true, true);
         $template->setVariable('MODAL', $default_renderer->render($modal));
@@ -68,6 +70,9 @@ class Renderer extends AbstractComponentRenderer
 
         $dropzone = $this->initClientsideDropzone($dropzone);
         $dropzone = $dropzone->withAdditionalDrop($modal->getShowSignal());
+        $dropzone = $dropzone->withAdditionalOnLoadCode(function ($id) use ($clear_signal): string {
+            return "$('#$id').on('$clear_signal', function() { il.UI.Dropzone.removeAllFilesFromQueue('$id');});";
+        });
 
         $this->bindAndApplyJavaScript($dropzone, $template);
 

--- a/src/UI/Implementation/Component/Dropzone/File/Wrapper.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Wrapper.php
@@ -28,6 +28,10 @@ use ILIAS\UI\Component\Component;
 use LogicException;
 use ilLanguage;
 use ILIAS\UI\Component\Input\Field\Input;
+use ILIAS\UI\Implementation\Component\Triggerer;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
+use ILIAS\UI\Implementation\Component\Signal;
 
 /**
  * @author  nmaerchy <nm@studer-raimann.ch>
@@ -35,6 +39,8 @@ use ILIAS\UI\Component\Input\Field\Input;
  */
 class Wrapper extends File implements WrapperInterface
 {
+    protected SignalGeneratorInterface $signal_generator;
+    protected \ILIAS\UI\Implementation\Component\Signal $clear_signal;
     /**
      * @var Component[]
      */
@@ -44,6 +50,7 @@ class Wrapper extends File implements WrapperInterface
      * @param Component[]|Component $content
      */
     public function __construct(
+        SignalGeneratorInterface $signal_generator,
         InputFactory $input_factory,
         ilLanguage $language,
         UploadLimitResolver $upload_limit_resolver,
@@ -59,11 +66,30 @@ class Wrapper extends File implements WrapperInterface
         $this->checkEmptyArray($content);
 
         $this->components = $content;
+        $this->signal_generator = $signal_generator;
+        $this->initSignals();
+    }
+
+    protected function initSignals(): void
+    {
+        $this->clear_signal = $this->signal_generator->create();
     }
 
     public function getContent(): array
     {
         return $this->components;
+    }
+
+    public function getClearSignal(): Signal
+    {
+        return $this->clear_signal;
+    }
+
+    public function withResetSignals()
+    {
+        $clone = clone $this;
+        $clone->initSignals();
+        return $clone;
     }
 
     /**

--- a/src/UI/Implementation/Component/Modal/Modal.php
+++ b/src/UI/Implementation/Component/Modal/Modal.php
@@ -129,6 +129,16 @@ abstract class Modal implements M\Modal
         return $this->appendTriggeredSignal($signal, 'ready');
     }
 
+    public function withOnClose(Signal $signal): self
+    {
+        return $this->withTriggeredSignal($signal, 'hidden.bs.modal');
+    }
+
+    public function appendOnClose(Signal $signal): self
+    {
+        return $this->withTriggeredSignal($signal, 'hidden.bs.modal');
+    }
+
     /**
      * Set the show and close signals for this modal
      */

--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -98,8 +98,8 @@ class Renderer extends AbstractComponentRenderer
             $options["url"] = "#$id";
             $options = json_encode($options);
             $code =
-                "$(document).on('$show', function(event, signalData) { il.UI.modal.showModal('$id', $options, signalData); return false; });" .
-                "$(document).on('$close', function() { il.UI.modal.closeModal('$id'); return false; });";
+                "$(document).on('$show', function(event, signalData) { il.UI.modal.showModal('$id', $options, signalData);});" .
+                "$(document).on('$close', function() { il.UI.modal.closeModal('$id');});";
             if ($replace != "") {
                 $code .= "$(document).on('$replace', function(event, signalData) { il.UI.modal.replaceFromSignal('$id', signalData);});";
             }

--- a/src/UI/templates/js/Dropzone/File/dropzone.js
+++ b/src/UI/templates/js/Dropzone/File/dropzone.js
@@ -112,6 +112,14 @@ il.UI = il.UI || {};
             }
         }
 
+        let removeAllFilesFromQueue = function (dropzone_id) {
+            if (typeof dropzones[dropzone_id] === 'undefined') {
+                console.error(`Error: tried accessing unknown dropzone '${dropzone_id}'.`);
+                return;
+            }
+            il.UI.Input.File.removeAllFilesFromQueue(dropzones[dropzone_id].file_input_id);
+        }
+
         /**
          * @param {Event} event
          */
@@ -183,6 +191,7 @@ il.UI = il.UI || {};
 
         return {
             init: init,
+            removeAllFilesFromQueue: removeAllFilesFromQueue,
         }
     })($);
 })($, il.UI);

--- a/src/UI/templates/js/Input/Field/file.js
+++ b/src/UI/templates/js/Input/Field/file.js
@@ -491,8 +491,6 @@ il.UI.Input = il.UI.Input || {};
 		}
 
 		let removeAllFilesFromQueue = function (input_id) {
-			console.log(input_id);
-			console.log(dropzones);
 			if (typeof dropzones[input_id] === 'undefined') {
 				console.error(`Error: tried to access unknown input '${input_id}'.`);
 				return;

--- a/src/UI/templates/js/Input/Field/file.js
+++ b/src/UI/templates/js/Input/Field/file.js
@@ -480,7 +480,7 @@ il.UI.Input = il.UI.Input || {};
 				let current_input_id = dropzone.files[i].input_id;
 				if (typeof current_input_id !== 'undefined' && current_input_id === input_id) {
 					file_to_remove = dropzone.files[i];
-          break;
+          			break;
 				}
 			}
 
@@ -488,6 +488,24 @@ il.UI.Input = il.UI.Input || {};
 				// removes ONE file object at found position.
 				dropzone.removeFile(file_to_remove);
 			}
+		}
+
+		let removeAllFilesFromQueue = function (input_id) {
+			console.log(input_id);
+			console.log(dropzones);
+			if (typeof dropzones[input_id] === 'undefined') {
+				console.error(`Error: tried to access unknown input '${input_id}'.`);
+				return;
+			}
+
+			for (let i = 0; i < dropzones[input_id].files.length; ++i) {
+				let file = dropzones[input_id].files[i];
+				let file_id_input = $(`#${file.input_id}`);
+				let file_preview = file_id_input.closest(SELECTOR.file_list_entry);
+				file_preview.remove();
+			}
+
+			dropzones[input_id].removeAllFiles();
 		}
 
 		/**
@@ -641,6 +659,7 @@ il.UI.Input = il.UI.Input || {};
 		// ==========================================
 
 		return {
+			removeAllFilesFromQueue: removeAllFilesFromQueue,
 			renderFileEntry: renderFileEntryHook,
 			init: init,
 		}

--- a/tests/UI/Component/Dropzone/File/FileTestBase.php
+++ b/tests/UI/Component/Dropzone/File/FileTestBase.php
@@ -46,6 +46,7 @@ abstract class FileTestBase extends ILIAS_UI_TestBase
 
         $this->generator = new IncrementalSignalGenerator();
         $this->factory = new I\Component\Dropzone\File\Factory(
+            $this->generator,
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             $this->getInputFactory(),
             $this->getLanguage()


### PR DESCRIPTION
@Amstutz / @klees as mentioned in https://mantis.ilias.de/view.php?id=34523

But I misunderstood the Close-Signal, therefore I implemented an additional Closed-Signal (which naming is not good, i know, better Ideas appreciated...).

You therefore can listen to a triggered Signal on closing a Modal, the Dropzone\File\Wrapper uses this to clean the filelist (as mentioned in the initial bug ticket).