### PR TITLE
[FIX] PHP Deprecated:  Implicit conversion from float YX to int loses…

### DIFF
--- a/src/Data/DataSize.php
+++ b/src/Data/DataSize.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 namespace ILIAS\Data;
@@ -125,7 +141,7 @@ final class DataSize
             throw new \InvalidArgumentException('The given data size unit is not valid, please check the provided class constants of the DataSize class.');
         }
 
-        $this->size = (float) $size / $unit; //the div operation can return int and float
+        $this->size = floatval($size) / floatval($unit); //the div operation can return int and float
         $this->unit = $unit;
         $this->suffix = self::$suffixMap[$unit];
     }


### PR DESCRIPTION
… precision

This is a followup to #5028. PHP8.1 needs an explicit conversion as proposed here. Without, a `PHP Deprecated:  Implicit conversion from float YX to int loses precision` is thrown.