### PR TITLE
Search: Fix passing wrong PHP type as ID to search result entry

### DIFF
--- a/Services/Search/classes/class.ilUserDefinedFieldSearch.php
+++ b/Services/Search/classes/class.ilUserDefinedFieldSearch.php
@@ -24,7 +24,7 @@ class ilUserDefinedFieldSearch extends ilAbstractSearch
             $where;
         $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->search_result->addEntry($row->usr_id, 'usr', $this->__prepareFound($row));
+            $this->search_result->addEntry((int) $row->usr_id, 'usr', $this->__prepareFound($row));
         }
         return $this->search_result;
     }


### PR DESCRIPTION
See:
- https://mantis.ilias.de/view.php?id=35116
- http://testrail.ilias.de/index.php?/tests/view/59376

If approved, this commit MUST be cherry-picked to `release_8`.