### PR TITLE
fixed changes made to sahslaunch modifier return

### DIFF
--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -3271,7 +3271,7 @@ class ilObjectListGUI
 
         // workaround for scorm
         $modified_link =
-            $this->modifySAHSlaunch($def_cmd_link, $def_cmd_frame);
+            $this->modifySAHSlaunch($def_cmd_link, $def_cmd_frame)[0];
 
         $image = $this->ui->factory()
                           ->image()


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=34918

This fixed a bug caused by https://github.com/ILIAS-eLearning/ILIAS/commit/8a7f5bb2a5ff499483c4a748fc3ca4588facd553 by handling the changed return type correctly.

@Uwe-Kohnle unfortunatly i could not find the matching PR request to this to contribute that bug there, too. Could you send me the PR so i can add the information there to? (just for documentation)