### PR TITLE
Dashboard: Fix missing list_factory

### DIFF
--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockGUI.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockGUI.php
@@ -116,6 +116,7 @@ class ilPDSelectedItemsBlockGUI extends ilBlockGUI implements ilDesktopItemHandl
         $this->allow_moving = false;
 
         $this->initViewSettings();
+        $this->list_factory = new ilPDSelectedItemsBlockListGUIFactory($this, $this->blockView);
 
         if ($this->viewSettings->isTilePresentation()) {
             $this->setPresentation(self::PRES_MAIN_LEG);


### PR DESCRIPTION
Fixing mantis bug: https://mantis.ilias.de/view.php?id=35784
`$this->list_factory` is null.