### PR TITLE
Init: Don't report deprecations except for `DEVMODE` (ILIAS 7 only)

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1096,6 +1096,8 @@ class ilInitialisation
 
             // add notices to error reporting
             error_reporting(E_ALL);
+        } else {
+            error_reporting(E_ALL & ~E_NOTICE);
         }
 
         if (defined('DEBUGTOOLS') && DEBUGTOOLS) {


### PR DESCRIPTION
Depends on #5390 , where deprecation issues are not reported anymore (if `DEVMODE` is disabled).