### PR TITLE
Fix reference modules

### DIFF
--- a/Modules/CategoryReference/classes/class.ilObjCategoryReferenceListGUI.php
+++ b/Modules/CategoryReference/classes/class.ilObjCategoryReferenceListGUI.php
@@ -108,7 +108,7 @@ class ilObjCategoryReferenceListGUI extends ilObjCategoryListGUI
         $this->subscribe_enabled = true;
         $this->link_enabled = false;
         $this->info_screen_enabled = true;
-        $this->type = "cat";
+        $this->type = "catr";
         $this->gui_class_name = "ilobjcategorygui";
         
         include_once('Services/AdvancedMetaData/classes/class.ilAdvancedMDSubstitution.php');

--- a/Modules/CourseReference/classes/class.ilObjCourseReferenceListGUI.php
+++ b/Modules/CourseReference/classes/class.ilObjCourseReferenceListGUI.php
@@ -99,7 +99,7 @@ class ilObjCourseReferenceListGUI extends ilObjCourseListGUI
         $this->subscribe_enabled = true;
         $this->link_enabled = false;
         $this->info_screen_enabled = true;
-        $this->type = "crs";
+        $this->type = "crsr";
         $this->gui_class_name = "ilobjcoursegui";
         
         include_once('Services/AdvancedMetaData/classes/class.ilAdvancedMDSubstitution.php');

--- a/Modules/GroupReference/classes/class.ilObjGroupReferenceListGUI.php
+++ b/Modules/GroupReference/classes/class.ilObjGroupReferenceListGUI.php
@@ -83,7 +83,7 @@ class ilObjGroupReferenceListGUI extends ilObjGroupListGUI
         $this->subscribe_enabled = true;
         $this->link_enabled = false;
         $this->info_screen_enabled = true;
-        $this->type = "grp";
+        $this->type = "grpr";
         $this->gui_class_name = "ilobjgroupgui";
         
         include_once('Services/AdvancedMetaData/classes/class.ilAdvancedMDSubstitution.php');


### PR DESCRIPTION
I discovered that course-, group-, category- and studyprogramme-references behave slightly different. Course-, group- and categoryreference set type to course (crs), group (grp) and category (cat) in init, studyprogamme-references set their type to studyprogramme-reference (prgr). 
In had no side-effects in my tests, but I did not test every variant. I am about to prepare a feature-request for tiles for these objects where this fix is helpful. But anyway I assume these 4 object-types should have a consistent behaviour.

Any Feedback is welcome :-)