### PR TITLE
Test, partially fix import

### DIFF
--- a/Modules/LearningModule/classes/class.ilContObjParser.php
+++ b/Modules/LearningModule/classes/class.ilContObjParser.php
@@ -475,9 +475,9 @@ class ilContObjParser extends ilMDSaxParser
 
             case "Layout":
                 if (is_object($this->media_object) && $this->in_media_object) {
-                    $this->media_item->setWidth($a_attribs["Width"]);
-                    $this->media_item->setHeight($a_attribs["Height"]);
-                    $this->media_item->setHAlign($a_attribs["HorizontalAlign"]);
+                    $this->media_item->setWidth($a_attribs["Width"] ?? '');
+                    $this->media_item->setHeight($a_attribs["Height"] ?? '');
+                    $this->media_item->setHAlign($a_attribs["HorizontalAlign"] ?? '');
                 }
                 break;
 

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -6652,13 +6652,19 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                 $num = $questionSetConfig->getQuestionAmountPerTest();
             }
         } else {
-            if (count($this->questions) == 0) {
-                $this->loadQuestions();
-            }
+            $this->loadQuestions();
             $num = count($this->questions);
         }
 
         return $num;
+    }
+
+    public function getQuestionCountWithoutReloading(): int
+    {
+        if ($this->isRandomTest()) {
+            return $this->getQuestionCount();
+        }
+        return count($this->questions);
     }
 
     /**

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -6652,7 +6652,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
                 $num = $questionSetConfig->getQuestionAmountPerTest();
             }
         } else {
-            $this->loadQuestions();
+            if (count($this->questions) == 0) {
+                $this->loadQuestions();
+            }
             $num = count($this->questions);
         }
 

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1331,6 +1331,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
         // delete import directory
         ilFileUtils::delDir(ilObjTest::_getImportDirectory());
+        ilObjTest::_setImportDirectory();
 
         $this->tpl->setOnScreenMessage('success', $this->lng->txt("object_imported"), true);
         ilUtil::redirect("ilias.php?ref_id=" . $newObj->getRefId() . "&baseClass=ilObjTestGUI");

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1331,6 +1331,8 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
         // delete import directory
         ilFileUtils::delDir(ilObjTest::_getImportDirectory());
+        //Note, has been in ilTestImporter, however resetting this there, lead to problem in delDir.
+        // See: https://github.com/ILIAS-eLearning/ILIAS/pull/5097
         ilObjTest::_setImportDirectory();
 
         $this->tpl->setOnScreenMessage('success', $this->lng->txt("object_imported"), true);

--- a/Modules/Test/classes/class.ilTestFixedQuestionSetConfig.php
+++ b/Modules/Test/classes/class.ilTestFixedQuestionSetConfig.php
@@ -94,7 +94,7 @@ class ilTestFixedQuestionSetConfig extends ilTestQuestionSetConfig
 
         foreach ($this->testOBJ->questions as $key => $question_id) {
             $question = assQuestion::instantiateQuestion($question_id);
-            $cloneTestOBJ->questions[$key] = $question->duplicate(true, null, null, null, $cloneTestOBJ->getId());
+            $cloneTestOBJ->questions[$key] = $question->duplicate(true, '', '', '', $cloneTestOBJ->getId());
 
             $original_id = assQuestion::_getOriginalId($question_id);
 

--- a/Modules/Test/classes/class.ilTestFixedQuestionSetConfig.php
+++ b/Modules/Test/classes/class.ilTestFixedQuestionSetConfig.php
@@ -33,7 +33,7 @@ class ilTestFixedQuestionSetConfig extends ilTestQuestionSetConfig
      */
     public function isQuestionSetConfigured(): bool
     {
-        if ($this->testOBJ->getQuestionCount() > 0) {
+        if ($this->testOBJ->getQuestionCountWithoutReloading() > 0) {
             return true;
         }
         return false;

--- a/Modules/Test/classes/class.ilTestImporter.php
+++ b/Modules/Test/classes/class.ilTestImporter.php
@@ -79,6 +79,7 @@ class ilTestImporter extends ilXmlImporter
         $qtiParser = new ilQTIParser($qti_file, ilQTIParser::IL_MO_PARSE_QTI, $questionParentObjId, $idents);
         $qtiParser->setTestObject($newObj);
         $qtiParser->startParsing();
+        $newObj = $qtiParser->getTestObject();
 
         // import page data
         include_once("./Modules/LearningModule/classes/class.ilContObjParser.php");
@@ -131,8 +132,6 @@ class ilTestImporter extends ilXmlImporter
         $this->importSkillLevelThresholds($a_mapping, $importedAssignmentList, $newObj, $xml_file);
 
         $a_mapping->addMapping("Modules/Test", "tst", $a_id, $newObj->getId());
-
-        ilObjTest::_setImportDirectory();
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assErrorText.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorText.php
@@ -526,11 +526,11 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     * @param integer $question_counter A reference to a question counter to count the questions of an imported question pool
     * @param array $import_mapping An array containing references to included ILIAS objects
     */
-    public function fromXML($item, int $questionpool_id, ?int $tst_id, $tst_object, int $question_counter, array $import_mapping, array $solutionhints = []): void
+    public function fromXML($item, int $questionpool_id, ?int $tst_id, &$tst_object, int &$question_counter, array $import_mapping, array &$solutionhints = []): array
     {
         include_once "./Modules/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php";
         $import = new assErrorTextImport($this);
-        $import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
+        return $import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -1000,11 +1000,11 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     * @param integer $question_counter A reference to a question counter to count the questions of an imported question pool
     * @param array $import_mapping An array containing references to included ILIAS objects
     */
-    public function fromXML($item, int $questionpool_id, ?int $tst_id, $tst_object, int $question_counter, array $import_mapping, array $solutionhints = []): void
+    public function fromXML($item, int $questionpool_id, ?int $tst_id, &$tst_object, int &$question_counter, array $import_mapping, array &$solutionhints = []): array
     {
         include_once "./Modules/TestQuestionPool/classes/import/qti12/class.assFileUploadImport.php";
         $import = new assFileUploadImport($this);
-        $import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
+        return $import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assFlashQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFlashQuestion.php
@@ -589,11 +589,11 @@ class assFlashQuestion extends assQuestion implements ilObjQuestionScoringAdjust
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML($item, int $questionpool_id, ?int $tst_id, $tst_object, int $question_counter, array $import_mapping, array $solutionhints = []): void
+    public function fromXML($item, int $questionpool_id, ?int $tst_id, &$tst_object, int &$question_counter, array $import_mapping, array &$solutionhints = []): array
     {
         include_once "./Modules/TestQuestionPool/classes/import/qti12/class.assFlashQuestionImport.php";
         $import = new assFlashQuestionImport($this);
-        $import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
+        return $import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assOrderingHorizontal.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingHorizontal.php
@@ -491,11 +491,11 @@ class assOrderingHorizontal extends assQuestion implements ilObjQuestionScoringA
     * @param integer $question_counter A reference to a question counter to count the questions of an imported question pool
     * @param array $import_mapping An array containing references to included ILIAS objects
     */
-    public function fromXML($item, int $questionpool_id, ?int $tst_id, $tst_object, int $question_counter, array $import_mapping, array $solutionhints = []): void
+    public function fromXML($item, int $questionpool_id, ?int $tst_id, &$tst_object, int &$question_counter, array $import_mapping, array &$solutionhints = []): array
     {
         include_once "./Modules/TestQuestionPool/classes/import/qti12/class.assOrderingHorizontalImport.php";
         $import = new assOrderingHorizontalImport($this);
-        $import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
+        return $import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -402,20 +402,21 @@ abstract class assQuestion
     * @param integer $question_counter A reference to a question counter to count the questions of an imported question pool
     * @param array $import_mapping An array containing references to included ILIAS objects
     */
-    public function fromXML($item, int $questionpool_id, ?int $tst_id, $tst_object, int $question_counter, array $import_mapping, array $solutionhints = []): void
+    public function fromXML($item, int $questionpool_id, ?int $tst_id, &$tst_object, int &$question_counter, array $import_mapping, array &$solutionhints = []): array
     {
         $classname = $this->getQuestionType() . "Import";
         $import = new $classname($this);
-        $import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
+        $import_mapping = $import->fromXML($item, $questionpool_id, $tst_id, $tst_object, $question_counter, $import_mapping);
 
         foreach ($solutionhints as $hint) {
             $h = new ilAssQuestionHint();
             $h->setQuestionId($import->getQuestionId());
-            $h->setIndex($hint['index']);
-            $h->setPoints($hint['points']);
-            $h->setText($hint['txt']);
+            $h->setIndex($hint['index'] ?? "");
+            $h->setPoints($hint['points'] ?? "");
+            $h->setText($hint['txt'] ?? "");
             $h->save();
         }
+        return $import_mapping;
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assClozeTestImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assClozeTestImport.php
@@ -39,7 +39,7 @@ class assClozeTestImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -370,7 +370,7 @@ class assClozeTestImport extends assQuestionImport
         }
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
@@ -383,6 +383,7 @@ class assClozeTestImport extends assQuestionImport
             assClozeGapCombination::importGapCombinationToDb($this->object->getId(), $combination);
         }
         $this->object->saveToDb();
+        return $import_mapping;
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php
@@ -26,7 +26,7 @@ class assErrorTextImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -123,11 +123,12 @@ class assErrorTextImport extends assQuestionImport
         }
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assFileUploadImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assFileUploadImport.php
@@ -38,7 +38,7 @@ class assFileUploadImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -113,11 +113,12 @@ class assFileUploadImport extends assQuestionImport
         }
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assFlashQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assFlashQuestionImport.php
@@ -26,7 +26,7 @@ class assFlashQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -120,11 +120,12 @@ class assFlashQuestionImport extends assQuestionImport
         }
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
@@ -28,7 +28,7 @@ class assFormulaQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -135,11 +135,12 @@ class assFormulaQuestionImport extends assQuestionImport
         }
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true);
+            $question_id = $this->object->duplicate();
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assImagemapQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assImagemapQuestionImport.php
@@ -28,7 +28,7 @@ class assImagemapQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -274,11 +274,12 @@ class assImagemapQuestionImport extends assQuestionImport
         $this->object->saveToDb();
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assKprimChoiceImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assKprimChoiceImport.php
@@ -32,7 +32,7 @@ class assKprimChoiceImport extends assQuestionImport
      */
     public $object;
 
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -323,11 +323,12 @@ class assKprimChoiceImport extends assQuestionImport
         }
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assLongMenuImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assLongMenuImport.php
@@ -7,7 +7,7 @@ class assLongMenuImport extends assQuestionImport
 {
     public $object;
 
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -158,13 +158,13 @@ class assLongMenuImport extends assQuestionImport
         }
         $this->object->setAnswers($answers);
         // handle the import of media objects in XHTML code
-        if (count($feedbacks) > 0) {
+        if (isset($feedbacks) && count($feedbacks) > 0) {
             foreach ($feedbacks as $ident => $material) {
                 $m = $this->object->QTIMaterialToString($material);
                 $feedbacks[$ident] = $m;
             }
         }
-        if (is_array($feedbacksgeneric) && count($feedbacksgeneric) > 0) {
+        if (isset($feedbacksgeneric) && is_array($feedbacksgeneric) && count($feedbacksgeneric) > 0) {
             foreach ($feedbacksgeneric as $correctness => $material) {
                 $m = $this->object->QTIMaterialToString($material);
                 $feedbacksgeneric[$correctness] = $m;
@@ -189,7 +189,7 @@ class assLongMenuImport extends assQuestionImport
         );
         $this->object->saveToDb();
 
-        if (count($feedbacks) > 0) {
+        if (isset($feedbacks) && count($feedbacks) > 0) {
             foreach ($feedbacks as $ident => $material) {
                 $this->object->feedbackOBJ->importSpecificAnswerFeedback(
                     $this->object->getId(),
@@ -199,7 +199,7 @@ class assLongMenuImport extends assQuestionImport
                 );
             }
         }
-        if (is_array($feedbacksgeneric) && count($feedbacksgeneric) > 0) {
+        if (isset($feedbacksgeneric) && is_array($feedbacksgeneric) && count($feedbacksgeneric) > 0) {
             foreach ($feedbacksgeneric as $correctness => $material) {
                 $this->object->feedbackOBJ->importGenericFeedback(
                     $this->object->getId(),
@@ -218,12 +218,13 @@ class assLongMenuImport extends assQuestionImport
 
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 
     private function getIdFromGapIdent($ident)

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assMatchingQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assMatchingQuestionImport.php
@@ -45,7 +45,7 @@ class assMatchingQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -312,12 +312,13 @@ class assMatchingQuestionImport extends assQuestionImport
         $this->object->saveToDb();
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assMultipleChoiceImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assMultipleChoiceImport.php
@@ -42,7 +42,7 @@ class assMultipleChoiceImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -322,11 +322,12 @@ class assMultipleChoiceImport extends assQuestionImport
         }
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assNumericImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assNumericImport.php
@@ -28,7 +28,7 @@ class assNumericImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -181,11 +181,12 @@ class assNumericImport extends assQuestionImport
         $this->object->saveToDb();
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingHorizontalImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingHorizontalImport.php
@@ -28,7 +28,7 @@ class assOrderingHorizontalImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -119,11 +119,12 @@ class assOrderingHorizontalImport extends assQuestionImport
         }
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assOrderingQuestionImport.php
@@ -45,7 +45,7 @@ class assOrderingQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -336,7 +336,7 @@ class assOrderingQuestionImport extends assQuestionImport
         if ($tst_id > 0) {
             $this->object->setObjId($tst_id);
             $tstQid = $this->object->getId();
-            $qplQid = $this->object->duplicate(true, null, null, null, $questionpool_id);
+            $qplQid = $this->object->duplicate(true, "", "", "", $questionpool_id);
             assQuestion::resetOriginalId($qplQid);
             assQuestion::saveOriginalId($tstQid, $qplQid);
             $tst_object->questions[$question_counter++] = $tstQid;
@@ -344,5 +344,6 @@ class assOrderingQuestionImport extends assQuestionImport
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assQuestionImport.php
@@ -177,7 +177,7 @@ class assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
     }
 

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assSingleChoiceImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assSingleChoiceImport.php
@@ -42,7 +42,7 @@ class assSingleChoiceImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -326,11 +326,12 @@ class assSingleChoiceImport extends assQuestionImport
         }
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assTextQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assTextQuestionImport.php
@@ -33,7 +33,7 @@ class assTextQuestionImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -219,12 +219,13 @@ class assTextQuestionImport extends assQuestionImport
         $this->object->saveToDb();
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 
     protected function fetchTermScoring($item): array
@@ -235,14 +236,14 @@ class assTextQuestionImport extends assQuestionImport
             return array();
         }
 
-        $termScoring = @unserialize($termScoringString, ["allowed_classes" => false]);
+        $termScoring = @unserialize($termScoringString);
 
         if (is_array($termScoring)) {
             return $termScoring;
         }
 
         $termScoringString = base64_decode($termScoringString);
-        $termScoring = unserialize($termScoringString, ["allowed_classes" => false]);
+        $termScoring = unserialize($termScoringString);
 
         if (is_array($termScoring)) {
             return $termScoring;

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assTextSubsetImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assTextSubsetImport.php
@@ -28,7 +28,7 @@ class assTextSubsetImport extends assQuestionImport
     * @param array $import_mapping An array containing references to included ILIAS objects
     * @access public
     */
-    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, &$import_mapping): void
+    public function fromXML(&$item, $questionpool_id, &$tst_id, &$tst_object, &$question_counter, $import_mapping): array
     {
         global $DIC;
         $ilUser = $DIC['ilUser'];
@@ -199,11 +199,12 @@ class assTextSubsetImport extends assQuestionImport
         $this->object->saveToDb();
         if ($tst_id > 0) {
             $q_1_id = $this->object->getId();
-            $question_id = $this->object->duplicate(true, null, null, null, $tst_id);
+            $question_id = $this->object->duplicate(true, "", "", "", $tst_id);
             $tst_object->questions[$question_counter++] = $question_id;
             $import_mapping[$item->getIdent()] = array("pool" => $q_1_id, "test" => $question_id);
         } else {
             $import_mapping[$item->getIdent()] = array("pool" => $this->object->getId(), "test" => 0);
         }
+        return $import_mapping;
     }
 }

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -225,6 +225,11 @@ class ilQTIParser extends ilSaxParser
         $this->tst_id = $this->tst_object->getId();
     }
 
+    public function getTestObject(): ilObjTest
+    {
+        return $this->tst_object;
+    }
+
     /**
     * set event handler
     * should be overwritten by inherited class
@@ -761,7 +766,7 @@ class ilQTIParser extends ilSaxParser
                     $GLOBALS['ilDB'],
                     $GLOBALS['lng']
                 );
-                $question->fromXML(
+                $this->import_mapping = $question->fromXML(
                     $this->item,
                     $this->qpl_id,
                     $this->tst_id,


### PR DESCRIPTION
The test object is exhausting to test atm due to the broken copy and import/export functions. This PR partially fixes the import, so that we can at least import tests from a working 7 installation, maybe also 8. Note that this needs some further testing. Since the import is completely broken for the test atm, it might not hurt much to merge at this stage hower, there are some things we should discuss first.

Changes to be discussed:
- [ ] Partially fixed ilContObjParser to deal with unset attributes. Should they even be empty to begin with?
- [ ] Fixed getQuestionCount, so that the count is not reset if questions are in the object, but not the database (as the case if loaded from xml import). However, not sure if this is the place to do it. Maybe we want a clean count from the db here. We could also move this one layer up.
- [ ] `ilObjTest::_setImportDirectory();` is called to early in ilTestImporter, setting the import directory to null, which later leads to an error. Is it now to late for some cases?

Other changes:
-> fix duplicate function with null -> ''
-> fixed the passing as reference broken functionality by setting back to pass as reference (was dropped for some reason). However I don't like the passing as reference. I changed the maybe most important (import_mapping) to pass as value and return it when done.
-> fixed a broken unserialize class which tried to set the allowed_classes to "false" which then excepted no classes at all.
-> fixed passing by reference issue with the Test object by adding a getTestObject function.
-> minor type stuff.

Hope this helps.
