### PR TITLE
Bugfix 35452 et al.: filter out invalid users from an objects participants in Tracking

### DIFF
--- a/Services/Tracking/classes/class.ilTrQuery.php
+++ b/Services/Tracking/classes/class.ilTrQuery.php
@@ -1099,6 +1099,10 @@ class ilTrQuery
      */
     protected static function filterOutUsersWithoutData(array $user_ids): array
     {
+        if (ilObjUser::userExists($user_ids)) {
+            return $user_ids;
+        }
+
         $res = [];
         foreach ($user_ids as $user_id) {
             if (ilObjUser::userExists([$user_id])) {


### PR DESCRIPTION
This PR should hopefully fix [35452](https://mantis.ilias.de/view.php?id=35452), [35762](https://mantis.ilias.de/view.php?id=35762), and [35473](https://mantis.ilias.de/view.php?id=35473).

I'm not able to reproduce these issues locally as they seem to require a very specific setup, but from what I can tell they are caused by users with an entry in obj_data, but no entry in usr_data showing up as an object's participants in tracking queries. The issues are reported to occur with multiple types of objects (at least tests and exercises), so the best fix I could come up with is this band-aid in `ilTrQuery`, where these faulty users are filtered out before being passed on.