### PR TITLE
0029975 failed test online status

### DIFF
--- a/Modules/Test/classes/class.ilTestImporter.php
+++ b/Modules/Test/classes/class.ilTestImporter.php
@@ -35,8 +35,6 @@ class ilTestImporter extends ilXmlImporter
             $_SESSION['tst_import_subdir'] = $this->getImportPackageName();
             $newObj->saveToDb(); // this generates test id first time
             $questionParentObjId = $newObj->getId();
-            $newObj->setOfflineStatus(false);
-            $questionParentObjId = $newObj->getId();
         } else {
             // single object
             $new_id = $a_mapping->getMapping('Modules/Test', 'tst', 'new_id');

--- a/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -34,11 +34,9 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
         // Container import => pool object already created
         if ($new_id = $a_mapping->getMapping('Services/Container', 'objs', $a_id)) {
             $newObj = ilObjectFactory::getInstanceByObjId($new_id, false);
-            $newObj->setOnline(true);
+            $newObj->setOnline(true); // sets Question pools to always online
 
             $_SESSION['qpl_import_subdir'] = $this->getImportPackageName();
-
-            $newObj->setOnline(true);
         } elseif ($new_id = $a_mapping->getMapping('Modules/TestQuestionPool', 'qpl', "new_id")) {
             $newObj = ilObjectFactory::getInstanceByObjId($new_id, false);
         } else {

--- a/Services/Container/classes/class.ilContainerImporter.php
+++ b/Services/Container/classes/class.ilContainerImporter.php
@@ -134,7 +134,8 @@ class ilContainerImporter extends ilXmlImporter
                 if ($this->isRootNode($obj->getRefId(), $mapping)) {
                     $obj->setOfflineStatus(true);
                 } else {
-                    $obj->setOfflineStatus(false);
+                    // take the offline state of the XML file, and map it back: online to online and offline to offline
+                    $obj->setOfflineStatus(!((string)$offline === "0"));
                 }
                 $obj->update();
             }

--- a/Services/Container/classes/class.ilContainerImporter.php
+++ b/Services/Container/classes/class.ilContainerImporter.php
@@ -134,8 +134,8 @@ class ilContainerImporter extends ilXmlImporter
                 if ($this->isRootNode($obj->getRefId(), $mapping)) {
                     $obj->setOfflineStatus(true);
                 } else {
-                    // take the offline state of the XML file, and map it back: online to online and offline to offline
-                    $obj->setOfflineStatus(!((string)$offline === "0"));
+                    // use the offline status of the imported XML file and set the offline status for the new container objects accordingly
+                    $obj->setOfflineStatus(!((string) $offline === "0"));
                 }
                 $obj->update();
             }


### PR DESCRIPTION
Hello

This PR should fix the bug presented in: https://mantis.ilias.de/view.php?id=29975
It changes the default import behavior of ilTestObjects. Instead of defaulting to online it now uses the online/offline-state set by the ilContainerImporter.
It also fixes what, I believe, is a bug in the ilContainerImporter, at least in my test instance. The bug set other object lm, crs, grp etc. to online after the import, ignoring the online/offline-state of the imported XML file. With the proposed fix, the online/offline-state of the imported XML file is used for container imports.

I'm still learning ILIAS, so please let me know: if anything slipped my attention, or what can be improved further.