### PR TITLE
Fix T&A Mantis #36295

### DIFF
--- a/Modules/Test/classes/tables/class.ilTestQuestionsTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestQuestionsTableGUI.php
@@ -412,7 +412,7 @@ class ilTestQuestionsTableGUI extends ilTable2GUI
      */
     protected function buildPositionInput($questionId, $position) : string
     {
-        return '<input type="text" name="order[q_' . $questionId . ']" value="' . $position . '" maxlength="3" size="3" />';
+        return '<input type="text" name="order[q_' . $questionId . ']" value="' . $position . '" maxlength="4" size="4" />';
     }
 
     /**


### PR DESCRIPTION
Increased the maxlength and size of the text field for ordering questions from 3 to 4.