### PR TITLE
WIP: refactor deprecated update steps

### DIFF
--- a/Services/AccessControl/classes/class.ilRbacReview.php
+++ b/Services/AccessControl/classes/class.ilRbacReview.php
@@ -1332,10 +1332,12 @@ class ilRbacReview
         self::$assigned_users_cache = array();
     }
 
-    public static function _getCustomRBACOperationId(string $operation): ?int
+    public static function _getCustomRBACOperationId(string $operation, \ilDBInterface $ilDB = null): ?int
     {
-        global $DIC;
-        $ilDB = $DIC['ilDB'];
+        if (!$ilDB) {
+            global $DIC;
+            $ilDB = $DIC->database();
+        }
 
         $sql =
             "SELECT ops_id" . PHP_EOL
@@ -1349,7 +1351,7 @@ class ilRbacReview
         }
 
         $row = $ilDB->fetchAssoc($res);
-        return (int) $row["ops_id"] ?? null;
+        return (int) $row["ops_id"];
     }
 
     public static function _isRBACOperation(int $type_id, int $ops_id): bool

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -2023,6 +2023,6 @@ class ilObject
         }
 
         $row = $ilDB->fetchAssoc($res);
-        return (int) $row['obj_id'] ?? null;
+        return (int) $row['obj_id'];
     }
 } // END class.ilObject

--- a/Services/Skill/classes/Setup/class.ilSkillAgent.php
+++ b/Services/Skill/classes/Setup/class.ilSkillAgent.php
@@ -1,6 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+include_once 'Services/AccessControl/classes/Setup/class.ilAccessRBACOperationsAddedObjective.php';
+include_once 'Services/Object/classes/Setup/class.ilObjectNewTypeAddedObjective.php';
+include_once 'Services/AccessControl/classes/Setup/class.ilAccessCustomRBACOperationAddedObjective.php';
+include_once 'Services/Object/classes/class.ilObject.php';
+include_once 'Services/AccessControl/classes/class.ilRbacReview.php';
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -25,6 +29,91 @@ class ilSkillAgent extends Setup\Agent\NullAgent
 {
     public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
     {
-        return new ilDatabaseUpdateStepsExecutedObjective(new ilSkillDBUpdateSteps());
+        return new Setup\ObjectiveCollection(
+            "Service/Skill Objectives",
+            false,
+            new ilDatabaseUpdateStepsExecutedObjective(new ilSkillDBUpdateSteps()),
+            ...($this->step_4() + $this->step_5())
+        );
+    }
+
+    public function step_4() : array
+    {
+        $objectives = [];
+        $skill_tree_type_id = ilObject::_getObjectTypeIdByTitle('skee');
+
+        if (!$skill_tree_type_id) {
+            $skill_tree_type_id = ilDBUpdateNewObjectType::addNewType('skee', 'Skill Tree');
+
+            $objectives[] = new ilAccessCustomRBACOperationAddedObjective(
+                'read_comp',
+                'Read Competences',
+                'object',
+                6500
+            );
+            $objectives[] = new ilAccessCustomRBACOperationAddedObjective(
+                'read_profiles',
+                'Read Competence Profiles',
+                'object',
+                6510
+            );
+            $objectives[] = new ilAccessCustomRBACOperationAddedObjective(
+                'manage_comp',
+                'Manage Competences',
+                'object',
+                8500
+            );
+            $objectives[] = new ilAccessCustomRBACOperationAddedObjective(
+                'manage_comp_temp',
+                'Manage Competence Templates',
+                'object',
+                8510
+            );
+            $objectives[] = new ilAccessCustomRBACOperationAddedObjective(
+                'manage_profiles',
+                'Manage Competence Profiles',
+                'object',
+                8520
+            );
+
+            $objectives[] = new ilAccessRBACOperationsAddedObjective(
+                $skill_tree_type_id,
+                [
+                    ilDBUpdateNewObjectType::RBAC_OP_EDIT_PERMISSIONS,
+                    ilDBUpdateNewObjectType::RBAC_OP_VISIBLE,
+                    ilDBUpdateNewObjectType::RBAC_OP_READ,
+                    ilDBUpdateNewObjectType::RBAC_OP_WRITE,
+                    ilDBUpdateNewObjectType::RBAC_OP_DELETE,
+                    ilDBUpdateNewObjectType::RBAC_OP_COPY
+                ]
+            );
+
+            $ops_id = 1;
+
+            $skill_tree_type_id = ilObject::_getObjectTypeIdByTitle('skmg');
+            if ($skill_tree_type_id) {
+                $objectives[] = new ilAccessRBACOperationsAddedObjective($skill_tree_type_id, [$ops_id]);
+            }
+        }
+        return $objectives;
+    }
+
+    public function step_5() : array
+    {
+        $objectives = [];
+        $skill_tree_type_id = ilObject::_getObjectTypeIdByTitle('skee');
+        $ops_id = [ilRbacReview::_getCustomRBACOperationId('read_comp')];
+        if ($skill_tree_type_id !== null && $ops_id !== null) {
+            $objectives[] = new ilAccessRBACOperationsAddedObjective($skill_tree_type_id, $ops_id);
+        }
+        $skill_tree_type_id = ilObject::_getObjectTypeIdByTitle('skee');
+        $ops_ids[] = ilRbacReview::_getCustomRBACOperationId('read_profiles');
+        $ops_ids[] = ilRbacReview::_getCustomRBACOperationId('manage_comp');
+        $ops_ids[] = ilRbacReview::_getCustomRBACOperationId('manage_comp_temp');
+        $ops_ids[] = ilRbacReview::_getCustomRBACOperationId('manage_profiles');
+        if ($skill_tree_type_id !== null && !in_array(null, $ops_ids, true)) {
+            $objectives[] = new ilAccessRBACOperationsAddedObjective($skill_tree_type_id, [$ops_id]);
+        }
+        return $objectives;
     }
 }

--- a/Services/Skill/classes/Setup/class.ilSkillDBUpdateSteps.php
+++ b/Services/Skill/classes/Setup/class.ilSkillDBUpdateSteps.php
@@ -77,86 +77,10 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
 
     public function step_4(): void
     {
-        include_once 'Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php';
-
-        $skill_tree_type_id = ilDBUpdateNewObjectType::getObjectTypeId('skee');
-
-        if (!$skill_tree_type_id) {
-            // add basic object type
-            $skill_tree_type_id = ilDBUpdateNewObjectType::addNewType('skee', 'Skill Tree');
-
-            $opsId = [];
-            $opsId[] = ilDBUpdateNewObjectType::addCustomRBACOperation(
-                'read_comp',
-                'Read Competences',
-                'object',
-                6500
-            );
-
-            $opsId[] = ilDBUpdateNewObjectType::addCustomRBACOperation(
-                'read_profiles',
-                'Read Competence Profiles',
-                'object',
-                6510
-            );
-
-            $opsId[] = ilDBUpdateNewObjectType::addCustomRBACOperation(
-                'manage_comp',
-                'Manage Competences',
-                'object',
-                8500
-            );
-
-            $opsId[] = ilDBUpdateNewObjectType::addCustomRBACOperation(
-                'manage_comp_temp',
-                'Manage Competence Templates',
-                'object',
-                8510
-            );
-
-            $opsId[] = ilDBUpdateNewObjectType::addCustomRBACOperation(
-                'manage_profiles',
-                'Manage Competence Profiles',
-                'object',
-                8520
-            );
-
-            // common rbac operations
-            $rbacOperations = array(
-                ilDBUpdateNewObjectType::RBAC_OP_EDIT_PERMISSIONS,
-                ilDBUpdateNewObjectType::RBAC_OP_VISIBLE,
-                ilDBUpdateNewObjectType::RBAC_OP_READ,
-                ilDBUpdateNewObjectType::RBAC_OP_WRITE,
-                ilDBUpdateNewObjectType::RBAC_OP_DELETE,
-                ilDBUpdateNewObjectType::RBAC_OP_COPY
-            );
-
-            ilDBUpdateNewObjectType::addRBACOperations($skill_tree_type_id, $rbacOperations);
-
-            // add create operation for relevant container types
-
-            $parentTypes = array('skmg');
-            ilDBUpdateNewObjectType::addRBACCreate('create_skee', 'Create Skill Tree', $parentTypes);
-
-            //ilDBUpdateNewObjectType::applyInitialPermissionGuideline('skee', false);
-        }
     }
 
     public function step_5(): void
     {
-        include_once 'Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php';
-        $skill_tree_type_id = ilDBUpdateNewObjectType::getObjectTypeId('skee');
-        $ops_id = ilDBUpdateNewObjectType::getCustomRBACOperationId('read_comp');
-        ilDBUpdateNewObjectType::addRBACOperation($skill_tree_type_id, $ops_id);
-        $skill_tree_type_id = ilDBUpdateNewObjectType::getObjectTypeId('skee');
-        $ops_id = ilDBUpdateNewObjectType::getCustomRBACOperationId('read_profiles');
-        ilDBUpdateNewObjectType::addRBACOperation($skill_tree_type_id, $ops_id);
-        $ops_id = ilDBUpdateNewObjectType::getCustomRBACOperationId('manage_comp');
-        ilDBUpdateNewObjectType::addRBACOperation($skill_tree_type_id, $ops_id);
-        $ops_id = ilDBUpdateNewObjectType::getCustomRBACOperationId('manage_comp_temp');
-        ilDBUpdateNewObjectType::addRBACOperation($skill_tree_type_id, $ops_id);
-        $ops_id = ilDBUpdateNewObjectType::getCustomRBACOperationId('manage_profiles');
-        ilDBUpdateNewObjectType::addRBACOperation($skill_tree_type_id, $ops_id);
     }
 
     public function step_6(): void


### PR DESCRIPTION
This resolves deprecations withing the Skill update step, but isn't finished due to conceptional issues:
- Some deprecations should be resolved by objectives, wich (as far as i know) can not provide the same functional structure as update steps in total.
- e.g. Some of these refactored Objectives require the result/finished processing of another objective while they are collected inside the same group.
- The targeted objectives require a DB.

**Unfortunatly i dont have time to investigate this further. But im up for questions and further explanations.**