### PR TITLE
Auth: Fix missing includes for SOAPAuth

### DIFF
--- a/Services/SOAPAuth/classes/class.ilAuthProviderSoap.php
+++ b/Services/SOAPAuth/classes/class.ilAuthProviderSoap.php
@@ -64,6 +64,8 @@ class ilAuthProviderSoap extends ilAuthProvider
         if ($this->server_uri) {
             $this->uri .= ('/' . $this->server_uri);
         }
+
+        require_once './webservice/soap/lib/nusoap.php';
         $this->client = new nusoap_client($this->uri);
     }
 

--- a/Services/SOAPAuth/classes/class.ilSOAPAuth.php
+++ b/Services/SOAPAuth/classes/class.ilSOAPAuth.php
@@ -46,6 +46,7 @@ class ilSOAPAuth
             $uri .= "/" . $server_uri;
         }
 
+        require_once './webservice/soap/lib/nusoap.php';
         $soap_client = new nusoap_client($uri);
         if ($err = $soap_client->getError()) {
             return "SOAP Authentication Initialisation Error: " . $err;

--- a/Services/SOAPAuth/examples/dummy_client.php
+++ b/Services/SOAPAuth/examples/dummy_client.php
@@ -39,6 +39,7 @@ echo '<form>' .
 echo "<br /><br />----------------------------------------------<br /><br /> Calling Server...";
 
 // initialize soap client
+require_once './webservice/soap/lib/nusoap.php';
 $client = new nusoap_client($server);
 if ($err = $client->getError()) {
     echo '<h2>Constructor error</h2><pre>' . $err . '</pre>';


### PR DESCRIPTION
If approved, this has to be cherry-picked to `release_8`.