### PR TITLE
Various DC PHP 8 Fixes

### DIFF
--- a/Modules/DataCollection/classes/Adapters/Ui/class.ilDataCollectionUiAdapter.php
+++ b/Modules/DataCollection/classes/Adapters/Ui/class.ilDataCollectionUiAdapter.php
@@ -74,7 +74,7 @@ class ilDataCollectionUiAdapter implements ilDataCollectionUiPort
 
     public function addJavaScriptFile(string $filePath): void
     {
-        $this->ui->mainTemplate()->addJavaScript("./Services/UIComponent/Modal/js/Modal.js");
+        $this->ui->mainTemplate()->addJavaScript($filePath);
     }
 
     public function displayFailureMessage(string $message): void

--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseFieldModel.php
@@ -27,10 +27,7 @@
  */
 class ilDclBaseFieldModel
 {
-    /**
-     * @var int|string $id int for custom fields string for standard fields
-     */
-    protected $id = 0;
+    protected string $id = "";
     protected int $table_id = 0;
     protected string $title = "";
     protected string $description = "";
@@ -115,9 +112,8 @@ class ilDclBaseFieldModel
 
     /**
      * Get field id
-     * @return int|string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
@@ -570,7 +566,7 @@ class ilDclBaseFieldModel
     /**
      * @param mixed $value
      */
-    protected function normalizeValue($value): string
+    protected function normalizeValue($value): ?string
     {
         if (is_string($value)) {
             $value = trim(preg_replace("/\\s+/uism", " ", $value));

--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseFieldRepresentation.php
@@ -97,7 +97,7 @@ abstract class ilDclBaseFieldRepresentation
     /**
      * Returns field-input
      */
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ?ilFormPropertyGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ?ilFormPropertyGUI
     {
         return null;
     }

--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordFieldModel.php
@@ -28,7 +28,7 @@
  */
 class ilDclBaseRecordFieldModel
 {
-    protected int $id = 0;
+    protected ?int $id = null;
     protected ilDclBaseFieldModel $field;
     protected ilDclBaseRecordModel $record;
     protected ?ilDclBaseRecordRepresentation $record_representation = null;
@@ -361,7 +361,7 @@ class ilDclBaseRecordFieldModel
         return $this->field;
     }
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordModel.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordModel.php
@@ -47,11 +47,11 @@ class ilDclBaseRecordModel
     protected ILIAS\HTTP\Services $http;
     protected ILIAS\Refinery\Factory $refinery;
 
-    public function __construct(int $a_id = 0)
+    public function __construct(?int $a_id = 0)
     {
         global $DIC;
 
-        if ($a_id != 0) {
+        if ($a_id && $a_id != 0) {
             $this->id = $a_id;
             $this->doRead();
         }
@@ -59,11 +59,6 @@ class ilDclBaseRecordModel
         $this->notes = $DIC->notes();
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
-    }
-
-    private function fixDate(string $value): string
-    {
-        return $value;
     }
 
     public function doUpdate(bool $omit_notification = false): void
@@ -78,7 +73,7 @@ class ilDclBaseRecordModel
             ),
             "last_update" => array(
                 "date",
-                $this->fixDate($this->getLastUpdate()),
+                $this->getLastUpdate()->get(IL_CAL_DATETIME),
             ),
             "owner" => array(
                 "text",
@@ -121,8 +116,8 @@ class ilDclBaseRecordModel
         $rec = $ilDB->fetchAssoc($set);
 
         $this->setTableId($rec["table_id"]);
-        $this->setCreateDate($rec["create_date"]);
-        $this->setLastUpdate($rec["last_update"]);
+        $this->setCreateDate(new ilDateTime($rec["create_date"]));
+        $this->setLastUpdate(new ilDateTime($rec["last_update"]));
         $this->setOwner($rec["owner"]);
         $this->setLastEditBy($rec["last_edit_by"]);
     }
@@ -133,7 +128,7 @@ class ilDclBaseRecordModel
     public function doCreate(): void
     {
         global $DIC;
-        $ilDB = $DIC['ilDB'];
+        $ilDB = $DIC->database();
 
         if (!ilDclTable::_tableExists($this->getTableId())) {
             throw new ilException("The field does not have a related table!");
@@ -153,8 +148,8 @@ class ilDclBaseRecordModel
                 $this->getTableId(),
                 "integer"
             ) . ","
-            . $ilDB->quote($this->getCreateDate(), "timestamp") . "," . $ilDB->quote(
-                $this->getLastUpdate(),
+            . $ilDB->quote($this->getCreateDate()->get(IL_CAL_DATETIME), "timestamp") . "," . $ilDB->quote(
+                $this->getLastUpdate()->get(IL_CAL_DATETIME),
                 "timestamp"
             ) . ","
             . $ilDB->quote($this->getOwner(), "integer") . "," . $ilDB->quote($this->getLastEditBy(), "integer") . "

--- a/Modules/DataCollection/classes/Fields/Boolean/class.ilDclBooleanFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Boolean/class.ilDclBooleanFieldRepresentation.php
@@ -23,7 +23,7 @@
  */
 class ilDclBooleanFieldRepresentation extends ilDclBaseFieldRepresentation
 {
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilDclCheckboxInputGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilDclCheckboxInputGUI
     {
         $input = new ilDclCheckboxInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
         $this->setupInputField($input, $this->getField());

--- a/Modules/DataCollection/classes/Fields/Datetime/class.ilDclDatetimeFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Datetime/class.ilDclDatetimeFieldRepresentation.php
@@ -23,7 +23,7 @@
  */
 class ilDclDatetimeFieldRepresentation extends ilDclBaseFieldRepresentation
 {
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilDateTimeInputGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilDateTimeInputGUI
     {
         $input = new ilDateTimeInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
         $input->setStartYear(date("Y") - 100);

--- a/Modules/DataCollection/classes/Fields/Fileupload/class.ilDclFileuploadFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Fileupload/class.ilDclFileuploadFieldRepresentation.php
@@ -23,7 +23,7 @@
  */
 class ilDclFileuploadFieldRepresentation extends ilDclBaseFieldRepresentation
 {
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilFileInputGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilFileInputGUI
     {
         $input = new ilFileInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
         $input->setSuffixes($this->getField()->getSupportedExtensions());

--- a/Modules/DataCollection/classes/Fields/Formula/class.ilDclFormulaFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Formula/class.ilDclFormulaFieldRepresentation.php
@@ -22,7 +22,7 @@
  */
 class ilDclFormulaFieldRepresentation extends ilDclBaseFieldRepresentation
 {
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilTextInputGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilTextInputGUI
     {
         $input = new ilTextInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
         $input->setDisabled(true);

--- a/Modules/DataCollection/classes/Fields/IliasReference/class.ilDclIliasReferenceFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/IliasReference/class.ilDclIliasReferenceFieldRepresentation.php
@@ -23,7 +23,7 @@
  */
 class ilDclIliasReferenceFieldRepresentation extends ilDclBaseFieldRepresentation
 {
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilRepositorySelector2InputGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilRepositorySelector2InputGUI
     {
         $input = new ilRepositorySelector2InputGUI(
             $this->getField()->getTitle(),

--- a/Modules/DataCollection/classes/Fields/IliasReference/class.ilDclIliasReferenceRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/IliasReference/class.ilDclIliasReferenceRecordFieldModel.php
@@ -46,8 +46,11 @@ class ilDclIliasReferenceRecordFieldModel extends ilDclBaseRecordFieldModel
         global $DIC;
         $ilDB = $DIC['ilDB'];
         $ilUser = $DIC['ilUser'];
-        $usr_id = $ilUser->getId();
         $obj_ref = $this->getValue();
+        if (!$obj_ref) {
+            return false;
+        }
+        $usr_id = $ilUser->getId();
         $obj_id = ilObject2::_lookupObjectId($obj_ref);
         $query
             = "  SELECT status_changed, status
@@ -62,7 +65,11 @@ class ilDclIliasReferenceRecordFieldModel extends ilDclBaseRecordFieldModel
     {
         $ref_id = $this->getValue();
 
-        return ilObject2::_lookupTitle(ilObject2::_lookupObjectId($ref_id)) . ' [' . $ref_id . ']';
+        if ($ref_id) {
+            return ilObject2::_lookupTitle(ilObject2::_lookupObjectId($ref_id)) . ' [' . $ref_id . ']';
+        } else {
+            return "";
+        }
     }
 
     public function getExportValue(): string

--- a/Modules/DataCollection/classes/Fields/Mob/class.ilDclMobFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Mob/class.ilDclMobFieldRepresentation.php
@@ -23,7 +23,7 @@
  */
 class ilDclMobFieldRepresentation extends ilDclFileuploadFieldRepresentation
 {
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilFileInputGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilFileInputGUI
     {
         $input = new ilFileInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
         $input->setSuffixes(ilDclMobFieldModel::$mob_suffixes);

--- a/Modules/DataCollection/classes/Fields/Number/class.ilDclNumberFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Number/class.ilDclNumberFieldRepresentation.php
@@ -23,7 +23,7 @@
  */
 class ilDclNumberFieldRepresentation extends ilDclBaseFieldRepresentation
 {
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilNumberInputGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilNumberInputGUI
     {
         $input = new ilNumberInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
         // 9 is the maximum number of digits for an integer

--- a/Modules/DataCollection/classes/Fields/Rating/class.ilDclRatingFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Rating/class.ilDclRatingFieldRepresentation.php
@@ -23,7 +23,7 @@
  */
 class ilDclRatingFieldRepresentation extends ilDclBaseFieldRepresentation
 {
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilTextInputGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilTextInputGUI
     {
         $input = new ilTextInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
         $input->setValue($this->lng->txt("dcl_editable_in_table_gui"));

--- a/Modules/DataCollection/classes/Fields/Reference/class.ilDclReferenceFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Reference/class.ilDclReferenceFieldRepresentation.php
@@ -25,7 +25,7 @@ class ilDclReferenceFieldRepresentation extends ilDclBaseFieldRepresentation
 {
     public const REFERENCE_SEPARATOR = " -> ";
 
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilSelectInputGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilSelectInputGUI
     {
         if (!$this->getField()->getProperty(ilDclBaseFieldModel::PROP_N_REFERENCE)) {
             $input = new ilSelectInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());

--- a/Modules/DataCollection/classes/Fields/Selection/class.ilDclSelectionFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Selection/class.ilDclSelectionFieldRepresentation.php
@@ -65,7 +65,7 @@ abstract class ilDclSelectionFieldRepresentation extends ilDclBaseFieldRepresent
     /**
      * @return ilMultiSelectInputGUI|ilRadioGroupInputGUI|ilSelectInputGUI
      */
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilFormPropertyGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilFormPropertyGUI
     {
         /** @var ilDclSelectionOption[] $options */
         $options = ilDclSelectionOption::getAllForField($this->getField()->getId());

--- a/Modules/DataCollection/classes/Fields/Text/class.ilDclTextFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Text/class.ilDclTextFieldRepresentation.php
@@ -52,7 +52,7 @@ class ilDclTextFieldRepresentation extends ilDclBaseFieldRepresentation
         return $pass;
     }
 
-    public function getInputField(ilPropertyFormGUI $form, int $record_id = 0): ilFormPropertyGUI
+    public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilFormPropertyGUI
     {
         $input = new ilDclTextInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
         if ($this->getField()->hasProperty(ilDclBaseFieldModel::PROP_TEXTAREA)) {

--- a/Modules/DataCollection/classes/Fields/Text/class.ilDclTextRecordRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Text/class.ilDclTextRecordRepresentation.php
@@ -59,6 +59,10 @@ class ilDclTextRecordRepresentation extends ilDclBaseRecordRepresentation
             $html = (is_array($value) && isset($value['link'])) ? $value['link'] : $value;
         }
 
+        if (!$html) {
+            $html = "";
+        }
+
         return $html;
     }
 

--- a/Modules/DataCollection/classes/Fields/Text/class.ilDclTextRecordRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Text/class.ilDclTextRecordRepresentation.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * Class ilDclTextFieldRepresentation

--- a/Modules/DataCollection/classes/Fields/class.ilDclFieldFactory.php
+++ b/Modules/DataCollection/classes/Fields/class.ilDclFieldFactory.php
@@ -330,7 +330,7 @@ class ilDclFieldFactory
         return $title;
     }
 
-    public static function getRecordModelInstance(int $record_id): ilDclBaseRecordModel
+    public static function getRecordModelInstance(?int $record_id): ilDclBaseRecordModel
     {
         return new ilDclBaseRecordModel($record_id);
     }

--- a/Modules/DataCollection/classes/Helpers/class.ilDclCache.php
+++ b/Modules/DataCollection/classes/Helpers/class.ilDclCache.php
@@ -152,10 +152,10 @@ class ilDclCache
         return $fields_cache[$field_id];
     }
 
-    public static function getRecordCache(int $record_id = 0): ilDclBaseRecordModel
+    public static function getRecordCache(?int $record_id): ilDclBaseRecordModel
     {
         $records_cache = &self::$records_cache;
-        if (!isset($records_cache[$record_id])) {
+        if (!$record_id || !isset($records_cache[$record_id])) {
             $records_cache[$record_id] = ilDclFieldFactory::getRecordModelInstance($record_id);
         }
 

--- a/Modules/DataCollection/classes/Helpers/class.ilDclGenericMultiInputGUI.php
+++ b/Modules/DataCollection/classes/Helpers/class.ilDclGenericMultiInputGUI.php
@@ -173,7 +173,7 @@ class ilDclGenericMultiInputGUI extends ilFormPropertyGUI
      */
     public function setValueByArray(array $a_values): void
     {
-        $data = $a_values[$this->getPostVar() ?? null];
+        $data = $a_values[$this->getPostVar()] ?? null;
         if ($this->getMulti()) {
             $this->line_values = $data;
         } else {

--- a/Modules/DataCollection/classes/Helpers/class.ilDclTextInputGUI.php
+++ b/Modules/DataCollection/classes/Helpers/class.ilDclTextInputGUI.php
@@ -42,9 +42,10 @@ class ilDclTextInputGUI extends ilTextInputGUI
             if (substr($regex, 0, 1) != "/") {
                 $regex = "/" . $regex;
             }
-            if (substr($regex, -1) != "/") {
+            if (substr($regex, -1) != "/" || $regex == "/") {
                 $regex .= "/";
             }
+
             try {
                 preg_match($regex, '');
             } catch (Exception $e) {

--- a/Modules/DataCollection/classes/Table/class.ilDclTable.php
+++ b/Modules/DataCollection/classes/Table/class.ilDclTable.php
@@ -820,7 +820,7 @@ class ilDclTable
     /**
      * Get a field by title
      */
-    public function getFieldByTitle(string $title): ilDclBaseFieldModel
+    public function getFieldByTitle(string $title): ?ilDclBaseFieldModel
     {
         $return = null;
         foreach ($this->getFields() as $field) {

--- a/Modules/DataCollection/classes/TableView/class.ilDclTableView.php
+++ b/Modules/DataCollection/classes/TableView/class.ilDclTableView.php
@@ -472,7 +472,7 @@ class ilDclTableView extends ActiveRecord
      * @param bool $create_default_settings
      * @return ilDclTableView|ActiveRecord
      */
-    public static function createOrGetStandardView(int $table_id, bool $create_default_settings = true): ActiveRecord
+    public static function createOrGetSatndardView(int $table_id, bool $create_default_settings = true): ActiveRecord
     {
         if ($standardview = self::where(array('table_id' => $table_id))->orderBy('tableview_order')->first()) {
             return $standardview;

--- a/Modules/DataCollection/classes/TableView/class.ilDclTableView.php
+++ b/Modules/DataCollection/classes/TableView/class.ilDclTableView.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * Class ilDclTableView

--- a/Modules/DataCollection/classes/TableView/class.ilDclTableViewFieldSetting.php
+++ b/Modules/DataCollection/classes/TableView/class.ilDclTableViewFieldSetting.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * Class ilDclTableViewFieldSetting

--- a/Modules/DataCollection/classes/TableView/class.ilDclTableViewFieldSetting.php
+++ b/Modules/DataCollection/classes/TableView/class.ilDclTableViewFieldSetting.php
@@ -371,7 +371,7 @@ class ilDclTableViewFieldSetting extends ActiveRecord
     /**
      * @return ActiveRecord|self
      */
-    public static function getTableViewFieldSetting(int $id, int $tableview_id): ActiveRecord
+    public static function getTableViewFieldSetting(string $id, int $tableview_id): ActiveRecord
     {
         return parent::where(array('field' => $id,
                                    'tableview_id' => $tableview_id

--- a/Modules/DataCollection/classes/TableView/class.ilDclTableViewTableGUI.php
+++ b/Modules/DataCollection/classes/TableView/class.ilDclTableViewTableGUI.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
 
 /**
  * Class ilDclTableViewTableGUI

--- a/Modules/DataCollection/classes/class.ilObjDataCollection.php
+++ b/Modules/DataCollection/classes/class.ilObjDataCollection.php
@@ -137,7 +137,7 @@ class ilObjDataCollection extends ilObject2
         $http = $DIC->http();
         $refinery = $DIC->refinery();
 
-        $ref_id = $http->wrapper()->query()->retrieve('table_id', $refinery->kindlyTo()->int());
+        $ref_id = $http->wrapper()->query()->retrieve('ref_id', $refinery->kindlyTo()->int());
 
         // If coming from trash, never send notifications and don't load dcl Object
         if ($ref_id === SYSTEM_FOLDER_ID) {

--- a/Modules/DataCollection/classes/class.ilObjDataCollectionGUI.php
+++ b/Modules/DataCollection/classes/class.ilObjDataCollectionGUI.php
@@ -84,6 +84,7 @@ class ilObjDataCollectionGUI extends ilObject2GUI
 
         $this->dclEndPoint->saveParameterTableId($this);
         $this->ctrl->saveParameter($this, "table_id");
+        $this->ctrl->setParameter($this, "table_id", $this->table_id);
     }
 
     private function setTableId(int $objectOrRefId = 0): void
@@ -223,7 +224,6 @@ class ilObjDataCollectionGUI extends ilObject2GUI
                 $this->prepareOutput();
                 $this->tabs->activateTab("id_records");
 
-                $tableview_id = 1;
                 if ($this->http->wrapper()->query()->has('tableview_id')) {
                     $tableview_id = $this->http->wrapper()->query()->retrieve(
                         'tableview_id',
@@ -235,6 +235,11 @@ class ilObjDataCollectionGUI extends ilObject2GUI
                         'tableview_id',
                         $this->refinery->kindlyTo()->int()
                     );
+                }
+
+                if (!isset($tableview_id)) {
+                    $tableview_id = ilDclCache::getTableCache($this->table_id)
+                                                    ->getFirstTableViewId($this->getRefId());
                 }
 
                 $this->ctrl->setParameterByClass(ilDclRecordListGUI::class, 'tableview_id', $tableview_id);
@@ -342,8 +347,11 @@ class ilObjDataCollectionGUI extends ilObject2GUI
                 'tableview_id',
                 $this->refinery->kindlyTo()->int()
             );
-        } else {
-            $tableview_id = 0;
+        }
+
+        if (!isset($tableview_id)) {
+            $tableview_id = ilDclCache::getTableCache($this->table_id)
+                                            ->getFirstTableViewId($this->getRefId());
         }
 
         $this->ctrl->setParameterByClass('ilDclRecordListGUI', 'tableview_id', $tableview_id);
@@ -446,12 +454,16 @@ class ilObjDataCollectionGUI extends ilObject2GUI
 
         // read permission
         if ($this->dclAccess->hasReadPermission($refId) === true) {
-            $tableview_id = 1;
             if ($this->http->wrapper()->query()->has('tableview_id')) {
                 $tableview_id = $this->http->wrapper()->query()->retrieve(
                     'tableview_id',
                     $this->refinery->kindlyTo()->int()
                 );
+            }
+
+            if (!isset($tableview_id)) {
+                $tableview_id = ilDclCache::getTableCache($this->table_id)
+                                                ->getFirstTableViewId($this->getRefId());
             }
 
             // list records


### PR DESCRIPTION
Since I had to fix an a11y involving Icons in the DC, I needed to fix several things first in order to even check if my Icon fix works in the GUI. I labelled this a "Bugfix" without linking a specific one, since this targets a whole range of issues and should de-block a rather larger set of test cases.

With the here proposed fixes a was able to (PHP8):
-> Open an existin DC from Repo
-> Create a new DC
-> Create new Tables
-> Add Fields of to a DC (Text, Boolean, Reference and Formula has been tested, others are still with errors)
-> Change Fields in a DC (not all Types, see a above)
-> Use Formula Fields with Place Holder / Fix JS Loading
-> Add Entries (not all Types, see a above)
-> Change Entries  (not all Types, see a above)
-> Add Views to a DC 
-> Change Views in a DC
-> Add Detailed views to a Field
-> Look at detailled view in a DC

Note that overall state of the DC still remains very unstable. The migration performed by @mstuder, seems to have never been tested on the frontend. Many parts of the performed migration are broken or only partly done in order to make automated checks (style guide, MUST criteria of the projects etc) and the code review pass. 

I hope this helps somewhat. I would propose to merge this and then improve from this point on. Just picking individual improvements would also be an option.