### PR TITLE
Bugfix T&A 0031518 negativ point deduction in hints leads to incorrect scoring

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHint.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHint.php
@@ -45,7 +45,7 @@ class ilAssQuestionHint
      * when a user resorts to this hint
      *
      * @access	private
-     * @var		integer
+     * @var		float
      */
     private $points = null;
     
@@ -136,7 +136,7 @@ class ilAssQuestionHint
      * returns the points to ground-off for this hint
      *
      * @access	public
-     * @return	integer	$points
+     * @return	float	$points
      */
     public function getPoints()
     {
@@ -147,11 +147,11 @@ class ilAssQuestionHint
      * sets the passed points to ground-off for this hint
      *
      * @access	public
-     * @param	integer	$points
+     * @param	float   $points
      */
     public function setPoints($points)
     {
-        $this->points = (float) $points;
+        $this->points = abs((float) $points);
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintRequestStatisticData.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintRequestStatisticData.php
@@ -14,7 +14,7 @@ class ilAssQuestionHintRequestStatisticData
     /**
      * The sum of points deducted
      *
-     * @var integer
+     * @var float
      */
     private $requestsPoints = null;
     
@@ -33,10 +33,10 @@ class ilAssQuestionHintRequestStatisticData
     }
 
     /**
-     * Getter for requestsPonts
+     * Getter for requestsPoints
      *
      * @access public
-     * @return integer $requestsPoints
+     * @return float $requestsPoints
      */
     public function getRequestsPoints()
     {
@@ -44,14 +44,14 @@ class ilAssQuestionHintRequestStatisticData
     }
 
     /**
-     * Setter for requestsPonts
+     * Setter for requestsPoints
      *
      * @access public
-     * @param integer $requestsPoints
+     * @param float $requestsPoints
      */
     public function setRequestsPoints($requestsPoints)
     {
-        $this->requestsPoints = $requestsPoints;
+        $this->requestsPoints = abs($requestsPoints);
     }
 
     /**


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=31518

Two commits, one should fix newly created hints, the other should fix negative signs already stored in the database.
I decided to rather change the setters in the different data structure classes, then all places where the hint deduction points are accessed. This has the advantage, I hope, that in the future the error is not recreated by accident. 
Also, the user is able to enter decimals for the point deduction. Therefore, I changed some of the comments to float instead of Integer. Since I think it's better to expect the more complex value.

Again, happy to do additional changes to the code or change my strategy if you see things differently. Just let me know so I can improve.