### PR TITLE
Bugfix 36197: properly check permissions in systems check

### DIFF
--- a/Services/Object/classes/class.ilObjectOwnershipManagementGUI.php
+++ b/Services/Object/classes/class.ilObjectOwnershipManagementGUI.php
@@ -37,9 +37,10 @@ class ilObjectOwnershipManagementGUI
     protected ilTree $tree;
     protected int $user_id;
     protected int $own_id = 0;
+    protected bool $read_only;
     private ilObjectRequestRetriever $retriever;
 
-    public function __construct(int $user_id = null)
+    public function __construct(int $user_id = null, bool $read_only = false)
     {
         global $DIC;
 
@@ -56,6 +57,7 @@ class ilObjectOwnershipManagementGUI
         if (!is_null($user_id)) {
             $this->user_id = $user_id;
         }
+        $this->read_only = $read_only;
         $this->own_id = $this->retriever->getMaybeInt(self::P_OWNID, 0);
     }
 
@@ -179,6 +181,8 @@ class ilObjectOwnershipManagementGUI
 
     public function delete(): void
     {
+        $this->checkReadOnly();
+
         $this->redirectParentCmd(
             $this->own_id,
             "delete"
@@ -187,6 +191,8 @@ class ilObjectOwnershipManagementGUI
 
     public function move(): void
     {
+        $this->checkReadOnly();
+
         $this->redirectParentCmd(
             $this->own_id,
             "cut"
@@ -195,6 +201,8 @@ class ilObjectOwnershipManagementGUI
 
     public function export(): void
     {
+        $this->checkReadOnly();
+
         $this->redirectCmd(
             $this->own_id,
             ilExportGUI::class
@@ -203,10 +211,26 @@ class ilObjectOwnershipManagementGUI
 
     public function changeOwner(): void
     {
+        $this->checkReadOnly();
+
         $this->redirectCmd(
             $this->own_id,
             ilPermissionGUI::class,
             "owner"
         );
+    }
+
+    public function isReadOnly(): bool
+    {
+        return $this->read_only;
+    }
+
+    protected function checkReadOnly(): void
+    {
+        if ($this->read_only) {
+            throw new ilObjectException(
+                'Cannot perform actions when in read only mode'
+            );
+        }
     }
 }

--- a/Services/Object/classes/class.ilObjectOwnershipManagementTableGUI.php
+++ b/Services/Object/classes/class.ilObjectOwnershipManagementTableGUI.php
@@ -120,7 +120,7 @@ class ilObjectOwnershipManagementTableGUI extends ilTable2GUI
         $this->tpl->setVariable("TITLE", $set["title"]);
         $this->tpl->setVariable("PATH", $set["path"]);
 
-        if ($set["readable"]) {
+        if ($set["readable"] && !$this->isParentReadOnly()) {
             $this->tpl->setCurrentBlock("actions");
             $this->tpl->setVariable("ACTIONS", $this->buildActions($set["ref_id"], $set["type"]));
             $this->tpl->parseCurrentBlock();
@@ -190,5 +190,13 @@ class ilObjectOwnershipManagementTableGUI extends ilTable2GUI
         }
 
         return $path;
+    }
+
+    protected function isParentReadOnly(): bool
+    {
+        if (!method_exists($this->parent_obj, 'isReadOnly')) {
+            return false;
+        }
+        return $this->parent_obj->isReadOnly();
     }
 }

--- a/Services/SystemCheck/classes/class.ilObjSystemCheckGUI.php
+++ b/Services/SystemCheck/classes/class.ilObjSystemCheckGUI.php
@@ -72,6 +72,8 @@ class ilObjSystemCheckGUI extends ilObjectGUI
 
     public function executeCommand(): void
     {
+        $this->checkPermission('read');
+
         $next_class = $this->ctrl->getNextClass($this);
         $cmd = $this->ctrl->getCmd();
         $this->prepareOutput();
@@ -79,8 +81,11 @@ class ilObjSystemCheckGUI extends ilObjectGUI
         switch ($next_class) {
             case 'ilobjectownershipmanagementgui':
                 $this->setSubTabs(self::SECTION_MAIN, 'no_owner');
+                $this->tabs_gui->activateTab('overview');
 
-                $gui = new ilObjectOwnershipManagementGUI(0);
+                $read_only = !$this->checkPermissionBool('write');
+
+                $gui = new ilObjectOwnershipManagementGUI(0, $read_only);
                 $this->ctrl->forwardCommand($gui);
                 break;
 
@@ -95,7 +100,7 @@ class ilObjSystemCheckGUI extends ilObjectGUI
                 break;
 
             case 'ilpermissiongui':
-                $this->tabs_gui->setTabActive('perm_settings');
+                $this->tabs_gui->activateTab('perm_settings');
 
                 $perm_gui = new ilPermissionGUI($this);
                 $this->ctrl->forwardCommand($perm_gui);
@@ -126,11 +131,19 @@ class ilObjSystemCheckGUI extends ilObjectGUI
 
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess('read', $this->object->getRefId())) {
-            $this->tabs_gui->addTarget('overview', $this->ctrl->getLinkTarget($this, 'overview'));
+        if ($this->checkPermissionBool('read')) {
+            $this->tabs_gui->addTab(
+                'overview',
+                $this->lng->txt('overview'),
+                $this->ctrl->getLinkTarget($this, 'overview')
+            );
         }
-        if ($this->rbac_system->checkAccess('edit_permission', $this->object->getRefId())) {
-            $this->tabs_gui->addTarget('perm_settings', $this->ctrl->getLinkTargetByClass(array(get_class($this), 'ilpermissiongui'), 'perm'), array('perm', 'info', 'owner'), 'ilpermissiongui');
+        if ($this->checkPermissionBool('edit_permission')) {
+            $this->tabs_gui->addTab(
+                'perm_settings',
+                $this->lng->txt('perm_settings'),
+                $this->ctrl->getLinkTargetByClass(array(get_class($this), 'ilpermissiongui'), 'perm')
+            );
         }
     }
 
@@ -139,6 +152,7 @@ class ilObjSystemCheckGUI extends ilObjectGUI
         $this->getLang()->loadLanguageModule('sysc');
 
         $this->setSubTabs(self::SECTION_MAIN, 'overview');
+        $this->tabs_gui->activateTab('overview');
 
         $table = new ilSCGroupTableGUI($this, 'overview');
         $table->init();
@@ -164,7 +178,10 @@ class ilObjSystemCheckGUI extends ilObjectGUI
 
     protected function trash(ilPropertyFormGUI $form = null): void
     {
+        $this->checkPermission('write');
+
         $this->setSubTabs(self::SECTION_MAIN, 'trash');
+        $this->tabs_gui->activateTab('overview');
         if (!$form instanceof ilPropertyFormGUI) {
             $form = $this->initFormTrash();
         }
@@ -264,30 +281,44 @@ class ilObjSystemCheckGUI extends ilObjectGUI
     {
         switch ($a_section) {
             case self::SECTION_MAIN:
-                $this->tabs_gui->addSubTab(
-                    'overview',
-                    $this->getLang()->txt('sysc_groups'),
-                    $this->ctrl->getLinkTarget($this, 'overview')
-                );
-                $this->tabs_gui->addSubTab(
-                    'trash',
-                    $this->getLang()->txt('sysc_tab_trash'),
-                    $this->ctrl->getLinkTarget($this, 'trash')
-                );
-                $this->tabs_gui->addSubTab(
-                    'no_owner',
-                    $this->getLang()->txt('system_check_no_owner'),
-                    $this->ctrl->getLinkTargetByClass('ilobjectownershipmanagementgui')
-                );
+                $this->setMainSubTabs();
                 break;
 
             case self::SECTION_GROUP:
-                $this->tabs_gui->clearTargets();
-                $this->tabs_gui->setBackTarget(
-                    $this->lng->txt('back'),
-                    $this->ctrl->getLinkTarget($this, 'overview')
-                );
+                $this->setGroupSubTabs();
         }
         $this->tabs_gui->activateSubTab($a_active);
+    }
+
+    protected function setMainSubTabs(): void
+    {
+        $this->tabs_gui->addSubTab(
+            'overview',
+            $this->getLang()->txt('sysc_groups'),
+            $this->ctrl->getLinkTarget($this, 'overview')
+        );
+
+        if ($this->checkPermissionBool('write')) {
+            $this->tabs_gui->addSubTab(
+                'trash',
+                $this->getLang()->txt('sysc_tab_trash'),
+                $this->ctrl->getLinkTarget($this, 'trash')
+            );
+        }
+
+        $this->tabs_gui->addSubTab(
+            'no_owner',
+            $this->getLang()->txt('system_check_no_owner'),
+            $this->ctrl->getLinkTargetByClass('ilobjectownershipmanagementgui')
+        );
+    }
+
+    protected function setGroupSubTabs(): void
+    {
+        $this->tabs_gui->clearTargets();
+        $this->tabs_gui->setBackTarget(
+            $this->lng->txt('back'),
+            $this->ctrl->getLinkTarget($this, 'overview')
+        );
     }
 }


### PR DESCRIPTION
This PR fixes [36197](https://mantis.ilias.de/view.php?id=36197). Please note that it is dependent on #5412: without that fix Administration > Systems Check will whoops, since I replaced deprecated tabs methods with their (currently bugged) up-to-date counterparts.