### PR TITLE
Bugfix 32161: fix post handling of multi select inputs in adv md

### DIFF
--- a/Services/ADT/classes/Types/MultiEnum/class.ilADTMultiEnumFormBridge.php
+++ b/Services/ADT/classes/Types/MultiEnum/class.ilADTMultiEnumFormBridge.php
@@ -56,7 +56,15 @@ class ilADTMultiEnumFormBridge extends ilADTFormBridge
     public function importFromPost()
     {
         // ilPropertyFormGUI::checkInput() is pre-requisite
-        $this->getADT()->setSelections($this->getForm()->getInput($this->getElementId()));
+
+        /*
+         * BT 32161: post value is null when no checkbox is selected,
+         * check whether the corresponding form input really exists, just
+         * to be sure.
+         */
+        if (is_object($this->getForm()->getItemByPostVar($this->getElementId()))) {
+            $this->getADT()->setSelections($this->getForm()->getInput($this->getElementId()) ?? []);
+        }
     
         $field = $this->getForm()->getItemByPostvar($this->getElementId());
         $field->setValue($this->getADT()->getSelections());


### PR DESCRIPTION
This PR fixes [32161](https://mantis.ilias.de/view.php?id=32161) by properly handling the post output of empty multi select inputs of advanced metadata sets.

As far as I can see, this fix is not needed in R8 or trunk.