### PR TITLE
T&A Bugfix #0035679:  No tab-bar when switching from "Dashboard" or "Result" to "Statistics"

### DIFF
--- a/Modules/Test/classes/class.ilTestTabsManager.php
+++ b/Modules/Test/classes/class.ilTestTabsManager.php
@@ -656,7 +656,7 @@ class ilTestTabsManager
             // statistics tab
             $this->tabs->addTarget(
                 self::TAB_ID_STATISTICS,
-                $DIC->ctrl()->getLinkTargetByClass("iltestevaluationgui", "outEvaluation"),
+                $DIC->ctrl()->getLinkTargetByClass([ilRepositoryGUI::class, ilObjTestGUI::class, ilTestEvaluationGUI::class], "outEvaluation"),
                 array(
                     "statistics", "outEvaluation", "exportEvaluation", "detailedEvaluation", "eval_a", "evalUserDetail",
                     "passDetails", "outStatisticsResultsOverview", "statisticsPassDetails", "singleResults"


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=35679