### PR TITLE
Container: Handle `ref_id` being `null` and access check in deletion …

### DIFF
--- a/Modules/CourseReference/classes/class.ilObjCourseReferenceAccess.php
+++ b/Modules/CourseReference/classes/class.ilObjCourseReferenceAccess.php
@@ -49,7 +49,7 @@ class ilObjCourseReferenceAccess extends ilContainerReferenceAccess
                 include_once './Modules/CourseReference/classes/class.ilObjCourseReference.php';
                 $target_ref_id = ilObjCourseReference::_lookupTargetRefId($obj_id);
 
-                if (!$DIC->access()->checkAccessOfUser($user_id, $permission, $cmd, $target_ref_id)) {
+                if (!$target_ref_id || !$DIC->access()->checkAccessOfUser($user_id, $permission, $cmd, $target_ref_id)) {
                     return false;
                 }
                 break;

--- a/Services/ContainerReference/classes/class.ilContainerReference.php
+++ b/Services/ContainerReference/classes/class.ilContainerReference.php
@@ -188,7 +188,11 @@ class ilContainerReference extends ilObject
         }
         if ($this->getTargetId()) {// might be null...
             $ref_ids = ilObject::_getAllReferences($this->getTargetId());
-            $this->setTargetRefId(current($ref_ids));
+            $ref_id = current($ref_ids); // might be null in deletion cases, see #35150
+
+            if ($ref_id) {
+                $this->setTargetRefId($ref_id);
+            }
 
             if ($this->getTitleType() === self::TITLE_TYPE_REUSE) {
                 $this->title = ilObject::_lookupTitle($this->getTargetId());


### PR DESCRIPTION
…case

See: https://mantis.ilias.de/view.php?id=35150

If approved, this commit MUST be cherry-picked to `release_8`.