### PR TITLE
Init: Don't report deprecations (if `DEVMODE` is disabled / ILIAS >= 7.x)

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1180,7 +1180,7 @@ class ilInitialisation
     public static function handleErrorReporting(): void
     {
         // push the error level as high as possible / sane
-        error_reporting(E_ALL & ~E_NOTICE);
+        error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 
         // see handleDevMode() - error reporting might be overwritten again
         // but we need the client ini first


### PR DESCRIPTION
In my opinion `E_DEPRECATED` issues should **not** be reported if the `DEVMODE` is disabled. If `DEVMODE` is enabled, the `error_reporting` will be overwritten and deprecations will be already reported (see: `\ilInitialisation::handleDevMode`).

If approved, this MUST be cherry-picked to `release_8` and `release_7` (#5391 has to be respected for `release_7` as well).