### PR TITLE
Auth/PublicArea: Fix auto SSO for SOAP and Apache authentication

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -1630,9 +1630,12 @@ class ilStartUpGUI
 
         // In case of an valid session, redirect to starting page
         if ($GLOBALS['DIC']['ilAuthSession']->isValid()) {
-            include_once './Services/Init/classes/class.ilInitialisation.php';
-            ilInitialisation::redirectToStartingPage();
-            return;
+            if (!$this->user->isAnonymous() || ilPublicSectionSettings::getInstance()->isEnabledForDomain(
+                $this->httpRequest->getServerParams()['SERVER_NAME']
+            )) {
+                ilInitialisation::redirectToStartingPage();
+                return;
+            }
         }
 
         // no valid session => show client list, if no client info is given


### PR DESCRIPTION
With 871004d45b54647f4b683e674585a6baf19d217c the `cmd=force_login` parameter will always be used if a server request results in the presentation of the login page. So everytime the login page is displayed, this parameter is set, even if the `Public Area` is disabled.
Because of this, the automatic login attempts for `SOAP` and `Apache` authentication (`ilStartUpGUI::showLoginPage`) do not work anymore.
This change introduces a further check before
`ilInitialisation::redirectToStartingPage` is called. Without this change `// fallback, should never happen` in
`ilInitialisation::redirectToStartingPage` does always happen.

Mantis Issue: https://mantis.ilias.de/view.php?id=34619

This change MUST be cherry-picked (if approved) to `release_8` and `trunk`.