### PR TITLE
Fix orderning of Question Export

### DIFF
--- a/Modules/Test/classes/class.ilTestExport.php
+++ b/Modules/Test/classes/class.ilTestExport.php
@@ -401,7 +401,7 @@ abstract class ilTestExport
             $col = 0;
             
             // each participant gets an own row for question column headers
-            if ($this->test_obj->isRandomTest()) {
+            if ($this->test_obj->isRandomTest() && $firstwritten) {
                 $row++;
             }
 
@@ -490,25 +490,9 @@ abstract class ilTestExport
                     }
                     $worksheet->setCell($row, $col++, $pass + 1);
                     if (is_object($data->getParticipant($active_id)) && is_array($data->getParticipant($active_id)->getQuestions($pass))) {
-                        $evaluatedQuestions = $data->getParticipant($active_id)->getQuestions($pass);
-                        
-                        if ($this->test_obj->getShuffleQuestions()) {
-                            // reorder questions according to general fixed sequence,
-                            // so participant rows can share single questions header
-                            $questions = array();
-                            foreach ($this->test_obj->getQuestions() as $qId) {
-                                foreach ($evaluatedQuestions as $evaledQst) {
-                                    if ($evaledQst['id'] != $qId) {
-                                        continue;
-                                    }
-                                    
-                                    $questions[] = $evaledQst;
-                                }
-                            }
-                        } else {
-                            $questions = $evaluatedQuestions;
-                        }
-                        
+                        $evaluated_questions = $data->getParticipant($active_id)->getQuestions($pass);
+                        $questions = $this->orderQuestions($evaluated_questions);
+
                         foreach ($questions as $question) {
                             $question_data = $data->getParticipant($active_id)->getPass($pass)->getAnsweredQuestionByQuestionId($question["id"]);
                             $worksheet->setCell($row, $col, $question_data["reached"]);
@@ -945,14 +929,16 @@ abstract class ilTestExport
                             array_push($datarow, "");
                         }
                         array_push($datarow2, $pass + 1);
-                        if (is_object($data->getParticipant($active_id)) && is_array($data->getParticipant($active_id)->getQuestions($pass))) {
-                            foreach ($data->getParticipant($active_id)->getQuestions($pass) as $question) {
+                        if (is_object($data->getParticipant($active_id)) && is_array($evaluated_questions = $data->getParticipant($active_id)->getQuestions($pass))) {
+                            $questions = $this->orderQuestions($evaluated_questions);
+                            foreach ($questions as $question) {
                                 $question_data = $data->getParticipant($active_id)->getPass($pass)->getAnsweredQuestionByQuestionId($question["id"]);
                                 array_push($datarow2, $question_data["reached"]);
                                 array_push($datarow, preg_replace("/<.*?>/", "", $data->getQuestionTitle($question["id"])));
                             }
                         }
-                        if ($this->test_obj->isRandomTest() || $this->test_obj->getShuffleQuestions() || ($counter == 1 && $pass == 0)) {
+                        if ($this->test_obj->isRandomTest() ||
+                            $counter == 1 && $pass == 0) {
                             array_push($rows, $datarow);
                         }
                         $datarow = array();
@@ -975,6 +961,22 @@ abstract class ilTestExport
         } else {
             return $csv;
         }
+    }
+
+
+    protected function orderQuestions(array $questions) : array
+    {
+        $key = $this->test_obj->isRandomTest() ? 'qid' : 'sequence';
+        usort(
+            $questions,
+            function ($a, $b) use ($key) {
+                if ($a[$key] > $b[$key]) {
+                    return 1;
+                }
+                return -1;
+            }
+        );
+        return $questions;
     }
 
     abstract protected function initXmlExport();


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=14179

Ok, we had two different behaviors in the question export: In Excel questions where newly sorted before showing them in CSV they weren't.
This aligns the behavior. I refrained from entering deeply into the structure of these functions and kept my changes shallow. But the class needs some serious refactoring!

Behavior after the change:
* Questions are sorted by their sequence if the test is not based on a RandomQuestionSet. If it is based on a RandomQuestionSet questions are sorted by their qid.
* There is only one header row, if the test is not based on a RandomQuastioonSet. In the latter case one header row per result set is shown.
* I removed a small issue that the excel export would show the header row of the first result set on a new line, thus creating a split in the header rows of the first set.

As always @mbecker-databay : I will cherry-pick to 8 and 9 if this is accepted solution.