### PR TITLE
Bugfix 35492: disable rows selector in course LP statistics details table

### DIFF
--- a/Services/Tracking/classes/object_statistics/class.ilLPObjectStatisticsLPTableGUI.php
+++ b/Services/Tracking/classes/object_statistics/class.ilLPObjectStatisticsLPTableGUI.php
@@ -73,7 +73,7 @@ class ilLPObjectStatisticsLPTableGUI extends ilLPTableBaseGUI
             }
         } else {
             $this->setLimit(20);
-
+            $this->setShowRowsSelector(false);     // see #35492
             $this->addColumn($this->lng->txt("trac_figure"));
         }
         $this->initFilter();


### PR DESCRIPTION
This PR fixes [35492](https://mantis.ilias.de/view.php?id=35492) by disabling the rows selector in the 'details' slate (?) of the course LP statistics table.