### PR TITLE
[FIX] CI: copyright-checker now ignores UI examples.

### DIFF
--- a/CI/Copyright-Checker/copyright-checker.sh
+++ b/CI/Copyright-Checker/copyright-checker.sh
@@ -56,6 +56,10 @@ do
     continue
   fi
 
+  if [[ $FELONE == "./src/UI/examples" ]]; then
+    continue
+  fi
+
   # check for php extension
   if [ ! ${FELONE: -4} == ".php" ]; then
     continue


### PR DESCRIPTION
Hi all

UI code examples located at `src/UI/examples` are always violating the copyright-checker because they do not contain the copyright license header at the top of each file. The reason for this is, that these snippets are displayed in the UI documentation **as is**. The documentation would get rather crowded if all examples would contain this license header, therefore it was agreed to leave them out.

I adjusted the copyright-checker to ignore files containing the substring `src/UI/examples` as done for the `./libs` directory.
This change would need to be picked for release_7 & release_8 as well.

@mjansenDatabay I know you're not officially responsible for this, feel free to reassign.

Kind regards!