### PR TITLE
Reduce minimum size of bar charts

### DIFF
--- a/src/UI/Implementation/Component/Chart/Bar/Renderer.php
+++ b/src/UI/Implementation/Component/Chart/Bar/Renderer.php
@@ -136,10 +136,13 @@ class Renderer extends AbstractComponentRenderer
 
     protected function determineHeightForHorizontal(Bar\Bar $component): string
     {
-        $min_height = 300;
+        $min_height = 150;
         $max_height = 900;
         $item_count = count($component->getDataset()->getPoints());
         $height = $min_height + ($item_count - 2) * 50;
+        if ($height < $min_height) {
+            $height = $min_height;
+        }
         if ($height > $max_height) {
             $height = $max_height;
         }
@@ -149,7 +152,7 @@ class Renderer extends AbstractComponentRenderer
 
     protected function determineHeightForVertical(Bar\Bar $component): string
     {
-        $min_height = 300;
+        $min_height = 150;
         $max_height = 900;
         $data_max = $this->getHighestValueOfChart($component) - $this->getLowestValueOfChart($component);
         $height = $min_height + ($data_max / 10) * 50;

--- a/src/UI/examples/Chart/Bar/Horizontal/custom.php
+++ b/src/UI/examples/Chart/Bar/Horizontal/custom.php
@@ -76,7 +76,7 @@ function custom()
     $dataset = $dataset->withPoint(
         "Item 6",
         [
-            "Target" => [-0.01, 0.01],
+            "Target" => [0, 0.01],
             "Dataset 1" => 0,
             "Dataset 2" => 3,
             "Dataset 3" => 0.2

--- a/tests/UI/Component/Chart/Bar/ChartBarTest.php
+++ b/tests/UI/Component/Chart/Bar/ChartBarTest.php
@@ -316,7 +316,7 @@ class ChartBarTest extends ILIAS_UI_TestBase
 
         $expected_html = <<<EOT
 <div class="il-chart-bar-horizontal">
-    <canvas id="id_1" height="250px" aria-label="bar123" role="img"></canvas>
+    <canvas id="id_1" height="150px" aria-label="bar123" role="img"></canvas>
 </div>
 <div class="sr-only">
     <dl>
@@ -349,7 +349,7 @@ EOT;
 
         $expected_html = <<<EOT
 <div class="il-chart-bar-vertical">
-    <canvas id="id_1" height="315px" aria-label="bar123" role="img"></canvas>
+    <canvas id="id_1" height="165px" aria-label="bar123" role="img"></canvas>
 </div>
 <div class="sr-only">
     <dl>


### PR DESCRIPTION
This PR reduces the minimum size of bar charts. The practical work with the bar charts has shown, that it was chosen too big in the first implementation. Especially if only a small number of bars is used in the chart, the bars appear oversized and take much space of the screen.

Current implementation:
![bars_big](https://user-images.githubusercontent.com/35489053/215136055-9454750b-e23a-4e55-a47f-96c53c9a315c.png)

Proposal:
![bars_small](https://user-images.githubusercontent.com/35489053/215136051-ffe29d93-1ec7-45f8-98bd-0a9b26b66090.png)
