### PR TITLE
[FIX] 0034645: Verfügbarkeit ILIAS Lernmodul funktioniert nicht.

### DIFF
--- a/Modules/LearningModule/classes/class.ilObjContentObjectGUI.php
+++ b/Modules/LearningModule/classes/class.ilObjContentObjectGUI.php
@@ -102,7 +102,15 @@ class ilObjContentObjectGUI extends ilObjectGUI implements ilLinkCheckerGUIRowHa
     {
         if (!$this->getCreationMode()) {
             $baseclass = strtolower($_GET["baseClass"]);
+            $next_class = strtolower($this->ctrl->getNextClass());
+            // all calls must be routed through illmpresentationgui or
+            // illmeditorgui...
             if (!in_array($baseclass, ["illmpresentationgui", "illmeditorgui"])) {
+                // ...except the comman action handler routes to
+                // activation/condition GUI, see https://mantis.ilias.de/view.php?id=32858
+                if (in_array($next_class, ["ilcommonactiondispatchergui"])) {
+                    return;
+                }
                 throw new ilLMException("Wrong ctrl path");
             }
         }


### PR DESCRIPTION
This fixes https://mantis.ilias.de/view.php?id=34645
Same fix as already in release_7 made due to https://mantis.ilias.de/view.php?id=32858