### PR TITLE
Bugfix 33275: only assign object types to adv md record when necessary

### DIFF
--- a/Modules/Portfolio/classes/class.ilObjPortfolioBase.php
+++ b/Modules/Portfolio/classes/class.ilObjPortfolioBase.php
@@ -423,18 +423,19 @@ abstract class ilObjPortfolioBase extends ilObject2
              * BT 35494: reset assignement of the newly cloned local records,
              * and only append what's needed to global ones
              */
+            $target_type = ilObject::_lookupType($a_target->getId());
             if ($rec->getParentObject() == $a_target->getId()) {
                 $rec->setAssignedObjectTypes(
                     [[
-                         "obj_type" => ilObject::_lookupType($a_target->getId()),
+                         "obj_type" => $target_type,
                          "sub_type" => "pfpg",
                          "optional" => 0
                      ]
                     ]
                 );
-            } else {
+            } elseif (!$rec->isAssignedObjectType($target_type, 'pfpg')) {
                 $rec->appendAssignedObjectType(
-                    ilObject::_lookupType($a_target->getId()),
+                    $target_type,
                     "pfpg"
                 );
             }


### PR DESCRIPTION
This PR fixes [33725](https://mantis.ilias.de/view.php?id=0033725).