### PR TITLE
[FIX] Style: ilSystemStyleSkinContainerTest::testImportSkin

### DIFF
--- a/Services/Style/System/test/ilSystemStyleSkinContainerTest.php
+++ b/Services/Style/System/test/ilSystemStyleSkinContainerTest.php
@@ -291,8 +291,8 @@ class ilSystemStyleSkinContainerTest extends TestCase
             }
         }
 
-        //Only perform this test, if an unzip path has been found.
-        if (PATH_TO_UNZIP != "") {
+        //Only perform this test, if an unzip and zip path has been found.
+        if (PATH_TO_UNZIP !== "" && PATH_TO_ZIP !== "") {
             $container = ilSystemStyleSkinContainer::generateFromId($this->skin->getId(), null, $this->system_style_config);
             $skin = $container->getSkin();
 


### PR DESCRIPTION
Hi @Amstutz 

We came across this failed test when **only unzip** has been installed on the system. Apparently, unzip requires zip to be installed as well, otherwise the operation fails. Therefore this unit test failed as well, because it ist only skipped if unzip isn't available.

Kind regards!