### PR TITLE
 T&A-0036167-HTML-Quellcode-wird-in-das-Feld-Antwort-Text-übernommen

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
@@ -105,6 +105,8 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
     {
         $form = $this->buildEditForm();
         $form->setValuesByPost();
+        $errors = !$form->checkInput();
+        $form->setValuesByPost();
 
         if ($upload) {
             $answersInput = $form->getItemByPostVar('kprim_answers');
@@ -117,16 +119,14 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
             }
 
             $answersInput->collectValidFiles();
-        } elseif (!$form->checkInput()) {
+        } elseif ($errors) {
             $this->editQuestion($form);
             return 1;
         }
 
         $this->writeQuestionGenericPostData();
-
         $this->writeQuestionSpecificPostData($form);
         $this->writeAnswerSpecificPostData($form);
-
         $this->saveTaxonomyAssignments();
 
         return 0;

--- a/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -44,7 +44,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         $this->lng = $lng;
         $this->tpl = $tpl;
         
-        $this->files = array();
+        $this->files = [];
 
         $this->ignoreMissingUploadsEnabled = false;
     }
@@ -104,15 +104,12 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         include_once "./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php";
 
         if (is_array($_POST[$this->getPostVar()]) && $_POST["answer_type"] == "multiLine") {
-            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
-                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
-            }
+            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()],
+                false, ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
         } elseif (is_array($_POST[$this->getPostVar()]) && $_POST["answer_type"] == "singleLine") {
-            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
-                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  "<em>, <strong>");
-            }
+            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()],
+                true, ilSingleChoiceWizardInputGUI::ALLOWED_PAGE_HTML_TAGS);
         }
-
 
         $foundvalues = $_POST[$this->getPostVar()];
         
@@ -430,13 +427,13 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                 continue;
             }
 
-            $this->files[$index] = array(
+            $this->files[$index] = [
                 'position' => $index,
                 'tmp_name' => $_FILES[$this->getPostVar()]['tmp_name']['image'][$index],
                 'name' => $_FILES[$this->getPostVar()]['name']['image'][$index],
                 'type' => $_FILES[$this->getPostVar()]['type']['image'][$index],
                 'size' => $_FILES[$this->getPostVar()]['size']['image'][$index]
-            );
+            ];
         }
     }
 }

--- a/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -102,14 +102,13 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         $lng = $DIC['lng'];
 
         include_once "./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php";
-        if (is_array($_POST[$this->getPostVar()])) {
-            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive(
-                $_POST[$this->getPostVar()],
-                false,
-                ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment")
-            );
+
+        if (is_array($_POST[$this->getPostVar()]) && $_POST["answer_type"] == "multiLine") {
+            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], false, ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
+        } elseif (is_array($_POST[$this->getPostVar()]) && $_POST["answer_type"] == "singleLine") {
+            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], true, "<em>, <strong>");
         }
-        
+
         $foundvalues = $_POST[$this->getPostVar()];
         
         #vd($foundvalues);

--- a/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -104,10 +104,15 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         include_once "./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php";
 
         if (is_array($_POST[$this->getPostVar()]) && $_POST["answer_type"] == "multiLine") {
-            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], false, ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
+            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
+                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
+            }
         } elseif (is_array($_POST[$this->getPostVar()]) && $_POST["answer_type"] == "singleLine") {
-            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], true, "<em>, <strong>");
+            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
+                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  "<em>, <strong>");
+            }
         }
+
 
         $foundvalues = $_POST[$this->getPostVar()];
         

--- a/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -19,7 +19,7 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
     */
     public function setValue($a_value)
     {
-        $this->values = array();
+        $this->values = [];
         if (is_array($a_value)) {
             if (is_array($a_value['answer'])) {
                 foreach ($a_value['answer'] as $index => $value) {
@@ -44,13 +44,11 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         include_once "./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php";
 
         if (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 1) {
-            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
-                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
-            }
+            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()],
+                    false, ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
         } elseif (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 0) {
-            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
-                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  "<em>, <strong>");
-            }
+                $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()],
+                    true, ilSingleChoiceWizardInputGUI::ALLOWED_PAGE_HTML_TAGS);
         }
 
         $foundvalues = $_POST[$this->getPostVar()];

--- a/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -42,9 +42,13 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         $lng = $DIC['lng'];
         
         include_once "./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php";
-        if (is_array($_POST[$this->getPostVar()])) {
+
+        if (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 1) {
             $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], false, ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
+        } elseif (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 0) {
+            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], true, "<em>, <strong>");
         }
+
         $foundvalues = $_POST[$this->getPostVar()];
         if (is_array($foundvalues)) {
             // check answers

--- a/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -44,9 +44,13 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         include_once "./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php";
 
         if (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 1) {
-            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], false, ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
+            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
+                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
+            }
         } elseif (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 0) {
-            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], true, "<em>, <strong>");
+            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
+                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  "<em>, <strong>");
+            }
         }
 
         $foundvalues = $_POST[$this->getPostVar()];

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -13,8 +13,8 @@ require_once 'Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php';
 class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
 {
     /** @var string */
-    const ALLOWED_PAGE_HTML_TAGS = "<em>, <strong>";
-    
+    protected const ALLOWED_PAGE_HTML_TAGS = "<em>, <strong>";
+
     protected $values = [];
     protected $allowMove = false;
     protected $singleline = true;

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -12,11 +12,14 @@ require_once 'Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php';
 */
 class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
 {
-    protected $values = array();
+    /** @var string */
+    const ALLOWED_PAGE_HTML_TAGS = "<em>, <strong>";
+    
+    protected $values = [];
     protected $allowMove = false;
     protected $singleline = true;
     protected $qstObject = null;
-    protected $suffixes = array();
+    protected $suffixes = [];
     protected $showPoints = true;
     protected $hideImages = false;
     
@@ -29,7 +32,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     public function __construct($a_title = "", $a_postvar = "")
     {
         parent::__construct($a_title, $a_postvar);
-        $this->setSuffixes(array("jpg", "jpeg", "png", "gif"));
+        $this->setSuffixes(["jpg", "jpeg", "png", "gif"]);
         $this->setSize('25');
         $this->validationRegexp = "";
     }
@@ -41,7 +44,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     */
     public function setValue($a_value)
     {
-        $this->values = array();
+        $this->values = [];
         if (is_array($a_value)) {
             if (is_array($a_value['answer'])) {
                 foreach ($a_value['answer'] as $index => $value) {
@@ -186,13 +189,11 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         include_once "./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php";
 
         if (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 1) {
-            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
-                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
-            }
+            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()],
+                false, ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
         } elseif (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 0) {
-            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
-                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  "<em>, <strong>");
-            }
+            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()],
+                true, ilSingleChoiceWizardInputGUI::ALLOWED_PAGE_HTML_TAGS);
         }
 
         $foundvalues = $_POST[$this->getPostVar()];

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -185,8 +185,10 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         
         include_once "./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php";
 
-        if (is_array($_POST[$this->getPostVar()])) {
+        if (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 1) {
             $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], true, ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
+        } elseif (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 0) {
+            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], true, "<em>, <strong>");
         }
         $foundvalues = $_POST[$this->getPostVar()];
         if (is_array($foundvalues)) {

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -186,10 +186,15 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         include_once "./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php";
 
         if (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 1) {
-            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], true, ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
+            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
+                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment"));
+            }
         } elseif (is_array($_POST[$this->getPostVar()]) && $_POST["types"] == 0) {
-            $_POST[$this->getPostVar()] = ilUtil::stripSlashesRecursive($_POST[$this->getPostVar()], true, "<em>, <strong>");
+            foreach ($_POST[$this->getPostVar()]["answer"] as $index => $answer){
+                $_POST[$this->getPostVar()]["answer"][$index] = strip_tags($_POST[$this->getPostVar()]["answer"][$index],  "<em>, <strong>");
+            }
         }
+
         $foundvalues = $_POST[$this->getPostVar()];
         if (is_array($foundvalues)) {
             // check answers


### PR DESCRIPTION
Good day,
This fixes the Issue related to: https://mantis.ilias.de/view.php?id=36167

TinyMCE has acces to more HTML tags than the ILIAS Page editor. By switching from Multiple Line Answer to Single Line Answer, the additional TinyMCE HTML tags have not been removed. This fixes the issue without touching TinyMCE, but still allowing for `<em>` and `<strong>` HTML tag which are useable with the ILIAS Page editor.

As always, let me know if this correction can be improved, or if I forgot or didn't know something.

Reviewer:
@kergomard if I remember correctly