### PR TITLE
fixed 34193: CoPage: Inserting snippet from media pool leads to error

### DIFF
--- a/Modules/ContentPage/classes/PageMetrics/PageMetricsService.php
+++ b/Modules/ContentPage/classes/PageMetrics/PageMetricsService.php
@@ -68,7 +68,7 @@ final class PageMetricsService implements ilContentPageObjectConstants
     {
         $this->ensurePageObjectExists($command->getContentPageId(), $command->getLanguage());
 
-        $pageObjectGUI = new ilContentPagePageGUI($command->getContentPageId(), 0, true, $command->getLanguage());
+        $pageObjectGUI = new ilContentPagePageGUI($command->getContentPageId(), 0, false, $command->getLanguage());
         $pageObjectGUI->setEnabledTabs(false);
         $pageObjectGUI->setFileDownloadLink(ILIAS_HTTP_PATH);
         $pageObjectGUI->setFullscreenLink(ILIAS_HTTP_PATH);


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=34193
Is a partial backport of 
https://github.com/ILIAS-eLearning/ILIAS/commit/7fc81f675bda556dfd464b3a982720e5a03fe88c