### PR TITLE
A11y/UX, change dropdown and empty heading to link in listing panel

### DIFF
--- a/Services/Repository/Favourites/classes/class.ilFavouritesListGUI.php
+++ b/Services/Repository/Favourites/classes/class.ilFavouritesListGUI.php
@@ -65,15 +65,15 @@ class ilFavouritesListGUI
             $ctrl->setParameterByClass("ilPDSelectedItemsBlockGUI", "view", "0");
             $ctrl->setParameterByClass("ilPDSelectedItemsBlockGUI", "col_side", "center");
             $ctrl->setParameterByClass("ilPDSelectedItemsBlockGUI", "block_type", "pditems");
-            $panel = $f->panel()->secondary()->listing("", $item_groups);
-            $panel = $panel->withActions($f->dropdown()->standard([$f->link()->standard(
-                $this->lng->txt("rep_configure"),
-                $ctrl->getLinkTargetByClass(
-                    ["ilDashboardGUI", "ilColumnGUI", "ilPDSelectedItemsBlockGUI"],
-                    "manage"
+
+            $config_item = $f->item()->standard(
+                $f->link()->standard(
+                    $this->lng->txt("rep_configure"),
+                    $this->ctrl->getLinkTargetByClass(["ilDashboardGUI", "ilColumnGUI", "ilPDSelectedItemsBlockGUI"], "manage")
                 )
-            )
-            ]));
+            );
+            array_unshift($item_groups, $f->item()->group($this->lng->txt(""), [$config_item]));
+            $panel = $f->panel()->secondary()->listing("", $item_groups);
             return $this->ui->renderer()->render([$panel]);
         }
 


### PR DESCRIPTION
This is the long time ago promised follow up of: https://github.com/ILIAS-eLearning/ILIAS/pull/2943 ( see JF decision of the second of May):

@yvseiler and @Amstutz finally found time to look for a solution. Since we would like to fix especially the a11y issue for ILIAS 8 as well, we decided to opt. For a solution that is as minimally invasive as possible

The solution in the PR resolves to main issues:
- A11y: Empty Heading issue in Listing Panel, see: https://mantis.ilias.de/view.php?id=33884, and https://mantis.ilias.de/view.php?id=32356 . Note that this is a WCAG AA fail and would prevent passing an audit.
- UX: Currently we hide a single option in a dropdown, even though there cannot be more one action currently there in any setting and there is more than enough space to take the link out of the dropdown.

Currently the favourites list looks like this:
![image](https://user-images.githubusercontent.com/1866896/203553557-698a153e-666d-4f4b-bc79-6716dbe4c376.png)

With this change we would change it to this look:
![image](https://user-images.githubusercontent.com/1866896/203553724-ebffb632-4345-4cf2-9507-63292500ac49.png)

There is no change to the look if the list is empty.