### PR TITLE
Bugfix Conditions: fix copying of number of required materials

### DIFF
--- a/Services/Conditions/classes/class.ilConditionHandler.php
+++ b/Services/Conditions/classes/class.ilConditionHandler.php
@@ -1340,6 +1340,13 @@ class ilConditionHandler
                 
                 if ($newCondition->storeCondition()) {
                     $valid++;
+
+                    //Copy num_obligatory, to be checked below
+                    self::saveNumberOfRequiredTriggers(
+                        $a_target_ref_id,
+                        $target_obj,
+                        $con['num_obligatory']
+                    );
                 }
             }
         }


### PR DESCRIPTION
This PR fixes the copying of 'Number of Required Materials' of preconditions. It will be kept as is if still applicable, otherwise a fallback is calculated. Currently the fallback is always applied.