### PR TITLE
TA: 34411, prevent whoops on re-submitting after failed checkInput

### DIFF
--- a/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesInputGUI.php
@@ -211,6 +211,10 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
         if (is_array($F['tmp_name'])) {
             foreach ($F['tmp_name'] as $index => $tmpname) {
                 $filename = $F['name'][$index];
+                if (is_array($filename)) {
+                    $filename = array_shift($filename);
+                    $tmpname = array_shift($tmpname);
+                }
                 $filename_arr = pathinfo($filename);
                 $suffix = $filename_arr["extension"] ?? '';
                 $mimetype = $F['type'][$index];
@@ -227,6 +231,10 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
 
         foreach ($F['tmp_name'] as $index => $tmpname) {
             $filename = $F['name'][$index];
+            if (is_array($filename)) {
+                $filename = array_shift($filename);
+                $tmpname = array_shift($tmpname);
+            }
             $filename_arr = pathinfo($filename);
             $suffix = $filename_arr["extension"] ?? '';
             $mimetype = $F['type'][$index];


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=34411
this is not a real "fix", but rather hides the whoops when re-submitting a from that previously failed on checkInput.
The values are still not preserverd ;(
Please reject/close, if this feels awkward.