### PR TITLE
Bugfix 20932: info text for scope setting in advanced metadata

### DIFF
--- a/Services/AdvancedMetaData/classes/class.ilAdvancedMDSettingsGUI.php
+++ b/Services/AdvancedMetaData/classes/class.ilAdvancedMDSettingsGUI.php
@@ -82,7 +82,7 @@ class ilAdvancedMDSettingsGUI
     /**
      * @var ilAdvancedMDRecord
      */
-    protected  $record;
+    protected $record;
 
     
     /**
@@ -142,7 +142,7 @@ class ilAdvancedMDSettingsGUI
     /**
      * @return ilAdvancedMDPermissionHelper
      */
-    protected function getPermissions() :ilAdvancedMDPermissionHelper
+    protected function getPermissions() : ilAdvancedMDPermissionHelper
     {
         return $this->permissions;
     }
@@ -162,7 +162,7 @@ class ilAdvancedMDSettingsGUI
 
             case strtolower(ilAdvancedMDRecordTranslationGUI::class):
                 $record = $this->initRecordObject();
-                $this->setRecordSubTabs(1,true);
+                $this->setRecordSubTabs(1, true);
                 $int_gui = new \ilAdvancedMDRecordTranslationGUI($record);
                 $this->ctrl->forwardCommand($int_gui);
                 break;
@@ -778,7 +778,7 @@ class ilAdvancedMDSettingsGUI
             $this->ctrl->redirect($this, 'showRecords');
         }
         $this->initRecordObject();
-        $this->setRecordSubTabs(1,true);
+        $this->setRecordSubTabs(1, true);
         $this->tabs_gui->activateTab(self::TAB_RECORD_SETTINGS);
 
         if (!$form instanceof ilPropertyFormGUI) {
@@ -941,7 +941,7 @@ class ilAdvancedMDSettingsGUI
         }
         $this->initRecordObject();
         $this->initLanguage($record_id);
-        $this->showLanguageSwitch($record_id,'editRecord');
+        $this->showLanguageSwitch($record_id, 'editRecord');
 
         $this->initForm('edit');
         if (!$this->form->checkInput()) {
@@ -1006,11 +1006,10 @@ class ilAdvancedMDSettingsGUI
         if ($level == 1) {
             $this->tabs_gui->setBackTarget(
                 $this->lng->txt('md_adv_record_list'),
-                $this->ctrl->getLinkTarget($this,'showRecords')
+                $this->ctrl->getLinkTarget($this, 'showRecords')
             );
 
             if ($show_settings) {
-
                 $this->tabs_gui->addTab(
                     self::TAB_RECORD_SETTINGS,
                     $this->lng->txt('settings'),
@@ -1035,11 +1034,11 @@ class ilAdvancedMDSettingsGUI
         if ($level == 2) {
             $this->tabs_gui->setBack2Target(
                 $this->lng->txt('md_adv_record_list'),
-                $this->ctrl->getLinkTarget($this,'showRecords')
+                $this->ctrl->getLinkTarget($this, 'showRecords')
             );
             $this->tabs_gui->setBackTarget(
                 $this->lng->txt('md_adv_field_list'),
-                $this->ctrl->getLinkTarget($this,'editFields')
+                $this->ctrl->getLinkTarget($this, 'editFields')
             );
         }
     }
@@ -1160,7 +1159,7 @@ class ilAdvancedMDSettingsGUI
             $this->form->getInput('title'),
             $this->form->getInput('desc')
         );
-        ilUtil::sendSuccess($this->lng->txt('md_adv_added_new_record'),true);
+        ilUtil::sendSuccess($this->lng->txt('md_adv_added_new_record'), true);
         $this->ctrl->redirect($this, 'showRecords');
     }
     
@@ -1325,8 +1324,7 @@ class ilAdvancedMDSettingsGUI
         $translations = ilAdvancedMDFieldTranslations::getInstanceByRecordId($this->record->getRecordId());
         if ($is_creation_mode) {
             $form->setDescription($a_definition->getDescription());
-        }
-        else {
+        } else {
             $form->setDescription($translations->getFormTranslationInfo(
                 $a_definition->getFieldId(),
                 $this->active_language
@@ -1422,11 +1420,16 @@ class ilAdvancedMDSettingsGUI
         if (!$this->obj_type) {
             // scope
             $scope = new ilCheckboxInputGUI($this->lng->txt('md_adv_scope'), 'scope');
+            $scope->setInfo($this->lng->txt('md_adv_scope_info'));
             $scope->setChecked($this->record->enabledScope());
             $scope->setValue(1);
             $this->form->addItem($scope);
 
-            $subitems = new ilRepositorySelector2InputGUI($this->lng->txt("objects"), "scope_containers", true);
+            $subitems = new ilRepositorySelector2InputGUI(
+                $this->lng->txt('md_adv_scope_objects'),
+                "scope_containers",
+                true
+            );
             $subitems->setValue($this->record->getScopeRefIds());
             $exp = $subitems->getExplorerGUI();
             
@@ -1833,7 +1836,6 @@ class ilAdvancedMDSettingsGUI
         
         if (!$this->obj_type) {
             if ($perm[ilAdvancedMDPermissionHelper::ACTION_RECORD_EDIT_PROPERTY][ilAdvancedMDPermissionHelper::SUBACTION_RECORD_OBJECT_TYPES]) {
-
                 $obj_types = [];
                 foreach (ilAdvancedMDRecord::_getAssignableObjectTypes(true) as $type) {
                     $t = $type["obj_type"] . ":" . $type["sub_type"];
@@ -1873,7 +1875,7 @@ class ilAdvancedMDSettingsGUI
         if (!$this->record instanceof ilAdvancedMDRecord) {
             $record_id = $this->request->getQueryParams()['record_id'] ?? 0;
             $this->record = ilAdvancedMDRecord::_getInstanceByRecordId($record_id);
-            $this->ctrl->saveParameter($this,'record_id');
+            $this->ctrl->saveParameter($this, 'record_id');
 
             // bind to parent object (aka local adv md)
             if (!$record_id &&
@@ -2111,7 +2113,8 @@ class ilAdvancedMDSettingsGUI
         $this->ctrl->setParameter($this, 'mdlang', $this->active_language);
         $view_control = $this->ui_factory->viewControl()->mode(
             $actions,
-            $this->lng->txt('meta_aria_language_selection'))->withActive($this->active_language);
+            $this->lng->txt('meta_aria_language_selection')
+        )->withActive($this->active_language);
         $this->toolbar->addComponent($view_control);
     }
 }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11080,7 +11080,9 @@ meta#:#md_adv_record_lng_table_lng#:#Sprache
 meta#:#md_adv_records#:#Enthaltene Datensätze
 meta#:#md_adv_records_exported#:#Eine neue Exportdatei wurde angelegt.
 meta#:#md_adv_scope#:#Gültigkeitsbereich
+meta#:#md_adv_scope_info#:#Die Nutzung dieses benutzerdefinierten Metadatensatzes wird auf Teilbereiche des Magazins beschränkt.
 meta#:#md_adv_scope_list_header#:#Beschränkt auf:
+meta#:#md_adv_scope_objects#:#Datensatz wirksam ab
 meta#:#md_adv_searchable#:#Durchsuchbar
 meta#:#md_adv_select_one_file#:#Bitte wählen Sie eine Datei aus.
 meta#:#md_adv_show#:#Anzeigen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11081,7 +11081,9 @@ meta#:#md_adv_record_lng_table_lng#:#Language
 meta#:#md_adv_records#:#Included Data Sets
 meta#:#md_adv_records_exported#:#A new export file has been created.
 meta#:#md_adv_scope#:#Scope
+meta#:#md_adv_scope_info#:#Usage of this custom metadata set will be limited to selected parts of the repository.
 meta#:#md_adv_scope_list_header#:#Limited to:
+meta#:#md_adv_scope_objects#:#Data Set Effective From
 meta#:#md_adv_searchable#:#Searchable
 meta#:#md_adv_select_one_file#:#Please choose one file.
 meta#:#md_adv_show#:#Show


### PR DESCRIPTION
This PR fixes [20932](https://mantis.ilias.de/view.php?id=20932) by introducing a by-line for the 'Scope' setting of advanced metadata sets, and making the title of the corresponding repository selector more specific.