### PR TITLE
Bugfix 31323 Next Button was deactivated in visited Content Page

### DIFF
--- a/Modules/LearningSequence/classes/Player/class.ilLSPlayer.php
+++ b/Modules/LearningSequence/classes/Player/class.ilLSPlayer.php
@@ -103,16 +103,6 @@ class ilLSPlayer
             $state = $this->ls_items->getStateFor($next_item, $view);
         }
 
-        //get position
-        list($item_position, $item) = $this->findItemByRefId($items, $next_item->getRefId());
-
-        //have the view build controls
-        $control_builder = $this->control_builder;
-        $view->buildControls($state, $control_builder);
-
-        //amend controls not set by the view
-        $control_builder = $this->buildDefaultControls($control_builder, $item, $item_position, $items);
-
         //content
         $obj_title = $next_item->getTitle();
         $icon = $this->ui_factory->symbol()->icon()
@@ -126,6 +116,17 @@ class ilLSPlayer
         );
         $content = [$panel];
 
+        $items = $this->ls_items->getItems(); //reload items after renderComponentView content
+
+        //get position
+        list($item_position, $item) = $this->findItemByRefId($items, $next_item->getRefId());
+
+        //have the view build controls
+        $control_builder = $this->control_builder;
+        $view->buildControls($state, $control_builder);
+
+        //amend controls not set by the view
+        $control_builder = $this->buildDefaultControls($control_builder, $item, $item_position, $items);
 
         $rendered_body = $this->page_renderer->render(
             $this->lso_title,


### PR DESCRIPTION
#bugfix
Mantis issue: 0031323
Target: release_7
https://mantis.ilias.de/view.php?id=31323

The next button of a Learning Sequence was incorrectly deactivated when the first page needs to be visited for the user to continue. This is because the next button has already been created when the content is loaded and the page is set to visted.
Thats why I swapped this steps and reload the items before creating the next-Button, so the visited-Status is set correctly.