### PR TITLE
Preconditions: Fix wrong PHP type (float != int)

### DIFF
--- a/Services/Conditions/classes/class.ilConditionHandlerGUI.php
+++ b/Services/Conditions/classes/class.ilConditionHandlerGUI.php
@@ -368,7 +368,7 @@ class ilConditionHandlerGUI
                     ilConditionHandler::saveNumberOfRequiredTriggers(
                         $this->getTargetRefId(),
                         $this->getTargetId(),
-                        $num_req
+                        (int) $num_req
                     );
                     break;
             }


### PR DESCRIPTION
See:
- https://mantis.ilias.de/view.php?id=33921
- http://testrail.ilias.de/index.php?/tests/view/57407

If approved, this commit MUST be cherry-picked to `release_8`.