### PR TITLE
TA: 36161, hide whitespace in header. DO NOT PICK TO TRUNK, please.

### DIFF
--- a/Modules/Test/ROADMAP.md
+++ b/Modules/Test/ROADMAP.md
@@ -10,6 +10,11 @@ Priorities for the development of the Test & Assessment and the Test Question Po
 ## Others
 * Fixing access to Learning Status when access to test results is limited (see: [Mantis 25064](https://mantis.ilias.de/view.php?id=25064&nbn=9))
 
+## Kiosk-Mode
+* current kiosk-mode enforces the header to be removed without it (the header) being a UI-Component. 
+* In consequence, a test_kiosk_header.css is neccessary to hide whitespace (https://mantis.ilias.de/view.php?id=36161)
+* This SHOULD be removed in favor of a concept with better integration.
+
 ## Open Warnings / Issues without Tickets
 These are open findings from the PHP8 Project which couldn't be solved in the scope of the project itself. They are documented here for transparency.
 Remarks on the individual items are marked with "@PHP8-CR"

--- a/Modules/Test/classes/Screen/class.ilTestPlayerLayoutProvider.php
+++ b/Modules/Test/classes/Screen/class.ilTestPlayerLayoutProvider.php
@@ -65,6 +65,20 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
 
         return null;
     }
+    public function getResponsiveLogoModification(CalledContexts $called_contexts): ?LogoModification
+    {
+        if ($this->isKioskModeEnabled($called_contexts)) {
+            $logo = $this->globalScreen()->layout()->factory()->logo();
+
+            $logo = $logo->withModification(function (Image $current) {
+                return null;
+            });
+
+            return $logo->withHighPriority();
+        }
+
+        return null;
+    }
 
     public function getMainBarModification(CalledContexts $called_contexts): ?MainBarModification
     {
@@ -148,4 +162,5 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         }
         return null;
     }
+
 }

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1059,6 +1059,11 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         global $DIC;
         $ilUser = $DIC['ilUser'];
 
+        //this is an abomination for release_8! 
+        //proper "kiosk-handling" is _very_ much encouraged for 9.
+        $this->tpl->addCSS('Modules/Test/templates/default/test_kiosk_header.css');
+        //end of hack
+
         $template = new ilTemplate('tpl.il_as_tst_kiosk_head.html', true, true, 'Modules/Test');
         if ($this->object->getShowKioskModeTitle()) {
             $template->setCurrentBlock("kiosk_show_title");

--- a/Modules/Test/templates/default/test_kiosk_header.css
+++ b/Modules/Test/templates/default/test_kiosk_header.css
@@ -1,0 +1,11 @@
+ /*
+ this is an abomination for release_8! 
+ proper "kiosk-handling" is _very_ much encouraged for 9.
+ */
+
+body .il-layout-page {
+    grid-template-rows: auto 0px 1fr !important;
+}
+body header .header-inner {
+    display:none !important;
+}


### PR DESCRIPTION
- this adds an additional css-file, which hsould be removed in favor of a better integrating concept of kiosk-mode/test-player.
- the responsive logo is removed via gs-modification

For trunk, we should come up with proper concept for T&A Kiosk Mode, so better not apply this one there.

https://mantis.ilias.de/view.php?id=36161