### PR TITLE
Hiding patches folder and .github folder from the public using htaccess.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,6 +15,8 @@
 </IfModule>
 <IfModule mod_alias.c>
 	RedirectMatch 404 /\.git
+	RedirectMatch 404 /patches
+	RedirectMatch 404 /\.github
 </IfModule>
 <IfModule mod_xsendfile.c>
 	XSendFile On


### PR DESCRIPTION
I noticed that there is now a patches folder and also a .github folder. I think those should be hidden from being served by default so I added some lines to the .htaccess file.

An example, as of 1/3/2023 https://docu.ilias.de/patches/owl.carousel+2.3.4.patch is available to the public, it is a JS file so not a big deal but if there are patches for other files like PHP it is probably better to hide that. Might also be better to hide other patches paths like https://docu.ilias.de/libs/composer/patches/simplesamlphp.patch.

What do folks think? Useful? Should we add the other paths?

I am mostly thinking that if we add our own patches to that folder and we don't have our code open then it might be good to hide it from prying eyes but it might not be necessary for open source versions.