### PR TITLE
Auth/SAML: Store used auth_mode explicitly and move SAML logout to ev…

### DIFF
--- a/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
+++ b/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use Jumbojett\OpenIDConnectClient;
 
@@ -163,7 +163,7 @@ class ilAuthProviderOpenIdConnect extends ilAuthProvider
             $sync->updateUser();
 
             $user_id = $sync->getUserId();
-            ilSession::set('used_external_auth', true);
+            ilSession::set('used_external_auth_mode', ilAuthUtils::AUTH_OPENID_CONNECT);
             $status->setAuthenticatedUserId($user_id);
             $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
 

--- a/Services/SOAPAuth/classes/class.ilAuthProviderSoap.php
+++ b/Services/SOAPAuth/classes/class.ilAuthProviderSoap.php
@@ -87,7 +87,7 @@ class ilAuthProviderSoap extends ilAuthProvider
         if ($status->getAuthenticatedUserId() > 0 && $status->getAuthenticatedUserId() !== ANONYMOUS_USER_ID) {
             $this->logger->info('Successfully authenticated user via SOAP: ' . $this->getCredentials()->getUsername());
             $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
-            ilSession::set('used_external_auth', true);
+            ilSession::set('used_external_auth_mode', ilAuthUtils::AUTH_SOAP);
 
             return true;
         }

--- a/Services/Saml/classes/class.ilAuthProviderSaml.php
+++ b/Services/Saml/classes/class.ilAuthProviderSaml.php
@@ -206,7 +206,7 @@ final class ilAuthProviderSaml extends ilAuthProvider implements ilAuthProviderA
 
             $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
             $status->setAuthenticatedUserId(ilObjUser::_lookupId($internal_account));
-            ilSession::set('used_external_auth', true);
+            ilSession::set('used_external_auth_mode', $this->getTriggerAuthMode());
 
             return true;
         }
@@ -245,7 +245,7 @@ final class ilAuthProviderSaml extends ilAuthProvider implements ilAuthProviderA
 
             ilSession::set(self::SESSION_TMP_ATTRIBUTES, null);
             ilSession::set(self::SESSION_TMP_RETURN_TO, null);
-            ilSession::set('used_external_auth', true);
+            ilSession::set('used_external_auth_mode', $this->getTriggerAuthMode());
 
             $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
             $status->setAuthenticatedUserId(ilObjUser::_lookupId($new_name));

--- a/Services/Saml/classes/class.ilSamlAppEventListener.php
+++ b/Services/Saml/classes/class.ilSamlAppEventListener.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilSamlAppEventListener implements ilAppEventListener
+{
+    public static function handleEvent(string $a_component, string $a_event, array $a_parameter): void
+    {
+        global $DIC;
+
+        if ($a_component === 'Services/Authentication' && $a_event === 'afterLogout' &&
+            isset($a_parameter['is_explicit_logout']) && $a_parameter['is_explicit_logout'] === true &&
+            isset($a_parameter['used_external_auth_mode']) && $a_parameter['used_external_auth_mode']) {
+            if ((int) $a_parameter['used_external_auth_mode'] === ilAuthUtils::AUTH_SAML) {
+                $DIC->ctrl()->redirectToURL('saml.php?action=logout&logout_url=' . urlencode(ILIAS_HTTP_PATH . '/login.php'));
+            }
+        }
+    }
+}

--- a/Services/Saml/classes/class.ilSimpleSAMLphpWrapper.php
+++ b/Services/Saml/classes/class.ilSimpleSAMLphpWrapper.php
@@ -112,7 +112,7 @@ final class ilSimpleSAMLphpWrapper implements ilSamlAuth
 
     public function logout(string $returnUrl = ''): void
     {
-        ilSession::set('used_external_auth', false);
+        ilSession::clear('used_external_auth_mode');
 
         $params = [
             'ReturnStateParam' => 'LogoutState',

--- a/Services/Saml/lib/saml2-logout.php
+++ b/Services/Saml/lib/saml2-logout.php
@@ -67,6 +67,7 @@ $GLOBALS['ilAppEventHandler']->raise(
     'afterLogout',
     [
         'username' => $GLOBALS['DIC']->user()->getLogin(),
+        'is_explicit_logout' => false,
     ]
 );
 

--- a/Services/Saml/service.xml
+++ b/Services/Saml/service.xml
@@ -1,0 +1,6 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<service xmlns="http://www.w3.org" id="saml">
+	<events>
+		<event type="listen" id="Services/Authentication" />
+	</events>
+</service>

--- a/Services/User/Settings/classes/class.ilPersonalSettingsGUI.php
+++ b/Services/User/Settings/classes/class.ilPersonalSettingsGUI.php
@@ -263,7 +263,7 @@ class ilPersonalSettingsGUI
      */
     protected function allowPasswordChange(): bool
     {
-        if (\ilSession::get('used_external_auth')) {
+        if (\ilSession::get('used_external_auth_mode')) {
             return false;
         }
 

--- a/Services/User/classes/class.ilForcedUserPasswordChangeStartUpStep.php
+++ b/Services/User/classes/class.ilForcedUserPasswordChangeStartUpStep.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Init\StartupSequence\StartUpSequenceStep;
 use Psr\Http\Message\ServerRequestInterface;
@@ -62,7 +62,7 @@ class ilForcedUserPasswordChangeStartUpStep extends StartUpSequenceStep
 
     public function shouldInterceptRequest(): bool
     {
-        if (ilSession::get('used_external_auth')) {
+        if (ilSession::get('used_external_auth_mode')) {
             return false;
         }
 


### PR DESCRIPTION
…ent listener

This commit removes the SAML specific code from `ilStartupGUI` to an event listener in `Services/SAML`.
Furthermore, it renames the session key `used_external_auth_mode` used for some external authentication modes and stores the used mode instead of a boolean flag.