### PR TITLE
Prevent non-numeric inputs within the client

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assClozeGapCombination.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeGapCombination.php
@@ -116,7 +116,7 @@ class assClozeGapCombination
                             $gap_combinations['select'][$i][$k],
                             $j,
                             $gap_values[$i][$j][$k],
-                            $gap_combinations['points'][$i][$j],
+                            (float) $gap_combinations['points'][$i][$j], //Temporary cast solution demanded by @kergomard in https://github.com/ILIAS-eLearning/ILIAS/pull/5178#issuecomment-1301983937
                             $best_solution
                         )
                     );


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=35267

This would be better solved with a whole refactoring of the ilAssClozeTestCombinationVariantsInputGUI since it has major issues with the verification of Inputs in general and is isolated from common input checks.

Due to time issues i would still recommend this PR as a temporary solution.