### PR TITLE
User: Fix wrong argument type for system notification

### DIFF
--- a/Services/User/Settings/classes/class.ilPersonalSettingsGUI.php
+++ b/Services/User/Settings/classes/class.ilPersonalSettingsGUI.php
@@ -884,7 +884,7 @@ class ilPersonalSettingsGUI
             )
         );
 
-        $message = $ntf->composeAndGetMessage($ilUser->getId(), null, null, true);
+        $message = $ntf->composeAndGetMessage($ilUser->getId(), null, 'read', true);
         $subject = $this->lng->txt("user_delete_own_account_email_subject");
 
 


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=34248

If approved, this has to be cherry-picked to `release_8`.