### PR TITLE
VirusScanner: Allow _getInstace to Return Null

### DIFF
--- a/Services/VirusScanner/classes/class.ilVirusScannerFactory.php
+++ b/Services/VirusScanner/classes/class.ilVirusScannerFactory.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 class ilVirusScannerFactory
 {
-    public static function _getInstance(): ilVirusScanner
+    public static function _getInstance(): ?ilVirusScanner
     {
         $vs = null;
 


### PR DESCRIPTION
I think this needs to be as trivial as this, ...for the time being.