### PR TITLE
Init: Always use `-1` for `error_reporting` in `DEVMODE` (ILIAS >= 9)

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1094,9 +1094,7 @@ class ilInitialisation
      */
     protected static function handleDevMode(): void
     {
-        if ((defined(SHOWNOTICES) && SHOWNOTICES) || version_compare(PHP_VERSION, '8.0', '>=')) {
-            error_reporting(-1);
-        }
+        error_reporting(-1);
     }
 
     protected static bool $already_initialized = false;


### PR DESCRIPTION
PHP 8.1 is required for ILIAS 9.x, so we can remove the conditions and set `error_reporting` to `-1` if `DEVMODE` is active without any condition.

This is only relevant for ILIAS 9.x (current `trunk`).