### PR TITLE
log4j multirelease warning fix for java >= 11

### DIFF
--- a/Services/WebServices/RPC/lib/build.xml
+++ b/Services/WebServices/RPC/lib/build.xml
@@ -66,6 +66,7 @@
     		<manifest>
     			<attribute name="Main-Class" value="de.ilias.ilServer"/>
     			<attribute name="MODULE-VERSION" value="5.4.1" />
+    			<attribute name="Multi-Release" value="true"/>
 			<section name="de/ilias/config/unifont.ttf">
 				<attribute name="Content-Type" value="application/x-font" />
 			</section>


### PR DESCRIPTION
The log4j fix introduced an anoying warning message when using java version 11 or above everytime the ilServer.jar is invoked:
`WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.`

While this is not actually a performance issue and not an issue for the ilServer process itself,
it it rather anoying for health- and performance-monitoring scripts.

For example checking current status with:
`/usr/bin/java -jar '/srv/www/ilias/Services/WebServices/RPC/lib/ilServer.jar' '/var/lib/lucene/ilServer.ini' status`

Or when you want to monitor ilServer response-time and answer content locally via cli:
`/usr/bin/java -jar /srv/www/ilias/Services/WebServices/RPC/lib/ilServer.jar /var/lib/lucene/ilServer.ini search CLIENTID_NID 'Test'`.

In both cases a warning message will be send to stdout not even stderr stream, so there is no easy way to filter it out...

By enabling `Multi-Release` in the ant-build, newer Java version do not complain about this anymore, see: 
* https://stackoverflow.com/questions/53049346/is-log4j2-compatible-with-java-11
* https://www.baeldung.com/java-multi-release-jar

---

Related Mantis-Ticket: https://mantis.ilias.de/view.php?id=34806