### PR TITLE
Fix for #35542: Using Manual Scoring on unanswered questions changes …

### DIFF
--- a/Modules/Test/classes/class.ilTestScoringByQuestionsGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringByQuestionsGUI.php
@@ -244,26 +244,32 @@ class ilTestScoringByQuestionsGUI extends ilTestScoringGUI
             if (false == $skipParticipant[$pass][$active_id]) {
                 foreach ((array) $questions as $qst_id => $reached_points) {
                     $this->saveFeedback($active_id, $qst_id, $pass, $ajax);
-                    $update_participant = assQuestion::_setReachedPoints(
-                        $active_id,
-                        $qst_id,
-                        $reached_points,
-                        $maxPointsByQuestionId[$qst_id],
-                        $pass,
-                        1,
-                        $this->object->areObligationsEnabled()
-                    );
+
+                    // fix #35543: save manual points only if they differ from the existing points
+                    // this prevents a question being set to "answered" if only feedback is entered
+                    $old_points = assQuestion::_getReachedPoints($active_id, $qst_id, $pass);
+                    if ($reached_points != $old_points) {
+                        $update_participant = assQuestion::_setReachedPoints(
+                            $active_id,
+                            $qst_id,
+                            $reached_points,
+                            $maxPointsByQuestionId[$qst_id],
+                            $pass,
+                            1,
+                            $this->object->areObligationsEnabled()
+                        );
+                    }
                 }
 
                 if ($update_participant) {
-                    $changed_one = true;
-                    $lastAndHopefullyCurrentQuestionId = $qst_id;
-
                     ilLPStatusWrapper::_updateStatus(
                         $this->object->getId(),
                         ilObjTestAccess::_getParticipantId($active_id)
                     );
                 }
+
+                $changed_one = true;
+                $lastAndHopefullyCurrentQuestionId = $qst_id;
             }
         }
 

--- a/Modules/Test/classes/class.ilTestScoringGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringGUI.php
@@ -288,15 +288,20 @@ class ilTestScoringGUI extends ilTestServiceGUI
         foreach ($questionGuiList as $questionId => $questionGui) {
             $reachedPoints = $form->getItemByPostVar("question__{$questionId}__points")->getValue();
 
-            assQuestion::_setReachedPoints(
-                $activeId,
-                $questionId,
-                $reachedPoints,
-                $maxPointsByQuestionId[$questionId],
-                $pass,
-                1,
-                $this->object->areObligationsEnabled()
-            );
+            // fix #35543: save manual points only if they differ from the existing points
+            // this prevents a question being set to "answered" if only feedback is entered
+            $oldPoints = assQuestion::_getReachedPoints($activeId, $questionId, $pass);
+            if ($reachedPoints != $oldPoints) {
+                assQuestion::_setReachedPoints(
+                    $activeId,
+                    $questionId,
+                    $reachedPoints,
+                    $maxPointsByQuestionId[$questionId],
+                    $pass,
+                    1,
+                    $this->object->areObligationsEnabled()
+                );
+            }
 
             $feedback = ilUtil::stripSlashes(
                 $form->getItemByPostVar("question__{$questionId}__feedback")->getValue(),


### PR DESCRIPTION
…their status to 'answered'

Points are now only saved in the manual scoring by question or by participant, if they differ from the existing points. If no points are given to an unanswered question, then the question keeps its status as not answered, even if feedback is given. This allows to score unanswered question (e.g. if the answer is given on paper) but prevents setting questions unintentionally as answered.