### PR TITLE
Legacy-Form: Fix Error with Nested RadioGroups

### DIFF
--- a/Services/Form/classes/class.ilRadioGroupInputGUI.php
+++ b/Services/Form/classes/class.ilRadioGroupInputGUI.php
@@ -129,9 +129,11 @@ class ilRadioGroupInputGUI extends ilSubEnabledFormPropertyGUI implements ilTabl
                             "il.Form.hideSubForm('subform_$hop_id');"
                         );
                     }
-                    $this->getParentForm()->addAsyncOnloadCode(
-                        "il.Form.hideSubForm('subform_$hop_id');"
-                    );
+                    if ($this->getParentForm() !== null) {
+                        $this->getParentForm()->addAsyncOnloadCode(
+                            "il.Form.hideSubForm('subform_$hop_id');"
+                        );
+                    }
                 }
                 $tpl->setCurrentBlock("radio_option_subform");
                 $pf = new ilPropertyFormGUI();


### PR DESCRIPTION
This commit here
https://github.com/ILIAS-eLearning/ILIAS/commit/9aa888407b50c891fad6c0c53ea6c2c0ebada7a2#diff-442c3a79da205f00191d1f37414279a6c89e4543dccc90e3dcd7981e54b0f03bR132
has side-effects. `getParentForm()` can return null and does so in the case of nested ilRadioGroups. In these cases the code has been loaded anyways and is not needed.

Mantis report here: https://mantis.ilias.de/view.php?id=34974