### PR TITLE
Improve argument passing when calling PHPStan

### DIFF
--- a/CI/PHPStan/run_check.sh
+++ b/CI/PHPStan/run_check.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./libs/composer/vendor/bin/phpstan analyse -c ./CI/PHPStan/phpstan.neon $@
+./libs/composer/vendor/bin/phpstan analyse -c ./CI/PHPStan/phpstan.neon "$@"


### PR DESCRIPTION
This is just a tiny improvement to the bash script for starting PHPStan. See the commit message for details.