### PR TITLE
Implemented UFTNormalization as Transformation

### DIFF
--- a/src/Refinery/String/Group.php
+++ b/src/Refinery/String/Group.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\Refinery\String;
 
@@ -125,5 +125,15 @@ class Group
     public function levenshtein(): Levenshtein
     {
         return new Levenshtein();
+    }
+
+    /**
+     * This method returns an instance of the UTFNormal class which can be used to get Transformations that can be used
+     * to normalize a string to one of the Unicode Normalization Form (C, D, KC, KD).
+     * See https://unicode.org/reports/tr15/ for more information.
+     */
+    public function utfnormal(): UTFNormal
+    {
+        return new UTFNormal();
     }
 }

--- a/src/Refinery/String/Transformation/UTFNormalTransformation.php
+++ b/src/Refinery/String/Transformation/UTFNormalTransformation.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery\String\Transformation;
+
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+use ILIAS\Refinery\Transformation;
+use InvalidArgumentException;
+use Symfony\Polyfill\Intl\Normalizer\Normalizer as PolyfillNormalizer;
+use Normalizer as NativeNormalizer;
+
+class UTFNormalTransformation implements Transformation
+{
+    use DeriveApplyToFromTransform;
+    use DeriveInvokeFromTransform;
+
+    protected const METHOD_NORMALIZER = 1;
+    protected const METHOD_POLYFILL = 2;
+
+    public const FORM_D = 4;
+    public const FORM_KD = 8;
+    public const FORM_C = 16;
+    public const FORM_KC = 32;
+
+    private int $form = self::FORM_C;
+    private int $method = self::METHOD_POLYFILL;
+
+    public function __construct(
+        int $form = self::FORM_C
+    ) {
+        $this->form = $form;
+        $this->determineMethod();
+    }
+
+    private function determineMethod(): void
+    {
+        if ($this->normalizerExists()) {
+            $this->method = self::METHOD_NORMALIZER;
+        } else {
+            // We luckily have a polyfill for this in libs/composer/vendor/symfony/polyfill-intl-normalizer
+            $this->method = self::METHOD_POLYFILL;
+        }
+    }
+
+    protected function normalizerExists(): bool
+    {
+        return class_exists(NativeNormalizer::class) && method_exists(NativeNormalizer::class, 'normalize');
+    }
+
+    protected function determineNativeOrPolyfillForm(): int
+    {
+        switch ($this->form) {
+            case self::FORM_D:
+                $form = NativeNormalizer::FORM_D;
+                break;
+            case self::FORM_KD:
+                $form = NativeNormalizer::FORM_KD;
+                break;
+            case self::FORM_KC:
+                $form = NativeNormalizer::FORM_KC;
+                break;
+            case self::FORM_C:
+            default:
+                $form = NativeNormalizer::FORM_C;
+                break;
+        }
+        return $form;
+    }
+
+    private function fromPolyfill(string $from): string
+    {
+        $form = $this->determineNativeOrPolyfillForm();
+        if (PolyfillNormalizer::isNormalized($from, $form)) {
+            return $from;
+        }
+
+        return PolyfillNormalizer::normalize($from, $form) ?: "";
+    }
+
+    private function fromNormalizer(string $from): string
+    {
+        $form = $this->determineNativeOrPolyfillForm();
+        if (NativeNormalizer::isNormalized($from, $form)) {
+            return $from;
+        }
+
+        return NativeNormalizer::normalize($from, $form) ?: "";
+    }
+
+    /**
+     * The transform method checks if the $form variable contains a string
+     * alternatively an InvalidArgumentException is thrown.
+     * After the string will be normalized to the desired form.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function transform($from): string
+    {
+        if (!is_string($from)) {
+            throw new InvalidArgumentException(__METHOD__ . " the argument is not a string.");
+        }
+
+        switch ($this->method) {
+            case self::METHOD_NORMALIZER:
+                return $this->fromNormalizer($from);
+            case self::METHOD_POLYFILL:
+                return $this->fromPolyfill($from);
+        }
+
+        return "";
+    }
+}

--- a/src/Refinery/String/UTFNormal.php
+++ b/src/Refinery/String/UTFNormal.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery\String;
+
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\String\Transformation\LevenshteinTransformation;
+use ILIAS\Refinery\String\Transformation\UTFNormalTransformation;
+
+class UTFNormal
+{
+    /**
+     * Normalization Form C (NFC), also known as Canonical Decomposition followed by Canonical Composition.
+     */
+    public function formC(): Transformation
+    {
+        return new UTFNormalTransformation(UTFNormalTransformation::FORM_C);
+    }
+
+    /**
+     * Normalization Form D (NFD), also known as Canonical Decomposition.
+     */
+    public function formD(): Transformation
+    {
+        return new UTFNormalTransformation(UTFNormalTransformation::FORM_D);
+    }
+
+    /**
+     * Normalization Form KC (NFKC), also known as Compatibility Decomposition followed by Canonical Composition.
+     */
+    public function formKD(): Transformation
+    {
+        return new UTFNormalTransformation(UTFNormalTransformation::FORM_KD);
+    }
+
+    /**
+     * Normalization Form KD (NFKD), also known as Compatibility Decomposition.
+     */
+    public function formKC(): Transformation
+    {
+        return new UTFNormalTransformation(UTFNormalTransformation::FORM_KC);
+    }
+}

--- a/tests/Refinery/String/UTFNormalTest.php
+++ b/tests/Refinery/String/UTFNormalTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\src\Refinery\String;
+
+use ILIAS\Data\Factory;
+use ILIAS\Refinery\String\Group;
+use ILIAS\Tests\Refinery\TestCase;
+use ilLanguage;
+use InvalidArgumentException;
+use ILIAS\Refinery\String\Transformation\UTFNormalTransformation;
+use ILIAS\Refinery\Transformation;
+
+class UTFNormalTest extends TestCase
+{
+    private Transformation $form_d;
+    private Transformation $form_c;
+    private Transformation $form_kc;
+    private Transformation $form_kd;
+
+    public function setUp(): void
+    {
+        $language = $this->getMockBuilder(ilLanguage::class)
+                         ->disableOriginalConstructor()
+                         ->getMock();
+        $group = new Group(new Factory(), $language);
+
+        $this->form_d = $group->utfnormal()->formD();
+        $this->form_c = $group->utfnormal()->formC();
+        $this->form_kc = $group->utfnormal()->formKC();
+        $this->form_kd = $group->utfnormal()->formKD();
+    }
+
+    public function stringProvider(): array
+    {
+        // Never ever try to change something on this array :-) e.g. a 'ä' isn't a 'ä' but a 'ä' ;-)
+        return [
+            ["Ä\uFB03n", "Ä\uFB03n", 'Ä\uFB03n', 'Ä\uFB03n', 'Ä\uFB03n'],
+            ["\xC3\x85", 'Å', 'Å', 'Å', 'Å'],
+            ["\xCC\x8A", '̊', '̊', '̊', '̊'],
+            ["\u{FFDA}", 'ￚ', 'ￚ', 'ᅳ', 'ᅳ'],
+            ["\u{FDFA}", 'ﷺ', 'ﷺ', 'صلى الله عليه وسلم', 'صلى الله عليه وسلم'],
+            ["\xF5", '', '', '', ''],
+            ["ä", 'ä', 'ä', 'ä', 'ä'],
+            ["🤔", "🤔", "🤔", "🤔", "🤔"],
+            ["你好", "你好", "你好", "你好", "你好"],
+        ];
+    }
+
+    /**
+     * @dataProvider stringProvider
+     */
+    public function testNormalization(
+        string $string,
+        string $expected_form_c,
+        string $expected_form_d,
+        string $expected_form_kc,
+        string $expected_form_kd
+    ): void {
+        // FORM C
+        $this->assertEquals($expected_form_c, $this->form_c->transform($string));
+
+        // FORM D
+        $this->assertEquals($expected_form_d, $this->form_d->transform($string));
+
+        // FORM KC
+        $this->assertEquals($expected_form_kc, $this->form_kc->transform($string));
+
+        // FORM KD
+        $this->assertEquals($expected_form_kd, $this->form_kd->transform($string));
+    }
+}


### PR DESCRIPTION
Hi @klees 
This is a followup from a mantis-ticket, there are some places we should be able to normalize strings to one of the Unicode Normalization Forms (see https://unicode.org/reports/tr15/)

The usage currently (or as it was with ilStr::normalizeUtf8String) are bad and we will get rid of them anyway (by using the new Inputs).

But since this isn't a big deal to write this Transformation, here it is...

https://mantis.ilias.de/view.php?id=34241