### PR TITLE
Legacy-Table: Fix missing Header on Checkboxes

### DIFF
--- a/Services/Table/classes/class.ilTable2GUI.php
+++ b/Services/Table/classes/class.ilTable2GUI.php
@@ -1069,6 +1069,19 @@ class ilTable2GUI extends ilTableGUI
                 $this->tpl->parseCurrentBlock();
                 continue;
             }
+
+            if ($column['is_checkbox_action_column'] && !$this->select_all_on_top) {
+                $this->tpl->setCurrentBlock('tbl_header_top_select_column');
+                if ($column["width"] != "") {
+                    $width = (is_numeric($column["width"]))
+                        ? $column["width"] . "px"
+                        : $column["width"];
+                    $this->tpl->setVariable("TBL_COLUMN_WIDTH", " style=\"width:" . $width . "\"");
+                }
+                $this->tpl->parseCurrentBlock();
+                continue;
+            }
+
             if (
                 !$this->enabled["sort"] ||
                 (($column["sort_field"] == "") &&

--- a/Services/Table/templates/default/tpl.table2.html
+++ b/Services/Table/templates/default/tpl.table2.html
@@ -92,7 +92,7 @@
 		</div>
 	</div>
     <!-- END template_editor_delete -->
-	
+
 	</td>
 	</tr></table>
 </div>
@@ -150,9 +150,13 @@
 	  <!-- BEGIN tbl_header_top_select_all -->
 	  <td>
 		  <input type="checkbox" name="{HEAD_CHECKBOXNAME}" id="{HEAD_CHECKBOXNAME}" value="1" title='{HEAD_SELECT_ALL_TXT_SELECT_ALL}'
-				 onClick='il.Util.setChecked('{HEAD_SELECT_ALL_FORM_NAME}', '{HEAD_SELECT_ALL_CHECKBOX_NAME}', document.forms['{HEAD_SELECT_ALL_FORM_NAME}'].elements['{HEAD_CHECKBOXNAME}'].checked);" />
+				 onClick="il.Util.setChecked('{HEAD_SELECT_ALL_FORM_NAME}', '{HEAD_SELECT_ALL_CHECKBOX_NAME}', document.forms['{HEAD_SELECT_ALL_FORM_NAME}'].elements['{HEAD_CHECKBOXNAME}'].checked);" />
 	  </td>
 	  <!-- END tbl_header_top_select_all -->
+      <!-- BEGIN tbl_header_top_select_column -->
+	  <td {TBL_COLUMN_WIDTH}>
+	  </td>
+	  <!-- END tbl_header_top_select_column -->
 <!-- BEGIN tbl_header_no_link -->
 		<th {TBL_COLUMN_WIDTH_NO_LINK} {TBL_COLUMN_CLASS_NO_LINK}><span id="{HEAD_CELL_NL_ID}">{TBL_HEADER_CELL_NO_LINK}</span></th>
 <!-- END tbl_header_no_link -->


### PR DESCRIPTION
This fixes the table checkbox headers for tables as they pose a problem for accessibility.

See: https://mantis.ilias.de/view.php?id=32871

If there is a top select all checkbox at the top they didn't work at all up to now, as they was a small typo. Additionally if there was no checkbox there was a `<th>` instead of a `<td>`.