### PR TITLE
Bugfix 36261: replace superglobal access in MD editor

### DIFF
--- a/Services/MetaData/classes/class.ilMDEditorGUI.php
+++ b/Services/MetaData/classes/class.ilMDEditorGUI.php
@@ -110,6 +110,22 @@ class ilMDEditorGUI
         return $section;
     }
 
+    protected function initSectionFromRequest(): string
+    {
+        if ($section = $this->initSectionFromQuery()) {
+            return $section;
+        }
+
+        if ($this->http->wrapper()->post()->has('section')) {
+            $section = $this->http->wrapper()->post()->retrieve(
+                'section',
+                $this->refinery->kindlyTo()->string()
+            );
+        }
+
+        return $section;
+    }
+
     public function executeCommand(): void
     {
         $next_class = $this->ctrl->getNextClass($this);
@@ -3731,7 +3747,7 @@ class ilMDEditorGUI
 
     public function listSection(): void
     {
-        switch ($_REQUEST['section'] ?? '') {
+        switch ($this->initSectionFromRequest()) {
             case 'meta_general':
                 $this->listGeneral();
                 break;

--- a/Services/MetaData/classes/class.ilMDEditorGUI.php
+++ b/Services/MetaData/classes/class.ilMDEditorGUI.php
@@ -3731,7 +3731,7 @@ class ilMDEditorGUI
 
     public function listSection(): void
     {
-        switch ($_REQUEST['section']) {
+        switch ($_REQUEST['section'] ?? '') {
             case 'meta_general':
                 $this->listGeneral();
                 break;


### PR DESCRIPTION
This PR fixes [36261](https://mantis.ilias.de/view.php?id=0036261). It seems like this error appeared on test8 because `prevent_super_global_replacement` was turned on in the `client.ini`. This config change might be causing other issues, a quick search suggests that not every access of superglobals has a failsafe.