### PR TITLE
#BUG 30566 export date use user setting date format

### DIFF
--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordFieldModel.php
@@ -266,7 +266,7 @@ class ilDclBaseRecordFieldModel
 
 
     /**
-     * Function to parse incoming data from form input value $value. returns the string/number/etc. to store in the database.
+     * Function to parse incoming data from form input value $value. returns the string/number/etc. to export.
      *
      * @param mixed $value
      *

--- a/Modules/DataCollection/classes/Fields/Datetime/class.ilDclDatetimeRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Datetime/class.ilDclDatetimeRecordFieldModel.php
@@ -12,6 +12,17 @@
  */
 class ilDclDatetimeRecordFieldModel extends ilDclBaseRecordFieldModel
 {
+    protected string $date_format;
+
+    public function __construct(ilDclBaseRecordModel $record, ilDclBaseFieldModel $field)
+    {
+        parent::__construct($record, $field);
+        $this->date_format = ilCalendarSettings::getDateFormatString(
+            ilCalendarUserSettings::_getInstanceByUserId($this->user->getId())->getDateFormat()
+        );
+
+    }
+
     public function parseValue($value)
     {
         return $value;
@@ -40,10 +51,7 @@ class ilDclDatetimeRecordFieldModel extends ilDclBaseRecordFieldModel
      */
     public function parseExportValue($value)
     {
-        $datetime = date_create($value);
-        $user_settings = ilCalendarUserSettings::_getInstanceByUserId($this->user->getId());
-        $dateFormat = ilCalendarSettings::getDateFormatString($user_settings->getDateFormat());
-        return $datetime->format($dateFormat);
+        return date_create($value)->format($this->date_format);
     }
 
 

--- a/Modules/DataCollection/classes/Fields/Datetime/class.ilDclDatetimeRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Datetime/class.ilDclDatetimeRecordFieldModel.php
@@ -32,7 +32,7 @@ class ilDclDatetimeRecordFieldModel extends ilDclBaseRecordFieldModel
 
 
     /**
-     * Function to parse incoming data from form input value $value. returns the string/number/etc. to store in the export file.
+     * Function to parse incoming data from form input value $value. returns the string/number/etc. to export.
      *
      * @param mixed $value
      *
@@ -40,10 +40,8 @@ class ilDclDatetimeRecordFieldModel extends ilDclBaseRecordFieldModel
      */
     public function parseExportValue($value)
     {
-        global $DIC;
-        $ilUser = $DIC->user();
         $datetime = date_create($value);
-        $user_settings = ilCalendarUserSettings::_getInstanceByUserId($ilUser->getId());
+        $user_settings = ilCalendarUserSettings::_getInstanceByUserId($this->user->getId());
         $dateFormat = ilCalendarSettings::getDateFormatString($user_settings->getDateFormat());
         return $datetime->format($dateFormat);
     }

--- a/Modules/DataCollection/classes/Fields/Datetime/class.ilDclDatetimeRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Datetime/class.ilDclDatetimeRecordFieldModel.php
@@ -32,7 +32,7 @@ class ilDclDatetimeRecordFieldModel extends ilDclBaseRecordFieldModel
 
 
     /**
-     * Function to parse incoming data from form input value $value. returns the string/number/etc. to store in the database.
+     * Function to parse incoming data from form input value $value. returns the string/number/etc. to store in the export file.
      *
      * @param mixed $value
      *
@@ -40,7 +40,12 @@ class ilDclDatetimeRecordFieldModel extends ilDclBaseRecordFieldModel
      */
     public function parseExportValue($value)
     {
-        return substr($value, 0, 10);
+        global $DIC;
+        $ilUser = $DIC->user();
+        $datetime = date_create($value);
+        $user_settings = ilCalendarUserSettings::_getInstanceByUserId($ilUser->getId());
+        $dateFormat = ilCalendarSettings::getDateFormatString($user_settings->getDateFormat());
+        return $datetime->format($dateFormat);
     }
 
 

--- a/Services/Calendar/classes/class.ilCalendarSettings.php
+++ b/Services/Calendar/classes/class.ilCalendarSettings.php
@@ -668,6 +668,27 @@ class ilCalendarSettings
     }
 
     /**
+     * returns the date format string corresponding to the int constant date format value
+     * @param $dateFormat
+     * @return string
+     */
+    public static function getDateFormatString($dateFormat) {
+        switch ($dateFormat) {
+            case ilCalendarSettings::DATE_FORMAT_DMY:
+                $formatString = 'd.m.Y';
+                break;
+            case ilCalendarSettings::DATE_FORMAT_MDY:
+                $formatString = 'm/d/Y';
+                break;
+            case ilCalendarSettings::DATE_FORMAT_YMD:
+            default:
+                $formatString = 'Y-m-d';
+                break;
+        }
+        return $formatString;
+    }
+
+    /**
      * Read settings
      *
      * @access private

--- a/Services/Calendar/classes/class.ilCalendarSettings.php
+++ b/Services/Calendar/classes/class.ilCalendarSettings.php
@@ -669,10 +669,11 @@ class ilCalendarSettings
 
     /**
      * returns the date format string corresponding to the int constant date format value
-     * @param $dateFormat
+     * @param int $dateFormat
      * @return string
      */
-    public static function getDateFormatString($dateFormat) {
+    public static function getDateFormatString(int $dateFormat): string
+    {
         switch ($dateFormat) {
             case ilCalendarSettings::DATE_FORMAT_DMY:
                 $formatString = 'd.m.Y';


### PR DESCRIPTION
#bugfix
mantis issue: 30566
https://mantis.ilias.de/view.php?id=30566

Now the user setting Date Format is considered when exporting a data collection.
Since getting the date format string (e.g. d.m.Y) is not specific to this issue I opted to add a new function to the ilCalendarSettings, mapping the constant values (1,2,3) to the corresponding format string.