### PR TITLE
Bugfix 36294: show updated number of required preconditions in ObjectList and InfoScreen

### DIFF
--- a/Services/InfoScreen/classes/class.ilInfoScreenGUI.php
+++ b/Services/InfoScreen/classes/class.ilInfoScreenGUI.php
@@ -1238,7 +1238,10 @@ class ilInfoScreenGUI
             if ($obligatory) {
                 $this->addSection($lng->txt("preconditions_obligatory_hint"));
             } else {
-                $this->addSection(sprintf($lng->txt("preconditions_optional_hint"), $num_optional_required));
+                $this->addSection(sprintf(
+                    $lng->txt("preconditions_optional_hint"),
+                    $num_optional_required - $passed_optional
+                ));
             }
 
             foreach ($properties as $p) {

--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -1550,7 +1550,10 @@ class ilObjectListGUI
             $this->tpl->setVariable("CONDITION_TOGGLE_ID", "_opt_" . $toggle_id);
             $this->tpl->setVariable(
                 "TXT_PRECONDITIONS",
-                sprintf($this->lng->txt("preconditions_optional_hint"), $num_optional_required)
+                sprintf(
+                    $this->lng->txt("preconditions_optional_hint"),
+                    $num_optional_required - $passed_optional
+                )
             );
             $this->tpl->parseCurrentBlock();
         }


### PR DESCRIPTION
This PR fixes [36294](https://mantis.ilias.de/view.php?id=36294).