### PR TITLE
[FIX] removed duplicate showMessageForm() call.

### DIFF
--- a/Services/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/Services/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -210,11 +210,15 @@ class ilPasswordAssistanceGUI
 
             $usrId = \ilObjUser::getUserIdByLogin($username);
             if (!is_numeric($usrId) || !($usrId > 0)) {
-                \ilLoggerFactory::getLogger('usr')->info(sprintf(
-                    'Could not process password assistance form (reason: no user found) %s / %s',
-                    $username,
-                    $email
-                ));
+                \ilLoggerFactory::getLogger('usr')->info(
+                    sprintf(
+                        'Could not process password assistance form (reason: no user found) %s / %s',
+                        $username,
+                        $email
+                    )
+                );
+
+                return;
             }
 
             $user = new \ilObjUser($usrId);

--- a/Services/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/Services/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -215,8 +215,6 @@ class ilPasswordAssistanceGUI
                     $username,
                     $email
                 ));
-
-                $this->showMessageForm(sprintf($this->lng->txt('pwassist_mail_sent'), $email));
             }
 
             $user = new \ilObjUser($usrId);


### PR DESCRIPTION
Hi @pascalseeland

@mjansenDatabay drew my attention to the (IMO redundant `showMessageForm` call) within the callback I introduced while implementing the `CallbackDuration`, so I felt kind of responsible for leaving this code-snippet in there. First we thought the method-call triggers a `RuntimeException` due to the new shutdown-function of the HTTP-service, but then we realized that `ilGlobalTemplate::printToStdout` doesn't contain an exit-statement (anymore?).

Anyways, the `showMessageForm` will also be called after the callback finished.

Kind regards!