### PR TITLE
Group: Fix wrong type for `max_members`

### DIFF
--- a/Modules/Group/classes/class.ilGroupXMLParser.php
+++ b/Modules/Group/classes/class.ilGroupXMLParser.php
@@ -511,7 +511,7 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
         }
         $this->group_obj->setPassword($this->group_data['password'] ?? '');
         $this->group_obj->enableMembershipLimitation((bool) ($this->group_data['max_members_enabled'] ?? false));
-        $this->group_obj->setMaxMembers($this->group_data['max_members'] ?: 0);
+        $this->group_obj->setMaxMembers((int) ($this->group_data['max_members'] ?? 0));
         $this->group_obj->enableWaitingList((bool) ($this->group_data['waiting_list_enabled'] ?? false));
 
         $this->group_obj->setWaitingListAutoFill((bool) ($this->group_data['auto_wait'] ?? false));


### PR DESCRIPTION
See:
- https://mantis.ilias.de/view.php?id=35218
- https://testrail.ilias.de/index.php?/tests/view/54130

If approved, this commit MUST be cherry-picked to `release_8`.