### PR TITLE
Added info on ECS Interface

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -366,8 +366,8 @@ the [Classic Model](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/docs/dev
 * **ECS Interface**
 	* 1st Maintainer: [PerPascalSeeland](https://docu.ilias.de/goto_docu_usr_31492.html)
 	* 2nd Maintainer: N.A.
-	* Testcases: [AUTHOR MISSING](https://docu.ilias.de/goto_docu_pg_64423_4793.html)
-	* Tester: [TESTER MISSING](https://docu.ilias.de/goto_docu_pg_64423_4793.html)
+	* Testcases: [SIG CampusConnect und ECS(A)](https://docu.ilias.de/goto_docu_grp_7893.html)
+	* Tester: [SIG CampusConnect und ECS(A)](https://docu.ilias.de/goto_docu_grp_7893.html)
 
 [//]: # (END ECSInterface)
 


### PR DESCRIPTION
“Missing” is simply false. It used to be (just) me (even though it proved to be too herculean a task for me alone).

I suggest to name the SIG CampusConnect which _is_ jointly working on new test cases and test infrastructure (under the lead of Johannes Heim).