### PR TITLE
Test: Fix calculation of starting time (Mantis 35353)

### DIFF
--- a/Modules/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
+++ b/Modules/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
@@ -185,7 +185,7 @@ class ilCronFinishUnfinishedTestPasses extends ilCronJob
                     $this->log->info('Test (' . $test_id . ') has processing time (' . $this->test_ending_times[$test_id]['processing_time'] . ')');
                     $obj_id = $this->test_ending_times[$test_id]['obj_fi'];
                     $test_obj = new ilObjTest($obj_id, false);
-                    $startingTime = $test_obj->getStartingTimeOfUser($data['active_id'], $data['last_started_pass']);
+                    $startingTime = $test_obj->getStartingTimeOfUser($data['active_id'], $data['last_started']);
                     $max_processing_time = $test_obj->isMaxProcessingTimeReached($startingTime, $data['active_id']);
                     if ($max_processing_time) {
                         $this->log->info('Max Processing time reached for user id (' . $data['usr_id'] . ') so test with active id (' . $data['active_id'] . ') will be finished.');


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=35353

This has to be cherry-picked to `trunk` as well.