### PR TITLE
Bugfix: LearningSequence copy incl. LSItems 28896

### DIFF
--- a/Modules/LearningSequence/classes/class.ilObjLearningSequence.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequence.php
@@ -581,4 +581,35 @@ class ilObjLearningSequence extends ilContainer
             \ilLPStatus::LP_STATUS_COMPLETED_NUM
         ];
     }
+
+    public function handleChildCloning($a_target_id, $a_copy_id)
+    {
+        $this->cloneLsItem($a_target_id, $a_copy_id);
+    }
+
+    private function cloneLsItem($a_target_id, $a_copy_id)
+    {
+        $items = $this->getLSItems();
+        $ls_item = array();
+        foreach ($items as $item) {
+            if($item->getRefId() == $a_target_id) {
+                $post_condition = new ilLSPostCondition(
+                    (int) $a_copy_id,
+                    $item->getPostCondition()->getConditionOperator(),
+                    $item->getPostCondition()->getValue()
+                );
+                $ls_item[] = new LSItem($item->getType(),
+                    $item->getTitle(),
+                    $item->getDescription(),
+                    $item->getIconPath(),
+                    $item->isOnline(),
+                    $item->getOrderNumber(),
+                    $post_condition,
+                    (int) $a_copy_id
+                );
+                break;
+            }
+        }
+        $this->storeLSItems($ls_item);
+    }
 }

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequence.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequence.php
@@ -587,14 +587,14 @@ class ilObjLearningSequence extends ilContainer
         $this->cloneLsItem($a_target_id, $a_copy_id);
     }
 
-    private function cloneLsItem($a_target_id, $a_copy_id)
+    private function cloneLsItem($a_child_ref_id, $a_clone_ref_id)
     {
         $items = $this->getLSItems();
         $ls_item = array();
         foreach ($items as $item) {
-            if($item->getRefId() == $a_target_id) {
+            if($item->getRefId() == $a_child_ref_id) {
                 $post_condition = new ilLSPostCondition(
-                    (int) $a_copy_id,
+                    (int) $a_clone_ref_id,
                     $item->getPostCondition()->getConditionOperator(),
                     $item->getPostCondition()->getValue()
                 );
@@ -605,7 +605,7 @@ class ilObjLearningSequence extends ilContainer
                     $item->isOnline(),
                     $item->getOrderNumber(),
                     $post_condition,
-                    (int) $a_copy_id
+                    (int) $a_clone_ref_id
                 );
                 break;
             }

--- a/Services/Container/classes/class.ilContainer.php
+++ b/Services/Container/classes/class.ilContainer.php
@@ -1478,4 +1478,14 @@ class ilContainer extends ilObject
 
         return $obj_ids;
     }
+
+    /**
+     * @param $a_child_ref_id
+     * @param $a_clone_ref_id
+     * @return void
+     */
+    public function handleChildCloning($a_child_ref_id, $a_clone_ref_id)
+    {
+        // Kann ggf. überschrieben werden.
+    }
 } // END class ilContainer

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1900,6 +1900,17 @@ class ilObject
             'cloned_from_object' => $this,
         ));
 
+        $tree = $DIC->repositoryTree();
+
+        $parent_nd = $tree->getParentNodeData($this->getRefId());
+
+        include_once './Services/Object/classes/class.ilObjectFactory.php';
+        $factory = new ilObjectFactory();
+        $parentObj = $factory->getInstanceByRefId($parent_nd['ref_id'], false);
+        if ($parentObj) {
+            $parentObj->handleChildCloning($this->getRefId(), $new_obj->getRefId());
+        }
+
         return $new_obj;
     }
     
@@ -2319,5 +2330,15 @@ class ilObject
     public function getPossibleSubObjects($a_filter = true)
     {
         return $this->objDefinition->getSubObjects($this->type, $a_filter);
+    }
+
+    /**
+     * @param $a_target_id
+     * @param $a_copy_id
+     * @return void
+     */
+    public function handleChildCloning($a_target_id, $a_copy_id)
+    {
+        // Kann ggf. überschrieben werden.
     }
 } // END class.ilObject

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -2337,7 +2337,7 @@ class ilObject
      * @param $a_copy_id
      * @return void
      */
-    public function handleChildCloning($a_target_id, $a_copy_id)
+    public function handleChildCloning($a_child_ref_id, $a_clone_ref_id)
     {
         // Kann ggf. überschrieben werden.
     }

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1900,14 +1900,12 @@ class ilObject
             'cloned_from_object' => $this,
         ));
 
-        $tree = $DIC->repositoryTree();
 
-        $parent_nd = $tree->getParentNodeData($this->getRefId());
+        $parent_nd = $this->tree->getParentNodeData($this->getRefId());
 
-        include_once './Services/Object/classes/class.ilObjectFactory.php';
         $factory = new ilObjectFactory();
         $parentObj = $factory->getInstanceByRefId($parent_nd['ref_id'], false);
-        if ($parentObj) {
+        if ($parentObj instanceof ilContainer) {
             $parentObj->handleChildCloning($this->getRefId(), $new_obj->getRefId());
         }
 
@@ -2332,13 +2330,4 @@ class ilObject
         return $this->objDefinition->getSubObjects($this->type, $a_filter);
     }
 
-    /**
-     * @param $a_child_ref_id
-     * @param $a_clone_ref_id
-     * @return void
-     */
-    public function handleChildCloning($a_child_ref_id, $a_clone_ref_id)
-    {
-        // Kann ggf. überschrieben werden.
-    }
 } // END class.ilObject

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -2333,8 +2333,8 @@ class ilObject
     }
 
     /**
-     * @param $a_target_id
-     * @param $a_copy_id
+     * @param $a_child_ref_id
+     * @param $a_clone_ref_id
      * @return void
      */
     public function handleChildCloning($a_child_ref_id, $a_clone_ref_id)


### PR DESCRIPTION
#bugfix
Mantis issue: 0028896
Target: release_7
https://mantis.ilias.de/view.php?id=28896

This is the cleanest solution I could come up with.
The main Issue is that when a Learning Sequence is copied, LSItems for every child item of the LS (that is also selected for copy) one LSItem needs to be cloned too, but these LSItems are not handled by the individual child items, they are handled by the parent LS item. The child items themselves don't even know they are associated with an LSItem.

In this approach, the cloneObject Method was modified on the ilObject base class (which all other objects in the tree inherit from) in that at the end of the cloning process the parent is called with a new (per default empty) function "handleChildCloning".
Everywhere else this makes no difference as the function is empty in ilObject. But in the ilObjLearningSequence the function is overridden and the respective LSItem cloning is handled there.
In principle any other Structure that should potentially face a similar issue can now use the same approach here. Override the "handleChildClonig" and implement the required changes there.

One thing I am still not happy about is that, when creating the clone for the LSItem, I use getLSItems(), and iterate over all of them until I find the correct entry. I was unable to find a way to reconstruct the full LSItem directly without getting the entire List, mainly because without the full array I am unable to find out which position the LSItem should have. This value is required for the creation of the LSItem.