### PR TITLE
Trunk: Use Plugins language handler to update language

### DIFF
--- a/Services/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
+++ b/Services/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
@@ -154,10 +154,7 @@ class ilObjComponentSettingsGUI extends ilObjectGUI
     protected function refreshLanguages(): void
     {
         try {
-            $plugin_name = $this->request_wrapper->retrieve(self::P_PLUGIN_NAME, $this->refinery->kindlyTo()->string());
-            $plugin = $this->component_repository->getPluginByName($plugin_name);
-            $language_handler = new ilPluginLanguage($plugin);
-            $language_handler->updateLanguages();
+            $this->getPlugin()->getLanguageHandler()->updateLanguages();
             $this->tpl->setOnScreenMessage("success", $this->lng->txt("cmps_refresh_lng"), true);
         } catch (Exception $e) {
             $this->tpl->setOnScreenMessage("failure", $e->getMessage(), true);


### PR DESCRIPTION
Current version forces the use/creation of an "ilPluginLanguage" handler   
but doesn't even use it to actually update the languages. Instead it creates a new one that would ignore any plugins custom changes.