### PR TITLE
Info: IRSS Flavours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ phpstan-baseline.neon
 
 # File Delivery
 override.php
+Services/ResourceStorage/artifacts/flavour_data.php

--- a/Services/Init/classes/Dependencies/InitResourceStorage.php
+++ b/Services/Init/classes/Dependencies/InitResourceStorage.php
@@ -111,7 +111,7 @@ class InitResourceStorage
 
         // Source Builder for Consumers
         $c[self::D_SOURCE_BUILDER] = static function (Container $c): ?SrcBuilder {
-            return null;
+            return new ilWACSrcBuilder();
         };
 
         // Filename Policy for Consumers

--- a/Services/ResourceStorage/classes/FlavourDBRepository.php
+++ b/Services/ResourceStorage/classes/FlavourDBRepository.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Resource\Repository;
+
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Flavour;
+use ILIAS\ResourceStorage\Flavour\FlavourIdentification;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class FlavourDBRepository implements FlavourRepository
+{
+    protected const TABLE_NAME = 'il_resource_flavour';
+    protected const F_RESOURCE_ID = 'rid';
+    protected const F_REVISION = 'revision';
+    protected const F_DEFINITION = 'definition_id';
+    protected const F_VARIANT = 'variant';
+    private array $results_cache = [];
+    private \ilDBInterface $db;
+
+    public function __construct(\ilDBInterface $db)
+    {
+        $this->db = $db;
+    }
+
+
+    public function has(ResourceIdentification $rid, int $revision, FlavourDefinition $definition): bool
+    {
+        return $this->buildResult($rid, $revision, $definition)->numRows() > 0;
+    }
+
+    public function store(Flavour $flavour): void
+    {
+        if (!$this->has($flavour->getResourceId(), $flavour->getRevision(), $flavour->getDefinition())) {
+            $this->db->insert(
+                self::TABLE_NAME,
+                [
+                    self::F_RESOURCE_ID => ['text', $flavour->getResourceId()->serialize()],
+                    self::F_REVISION => ['integer', $flavour->getRevision()],
+                    self::F_DEFINITION => ['text', $flavour->getDefinition()->getId()],
+                    self::F_VARIANT => ['text', $flavour->getDefinition()->getVariantName()]
+                ]
+            );
+        }
+    }
+
+    public function get(ResourceIdentification $rid, int $revision, FlavourDefinition $definition): Flavour
+    {
+        return new Flavour(
+            $definition,
+            $rid,
+            $revision
+        );
+    }
+
+
+    public function delete(Flavour $flavour): void
+    {
+        $rid = $flavour->getResourceId();
+        $definition = $flavour->getDefinition();
+
+        $r = $this->db->manipulateF(
+            "DELETE FROM " . self::TABLE_NAME
+            . " WHERE " . self::F_RESOURCE_ID . " = %s AND "
+            . self::F_REVISION . " = %s AND "
+            . self::F_DEFINITION . " = %s AND (" . self::F_VARIANT . " = %s OR " . self::F_VARIANT . " IS NULL)",
+            ['text', 'integer', 'text', 'text'],
+            [$rid->serialize(), $flavour->getRevision(), $definition->getId(), $definition->getVariantName()]
+        );
+    }
+
+
+    public function preload(array $identification_strings): void
+    {
+        // TODO: Implement preload() method.
+    }
+
+    public function populateFromArray(array $data): void
+    {
+        // TODO: Implement populateFromArray() method.
+    }
+
+
+    private function buildResult(
+        ResourceIdentification $rid,
+        int $revision,
+        FlavourDefinition $definition
+    ): \ilDBStatement {
+        $rcache = $rid->serialize() . $definition->getId() . $definition->getVariantName();
+        if (isset($this->results_cache[$rcache])) {
+            return $this->results_cache[$rcache];
+        }
+
+        $r = $this->db->queryF(
+            "SELECT *  FROM " . self::TABLE_NAME
+            . " WHERE " . self::F_RESOURCE_ID . " = %s AND "
+            . self::F_REVISION . " = %s AND "
+            . self::F_DEFINITION . " = %s AND (" . self::F_VARIANT . " = %s OR " . self::F_VARIANT . " IS NULL)",
+            ['text', 'integer', 'text', 'text'],
+            [$rid->serialize(), $revision, $definition->getId(), $definition->getVariantName()]
+        );
+        return $this->results_cache[$rcache] = $r;
+    }
+}

--- a/Services/ResourceStorage/classes/Setup/Artifact/class.ilResourceStorageFlavourArtifact.php
+++ b/Services/ResourceStorage/classes/Setup/Artifact/class.ilResourceStorageFlavourArtifact.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\ResourceStorage\Flavour\Definition\DefaultDefinitions;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\DefaultMachines;
+use ILIAS\ResourceStorage\Flavour\Machine\FlavourMachine;
+use ILIAS\Setup\Artifact;
+use ILIAS\Setup\Artifact\ArrayArtifact;
+use ILIAS\Setup\Artifact\BuildArtifactObjective;
+use ILIAS\Setup\ImplementationOfInterfaceFinder;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ilResourceStorageFlavourArtifact extends BuildArtifactObjective
+{
+    public const PATH = './Services/ResourceStorage/artifacts/flavour_data.php';
+
+    public function getArtifactPath(): string
+    {
+        return self::PATH;
+    }
+
+    public function build(): Artifact
+    {
+        $default_machine_ids = (new DefaultMachines())->get();
+        $machines = [];
+
+        $finder = new ImplementationOfInterfaceFinder();
+
+        foreach ($finder->getMatchingClassNames(FlavourMachine::class) as $machine_name) {
+            /** @var $machine \ILIAS\ResourceStorage\Flavour\Machine\FlavourMachine */
+            $machine = new $machine_name();
+            $machine_id = $machine->getId();
+
+            if ($machine_name === $machine_id) {
+                throw new LogicException(
+                    "PLEASE beware that class-related magic constants are not recommended. Altering the implementation-name may result in lost flavours."
+                );
+            }
+
+            if (64 < strlen($machine_id)) {
+                throw new LogicException("ID of machine '$machine_name' exceeds 64 characters.");
+            }
+
+            if (isset($default_machine_ids[$machine_id])) {
+                throw new LogicException(
+                    "Machine '$default_machine_ids[$machine_id]' and '$machine_name' implement the same ID ($machine_id)."
+                );
+            }
+
+            if (isset($machines[$machine_id])) {
+                throw new LogicException(
+                    "Machine '$machines[$machine_id]' and '$machine_name' implement the same ID ($machine_id)."
+                );
+            }
+
+            $machines[$machine_id] = $machine_name;
+        }
+
+        $default_definition_ids = (new DefaultDefinitions())->get();
+        $definitions = [];
+
+        foreach ($finder->getMatchingClassNames(FlavourDefinition::class) as $definition_name) {
+            /** @var $definition FlavourDefinition */
+            $definition = new $definition_name();
+            $definition_id = $definition->getId();
+
+            if ($definition_name === $definition_id) {
+                throw new LogicException(
+                    "PLEASE beware that class-related magic constants are not recommended. Altering the implementation-name may result in lost flavours."
+                );
+            }
+
+            if (64 < strlen($definition_id)) {
+                throw new LogicException("ID of definition '$definition_name' exceeds 64 characters.");
+            }
+
+            if (isset($definitions[$definition_id])) {
+                throw new LogicException(
+                    "Definition '$definitions[$definition_id]' and '$definition_name' implement the same ID ($definition_id)."
+                );
+            }
+
+            if (isset($default_definition_ids[$definition_id])) {
+                throw new LogicException(
+                    "Definition '$default_definition_ids[$definition_id]' and '$definition_name' implement the same ID ($definition_id)."
+                );
+            }
+
+            $definitions[$definition_id] = $definition_name;
+        }
+
+        return new ArrayArtifact([
+            'machines' => $machines,
+            'definitions' => $definitions
+        ]);
+    }
+}

--- a/Services/ResourceStorage/classes/Setup/DB/class.ilResourceStorageDB90.php
+++ b/Services/ResourceStorage/classes/Setup/DB/class.ilResourceStorageDB90.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
+ * Class ilResourceStorageDB90
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class ilResourceStorageDB90 implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+
+    /**
+     * creates a new database table "il_resource_flavour" that is used to reference
+     * resource flavours to it's original resource.
+     */
+    public function step_1(): void
+    {
+        $flavour_table = "il_resource_flavour";
+        $this->db->dropTable($flavour_table, false);
+        if ($this->db->tableExists($flavour_table)) {
+            return;
+        }
+
+        $this->db->createTable($flavour_table, [
+            'rid' => [
+                'notnull' => true,
+                'length' => '64',
+                'type' => 'text',
+            ],
+            'revision' => [
+                'notnull' => true,
+                'length' => '8',
+                'type' => 'integer',
+            ],
+            'definition_id' => [
+                'notnull' => true,
+                'length' => '64',
+                'type' => 'text',
+            ],
+            'variant' => [
+                'notnull' => false,
+                'length' => '768',
+                'type' => 'text',
+            ]
+        ]);
+
+        $this->db->addIndex($flavour_table, ['rid'], 'i1');
+        $this->db->addIndex($flavour_table, ['definition_id'], 'i3');
+        $this->db->addIndex($flavour_table, ['variant'], 'i4');
+        $this->db->addPrimaryKey($flavour_table, ['rid', 'revision', 'definition_id', 'variant']);
+    }
+}

--- a/Services/ResourceStorage/classes/Setup/class.ilResourceStorageSetupAgent.php
+++ b/Services/ResourceStorage/classes/Setup/class.ilResourceStorageSetupAgent.php
@@ -63,13 +63,16 @@ class ilResourceStorageSetupAgent implements Agent
             new ilStorageContainersExistingObjective(),
             new ilDatabaseUpdateStepsExecutedObjective(
                 new ilResourceStorageDB80()
+            ),
+            new ilDatabaseUpdateStepsExecutedObjective(
+                new ilResourceStorageDB90()
             )
         );
     }
 
     public function getBuildArtifactObjective(): Objective
     {
-        return new Objective\NullObjective();
+        return new ilResourceStorageFlavourArtifact();
     }
 
     public function getStatusObjective(Metrics\Storage $storage): Objective

--- a/Services/ResourceStorage/classes/class.ilWACSignedResourceStorage.php
+++ b/Services/ResourceStorage/classes/class.ilWACSignedResourceStorage.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
+ * Class ilWACSignedResourceStorage
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class ilWACSignedResourceStorage implements ilWACCheckingClass
+{
+    public function canBeDelivered(ilWACPath $ilWACPath): bool
+    {
+        return false;
+    }
+}

--- a/Services/ResourceStorage/service.xml
+++ b/Services/ResourceStorage/service.xml
@@ -1,0 +1,6 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<service xmlns="http://www.w3.org" id="irss">
+    <web_access_checker>
+        <secure_path path="rs" checking-class="ilWACSignedResourceStorage" in-sec-folder='1'/>
+    </web_access_checker>
+</service>

--- a/Services/WebAccessChecker/classes/ResourceStorage/class.ilWACSrcBuilder.php
+++ b/Services/WebAccessChecker/classes/ResourceStorage/class.ilWACSrcBuilder.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Renderer\Hasher;
+use ILIAS\ResourceStorage\Consumer\InlineSrcBuilder;
+use ILIAS\ResourceStorage\Consumer\SrcBuilder;
+use ILIAS\ResourceStorage\Flavour\Flavour;
+use ILIAS\ResourceStorage\Revision\Revision;
+use ILIAS\ResourceStorage\StorageHandler\StorageHandler;
+
+/**
+ * Class ilWACSrcBuilder
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class ilWACSrcBuilder extends InlineSrcBuilder implements SrcBuilder
+{
+    public const WAC_BASE_URL = './Services/WebAccessChecker/wac.php';
+
+    public function getResourceURL(Revision $revision, bool $signed = true): string
+    {
+        $access_key = $revision->maybeGetToken()->getAccessKey();
+
+        return $this->signURL($access_key, $signed);
+    }
+
+
+    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator
+    {
+        foreach ($flavour->getAccessTokens() as $index => $token) {
+            if ($token->hasInMemoryStream()) {
+                yield from parent::getFlavourURLs($flavour, $signed);
+            } else {
+                $access_key = $token->getAccessKey();
+                yield $this->signURL($access_key, true);
+            }
+        }
+    }
+
+    protected function signURL(string $access_key, bool $sign): string
+    {
+        $url = "./data/" . CLIENT_NAME . "/sec/rs/" . $access_key;
+        if ($sign === false) {
+            return $url;
+        }
+        return ilWACSignedPath::signFile($url);
+    }
+}

--- a/Services/WebAccessChecker/classes/class.ilWACSignedPath.php
+++ b/Services/WebAccessChecker/classes/class.ilWACSignedPath.php
@@ -41,7 +41,7 @@ class ilWACSignedPath
     protected ?ilWACPath $path_object = null;
     protected ?ilWACToken $token_instance = null;
     protected int $type = PathType::FILE;
-    protected static int $token_max_lifetime_in_seconds = 3;
+    protected static int $token_max_lifetime_in_seconds = 5;
     protected static int $cookie_max_lifetime_in_seconds = 300;
     protected bool $checked = false;
     private GlobalHttpState $httpService;

--- a/src/ResourceStorage/Artifacts.php
+++ b/src/ResourceStorage/Artifacts.php
@@ -18,23 +18,31 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\ResourceStorage\Consumer;
-
-use ILIAS\ResourceStorage\Flavour\Flavour;
-use ILIAS\ResourceStorage\Revision\Revision;
+namespace ILIAS\ResourceStorage;
 
 /**
+ * Class Artifacts
+ * @internal
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-interface SrcBuilder
+class Artifacts
 {
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getRevisionURL(Revision $revision, bool $signed = true): string;
+    private array $flavour_machines;
+    private array $flavour_definitions;
 
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator;
+    public function __construct(array $flavour_machines, array $flavour_definitions)
+    {
+        $this->flavour_machines = $flavour_machines;
+        $this->flavour_definitions = $flavour_definitions;
+    }
+
+    public function getFlavourMachines(): array
+    {
+        return $this->flavour_machines;
+    }
+
+    public function getFlavourDefinitions(): array
+    {
+        return $this->flavour_definitions;
+    }
 }

--- a/src/ResourceStorage/Consumer/ConsumerFactory.php
+++ b/src/ResourceStorage/Consumer/ConsumerFactory.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\ResourceStorage\Consumer;
 
 use ILIAS\ResourceStorage\Consumer\StreamAccess\StreamAccess;
+use ILIAS\ResourceStorage\Flavour\Flavour;
 use ILIAS\ResourceStorage\Policy\FileNamePolicy;
 use ILIAS\ResourceStorage\Policy\NoneFileNamePolicy;
 use ILIAS\ResourceStorage\Resource\StorableResource;
@@ -98,6 +99,14 @@ class ConsumerFactory
             $src_builder,
             $resource,
             $this->stream_access
+        );
+    }
+
+    public function flavourUrl(Flavour $flavour, SrcBuilder $src_builder): FlavourURLs
+    {
+        return new FlavourURLs(
+            $src_builder,
+            $flavour
         );
     }
 

--- a/src/ResourceStorage/Consumer/Consumers.php
+++ b/src/ResourceStorage/Consumer/Consumers.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\ResourceStorage\Consumer;
 
 use ILIAS\ResourceStorage\Collection\CollectionBuilder;
+use ILIAS\ResourceStorage\Flavour\Flavour;
 use ILIAS\ResourceStorage\Identification\ResourceCollectionIdentification;
 use ILIAS\ResourceStorage\Identification\ResourceIdentification;
 use ILIAS\ResourceStorage\Resource\ResourceBuilder;
@@ -98,5 +99,10 @@ class Consumers
             $resources,
             $zip_filename
         );
+    }
+
+    public function flavourUrls(Flavour $flavour): FlavourURLs
+    {
+        return $this->consumer_factory->flavourUrl($flavour, $this->src_builder);
     }
 }

--- a/src/ResourceStorage/Consumer/FlavourURLs.php
+++ b/src/ResourceStorage/Consumer/FlavourURLs.php
@@ -21,20 +21,28 @@ declare(strict_types=1);
 namespace ILIAS\ResourceStorage\Consumer;
 
 use ILIAS\ResourceStorage\Flavour\Flavour;
-use ILIAS\ResourceStorage\Revision\Revision;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-interface SrcBuilder
+class FlavourURLs
 {
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getRevisionURL(Revision $revision, bool $signed = true): string;
+    private SrcBuilder $src_builder;
+    private Flavour $flavour;
 
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator;
+    public function __construct(SrcBuilder $src_builder, Flavour $flavour)
+    {
+        $this->src_builder = $src_builder;
+        $this->flavour = $flavour;
+    }
+
+    public function getURLs(bool $signed = false): \Generator
+    {
+        yield from $this->src_builder->getFlavourURLs($this->flavour, $signed);
+    }
+
+    public function getURLsAsArray(bool $signed = false): array
+    {
+        return iterator_to_array($this->getURLs($signed));
+    }
 }

--- a/src/ResourceStorage/Consumer/InlineSrcBuilder.php
+++ b/src/ResourceStorage/Consumer/InlineSrcBuilder.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\ResourceStorage\Consumer;
 
+use ILIAS\ResourceStorage\Flavour\Flavour;
 use ILIAS\ResourceStorage\Revision\Revision;
 
 /**
@@ -44,5 +45,20 @@ class InlineSrcBuilder implements SrcBuilder
             return "data:$mime;base64,$base64";
         }
         return '';
+    }
+
+    public function getFlavourURLs(
+        Flavour $flavour,
+        bool $signed = true
+    ): \Generator {
+        if ($signed) {
+            throw new \RuntimeException('InlineSrcBuilder does not support signed URLs');
+        }
+        foreach ($flavour->getAccessTokens() as $token) {
+            $stream = $token->resolveStream();
+            $mime = $stream->getMimeType();
+            $base64 = base64_encode((string)$stream);
+            yield "data:$mime;base64,$base64";
+        }
     }
 }

--- a/src/ResourceStorage/Consumer/StreamAccess/StreamAccess.php
+++ b/src/ResourceStorage/Consumer/StreamAccess/StreamAccess.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\ResourceStorage\Consumer\StreamAccess;
 
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\ResourceStorage\Flavour\Flavour;
 use ILIAS\ResourceStorage\Revision\Revision;
 use ILIAS\ResourceStorage\StorageHandler\StorageHandlerFactory;
 
@@ -50,5 +52,16 @@ class StreamAccess
         $token = $this->factory->lease($stream);
 
         return $revision->withToken($token);
+    }
+
+    public function populateFlavour(
+        Flavour $flavour,
+        FileStream $file_stream,
+        int $index
+    ): Flavour {
+        return $flavour->addAccessToken(
+            $index,
+            $this->factory->lease($file_stream, true)
+        );
     }
 }

--- a/src/ResourceStorage/Flavour/Definition/CropToSquare.php
+++ b/src/ResourceStorage/Flavour/Definition/CropToSquare.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Definition;
+
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\CropSquare as MaxSquareSizeMachine;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class CropToSquare implements FlavourDefinition
+{
+    public const FOREVER_ID = '013dd0d556b5716fe54f554623f92449bd0c86d80c698eaf3959b057b7a069a0';
+    protected int $max_size = 500;
+    protected int $quality = 50;
+
+    public function __construct(int $max_size = null)
+    {
+        $this->max_size = $max_size ?? $this->max_size;
+    }
+
+    public function getId(): string
+    {
+        return self::FOREVER_ID;
+    }
+
+
+    public function getFlavourMachineId(): string
+    {
+        return MaxSquareSizeMachine::ID;
+    }
+
+    public function getQuality(): int
+    {
+        return $this->quality;
+    }
+
+    public function getMaxSize(): int
+    {
+        return $this->max_size;
+    }
+
+    public function getInternalName(): string
+    {
+        return 'crop_to_square';
+    }
+
+    public function getVariantName(): ?string
+    {
+        return $this->max_size . 'x' . $this->max_size;
+    }
+
+    public function persist(): bool
+    {
+        return false;
+    }
+}

--- a/src/ResourceStorage/Flavour/Definition/DefaultDefinitions.php
+++ b/src/ResourceStorage/Flavour/Definition/DefaultDefinitions.php
@@ -18,23 +18,27 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\ResourceStorage\Consumer;
-
-use ILIAS\ResourceStorage\Flavour\Flavour;
-use ILIAS\ResourceStorage\Revision\Revision;
+namespace ILIAS\ResourceStorage\Flavour\Definition;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-interface SrcBuilder
+class DefaultDefinitions
 {
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getRevisionURL(Revision $revision, bool $signed = true): string;
+    private array $definitions;
 
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator;
+    public function __construct()
+    {
+        $this->definitions = [
+            PagesToExtract::FOREVER_ID => PagesToExtract::class,
+            CropToSquare::FOREVER_ID => CropToSquare::class,
+            FitToSquare::FOREVER_ID => FitToSquare::class,
+            ToGreyScale::FOREVER_ID => ToGreyScale::class,
+        ];
+    }
+
+    public function get(): array
+    {
+        return $this->definitions;
+    }
 }

--- a/src/ResourceStorage/Flavour/Definition/FitToSquare.php
+++ b/src/ResourceStorage/Flavour/Definition/FitToSquare.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Definition;
+
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\FitSquare;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class FitToSquare implements FlavourDefinition
+{
+    public const FOREVER_ID = '5cd8cb02a6382208da39cc142cbf993f42995452bb6c8d9897a2e227fb238c62';
+    protected int $max_size = 500;
+    protected int $quality = 50;
+
+    public function __construct(int $max_size = null)
+    {
+        $this->max_size = $max_size ?? $this->max_size;
+    }
+
+    public function getId(): string
+    {
+        return self::FOREVER_ID;
+    }
+
+
+    public function getFlavourMachineId(): string
+    {
+        return FitSquare::ID;
+    }
+
+    public function getQuality(): int
+    {
+        return $this->quality;
+    }
+
+    public function getMaxSize(): int
+    {
+        return $this->max_size;
+    }
+
+    public function getInternalName(): string
+    {
+        return 'fit_to_square';
+    }
+
+    public function getVariantName(): ?string
+    {
+        return $this->max_size . 'x' . $this->max_size;
+    }
+
+
+    public function persist(): bool
+    {
+        return false;
+    }
+}

--- a/src/ResourceStorage/Flavour/Definition/FlavourDefinition.php
+++ b/src/ResourceStorage/Flavour/Definition/FlavourDefinition.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\ResourceStorage\Flavour\Definition;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+interface FlavourDefinition
+{
+    /**
+     * @return string max. 64 characters, MUST be unique and NOT a class-related magic-constant.
+     * E.g. you can generate a random one with
+     *   $ php -r"echo hash('sha256', uniqid());" | pbcopy
+     * in your shell and paste string in your getId() implementation.
+     *
+     * If you ever change the ID, existing - maybe persisted - flavours created based on this
+     * definition will not be found anymore and have to be regenerated.
+     */
+    public function getId(): string;
+
+    /**
+     * Defines the ID of the machine that supports this definition. The machine MUST exist.
+     */
+    public function getFlavourMachineId(): string;
+
+    /**
+     * This defines the speaky internal name of the definition, as the consumer would like to use it, e.g. to be
+     * able to distinguish between several flavors.
+     */
+    public function getInternalName(): string;
+
+    /**
+     * If a definition can be used in several variants (e.g. configurable size of a thumbnail),
+     * such variants must be distinguishable. For example, a variant name may contain "{height}x{width}"
+     * if these are configurable values.
+     *
+     * The Variant-Name MUST be less than 768 characters long!
+     */
+    public function getVariantName(): ?string;
+
+    /**
+     * Define whether the generated flavor and the respective streams should be persisted,
+     * or whether they should only be generated and used in-memory.
+     */
+    public function persist(): bool;
+}

--- a/src/ResourceStorage/Flavour/Definition/PagesToExtract.php
+++ b/src/ResourceStorage/Flavour/Definition/PagesToExtract.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Definition;
+
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\ExtractPages;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class PagesToExtract implements FlavourDefinition
+{
+    public const FOREVER_ID = 'cbcb933538e2dfe9460d7a225f7b543b556ee580f41bd4f06cf16a4ca8dd8c8c';
+    private const QUALITY = 20;
+    protected bool $persist;
+    protected int $max_size = 500;
+    protected int $max_pages = 5;
+    protected bool $fill = false;
+
+    public function __construct(bool $persist, int $max_size = 500, int $max_pages = 5, bool $fill = false)
+    {
+        $this->persist = $persist;
+        $this->max_size = $max_size;
+        $this->max_pages = $max_pages;
+        $this->fill = $fill;
+    }
+
+    public function getId(): string
+    {
+        return self::FOREVER_ID;
+    }
+
+
+    public function getFlavourMachineId(): string
+    {
+        return ExtractPages::ID;
+    }
+
+    public function getMaxPages(): int
+    {
+        return $this->max_pages;
+    }
+
+
+    public function getMaxSize(): int
+    {
+        return $this->max_size;
+    }
+
+    public function isFill(): bool
+    {
+        return $this->fill;
+    }
+
+    public function getQuality(): int
+    {
+        return self::QUALITY;
+    }
+
+    public function getInternalName(): string
+    {
+        return 'extracted_pages';
+    }
+
+    public function getVariantName(): ?string
+    {
+        return $this->max_size . 'x' . $this->max_size . ($this->fill ? '_fill' : '');
+    }
+
+
+    public function persist(): bool
+    {
+        return $this->persist;
+    }
+}

--- a/src/ResourceStorage/Flavour/Definition/ToGreyScale.php
+++ b/src/ResourceStorage/Flavour/Definition/ToGreyScale.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Definition;
+
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\MakeGreyScale as GreyScaleMachine;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ToGreyScale implements \ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition
+{
+    public const FOREVER_ID = '0afbf77b53955882c43b6673251261583f3d52ed5e980b6ea6c869c065991406';
+
+    public function getFlavourMachineId(): string
+    {
+        return GreyScaleMachine::ID;
+    }
+
+    public function getId(): string
+    {
+        return self::FOREVER_ID;
+    }
+
+
+    public function getInternalName(): string
+    {
+        return 'greyscale';
+    }
+
+    public function getVariantName(): ?string
+    {
+        return null;
+    }
+
+
+    public function persist(): bool
+    {
+        return false;
+    }
+}

--- a/src/ResourceStorage/Flavour/Engine/DefaultEngines.php
+++ b/src/ResourceStorage/Flavour/Engine/DefaultEngines.php
@@ -18,23 +18,29 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\ResourceStorage\Consumer;
+namespace ILIAS\ResourceStorage\Flavour\Definition;
 
-use ILIAS\ResourceStorage\Flavour\Flavour;
-use ILIAS\ResourceStorage\Revision\Revision;
+use ILIAS\ResourceStorage\Flavour\Engine\GDEngine;
+use ILIAS\ResourceStorage\Flavour\Engine\ImagickEngine;
+use ILIAS\ResourceStorage\Flavour\Engine\NoEngine;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-interface SrcBuilder
+class DefaultEngines
 {
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getRevisionURL(Revision $revision, bool $signed = true): string;
+    private array $engines = [
+        NoEngine::class,
+        GDEngine::class,
+        ImagickEngine::class
+    ];
 
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator;
+    public function __construct()
+    {
+    }
+
+    public function get(): array
+    {
+        return $this->engines;
+    }
 }

--- a/src/ResourceStorage/Flavour/Engine/Engine.php
+++ b/src/ResourceStorage/Flavour/Engine/Engine.php
@@ -18,23 +18,16 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\ResourceStorage\Consumer;
-
-use ILIAS\ResourceStorage\Flavour\Flavour;
-use ILIAS\ResourceStorage\Revision\Revision;
+namespace ILIAS\ResourceStorage\Flavour\Engine;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-interface SrcBuilder
+interface Engine
 {
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getRevisionURL(Revision $revision, bool $signed = true): string;
+    public function __construct();
 
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator;
+    public function supports(string $suffix): bool;
+
+    public function isRunning(): bool;
 }

--- a/src/ResourceStorage/Flavour/Engine/Factory.php
+++ b/src/ResourceStorage/Flavour/Engine/Factory.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Engine;
+
+use ILIAS\ResourceStorage\Flavour\Machine\FlavourMachine;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class Factory
+{
+    private array $engines_strings = [];
+    private array $engines = [];
+
+    public function __construct(array $additional_engines = [])
+    {
+        $this->engines_strings = array_merge($additional_engines, [
+            ImagickEngine::class,
+            GDEngine::class,
+            NoEngine::class
+        ]);
+    }
+
+    public function get(FlavourMachine $machine): ?Engine
+    {
+        $depends_on = $machine->dependsOnEngine();
+        if (!in_array($depends_on, $this->engines_strings)) {
+            return null;
+        }
+        if (isset($this->engines[$depends_on])) {
+            return $this->engines[$depends_on];
+        }
+
+        try {
+            $engine = $this->engines[$depends_on] = new $depends_on();
+        } catch (\Throwable $t) {
+            return null;
+        }
+        return $engine;
+    }
+}

--- a/src/ResourceStorage/Flavour/Engine/GDEngine.php
+++ b/src/ResourceStorage/Flavour/Engine/GDEngine.php
@@ -18,23 +18,36 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\ResourceStorage\Consumer;
-
-use ILIAS\ResourceStorage\Flavour\Flavour;
-use ILIAS\ResourceStorage\Revision\Revision;
+namespace ILIAS\ResourceStorage\Flavour\Engine;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-interface SrcBuilder
+class GDEngine implements Engine
 {
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getRevisionURL(Revision $revision, bool $signed = true): string;
+    protected array $supported = [
+        'jpg',
+        'jpeg',
+        'png',
+        'gif',
+        'bmp',
+        'tiff',
+        'tif',
+        'webp'
+    ];
 
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator;
+    public function __construct()
+    {
+    }
+
+
+    public function supports(string $suffix): bool
+    {
+        return in_array(strtolower($suffix), $this->supported);
+    }
+
+    public function isRunning(): bool
+    {
+        return extension_loaded('gd');
+    }
 }

--- a/src/ResourceStorage/Flavour/Engine/ImagickEngine.php
+++ b/src/ResourceStorage/Flavour/Engine/ImagickEngine.php
@@ -18,23 +18,28 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\ResourceStorage\Consumer;
-
-use ILIAS\ResourceStorage\Flavour\Flavour;
-use ILIAS\ResourceStorage\Revision\Revision;
+namespace ILIAS\ResourceStorage\Flavour\Engine;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-interface SrcBuilder
+class ImagickEngine implements Engine
 {
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getRevisionURL(Revision $revision, bool $signed = true): string;
+    protected array $supported;
 
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator;
+    public function __construct()
+    {
+        $this->supported = $this->isRunning() ? array_map(fn ($item): string => strtolower($item), \Imagick::queryFormats()) : [];
+    }
+
+
+    public function supports(string $suffix): bool
+    {
+        return in_array(strtolower($suffix), $this->supported);
+    }
+
+    public function isRunning(): bool
+    {
+        return extension_loaded('imagick') && class_exists(\Imagick::class);
+    }
 }

--- a/src/ResourceStorage/Flavour/Engine/NoEngine.php
+++ b/src/ResourceStorage/Flavour/Engine/NoEngine.php
@@ -18,23 +18,25 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\ResourceStorage\Consumer;
-
-use ILIAS\ResourceStorage\Flavour\Flavour;
-use ILIAS\ResourceStorage\Revision\Revision;
+namespace ILIAS\ResourceStorage\Flavour\Engine;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-interface SrcBuilder
+class NoEngine implements Engine
 {
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getRevisionURL(Revision $revision, bool $signed = true): string;
+    public function __construct()
+    {
+    }
 
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator;
+
+    public function supports(string $suffix): bool
+    {
+        return true;
+    }
+
+    public function isRunning(): bool
+    {
+        return true;
+    }
 }

--- a/src/ResourceStorage/Flavour/Flavour.php
+++ b/src/ResourceStorage/Flavour/Flavour.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour;
+
+use ILIAS\ResourceStorage\Consumer\StreamAccess\Token;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class Flavour
+{
+    private array $streams = [];
+    private array $tokens = [];
+    private FlavourDefinition $definition;
+    private ResourceIdentification $resource_id;
+    private int $revision;
+
+    public function __construct(FlavourDefinition $definition, ResourceIdentification $resource_id, int $revision)
+    {
+        $this->definition = $definition;
+        $this->resource_id = $resource_id;
+        $this->revision = $revision;
+    }
+
+    /**
+     * Flavours are stored in the file system by the StroageHandler. Thereby you use this hash.
+     * By crc32 these hashes have always a length of 8 characters.
+     * Possible collisions are accepted, because they are very unlikely.
+     */
+    public function getPersistingName(): string
+    {
+        return hash('crc32', $this->getName());
+    }
+
+    public function getName(): string
+    {
+        return $this->definition->getInternalName() . $this->definition->getVariantName();
+    }
+
+    public function getResourceId(): ResourceIdentification
+    {
+        return $this->resource_id;
+    }
+
+    // Tokens
+    public function addAccessToken(int $index, Token $token): Flavour
+    {
+        $this->tokens[$index] = $token;
+
+        return $this;
+    }
+
+    /**
+     * @return Token[]
+     */
+    public function getAccessTokens(): array
+    {
+        return $this->tokens;
+    }
+
+
+    public function getDefinition(): FlavourDefinition
+    {
+        return $this->definition;
+    }
+
+    public function getRevision(): int
+    {
+        return $this->revision;
+    }
+}

--- a/src/ResourceStorage/Flavour/FlavourBuilder.php
+++ b/src/ResourceStorage/Flavour/FlavourBuilder.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour;
+
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\ResourceStorage\Consumer\StreamAccess\StreamAccess;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Machine\Factory;
+use ILIAS\ResourceStorage\Flavour\Machine\NullMachine;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+use ILIAS\ResourceStorage\Resource\Repository\FlavourRepository;
+use ILIAS\ResourceStorage\Resource\ResourceBuilder;
+use ILIAS\ResourceStorage\Resource\ResourceNotFoundException;
+use ILIAS\ResourceStorage\Revision\Revision;
+use ILIAS\ResourceStorage\StorageHandler\StorageHandlerFactory;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ * @internal This class is not part of the public API and may be changed without notice. Do not use this class in your code.
+ */
+class FlavourBuilder
+{
+    public const VARIANT_NAME_MAX_LENGTH = 768;
+    private array $current_revision_cache = [];
+    private array $resources_cache = [];
+    private FlavourRepository $flavour_resource_repository;
+    private Factory $flavour_machine_factory;
+    private ResourceBuilder $resource_builder;
+    private StorageHandlerFactory $storage_handler_factory;
+    private StreamAccess $stream_access;
+
+    public function __construct(
+        FlavourRepository $flavour_resource_repository,
+        Factory $flavour_machine_factory,
+        ResourceBuilder $resource_builder,
+        StorageHandlerFactory $storage_handler_factory,
+        StreamAccess $stream_access
+    ) {
+        $this->flavour_resource_repository = $flavour_resource_repository;
+        $this->flavour_machine_factory = $flavour_machine_factory;
+        $this->resource_builder = $resource_builder;
+        $this->storage_handler_factory = $storage_handler_factory;
+        $this->stream_access = $stream_access;
+    }
+
+    public function has(
+        ResourceIdentification $identification,
+        FlavourDefinition $definition
+    ): bool {
+        $this->checkDefinition($definition);
+        return $this->flavour_resource_repository->has(
+            $identification,
+            $this->getResource($identification)->getCurrentRevision()->getVersionNumber(),
+            $definition
+        );
+    }
+
+    /**
+     * @throws ResourceNotFoundException
+     */
+    public function get(
+        ResourceIdentification $rid,
+        FlavourDefinition $definition,
+        bool $force_building = false
+    ): Flavour {
+        $this->checkDefinition($definition);
+        if (!$this->resource_builder->has($rid)) {
+            throw new ResourceNotFoundException($rid->serialize());
+        }
+        if ($this->has($rid, $definition)) {
+            return $this->read($rid, $definition, $force_building);
+        } else {
+            return $this->build($rid, $definition);
+        }
+    }
+
+    private function build(
+        ResourceIdentification $rid,
+        FlavourDefinition $definition
+    ): Flavour {
+        $flavour = $this->new($definition, $rid);
+        $flavour = $this->runMachine($rid, $definition, $flavour);
+
+        if ($definition->persist()) {
+            $this->flavour_resource_repository->store($flavour);
+            $flavour = $this->populateFlavourWithExistingStreams($flavour);
+        }
+
+
+        return $flavour;
+    }
+
+
+    private function read(
+        ResourceIdentification $rid,
+        FlavourDefinition $definition,
+        bool $force_building = false
+    ): Flavour {
+        $current_revision = $this->getResource($rid)->getCurrentRevision();
+        $flavour = $this->flavour_resource_repository->get(
+            $rid,
+            $current_revision->getVersionNumber(),
+            $definition
+        );
+
+        if ($force_building || !$this->hasFlavourStreams($flavour)) {
+            // ensure deletion of old streams
+            $storage = $this->getStorageHandler($flavour);
+            $storage->deleteFlavour($current_revision, $flavour);
+            // run Machine
+            $flavour = $this->runMachine($rid, $definition, $flavour);
+        } else {
+            $flavour = $this->populateFlavourWithExistingStreams($flavour);
+        }
+
+        return $flavour;
+    }
+
+    private function new(FlavourDefinition $definition, ResourceIdentification $rid): Flavour
+    {
+        return new Flavour(
+            $definition,
+            $rid,
+            $this->getResource($rid)->getCurrentRevision()->getVersionNumber()
+        );
+    }
+
+    public function delete(
+        ResourceIdentification $rid,
+        FlavourDefinition $definition
+    ): bool {
+        $current_revision = $this->getResource($rid)->getCurrentRevision();
+        $revision_number = $current_revision->getVersionNumber();
+
+        if ($this->flavour_resource_repository->has($rid, $revision_number, $definition)) {
+            $flavour = $this->flavour_resource_repository->get($rid, $revision_number, $definition);
+            $this->flavour_resource_repository->delete($flavour);
+            $storage = $this->getStorageHandler($flavour);
+            $storage->deleteFlavour($current_revision, $flavour);
+
+            return true;
+        }
+
+
+        return false;
+    }
+
+    // STREAMS
+
+    private function hasFlavourStreams(Flavour $flavour): bool
+    {
+        return $this->getStorageHandler($flavour)->hasFlavour(
+            $this->getCurrentRevision($flavour),
+            $flavour
+        );
+    }
+
+
+    private function storeFlavourStreams(Flavour $flavour, array $streams): void
+    {
+        $storable = new StorableFlavourDecorator($flavour);
+        $storable->setStreams($streams);
+
+        $this->getStorageHandler($flavour)->storeFlavour(
+            $this->getCurrentRevision($flavour),
+            $storable
+        );
+    }
+
+    private function populateFlavourWithExistingStreams(Flavour $flavour): Flavour
+    {
+        $handler = $this->getStorageHandler($flavour);
+        $identification = $flavour->getResourceId();
+        $revision = $this->getCurrentRevision($flavour);
+        foreach (
+            $handler->getFlavourStreams(
+                $revision,
+                $flavour
+            ) as $index => $file_stream
+        ) {
+            $flavour = $this->stream_access->populateFlavour($flavour, $file_stream, $index);
+        }
+        return $flavour;
+    }
+
+    // DEFINITIONS AND MACHINES
+    private function checkDefinitionForMachine(FlavourDefinition $definition, Machine\FlavourMachine $machine): void
+    {
+        if (!$machine->canHandleDefinition($definition)) {
+            throw new \InvalidArgumentException("FlavourDefinition not supported by machine");
+        }
+    }
+
+    private function checkDefinition(FlavourDefinition $definition): void
+    {
+        if (strlen($definition->getVariantName()) > self::VARIANT_NAME_MAX_LENGTH) {
+            throw new \InvalidArgumentException("FlavourDefinition variant name too long");
+        }
+    }
+
+    public function testDefinition(
+        ResourceIdentification $rid,
+        FlavourDefinition $definition
+    ): bool {
+        try {
+            $this->checkDefinition($definition);
+            $machine = $this->flavour_machine_factory->get($definition);
+            $this->checkDefinitionForMachine($definition, $machine);
+        } catch (\Throwable $e) {
+            return false;
+        }
+        if ($machine instanceof NullMachine) {
+            return false;
+        }
+        $engine = $machine->getEngine();
+        if (!$engine->isRunning()) {
+            return false;
+        }
+        $current_revision = $this->getResource($rid)->getCurrentRevision();
+        $suffix = $current_revision->getInformation()->getSuffix();
+
+        return $engine->supports($suffix);
+    }
+
+    // STREAMS GENERATION
+    protected function runMachine(
+        ResourceIdentification $rid,
+        FlavourDefinition $definition,
+        Flavour $flavour
+    ): Flavour {
+        $revision = $this->getCurrentRevision($flavour);
+
+        // Get Orignal Stream of Resource/Revision
+        $handler = $this->getStorageHandler($flavour);
+        $stream = $this->resource_builder->extractStream($revision);
+        $stream->rewind();
+
+        // Get Machine
+        $machine = $this->flavour_machine_factory->get($definition);
+        $this->checkDefinitionForMachine($definition, $machine);
+
+        // Run Machine and get Streams
+        $storable_streams = [];
+        foreach (
+            $machine->processStream(
+                $revision->getInformation(),
+                $stream,
+                $definition
+            ) as $result
+        ) {
+            $generated_stream = $result->getStream();
+            if ($result->isStoreable()) {
+                // Collect Streams to store persistently
+                $storable_streams[$result->getIndex()] = $generated_stream;
+            }
+
+            $cloned_stream = Streams::ofString((string)$generated_stream);
+
+            $flavour = $this->stream_access->populateFlavour(
+                $flavour,
+                $cloned_stream,
+                $result->getIndex()
+            );
+        }
+
+        // Store Streams persistently if needed
+        if ($definition->persist()) {
+            $this->storeFlavourStreams($flavour, $storable_streams);
+        }
+
+        return $flavour;
+    }
+
+
+    // Helpers
+
+    private function getCurrentRevision(Flavour $flavour): Revision
+    {
+        $rid = $flavour->getResourceId()->serialize();
+        if (isset($this->current_revision_cache[$rid])) {
+            return $this->current_revision_cache[$rid];
+        }
+        return $this->current_revision_cache[$rid] = $this->getResourceOfFlavour($flavour)->getCurrentRevision();
+    }
+
+    private function getResource(ResourceIdentification $rid): \ILIAS\ResourceStorage\Resource\StorableResource
+    {
+        $rid_string = $rid->serialize();
+        if (isset($this->resources_cache[$rid_string])) {
+            return $this->resources_cache[$rid_string];
+        }
+        return $this->resources_cache[$rid_string] = $this->resource_builder->get($rid);
+    }
+
+    private function getResourceOfFlavour(Flavour $flavour): \ILIAS\ResourceStorage\Resource\StorableResource
+    {
+        return $this->getResource($flavour->getResourceID());
+    }
+
+    private function getStorageHandler(Flavour $flavour): \ILIAS\ResourceStorage\StorageHandler\StorageHandler
+    {
+        return $this->storage_handler_factory->getHandlerForResource($this->getResourceOfFlavour($flavour));
+    }
+}

--- a/src/ResourceStorage/Flavour/Flavours.php
+++ b/src/ResourceStorage/Flavour/Flavours.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour;
+
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+use ILIAS\ResourceStorage\Resource\ResourceBuilder;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class Flavours
+{
+    protected FlavourBuilder $flavour_builder;
+    protected ResourceBuilder $resource_builder;
+
+    public function __construct(
+        FlavourBuilder $flavour_builder,
+        ResourceBuilder $resource_builder
+    ) {
+        $this->flavour_builder = $flavour_builder;
+        $this->resource_builder = $resource_builder;
+    }
+
+
+    /**
+     * @description Use get() to get a Flavour for the FlavourDefinition for a ResourceIdentification.
+     * If the Flavour already exists you will get it, if not it will be created and returned directly.
+     *
+     * Take into account that a Flavour can come back without Tokens for accessing the streams of the Flavour,
+     * namely if the Flavour does not contain any Streams. You will usually use the flavor with the Consumers of
+     * the IRSS anyway, so you don't have to worry about that.
+     */
+    public function get(ResourceIdentification $rid, FlavourDefinition $flavour_definition): Flavour
+    {
+        return $this->flavour_builder->get($rid, $flavour_definition, false);
+    }
+
+    /**
+     * @description Actually like get(), but without return and can be used to create Flavour before you want to get them.
+     */
+    public function ensure(ResourceIdentification $rid, FlavourDefinition $flavour_definition): void
+    {
+        if ($this->flavour_builder->has($rid, $flavour_definition)) {
+            return;
+        }
+        $this->flavour_builder->get($rid, $flavour_definition, true);
+    }
+
+    /**
+     * @description This can be used to ask whether a Flavor already exists for the FlavourDefinition for a
+     * certain IRSS ResourceIdentification.
+     */
+    public function has(ResourceIdentification $rid, FlavourDefinition $flavour_definition): bool
+    {
+        return $this->flavour_builder->has($rid, $flavour_definition);
+    }
+
+
+    /**
+     * @description You don't need a flavor anymore or you want to delete it because you explicitly want to regenerate it?
+     * Use delete for this
+     */
+    public function remove(ResourceIdentification $rid, FlavourDefinition $flavour_definition): void
+    {
+        if ($this->has($rid, $flavour_definition)) {
+            $this->flavour_builder->delete($rid, $flavour_definition);
+        }
+    }
+
+
+    /**
+     * @description Hereby you can check in advance, if there is a Machine and an Engine for your FlavourDefinition,
+     * which can generate the Flavour you want.
+     */
+    public function possible(ResourceIdentification $rid, FlavourDefinition $flavour_definition): bool
+    {
+        return $this->flavour_builder->testDefinition($rid, $flavour_definition);
+    }
+}

--- a/src/ResourceStorage/Flavour/Machine/DefaultMachines/AbstractMachine.php
+++ b/src/ResourceStorage/Flavour/Machine/DefaultMachines/AbstractMachine.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines;
+
+use ILIAS\ResourceStorage\Flavour\Engine\Engine;
+use ILIAS\ResourceStorage\Flavour\Machine\FlavourMachine;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+abstract class AbstractMachine implements FlavourMachine
+{
+    protected ?Engine $engine = null;
+
+    public function __construct()
+    {
+    }
+
+    public function withEngine(Engine $engine): FlavourMachine
+    {
+        $clone = clone $this;
+        $clone->engine = $engine;
+        return $clone;
+    }
+
+    public function getEngine(): Engine
+    {
+        if ($this->engine === null) {
+            throw new \OutOfBoundsException("Engine not available");
+        }
+        return $this->engine;
+    }
+}

--- a/src/ResourceStorage/Flavour/Machine/DefaultMachines/CropSquare.php
+++ b/src/ResourceStorage/Flavour/Machine/DefaultMachines/CropSquare.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\ResourceStorage\Flavour\Definition\CropToSquare;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Engine\GDEngine;
+use ILIAS\ResourceStorage\Flavour\Machine\FlavourMachine;
+use ILIAS\ResourceStorage\Flavour\Machine\Result;
+use ILIAS\ResourceStorage\Information\FileInformation;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class CropSquare extends AbstractMachine implements FlavourMachine
+{
+    use GdImageToStreamTrait;
+
+    public const ID = 'crop_square';
+    public const QUALITY = 30;
+
+    public function getId(): string
+    {
+        return self::ID;
+    }
+
+
+    public function canHandleDefinition(FlavourDefinition $definition): bool
+    {
+        return $definition instanceof CropToSquare;
+    }
+
+    public function dependsOnEngine(): ?string
+    {
+        return GDEngine::class;
+    }
+
+
+    public function processStream(
+        FileInformation $information,
+        FileStream $stream,
+        FlavourDefinition $for_definition
+    ): \Generator {
+        if (!$for_definition instanceof \ILIAS\ResourceStorage\Flavour\Definition\CropToSquare) {
+            throw new \InvalidArgumentException('Invalid definition');
+        }
+        $image = $this->from($stream);
+        if (!is_resource($image) && !$image instanceof \GdImage) {
+            return;
+        }
+
+        $stream_path = $stream->getMetadata('uri');
+        [$width, $height] = getimagesize($stream_path);
+
+        if ($width > $height) {
+            $y = 0;
+            $x = ($width - $height) / 2;
+            $smallest_side = $height;
+        } else {
+            $x = 0;
+            $y = ($height - $width) / 2;
+            $smallest_side = $width;
+        }
+
+        $size = $for_definition->getMaxSize();
+
+        $thumb = imagecreatetruecolor($size, $size);
+        imagecopyresampled(
+            $thumb,
+            $image,
+            0,
+            0,
+            $x,
+            $y,
+            $size,
+            $size,
+            $smallest_side,
+            $smallest_side
+        );
+
+        imagedestroy($image);
+
+        $stream = $this->to($thumb);
+
+        yield new Result(
+            $for_definition,
+            $stream,
+            0,
+            true
+        );
+    }
+}

--- a/src/ResourceStorage/Flavour/Machine/DefaultMachines/DefaultMachines.php
+++ b/src/ResourceStorage/Flavour/Machine/DefaultMachines/DefaultMachines.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,23 +17,28 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\ResourceStorage\Consumer;
-
-use ILIAS\ResourceStorage\Flavour\Flavour;
-use ILIAS\ResourceStorage\Revision\Revision;
+namespace ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-interface SrcBuilder
+class DefaultMachines
 {
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getRevisionURL(Revision $revision, bool $signed = true): string;
+    private array $machines = [];
 
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator;
+    public function __construct()
+    {
+        $this->machines = [
+            MakeGreyScale::ID => MakeGreyScale::class,
+            CropSquare::ID => CropSquare::class,
+            FitSquare::ID => FitSquare::class,
+            ExtractPages::ID => ExtractPages::class,
+        ];
+    }
+
+
+    public function get(): array
+    {
+        return $this->machines;
+    }
 }

--- a/src/ResourceStorage/Flavour/Machine/DefaultMachines/ExtractPages.php
+++ b/src/ResourceStorage/Flavour/Machine/DefaultMachines/ExtractPages.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Definition\PagesToExtract;
+use ILIAS\ResourceStorage\Flavour\Engine\ImagickEngine;
+use ILIAS\ResourceStorage\Flavour\Machine\FlavourMachine;
+use ILIAS\ResourceStorage\Flavour\Machine\Result;
+use ILIAS\ResourceStorage\Information\FileInformation;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ExtractPages extends AbstractMachine implements FlavourMachine
+{
+    use GdImageToStreamTrait;
+
+    public const ID = 'extract_pages';
+    public const PREVIEW_IMAGE_FORMAT = 'jpg';
+
+
+    public function getId(): string
+    {
+        return self::ID;
+    }
+
+    public function dependsOnEngine(): ?string
+    {
+        return ImagickEngine::class;
+    }
+
+
+    public function canHandleDefinition(FlavourDefinition $definition): bool
+    {
+        return $definition instanceof PagesToExtract;
+    }
+
+    public function processStream(
+        FileInformation $information,
+        FileStream $stream,
+        FlavourDefinition $for_definition
+    ): \Generator {
+        if (!$for_definition instanceof PagesToExtract) {
+            throw new \InvalidArgumentException('Invalid definition');
+        }
+
+        if (!class_exists(\Imagick::class)) {
+            return;
+        }
+
+        $img = new \Imagick();
+
+        try {
+            $resource = $stream->detach();
+            fseek($resource, 0);
+            $img->readImageFile($resource);
+        } catch (\ImagickException $e) {
+            // due to possible security risks, gs disabled access to files, see e.g. https://en.linuxportal.info/tutorials/troubleshooting/how-to-fix-errors-from-imagemagick-imagick-conversion-system-security-policy
+            return;
+        }
+
+
+        $img->setBackgroundColor('white');
+        $img->mergeImageLayers(\Imagick::LAYERMETHOD_FLATTEN);
+        $img->resetIterator();
+
+        $use_thumbnail = true;
+        $max_size = $for_definition->getMaxSize();
+
+        for ($x = 0; ($x < $for_definition->getMaxPages() && $x < $img->getNumberImages()); $x++) {
+            $img->setIteratorIndex($x);
+            $img->setImageAlphaChannel(\Imagick::ALPHACHANNEL_REMOVE);
+            $img->setImageFormat(self::PREVIEW_IMAGE_FORMAT);
+            if ($use_thumbnail) {
+                $yield = $img->thumbnailImage($max_size, $max_size, true, $for_definition->isFill());
+            } else {
+                $img->setImageCompression(\Imagick::COMPRESSION_JPEG);
+                $img->setImageCompressionQuality($for_definition->getQuality());
+                $img->stripImage();
+                $img->scaleImage($max_size, 0);
+                $yield = true;
+            }
+
+            if ($yield) {
+                yield new Result(
+                    $for_definition,
+                    Streams::ofString($img->getImageBlob()),
+                    $x,
+                    $for_definition->persist()
+                );
+            }
+        }
+        $img->destroy();
+    }
+}

--- a/src/ResourceStorage/Flavour/Machine/DefaultMachines/FitSquare.php
+++ b/src/ResourceStorage/Flavour/Machine/DefaultMachines/FitSquare.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\ResourceStorage\Flavour\Definition\FitToSquare;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Engine\GDEngine;
+use ILIAS\ResourceStorage\Flavour\Machine\FlavourMachine;
+use ILIAS\ResourceStorage\Flavour\Machine\Result;
+use ILIAS\ResourceStorage\Information\FileInformation;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class FitSquare extends AbstractMachine implements FlavourMachine
+{
+    use GdImageToStreamTrait;
+
+    public const ID = 'fit_square';
+
+
+    public function getId(): string
+    {
+        return self::ID;
+    }
+
+
+    public function canHandleDefinition(FlavourDefinition $definition): bool
+    {
+        return $definition instanceof FitToSquare;
+    }
+
+    public function dependsOnEngine(): ?string
+    {
+        return GDEngine::class;
+    }
+
+    public function processStream(
+        FileInformation $information,
+        FileStream $stream,
+        FlavourDefinition $for_definition
+    ): \Generator {
+        if (!$for_definition instanceof \ILIAS\ResourceStorage\Flavour\Definition\FitToSquare) {
+            throw new \InvalidArgumentException('Invalid definition');
+        }
+        $image = $this->from($stream);
+        if (!is_resource($image) && !$image instanceof \GdImage) {
+            return;
+        }
+
+        $size = $for_definition->getMaxSize();
+
+        $cur_width = imagesx($image);
+        $cur_height = imagesy($image);
+
+        if ($cur_width < $size && $cur_height < $size) {
+            return;
+        }
+
+        $width_ratio = $size / $cur_width;
+        $height_ratio = $size / $cur_height;
+        $ratio = min($width_ratio, $height_ratio);
+
+        $new_height = (int)floor($cur_height * $ratio);
+        $new_width = (int)floor($cur_width * $ratio);
+        $resized = imagescale($image, $new_width, $new_height);
+        imagedestroy($image);
+        // TODO REMOVE Filters
+        imagefilter($resized, IMG_FILTER_EDGEDETECT, 50, true);
+        imagefilter($resized, IMG_FILTER_NEGATE, 50, true);
+        imagefilter($resized, IMG_FILTER_CONTRAST, -100);
+
+        $stream = $this->to($resized);
+
+        yield new Result($for_definition, $stream, 0, true);
+    }
+}

--- a/src/ResourceStorage/Flavour/Machine/DefaultMachines/GdImageToStreamTrait.php
+++ b/src/ResourceStorage/Flavour/Machine/DefaultMachines/GdImageToStreamTrait.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\Filesystem\Stream\Streams;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+trait GdImageToStreamTrait
+{
+    /**
+     * Currently this is the only way to make a FileStream from a GD image resource.
+     * As soon as this is possible diretly, we can just switch the implementation here.
+     */
+    protected function to(\GdImage $image, int $quality = null): FileStream
+    {
+        ob_start();
+        imagejpeg($image, null, $quality ?? 75);
+        $stringdata = ob_get_contents();
+        imagedestroy($image);
+        ob_end_clean();
+
+        return Streams::ofString($stringdata);
+    }
+
+    protected function from(FileStream $stream): ?\GdImage
+    {
+        return imagecreatefromstring($stream->getContents()) ?: null;
+    }
+}

--- a/src/ResourceStorage/Flavour/Machine/DefaultMachines/MakeGreyScale.php
+++ b/src/ResourceStorage/Flavour/Machine/DefaultMachines/MakeGreyScale.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Definition\ToGreyScale;
+use ILIAS\ResourceStorage\Flavour\Engine\GDEngine;
+use ILIAS\ResourceStorage\Flavour\Machine\Result;
+use ILIAS\ResourceStorage\Information\FileInformation;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class MakeGreyScale extends AbstractMachine implements \ILIAS\ResourceStorage\Flavour\Machine\FlavourMachine
+{
+    use GdImageToStreamTrait;
+
+    public const ID = 'greyscale';
+    public const QUALITY = 70;
+
+
+    public function getId(): string
+    {
+        return self::ID;
+    }
+
+    public function canHandleDefinition(FlavourDefinition $definition): bool
+    {
+        return $definition instanceof ToGreyScale;
+    }
+
+    public function dependsOnEngine(): ?string
+    {
+        return GDEngine::class;
+    }
+
+    public function processStream(
+        FileInformation $information,
+        FileStream $stream,
+        FlavourDefinition $for_definition
+    ): \Generator {
+        $image = $this->from($stream);
+        if (!is_resource($image) && !$image instanceof \GdImage) {
+            return;
+        }
+        imagefilter($image, IMG_FILTER_GRAYSCALE, 50, true);
+
+        yield new Result($for_definition, $this->to($image, self::QUALITY), 0, true);
+    }
+}

--- a/src/ResourceStorage/Flavour/Machine/Factory.php
+++ b/src/ResourceStorage/Flavour/Machine/Factory.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Machine;
+
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\DefaultMachines;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class Factory
+{
+    /**
+     * @var array<string, class-string<FlavourMachine>>
+     */
+    protected array $machines_string = [];
+    /**
+     * @var FlavourMachine[]
+     */
+    protected array $machines_instances = [];
+    private \ILIAS\ResourceStorage\Flavour\Engine\Factory $engines;
+
+    public function __construct(
+        \ILIAS\ResourceStorage\Flavour\Engine\Factory $engine_factory,
+        array $machines_string = []
+    ) {
+        $default_machines = new DefaultMachines();
+        $this->machines_string = array_merge($default_machines->get(), $machines_string);
+        $this->engines = $engine_factory;
+    }
+
+    public function get(FlavourDefinition $definition): FlavourMachine
+    {
+        $null_machine = new NullMachine();
+        $definition_id = $definition->getFlavourMachineId();
+
+        $machine_string = $this->machines_string[$definition_id] ?? null;
+        if ($machine_string === null) {
+            return $null_machine->withReason('No machine found for definition ' . $definition->getId());
+        }
+        if (isset($this->machines_instances[$definition_id])) {
+            return $this->machines_instances[$definition_id];
+        }
+        try {
+            $machine = new $machine_string();
+        } catch (\Throwable $t) {
+            return $null_machine->withReason('Could not instantiate machine ' . $machine_string);
+        }
+
+        if (!$machine instanceof FlavourMachine) {
+            return $null_machine->withReason('Machine ' . $machine_string . ' does not implement FlavourMachine');
+        }
+
+        $engine = $this->engines->get($machine);
+
+        if (!$engine instanceof \ILIAS\ResourceStorage\Flavour\Engine\Engine || !$engine->isRunning()) {
+            return $null_machine->withReason(
+                'Machine ' . $machine_string . ' depends on engine ' .
+                $machine->dependsOnEngine()
+                . ' which is not running or available.'
+            );
+        }
+
+        $machine = $machine->withEngine($engine);
+
+        return $this->machines_instances[$definition_id] = $machine;
+    }
+}

--- a/src/ResourceStorage/Flavour/Machine/FlavourMachine.php
+++ b/src/ResourceStorage/Flavour/Machine/FlavourMachine.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\ResourceStorage\Flavour\Machine;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Engine\Engine;
+use ILIAS\ResourceStorage\Information\FileInformation;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+interface FlavourMachine
+{
+    /**
+     * FlavourMachines must be able to be created without further dependencies
+     */
+    public function __construct();
+
+    /**
+     * @return string max. 64 characters, MUST be unique and NOT a class-related magic-constant.
+     * E.g. you can generate a random one with
+     *   $ php -r"echo hash('sha256', uniqid());" | pbcopy
+     * in your shell and paste string in your getId() implementation.
+     *
+     * If you ever change the ID, FlavourDefinitions may no longer process anything with your
+     * machine that previously designated you as the processing machine.
+     */
+    public function getId(): string;
+
+    /**
+     * Check if a corresponding configuration can be processed by this Machine.
+     */
+    public function canHandleDefinition(FlavourDefinition $definition): bool;
+
+    /**
+     * Return the class name of the Engine that is required for this Machine to work. Returning null will
+     * result in a NullEngine passed to the Machine.
+     */
+    public function dependsOnEngine(): ?string;
+
+    /**
+     * The demanded Engine will be passed here. If the Machine does not depend on an Engine, a NullEngine
+     */
+    public function withEngine(Engine $engine): FlavourMachine;
+
+    /**
+     * @throws \OutOfBoundsException if the Machine is not yet initialized with an Engine
+     */
+    public function getEngine(): Engine;
+
+    /**
+     * @param FileInformation $information of the original File.
+     * @param FileStream $stream of the original File.
+     * @param FlavourDefinition $for_definition the definition for which the stream should be processed.
+     *
+     * @return Result[]|\Generator For each "thing" that the machine generates, a result can be returned.
+     * E.g. when extracting 5 images from a PDF, 5 results are returned (Generator).
+     */
+    public function processStream(
+        FileInformation $information,
+        FileStream $stream,
+        FlavourDefinition $for_definition
+    ): \Generator;
+}

--- a/src/ResourceStorage/Flavour/Machine/NonStoreableResult.php
+++ b/src/ResourceStorage/Flavour/Machine/NonStoreableResult.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,23 +17,26 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\ResourceStorage\Consumer;
+namespace ILIAS\ResourceStorage\Flavour\Machine;
 
-use ILIAS\ResourceStorage\Flavour\Flavour;
-use ILIAS\ResourceStorage\Revision\Revision;
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
-interface SrcBuilder
+class NonStoreableResult extends Result
 {
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getRevisionURL(Revision $revision, bool $signed = true): string;
+    protected FlavourDefinition $definition;
+    protected FileStream $stream;
 
-    /**
-     * @throw \RuntimeException if signing is not possible or failed, but was requested with $signed = true
-     */
-    public function getFlavourURLs(Flavour $flavour, bool $signed = true): \Generator;
+    public function __construct(
+        FlavourDefinition $definition,
+        FileStream $stream,
+        int $index = 0
+    ) {
+        $this->definition = $definition;
+        $this->stream = $stream;
+        parent::__construct($definition, $stream, $index, false);
+    }
 }

--- a/src/ResourceStorage/Flavour/Machine/NullMachine.php
+++ b/src/ResourceStorage/Flavour/Machine/NullMachine.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\ResourceStorage\Flavour\Machine;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Engine\NoEngine;
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\AbstractMachine;
+use ILIAS\ResourceStorage\Information\FileInformation;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class NullMachine extends AbstractMachine implements FlavourMachine
+{
+    private string $reason = '';
+
+
+    public function getId(): string
+    {
+        return 'null_machine';
+    }
+
+    public function canHandleDefinition(FlavourDefinition $definition): bool
+    {
+        return true;
+    }
+
+    public function dependsOnEngine(): ?string
+    {
+        return NoEngine::class;
+    }
+
+    public function withReason(string $reason): FlavourMachine
+    {
+        $clone = clone $this;
+        $clone->reason = $reason;
+        return $clone;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+
+    public function processStream(
+        FileInformation $information,
+        FileStream $stream,
+        FlavourDefinition $for_definition
+    ): \Generator {
+        yield new NonStoreableResult(
+            $for_definition,
+            Streams::ofString('empty')
+        );
+    }
+}

--- a/src/ResourceStorage/Flavour/Machine/Result.php
+++ b/src/ResourceStorage/Flavour/Machine/Result.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour\Machine;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class Result
+{
+    protected FlavourDefinition $definition;
+    protected FileStream $stream;
+    protected int $index = 0;
+    protected bool $storeable = true;
+
+    public function __construct(
+        FlavourDefinition $definition,
+        FileStream $stream,
+        int $index = 0,
+        bool $storeable = true
+    ) {
+        $this->definition = $definition;
+        $this->stream = $stream;
+        $this->index = $index;
+        $this->storeable = $storeable;
+    }
+
+    public function getIndex(): int
+    {
+        return $this->index;
+    }
+
+
+    public function getDefinition(): FlavourDefinition
+    {
+        return $this->definition;
+    }
+
+    public function getStream(): FileStream
+    {
+        return $this->stream;
+    }
+
+    public function isStoreable(): bool
+    {
+        return $this->storeable;
+    }
+}

--- a/src/ResourceStorage/Flavour/StorableFlavourDecorator.php
+++ b/src/ResourceStorage/Flavour/StorableFlavourDecorator.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Flavour;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ * @internal
+ */
+final class StorableFlavourDecorator extends Flavour
+{
+    private array $streams = [];
+    protected Flavour $flavour;
+
+    public function __construct(Flavour $flavour)
+    {
+        $this->flavour = $flavour;
+    }
+
+    public function getFlavour(): Flavour
+    {
+        return $this->flavour;
+    }
+
+    public function getPersistingName(): string
+    {
+        return $this->flavour->getPersistingName();
+    }
+
+    public function getName(): string
+    {
+        return $this->flavour->getName();
+    }
+
+    public function getResourceId(): ResourceIdentification
+    {
+        return $this->flavour->getResourceId();
+    }
+
+    public function getDefinition(): FlavourDefinition
+    {
+        return $this->flavour->getDefinition();
+    }
+
+    public function getRevision(): int
+    {
+        return $this->flavour->getRevision();
+    }
+
+    // STREAMS
+
+    /**
+     * @description Filter Streams with a Closure which accepts a FileStream and returns bool
+     */
+    public function filterStreams(\Closure $filter): void
+    {
+        $this->streams = array_filter(
+            $this->streams,
+            $filter
+        );
+    }
+
+    public function setStreams(array $streams): void
+    {
+        foreach ($streams as $index => $stream) {
+            $this->addStream($index, $stream);
+        }
+    }
+
+
+    public function addStream(int $index, FileStream $stream): self
+    {
+        $this->streams[$index] = $stream;
+
+        return $this;
+    }
+
+    public function getStream(int $index = 0): ?FileStream
+    {
+        return $this->streams[$index] ?? null;
+    }
+
+    /**
+     * @return FileStream[]
+     */
+    public function getStreams(): array
+    {
+        return $this->streams;
+    }
+}

--- a/src/ResourceStorage/Preloader/StandardRepositoryPreloader.php
+++ b/src/ResourceStorage/Preloader/StandardRepositoryPreloader.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\ResourceStorage\Preloader;
 
 use ILIAS\ResourceStorage\Repositories;
+use ILIAS\ResourceStorage\Resource\Repository\FlavourRepository;
 
 /**
  * Class StandardRepositoryPreloader
@@ -32,6 +33,7 @@ class StandardRepositoryPreloader implements RepositoryPreloader
     protected \ILIAS\ResourceStorage\Revision\Repository\RevisionRepository $revision_repository;
     protected \ILIAS\ResourceStorage\Information\Repository\InformationRepository $information_repository;
     protected \ILIAS\ResourceStorage\Stakeholder\Repository\StakeholderRepository $stakeholder_repository;
+    protected FlavourRepository $flavour_repository;
 
     public function __construct(Repositories $repositories)
     {
@@ -39,6 +41,7 @@ class StandardRepositoryPreloader implements RepositoryPreloader
         $this->revision_repository = $repositories->getRevisionRepository();
         $this->information_repository = $repositories->getInformationRepository();
         $this->stakeholder_repository = $repositories->getStakeholderRepository();
+        $this->flavour_repository = $repositories->getFlavourRepository();
     }
 
     public function preload(array $identification_strings): void
@@ -47,5 +50,6 @@ class StandardRepositoryPreloader implements RepositoryPreloader
         $this->revision_repository->preload($identification_strings);
         $this->information_repository->preload($identification_strings);
         $this->stakeholder_repository->preload($identification_strings);
+        $this->flavour_repository->preload($identification_strings);
     }
 }

--- a/src/ResourceStorage/Repositories.php
+++ b/src/ResourceStorage/Repositories.php
@@ -22,6 +22,7 @@ namespace ILIAS\ResourceStorage;
 
 use ILIAS\ResourceStorage\Collection\Repository\CollectionRepository;
 use ILIAS\ResourceStorage\Information\Repository\InformationRepository;
+use ILIAS\ResourceStorage\Resource\Repository\FlavourRepository;
 use ILIAS\ResourceStorage\Resource\Repository\ResourceRepository;
 use ILIAS\ResourceStorage\Revision\Repository\RevisionRepository;
 use ILIAS\ResourceStorage\Stakeholder\Repository\StakeholderRepository;
@@ -38,19 +39,22 @@ class Repositories
     private CollectionRepository $collection_repository;
     private InformationRepository $information_repository;
     private StakeholderRepository $stakeholder_repository;
+    private FlavourRepository $flavour_repository;
 
     public function __construct(
         RevisionRepository $revision_repository,
         ResourceRepository $resource_repository,
         CollectionRepository $collection_repository,
         InformationRepository $information_repository,
-        StakeholderRepository $stakeholder_repository
+        StakeholderRepository $stakeholder_repository,
+        FlavourRepository $flavour_repository
     ) {
         $this->revision_repository = $revision_repository;
         $this->resource_repository = $resource_repository;
         $this->collection_repository = $collection_repository;
         $this->information_repository = $information_repository;
         $this->stakeholder_repository = $stakeholder_repository;
+        $this->flavour_repository = $flavour_repository;
     }
 
     public function getRevisionRepository(): RevisionRepository
@@ -76,5 +80,10 @@ class Repositories
     public function getStakeholderRepository(): StakeholderRepository
     {
         return $this->stakeholder_repository;
+    }
+
+    public function getFlavourRepository(): FlavourRepository
+    {
+        return $this->flavour_repository;
     }
 }

--- a/src/ResourceStorage/Resource/Repository/FlavourRepository.php
+++ b/src/ResourceStorage/Resource/Repository/FlavourRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\ResourceStorage\Resource\Repository;
+
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Flavour;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+use ILIAS\ResourceStorage\Preloader\PreloadableRepository;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+interface FlavourRepository extends PreloadableRepository
+{
+    public function has(ResourceIdentification $rid, int $revision, FlavourDefinition $definition): bool;
+
+    public function store(Flavour $flavour): void;
+
+    public function get(ResourceIdentification $rid, int $revision, FlavourDefinition $definition): Flavour;
+
+    public function delete(Flavour $flavour): void;
+}

--- a/src/ResourceStorage/Services.php
+++ b/src/ResourceStorage/Services.php
@@ -28,6 +28,9 @@ use ILIAS\ResourceStorage\Consumer\InlineSrcBuilder;
 use ILIAS\ResourceStorage\Consumer\SrcBuilder;
 use ILIAS\ResourceStorage\Consumer\StreamAccess\StreamAccess;
 use ILIAS\ResourceStorage\Consumer\StreamAccess\TokenFactory;
+use ILIAS\ResourceStorage\Flavour\FlavourBuilder;
+use ILIAS\ResourceStorage\Flavour\Flavours;
+use ILIAS\ResourceStorage\Flavour\Machine\Factory;
 use ILIAS\ResourceStorage\Identification\UniqueIDCollectionIdentificationGenerator;
 use ILIAS\ResourceStorage\Lock\LockHandler;
 use ILIAS\ResourceStorage\Manager\Manager;
@@ -49,6 +52,7 @@ class Services
     protected \ILIAS\ResourceStorage\Manager\Manager $manager;
     protected \ILIAS\ResourceStorage\Consumer\Consumers $consumers;
     protected \ILIAS\ResourceStorage\Collection\Collections $collections;
+    protected \ILIAS\ResourceStorage\Flavour\Flavours $flavours;
     protected \ILIAS\ResourceStorage\Preloader\RepositoryPreloader $preloader;
 
     /**
@@ -57,6 +61,7 @@ class Services
     public function __construct(
         StorageHandlerFactory $storage_handler_factory,
         Repositories $repositories,
+        Artifacts $artifacts,
         LockHandler $lock_handler,
         FileNamePolicy $file_name_policy,
         StreamAccess $stream_access,
@@ -98,6 +103,24 @@ class Services
             $collection_builder,
             $this->preloader
         );
+
+        $machine_factory = new Factory(
+            new \ILIAS\ResourceStorage\Flavour\Engine\Factory(),
+            $artifacts->getFlavourMachines()
+        );
+
+        $flavour_builder = new FlavourBuilder(
+            $repositories->getFlavourRepository(),
+            $machine_factory,
+            $resource_builder,
+            $storage_handler_factory,
+            $stream_access
+        );
+
+        $this->flavours = new Flavours(
+            $flavour_builder,
+            $resource_builder
+        );
     }
 
     public function manage(): Manager
@@ -113,6 +136,11 @@ class Services
     public function collection(): Collections
     {
         return $this->collections;
+    }
+
+    public function flavours(): Flavours
+    {
+        return $this->flavours;
     }
 
     public function preload(array $identification_strings): void

--- a/src/ResourceStorage/StorageHandler/StorageHandler.php
+++ b/src/ResourceStorage/StorageHandler/StorageHandler.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 namespace ILIAS\ResourceStorage\StorageHandler;
 
 use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\ResourceStorage\Flavour\Flavour;
+use ILIAS\ResourceStorage\Flavour\StorableFlavourDecorator;
 use ILIAS\ResourceStorage\Identification\IdentificationGenerator;
 use ILIAS\ResourceStorage\Identification\ResourceIdentification;
 use ILIAS\ResourceStorage\Resource\StorableResource;
@@ -47,11 +49,29 @@ interface StorageHandler
 
     public function has(ResourceIdentification $identification): bool;
 
+    // STREAMS
+
     public function getStream(Revision $revision): FileStream;
 
     public function storeUpload(UploadedFileRevision $revision): bool;
 
     public function storeStream(FileStreamRevision $revision): bool;
+
+
+    // FLAVOURS
+
+    public function hasFlavour(Revision $revision, Flavour $flavour): bool;
+
+    public function storeFlavour(Revision $revision, StorableFlavourDecorator $storabel_flavour): bool;
+
+    public function deleteFlavour(Revision $revision, Flavour $flavour): bool;
+
+    public function getFlavourStreams(Revision $revision, Flavour $flavour): \Generator;
+
+
+    public function getFlavourPath(Revision $revision, Flavour $flavour): string;
+
+    // REVISIONS
 
     public function cloneRevision(CloneRevision $revision): bool;
 

--- a/tests/ResourceStorage/AbstractBaseResourceBuilderTest.php
+++ b/tests/ResourceStorage/AbstractBaseResourceBuilderTest.php
@@ -29,6 +29,7 @@ use ILIAS\ResourceStorage\Information\Information;
 use ILIAS\ResourceStorage\Information\Repository\InformationRepository;
 use ILIAS\ResourceStorage\Lock\LockHandler;
 use ILIAS\ResourceStorage\Resource\InfoResolver\UploadInfoResolver;
+use ILIAS\ResourceStorage\Resource\Repository\FlavourRepository;
 use ILIAS\ResourceStorage\Resource\Repository\ResourceRepository;
 use ILIAS\ResourceStorage\Resource\StorableFileResource;
 use ILIAS\ResourceStorage\Revision\Repository\RevisionRepository;
@@ -45,6 +46,7 @@ use Psr\Http\Message\UploadedFileInterface;
  */
 abstract class AbstractBaseResourceBuilderTest extends AbstractBaseTest
 {
+    public $flavour_repository;
     /**
      * @var Revision|\PHPUnit\Framework\MockObject\MockObject
      */
@@ -107,12 +109,14 @@ abstract class AbstractBaseResourceBuilderTest extends AbstractBaseTest
         $this->collection_repository = $this->createMock(CollectionRepository::class);
         $this->information_repository = $this->createMock(InformationRepository::class);
         $this->stakeholder_repository = $this->createMock(StakeholderRepository::class);
+        $this->flavour_repository = $this->createMock(FlavourRepository::class);
         $this->repositories = new Repositories(
             $this->revision_repository,
             $this->resource_repository,
             $this->collection_repository,
             $this->information_repository,
-            $this->stakeholder_repository
+            $this->stakeholder_repository,
+            $this->flavour_repository
         );
         $this->locking = $this->createMock(LockHandler::class);
         $this->stream_access = $this->createMock(StreamAccess::class);

--- a/tests/ResourceStorage/Flavours/BrokenDummyMachine.php
+++ b/tests/ResourceStorage/Flavours/BrokenDummyMachine.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\ResourceStorage\Flavours;
+
+/**
+ * @internal
+ */
+require_once __DIR__ . '/DummyMachine.php';
+
+class BrokenDummyMachine extends DummyMachine
+{
+    public function __construct()
+    {
+        throw new \Exception('This machine is broken');
+    }
+}

--- a/tests/ResourceStorage/Flavours/DummyDefinition.php
+++ b/tests/ResourceStorage/Flavours/DummyDefinition.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\ResourceStorage\Flavours;
+
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+
+/**
+ * @internal
+ */
+class DummyDefinition implements FlavourDefinition
+{
+    private string $id;
+    private string $machine_id;
+    private bool $persists = false;
+
+    public function __construct(string $id, string $machine_id, bool $persists = false)
+    {
+        $this->id = $id;
+        $this->machine_id = $machine_id;
+        $this->persists = $persists;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getFlavourMachineId(): string
+    {
+        return $this->machine_id;
+    }
+
+    public function getInternalName(): string
+    {
+        return 'foo';
+    }
+
+    public function getVariantName(): ?string
+    {
+        return null;
+    }
+
+    public function persist(): bool
+    {
+        return $this->persists;
+    }
+}

--- a/tests/ResourceStorage/Flavours/DummyMachine.php
+++ b/tests/ResourceStorage/Flavours/DummyMachine.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\ResourceStorage\Flavours;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Engine\Engine;
+use ILIAS\ResourceStorage\Flavour\Engine\NoEngine;
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\AbstractMachine;
+use ILIAS\ResourceStorage\Flavour\Machine\FlavourMachine;
+use ILIAS\ResourceStorage\Flavour\Machine\NonStoreableResult;
+use ILIAS\ResourceStorage\Information\FileInformation;
+
+/**
+ * @internal
+ */
+class DummyMachine extends AbstractMachine implements FlavourMachine
+{
+    private string $depends_on_engine = NoEngine::class;
+    private string $id = self::class;
+    private ?string $can_handle_definition_id = null;
+
+    public function load(
+        string $id,
+        string $can_handle_definition_id = null,
+        string $depends_on_engine = NoEngine::class
+    ): void {
+        $this->id = $id;
+        $this->depends_on_engine = $depends_on_engine;
+        $this->can_handle_definition_id = $can_handle_definition_id;
+    }
+
+    public function __construct()
+    {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function canHandleDefinition(FlavourDefinition $definition): bool
+    {
+        if ($this->can_handle_definition_id === null) {
+            return true;
+        }
+        return $this->can_handle_definition_id === $definition->getId();
+    }
+
+    public function dependsOnEngine(): ?string
+    {
+        return $this->depends_on_engine;
+    }
+
+
+    public function processStream(
+        FileInformation $information,
+        FileStream $stream,
+        FlavourDefinition $for_definition
+    ): \Generator {
+        yield new NonStoreableResult($for_definition, $stream);
+    }
+}

--- a/tests/ResourceStorage/Flavours/FlavourMachineTest.php
+++ b/tests/ResourceStorage/Flavours/FlavourMachineTest.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\ResourceStorage\Flavours;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\ResourceStorage\AbstractBaseTest;
+use ILIAS\ResourceStorage\Flavour\Definition\CropToSquare;
+use ILIAS\ResourceStorage\Flavour\Definition\FitToSquare;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Definition\PagesToExtract;
+use ILIAS\ResourceStorage\Flavour\Definition\ToGreyScale;
+use ILIAS\ResourceStorage\Flavour\Engine\Engine;
+use ILIAS\ResourceStorage\Flavour\Engine\GDEngine;
+use ILIAS\ResourceStorage\Flavour\Engine\ImagickEngine;
+use ILIAS\ResourceStorage\Flavour\Engine\NoEngine;
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\CropSquare;
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\ExtractPages;
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\FitSquare;
+use ILIAS\ResourceStorage\Flavour\Machine\DefaultMachines\MakeGreyScale;
+use ILIAS\ResourceStorage\Flavour\Machine\Factory;
+use ILIAS\ResourceStorage\Flavour\Machine\NullMachine;
+use ILIAS\ResourceStorage\Flavour\Machine\Result;
+use ILIAS\ResourceStorage\Information\FileInformation;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class FlavourMachineTest
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+require_once __DIR__ . '/../AbstractBaseTest.php';
+require_once __DIR__ . '/DummyDefinition.php';
+require_once __DIR__ . '/DummyMachine.php';
+require_once __DIR__ . '/BrokenDummyMachine.php';
+require_once __DIR__ . '/SVGDummyMachine.php';
+
+class FlavourMachineTest extends AbstractBaseTest
+{
+    /**
+     * @var ImagickEngine|MockObject
+     */
+    private $imagick_mock;
+    /**
+     * @var GDEngine|MockObject
+     */
+    private $gd_mock;
+    /**
+     * @var \ILIAS\ResourceStorage\Flavour\Engine\Factory|MockObject
+     */
+    private \PHPUnit\Framework\MockObject\MockObject $engine_factory_mock;
+
+    private array $engine_mocks = [];
+
+    protected function setUp(): void
+    {
+        $this->engine_factory_mock = $this->createMock(\ILIAS\ResourceStorage\Flavour\Engine\Factory::class);
+    }
+
+    public function testFactory(): void
+    {
+        $factory = new Factory($this->engine_factory_mock, [
+            \stdClass::class => \stdClass::class,
+            BrokenDummyMachine::class => BrokenDummyMachine::class
+        ]);
+
+        // Not a machine
+        $definition = $this->createMock(FlavourDefinition::class);
+        $definition->expects($this->once())->method('getFlavourMachineId')->willReturn(\stdClass::class);
+
+        $null_machine = $factory->get($definition);
+        $this->assertInstanceOf(NullMachine::class, $null_machine);
+        $this->assertEquals('Machine stdClass does not implement FlavourMachine', $null_machine->getReason());
+        $this->assertEquals('null_machine', $null_machine->getId());
+        $this->assertEquals(NoEngine::class, $null_machine->dependsOnEngine());
+
+        // Broken machine
+        $definition = $this->createMock(FlavourDefinition::class);
+        $definition->expects($this->once())->method('getFlavourMachineId')->willReturn(BrokenDummyMachine::class);
+        $null_machine = $factory->get($definition);
+        $this->assertInstanceOf(NullMachine::class, $null_machine);
+        $this->assertEquals(
+            'Could not instantiate machine ILIAS\ResourceStorage\Flavours\BrokenDummyMachine',
+            $null_machine->getReason()
+        );
+        $this->assertEquals('null_machine', $null_machine->getId());
+        $this->assertEquals(NoEngine::class, $null_machine->dependsOnEngine());
+    }
+
+    public function definitionsToMachines(): array
+    {
+        return [
+            [new PagesToExtract(true), ExtractPages::class, ImagickEngine::class],
+            [new CropToSquare(), CropSquare::class, GDEngine::class],
+            [new FitToSquare(), FitSquare::class, GDEngine::class],
+            [new ToGreyScale(), MakeGreyScale::class, GDEngine::class],
+        ];
+    }
+
+
+    /**
+     * @dataProvider definitionsToMachines
+     */
+    public function testDefaultMachines(FlavourDefinition $d, string $machine): void
+    {
+        $factory = new Factory($this->engine_factory_mock);
+        $this->engine_factory_mock->expects($this->exactly(1))
+            ->method('get')
+            ->willReturn(new NoEngine());
+
+        $machine_instance = $factory->get($d);
+        $this->assertInstanceOf($machine, $machine_instance);
+        $machine_instance_second_get = $factory->get($d);
+        $this->assertSame($machine_instance, $machine_instance_second_get);
+    }
+
+    public function machinesToEngines(): array
+    {
+        return [
+            [ExtractPages::class, ImagickEngine::class],
+            [CropSquare::class, GDEngine::class],
+            [FitSquare::class, GDEngine::class],
+            [MakeGreyScale::class, GDEngine::class],
+        ];
+    }
+
+    /**
+     * @dataProvider machinesToEngines
+     */
+    public function testDefaultMachineEngines(string $machine, string $engine): void
+    {
+        $factory = new \ILIAS\ResourceStorage\Flavour\Engine\Factory();
+        $engin_instance = $factory->get(new $machine());
+        $this->assertInstanceOf($engine, $engin_instance);
+    }
+
+    /**
+     * @dataProvider definitionsToMachines
+     */
+    public function testNullMachineFallback(FlavourDefinition $d, string $machine, string $engine): void
+    {
+        $factory = new Factory($this->engine_factory_mock);
+
+        $engine_mock = $this->createMock(Engine::class);
+
+        $this->engine_factory_mock->expects($this->once())
+            ->method('get')
+            ->willReturn($engine_mock);
+
+        $engine_mock->expects($this->once())
+            ->method('isRunning')
+            ->willReturn(false);
+
+        $machine_instance = $factory->get($d);
+        $this->assertInstanceOf(NullMachine::class, $machine_instance);
+        $this->assertEquals(
+            "Machine $machine depends on engine $engine which is not running or available.",
+            $machine_instance->getReason()
+        );
+    }
+
+
+    public function testMachineResult(): void
+    {
+        $svg_stream = Streams::ofString(
+            '<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 155 155"><defs><style>.cls-1{fill:red;}</style></defs><g><g><rect class="cls-1" x="3" y="3" width="150" height="150"/><path d="M151.14,6V151.14H6V6H151.14m6-6H0V157.14H157.14V0h0Z"/></g></g></svg>'
+        );
+        $machine = new SVGDummyMachine();
+        ;
+        $definition = $this->createSVGColorChangeDefinition('red', 'blue');
+        $file_info = new FileInformation();
+
+        $result = iterator_to_array($machine->processStream($file_info, $svg_stream, $definition));
+        $this->assertCount(1, $result);
+        $result_one = $result[0];
+        $this->assertInstanceOf(Result::class, $result_one);
+        $this->assertEquals($definition, $result_one->getDefinition());
+        $this->assertInstanceOf(FileStream::class, $result_one->getStream());
+        $this->assertEquals(
+            '<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 155 155"><defs><style>.cls-1{fill:blue;}</style></defs><g><g><rect class="cls-1" x="3" y="3" width="150" height="150"/><path d="M151.14,6V151.14H6V6H151.14m6-6H0V157.14H157.14V0h0Z"/></g></g></svg>',
+            (string)$result_one->getStream()
+        );
+    }
+
+    private function createSVGColorChangeDefinition(string $color, string $to_color): FlavourDefinition
+    {
+        return new class ($color, $to_color) extends DummyDefinition {
+            private string $color;
+            private string $to_color;
+
+            public function __construct(string $color, string $to_color)
+            {
+                $this->color = $color;
+                $this->to_color = $to_color;
+                parent::__construct(
+                    'svg_color_changer',
+                    'svg_color_changing_machine'
+                );
+            }
+
+            public function getColor(): string
+            {
+                return $this->color;
+            }
+
+            public function getToColor(): string
+            {
+                return $this->to_color;
+            }
+        };
+    }
+}

--- a/tests/ResourceStorage/Flavours/FlavourTest.php
+++ b/tests/ResourceStorage/Flavours/FlavourTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\ResourceStorage\Flavours;
+
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\ResourceStorage\AbstractBaseTest;
+use ILIAS\ResourceStorage\Consumer\StreamAccess\StreamAccess;
+use ILIAS\ResourceStorage\Consumer\StreamAccess\StreamInfoFactory;
+use ILIAS\ResourceStorage\Consumer\StreamAccess\Token;
+use ILIAS\ResourceStorage\Consumer\StreamAccess\TokenStream;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Flavour;
+use ILIAS\ResourceStorage\Flavour\FlavourBuilder;
+use ILIAS\ResourceStorage\Flavour\Machine\Factory;
+use ILIAS\ResourceStorage\Flavour\Streams\FlavourStream;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+use ILIAS\ResourceStorage\Information\FileInformation;
+use ILIAS\ResourceStorage\Resource\Repository\FlavourRepository;
+use ILIAS\ResourceStorage\Resource\ResourceBuilder;
+use ILIAS\ResourceStorage\Resource\StorableResource;
+use ILIAS\ResourceStorage\Revision\FileRevision;
+use ILIAS\ResourceStorage\StorageHandler\StorageHandler;
+use ILIAS\ResourceStorage\StorageHandler\StorageHandlerFactory;
+
+/**
+ * Class FlavorTest
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+require_once __DIR__ . '/../AbstractBaseTest.php';
+
+class FlavourTest extends AbstractBaseTest
+{
+    public $resource_builder;
+    private const BASE_DIR = '/var';
+    private Factory $machine_factory;
+    private StorageHandler $storage_handler_mock;
+    /**
+     * @var StorageHandlerFactory|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $storage_handler_factory;
+    private FlavourRepository $flavour_repo;
+    private StreamAccess $stream_access;
+
+    protected function setUp(): void
+    {
+        $this->machine_factory = new Factory(new \ILIAS\ResourceStorage\Flavour\Engine\Factory());
+        $this->storage_handler_mock = $this->createMock(StorageHandler::class);
+        $this->storage_handler_mock->expects($this->any())->method('isPrimary')->willReturn(true);
+        $this->storage_handler_factory = new StorageHandlerFactory([
+            $this->storage_handler_mock
+        ], self::BASE_DIR);
+        $this->flavour_repo = $this->createMock(FlavourRepository::class);
+        $this->resource_builder = $this->createMock(ResourceBuilder::class);
+        $this->stream_access = new StreamAccess(self::BASE_DIR, $this->storage_handler_factory);
+    }
+
+
+    public function testDefinitionVariantNameLengths(): void
+    {
+        $flavour_builder = new FlavourBuilder(
+            $this->flavour_repo,
+            $this->machine_factory,
+            $this->resource_builder,
+            $this->storage_handler_factory,
+            $this->stream_access
+        );
+
+        // Length OK
+        $flavour_definition = $this->createMock(FlavourDefinition::class);
+        $flavour_definition->expects($this->once())
+            ->method('getVariantName')
+            ->willReturn(str_repeat('a', 768));
+
+        $flavour_builder->has(
+            new ResourceIdentification('1'),
+            $flavour_definition
+        );
+        $this->assertTrue(true); // no exception thrown
+
+        // Too long
+        $flavour_definition = $this->createMock(FlavourDefinition::class);
+        $flavour_definition->expects($this->once())
+            ->method('getVariantName')
+            ->willReturn(str_repeat('a', 769));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $flavour_builder->has(
+            new ResourceIdentification('1'),
+            $flavour_definition
+        );
+    }
+
+    public function testHasFlavour(): void
+    {
+        // Data
+        $rid_one = new ResourceIdentification('1');
+        $rid_two = new ResourceIdentification('2');
+        $flavour_builder = new FlavourBuilder(
+            $this->flavour_repo,
+            $this->machine_factory,
+            $this->resource_builder,
+            $this->storage_handler_factory,
+            $this->stream_access
+        );
+
+        // Expectations
+        $flavour_definition = $this->createMock(FlavourDefinition::class);
+        $flavour_definition->expects($this->exactly(2))
+            ->method('getVariantName')
+            ->willReturn('short');
+
+        $this->flavour_repo->expects($this->exactly(2))
+            ->method('has')
+            ->withConsecutive([$rid_one, 0, $flavour_definition], [$rid_two, 0, $flavour_definition])
+            ->willReturnOnConsecutiveCalls(false, true);
+
+
+        // Assertions
+        $this->assertFalse(
+            $flavour_builder->has(
+                $rid_one,
+                $flavour_definition
+            )
+        );
+        $this->assertTrue(
+            $flavour_builder->has(
+                $rid_two,
+                $flavour_definition
+            )
+        );
+    }
+
+    public function testNewFlavour(): void
+    {
+        // Data
+        $rid_one = new ResourceIdentification('1');
+        $flavour_builder = new FlavourBuilder(
+            $this->flavour_repo,
+            $this->machine_factory,
+            $this->resource_builder,
+            $this->storage_handler_factory,
+            $this->stream_access
+        );
+
+        // Expectations
+        $flavour_definition = $this->createMock(FlavourDefinition::class);
+        $flavour_definition->expects($this->any())
+            ->method('getVariantName')
+            ->willReturn('short');
+
+        $this->flavour_repo->expects($this->once())
+            ->method('has')
+            ->with($rid_one, 0, $flavour_definition)
+            ->willReturn(false);
+
+        $this->resource_builder->expects($this->exactly(1))
+            ->method('has')
+            ->with($rid_one)
+            ->willReturn(true);
+
+        $revision = $this->createMock(FileRevision::class);
+
+        $revision->expects($this->once())
+            ->method('getInformation')
+            ->willReturn($this->createMock(FileInformation::class));
+
+        $stream = Streams::ofString('test');
+
+        $resource = $this->createMock(StorableResource::class);
+
+        $this->resource_builder->expects($this->once())
+            ->method('get')
+            ->with($rid_one)
+            ->willReturn($resource);
+
+        $resource->expects($this->any())
+            ->method('getCurrentRevision')
+            ->willReturn($revision);
+
+
+        $this->resource_builder->expects($this->exactly(1))
+            ->method('extractStream')
+            ->with($revision)
+            ->willReturn($stream);
+
+
+        // Assertions
+        $flavour = $flavour_builder->get(
+            $rid_one,
+            $flavour_definition
+        );
+        $this->assertInstanceOf(Flavour::class, $flavour);
+        $tokens = $flavour->getAccessTokens();
+        $this->assertCount(1, $tokens);
+        $first_token = $tokens[0];
+        $this->assertInstanceOf(Token::class, $first_token);
+        $this->assertFalse($first_token->hasStreamableStream());
+        $resolved_stream = $first_token->resolveStream();
+        $this->assertInstanceOf(TokenStream::class, $resolved_stream);
+        $this->assertEquals('empty', (string)$resolved_stream);
+    }
+}

--- a/tests/ResourceStorage/Flavours/SVGDummyMachine.php
+++ b/tests/ResourceStorage/Flavours/SVGDummyMachine.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\ResourceStorage\Flavours;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
+use ILIAS\ResourceStorage\Flavour\Machine\Result;
+use ILIAS\ResourceStorage\Information\FileInformation;
+
+/**
+ * @internal
+ */
+class SVGDummyMachine extends DummyMachine
+{
+    public function __construct()
+    {
+        $this->load(
+            'svg_color_changing_machine',
+            'svg_color_changing'
+        );
+    }
+
+
+    public function processStream(
+        FileInformation $information,
+        FileStream $stream,
+        FlavourDefinition $for_definition
+    ): \Generator {
+        $content = (string)$stream;
+
+        $from_color = ':' . $for_definition->getColor() . ';';
+        $to_color = ':' . $for_definition->getToColor() . ';';
+        $content = str_replace($from_color, $to_color, $content);
+
+        yield new Result(
+            $for_definition,
+            Streams::ofString($content)
+        );
+    }
+}


### PR DESCRIPTION
Flavours are derivatives of resources that can be created, managed and used alongside the original resource. A simple example are different resolutions of images: If a person uploads e.g. a profile picture with 20MB size, the IRSS can generate several flavours from it, e.g. a 500x500px flavour in an adapted quality, which can be used for the representation in a member gallery, without the full resolution with 20MB having to be loaded and displayed in the browser.
Similar approaches exist in ILIAS in many places, but always the components themselves must ensure that the desired "derivatives" are available, stored and can be retrieved. With the Flavours the IRSS offers this centrally.

Please see the [documentation](https://github.com/srsolutionsag/ILIAS/blob/6eb081047a5fc180b9998c64307a3881851bd874/src/ResourceStorage/README.md#resource-flavours) and ask me for infos/additions if needed.

Flavours are used as part of a refactoring on ilPreview. ilPreview is a service that was originally intended to provide preview images for various object types. Currently, however, it only works for file objects and is also very outdated.

ilPreview requires installed binaries and uses exec internally, which is to be abolished. 
In a separate [PR](https://github.com/ILIAS-eLearning/ILIAS/pull/5172), the default for PHP imagick instead of direct binaries is proposed.
