### PR TITLE
Trunk: actually use plugins language handler

### DIFF
--- a/Services/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
+++ b/Services/Component/classes/Settings/class.ilObjComponentSettingsGUI.php
@@ -154,10 +154,7 @@ class ilObjComponentSettingsGUI extends ilObjectGUI
     protected function refreshLanguages(): void
     {
         try {
-            $plugin_name = $this->request_wrapper->retrieve(self::P_PLUGIN_NAME, $this->refinery->kindlyTo()->string());
-            $plugin = $this->component_repository->getPluginByName($plugin_name);
-            $language_handler = new ilPluginLanguage($plugin);
-            $language_handler->updateLanguages();
+            $this->getPlugin()->getLanguageHandler()->updateLanguages();
             $this->tpl->setOnScreenMessage("success", $this->lng->txt("cmps_refresh_lng"), true);
         } catch (Exception $e) {
             $this->tpl->setOnScreenMessage("failure", $e->getMessage(), true);

--- a/Services/Component/classes/class.ilPlugin.php
+++ b/Services/Component/classes/class.ilPlugin.php
@@ -333,7 +333,7 @@ abstract class ilPlugin
     // Language Handling
     // ------------------------------------------
 
-    protected function getLanguageHandler(): ilPluginLanguage
+    public function getLanguageHandler(): ilPluginLanguage
     {
         if ($this->language_handler === null) {
             $this->language_handler = $this->buildLanguageHandler();


### PR DESCRIPTION
Previously merged request: https://github.com/ILIAS-eLearning/ILIAS/pull/5334

Addition: Fixed `getLanguageHandler` method not public in default `ilPlugin` implementation
Fixes: https://mantis.ilias.de/view.php?id=36169