### PR TITLE
[FIX] make test more robust in macOS

### DIFF
--- a/Services/Component/test/Setup/ilComponentBuildPluginInfoObjectiveTest.php
+++ b/Services/Component/test/Setup/ilComponentBuildPluginInfoObjectiveTest.php
@@ -13,13 +13,14 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 use PHPUnit\Framework\TestCase;
 
 class ilComponentBuildPluginInfoObjectiveTest extends TestCase
 {
+    private ?ilComponentBuildPluginInfoObjective $builder = null;
+
     protected function setUp(): void
     {
         $this->scanned = [];
@@ -120,7 +121,12 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     {
         // Use the component directory without artifacts, because this should be mostly stable.
         $expected = ["ROADMAP.md", "classes", "exceptions", "maintenance.json", "service.xml", "test"];
-        $actual = array_values(array_diff($this->builder->_scanDir(__DIR__ . "/../.."), ["artifacts"]));
+        $actual = array_values(
+            array_diff(
+                $this->builder->_scanDir(__DIR__ . "/../.."),
+                ["artifacts", ".DS_Store"] // .DS_Store is a macOS artifact which is not relevant for the test.
+            )
+        );
         $this->assertEquals($expected, $actual);
     }
 


### PR DESCRIPTION
This test fails after you opened the directory using Finder in macOS (which creates a .DS_Store file in it)