### PR TITLE
fix 31362 part 2

### DIFF
--- a/Modules/TestQuestionPool/templates/default/tpl.il_tst_question_hints_kiosk_page.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.il_tst_question_hints_kiosk_page.html
@@ -1,4 +1,4 @@
 {KIOSK_HEAD}
-<div id="tst_output">
+<div>
 	{KIOSK_CONTENT}
 </div>


### PR DESCRIPTION
This will fix : https://mantis.ilias.de/view.php?id=31362#c86573 
By removing "id=tst_output" the view will be the same as if "Exam View/ Prüfungsansicht" was not activated. 
It removes "display:flex" in the CSS.