### PR TITLE
T&A #0035319: ECTS-FX Einstellungen speichern

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -1754,12 +1754,12 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
 
     public function getECTSFX(): ?float
     {
-        return (strlen($this->ects_fx)) ? $this->ects_fx : null;
+        return $this->ects_fx;
     }
 
     public function setECTSFX($a_ects_fx): void
     {
-        $this->ects_fx = $a_ects_fx;
+        $this->ects_fx = (float) str_replace(",", ".", $a_ects_fx);
     }
 
     public function getECTSGrades(): array

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -764,11 +764,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
         $ilDB = $DIC['ilDB'];
 
         if ($this->getTestId() > 0) {
-            $this->setECTSFX(preg_replace('/,/', '.', $this->getECTSFX()));
-            if (!preg_match('/\d+/', $this->getECTSFX())) {
-                $this->setECTSFX(null);
-            }
-
             $grades = $this->getECTSGrades();
             $ilDB->manipulateF(
                 "UPDATE tst_tests


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=35319

removed string manipulation because ilObjTest::$ects_fx is already float
Only works because ilObjTest has no declare(strict_types=1)