### PR TITLE
Toasts: JS Error in console

### DIFF
--- a/src/UI/Implementation/Component/Toast/Renderer.php
+++ b/src/UI/Implementation/Component/Toast/Renderer.php
@@ -82,10 +82,13 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable("ICON", $default_renderer->render($component->getIcon()));
         $tpl->setVariable("CLOSE", $default_renderer->render($this->getUIFactory()->button()->close()));
 
-        $component = $component->withAdditionalOnLoadCode(fn ($id) => "
-                il.UI.toast.setToastSettings($id);
-                il.UI.toast.showToast($id);
-            ");
+        $component = $component->withAdditionalOnLoadCode(static fn (string $id): string => "{
+            const node = document.getElementById('$id');
+            if (node) {
+                il.UI.toast.setToastSettings(node);
+                il.UI.toast.showToast(node);
+            }
+        }");
 
         $tpl->setCurrentBlock("id");
         $tpl->setVariable('ID', $this->bindJavaScript($component));


### PR DESCRIPTION
Mantis Bug: https://mantis.ilias.de/view.php?id=34590

The `ILIAS\UI\Renderer::renderAsync(...)` method adds all JS code to the generated `HTML` **and** to the `tpl.standardpage.html`.
This is no issue when used in an asynch request where the `tpl.standardpage.html` is not rendered anyways but when the method is used in a normal request the JS onload code is added twice.

The JS error in the mantis bug also occurs in the documentation / examples for the toasts because of this issue.

This PR doesn't fix the issue with `renderAsync` but prevents the JS error.

The question arises if the `renderAync` method must not be used in a non asynchronous call or if this is a bug.