### PR TITLE
Bugfix 36127: do not show copyright entry if selection is inactive

### DIFF
--- a/Services/MetaData/classes/class.ilMDCopyrightSelectionEntry.php
+++ b/Services/MetaData/classes/class.ilMDCopyrightSelectionEntry.php
@@ -183,6 +183,14 @@ class ilMDCopyrightSelectionEntry
         }
         return $matches[2] ? $matches[2] : 0;
     }
+
+    public static function isEntry($a_cp_string) : bool
+    {
+        if (!preg_match('/il_copyright_entry__([0-9]+)__([0-9]+)/', $a_cp_string)) {
+            return false;
+        }
+        return true;
+    }
     
     /**
      * get usage

--- a/Services/MetaData/classes/class.ilMDUtils.php
+++ b/Services/MetaData/classes/class.ilMDUtils.php
@@ -125,13 +125,13 @@ class ilMDUtils
         include_once('Services/MetaData/classes/class.ilMDSettings.php');
         $settings = ilMDSettings::_getInstance();
         if (!$settings->isCopyrightSelectionActive()) {
-            return $a_copyright;
+            return ilMDCopyrightSelectionEntry::isEntry($a_copyright) ? '' : $a_copyright;
         }
         include_once('Services/MetaData/classes/class.ilMDCopyrightSelectionEntry.php');
         return ilMDCopyrightSelectionEntry::_lookupCopyright($a_copyright);
     }
 
-    public static function _getDefaultCopyright(): string
+    public static function _getDefaultCopyright() : string
     {
         $default_id = ilMDCopyrightSelectionEntry::getDefault();
         return self::_parseCopyright(


### PR DESCRIPTION
This PR fixes [36127](https://mantis.ilias.de/view.php?id=36127) and [28893](https://mantis.ilias.de/view.php?id=28893#c88741). This should also be merged into R8 and trunk, let me know if you'd like a separate PR for that.