### PR TITLE
Move ilContObjParser to Test and Rename

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1313,9 +1313,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
             $qtiParser->setTestObject($newObj);
             $qtiParser->startParsing();
             $newObj->saveToDb();
-            $contParser = new ilContObjParser($newObj, ilSession::get("tst_import_xml_file"), ilSession::get("tst_import_subdir"));
-            $contParser->setQuestionMapping($qtiParser->getImportMapping());
-            $contParser->startParsing();
+            $questionPageParser = new ilQuestionPageParser($newObj, ilSession::get("tst_import_xml_file"), ilSession::get("tst_import_subdir"));
+            $questionPageParser->setQuestionMapping($qtiParser->getImportMapping());
+            $questionPageParser->startParsing();
 
             if (isset($_POST["ident"]) && is_array($_POST["ident"]) && count($_POST["ident"]) == $qtiParser->getNumImportedItems()) {
                 // import test results

--- a/Modules/Test/classes/class.ilQuestionPageParser.php
+++ b/Modules/Test/classes/class.ilQuestionPageParser.php
@@ -19,7 +19,7 @@
  * @author Alexander Killing <killing@leifos.de>
  * @deprecated use COPage dependency to export/import COPages instead
  */
-class ilContObjParser extends ilMDSaxParser
+class ilQuestionPageParser extends ilMDSaxParser
 {
     /**
      * @var false

--- a/Modules/Test/classes/class.ilQuestionPageParser.php
+++ b/Modules/Test/classes/class.ilQuestionPageParser.php
@@ -1,18 +1,20 @@
 <?php
 
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 /**
  * Legacy Content Object Parser
  *

--- a/Modules/Test/classes/class.ilTestImporter.php
+++ b/Modules/Test/classes/class.ilTestImporter.php
@@ -94,10 +94,9 @@ class ilTestImporter extends ilXmlImporter
         $newObj = $qtiParser->getTestObject();
 
         // import page data
-        include_once("./Modules/LearningModule/classes/class.ilContObjParser.php");
-        $contParser = new ilContObjParser($newObj, $xml_file, basename($this->getImportDirectory()));
-        $contParser->setQuestionMapping($qtiParser->getImportMapping());
-        $contParser->startParsing();
+        $questionPageParser = new ilQuestionPageParser($newObj, $xml_file, basename($this->getImportDirectory()));
+        $questionPageParser->setQuestionMapping($qtiParser->getImportMapping());
+        $questionPageParser->startParsing();
 
         foreach ($qtiParser->getQuestionIdMapping() as $oldQuestionId => $newQuestionId) {
             $a_mapping->addMapping(

--- a/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -109,10 +109,9 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
 
         // import page data
         if (strlen($xml_file)) {
-            include_once("./Modules/LearningModule/classes/class.ilContObjParser.php");
-            $contParser = new ilContObjParser($newObj, $xml_file, basename($this->getImportDirectory()));
-            $contParser->setQuestionMapping($qtiParser->getImportMapping());
-            $contParser->startParsing();
+            $questionPageParser = new ilQuestionPageParser($newObj, $xml_file, basename($this->getImportDirectory()));
+            $questionPageParser->setQuestionMapping($qtiParser->getImportMapping());
+            $questionPageParser->startParsing();
 
             foreach ($qtiParser->getImportMapping() as $k => $v) {
                 $oldQuestionId = substr($k, strpos($k, 'qst_') + strlen('qst_'));

--- a/Services/COPage/classes/class.ilPageObject.php
+++ b/Services/COPage/classes/class.ilPageObject.php
@@ -2402,8 +2402,8 @@ s     */
 
     /**
      * Updates page object with current xml content
-     * This function is currently (4.4.0 alpha) called by:
-     * - ilContObjParser (LM and Glossary import parser)
+     * This function is currently (8 beta) called by:
+     * - ilQuestionPageParser (Test and TestQuestionPool)
      * - ilSCORM13Package->dbImportSco (SCORM importer)
      * - assQuestion->copyPageOfQuestion
      */


### PR DESCRIPTION
I @alex40724 
I would suggest to move as by your suggestion in [this comment](https://github.com/ILIAS-eLearning/ILIAS/pull/5097#issuecomment-1270238258) and move the `ilContParser` class to the test. OK?