### PR TITLE
CoPage: Fix check for `res_node` (Mantis 34585)

### DIFF
--- a/Services/COPage/classes/class.ilPCLoginPageElement.php
+++ b/Services/COPage/classes/class.ilPCLoginPageElement.php
@@ -92,7 +92,7 @@ class ilPCLoginPageElement extends ilPageContent
 
     public function getAlignment(): string
     {
-        if (isset($this->res_name) && is_object($this->res_node)) {
+        if (isset($this->res_node) && is_object($this->res_node)) {
             return $this->res_node->get_attribute('HorizontalAlign');
         }
         return "";


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=34585

If approved, this should be cherry-picked to `trunk` as well.