### PR TITLE
Deprecation/Removal in ILIAS 10: Services/FileSystem

### DIFF
--- a/Services/FileSystem/classes/class.ilFile.php
+++ b/Services/FileSystem/classes/class.ilFile.php
@@ -16,7 +16,7 @@
  * Base class for all file (directory) operations
  * This class is abstract and needs to be extended
  *
- * @deprecated
+ * @deprecated Will be removed in ILIAS 10. Use ILIAS ResourceStorageService as replacement.
  */
 abstract class ilFile
 {

--- a/Services/FileSystem/classes/class.ilFileData.php
+++ b/Services/FileSystem/classes/class.ilFileData.php
@@ -13,7 +13,7 @@
  *
  *****************************************************************************/
 /**
- * @deprecated
+ * @deprecated Will be removed in ILIAS 10. Use ILIAS ResourceStorageService as replacement.
  */
 class ilFileData extends ilFile
 {

--- a/Services/FileSystem/classes/class.ilFileDataImport.php
+++ b/Services/FileSystem/classes/class.ilFileDataImport.php
@@ -13,7 +13,7 @@
  *
  *****************************************************************************/
 /**
- * @deprecated
+ * @deprecated Will be removed in ILIAS 10. Use ILIAS ResourceStorageService as replacement.
  */
 class ilFileDataImport extends ilFileData
 {

--- a/Services/FileSystem/classes/class.ilFileSystemAbstractionStorage.php
+++ b/Services/FileSystem/classes/class.ilFileSystemAbstractionStorage.php
@@ -21,7 +21,7 @@ use ILIAS\Filesystem\Util\LegacyPathHelper;
 use ILIAS\Filesystem\Filesystem;
 
 /**
- * @deprecated
+ * @deprecated Will be removed in ILIAS 10. Use ILIAS ResourceStorageService as replacement.
  */
 abstract class ilFileSystemAbstractionStorage
 {

--- a/Services/FileSystem/classes/class.ilFileSystemGUI.php
+++ b/Services/FileSystem/classes/class.ilFileSystemGUI.php
@@ -24,7 +24,7 @@ use ILIAS\Filesystem\Util\LegacyPathHelper;
 /**
  * File System Explorer GUI class
  *
- * @deprecated
+ * @deprecated Will be removed in ILIAS 10. Use ILIAS ResourceStorageService as replacement.
  */
 class ilFileSystemGUI
 {

--- a/Services/FileSystem/classes/class.ilFileSystemTableGUI.php
+++ b/Services/FileSystem/classes/class.ilFileSystemTableGUI.php
@@ -19,7 +19,7 @@ use ILIAS\FileUpload\MimeType;
 use ILIAS\Filesystem\Util\LegacyPathHelper;
 
 /**
- * @deprecated $
+ * @deprecated Will be removed in ILIAS 10. Use ILIAS ResourceStorageService as replacement.
  */
 class ilFileSystemTableGUI extends ilTable2GUI
 {

--- a/Services/FileSystem/classes/class.ilUploadFiles.php
+++ b/Services/FileSystem/classes/class.ilUploadFiles.php
@@ -13,7 +13,8 @@
  *
  *****************************************************************************/
 /**
- * @deprecated Will be removed in the next release
+ * @deprecated Will be removed in ILIAS 10. No replacement suggested. This feature is only used in CmiXApi and SCORM
+ * and must be implemented there
  */
 class ilUploadFiles
 {


### PR DESCRIPTION
ILIAS has since several releases modern and reliable services to work with files. These include the src/ResourceStorage, the src/FileUpload and the src/Filesystem.

Under "Services" there are several legacy implementations that were used in different places to work with files. These will be completely removed with ILIAS 10 - or maintained by the remaining maintainers. 

For the deprecations listed here in the PR, alternatives have existed for a long time with the above-mentioned services - for the storage and administration part - but these were not and only little used.

For the UI side (like e.g. the removal of ilFileSystemGUI/ilFileSystemTableGUI) new concepts have to be found for ILIAS 10 anyway, because these legacy UI things like the table will be removed with ILIAS 10 as well.

Enclosed is a list of the remaining uses of the classes. Please contact me regarding migration of the usages if the existing documentation (see Services/ResourceStorage/MIGRATIONS.md) is not sufficient. As said, for the UI side there is currently no direct replacement, here also suggestions from the using component maintainers are welcome, since I myself do not use them.


**ilFile**

- class.ilFileData.php
- class.ilFileDataCourse.php
- class.ilFileDataImport.php
- class.ilFileDataMail.php

already planed/prepared/done migrations for ILIAS 9:

- class.ilFileDataForum.php
- class.ilFileDataForumDrafts.php


**ilFileSystemAbstractionStorage**

- class.ilAssQuestionProcessLockFileStorage.php
- class.ilFSStorageBadge.php
- class.ilFSStorageBadgeImageTemplate.php
- class.ilFSStorageBlog.php
- class.ilFSStorageBooking.php
- class.ilFSStorageCourse.php
- class.ilFSStorageExercise.php
- class.ilFSStorageGroup.php
- class.ilFSStorageMail.php
- class.ilFSStoragePoll.php
- class.ilFSStoragePortfolio.php
- class.ilFSStorageSession.php
- class.ilFSWebStorageExercise.php
- class.ilIndividualAssessmentFileStorage.php
- class.ilLearningSequenceFilesystem.php
- class.ilRestFileStorage.php
- class.ilTestProcessLockFileStorage.php
- class.ilVerificationStorageFile.php

Planes migrations with ILIAS 9:
- class.ilFSStorageUserFolder.php

already planed/prepared/done migrations for ILIAS 9:
- class.ilFSStorageFile.php
- class.ilFSStoragePreview.php


**ilFileSystemGUI**

With Directories
- class.ilObjFileBasedLMGUI.php
- class.ilObjMediaObjectGUI.php
- class.ilObjSAHSLearningModuleGUI.php

Currently missing directory support in IRSS, please contact @chfsx if you need this.

Without Directories
- class.ilExAssignmentFileSystemGUI.php
- class.ilExerciseManagementGUI.php
- class.ilExPeerReviewGUI.php
- class.ilObjMediaPoolGUI.php

**ilFileSystemTableGUI**
Must be removed anyway since this is a legacy ui imlementation.

- class.ilFileSystemGUI.php
- class.ilExAssignmentFileSystemTableGUI.php


**ilUploadFiles**
No replacement suggested. This feature is only used in CmiXApi and SCORM and must be implemented there

- class.ilObjFileBasedLMGUI.php
- class.ilObjSAHSLearningModuleGUI.php
- class.ilObjCmiXapiGUI.php
- class.ilObjSCORMLearningModuleGUI.php

I am aware that some consumers of this code have unanswered questions. i am sure that we will find good solutions together, the necessary infr structure is in place and together we will find suitable solutions for this replacement.