### PR TITLE
Convert to string, because str_pad requires the first argument to be …

### DIFF
--- a/Services/Object/classes/class.ilObjectDefinition.php
+++ b/Services/Object/classes/class.ilObjectDefinition.php
@@ -139,7 +139,7 @@ class ilObjectDefinition
                 "rbac" => $rec["rbac"],
                 "group" => $rec["grp"],
                 "system" => $rec["system"],
-                "default_pos" => "9999" . str_pad($rec["default_pos"], 4, "0", STR_PAD_LEFT), // "unassigned" group
+                "default_pos" => "9999" . str_pad((string) $rec["default_pos"], 4, "0", STR_PAD_LEFT), // "unassigned" group
                 "sideblock" => $rec["sideblock"],
                 'export' => $rec['export'],
                 'repository' => $rec['repository'],


### PR DESCRIPTION
…string. Found during initial call to index.php after initial setup.

Found in PHP Version: `8.1`

According to `setup/sql/ilias3.sql:9157` this is considered to be an `integer` which makes absolutely sense. This is just a quickfix for me, to keep the installation running. Feel free to give feedback, what should be done here! 

Cheers!

