### PR TITLE
T&A 0016123 fix deletion of mc answer also deletes corresponding feedback

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php
@@ -44,7 +44,7 @@ class ASS_AnswerBinaryStateImage extends ASS_AnswerBinaryState
      */
     public function __construct($answertext = "", $points = 0.0, $order = 0, $state = 0, $a_image = "", $id = -1)
     {
-        parent::__construct($answertext, $points, $order, $id);
+        parent::__construct($answertext, $points, $order, $state, $id);
         $this->image = $a_image;
     }
 

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -746,7 +746,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         $feedback = $ilDB->fetchAll($result);
 
         // Check if feedback exists
-        if (sizeof($feedback) >= 1){
+        if (sizeof($feedback) >= 1 && $this->getAdditionalContentEditingMode() == 'default'){
             // Get all existing answer data for question
             $result = $ilDB->queryF(
                 "SELECT answer_id, aorder  FROM qpl_a_mc WHERE question_fi = %s",
@@ -783,30 +783,25 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             }
 
             // Delete all feedback in database
-            $ilDB->manipulateF(
-                "DELETE FROM qpl_fb_specific 
-                WHERE question_fi = %s ",
-                array( 'integer'),
-                array( $this->getId())
-            );
-
+            $this->feedbackOBJ->deleteSpecificAnswerFeedbacks($this->getId(), false);
             // Recreate remaining feedback in database
-            foreach ($feedback as $feedback_option){
+            foreach ($feedback as $feedback_option) {
                 $next_id = $ilDB->nextId('qpl_fb_specific');
                 $ilDB->manipulateF(
                     "INSERT INTO qpl_fb_specific (feedback_id, question_fi, answer, tstamp, feedback, question) 
-                    VALUES (%s, %s, %s, %s, %s, %s)",
-                    array( 'integer', 'integer', 'integer', 'integer', 'text', 'integer'),
-                    array(
-                        $next_id,
-                        $feedback_option["question_fi"],
-                        $feedback_option["answer"],
-                        time(),
-                        $feedback_option["feedback"],
-                        $feedback_option["question"]
-                    )
+                            VALUES (%s, %s, %s, %s, %s, %s)",
+                            ['integer', 'integer', 'integer', 'integer', 'text', 'integer'],
+                            [
+                                $next_id,
+                                $feedback_option["question_fi"],
+                                $feedback_option["answer"],
+                                time(),
+                                $feedback_option["feedback"],
+                                $feedback_option["question"]
+                            ]
                 );
             }
+
         }
 
         // Delete all entries in qpl_a_mc for question
@@ -1010,9 +1005,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
     {
         global $DIC;
         $ilLog = $DIC['ilLog'];
-
         $imagepath = $this->getImagePath();
-
         $question_id = $this->getOriginalId();
         $originalObjId = parent::lookupParentObjId($this->getOriginalId());
         $imagepath_original = $this->getImagePath($question_id, $originalObjId);

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -278,7 +278,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
                 }
                 include_once("./Services/RTE/classes/class.ilRTE.php");
                 $data["answertext"] = ilRTE::_replaceMediaObjectImageSrc($data["answertext"], 1);
-                array_push($this->answers, new ASS_AnswerMultipleResponseImage($data["answertext"], $data["points"], $data["aorder"], $data["points_unchecked"], $data["imagefile"]));
+                array_push($this->answers, new ASS_AnswerMultipleResponseImage($data["answertext"], $data["points"], $data["aorder"], $data["points_unchecked"], $data["imagefile"], $data["answer_id"]));
             }
         }
 
@@ -435,6 +435,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      * @param float   $points_unchecked The points for not selecting the answer (even positive points can be used)
      * @param integer $order      		A possible display order of the answer
      * @param string  $answerimage
+     * @param int     $answer_id        The Answer id used in the database
      *
      * @see      $answers
      * @see      ASS_AnswerBinaryStateImage
@@ -444,7 +445,8 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         $points = 0.0,
         $points_unchecked = 0.0,
         $order = 0,
-        $answerimage = ""
+        $answerimage = "",
+        $answer_id = -1
     ) {
         include_once "./Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php";
         $answertext = $this->getHtmlQuestionContentPurifier()->purify($answertext);
@@ -464,7 +466,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             $this->answers = $newchoices;
         } else {
             // add answer
-            $answer = new ASS_AnswerMultipleResponseImage($answertext, $points, count($this->answers), $points_unchecked, $answerimage);
+            $answer = new ASS_AnswerMultipleResponseImage($answertext, $points, count($this->answers), $points_unchecked, $answerimage, $answer_id);
             array_push($this->answers, $answer);
         }
     }
@@ -724,33 +726,114 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         );
     }
 
+    /**
+     * Deletes all existing Answer data from a question and reintroduces old data and changes.
+     * Additionally, it updates the corresponding feedback.
+     * @return void
+     */
     public function saveAnswerSpecificDataToDb()
     {
         /** @var $ilDB ilDBInterface */
         global $DIC;
         $ilDB = $DIC['ilDB'];
+
+        // Get all feedback entrys
+        $result = $ilDB->queryF(
+            "SELECT * FROM qpl_fb_specific WHERE question_fi = %s",
+            array( 'integer' ),
+            array( $this->getId() )
+        );
+        $feedback = $ilDB->fetchAll($result);
+
+        // Check if feedback exists
+        if (sizeof($feedback) >= 1){
+            // Get all existing answer data for question
+            $result = $ilDB->queryF(
+                "SELECT answer_id, aorder  FROM qpl_a_mc WHERE question_fi = %s",
+                array( 'integer' ),
+                array( $this->getId() )
+            );
+            $db_answers = $ilDB->fetchAll($result);
+
+            // Collect old and new order entries by ids and order to calculate a diff/intersection and remove/update feedback
+            $db_ids = array();
+            $post_ids = array();
+            $db_idsr = array();
+            foreach ($this->answers as $answer){
+                // Only the first appearance of an id is used
+                if ($answer->getId() !== null && !in_array($answer->getId(), array_keys($post_ids))) {
+                    $post_ids[$answer->getId()] = $answer->getOrder();
+                }
+            }
+            foreach ($db_answers as $old_answer){
+                $db_ids[$old_answer["answer_id"]] = intval($old_answer["aorder"]);
+                $db_idsr[intval($old_answer["aorder"])] = $old_answer["answer_id"];
+            }
+
+            // Handle feedback
+            $id_diff = array_diff(array_keys($db_ids), array_keys($post_ids)); // should be deleted
+            // delete corresponding feedback from array
+            foreach (array_keys($id_diff) as $key){
+                unset($feedback[$key]);
+            }
+
+            // Reorder feedback in array
+            foreach ($feedback as $feedback_option){
+                $feedback[array_search($feedback_option, $feedback)]["answer"] = $post_ids[$db_idsr[$feedback_option["answer"]]];
+            }
+
+            // Delete all feedback in database
+            $ilDB->manipulateF(
+                "DELETE FROM qpl_fb_specific 
+                WHERE question_fi = %s ",
+                array( 'integer'),
+                array( $this->getId())
+            );
+
+            // Recreate remaining feedback in database
+            foreach ($feedback as $feedback_option){
+                $next_id = $ilDB->nextId('qpl_fb_specific');
+                $ilDB->manipulateF(
+                    "INSERT INTO qpl_fb_specific (feedback_id, question_fi, answer, tstamp, feedback, question) 
+                    VALUES (%s, %s, %s, %s, %s, %s)",
+                    array( 'integer', 'integer', 'integer', 'integer', 'text', 'integer'),
+                    array(
+                        $next_id,
+                        $feedback_option["question_fi"],
+                        $feedback_option["answer"],
+                        time(),
+                        $feedback_option["feedback"],
+                        $feedback_option["question"]
+                    )
+                );
+            }
+        }
+
+        // Delete all entries in qpl_a_mc for question
         $ilDB->manipulateF(
             "DELETE FROM qpl_a_mc WHERE question_fi = %s",
             array( 'integer' ),
             array( $this->getId() )
         );
 
+        // Recreate answers one by one
         foreach ($this->answers as $key => $value) {
             $answer_obj = $this->answers[$key];
             $next_id = $ilDB->nextId('qpl_a_mc');
             $ilDB->manipulateF(
-                "INSERT INTO qpl_a_mc (answer_id, question_fi, answertext, points, points_unchecked, aorder, imagefile, tstamp) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+                "INSERT INTO qpl_a_mc (answer_id, question_fi, answertext, points, points_unchecked, aorder, imagefile, tstamp) 
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
                 array( 'integer', 'integer', 'text', 'float', 'float', 'integer', 'text', 'integer' ),
                 array(
-                                    $next_id,
-                                    $this->getId(),
-                                    ilRTE::_replaceMediaObjectImageSrc($answer_obj->getAnswertext(), 0),
-                                    $answer_obj->getPoints(),
-                                    $answer_obj->getPointsUnchecked(),
-                                    $answer_obj->getOrder(),
-                                    $answer_obj->getImage(),
-                                    time()
-                                )
+                        $next_id,
+                        $this->getId(),
+                        ilRTE::_replaceMediaObjectImageSrc($answer_obj->getAnswertext(), 0),
+                        $answer_obj->getPoints(),
+                        $answer_obj->getPointsUnchecked(),
+                        $answer_obj->getOrder(),
+                        $answer_obj->getImage(),
+                        time()
+                    )
             );
         }
         $this->rebuildThumbnails();

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -756,9 +756,9 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             $db_answers = $ilDB->fetchAll($result);
 
             // Collect old and new order entries by ids and order to calculate a diff/intersection and remove/update feedback
-            $db_ids = array();
-            $post_ids = array();
-            $db_idsr = array();
+            $db_ids = [];
+            $post_ids = [];
+            $db_idsr = [];
             foreach ($this->answers as $answer){
                 // Only the first appearance of an id is used
                 if ($answer->getId() !== null && !in_array($answer->getId(), array_keys($post_ids))) {

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -706,15 +706,13 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         if ($this->object->isSingleline) {
             foreach ($_POST['choice']['answer'] as $index => $answertext) {
                 $answertext = ilUtil::secureString(htmlentities($answertext));
-
                 $picturefile = $_POST['choice']['imagename'][$index];
                 $file_org_name = $_FILES['choice']['name']['image'][$index];
                 $file_temp_name = $_FILES['choice']['tmp_name']['image'][$index];
 
                 if (strlen($file_temp_name)) {
                     // check suffix
-                    $tmp = explode(".", $file_org_name);
-                    $suffix = strtolower(array_pop($tmp));
+                    $suffix = strtolower(array_pop(explode(".", $file_org_name)));
                     if (in_array($suffix, array( "jpg", "jpeg", "png", "gif" ))) {
                         // upload image
                         $filename = $this->object->buildHashedImageFilename($file_org_name);
@@ -723,7 +721,6 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
                         }
                     }
                 }
-                $tmp = $_POST['choice']['answer_id'][$index];
                 $this->object->addAnswer(
                     $answertext,
                     $_POST['choice']['points'][$index],

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -713,7 +713,8 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
 
                 if (strlen($file_temp_name)) {
                     // check suffix
-                    $suffix = strtolower(array_pop(explode(".", $file_org_name)));
+                    $tmp = explode(".", $file_org_name);
+                    $suffix = strtolower(array_pop($tmp));
                     if (in_array($suffix, array( "jpg", "jpeg", "png", "gif" ))) {
                         // upload image
                         $filename = $this->object->buildHashedImageFilename($file_org_name);
@@ -722,12 +723,14 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
                         }
                     }
                 }
+                $tmp = $_POST['choice']['answer_id'][$index];
                 $this->object->addAnswer(
                     $answertext,
                     $_POST['choice']['points'][$index],
                     $_POST['choice']['points_unchecked'][$index],
                     $index,
-                    $picturefile
+                    $picturefile,
+                    $_POST['choice']['answer_id'][$index]
                 );
             }
         } else {
@@ -737,7 +740,8 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
                     $answertext,
                     $_POST['choice']['points'][$index],
                     $_POST['choice']['points_unchecked'][$index],
-                    $index
+                    $index,
+                    $_POST['choice']['answer_id'][$index]
                 );
             }
         }

--- a/Modules/TestQuestionPool/classes/class.assSingleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoice.php
@@ -716,7 +716,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         $feedback = $ilDB->fetchAll($result);
 
         // Check if feedback exists
-        if (sizeof($feedback) >= 1){
+        if (sizeof($feedback) >= 1 && $this->getAdditionalContentEditingMode() == 'default'){
             // Get all existing answer data for question
             $result = $ilDB->queryF(
                 "SELECT answer_id, aorder  FROM qpl_a_sc WHERE question_fi = %s",
@@ -753,30 +753,24 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
             }
 
             // Delete all feedback in database
-            $ilDB->manipulateF(
-                "DELETE FROM qpl_fb_specific 
-                WHERE question_fi = %s ",
-                array( 'integer'),
-                array( $this->getId())
-            );
-
+            $this->feedbackOBJ->deleteSpecificAnswerFeedbacks($this->getId(), false);
             // Recreate remaining feedback in database
             foreach ($feedback as $feedback_option){
                 $next_id = $ilDB->nextId('qpl_fb_specific');
                 $ilDB->manipulateF(
                     "INSERT INTO qpl_fb_specific (feedback_id, question_fi, answer, tstamp, feedback, question) 
-                    VALUES (%s, %s, %s, %s, %s, %s)",
-                    array( 'integer', 'integer', 'integer', 'integer', 'text', 'integer'),
-                    array(
-                        $next_id,
-                        $feedback_option["question_fi"],
-                        $feedback_option["answer"],
-                        time(),
-                        $feedback_option["feedback"],
-                        $feedback_option["question"]
-                    )
-                );
+                            VALUES (%s, %s, %s, %s, %s, %s)",
+                            [ 'integer', 'integer', 'integer', 'integer', 'text', 'integer'],
+                            [
+                                $next_id,
+                                $feedback_option["question_fi"],
+                                $feedback_option["answer"],
+                                time(),
+                                $feedback_option["feedback"],
+                                $feedback_option["question"]
+                            ]);
             }
+
         }
 
         // Delete all entries in qpl_a_sc for question

--- a/Modules/TestQuestionPool/classes/class.assSingleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoice.php
@@ -252,7 +252,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
                 }
                 include_once("./Services/RTE/classes/class.ilRTE.php");
                 $data["answertext"] = ilRTE::_replaceMediaObjectImageSrc($data["answertext"], 1);
-                array_push($this->answers, new ASS_AnswerBinaryStateImage($data["answertext"], $data["points"], $data["aorder"], 1, $data["imagefile"]));
+                array_push($this->answers, new ASS_AnswerBinaryStateImage($data["answertext"], $data["points"], $data["aorder"], 1, $data["imagefile"], $data["answer_id"]));
             }
         }
 
@@ -422,13 +422,14 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         $answertext = "",
         $points = 0.0,
         $order = 0,
-        $answerimage = ""
+        $answerimage = "",
+        $answer_id = -1
     ) {
         include_once "./Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php";
         $answertext = $this->getHtmlQuestionContentPurifier()->purify($answertext);
         if (array_key_exists($order, $this->answers)) {
             // insert answer
-            $answer = new ASS_AnswerBinaryStateImage($answertext, $points, $order, 1, $answerimage);
+            $answer = new ASS_AnswerBinaryStateImage($answertext, $points, $order, 1, $answerimage, $answer_id);
             $newchoices = array();
             for ($i = 0; $i < $order; $i++) {
                 array_push($newchoices, $this->answers[$i]);
@@ -442,7 +443,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
             $this->answers = $newchoices;
         } else {
             // add answer
-            $answer = new ASS_AnswerBinaryStateImage($answertext, $points, count($this->answers), 1, $answerimage);
+            $answer = new ASS_AnswerBinaryStateImage($answertext, $points, count($this->answers), 1, $answerimage, $answer_id);
             array_push($this->answers, $answer);
         }
     }
@@ -692,20 +693,100 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         );
     }
 
+    /**
+     * Deletes all existing Answer data from a question and reintroduces old data and changes.
+     * Additionally, it updates the corresponding feedback.
+     * @return void
+     */
     public function saveAnswerSpecificDataToDb()
     {
-        /** @var ilDBInterface $ilDB */
+        /** @var $ilDB ilDBInterface */
         global $DIC;
         $ilDB = $DIC['ilDB'];
+
         if (!$this->isSingleline) {
             ilUtil::delDir($this->getImagePath());
         }
+        // Get all feedback entrys
+        $result = $ilDB->queryF(
+            "SELECT * FROM qpl_fb_specific WHERE question_fi = %s",
+            array( 'integer' ),
+            array( $this->getId() )
+        );
+        $feedback = $ilDB->fetchAll($result);
+
+        // Check if feedback exists
+        if (sizeof($feedback) >= 1){
+            // Get all existing answer data for question
+            $result = $ilDB->queryF(
+                "SELECT answer_id, aorder  FROM qpl_a_sc WHERE question_fi = %s",
+                array( 'integer' ),
+                array( $this->getId() )
+            );
+            $db_answers = $ilDB->fetchAll($result);
+
+            // Collect old and new order entries by ids and order to calculate a diff/intersection and remove/update feedback
+            $db_ids = [];
+            $post_ids = [];
+            $db_idsr = [];
+            foreach ($this->answers as $answer){
+                // Only the first appearance of an id is used
+                if ($answer->getId() !== null && !in_array($answer->getId(), array_keys($post_ids))) {
+                    $post_ids[$answer->getId()] = $answer->getOrder();
+                }
+            }
+            foreach ($db_answers as $old_answer){
+                $db_ids[$old_answer["answer_id"]] = intval($old_answer["aorder"]);
+                $db_idsr[intval($old_answer["aorder"])] = $old_answer["answer_id"];
+            }
+
+            // Handle feedback
+            $id_diff = array_diff(array_keys($db_ids), array_keys($post_ids)); // should be deleted
+            // delete corresponding feedback from array
+            foreach (array_keys($id_diff) as $key){
+                unset($feedback[$key]);
+            }
+
+            // Reorder feedback in array
+            foreach ($feedback as $feedback_option){
+                $feedback[array_search($feedback_option, $feedback)]["answer"] = $post_ids[$db_idsr[$feedback_option["answer"]]];
+            }
+
+            // Delete all feedback in database
+            $ilDB->manipulateF(
+                "DELETE FROM qpl_fb_specific 
+                WHERE question_fi = %s ",
+                array( 'integer'),
+                array( $this->getId())
+            );
+
+            // Recreate remaining feedback in database
+            foreach ($feedback as $feedback_option){
+                $next_id = $ilDB->nextId('qpl_fb_specific');
+                $ilDB->manipulateF(
+                    "INSERT INTO qpl_fb_specific (feedback_id, question_fi, answer, tstamp, feedback, question) 
+                    VALUES (%s, %s, %s, %s, %s, %s)",
+                    array( 'integer', 'integer', 'integer', 'integer', 'text', 'integer'),
+                    array(
+                        $next_id,
+                        $feedback_option["question_fi"],
+                        $feedback_option["answer"],
+                        time(),
+                        $feedback_option["feedback"],
+                        $feedback_option["question"]
+                    )
+                );
+            }
+        }
+
+        // Delete all entries in qpl_a_sc for question
         $ilDB->manipulateF(
             "DELETE FROM qpl_a_sc WHERE question_fi = %s",
             array( 'integer' ),
             array( $this->getId() )
         );
 
+        // Recreate answers one by one
         foreach ($this->answers as $key => $value) {
             /** @var ASS_AnswerMultipleResponseImage $answer_obj */
             $answer_obj = $this->answers[$key];
@@ -714,14 +795,14 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
                 "INSERT INTO qpl_a_sc (answer_id, question_fi, answertext, points, aorder, imagefile, tstamp) VALUES (%s, %s, %s, %s, %s, %s, %s)",
                 array( 'integer', 'integer', 'text', 'float', 'integer', 'text', 'integer' ),
                 array(
-                                    $next_id,
-                                    $this->getId(),
-                                    ilRTE::_replaceMediaObjectImageSrc($answer_obj->getAnswertext(), 0),
-                                    $answer_obj->getPoints(),
-                                    $answer_obj->getOrder(),
-                                    $answer_obj->getImage(),
-                                    time()
-                                )
+                        $next_id,
+                        $this->getId(),
+                        ilRTE::_replaceMediaObjectImageSrc($answer_obj->getAnswertext(), 0),
+                        $answer_obj->getPoints(),
+                        $answer_obj->getOrder(),
+                        $answer_obj->getImage(),
+                        time()
+                )
             );
         }
         $this->rebuildThumbnails();

--- a/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -631,7 +631,6 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         if ($this->object->isSingleline) {
             foreach ($_POST['choice']['answer'] as $index => $answertext) {
                 $answertext = ilUtil::secureString(htmlentities($answertext));
-
                 $picturefile = $_POST['choice']['imagename'][$index];
                 $file_org_name = $_FILES['choice']['name']['image'][$index];
                 $file_temp_name = $_FILES['choice']['tmp_name']['image'][$index];
@@ -647,13 +646,12 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
                         }
                     }
                 }
-
-                $this->object->addAnswer($answertext, $_POST['choice']['points'][$index], $index, $picturefile);
+                $this->object->addAnswer($answertext, $_POST['choice']['points'][$index], $index, $picturefile, $_POST['choice']['answer_id'][$index]);
             }
         } else {
             foreach ($_POST['choice']['answer'] as $index => $answer) {
                 $answertext = $answer;
-                $this->object->addAnswer($answertext, $_POST['choice']['points'][$index], $index);
+                $this->object->addAnswer($answertext, $_POST['choice']['points'][$index], $index, $_POST['choice']['answer_id'][$index]);
             }
         }
     }

--- a/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -228,6 +228,9 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                     $tpl->setCurrentBlock("prop_points_unchecked_propval");
                     $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getPointsUnchecked()));
                     $tpl->parseCurrentBlock();
+                    $tpl->setCurrentBlock("prop_answer_id_propval");
+                    $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getId()));
+                    $tpl->parseCurrentBlock();
                 }
                 $tpl->setCurrentBlock('singleline');
                 $tpl->setVariable("SIZE", $this->getSize());

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -46,7 +46,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
             if (is_array($a_value['answer'])) {
                 foreach ($a_value['answer'] as $index => $value) {
                     include_once "./Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php";
-                    $answer = new ASS_AnswerBinaryStateImage($value, $a_value['points'][$index], $index, 1, $a_value['imagename'][$index]);
+                    $answer = new ASS_AnswerBinaryStateImage($value, $a_value['points'][$index], $index, 1, $a_value['imagename'][$index], $a_value['answer_id']);
                     array_push($this->values, $answer);
                 }
             }
@@ -361,6 +361,9 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                         $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getPoints()));
                         $tpl->parseCurrentBlock();
                     }
+                    $tpl->setCurrentBlock("prop_answer_id_propval");
+                    $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getId()));
+                    $tpl->parseCurrentBlock();
                 }
                 $tpl->setCurrentBlock('singleline');
                 $tpl->setVariable("SIZE", $this->getSize());

--- a/Modules/TestQuestionPool/templates/default/multiplechoicewizard.js
+++ b/Modules/TestQuestionPool/templates/default/multiplechoicewizard.js
@@ -30,6 +30,11 @@ var ilMultipleChoiceWizardInputTemplate = {
 				that.handleId(this, 'name', rowindex);
 			});
 
+			// hidden answer id
+			$(this).find('input:hidden[name*="[answer_id]"]').each(function() {
+				that.handleId(this, 'name', rowindex);
+			});
+
 			// answer
 			$(this).find('input:text[id*="[answer]"]').each(function() {
 				that.handleId(this, 'name', rowindex);

--- a/Modules/TestQuestionPool/templates/default/singlechoicewizard.js
+++ b/Modules/TestQuestionPool/templates/default/singlechoicewizard.js
@@ -30,6 +30,11 @@ var ilSingleChoiceWizardInputTemplate = {
 				that.handleId(this, 'name', rowindex);
 			});
 
+			// hidden answer id
+			$(this).find('input:hidden[name*="[answer_id]"]').each(function() {
+				that.handleId(this, 'name', rowindex);
+			});
+
 			// answer
 			$(this).find('input:text[id*="[answer]"]').each(function() {
 				that.handleId(this, 'name', rowindex);

--- a/Modules/TestQuestionPool/templates/default/tpl.prop_multiplechoicewizardinput.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.prop_multiplechoicewizardinput.html
@@ -64,6 +64,8 @@
 				<td class="ilValignTop">
 					<input class="form-control text-right" type="text" size="5" id="{POINTS_UNCHECKED_ID}" name="{POST_VAR}[points_unchecked][{ROW_NUMBER}]" <!-- BEGIN prop_points_unchecked_propval -->value="{PROPERTY_VALUE}" <!-- END prop_points_unchecked_propval -->{DISABLED_POINTS_UNCHECKED}/>
 				</td>
+				<input class="form-control" type="hidden" name="{POST_VAR}[answer_id][{ROW_NUMBER}]" <!-- BEGIN prop_answer_id_propval -->value="{PROPERTY_VALUE}" <!-- END prop_answer_id_propval -->/>
+
 				<td class="ilValignTop ilWhiteSpaceNowrap">
 					<button type="button" name="{CMD_ADD}" class="multiplechoice_add btn btn-link" id="add_{ID}">{ADD_BUTTON}</button>
 					<button type="button" name="{CMD_REMOVE}" class="multiplechoice_remove btn btn-link" id="remove_{ID}">{REMOVE_BUTTON}</button>

--- a/Modules/TestQuestionPool/templates/default/tpl.prop_singlechoicewizardinput.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.prop_singlechoicewizardinput.html
@@ -51,9 +51,12 @@
 				</td>
 <!-- BEGIN points -->
 				<td class="ilValignTop">
-					<input type="text" class="form-control text-right" size="5" id="{POINTS_ID}" name="{POINTS_POST_VAR}[points][{POINTS_ROW_NUMBER}]" <!-- BEGIN prop_points_propval -->value="{PROPERTY_VALUE}" <!-- END prop_points_propval -->{DISABLED_POINTS}/>
+					<input type="text" class=0"form-control text-right" size="5" id="{POINTS_ID}" name="{POINTS_POST_VAR}[points][{POINTS_ROW_NUMBER}]" <!-- BEGIN prop_points_propval -->value="{PROPERTY_VALUE}" <!-- END prop_points_propval -->{DISABLED_POINTS}/>
 				</td>
 <!-- END points -->
+<!-- BEGIN answer id field -->
+				<input class="form-control" type="hidden" name="{POST_VAR}[answer_id][{ROW_NUMBER}]" <!-- BEGIN prop_answer_id_propval -->value="{PROPERTY_VALUE}" <!-- END prop_answer_id_propval -->/>
+<!-- END answer id field -->
 				<td class="ilValignTop">
 					<button type="button" name="{CMD_ADD}" class="singlechoice_add btn btn-link" id="add_{ID}">{ADD_BUTTON}</button>
 					<button type="button" name="{CMD_REMOVE}" class="singlechoice_remove btn btn-link" id="remove_{ID}">{REMOVE_BUTTON}</button>


### PR DESCRIPTION
Hello,

This is a "fix" for https://mantis.ilias.de/view.php?id=16123

By adding a hidden field, a comparison is made between the answer IDs that are already exists in the database and the post answer IDs from the hidden field. This allows for the correct identification of feedback that need to be deleted and reordered. This fixes the error with the number 0016123.

However, the functionality of the JavaScript "+" button to add a new answer text duplicates all values of the table row where it is placed. This creates a new side effect. Allows retaining feedback that should actually be deleted.

This PR is open for evaluation to decide if the fix is sufficient as a temporary improvement until a full kitchen sink rework is done.  

Best wishes and a relaxing vacation
Ulf

@kergomard  wants to test the fix in the new year