### PR TITLE
T&A Fix 35321

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -2526,6 +2526,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
             $this->tpl->setOnScreenMessage('info', $this->lng->txt("tst_defaults_apply_select_one"));
 
             $this->defaultsObject();
+            return;
         }
 
         // do not apply if user datasets exist
@@ -2533,6 +2534,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
             $this->tpl->setOnScreenMessage('info', $this->lng->txt("tst_defaults_apply_not_possible"));
 
             $this->defaultsObject();
+            return;
         }
 
         $defaults = $this->object->getTestDefaults($_POST["chb_defaults"][0]);


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=35321 
The only problem is, that after checking if the user did choose default-settings the rest of the function still execeuted.
Thats why I added "return".
I also noticed that there was the same problem, when a test already has results from participants. The settings of the test should not be changed, when results are already present. That's why I added a second "return".