### PR TITLE
IRSS Migration of Posting Files

### DIFF
--- a/Modules/Forum/classes/Files/class.ilFileDataForum.php
+++ b/Modules/Forum/classes/Files/class.ilFileDataForum.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\ResourceStorage\Identification\ResourceCollectionIdentification;
+
+/**
+ * This class handles all operations on files for the forum object.
+ * @author    Stefan Meyer <meyer@leifos.com>
+ * @ingroup   ModulesForum
+ */
+class ilFileDataForum implements ilFileDataForumInterface
+{
+    private array $posting_cache = [];
+    private ilFileDataForumInterface $legacy_implementation;
+    private ilFileDataForumInterface $rc_implementation;
+
+    public function __construct(
+        private int $obj_id = 0,
+        private int $pos_id = 0
+    ) {
+        $this->legacy_implementation = new ilFileDataForumLegacyImplementation(
+            $this->obj_id,
+            $this->pos_id
+        );
+        $this->rc_implementation = new ilFileDataForumRCImplementation(
+            $this->obj_id,
+            $this->pos_id
+        );
+    }
+
+    private function getCurrentPosting(): ilForumPost
+    {
+        if (isset($this->posting_cache[$this->pos_id])) {
+            return $this->posting_cache[$this->pos_id];
+        }
+        return $this->posting_cache[$this->pos_id] = new ilForumPost($this->pos_id);
+    }
+
+    private function getImplementation(): ilFileDataForumInterface
+    {
+        $posting = $this->getCurrentPosting();
+        if ($posting->getRCID() !== ilForumPost::NO_RCID) {
+            return $this->rc_implementation;
+        }
+
+        return $this->legacy_implementation;
+    }
+
+    public function getObjId(): int
+    {
+        return $this->getImplementation()->getObjId();
+    }
+
+    public function getPosId(): int
+    {
+        return $this->getImplementation()->getPosId();
+    }
+
+    public function setPosId(int $posting_id): void
+    {
+        $this->getImplementation()->setPosId($posting_id);
+    }
+
+    public function getForumPath(): string
+    {
+        return $this->getImplementation()->getForumPath();
+    }
+
+    /**
+     * @return array<string, array{path: string, md5: string, name: string, size: int, ctime: string}>
+     */
+    public function getFilesOfPost(): array
+    {
+        return $this->getImplementation()->getFilesOfPost();
+    }
+
+    public function moveFilesOfPost(int $new_frm_id = 0): bool
+    {
+        return $this->getImplementation()->moveFilesOfPost($new_frm_id);
+    }
+
+    public function ilClone(int $new_obj_id, int $new_posting_id): bool
+    {
+        return $this->getImplementation()->ilClone($new_obj_id, $new_posting_id);
+    }
+
+    public function delete(array $posting_ids_to_delete = null): bool
+    {
+        return $this->getImplementation()->delete($posting_ids_to_delete);
+    }
+
+    public function storeUploadedFiles(): bool
+    {
+        return $this->getImplementation()->storeUploadedFiles();
+    }
+
+    public function unlinkFile(string $filename): bool
+    {
+        return $this->getImplementation()->unlinkFile($filename);
+    }
+
+    /**
+     * @return array{path: string, filename: string, clean_filename: string}|null
+     */
+    public function getFileDataByMD5Filename(string $hashed_filename): ?array
+    {
+        return $this->getImplementation()->getFileDataByMD5Filename($hashed_filename);
+    }
+
+    /**
+     * @param string|string[] $hashed_filename_or_filenames
+     */
+    public function unlinkFilesByMD5Filenames($hashed_filename_or_filenames): bool
+    {
+        return $this->getImplementation()->unlinkFilesByMD5Filenames($hashed_filename_or_filenames);
+    }
+
+
+    public function deliverFile(string $file): void
+    {
+        $this->getImplementation()->deliverFile($file);
+    }
+
+    public function deliverZipFile(): bool
+    {
+        return $this->getImplementation()->deliverZipFile();
+    }
+
+    public function importPath(string $path_to_file, int $posting_id): void
+    {
+        // Importing is only possible for IRSS based files
+        $this->setPosId($posting_id);
+        $this->rc_implementation->importFileToCollection($path_to_file, $this->getCurrentPosting());
+    }
+}

--- a/Modules/Forum/classes/Files/class.ilFileDataForumRCImplementation.php
+++ b/Modules/Forum/classes/Files/class.ilFileDataForumRCImplementation.php
@@ -1,0 +1,274 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\ResourceStorage\Collection\ResourceCollection;
+use ILIAS\ResourceStorage\Identification\ResourceCollectionIdentification;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+use ILIAS\UI\NotImplementedException;
+
+/**
+ * Class ilFileDataForumRCImplementation
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class ilFileDataForumRCImplementation implements ilFileDataForumInterface
+{
+    public const FORUM_PATH_RCID = 'RCID';
+    private \ILIAS\ResourceStorage\Services $irss;
+    private \ILIAS\FileUpload\FileUpload $upload;
+    private array $collection_cache = [];
+    private array $posting_cache = [];
+    private ilForumPostingFileStakeholder $stakeholder;
+
+
+    public function __construct(private int $obj_id = 0, private int $pos_id = 0)
+    {
+        global $DIC;
+        $this->irss = $DIC->resourceStorage();
+        $this->upload = $DIC->upload();
+        $this->stakeholder = new ilForumPostingFileStakeholder();
+    }
+
+    private function getCurrentPosting(): ilForumPost
+    {
+        return $this->getPostingById($this->pos_id);
+    }
+
+    private function getPostingById(int $posting_id): ilForumPost
+    {
+        if (isset($this->posting_cache[$posting_id])) {
+            return $this->posting_cache[$posting_id];
+        }
+        return $this->posting_cache[$posting_id] = new ilForumPost($posting_id);
+    }
+
+    private function getCurrentCollection(): \ILIAS\ResourceStorage\Collection\ResourceCollection
+    {
+        if (isset($this->collection_cache[$this->pos_id])) {
+            return $this->collection_cache[$this->pos_id];
+        }
+        return $this->collection_cache[$this->pos_id] = $this->irss->collection()->get(
+            $this->irss->collection()->id(
+                $this->getCurrentPosting()->getRCID()
+            )
+        );
+    }
+
+    private function getResourceIdByHash(string $hash): ?ResourceIdentification
+    {
+        foreach ($this->getCurrentCollection()->getResourceIdentifications() as $identification) {
+            $revision = $this->irss->manage()->getCurrentRevision($identification);
+            if ($revision->getTitle() === $hash) {
+                return $identification;
+            }
+        }
+        return null;
+    }
+
+    private function getResourceIdByName(string $filename): ?ResourceIdentification
+    {
+        return $this->getFileDataByMD5Filename(md5($filename));
+    }
+
+    public function getObjId(): int
+    {
+        return $this->obj_id;
+    }
+
+    public function getPosId(): int
+    {
+        return $this->pos_id;
+    }
+
+    public function setPosId(int $posting_id): void
+    {
+        $this->pos_id = $posting_id;
+    }
+
+    public function getForumPath(): string
+    {
+        return self::FORUM_PATH_RCID;
+    }
+
+    /**
+     * @return array<string, array{path: string, md5: string, name: string, size: int, ctime: string}>
+     */
+    public function getFilesOfPost(): array
+    {
+        $files = [];
+        foreach ($this->getCurrentCollection()->getResourceIdentifications() as $identification) {
+            $revision = $this->irss->manage()->getCurrentRevision($identification);
+            $info = $revision->getInformation();
+            $files[] = [
+                'path' => $this->irss->consume()->stream($identification)->getStream()->getMetadata('uri'),
+                'md5' => $revision->getTitle(),
+                'name' => $info->getTitle(),
+                'size' => $info->getSize(),
+                'ctime' => $info->getCreationDate()->format('Y-m-d H:i:s')
+            ];
+        }
+
+        return $files;
+    }
+
+    public function moveFilesOfPost(int $new_frm_id = 0): bool
+    {
+        // nothing to do here since collections are related to the post
+        return true;
+    }
+
+    public function ilClone(int $new_obj_id, int $new_posting_id): bool
+    {
+        $current_collection_id = $this->getCurrentCollection()->getIdentification();
+        $new_collection_id = $this->irss->collection()->clone($current_collection_id);
+        $new_posting = $this->getPostingById($new_posting_id);
+        $new_posting->setRCID($new_collection_id->serialize());
+        $new_posting->update();
+        return true;
+    }
+
+    public function delete(array $posting_ids_to_delete = null): bool
+    {
+        foreach ($posting_ids_to_delete as $post_id) {
+            $this->irss->collection()->remove(
+                $this->irss->collection()->id(
+                    $this->getPostingById($post_id)->getRCID()
+                ),
+                $this->stakeholder,
+                true
+            );
+        }
+        return true;
+    }
+
+    public function storeUploadedFiles(): bool
+    {
+        if (!$this->upload->hasBeenProcessed()) {
+            $this->upload->process();
+        }
+        $collection = $this->getCurrentCollection();
+
+        foreach ($this->upload->getResults() as $result) {
+            if (!$result->isOK()) {
+                continue;
+            }
+            $rid = $this->irss->manage()->upload(
+                $result,
+                $this->stakeholder,
+                md5($result->getName())
+            );
+            $collection->add($rid);
+        }
+        $this->irss->collection()->store($collection);
+        $posting = $this->getCurrentPosting();
+        $posting->setRCID($collection->getIdentification()->serialize());
+        $posting->update();
+
+        return true;
+    }
+
+    public function unlinkFile(string $filename): bool
+    {
+        $rid = $this->getResourceIdByName($filename);
+        if ($rid !== null) {
+            $this->irss->manage()->remove($rid, $this->stakeholder);
+        }
+        return true;
+    }
+
+    /**
+     * @return array{path: string, filename: string, clean_filename: string}|null
+     */
+    public function getFileDataByMD5Filename(string $hashed_filename): ?array
+    {
+        foreach ($this->getCurrentCollection()->getResourceIdentifications() as $identification) {
+            $revision = $this->irss->manage()->getCurrentRevision($identification);
+            if ($revision->getTitle() === $hashed_filename) {
+                $info = $revision->getInformation();
+                return [
+                    'path' => '',
+                    'filename' => $info->getTitle(),
+                    'clean_filename' => $info->getTitle()
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string|string[] $hashed_filename_or_filenames
+     */
+    public function unlinkFilesByMD5Filenames($hashed_filename_or_filenames): bool
+    {
+        $hashes = is_array($hashed_filename_or_filenames)
+            ? $hashed_filename_or_filenames
+            : [$hashed_filename_or_filenames];
+
+        foreach ($hashes as $hash) {
+            $identification = $this->getResourceIdByHash($hash);
+            if ($identification !== null) {
+                $this->irss->manage()->remove($identification, $this->stakeholder);
+            }
+        }
+        return true;
+    }
+
+
+    public function deliverFile(string $file): void
+    {
+        $rid = $this->getResourceIdByHash($file);
+        if ($rid !== null) {
+            $this->irss->consume()->download($rid)->run();
+        }
+    }
+
+    public function deliverZipFile(): bool
+    {
+        $zip_filename = $this->getCurrentPosting()->getSubject() . '.zip';
+        $rcid = $this->getCurrentCollection()->getIdentification();
+
+        $this->irss->consume()->downloadCollection($rcid, $zip_filename)
+            ->useRevisionTitlesForFileNames(false)
+            ->run();
+        return true;
+    }
+
+    public function importFileToCollection(string $path_to_file, ilForumPost $post): void
+    {
+        if ($post->getRCID() === ilForumPost::NO_RCID || empty($post->getRCID())) {
+            $rcid = $this->irss->collection()->id();
+            $post->setRCID($rcid->serialize());
+            $post->update();
+        } else {
+            $rcid = $this->irss->collection()->id($post->getRCID());
+        }
+
+        $collection = $this->irss->collection()->get($rcid);
+        $rid = $this->irss->manage()->stream(
+            Streams::ofResource(fopen($path_to_file, 'rb')),
+            $this->stakeholder,
+            md5(basename($path_to_file))
+        );
+        $collection->add($rid);
+        $this->irss->collection()->store($collection);
+    }
+}

--- a/Modules/Forum/classes/Setup/Migrations/class.ilForumPostingFilesMigration.php
+++ b/Modules/Forum/classes/Setup/Migrations/class.ilForumPostingFilesMigration.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
+ * Class ilForumPostingFilesMigration
+ *
+ * @author Fabian Schmid <fs@studer-raimann.ch>
+ */
+use ILIAS\ResourceStorage\Collection\ResourceCollection;
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Migration;
+use ILIAS\Setup\Objective;
+
+class ilForumPostingFilesMigration implements Migration
+{
+    protected \ilResourceStorageMigrationHelper $helper;
+
+    public function getLabel(): string
+    {
+        return "Migration of Files in Forum Posts to the Resource Storage Service.";
+    }
+
+    public function getDefaultAmountOfStepsPerRun(): int
+    {
+        return 10000;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return \ilResourceStorageMigrationHelper::getPreconditions();
+    }
+
+    public function prepare(Environment $environment): void
+    {
+        $this->helper = new \ilResourceStorageMigrationHelper(
+            new \ilForumPostingFileStakeholder(),
+            $environment
+        );
+    }
+
+    public function step(Environment $environment): void
+    {
+        $db = $this->helper->getDatabase();
+
+        $r = $this->helper->getDatabase()->query(
+            "SELECT
+    frm_posts.pos_pk AS posting_id,
+    frm_posts.pos_author_id AS owner_id,
+    frm_data.top_frm_fk AS object_id
+FROM frm_posts
+JOIN frm_data ON frm_posts.pos_top_fk = frm_data.top_pk
+WHERE frm_posts.rcid IS NULL OR frm_posts.rcid = ''
+LIMIT 1;"
+        );
+
+        $d = $this->helper->getDatabase()->fetchObject($r);
+        $posting_id = (int)$d->posting_id;
+        $object_id = (int)$d->object_id;
+        $resource_owner_id = (int)$d->owner_id;
+
+        $base_path = $this->buildBasePath();
+        $filename_pattern = '/^' . $object_id . '\_' . $posting_id . '\_(.*)/m';
+        $pattern = '/.*\/' . $object_id . '\_' . $posting_id . '\_(.*)/m';
+
+        $collection_id = $this->helper->moveFilesOfPatternToCollection(
+            $base_path,
+            $pattern,
+            $resource_owner_id,
+            ResourceCollection::NO_SPECIFIC_OWNER,
+            $this->getFileNameCallback($filename_pattern),
+            $this->getRevisionNameCallback()
+        );
+
+        $save_colletion_id = $collection_id === null ? '-' : $collection_id->serialize();
+        $this->helper->getDatabase()->update(
+            'frm_posts',
+            ['rcid' => ['text', $save_colletion_id]],
+            ['pos_pk' => ['integer', $posting_id],]
+        );
+    }
+
+    public function getRemainingAmountOfSteps(): int
+    {
+        $r = $this->helper->getDatabase()->query(
+            "SELECT
+    count(frm_posts.pos_pk) AS amount
+FROM frm_posts
+JOIN frm_data ON frm_posts.pos_top_fk = frm_data.top_pk
+WHERE frm_posts.rcid IS NULL OR frm_posts.rcid = '';"
+        );
+        $d = $this->helper->getDatabase()->fetchObject($r);
+
+        return (int)$d->amount;
+    }
+
+    protected function buildBasePath(): string
+    {
+        return CLIENT_DATA_DIR . '/forum/';
+    }
+
+    public function getFileNameCallback(string $pattern): Closure
+    {
+        return function (string $file_name) use ($pattern): string {
+            if (preg_match($pattern, $file_name, $matches)) {
+                return $matches[1] ?? $file_name;
+            }
+            return $file_name;
+        };
+    }
+
+    public function getRevisionNameCallback(): Closure
+    {
+        return function (string $file_name): string {
+            return md5($file_name);
+        };
+    }
+}

--- a/Modules/Forum/classes/Setup/class.ilForumDatabaseUpdateSteps.php
+++ b/Modules/Forum/classes/Setup/class.ilForumDatabaseUpdateSteps.php
@@ -47,4 +47,20 @@ class ilForumDatabaseUpdateSteps implements ilDatabaseUpdateSteps
     {
         $this->db->manipulateF("UPDATE object_data SET offline = %s WHERE type = %s", ['integer', 'text'], [0, 'frm']);
     }
+
+    public function step_3(): void
+    {
+        if (!$this->db->tableColumnExists('frm_posts', 'rcid')) {
+            $this->db->addTableColumn(
+                'frm_posts',
+                'rcid',
+                [
+                    'type' => 'text',
+                    'notnull' => false,
+                    'length' => 64,
+                    'default' => ''
+                ]
+            );
+        }
+    }
 }

--- a/Modules/Forum/classes/Setup/class.ilForumSetupAgent.php
+++ b/Modules/Forum/classes/Setup/class.ilForumSetupAgent.php
@@ -62,6 +62,8 @@ class ilForumSetupAgent implements Setup\Agent
 
     public function getMigrations(): array
     {
-        return [];
+        return [
+             new ilForumPostingFilesMigration()
+        ];
     }
 }

--- a/Modules/Forum/classes/class.ilForumPost.php
+++ b/Modules/Forum/classes/class.ilForumPost.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
  */
 class ilForumPost
 {
+    public const NO_RCID = '-';
     private int $forum_id = 0;
     private int $thread_id = 0;
     private int $display_user_id = 0;
@@ -51,6 +52,7 @@ class ilForumPost
     private bool $post_read = false;
     private int $pos_author_id = 0;
     private ?string $post_activation_date = null;
+    private string $rcid = self::NO_RCID;
 
     public function __construct(private int $id = 0, bool $a_is_moderator = false, bool $preventImplicitRead = false)
     {
@@ -106,7 +108,8 @@ class ilForumPost
                     'pos_cens_date' => ['timestamp', $this->censored_date],
                     'pos_cens_com' => ['text', $this->censorship_comment],
                     'notify' => ['integer', (int) $this->notification],
-                    'pos_status' => ['integer', (int) $this->status]
+                    'pos_status' => ['integer', (int) $this->status],
+                    'rcid' => ['text', ($this->rcid ?? self::NO_RCID)]
                 ],
                 [
                     'pos_pk' => ['integer', $this->id]
@@ -163,7 +166,7 @@ class ilForumPost
                 $this->pos_author_id = (int) $row->pos_author_id;
                 $this->is_author_moderator = (bool) $row->is_author_moderator;
                 $this->post_activation_date = $row->pos_activation_date;
-
+                $this->rcid = (string) $row->rcid;
                 $this->objThread = new ilForumTopic($this->thread_id, $this->is_moderator);
             }
         }
@@ -349,6 +352,16 @@ class ilForumPost
     public function getThreadId(): int
     {
         return $this->thread_id;
+    }
+
+    public function getRCID(): string
+    {
+        return $this->rcid;
+    }
+
+    public function setRCID(string $rcid): void
+    {
+        $this->rcid = $rcid;
     }
 
     public function setDisplayUserId(int $a_user_id): void
@@ -606,6 +619,7 @@ class ilForumPost
         $this->setDisplayUserId((int) $row['pos_display_user_id']);
         $this->setPosAuthorId((int) $row['pos_author_id']);
         $this->setIsAuthorModerator((bool) $row['is_author_moderator']);
+        $this->setRCID((string)($row['rcid'] ?? self::NO_RCID));
     }
 
     /**

--- a/Modules/Forum/classes/class.ilForumPostingFileStakeholder.php
+++ b/Modules/Forum/classes/class.ilForumPostingFileStakeholder.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class ilForumPostingFileStakeholder extends AbstractResourceStakeholder
+{
+    private int $default_owner;
+
+    public function __construct()
+    {
+        global $DIC;
+        $this->default_owner = $DIC->isDependencyAvailable('user') ? $DIC->user()->getId() : 6;
+    }
+
+
+    public function getId(): string
+    {
+        return 'frm_post';
+    }
+
+    public function getOwnerOfNewResources(): int
+    {
+        return $this->default_owner;
+    }
+}

--- a/Modules/Forum/classes/class.ilForumTopic.php
+++ b/Modules/Forum/classes/class.ilForumTopic.php
@@ -428,7 +428,7 @@ class ilForumTopic
         $query = '
 			SELECT 			is_author_moderator, pos_author_id, pos_pk, fpt_date, rgt, pos_top_fk, pos_thr_fk, 
 							pos_display_user_id, pos_usr_alias, pos_subject,
-							pos_status, pos_message, pos_date, pos_update,
+							pos_status, pos_message, pos_date, pos_update, rcid,
 							update_user, pos_cens, pos_cens_com, notify,
 							import_name, fpt_pk, parent_pos, lft, depth,
 							(CASE

--- a/Modules/Forum/classes/class.ilForumXMLParser.php
+++ b/Modules/Forum/classes/class.ilForumXMLParser.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 class ilForumXMLParser extends ilSaxParser
 {
@@ -579,19 +579,10 @@ class ilForumXMLParser extends ilSaxParser
             case 'Attachment':
                 $filedata = new ilFileDataForum($this->forum->getId(), $this->lastHandledPostId);
 
-                $importPath = $this->contentArray['content'];
-
-                if ($importPath !== '') {
-                    $importPath = $this->getImportDirectory() . '/' . $importPath;
-
-                    $newFilename = preg_replace(
-                        "/^\d+_\d+(_.*)/ms",
-                        $this->forum->getId() . "_" . $this->lastHandledPostId . "$1",
-                        basename($importPath)
-                    );
-                    $path = $filedata->getForumPath();
-                    $newPath = $path . '/' . $newFilename;
-                    @copy($importPath, $newPath);
+                $import_path = $this->contentArray['content'];
+                if ($import_path !== '') {
+                    $import_path = $this->getImportDirectory() . '/' . $import_path;
+                    $filedata->importPath($import_path, (int)$this->lastHandledPostId);
                 }
                 break;
         }

--- a/Modules/Forum/classes/class.ilForumXMLWriter.php
+++ b/Modules/Forum/classes/class.ilForumXMLWriter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * XML writer class
@@ -183,9 +183,8 @@ class ilForumXMLWriter extends ilXmlWriter
 
                 foreach ($tmp_file_obj->getFilesOfPost() as $file) {
                     $this->xmlStartTag("Attachment");
-
-                    copy($file['path'], $this->target_dir_absolute . "/" . basename($file['path']));
-                    $content = $this->target_dir_relative . "/" . basename($file['path']);
+                    copy($file['path'], $this->target_dir_absolute . "/" . basename($file['name']));
+                    $content = $this->target_dir_relative . "/" . basename($file['name']);
                     $this->xmlElement("Content", null, $content);
 
                     $this->xmlEndTag("Attachment");

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -2445,7 +2445,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
                 $file = $_FILES['userfile'] ?? [];
                 if (is_array($file) && !empty($file)) {
                     $tmp_file_obj = new ilFileDataForum($this->object->getId(), $newPost);
-                    $tmp_file_obj->storeUploadedFile($file);
+                    $tmp_file_obj->storeUploadedFiles();
                 }
 
                 //move files of draft to posts directory
@@ -2628,7 +2628,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
                     $oFDForum = new ilFileDataForum($forumObj->getId(), $newPost);
                     $file = $_FILES['userfile'];
                     if (is_array($file) && !empty($file)) {
-                        $oFDForum->storeUploadedFile($file);
+                        $oFDForum->storeUploadedFiles();
                     }
                 }
 
@@ -2744,7 +2744,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
                     if ($this->objProperties->isFileUploadAllowed()) {
                         $file = $_FILES['userfile'];
                         if (is_array($file) && !empty($file)) {
-                            $oFDForum->storeUploadedFile($file);
+                            $oFDForum->storeUploadedFiles();
                         }
                     }
 
@@ -3979,7 +3979,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
                 $file = $_FILES['userfile'];
                 if (is_array($file) && !empty($file)) {
                     $fileData = new ilFileDataForum($this->object->getId(), $newPost);
-                    $fileData->storeUploadedFile($file);
+                    $fileData->storeUploadedFiles();
                 }
             }
 

--- a/Modules/Forum/interfaces/class.ilFileDataForumInterface.php
+++ b/Modules/Forum/interfaces/class.ilFileDataForumInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
+ * This class handles all operations on files for the forum object.
+ * @author    Stefan Meyer <meyer@leifos.com>
+ * @ingroup   ModulesForum
+ */
+interface ilFileDataForumInterface
+{
+    public function getObjId(): int;
+
+    public function getPosId(): int;
+
+    public function setPosId(int $posting_id): void;
+
+    public function getForumPath(): string;
+    /**
+     * @return array<string, array{path: string, md5: string, name: string, size: int, ctime: string}>
+     */
+    public function getFilesOfPost(): array;
+
+    public function moveFilesOfPost(int $new_frm_id = 0): bool;
+
+    public function ilClone(int $new_obj_id, int $new_posting_id): bool;
+
+    public function delete(array $posting_ids_to_delete = null): bool;
+
+    public function storeUploadedFiles(): bool;
+
+    public function unlinkFile(string $filename): bool;
+
+    /**
+     * @return array{path: string, filename: string, clean_filename: string}|null
+     */
+    public function getFileDataByMD5Filename(string $hashed_filename): ?array;
+
+    /**
+     * @param string|string[] $hashed_filename_or_filenames
+     */
+    public function unlinkFilesByMD5Filenames($hashed_filename_or_filenames): bool;
+
+    public function deliverFile(string $file): void;
+
+    public function deliverZipFile(): bool;
+}

--- a/Services/Init/classes/Dependencies/InitResourceStorage.php
+++ b/Services/Init/classes/Dependencies/InitResourceStorage.php
@@ -66,6 +66,7 @@ class InitResourceStorage
                 $c[self::D_STORAGE_HANDLERS],
                 $c[self::D_REPOSITORIES],
                 $c[self::D_LOCK_HANDLER],
+                $c[self::D_STREAM_ACCESS],
                 $c[self::D_FILENAME_POLICY],
             );
         };

--- a/Services/ResourceStorage/classes/Setup/class.ilResourceStorageMigrationHelper.php
+++ b/Services/ResourceStorage/classes/Setup/class.ilResourceStorageMigrationHelper.php
@@ -67,6 +67,9 @@ class ilResourceStorageMigrationHelper
         if (!defined("CLIENT_ID")) {
             define("CLIENT_ID", $client_id);
         }
+        if (!defined("ILIAS_DATA_DIR")) {
+            define("ILIAS_DATA_DIR", $data_dir);
+        }
         $this->client_data_dir = $client_data_dir;
         $this->database = $db;
 
@@ -164,11 +167,7 @@ class ilResourceStorageMigrationHelper
     ): ?ResourceCollectionIdentification {
         $collection = $this->getCollectionBuilder()->new($collection_owner_user_id);
 
-        $regex_iterator = new RecursiveRegexIterator(
-            new RecursiveDirectoryIterator($absolute_base_path),
-            $pattern,
-            RecursiveRegexIterator::MATCH
-        );
+        $regex_iterator = $this->buildRecursivePatternIterator($absolute_base_path, $pattern);
 
         foreach ($regex_iterator as $file_info) {
             if (!$file_info->isFile()) {
@@ -191,6 +190,33 @@ class ilResourceStorageMigrationHelper
         if ($this->getCollectionBuilder()->store($collection)) {
             return $collection->getIdentification();
         }
+        return null;
+    }
+
+    public function moveFirstFileOfPatternToStorage(
+        string $absolute_base_path,
+        string $pattern,
+        int $resource_owner_id,
+        ?Closure $file_name_callback = null,
+        ?Closure $revision_name_callback = null
+    ): ?ResourceIdentification {
+        $regex_iterator = $this->buildRecursivePatternIterator($absolute_base_path, $pattern);
+
+        foreach ($regex_iterator as $file_info) {
+            if (!$file_info->isFile()) {
+                continue;
+            }
+            $resource_id = $this->movePathToStorage(
+                $file_info->getRealPath(),
+                $resource_owner_id,
+                $file_name_callback,
+                $revision_name_callback
+            );
+            if ($resource_id !== null) {
+                return $resource_id; // stop after first file
+            }
+        }
+
         return null;
     }
 
@@ -232,5 +258,16 @@ class ilResourceStorageMigrationHelper
         $this->resource_builder->store($resource);
 
         return $resource->getIdentification();
+    }
+
+    protected function buildRecursivePatternIterator(
+        string $absolute_base_path,
+        string $pattern = '.*'
+    ): RecursiveRegexIterator {
+        return new RecursiveRegexIterator(
+            new RecursiveDirectoryIterator($absolute_base_path),
+            $pattern,
+            RecursiveRegexIterator::MATCH
+        );
     }
 }


### PR DESCRIPTION
Hello @mjansenDatabay 

In this PR we propose drop-in replacement migration of files that can be uploaded in a forum post. To make the changes in the forum as non-invasive as possible (and still support migrated and also non-migrated files) we have two implementations of `ilFileDataForum` for this.  Of course this can be completely rebuilt e.g. with ILIAS 10 if you want to. Then the migration has to be done and you don't have to support non-migrated files anymore.

Thanks for your commitment to look at this PR in such a straightforward way with no additional funding. We can always discuss this PR in a meeting as well and I can explain every detail to you, if needed.

The following is included in this PR:

The Migration:
- Extension of the existing `ilForumSetupAgent` to provide the new migration: https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:feature/9/irss-forum-files?expand=1#diff-9219530cd42a76dc616e94e3c14f622b9efe90578c7c824f46485123aabc38f9
- A `Stakeholder` for this kind of files: https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:feature/9/irss-forum-files?expand=1#diff-2d8c7f9e0e7cbb0ab50da8eb7423b148e121ea7f1b6e79e2200ee8e036eeacf7
- A `DatabaseUpdateStep` to create a new rcid (Resource Collection ID) column for Porums posts: https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:feature/9/irss-forum-files?expand=1#diff-aa21b895a57fe6d892d5cf6bb6140be03a7742b979488fa19c7cefa718107dab
- The actual `Migration`: https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:feature/9/irss-forum-files?expand=1#diff-a9aaac5aa5be3dcb596c6843dfcee096f1eb68f2aa332de5f68e1497a723be49

Migration moves all files of a post to the IRSS using a regex pattern: https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:feature/9/irss-forum-files?expand=1#diff-a9aaac5aa5be3dcb596c6843dfcee096f1eb68f2aa332de5f68e1497a723be49R79
Thereby the md5-hash of the filename is used as revision title, because the whole `ilFileDataForum` is designed for it: https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:feature/9/irss-forum-files?expand=1#diff-a9aaac5aa5be3dcb596c6843dfcee096f1eb68f2aa332de5f68e1497a723be49R128


Special cases:

- Moving files from posting drafts currently needs a somewhat special solution: https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:feature/9/irss-forum-files?expand=1#diff-6b8f50962e1366270847be0933555fb3c655e43b0638dcbcb874a6b43e408913R132
- Import/Export is also adjusted, but if necessary it could be solved easier. With this variant here, however, import/exports are done exactly as before and export files remain compatible.
- Posts that are not migrated yet have a '-' as rcid, see https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:feature/9/irss-forum-files?expand=1#diff-acc679d8a92156d1c1bfcdbbb7b3aeb96ff6d4a3eaf4550210b744595e22d5ceR55

If you have any questions, feel free to contact me. Thank you very much!