### PR TITLE
Bugfix 32045 Test in imported learning sequence description error

### DIFF
--- a/Modules/LearningSequence/classes/Player/class.ilLegacyKioskModeView.php
+++ b/Modules/LearningSequence/classes/Player/class.ilLegacyKioskModeView.php
@@ -133,8 +133,13 @@ class ilLegacyKioskModeView implements ILIAS\KioskMode\View
 
         $info = $factory->item()->standard($this->object->getTitle())
             ->withLeadIcon($icon)
-            ->withDescription($this->object->getDescription())
             ->withProperties($props);
+
+        $description = $this->object->getDescription();
+        if ($description != null) {
+            $info = $info->withDescription($description);
+        }
+
 
         return $info;
     }


### PR DESCRIPTION
#bugfix
Mantis issue: 0032045
Target: release_7
https://mantis.ilias.de/view.php?id=32045
Follow up PR for: #5083 

The error only occurred if the test in the imported learning sequence did not contain a description. The ilLegacyKioskModeView class couldn't handle an empty variable, so I added an if statement.