### PR TITLE
Fixed Initialization of Anonymous User

### DIFF
--- a/Services/Authentication/classes/class.ilAuthSession.php
+++ b/Services/Authentication/classes/class.ilAuthSession.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
@@ -71,11 +71,11 @@ class ilAuthSession
 
         $this->setId(session_id());
 
-        $user_id = (int) ilSession::get(self::SESSION_AUTH_USER_ID);
+        $user_id = (int)(ilSession::get(self::SESSION_AUTH_USER_ID) ?? ANONYMOUS_USER_ID);
 
         if ($user_id) {
             $this->getLogger()->debug('Resuming old session for user: ' . $user_id);
-            $this->setUserId((int) ilSession::get(self::SESSION_AUTH_USER_ID));
+            $this->setUserId($user_id);
             $this->expired = (bool) ilSession::get(self::SESSION_AUTH_EXPIRED);
             $this->authenticated = (bool) ilSession::get(self::SESSION_AUTH_AUTHENTICATED);
 
@@ -126,7 +126,7 @@ class ilAuthSession
      */
     public function isAuthenticated(): bool
     {
-        return $this->authenticated;
+        return $this->authenticated || $this->user_id === (int)ANONYMOUS_USER_ID;
     }
 
     /**
@@ -149,7 +149,7 @@ class ilAuthSession
      */
     public function isExpired(): bool
     {
-        return $this->expired;
+        return $this->expired && $this->user_id !== (int)ANONYMOUS_USER_ID;
     }
 
     /**

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1324,7 +1324,7 @@ class ilInitialisation
         // $ilUser
         self::initGlobal(
             "ilUser",
-            "ilObjUser",
+            new ilObjUser(ANONYMOUS_USER_ID),
             "./Services/User/classes/class.ilObjUser.php"
         );
         $ilias->account = $ilUser;
@@ -1689,6 +1689,24 @@ class ilInitialisation
             ilLoggerFactory::getLogger('auth')->debug('Blocked authentication for goto target: ' . $target);
             return true;
         }
+
+
+        $current_ref_id = $DIC->http()->wrapper()->query()->has('ref_id')
+            ? $DIC->http()->wrapper()->query()->retrieve('ref_id', $DIC->refinery()->kindlyTo()->int())
+            : null;
+
+        if (null !== $current_ref_id
+            && $DIC->user()->getId() === 0
+            && $DIC->access()->checkAccessOfUser(
+                ANONYMOUS_USER_ID,
+                'visible',
+                '',
+                $current_ref_id
+            )) {
+            return true;
+        }
+
+
         ilLoggerFactory::getLogger('auth')->debug('Authentication required');
         return false;
     }

--- a/Services/Style/System/classes/class.ilStyleDefinition.php
+++ b/Services/Style/System/classes/class.ilStyleDefinition.php
@@ -108,7 +108,7 @@ class ilStyleDefinition
                     $messages->sendMessages();
                     $skin_id = $system_style_conf->getDefaultSkinId();
                 }
-                return $skin_id;
+                return $skin_id === '' ? $system_style_conf->getDefaultSkinId() : $skin_id;
             } else {
                 return null;
             }


### PR DESCRIPTION
This PR proposes a fix for https://mantis.ilias.de/view.php?id=36312

@pascalseeland, @kergomard and I discussed this issue last week and this is a proposal to avoid it.

We are not sure why there should be the state of initialization where a user with ID 0 exists. This PR ensures that the user session always has at least `ANONYMOUS_USER_ID`.

In addition, it is prevented that a request is redirected to the login page, when a request should actually reach a publicly accessible page: https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:fix/0036312/9/user-initialization?expand=1#diff-5c2233ae6af0264344f1d3415e104429899c63359ffb40cd2503cbd7fd44d894R1694

By initializing the user with the `ANONYMOUS_USER_ID` a problem had to be fixed that a skin with the ID `''` is searched for: https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:fix/0036312/9/user-initialization?expand=1#diff-1d6ee119cb221ac919799f18da915ebd8c7e44a3e427d851eac7bd2be1513d2cR111 . @Amstutz could you have a look at this as well?
