### PR TITLE
A11y, fix of focus search issue, see #35523

### DIFF
--- a/Services/Search/js/SearchMainMenu.js
+++ b/Services/Search/js/SearchMainMenu.js
@@ -23,8 +23,6 @@ il.Util.addOnLoad(
         });
 
         $("#ilMMSearchMenu input[type='radio']").change(function () {
-            $("#main_menu_search").focus();
-
             /* close current search */
             $("#main_menu_search").autocomplete("close");
 


### PR DESCRIPTION
Fix of https://mantis.ilias.de/view.php?id=35523 . 

Concerns: 
"WCAG Issue: When selecting one of the radio buttons in the "Search" fieldset, focus is redirected to the input field without warning to the user, and without the name of the radio button being read to the user."

Note, this fix comes at a convenience price for people with vision. For them it will probably feel like a decrease of usability, since the cursor will not jump automatically into the search field anymore after making a choice.
