### PR TITLE
CSS: Maintainance Model Change

### DIFF
--- a/templates/Guidelines_SCSS-Coding.md
+++ b/templates/Guidelines_SCSS-Coding.md
@@ -1,5 +1,8 @@
 # General
 
+*Please note, that you need to provide a Pull Request for all CSS related changes done in this folder. The CSS Coordinators
+will then review the PR and give you feedback and/or merge your canges.*
+
 This section of the codebase defines the design and layout of ILIAS. All CSS code is build here. HTML templates can be found elsewhere (see section "HTML").
 
 The following guidelines will help you to

--- a/templates/Guidelines_SCSS-Coding.md
+++ b/templates/Guidelines_SCSS-Coding.md
@@ -1,7 +1,7 @@
 # General
 
 *Please note, that you need to provide a Pull Request for all CSS related changes done in this folder. The CSS Coordinators
-will then review the PR and give you feedback and/or merge your canges.*
+will then review the PR and give you feedback and/or merge your changes.*
 
 This section of the codebase defines the design and layout of ILIAS. All CSS code is build here. HTML templates can be found elsewhere (see section "HTML").
 

--- a/templates/maintenance.json
+++ b/templates/maintenance.json
@@ -1,0 +1,16 @@
+{
+    "maintenance_model": "Coordinator",
+    "first_maintainer": "",
+    "second_maintainer": "",
+    "implicit_maintainers": [],
+    "coordinator": [
+        "amstutz(26468)"
+    ],
+    "tester": "",
+    "testcase_writer": "",
+    "path": "templates",
+    "belong_to_component": "",
+    "used_in_components": [
+        "All"
+    ]
+}


### PR DESCRIPTION
With the PR we announce two changes:

1. We change to maintainance model of CSS / Templates (./templates) to the Coordinator Model, see: https://github.com/ILIAS-eLearning/ILIAS/blob/release_7/docs/development/maintenance-coordinator.md
2. For all changes to CSS / Templates (all files in ./templates) all developers excluding the coordinators are strictly required to provide a PR to be merged by one of the coordinators.

Thx.