### PR TITLE
Bugfix 36292: set correct mode for Preconditions table

### DIFF
--- a/Services/AccessControl/templates/default/tpl.condition_handler_row.html
+++ b/Services/AccessControl/templates/default/tpl.condition_handler_row.html
@@ -12,7 +12,7 @@
 	</td>
 	<td class="std" valign="top" style="text-align: left">
 		<!-- BEGIN obligatory_static -->
-		<img src="{OBL_SRC}" title="{OBL_ALT}" alt="{OBL_ALT}" />
+		<img class="ilIcon" src="{OBL_SRC}" title="{OBL_ALT}" alt="{OBL_ALT}" />
 		<!-- END obligatory_static -->
 		<!-- BEGIN obligatory_edit -->
 		<input type="checkbox" name="obl[]" value="{OBL_ID}"{OBL_STATUS} />

--- a/Services/Conditions/classes/class.ilConditionHandlerGUI.php
+++ b/Services/Conditions/classes/class.ilConditionHandlerGUI.php
@@ -319,7 +319,7 @@ class ilConditionHandlerGUI
             }
         }
 
-        $table = new ilConditionHandlerTableGUI($this, 'listConditions', $list_mode === self::LIST_MODE_ALL);
+        $table = new ilConditionHandlerTableGUI($this, 'listConditions', $list_mode !== self::LIST_MODE_ALL);
         $table->setConditions(
             ilConditionHandler::_getPersistedConditionsOfTarget(
                 $this->getTargetRefId(),


### PR DESCRIPTION
This PR fixes [36292](https://mantis.ilias.de/view.php?id=36292). I'm not sure why the row template for the Preconditions table is in `Services/AccessControl`, but it is only used in `Services/Conditions`.