### PR TITLE
Registration: Fix issue with user email address being NULL (Mantis 35…

### DIFF
--- a/Services/Registration/classes/class.ilAccountRegistrationMail.php
+++ b/Services/Registration/classes/class.ilAccountRegistrationMail.php
@@ -187,6 +187,15 @@ class ilAccountRegistrationMail extends \ilMimeMailNotification
      */
     private function sendLanguageVariableBasedAccountMail(ilObjUser $user, $rawPassword, $usedRegistrationCode)
     {
+        if (!$user->getEmail()) {
+            $this->logger->debug(sprintf(
+                "Missing email address, did not send account registration mail for user %s (id: %s) ...",
+                $user->getLogin(),
+                $user->getId()
+            ));
+            return;
+        }
+
         $this->logger->debug(sprintf(
             "Sending language variable dependent welcome email to user %s (id: %s|language: %s) as fallback ...",
             $user->getLogin(),


### PR DESCRIPTION
…901)

Mantis Issue: https://mantis.ilias.de/view.php?id=35901

IF approved, this has to be cherry-picked to `release_7`, `release_8` and `trunk`.