### PR TITLE
[FIX] #35763: fixed purification on NULL when no feedback was found.

### DIFF
--- a/Modules/TestQuestionPool/classes/feedback/class.ilAssMultiOptionQuestionFeedback.php
+++ b/Modules/TestQuestionPool/classes/feedback/class.ilAssMultiOptionQuestionFeedback.php
@@ -148,8 +148,9 @@ abstract class ilAssMultiOptionQuestionFeedback extends ilAssQuestionFeedback
             array($questionId, $questionIndex, $answerIndex)
         );
 
+        $feedbackContent = '';
         while ($row = $this->db->fetchAssoc($res)) {
-            if (array_key_exists('feedback ', $row) && $feedbackContent !== null) {
+            if (array_key_exists('feedback', $row) && $row['feedback'] !== null) {
                 $feedbackContent = ilRTE::_replaceMediaObjectImageSrc($this->questionOBJ->getHtmlQuestionContentPurifier()->purify($row['feedback']), 1);
                 break;
             }


### PR DESCRIPTION
Hi all

We found a bug (see https://mantis.ilias.de/view.php?id=35763) where `null` was being purified. This should fix the issue by checking the correct array-key with `array_key_exists`. I also initialized `$feedbackContent` properly.

Kind regards