### PR TITLE
T&A Tweak 0029559 Adds additional Information about the E-Mail notification behavior.

### DIFF
--- a/Modules/Test/classes/class.ilObjTestSettingsGeneralGUI.php
+++ b/Modules/Test/classes/class.ilObjTestSettingsGeneralGUI.php
@@ -1510,6 +1510,7 @@ class ilObjTestSettingsGeneralGUI extends ilTestSettingsGUI
         $mailnottype = new ilCheckboxInputGUI('', "mailnottype");
         $mailnottype->setValue(1);
         $mailnottype->setOptionTitle($this->lng->txt("mailnottype"));
+        $mailnottype->setInfo($this->lng->txt("mailnottype_desc"));
         $mailnottype->setChecked($this->testOBJ->getMailNotificationType());
         $mailnotification->addSubItem($mailnottype);
     }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -887,6 +887,7 @@ assessment#:#log_wrong_test_password_entered#:#Teilnehmer hat falsches Testpassw
 assessment#:#longmenu#:#Longmenu
 assessment#:#longmenu_text#:#‘Long Menu’-Text
 assessment#:#mailnottype#:#Ein Versand findet auch beim Beenden einzelner Testdurchläufe statt
+assessment#:#mailnottype_desc#:#Aktivieren Sie diese Checkbox, um auch dann benachrichtigt zu werden, wenn die Anzahl an Testdurchläufen nicht von Ihnen begrenzt wurde.
 assessment#:#maintenance#:#Wartung
 assessment#:#manscoring#:#Manuelle Bewertung
 assessment#:#manscoring_done#:#Bereits bewertete Teilnehmer

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -887,7 +887,7 @@ assessment#:#log_wrong_test_password_entered#:#Teilnehmer hat falsches Testpassw
 assessment#:#longmenu#:#Longmenu
 assessment#:#longmenu_text#:#‘Long Menu’-Text
 assessment#:#mailnottype#:#Ein Versand findet auch beim Beenden einzelner Testdurchläufe statt
-assessment#:#mailnottype_desc#:#Aktivieren Sie diese Checkbox, um auch dann benachrichtigt zu werden, wenn die Anzahl an Testdurchläufen nicht von Ihnen begrenzt wurde.
+assessment#:#mailnottype_desc#:#Der Besitzer des Tests wird auch dann benachrichtigt, wenn die Anzahl Durchläufe nicht beschränkt ist.
 assessment#:#maintenance#:#Wartung
 assessment#:#manscoring#:#Manuelle Bewertung
 assessment#:#manscoring_done#:#Bereits bewertete Teilnehmer

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -887,6 +887,7 @@ assessment#:#log_wrong_test_password_entered#:#Participant entered wrong test pa
 assessment#:#longmenu#:#Longmenu
 assessment#:#longmenu_text#:#Long Menu Text
 assessment#:#mailnottype#:#Send notification even if a user finishes a test pass
+assessment#:#mailnottype_desc#:#Select this checkbox to be notified, even if the number of test runs has not been limited by you.
 assessment#:#maintenance#:#Maintenance
 assessment#:#manscoring#:#Manual Scoring
 assessment#:#manscoring_done#:#Scored Participants

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -887,7 +887,7 @@ assessment#:#log_wrong_test_password_entered#:#Participant entered wrong test pa
 assessment#:#longmenu#:#Longmenu
 assessment#:#longmenu_text#:#Long Menu Text
 assessment#:#mailnottype#:#Send notification even if a user finishes a test pass
-assessment#:#mailnottype_desc#:#Select this checkbox to be notified, even if the number of test runs has not been limited by you.
+assessment#:#mailnottype_desc#:#Notify the owner of the test <strong>even if</strong> the number of test attempts has not been limited.
 assessment#:#maintenance#:#Maintenance
 assessment#:#manscoring#:#Manual Scoring
 assessment#:#manscoring_done#:#Scored Participants


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=29559
Adds a Byline explaining the E-Mail notification behavior in the test object settings. The Byline is currently available in the German and English language.