### PR TITLE
Test: Fix Formula Question Presentation

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
@@ -299,67 +299,26 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
                 ) {
                     $is_frac = true;
                 }
-                if (is_array($userdata) && isset($userdata[$result])) {
-                    if (is_array($userdata[$result])) {
-                        if (false && $forsolution && $result_output) { // fix for mantis #25956
-                            $value_org = $resObj->calculateFormula($this->getVariables(), $this->getResults(), parent::getId());
-                            $value = sprintf("%." . $resObj->getPrecision() . "f", $value_org);
-                            if ($is_frac) {
-                                $value = assFormulaQuestionResult::convertDecimalToCoprimeFraction($value_org);
-                                if (is_array($value)) {
-                                    $frac_helper = $value[1];
-                                    $value = $value[0];
-                                }
-                            }
-                        } else {
-                            if ($forsolution) {
-                                $value = $userdata[$result]["value"];
-                            } else {
-                                $value = ' value="' . $userdata[$result]["value"] . '"';
-                            }
-                        }
-                    }
-                } else {
-                    if ($forsolution) {
-                        $value = $resObj->calculateFormula($this->getVariables(), $this->getResults(), parent::getId());
-                        $value = sprintf("%." . $resObj->getPrecision() . "f", $value);
-
-                        if ($is_frac) {
-                            $value = assFormulaQuestionResult::convertDecimalToCoprimeFraction($value);
-                            if (is_array($value)) {
-                                $frac_helper = $value[1];
-                                $value = $value[0];
-                            }
-                            $value = ' value="' . $value . '"';
-                        }
-                    } else {
-                        // Precision fix for Preview by tjoussen
-                        // If all default values are set, this function is called in getPreview
-                        $use_precision = !($userdata == null && $graphicalOutput == false && $forsolution == false && $result_output == false);
-
-                        $val = $resObj->calculateFormula($this->getVariables(), $this->getResults(), parent::getId(), $use_precision);
-
-                        if ($resObj->getResultType() == assFormulaQuestionResult::RESULT_FRAC
-                            || $resObj->getResultType() == assFormulaQuestionResult::RESULT_CO_FRAC) {
-                            $val = $resObj->convertDecimalToCoprimeFraction($val);
-                            if (is_array($val)) {
-                                $frac_helper = $val[1];
-                                $val = $val[0];
-                            }
-                        } else {
-                            $val = sprintf("%." . $resObj->getPrecision() . "f", $val);
-                            $val = (strlen($val) > 8) ? strtoupper(sprintf("%e", $val)) : $val;
-                        }
-                        $value = ' value="' . $val . '"';
-                    }
-                }
-
                 if ($forsolution) {
+                    $value = $resObj->calculateFormula($this->getVariables(), $this->getResults(), parent::getId());
+                    $value = sprintf("%." . $resObj->getPrecision() . "f", $value);
+
+                    if ($is_frac) {
+                        $value = assFormulaQuestionResult::convertDecimalToCoprimeFraction($value);
+                        if (is_array($value)) {
+                            $frac_helper = $value[1];
+                            $value = $value[0];
+                        }
+                        $value = ' value="' . $value . '"';
+                    }
+
                     $input = '<span class="ilc_qinput_TextInput solutionbox">' . ilLegacyFormElementsUtil::prepareFormOutput(
                         $value
                     ) . '</span>';
+                } elseif (is_array($userdata) && isset($userdata[$result])) {
+                    $input = $this->generateResultInputHtml($result, $userdata[$result]["value"]);
                 } else {
-                    $input = '<input class="ilc_qinput_TextInput" type="text" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" name="result_' . $result . '"' . $value . ' />';
+                    $input = $this->generateResultInputHTML($result, '');
                 }
 
                 $units = "";
@@ -492,6 +451,15 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
             }
         }
         return $text;
+    }
+
+    protected function generateResultInputHTML(string $result_key, string $result_value): string
+    {
+        $input = '<input class="ilc_qinput_TextInput" type="text"';
+        $input .= 'spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off"';
+        $input .= 'name="result_' . $result_key . '"';
+        $input .= ' value="' . $result_value . '"/>';
+        return $input;
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -978,7 +978,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
 
         $template = new ilTemplate("tpl.il_as_qpl_formulaquestion_output.html", true, true, 'Modules/TestQuestionPool');
         if (is_object($this->getPreviewSession())) {
-            $questiontext = $this->object->substituteVariables($user_solution, false, false, false);
+            $questiontext = $this->object->substituteVariables($user_solution);
         } else {
             $questiontext = $this->object->substituteVariables(array());
         }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=34227

We should actually have a look at this whole branching catastrophe for ILIAS 9, but this branches that cannot (```if (false &&```) or should not (see the current leakage of the result in the question view) be taken.

I wouldn't leave this too long, if you don't want another gazillion duplicate Mantis-Issues ;-)