### PR TITLE
Proposal: DateFormat from User

### DIFF
--- a/Modules/DataCollection/classes/Fields/Datetime/class.ilDclDatetimeRecordRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Datetime/class.ilDclDatetimeRecordRepresentation.php
@@ -36,25 +36,10 @@ class ilDclDatetimeRecordRepresentation extends ilDclBaseRecordRepresentation
             return $this->lng->txt('no_date');
         }
 
-        return $this->formatDate($value, $ilUser->getDateFormat());
-    }
-
-    /**
-     * @return bool|string
-     */
-    protected function formatDate(string $value, string $format)
-    {
-        $timestamp = strtotime($value);
-        switch ($format) {
-            case ilCalendarSettings::DATE_FORMAT_DMY:
-                return date("d.m.Y", $timestamp);
-            case ilCalendarSettings::DATE_FORMAT_YMD:
-                return date("Y-m-d", $timestamp);
-            case ilCalendarSettings::DATE_FORMAT_MDY:
-                return date("m/d/Y", $timestamp);
-        }
-
-        return $this->lng->txt('no_date');
+        return date(
+            (string) $ilUser->getDateFormat(),
+            strtotime($value)
+        );
     }
 
     /**

--- a/Services/Calendar/classes/class.ilCalendarUserSettings.php
+++ b/Services/Calendar/classes/class.ilCalendarUserSettings.php
@@ -19,8 +19,6 @@
 declare(strict_types=1);
 
 use ILIAS\Data\DateFormat\DateFormat;
-use ILIAS\Data\DateFormat\Factory as DateFormatFactory;
-use ILIAS\Data\Factory as DataFactory;
 
 /**
  * @author  Stefan Meyer <smeyer.ilias@gmx.de>
@@ -37,7 +35,6 @@ class ilCalendarUserSettings
     public static array $instances = array();
 
     protected ilObjUser $user;
-    protected DateFormatFactory $date_format_factory;
     protected ilCalendarSettings $settings;
 
     private int $calendar_selection_type = 1;
@@ -56,7 +53,6 @@ class ilCalendarUserSettings
         global $DIC;
 
         $this->user = $DIC->user();
-        $this->date_format_factory = (new DataFactory())->dateFormat();
 
         if ($this->user->getId() !== $a_user_id) {
             $user = ilObjectFactory::getInstanceByObjId($a_user_id, false);
@@ -219,7 +215,7 @@ class ilCalendarUserSettings
             $this->export_tz_type
         );
         $this->date_format = $this->translateDateFormatToId(
-            $this->user->getDateFormat($this->date_format_factory)
+            $this->user->getDateFormat()
         );
         $this->time_format = (int) $this->user->getTimeFormat();
         if (($weekstart = $this->user->getPref('weekstart')) === false) {

--- a/Services/Calendar/classes/class.ilCalendarUserSettings.php
+++ b/Services/Calendar/classes/class.ilCalendarUserSettings.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 use ILIAS\Data\DateFormat\DateFormat;

--- a/Services/Calendar/classes/class.ilCalendarUtil.php
+++ b/Services/Calendar/classes/class.ilCalendarUtil.php
@@ -481,37 +481,28 @@ class ilCalendarUtil
         global $DIC;
 
         $ilUser = $DIC['ilUser'];
-        $format = '';
-        switch ($ilUser->getDateFormat()) {
-            case ilCalendarSettings::DATE_FORMAT_DMY:
-                $format = "DD.MM.YYYY";
-                break;
+        $factory = new ILIAS\Data\Factory();
 
-            case ilCalendarSettings::DATE_FORMAT_YMD:
-                $format = "YYYY-MM-DD";
-                break;
+        $format = (string) $ilUser->getDateFormat($factory->dateFormat());
 
-            case ilCalendarSettings::DATE_FORMAT_MDY:
-                $format = "MM/DD/YYYY";
-                break;
-        }
         if ($a_add_time) {
             $format .= " " . (($ilUser->getTimeFormat() == ilCalendarSettings::TIME_FORMAT_24)
-                    ? "HH:mm"
-                    : "hh:mma");
+                    ? "H:i"
+                    : "h:ia");
             if ($a_add_time == 2) {
-                $format .= ":ss";
+                $format .= ":s";
             }
         }
 
         // translate datepicker format to PHP format
-        if ($a_for_parsing) {
-            $format = str_replace("DD", "d", $format);
-            $format = str_replace("MM", "m", $format);
-            $format = str_replace("mm", "i", $format);
-            $format = str_replace("YYYY", "Y", $format);
-            $format = str_replace("HH", "H", $format);
-            $format = str_replace("hh", "h", $format);
+        if (!$a_for_parsing) {
+            $format = str_replace("d", "DD", $format);
+            $format = str_replace("m", "MM", $format);
+            $format = str_replace("i", "mm", $format);
+            $format = str_replace("Y", "YYYY", $format);
+            $format = str_replace("H", "HH", $format);
+            $format = str_replace("h", "hh", $format);
+            $format = str_replace("s", "ss", $format);
         }
 
         return $format;

--- a/Services/Calendar/classes/class.ilCalendarUtil.php
+++ b/Services/Calendar/classes/class.ilCalendarUtil.php
@@ -1,25 +1,20 @@
 <?php
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2007 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Class ilCalendarUtil

--- a/Services/Calendar/classes/class.ilCalendarUtil.php
+++ b/Services/Calendar/classes/class.ilCalendarUtil.php
@@ -476,9 +476,8 @@ class ilCalendarUtil
         global $DIC;
 
         $ilUser = $DIC['ilUser'];
-        $factory = new ILIAS\Data\Factory();
 
-        $format = (string) $ilUser->getDateFormat($factory->dateFormat());
+        $format = (string) $ilUser->getDateFormat();
 
         if ($a_add_time) {
             $format .= " " . (($ilUser->getTimeFormat() == ilCalendarSettings::TIME_FORMAT_24)

--- a/Services/User/classes/class.ilObjUser.php
+++ b/Services/User/classes/class.ilObjUser.php
@@ -17,6 +17,8 @@
  *********************************************************************/
 
 use ILIAS\UI\Component\Symbol\Avatar\Avatar;
+use ILIAS\Data\DateFormat\DateFormat;
+use ILIAS\Data\DateFormat\Factory as DateFormatFactory;
 
 /**
  * User class
@@ -1012,6 +1014,21 @@ class ilObjUser extends ilObject
         } else {
             $settings = ilCalendarSettings::_getInstance();
             return $settings->getDefaultDateFormat();
+        }
+    }
+
+    public function getDataDateFormat(DateFormatFactory $factory): DateFormat
+    {
+        switch ($this->getDateFormat()) {
+            case ilCalendarSettings::DATE_FORMAT_DMY:
+                return $factory->germanShort();
+
+            case ilCalendarSettings::DATE_FORMAT_MDY:
+                return $factory->americanShort();
+
+            case ilCalendarSettings::DATE_FORMAT_YMD:
+            default:
+                return $factory->standard();
         }
     }
 

--- a/Services/User/classes/class.ilObjUser.php
+++ b/Services/User/classes/class.ilObjUser.php
@@ -1007,19 +1007,14 @@ class ilObjUser extends ilObject
         }
     }
 
-    public function getDateFormat(): string
+    public function getDateFormat(DateFormatFactory $factory): DateFormat
     {
-        if ($format = $this->getPref('date_format')) {
-            return $format;
-        } else {
+        if (!($format = $this->getPref('date_format'))) {
             $settings = ilCalendarSettings::_getInstance();
-            return $settings->getDefaultDateFormat();
+            $format = $settings->getDefaultDateFormat();
         }
-    }
 
-    public function getDataDateFormat(DateFormatFactory $factory): DateFormat
-    {
-        switch ($this->getDateFormat()) {
+        switch ($format) {
             case ilCalendarSettings::DATE_FORMAT_DMY:
                 return $factory->germanShort();
 

--- a/Services/User/classes/class.ilObjUser.php
+++ b/Services/User/classes/class.ilObjUser.php
@@ -19,6 +19,7 @@
 use ILIAS\UI\Component\Symbol\Avatar\Avatar;
 use ILIAS\Data\DateFormat\DateFormat;
 use ILIAS\Data\DateFormat\Factory as DateFormatFactory;
+use ILIAS\Data\Factory as DataFactory;
 
 /**
  * User class
@@ -110,6 +111,8 @@ class ilObjUser extends ilObject
     protected string $first_login = "";	// timestamp
     protected bool $profile_incomplete = false;
 
+    protected DateFormatFactory $date_format_factory;
+
     public function __construct(
         int $a_user_id = 0,
         bool $a_call_by_reference = false
@@ -135,6 +138,7 @@ class ilObjUser extends ilObject
         }
 
         $this->app_event_handler = $DIC['ilAppEventHandler'];
+        $this->date_format_factory = (new DataFactory())->dateFormat();
     }
 
     /**
@@ -1007,7 +1011,7 @@ class ilObjUser extends ilObject
         }
     }
 
-    public function getDateFormat(DateFormatFactory $factory): DateFormat
+    public function getDateFormat(): DateFormat
     {
         if (!($format = $this->getPref('date_format'))) {
             $settings = ilCalendarSettings::_getInstance();
@@ -1016,14 +1020,14 @@ class ilObjUser extends ilObject
 
         switch ($format) {
             case ilCalendarSettings::DATE_FORMAT_DMY:
-                return $factory->germanShort();
+                return $this->date_format_factory->germanShort();
 
             case ilCalendarSettings::DATE_FORMAT_MDY:
-                return $factory->americanShort();
+                return $this->date_format_factory->americanShort();
 
             case ilCalendarSettings::DATE_FORMAT_YMD:
             default:
-                return $factory->standard();
+                return $this->date_format_factory->standard();
         }
     }
 

--- a/src/Data/DateFormat/Factory.php
+++ b/src/Data/DateFormat/Factory.php
@@ -2,7 +2,21 @@
 
 declare(strict_types=1);
 
-/* Copyright (c) 2019 Nils Haagen <nils.haagen@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 namespace ILIAS\Data\DateFormat;
 

--- a/src/Data/DateFormat/Factory.php
+++ b/src/Data/DateFormat/Factory.php
@@ -44,4 +44,24 @@ class Factory
         return $this->builder->weekday()->comma()->space()
                              ->day()->dot()->month()->dot()->year()->get();
     }
+
+    public function americanShort(): DateFormat
+    {
+        return $this->builder->month()->slash()->day()->slash()->year()->get();
+    }
+
+    public function fromUser(\ilObjUser $user): DateFormat
+    {
+        switch ($user->getDateFormat()) {
+            case \ilCalendarSettings::DATE_FORMAT_DMY:
+                return $this->germanShort();
+
+            case \ilCalendarSettings::DATE_FORMAT_MDY:
+                return $this->americanShort();
+
+            case \ilCalendarSettings::DATE_FORMAT_YMD:
+            default:
+                return $this->standard();
+        }
+    }
 }

--- a/src/Data/DateFormat/Factory.php
+++ b/src/Data/DateFormat/Factory.php
@@ -63,19 +63,4 @@ class Factory
     {
         return $this->builder->month()->slash()->day()->slash()->year()->get();
     }
-
-    public function fromUser(\ilObjUser $user): DateFormat
-    {
-        switch ($user->getDateFormat()) {
-            case \ilCalendarSettings::DATE_FORMAT_DMY:
-                return $this->germanShort();
-
-            case \ilCalendarSettings::DATE_FORMAT_MDY:
-                return $this->americanShort();
-
-            case \ilCalendarSettings::DATE_FORMAT_YMD:
-            default:
-                return $this->standard();
-        }
-    }
 }

--- a/tests/Data/DateFormatTest.php
+++ b/tests/Data/DateFormatTest.php
@@ -36,6 +36,7 @@ class DateFormatTest extends TestCase
         $this->assertInstanceOf(DateFormat\DateFormat::class, $this->df->standard());
         $this->assertInstanceOf(DateFormat\DateFormat::class, $this->df->germanShort());
         $this->assertInstanceOf(DateFormat\DateFormat::class, $this->df->germanLong());
+        $this->assertInstanceOf(DateFormat\DateFormat::class, $this->df->americanShort());
         $this->assertInstanceOf(DateFormat\FormatBuilder::class, $this->df->custom());
     }
 


### PR DESCRIPTION
Currently, using the KS datetime input field is a bit annoying: its format has to be given as a Data/DateFormat, but the format from the user's preferences is returned as an ilCalenderSettings constant. So, to have the input use the user-preferred format for dates, one has to write an adapter. This adapter is pretty simple, but especially with an eye toward the big KS initiative it would have to be replicated in quite a lot of Services and Modules. In my opinion it would be better to have it someplace central, to avoid this needless repetition.

To this end I added 'americanShort' as a preset DateFormat to the DateFormat factory, so that all three possible user preferences are available as presets. Further, I added the aforementioned adapter as a method 'fromUser', taking ilObjUser as an argument.

I'm aware that adding this kind of dependency on ilObjUser (and ilCalenderSettings) to src/Data is a big no-no. However, I'm not sure where else it should go, and want to open that question up to discussion.

So, in summary: making KS datetime inputs work with the format from the user preferences is annoying, and a publicly available adapter would help. Where should we put it?