### PR TITLE
Text: Fix Removal of "Pseudo-Tags" in Single Choice Question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -705,8 +705,8 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         $this->object->flushAnswers();
         if ($this->object->isSingleline) {
             foreach ($_POST['choice']['answer'] as $index => $answertext) {
-                $answertext = ilUtil::secureString($answertext);
-                
+                $answertext = ilUtil::secureString(htmlentities($answertext));
+
                 $picturefile = $_POST['choice']['imagename'][$index];
                 $file_org_name = $_FILES['choice']['name']['image'][$index];
                 $file_temp_name = $_FILES['choice']['tmp_name']['image'][$index];
@@ -820,7 +820,13 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         if ($this->object->getAnswerCount() == 0) {
             $this->object->addAnswer("", 0, 0, 0);
         }
-        $choices->setValues($this->object->getAnswers());
+        $choices->setValues(array_map(
+            function (ASS_AnswerMultipleResponseImage $value) {
+                $value->setAnswerText(html_entity_decode($value->getAnswerText()));
+                return $value;
+            },
+            $this->object->getAnswers()
+        ));
         $form->addItem($choices);
     }
 

--- a/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -630,7 +630,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         $this->object->flushAnswers();
         if ($this->object->isSingleline) {
             foreach ($_POST['choice']['answer'] as $index => $answertext) {
-                $answertext = ilUtil::secureString($answertext);
+                $answertext = ilUtil::secureString(htmlentities($answertext));
 
                 $picturefile = $_POST['choice']['imagename'][$index];
                 $file_org_name = $_FILES['choice']['name']['image'][$index];
@@ -676,7 +676,13 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         if ($this->object->getAnswerCount() == 0) {
             $this->object->addAnswer("", 0, 0);
         }
-        $choices->setValues($this->object->getAnswers());
+        $choices->setValues(array_map(
+            function (ASS_AnswerBinaryStateImage $value) {
+                    $value->setAnswerText(html_entity_decode($value->getAnswerText()));
+                    return $value;
+                },
+            $this->object->getAnswers()
+        ));
         $form->addItem($choices);
     }
 


### PR DESCRIPTION
This is basically the same solution as applied in #5062 ported to the SingeChoice- and the MultipleChoiceQuestion.

See: https://mantis.ilias.de/view.php?id=32047

As always: Just let me know if you would like PRs to release_8, as soon as you have checked this.