### PR TITLE
Bugfix 25041 required comment in input UI Component

### DIFF
--- a/src/UI/Implementation/Component/Input/Container/Form/Form.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Form.php
@@ -41,7 +41,6 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
      */
     protected $error = null;
 
-
     /**
      * @param array $inputs
      */
@@ -116,6 +115,16 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
         $this->error = $error;
     }
 
+    public function getRequired()
+    {
+        $required = false;
+        foreach ($this->getInputs() as $input) {
+            if ($input->isRequired()) {
+                $required = true;
+            }
+        }
+        return $required;
+    }
 
     /**
      * @inheritdoc

--- a/src/UI/Implementation/Component/Input/Container/Form/Form.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Form.php
@@ -115,15 +115,14 @@ abstract class Form implements C\Input\Container\Form\Form, CI\Input\NameSource
         $this->error = $error;
     }
 
-    public function getRequired()
+    public function getRequired(): bool
     {
-        $required = false;
         foreach ($this->getInputs() as $input) {
             if ($input->isRequired()) {
-                $required = true;
+                return true;
             }
         }
-        return $required;
+        return false;
     }
 
     /**

--- a/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
@@ -45,6 +45,10 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl->setVariable("INPUTS", $default_renderer->render($component->getInputGroup()));
 
+        if($component->getRequired()) {
+            $tpl->setVariable("TXT_REQUIRED", $this->txt("required_field"));
+        }
+
         $error = $component->getError();
         if (!is_null($error)) {
             $tpl->setVariable("ERROR", $error);

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -75,6 +75,17 @@ class Group extends Input implements C\Input\Field\Group
         return $clone;
     }
 
+    public function isRequired()
+    {
+        $required = false;
+        foreach ($this->getInputs() as $input) {
+            if ($input->isRequired()) {
+                $required = true;
+            }
+        }
+        return $required;
+    }
+
     public function withOnUpdate(Signal $signal)
     {
         $clone = parent::withOnUpdate($signal);

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -77,13 +77,12 @@ class Group extends Input implements C\Input\Field\Group
 
     public function isRequired()
     {
-        $required = false;
         foreach ($this->getInputs() as $input) {
             if ($input->isRequired()) {
-                $required = true;
+                return true;
             }
         }
-        return $required;
+        return false;
     }
 
     public function withOnUpdate(Signal $signal)

--- a/src/UI/templates/default/Input/tpl.standard.html
+++ b/src/UI/templates/default/Input/tpl.standard.html
@@ -8,6 +8,11 @@
 	</div>
 	<!-- END error -->
 	{INPUTS}
+	<!-- BEGIN required_text -->
+	<div class="il-standard-form-footer clearfix">
+		<span class="asterisk">*</span><span class="small"> {TXT_REQUIRED}</span>
+	</div>
+	<!-- END required_text -->
 	<div class="il-standard-form-footer clearfix">
 		<div class="il-standard-form-cmd">{BUTTONS_BOTTOM}</div>
 	</div>


### PR DESCRIPTION
#bugfix
Mantis issue: 0025041
Target: release_7
https://mantis.ilias.de/view.php?id=25041

Required fields in a form, are marked with an asterisk, but there was no explanation under the form what the asterisk means.
Now the system checks if any of the fields in the form are marked as required. If so, an explanation is displayed. If the individual fields are divided into sections or groups, the individual groups are called first and then the fields within the groups are checked.