### PR TITLE
Bugfix Statistics and Learning Progress (3)

### DIFF
--- a/Services/Form/classes/class.ilCombinationInputGUI.php
+++ b/Services/Form/classes/class.ilCombinationInputGUI.php
@@ -139,6 +139,14 @@ class ilCombinationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTab
                     elseif (method_exists($this->items[$id], "setDate")) {
                         $this->items[$id]->setDate($value);
                     }
+                    // duration
+                    elseif (method_exists($this->items[$id], "setMonths")) {
+                        $this->items[$id]->setMonths((int) ($value['MM'] ?? 0));
+                        $this->items[$id]->setDays((int) ($value['dd'] ?? 0));
+                        $this->items[$id]->setHours((int) ($value['hh'] ?? 0));
+                        $this->items[$id]->setMinutes((int) ($value['mm'] ?? 0));
+                        $this->items[$id]->setSeconds((int) ($value['ss'] ?? 0));
+                    }
                 }
             }
         } elseif ($a_value === null) {
@@ -172,6 +180,10 @@ class ilCombinationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTab
             // datetime
             elseif (method_exists($obj, "setDate")) {
                 $result[$id] = $obj->getDate();
+            }
+            // duration
+            elseif (method_exists($obj, 'getValueAsArray')) {
+                $result[$id] = $obj->getValueAsArray();
             }
         }
         return $result;

--- a/Services/Form/classes/class.ilDurationInputGUI.php
+++ b/Services/Form/classes/class.ilDurationInputGUI.php
@@ -373,4 +373,18 @@ class ilDurationInputGUI extends ilFormPropertyGUI
         }
         return $value;
     }
+
+    /**
+     * @return array{MM: int, dd: int, hh: int, mm: int, ss: int}
+     */
+    public function getValueAsArray(): array
+    {
+        return [
+            'MM' => $this->getMonths(),
+            'dd' => $this->getDays(),
+            'hh' => $this->getHours(),
+            'mm' => $this->getMinutes(),
+            'ss' => $this->getSeconds()
+        ];
+    }
 }

--- a/Services/Table/classes/class.ilTable2GUI.php
+++ b/Services/Table/classes/class.ilTable2GUI.php
@@ -1626,16 +1626,19 @@ class ilTable2GUI extends ilTableGUI
             $this->tpl->parseCurrentBlock();
 
             // (keep) filter hidden?
-            if (!$this->isFilterVisible()) {
-                if (!$this->getDisableFilterHiding()) {
-                    $id = $this->getId();
-                    $this->main_tpl->addOnLoadCode("
-                        ilTableHideFilter['atfil_$id'] = true;
-                        ilTableHideFilter['tfil_$id'] = true;
-                        ilTableHideFilter['dtfil_$id'] = true;
-                    ");
-                }
+            if (!$this->isFilterVisible() && !$this->getDisableFilterHiding()) {
+                $id = $this->getId();
+                $this->main_tpl->addOnLoadCode("
+                    ilTableHideFilter['atfil_$id'] = true;
+                    ilTableHideFilter['tfil_$id'] = true;
+                    ilTableHideFilter['dtfil_$id'] = true;
+                ");
             }
+            /*
+             * BT 35757: filter has to be initialized after it has a chance to get hidden,
+             * moving this here from ServiceTable.js to avoid timing weirdness with onLoadCode.
+             */
+            $this->main_tpl->addOnLoadCode("ilInitTableFilters()");
         }
     }
 

--- a/Services/Table/js/ServiceTable.js
+++ b/Services/Table/js/ServiceTable.js
@@ -1,6 +1,5 @@
 
 // Hide all on load
-il.Util.addOnLoad(ilInitTableFilters)
 var ilTableHideFilter = new Object();
 
 /** 

--- a/Services/Tracking/classes/class.ilLPTableBaseGUI.php
+++ b/Services/Tracking/classes/class.ilLPTableBaseGUI.php
@@ -318,9 +318,9 @@ class ilLPTableBaseGUI extends ilTable2GUI
         }
 
         if (!$this->filter["area"]) {
-            $res->filter(ROOT_FOLDER_ID, false);
+            $res->filter(ROOT_FOLDER_ID, true);
         } else {
-            $res->filter($this->filter["area"], false);
+            $res->filter($this->filter["area"], true);
         }
 
         $objects = array();
@@ -898,7 +898,11 @@ class ilLPTableBaseGUI extends ilTable2GUI
         $timing_cache = ilTimingCache::getInstanceByRefId($a_ref_id);
         if ($timing_cache->isWarningRequired($a_user_id)) {
             $timings = ilTimingCache::_getTimings($a_ref_id);
-            if ($timings['item']['changeable'] && $timings['user'][$a_user_id]['end']) {
+            if (
+                $timings['item']['changeable'] &&
+                ($timings['user'][$a_user_id] ?? false) &&
+                $timings['user'][$a_user_id]['end']
+            ) {
                 $end = $timings['user'][$a_user_id]['end'];
             } elseif ($timings['item']['suggestion_end']) {
                 $end = $timings['item']['suggestion_end'];


### PR DESCRIPTION
This PR fixes [34693](https://mantis.ilias.de/view.php?id=34693), [35786](https://mantis.ilias.de/view.php?id=35786), and [35757](https://mantis.ilias.de/view.php?id=35757).

@alex40724, please note the changes in `ilTable2GUI` and `ServiceTable.js`: the order of execution of on load code caused filters to automatically un-hide ([35757](https://mantis.ilias.de/view.php?id=35757)).