### PR TITLE
Fix Mantis issue 35685 and follow-up issue with wrong types in LAC condition parsing

### DIFF
--- a/Modules/Test/ROADMAP.md
+++ b/Modules/Test/ROADMAP.md
@@ -15,14 +15,12 @@ These are open findings from the PHP8 Project which couldn't be solved in the sc
 Remarks on the individual items are marked with "@PHP8-CR"
 ### Test
 * \ilTestPlayerAbstractGUI::autosaveCmd / This looks like another issue in the autosaving. Left for review/analysis by TechSquad
-* \ilTestSkillEvaluation::determineReachedSkillPointsWithSolutionCompare / Incompatible type. Left for review/analysis by TechSquad
 * \ilAssLacCompositeValidator::validateSubTree / Incompatible type. Left for review/analysis by TechSquad
 ### TestQuestionPool
 * \ilObjQuestionPoolGUI::exportQuestionObject / Void result used. Left for review/analysis by TechSquad
 * \assMatchingQuestionGUI::writeAnswerSpecificPostData / Incompatible type. Left for review/analysis by TechSquad
 * \assMatchingQuestionGUI::populateAnswerSpecificFormPart / Incompatible type. Left for review/analysis by TechSquad
 * \assMatchingQuestionImport::fromXML / Incompatible type. Left for review/analysis by TechSquad
-* \ilAssQuestionSkillAssignmentsGUI::validateSolutionCompareExpression / Incompatible type. Left for review/analysis by TechSquad
 * \ilTestSkillEvaluation::determineReachedSkillPointsWithSolutionCompare / Incompatible type. Left for review/analysis by TechSquad
 * \ilAssLacCompositeValidator::validateSubTree / Incompatible type. Left for review/analysis by TechSquad
 * \assOrderingHorizontalGUI::saveFeedback / Undefined method. Left for review/analysis by TechSquad

--- a/Modules/Test/classes/class.ilTestSkillEvaluation.php
+++ b/Modules/Test/classes/class.ilTestSkillEvaluation.php
@@ -271,8 +271,6 @@ class ilTestSkillEvaluation
                 $this->getActiveId(),
                 $this->getPass()
             );
-            // @PHP8-CR I have flat zero clue what is going on here. I like to leave this "intact" for further analysis
-            // and not remove eventually helpful hints.
             if ($compositeEvaluator->evaluate($conditionComposite)) {
                 return $expression->getPoints();
             }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -681,8 +681,6 @@ class ilAssQuestionSkillAssignmentsGUI
             $questionProvider = new ilAssLacQuestionProvider();
             $questionProvider->setQuestion($question);
             $conditionValidator = new ilAssLacCompositeValidator($questionProvider);
-            // @PHP8-CR I have flat zero clue what is going on here. I like to leave this "intact" for further analysis
-            // and not remove eventually helpful hints.
             $conditionValidator->validate($conditionComposite);
         } catch (ilAssLacException $e) {
             if ($e instanceof ilAssLacFormAlertProvider) {

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Exception/ilAssLacCompositeBuilderException.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Exception/ilAssLacCompositeBuilderException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
+ * Thrown to signal a problem during building of composite tree structures.
+ */
+class ilAssLacCompositeBuilderException extends ilAssLacException
+{
+}

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeBuilder.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeBuilder.php
@@ -43,15 +43,29 @@ class ilAssLacCompositeBuilder
     }
 
     /**
-     * @param array $nodes
+     * Creates a composite tree structure from a nodes tree.
+     * <p>
+     * May fail on malformed input, e.g. because not all operators could be
+     * handled. So ensure only to call this function with well-formed input data
+     * or be prepared to handle type exceptions.
      *
-     * @return array
+     * @param array $nodes  an array structure of parsed nodes as returned by
+     *         ilAssLacConditionParser#createNodeArray(), with type 'group'.
+     *
+     * @return ilAssLacAbstractComposite
+     *
+     * @throws ilAssLacCompositeBuilderException in some cases of invalid input.
+     *
+     * @see ilAssLacConditionParser#createNodeArray() for details on the
+     * expected input structure.
      */
-    public function create($nodes): array
+    public function create(array $nodes): ilAssLacAbstractComposite
     {
         if ($nodes['type'] == 'group') {
             foreach ($nodes['nodes'] as $key => $child) {
-                $nodes['nodes'][$key] = $this->create($child);
+                if ($child['type'] == 'group') {
+                    $nodes['nodes'][$key] = $this->create($child);
+                }
             }
 
             foreach ($this->operators as $next_operator) {
@@ -79,7 +93,8 @@ class ilAssLacCompositeBuilder
             }
             return $nodes['nodes'][0];
         }
-        return $nodes;
+        throw new ilAssLacCompositeBuilderException(
+            'need node structure with type group as input');
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacConditionParser.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacConditionParser.php
@@ -79,9 +79,9 @@ class ilAssLacConditionParser
      * @param $condition
      *
      * @see CompositeBuilder::create()
-     * @return array
+     * @return ilAssLacAbstractComposite
      */
-    public function parse($condition): array
+    public function parse($condition): ilAssLacAbstractComposite
     {
         $this->condition = $condition;
         $this->index = 0;

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacConditionParser.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacConditionParser.php
@@ -84,6 +84,7 @@ class ilAssLacConditionParser
     public function parse($condition): array
     {
         $this->condition = $condition;
+        $this->index = 0;
         $this->checkBrackets();
         $this->fetchExpressions();
         $this->fetchOperators();


### PR DESCRIPTION
This is a minimal pull request to fix [Mantis issue 35685](https://mantis.ilias.de/view.php?id=35685 "Mantis 35685: Failed test: Lösungsvergleich 1") and a further issue which immediately occurred after the first fix when trying to execute the steps in the linked [TestRail T58768](https://testrail.ilias.de/index.php?/tests/view/58768 "T58768: Lösungsvergleich 1").

Please see the commit messages for further explanations.

This pull request is against the `release_8` branch because this is where the defect was noticed and fixed. Please also cherry-pick to `trunk`.

Note that this pull request just fixes the exact bug(s), but many other erroneous or improvement-worthy places in T&A LAC code have been found while working on this. I am going to send another pull request for other fixes and improvements.