### PR TITLE
Bugfix 36389: deleting member export files in courses and groups

### DIFF
--- a/Modules/Course/classes/class.ilFSStorageCourse.php
+++ b/Modules/Course/classes/class.ilFSStorageCourse.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=0);
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/Modules/Course/classes/class.ilFSStorageCourse.php
+++ b/Modules/Course/classes/class.ilFSStorageCourse.php
@@ -131,6 +131,11 @@ class ilFSStorageCourse extends ilFileSystemAbstractionStorage
         return $this->deleteFile($this->getMemberExportDirectory() . '/' . $a_export_name);
     }
 
+    public function hasMemberExportFile(string $a_export_name): bool
+    {
+        return $this->fileExists($this->getMemberExportDirectory() . '/' . $a_export_name);
+    }
+
     /**
      * Implementation of abstract method
      * @access protected

--- a/Modules/Group/classes/class.ilFSStorageGroup.php
+++ b/Modules/Group/classes/class.ilFSStorageGroup.php
@@ -109,6 +109,11 @@ class ilFSStorageGroup extends ilFileSystemAbstractionStorage
         return $this->deleteFile($this->getMemberExportDirectory() . '/' . $a_export_name);
     }
 
+    public function hasMemberExportFile(string $a_export_name): bool
+    {
+        return $this->fileExists($this->getMemberExportDirectory() . '/' . $a_export_name);
+    }
+
     /**
      * @inheritDoc
      */

--- a/Modules/Group/classes/class.ilFSStorageGroup.php
+++ b/Modules/Group/classes/class.ilFSStorageGroup.php
@@ -1,19 +1,23 @@
 <?php
 
 declare(strict_types=1);
-/******************************************************************************
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 /**
 *
 * @author Stefan Meyer <meyer@leifos.com>

--- a/Services/Membership/classes/Export/class.ilMemberExportGUI.php
+++ b/Services/Membership/classes/Export/class.ilMemberExportGUI.php
@@ -419,13 +419,20 @@ class ilMemberExportGUI
                 continue;
             }
 
-            $ret = $this->fss_export->deleteMemberExportFile($file['timest'] . '_participant_export_' .
-                $file['type'] . '_' . $this->obj_id . '.' . $file['type']);
+            $path = $file['timest'] . '_participant_export_' .
+                $file['type'] . '_' . $this->obj_id . '.' . $file['type'];
+            if ($this->fss_export->hasMemberExportFile($path)) {
+                $this->fss_export->deleteMemberExportFile($path);
+                continue;
+            }
 
-            //try xlsx if return is false and type is xls
-            if ($file['type'] === "xls" && !$ret) {
-                $this->fss_export->deleteMemberExportFile($file['timest'] . '_participant_export_' .
-                    $file['type'] . '_' . $this->obj_id . '.' . "xlsx");
+            if ($file['type'] !== "xls") {
+                continue;
+            }
+            //try xlsx if type is xls and file can't be found
+            $path = $file['timest'] . '_participant_export_xls_' . $this->obj_id . '.xlsx';
+            if ($this->fss_export->hasMemberExportFile($path)) {
+                $this->fss_export->deleteMemberExportFile($path);
             }
         }
 


### PR DESCRIPTION
This PR fixes [36389](https://mantis.ilias.de/view.php?id=36389), courses and groups are now a bit more careful when deleting member export files.