### PR TITLE
T&A: fix for 35424

### DIFF
--- a/Modules/Test/classes/class.ilTestOutputGUI.php
+++ b/Modules/Test/classes/class.ilTestOutputGUI.php
@@ -705,7 +705,7 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
             $this->getCurrentSequenceElement()
         );
 
-        if ($this->getAnswerChangedParameter() && !$this->isParticipantsAnswerFixed($questionId)) {
+        if (!$this->isParticipantsAnswerFixed($questionId)) {
             if ($this->saveQuestionSolution(true)) {
                 $this->removeIntermediateSolution();
                 $this->setAnswerChangedParameter(false);


### PR DESCRIPTION
This fixes https://mantis.ilias.de/view.php?id=35424
I simply remove the check if the user started editing the question.

My commit undoes this commit from 2019 
https://github.com/ILIAS-eLearning/ILIAS/commit/943e79f33483b61d899bd1b6d2547743d48f86d0
I did test my commit with the vertical ordering question and it works as expected.