### PR TITLE
Bugfix/0026255 text field of data collection with limit

### DIFF
--- a/Modules/DataCollection/classes/Fields/Text/class.ilDclTextFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Text/class.ilDclTextFieldRepresentation.php
@@ -47,12 +47,17 @@ class ilDclTextFieldRepresentation extends ilDclBaseFieldRepresentation
         $input = new ilDclTextInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
         if ($this->getField()->hasProperty(ilDclBaseFieldModel::PROP_TEXTAREA)) {
             $input = new ilTextAreaInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
+            //varchar(4000) in Database
+            $input->setMaxNumOfChars(4000);
+            //$input->setInfo($this->lng->txt("dcl_max_text_length") . ": " . $input->getMaxNumOfChars());
         }
 
         if ($this->getField()->hasProperty(ilDclBaseFieldModel::PROP_LENGTH)) {
             $input->setInfo($this->lng->txt("dcl_max_text_length") . ": " . $this->getField()->getProperty(ilDclBaseFieldModel::PROP_LENGTH));
             if (!$this->getField()->getProperty(ilDclBaseFieldModel::PROP_TEXTAREA)) {
                 $input->setMaxLength($this->getField()->getProperty(ilDclBaseFieldModel::PROP_LENGTH));
+            } else {
+                $input->setMaxNumOfChars($this->getField()->getProperty(ilDclBaseFieldModel::PROP_LENGTH));
             }
         }
 

--- a/Modules/DataCollection/classes/Fields/Text/class.ilDclTextFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Text/class.ilDclTextFieldRepresentation.php
@@ -49,7 +49,6 @@ class ilDclTextFieldRepresentation extends ilDclBaseFieldRepresentation
             $input = new ilTextAreaInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
             //varchar(4000) in Database
             $input->setMaxNumOfChars(4000);
-            //$input->setInfo($this->lng->txt("dcl_max_text_length") . ": " . $input->getMaxNumOfChars());
         }
 
         if ($this->getField()->hasProperty(ilDclBaseFieldModel::PROP_LENGTH)) {

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -8453,7 +8453,7 @@ dcl#:#dcl_last_update_description#:#Das Datum, an dem dieser Eintrag zuletzt ge�
 dcl#:#dcl_learning_progress#:#Lernfortschritt anzeigen
 dcl#:#dcl_legend_placeholders#:#Platzhalter
 dcl#:#dcl_length#:#Länge
-dcl#:#dcl_length_info#:#Maximale Anzahl von Zeichen, die ein Benutzer eingeben kann. Bei mehr als 200 Zeichen aktivieren Sie zusätzlich die Option "Mehrzeiliges Texteingabefeld".
+dcl#:#dcl_length_info#:#Anzahl von Zeichen, die ein Benutzer eingeben kann (Maximal 4000). Bei mehr als 200 Zeichen aktivieren Sie zusätzlich die Option "Mehrzeiliges Texteingabefeld".
 dcl#:#dcl_limit_end#:#Ende
 dcl#:#dcl_limit_start#:#Start
 dcl#:#dcl_limited#:#Zeitlich begrenzte Bearbeitung

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8454,7 +8454,7 @@ dcl#:#dcl_last_update_description#:#The date the entry was last edited.
 dcl#:#dcl_learning_progress#:#Show the learning progress of the linked module of the viewer
 dcl#:#dcl_legend_placeholders#:#Placeholders
 dcl#:#dcl_length#:#Length
-dcl#:#dcl_length_info#:#(for more than 200 characters, use the additional option Text Area)
+dcl#:#dcl_length_info#:#Number of characters a user can enter (maximum 4000). For more than 200 characters, use the additional option Text Area.
 dcl#:#dcl_limit_end#:#End
 dcl#:#dcl_limit_start#:#Start
 dcl#:#dcl_limited#:#Limited Add / Edit / Delete Period


### PR DESCRIPTION
#bugfix
Mantis issue: 0026255
Target: release_7
https://mantis.ilias.de/view.php?id=26255

When adding a new text field, the explanation now says that the field is limited to 4000 characters. Also, when writing in a text field, it shows how many remaining characters can be entered.
Increasing or removing the limitation of the field is complicated because the content of the text field is stored in a varchar(4000). You could replace this with a blob or clob, but this would require restructuring the database.