### PR TITLE
Fix localization with multiple correct answers in Long Menu question as Page content (Mantis #35064) (release_7)

### DIFF
--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -15,6 +15,7 @@ ilias.questions.txt = {
 	all_answers_correct: "Correct!",
 	enough_answers_correct: 'Correct, but not the best solution!',
 	nr_of_tries_exceeded: "Number of tries exceeded.",
+	correct_answers_separator: "or",
 	correct_answers_shown: "Correct solution see above.",
 	correct_answers_also: "Also correct are:",
 	correct_answer_also: "Also correct is:",
@@ -1177,9 +1178,11 @@ ilias.questions.showCorrectAnswers =function(a_id) {
 					correct_solution = '';
 					for (var j=0;j<questions[a_id].correct_answers[i][0].length;j++)
 					{
-						correct_solution += questions[a_id].correct_answers[i][0][j] + ' or ';
+						if (correct_solution.length > 0) {
+							correct_solution += ' ' + ilias.questions.txt.correct_answers_separator + ' ';
+						}
+						correct_solution += questions[a_id].correct_answers[i][0][j];
 					}
-					correct_solution = correct_solution.substring(0, correct_solution.length - 4);
 					if(questions[a_id].correct_answers[i][2] == 1)
 					{
 						a_node.find("[name='answer[" + i + "]']").val(correct_solution);

--- a/Services/COPage/classes/class.ilPCQuestion.php
+++ b/Services/COPage/classes/class.ilPCQuestion.php
@@ -461,6 +461,7 @@ class ilPCQuestion extends ilPageContent
 			ilias.questions.txt.all_answers_correct = "' . $lng->txtlng("content", "cont_all_answers_correct", $a_lang) . '";
 			ilias.questions.txt.enough_answers_correct = "' . $lng->txtlng("content", "cont_enough_answers_correct", $a_lang) . '";
 			ilias.questions.txt.nr_of_tries_exceeded = "' . $lng->txtlng("content", "cont_nr_of_tries_exceeded", $a_lang) . '";
+			ilias.questions.txt.correct_answers_separator = "' . $lng->txtlng("assessment", "or", $a_lang) . '";
 			ilias.questions.txt.correct_answers_shown = "' . $lng->txtlng("content", "cont_correct_answers_shown", $a_lang) . '";
 			ilias.questions.txt.correct_answers_also = "' . $lng->txtlng("content", "cont_correct_answers_also", $a_lang) . '";
 			ilias.questions.txt.correct_answer_also = "' . $lng->txtlng("content", "cont_correct_answer_also", $a_lang) . '";


### PR DESCRIPTION
This is a fix for [Mantis #35064](https://mantis.ilias.de/view.php?id=35064 "Mantis #35064: Failed test: Langes-Menü-Frage erstellen/bearbeiten"). See the commit message for details.

This is the pull request for the `release_7` branch. Other pull requests are opened for other branches.

@Uwe-Kohnle , can you please have a look at this? ILIAS 6 and ILIAS 7 still reference `question_handling.js` in the Scorm2004 code, but I have not found a location in the code which would require a change like the one for `class.ilPCQuestion.php` in this pull request. If there is none, fine. If there is, please point me to it so I can add the fix accordingly before this is merged.