### PR TITLE
SCSS broken Glyphicons

### DIFF
--- a/templates/default/010-settings/legacy-settings/_legacy-settings_symbol.scss
+++ b/templates/default/010-settings/legacy-settings/_legacy-settings_symbol.scss
@@ -11,4 +11,4 @@ $il-icon-size-large: 45px;
 //** Path for standard icons in ILIAS
 $il-standard-icon-path: $il-background-images-path;
 
-$il-mainbar-trigger-icon-filter: brightness(3);
+$il-mainbar-trigger-icon-filter: brightness(5);

--- a/templates/default/020-dependencies/modifications/bootstrap-3-scss/stylesheets/bootstrap/_modified-variables.scss
+++ b/templates/default/020-dependencies/modifications/bootstrap-3-scss/stylesheets/bootstrap/_modified-variables.scss
@@ -90,7 +90,7 @@ $navbar-height: rem-to-pixel($il-standard-page-small-mainbar-height);
 //## Icons are used to represent (and quickly identify) objects.
 
 //** Path to the font of the glyphicons. Note that the path must be put in "".
-$il-icon-font-path: "./020-dependencies/unmodified/bootstrap-3-scss/fonts/";
+$il-icon-font-path: "./020-dependencies/unmodified/bootstrap-3-scss/fonts/bootstrap/";
 $icon-font-path: $il-icon-font-path;
 
 //== Navs

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -234,15 +234,15 @@ th {
 /*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
 @media print {
   *,
-  *:before,
-  *:after {
+*:before,
+*:after {
     color: #000 !important;
     text-shadow: none !important;
     background: transparent !important;
     box-shadow: none !important;
   }
   a,
-  a:visited {
+a:visited {
     text-decoration: underline;
   }
   a[href]:after {
@@ -252,11 +252,11 @@ th {
     content: " (" attr(title) ")";
   }
   a[href^="#"]:after,
-  a[href^="javascript:"]:after {
+a[href^="javascript:"]:after {
     content: "";
   }
   pre,
-  blockquote {
+blockquote {
     border: 1px solid #999;
     page-break-inside: avoid;
   }
@@ -264,27 +264,27 @@ th {
     display: table-header-group;
   }
   tr,
-  img {
+img {
     page-break-inside: avoid;
   }
   img {
     max-width: 100% !important;
   }
   p,
-  h2,
-  h3 {
+h2,
+h3 {
     orphans: 3;
     widows: 3;
   }
   h2,
-  h3 {
+h3 {
     page-break-after: avoid;
   }
   .navbar {
     display: none;
   }
   .btn > .caret,
-  .dropup > .btn > .caret {
+.dropup > .btn > .caret {
     border-top-color: #000 !important;
   }
   .label {
@@ -294,18 +294,18 @@ th {
     border-collapse: collapse !important;
   }
   .table td,
-  .table th {
+.table th {
     background-color: #fff !important;
   }
   .table-bordered th,
-  .table-bordered td {
+.table-bordered td {
     border: 1px solid #ddd !important;
   }
 }
 @font-face {
   font-family: "Glyphicons Halflings";
-  src: url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/glyphicons-halflings-regular.eot");
-  src: url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/glyphicons-halflings-regular.woff2") format("woff2"), url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/glyphicons-halflings-regular.woff") format("woff"), url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/glyphicons-halflings-regular.ttf") format("truetype"), url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg");
+  src: url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/bootstrap/glyphicons-halflings-regular.eot");
+  src: url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/bootstrap/glyphicons-halflings-regular.woff2") format("woff2"), url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("./020-dependencies/unmodified/bootstrap-3-scss/fonts/bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg");
 }
 .glyphicon {
   position: relative;
@@ -2914,36 +2914,36 @@ th {
     margin-bottom: 0;
   }
   .table-responsive > .table > thead > tr > th,
-  .table-responsive > .table > thead > tr > td,
-  .table-responsive > .table > tbody > tr > th,
-  .table-responsive > .table > tbody > tr > td,
-  .table-responsive > .table > tfoot > tr > th,
-  .table-responsive > .table > tfoot > tr > td {
+.table-responsive > .table > thead > tr > td,
+.table-responsive > .table > tbody > tr > th,
+.table-responsive > .table > tbody > tr > td,
+.table-responsive > .table > tfoot > tr > th,
+.table-responsive > .table > tfoot > tr > td {
     white-space: nowrap;
   }
   .table-responsive > .table-bordered {
     border: 0;
   }
   .table-responsive > .table-bordered > thead > tr > th:first-child,
-  .table-responsive > .table-bordered > thead > tr > td:first-child,
-  .table-responsive > .table-bordered > tbody > tr > th:first-child,
-  .table-responsive > .table-bordered > tbody > tr > td:first-child,
-  .table-responsive > .table-bordered > tfoot > tr > th:first-child,
-  .table-responsive > .table-bordered > tfoot > tr > td:first-child {
+.table-responsive > .table-bordered > thead > tr > td:first-child,
+.table-responsive > .table-bordered > tbody > tr > th:first-child,
+.table-responsive > .table-bordered > tbody > tr > td:first-child,
+.table-responsive > .table-bordered > tfoot > tr > th:first-child,
+.table-responsive > .table-bordered > tfoot > tr > td:first-child {
     border-left: 0;
   }
   .table-responsive > .table-bordered > thead > tr > th:last-child,
-  .table-responsive > .table-bordered > thead > tr > td:last-child,
-  .table-responsive > .table-bordered > tbody > tr > th:last-child,
-  .table-responsive > .table-bordered > tbody > tr > td:last-child,
-  .table-responsive > .table-bordered > tfoot > tr > th:last-child,
-  .table-responsive > .table-bordered > tfoot > tr > td:last-child {
+.table-responsive > .table-bordered > thead > tr > td:last-child,
+.table-responsive > .table-bordered > tbody > tr > th:last-child,
+.table-responsive > .table-bordered > tbody > tr > td:last-child,
+.table-responsive > .table-bordered > tfoot > tr > th:last-child,
+.table-responsive > .table-bordered > tfoot > tr > td:last-child {
     border-right: 0;
   }
   .table-responsive > .table-bordered > tbody > tr:last-child > th,
-  .table-responsive > .table-bordered > tbody > tr:last-child > td,
-  .table-responsive > .table-bordered > tfoot > tr:last-child > th,
-  .table-responsive > .table-bordered > tfoot > tr:last-child > td {
+.table-responsive > .table-bordered > tbody > tr:last-child > td,
+.table-responsive > .table-bordered > tfoot > tr:last-child > th,
+.table-responsive > .table-bordered > tfoot > tr:last-child > td {
     border-bottom: 0;
   }
 }
@@ -3097,35 +3097,35 @@ input[type=search] {
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
   input[type=date].form-control,
-  input[type=time].form-control,
-  input[type=datetime-local].form-control,
-  input[type=month].form-control {
+input[type=time].form-control,
+input[type=datetime-local].form-control,
+input[type=month].form-control {
     line-height: 28px;
   }
   input[type=date].input-sm,
-  .input-group-sm > .input-group-btn > input[type=date].btn, .input-group-sm input[type=date],
-  input[type=time].input-sm,
-  .input-group-sm > .input-group-btn > input[type=time].btn,
-  .input-group-sm input[type=time],
-  input[type=datetime-local].input-sm,
-  .input-group-sm > .input-group-btn > input[type=datetime-local].btn,
-  .input-group-sm input[type=datetime-local],
-  input[type=month].input-sm,
-  .input-group-sm > .input-group-btn > input[type=month].btn,
-  .input-group-sm input[type=month] {
+.input-group-sm > .input-group-btn > input[type=date].btn, .input-group-sm input[type=date],
+input[type=time].input-sm,
+.input-group-sm > .input-group-btn > input[type=time].btn,
+.input-group-sm input[type=time],
+input[type=datetime-local].input-sm,
+.input-group-sm > .input-group-btn > input[type=datetime-local].btn,
+.input-group-sm input[type=datetime-local],
+input[type=month].input-sm,
+.input-group-sm > .input-group-btn > input[type=month].btn,
+.input-group-sm input[type=month] {
     line-height: 26px;
   }
   input[type=date].input-lg,
-  .input-group-lg > .input-group-btn > input[type=date].btn, .input-group-lg input[type=date],
-  input[type=time].input-lg,
-  .input-group-lg > .input-group-btn > input[type=time].btn,
-  .input-group-lg input[type=time],
-  input[type=datetime-local].input-lg,
-  .input-group-lg > .input-group-btn > input[type=datetime-local].btn,
-  .input-group-lg input[type=datetime-local],
-  input[type=month].input-lg,
-  .input-group-lg > .input-group-btn > input[type=month].btn,
-  .input-group-lg input[type=month] {
+.input-group-lg > .input-group-btn > input[type=date].btn, .input-group-lg input[type=date],
+input[type=time].input-lg,
+.input-group-lg > .input-group-btn > input[type=time].btn,
+.input-group-lg input[type=time],
+input[type=datetime-local].input-lg,
+.input-group-lg > .input-group-btn > input[type=datetime-local].btn,
+.input-group-lg input[type=datetime-local],
+input[type=month].input-lg,
+.input-group-lg > .input-group-btn > input[type=month].btn,
+.input-group-lg input[type=month] {
     line-height: 36px;
   }
 }
@@ -3473,8 +3473,8 @@ select[multiple].input-lg,
     vertical-align: middle;
   }
   .form-inline .input-group .input-group-addon,
-  .form-inline .input-group .input-group-btn,
-  .form-inline .input-group .form-control {
+.form-inline .input-group .input-group-btn,
+.form-inline .input-group .form-control {
     width: auto;
   }
   .form-inline .input-group > .form-control {
@@ -3485,18 +3485,18 @@ select[multiple].input-lg,
     vertical-align: middle;
   }
   .form-inline .radio,
-  .form-inline .checkbox {
+.form-inline .checkbox {
     display: inline-block;
     margin-top: 0;
     margin-bottom: 0;
     vertical-align: middle;
   }
   .form-inline .radio label,
-  .form-inline .checkbox label {
+.form-inline .checkbox label {
     padding-left: 0;
   }
   .form-inline .radio input[type=radio],
-  .form-inline .checkbox input[type=checkbox] {
+.form-inline .checkbox input[type=checkbox] {
     position: relative;
     margin-left: 0;
   }
@@ -4530,8 +4530,8 @@ tbody.collapse.in {
     border-radius: 0px 0px 0 0;
   }
   .nav-tabs-justified > .active > a, .nav-tabs.nav-justified > .active > a,
-  .nav-tabs-justified > .active > a:hover,
-  .nav-tabs-justified > .active > a:focus {
+.nav-tabs-justified > .active > a:hover,
+.nav-tabs-justified > .active > a:focus {
     border-bottom-color: white;
   }
 }
@@ -4605,7 +4605,7 @@ tbody.collapse.in {
 }
 @media (max-device-width: 480px) and (orientation: landscape) {
   .navbar-fixed-top .navbar-collapse,
-  .navbar-fixed-bottom .navbar-collapse {
+.navbar-fixed-bottom .navbar-collapse {
     max-height: 200px;
   }
 }
@@ -4619,9 +4619,9 @@ tbody.collapse.in {
 }
 @media (min-width: 768px) {
   .container > .navbar-header,
-  .container > .navbar-collapse,
-  .container-fluid > .navbar-header,
-  .container-fluid > .navbar-collapse {
+.container > .navbar-collapse,
+.container-fluid > .navbar-header,
+.container-fluid > .navbar-collapse {
     margin-right: 0;
     margin-left: 0;
   }
@@ -4646,7 +4646,7 @@ tbody.collapse.in {
 }
 @media (min-width: 768px) {
   .navbar-fixed-top,
-  .navbar-fixed-bottom {
+.navbar-fixed-bottom {
     border-radius: 0;
   }
 }
@@ -4728,7 +4728,7 @@ tbody.collapse.in {
     background-color: transparent;
   }
   .navbar-nav .open .dropdown-menu > li > a,
-  .navbar-nav .open .dropdown-menu .dropdown-header {
+.navbar-nav .open .dropdown-menu .dropdown-header {
     padding: 5px 15px 5px 25px;
   }
   .navbar-nav .open .dropdown-menu > li > a {
@@ -4782,8 +4782,8 @@ tbody.collapse.in {
     vertical-align: middle;
   }
   .navbar-form .input-group .input-group-addon,
-  .navbar-form .input-group .input-group-btn,
-  .navbar-form .input-group .form-control {
+.navbar-form .input-group .input-group-btn,
+.navbar-form .input-group .form-control {
     width: auto;
   }
   .navbar-form .input-group > .form-control {
@@ -4794,18 +4794,18 @@ tbody.collapse.in {
     vertical-align: middle;
   }
   .navbar-form .radio,
-  .navbar-form .checkbox {
+.navbar-form .checkbox {
     display: inline-block;
     margin-top: 0;
     margin-bottom: 0;
     vertical-align: middle;
   }
   .navbar-form .radio label,
-  .navbar-form .checkbox label {
+.navbar-form .checkbox label {
     padding-left: 0;
   }
   .navbar-form .radio input[type=radio],
-  .navbar-form .checkbox input[type=checkbox] {
+.navbar-form .checkbox input[type=checkbox] {
     position: relative;
     margin-left: 0;
   }
@@ -5366,7 +5366,7 @@ a.badge:hover, a.badge:focus {
     padding-left: 60px;
   }
   .jumbotron h1,
-  .jumbotron .h1 {
+.jumbotron .h1 {
     font-size: 4rem;
   }
 }
@@ -6878,20 +6878,20 @@ button.close {
 
 @media screen and (min-width: 768px) {
   .carousel-control .glyphicon-chevron-left,
-  .carousel-control .glyphicon-chevron-right,
-  .carousel-control .icon-prev,
-  .carousel-control .icon-next {
+.carousel-control .glyphicon-chevron-right,
+.carousel-control .icon-prev,
+.carousel-control .icon-next {
     width: 30px;
     height: 30px;
     margin-top: -10px;
     font-size: 30px;
   }
   .carousel-control .glyphicon-chevron-left,
-  .carousel-control .icon-prev {
+.carousel-control .icon-prev {
     margin-left: -10px;
   }
   .carousel-control .glyphicon-chevron-right,
-  .carousel-control .icon-next {
+.carousel-control .icon-next {
     margin-right: -10px;
   }
   .carousel-caption {
@@ -6998,7 +6998,7 @@ button.close {
     display: table-row !important;
   }
   th.visible-xs,
-  td.visible-xs {
+td.visible-xs {
     display: table-cell !important;
   }
 }
@@ -7031,7 +7031,7 @@ button.close {
     display: table-row !important;
   }
   th.visible-sm,
-  td.visible-sm {
+td.visible-sm {
     display: table-cell !important;
   }
 }
@@ -7064,7 +7064,7 @@ button.close {
     display: table-row !important;
   }
   th.visible-md,
-  td.visible-md {
+td.visible-md {
     display: table-cell !important;
   }
 }
@@ -7097,7 +7097,7 @@ button.close {
     display: table-row !important;
   }
   th.visible-lg,
-  td.visible-lg {
+td.visible-lg {
     display: table-cell !important;
   }
 }
@@ -7154,7 +7154,7 @@ button.close {
     display: table-row !important;
   }
   th.visible-print,
-  td.visible-print {
+td.visible-print {
     display: table-cell !important;
   }
 }
@@ -7709,7 +7709,7 @@ table.mceToolbar tbody, table.mceToolbar tr, table.mceToolbar td {
     box-shadow: none !important; */
   }
   a,
-  a:visited {
+a:visited {
     text-decoration: underline;
   }
   a[href]:after {
@@ -7719,11 +7719,11 @@ table.mceToolbar tbody, table.mceToolbar tr, table.mceToolbar td {
     content: " (" attr(title) ")";
   }
   a[href^="javascript:"]:after,
-  a[href^="#"]:after {
+a[href^="#"]:after {
     content: "";
   }
   pre,
-  blockquote {
+blockquote {
     border: 1px solid #757575;
     page-break-inside: avoid;
   }
@@ -7731,20 +7731,20 @@ table.mceToolbar tbody, table.mceToolbar tr, table.mceToolbar td {
     display: table-header-group;
   }
   tr,
-  img {
+img {
     page-break-inside: avoid;
   }
   img {
     max-width: 100% !important;
   }
   p,
-  h2,
-  h3 {
+h2,
+h3 {
     orphans: 3;
     widows: 3;
   }
   h2,
-  h3 {
+h3 {
     page-break-after: avoid;
   }
   select {
@@ -7754,11 +7754,11 @@ table.mceToolbar tbody, table.mceToolbar tr, table.mceToolbar td {
     display: none;
   }
   .table td,
-  .table th {
+.table th {
     background-color: white !important;
   }
   .btn > .caret,
-  .dropup > .btn > .caret {
+.dropup > .btn > .caret {
     border-top-color: black !important;
   }
   .label {
@@ -7768,19 +7768,19 @@ table.mceToolbar tbody, table.mceToolbar tr, table.mceToolbar td {
     border-collapse: collapse !important;
   }
   .table-bordered th,
-  .table-bordered td {
+.table-bordered td {
     border: 1px solid #dddddd !important;
   }
   #ilTopBar,
-  .osdNotificationContainer,
-  .ilMainHeader,
-  .ilMainMenu,
-  .ilTreeView,
-  .btn,
-  #ilTab,
-  #ilSubTab,
-  #minheight,
-  #ilFooter {
+.osdNotificationContainer,
+.ilMainHeader,
+.ilMainMenu,
+.ilTreeView,
+.btn,
+#ilTab,
+#ilSubTab,
+#minheight,
+#ilFooter {
     display: none;
   }
   #mainspacekeeper {
@@ -8472,7 +8472,7 @@ button .minimize, button .close {
   z-index: 300;
 }
 .il-card .il-card-repository-head .icon {
-  filter: brightness(3);
+  filter: brightness(5);
 }
 .il-card .il-card-repository-head > div {
   padding: 6px 6px;
@@ -9395,9 +9395,9 @@ select.form-control {
 }
 @media only screen and (max-width: 768px) {
   .radio input[type=radio],
-  .radio-inline input[type=radio],
-  .checkbox input[type=checkbox],
-  .checkbox-inline input[type=checkbox] {
+.radio-inline input[type=radio],
+.checkbox input[type=checkbox],
+.checkbox-inline input[type=checkbox] {
     min-width: 16px;
   }
 }
@@ -9835,7 +9835,7 @@ footer {
     padding-right: 15px;
   }
   .il-layout-page.with-mainbar-slates-engaged #il_center_col.col-sm-9,
-  .il-layout-page.with-mainbar-slates-engaged #il_right_col.col-sm-3 {
+.il-layout-page.with-mainbar-slates-engaged #il_right_col.col-sm-3 {
     float: none !important;
     width: 100% !important;
   }
@@ -9970,11 +9970,11 @@ footer {
     content: " \e604";
   }
   .il-header-locator .btn-default:active:hover,
-  .il-header-locator .btn-default:active:focus,
-  .il-header-locator .open > .dropdown-toggle.btn-default,
-  .il-header-locator .open > .dropdown-toggle.btn-default:hover .open > .dropdown-toggle.btn-default:active,
-  .il-header-locator .open > .dropdown-toggle.btn-default:active:hover,
-  .il-header-locator .open > .dropdown-toggle.btn-default:active:focus {
+.il-header-locator .btn-default:active:focus,
+.il-header-locator .open > .dropdown-toggle.btn-default,
+.il-header-locator .open > .dropdown-toggle.btn-default:hover .open > .dropdown-toggle.btn-default:active,
+.il-header-locator .open > .dropdown-toggle.btn-default:active:hover,
+.il-header-locator .open > .dropdown-toggle.btn-default:active:focus {
     background: white;
     border-color: white;
     color: #2c2c2c;
@@ -10064,14 +10064,14 @@ footer {
     background: none;
   }
   html body .il-layout-page header,
-  html body .il-layout-page .il-maincontrols,
-  html body .il-layout-page .breadcrumbs,
-  html body .il-layout-page footer,
-  html body .il-layout-page .ilFileDropTargetOverlay {
+html body .il-layout-page .il-maincontrols,
+html body .il-layout-page .breadcrumbs,
+html body .il-layout-page footer,
+html body .il-layout-page .ilFileDropTargetOverlay {
     display: none !important;
   }
   html body .il-layout-page-content,
-  html body .il-layout-page-content div {
+html body .il-layout-page-content div {
     display: block;
   }
 }
@@ -10644,7 +10644,7 @@ the il- variable in your less code and not the boostrap variable in your less co
     font-size: 1.25rem;
   }
   .il-metabar-slates .il-counter-status,
-  .il-metabar-slates .il-counter-novelty {
+.il-metabar-slates .il-counter-novelty {
     margin-top: 0;
     top: 6px;
   }
@@ -10761,7 +10761,7 @@ the il- variable in your less code and not the boostrap variable in your less co
 }
 .il-mainbar-triggers .btn-bulky .icon,
 .il-mainbar-triggers .il-link.link-bulky .icon {
-  filter: brightness(3);
+  filter: brightness(5);
 }
 .il-mainbar-triggers .btn-bulky .icon.small,
 .il-mainbar-triggers .il-link.link-bulky .icon.small {
@@ -10842,29 +10842,29 @@ the il- variable in your less code and not the boostrap variable in your less co
 }
 @media (hover: none) {
   .il-mainbar-triggers .btn-bulky:hover,
-  .il-mainbar-triggers .il-link.link-bulky:hover {
+.il-mainbar-triggers .il-link.link-bulky:hover {
     background-color: #2c2c2c;
     color: white;
   }
   .il-mainbar-triggers .btn-bulky:hover .icon,
-  .il-mainbar-triggers .il-link.link-bulky:hover .icon {
-    filter: brightness(3);
+.il-mainbar-triggers .il-link.link-bulky:hover .icon {
+    filter: brightness(5);
   }
   .il-mainbar-triggers .btn-bulky:hover .bulky-label,
-  .il-mainbar-triggers .il-link.link-bulky:hover .bulky-label {
+.il-mainbar-triggers .il-link.link-bulky:hover .bulky-label {
     color: white;
   }
   .il-mainbar-triggers .btn-bulky.engaged,
-  .il-mainbar-triggers .il-link.link-bulky.engaged {
+.il-mainbar-triggers .il-link.link-bulky.engaged {
     background-color: white;
     color: #2c2c2c;
   }
   .il-mainbar-triggers .btn-bulky.engaged .icon,
-  .il-mainbar-triggers .il-link.link-bulky.engaged .icon {
+.il-mainbar-triggers .il-link.link-bulky.engaged .icon {
     filter: invert(50%);
   }
   .il-mainbar-triggers .btn-bulky.engaged .bulky-label,
-  .il-mainbar-triggers .il-link.link-bulky.engaged .bulky-label {
+.il-mainbar-triggers .il-link.link-bulky.engaged .bulky-label {
     color: #2c2c2c;
   }
 }
@@ -10897,7 +10897,7 @@ the il- variable in your less code and not the boostrap variable in your less co
 }
 .il-mainbar-tools-button .btn-bulky .icon,
 .il-mainbar-tools-button .btn-bulky.engaged .icon {
-  filter: brightness(3);
+  filter: brightness(5);
 }
 .il-mainbar-tools-button .btn-bulky.engaged {
   background-color: #e2e8ef;
@@ -10923,7 +10923,7 @@ the il- variable in your less code and not the boostrap variable in your less co
 }
 .il-mainbar-tools-entries .btn-bulky .icon, .il-mainbar-tools-entries .btn-bulky .icon,
 .il-mainbar-tools-entries .il-link.link-bulky .icon {
-  filter: brightness(3);
+  filter: brightness(5);
 }
 .il-mainbar-tools-entries .btn-bulky .bulky-label, .il-mainbar-tools-entries .btn-bulky .bulky-label,
 .il-mainbar-tools-entries .il-link.link-bulky .bulky-label {
@@ -11052,14 +11052,14 @@ the il- variable in your less code and not the boostrap variable in your less co
     z-index: 1;
   }
   .il-mainbar-triggers .btn-bulky,
-  .il-mainbar-triggers .il-link.link-bulky {
+.il-mainbar-triggers .il-link.link-bulky {
     flex-shrink: 0;
     border: 0;
     height: 3.75rem;
     width: 80px;
   }
   .il-mainbar-triggers .btn-bulky .icon.small,
-  .il-mainbar-triggers .il-link.link-bulky .icon.small {
+.il-mainbar-triggers .il-link.link-bulky .icon.small {
     height: 20px;
     width: 20px;
   }
@@ -11076,10 +11076,10 @@ the il- variable in your less code and not the boostrap variable in your less co
 }
 @media only screen and (min-width: 768px) {
   .il-mainbar-tool-trigger-item:nth-of-type(1):nth-last-of-type(5) .btn-bulky,
-  .il-mainbar-tool-trigger-item:nth-of-type(2):nth-last-of-type(4) .btn-bulky,
-  .il-mainbar-tool-trigger-item:nth-of-type(3):nth-last-of-type(3) .btn-bulky,
-  .il-mainbar-tool-trigger-item:nth-of-type(4):nth-last-of-type(2) .btn-bulky,
-  .il-mainbar-tool-trigger-item:nth-of-type(5):nth-last-of-type(1) .btn-bulky {
+.il-mainbar-tool-trigger-item:nth-of-type(2):nth-last-of-type(4) .btn-bulky,
+.il-mainbar-tool-trigger-item:nth-of-type(3):nth-last-of-type(3) .btn-bulky,
+.il-mainbar-tool-trigger-item:nth-of-type(4):nth-last-of-type(2) .btn-bulky,
+.il-mainbar-tool-trigger-item:nth-of-type(5):nth-last-of-type(1) .btn-bulky {
     width: 63px;
   }
 }
@@ -19678,23 +19678,23 @@ div[id^=ilAdvSelListTable_] {
 
 @media only screen and (min-width: 1200px) {
   #ilAdvSelListAnchorText_asl + ul.dropdown-menu > li > div.row .row,
-  #ilAdvSelListAnchorText_asl + .dropdown-backdrop + ul.dropdown-menu > li > div.row .row,
-  #mm_adm_tr + span + ul.dropdown-menu > li > div.row .row,
-  #mm_adm_tr + ul.dropdown-menu > li > div.row .row {
+#ilAdvSelListAnchorText_asl + .dropdown-backdrop + ul.dropdown-menu > li > div.row .row,
+#mm_adm_tr + span + ul.dropdown-menu > li > div.row .row,
+#mm_adm_tr + ul.dropdown-menu > li > div.row .row {
     width: auto;
   }
   #ilAdvSelListAnchorText_asl + ul.dropdown-menu > li > div.row ul,
-  #ilAdvSelListAnchorText_asl + .dropdown-backdrop + ul.dropdown-menu > li > div.row ul,
-  #mm_adm_tr + span + ul.dropdown-menu > li > div.row ul,
-  #mm_adm_tr + ul.dropdown-menu > li > div.row ul {
+#ilAdvSelListAnchorText_asl + .dropdown-backdrop + ul.dropdown-menu > li > div.row ul,
+#mm_adm_tr + span + ul.dropdown-menu > li > div.row ul,
+#mm_adm_tr + ul.dropdown-menu > li > div.row ul {
     min-width: 250px;
   }
 }
 @media only screen and (max-width: 768px) {
   #ilAdvSelListAnchorText_asl + ul.dropdown-menu > li > div.row,
-  #ilAdvSelListAnchorText_asl + .dropdown-backdrop + ul.dropdown-menu > li > div.row,
-  #mm_adm_tr + span + ul.dropdown-menu > li > div.row,
-  #mm_adm_tr + ul.dropdown-menu > li > div.row {
+#ilAdvSelListAnchorText_asl + .dropdown-backdrop + ul.dropdown-menu > li > div.row,
+#mm_adm_tr + span + ul.dropdown-menu > li > div.row,
+#mm_adm_tr + ul.dropdown-menu > li > div.row {
     width: 100% !important;
     margin: 0;
   }


### PR DESCRIPTION
Some Glyphicons went missing after the less to scss refactoring.
* I restored Glyphicons by fixing a path and also
* adjusted the brightness of icons in the mainbar (they were very, very light blue).
Color before
![image](https://user-images.githubusercontent.com/59924129/202248804-22be0ca3-73a2-4c6a-b0c7-f8e873fdce69.png)
Color after
![image](https://user-images.githubusercontent.com/59924129/202248917-f4d06a44-3062-477b-93d5-d43d89dbe8e0.png)
