### PR TITLE
PHPStan-Rule Legacy UI

### DIFF
--- a/.github/workflows/legacy-ui.yml
+++ b/.github/workflows/legacy-ui.yml
@@ -1,14 +1,8 @@
 name: legacy-ui-checks
 on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to run checks on'
-        required: true
-        default: 'trunk'
   schedule:
-     # Runs every day bright and early
-    - cron: '0 3 * * 0'
+     # Run every 12 hours
+    - cron: '0 3,15 * * *'
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/legacy-ui.yml
+++ b/.github/workflows/legacy-ui.yml
@@ -1,0 +1,42 @@
+name: legacy-ui-checks
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run checks on'
+        required: true
+        default: 'trunk'
+  schedule:
+     # Runs every day bright and early
+    - cron: '0 3 * * 0'
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    outputs:
+      all: ${{ steps.changes.outputs.all }}
+    strategy:
+      fail-fast: false
+    steps:
+      - name: 'Checkout Code'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: 'Install Dependencies'
+        uses: php-actions/composer@v6
+        with:
+          php_version: 8.1
+          args: --no-interaction --no-progress --ignore-platform-reqs --no-scripts
+
+      - name: 'PHStan Custom Rules'
+        run: CI/PHPStan/run_legacy_ui_report.sh
+
+      - name: 'Store Report'
+        uses: actions/upload-artifact@v3
+        with:
+          name: Reports
+          path: Reports
+          retention-days: 30

--- a/CI/PHPStan/ErrorFormatter/CSVFormatter.php
+++ b/CI/PHPStan/ErrorFormatter/CSVFormatter.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\CI\PHPStan\ErrorFormatter;
+
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\ErrorFormatter\ErrorFormatter;
+use PHPStan\Command\Output;
+
+class CSVFormatter implements ErrorFormatter
+{
+    private const COMPONENT_REGEX = '/.*(Modules|Services|src)\/(.*?)\/.*/m';
+    private const H_COMPONENT = 'Component';
+    private const H_CLASS = 'Filename';
+    private const H_LINE = 'Line';
+    private const H_MESSAGE = 'Used Implementation';
+    private const COMPONENT_UNKNOWN = 'Unknown';
+    private const H_RULE = 'Rule';
+
+    private array $csv_headers = [
+        self::H_COMPONENT,
+        self::H_CLASS,
+        self::H_LINE,
+        self::H_RULE,
+        self::H_MESSAGE
+    ];
+
+
+    public function formatErrors(AnalysisResult $analysisResult, Output $output): int
+    {
+        $getcwd = getcwd();
+        $output->writeLineFormatted(implode(';', $this->csv_headers));
+
+        foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+            $filename = str_replace($getcwd, '', $fileSpecificError->getFile());
+            if (preg_match(self::COMPONENT_REGEX, $filename, $matches)) {
+                $component = $matches[1] . '/' . $matches[2];
+            } else {
+                $component = self::COMPONENT_UNKNOWN;
+            }
+
+            $result = [
+                self::H_COMPONENT => $component,
+                self::H_CLASS => basename($fileSpecificError->getFile()),
+                self::H_LINE => $fileSpecificError->getLine(),
+                self::H_RULE => $fileSpecificError->getMetadata()['rule'] ?? '',
+                self::H_MESSAGE => $fileSpecificError->getMessage()
+            ];
+            $output->writeLineFormatted(implode(';', $result));
+        }
+        return $analysisResult->hasErrors() ? 1 : 0;
+    }
+}

--- a/CI/PHPStan/README.md
+++ b/CI/PHPStan/README.md
@@ -1,0 +1,24 @@
+PHPStan Custom Rules
+====================
+
+With the ["Removing of Legacy-UIComponents-Service and Table" project](https://docu.ilias.de/goto_docu_grp_12110.html), a large number of UI elements that are not available in the UI service will be replaced by ILIAS 10. With the rules collected here, violations of the deprecations are found and collected in reports.
+
+The entire report comprises a CSV file for each component and a summarised file for the entire code base, this form of the report can be generated as follows:
+
+```bash
+./CI/PHPStan/run_legacy_ui_report.sh
+```
+
+All results will be written to the directory `./Reports`. 
+
+To run the rules individually (e.g. for the directory Modules/File), the following command can be used:
+
+```bash
+./CI/PHPStan/run_legacy_ui_report.sh Modules/File
+```
+
+If you want to just check and show violations directly (without csv-report), you can use the following command (for Modules/File):
+
+```bash
+./libs/composer/vendor/bin/phpstan analyse -c ./CI/PHPStan/legacy_ui.neon -a ./libs/composer/vendor/autoload.php --no-interaction --no-progress Modules/File 
+```

--- a/CI/PHPStan/Rules/LegacyClassUsageRule.php
+++ b/CI/PHPStan/Rules/LegacyClassUsageRule.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\CI\PHPStan\Rules;
+
+use PhpParser\Node\Expr\CallLike;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+
+abstract class LegacyClassUsageRule implements Rule
+{
+    protected ReflectionProvider $reflectionProvider;
+    protected \PHPStan\Rules\Generics\GenericAncestorsCheck $genericAncestorsCheck;
+    private array $forbidden_classes = [];
+    private array $ancestor_cache = [];
+
+    public function __construct(
+        ReflectionProvider $reflectionProvider,
+        \PHPStan\Rules\Generics\GenericAncestorsCheck $genericAncestorsCheck
+    ) {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->genericAncestorsCheck = $genericAncestorsCheck;
+
+        // Determine possible class-names (parents and children) of the forbidden classes
+        $forbidden_classes = [];
+
+        foreach ($this->getForbiddenClasses() as $forbidden_class) {
+            $ancestors = $this->getClassAncestors($forbidden_class);
+            $this->cacheAncestors($forbidden_class, $ancestors);
+            $forbidden_classes = array_merge(
+                $forbidden_classes,
+                $ancestors
+            );
+        }
+
+        $this->forbidden_classes = array_unique($forbidden_classes);
+    }
+
+    private function getClassAncestors(string $class_name): array
+    {
+        if (isset($this->ancestor_cache[$class_name])) {
+            return $this->ancestor_cache[$class_name];
+        }
+
+        $ancestors[] = $class_name;
+
+        try {
+            $reflection = $this->reflectionProvider->getClass($class_name);
+            $ancestors = array_merge($ancestors, $reflection->getParentClassesNames());
+        } catch (\PHPStan\Broker\ClassNotFoundException $e) {
+            // Do nothing
+        } finally {
+            unset($reflection);
+        }
+        return array_unique($ancestors);
+    }
+
+    private function cacheAncestors($class_name, array $ancestor_classes): void
+    {
+        $this->ancestor_cache[$class_name] = $ancestor_classes;
+    }
+
+    public function getNodeType(): string
+    {
+        return CallLike::class;
+    }
+
+    abstract protected function getForbiddenClasses(): array;
+
+    abstract protected function getHumanReadableRuleName(): string;
+
+    final public function processNode(Node $node, Scope $scope): array
+    {
+        switch (true) {
+            case $node instanceof Node\Expr\StaticCall:
+            case $node instanceof Node\Expr\New_:
+                if ($node->class instanceof Node\Name) {
+                    $class_name = $node->class->toString();
+                } else {
+                    return [];
+                }
+                break;
+            default:
+                return [];
+        }
+
+        $class_names_to_test = $this->getClassAncestors($class_name);
+
+        $array_intersect = array_intersect($class_names_to_test, $this->forbidden_classes);
+        if ($array_intersect !== []) {
+            $this->cacheAncestors($class_name, $class_names_to_test);
+            return [
+                RuleErrorBuilder::message("Usage of $class_name is forbidden.")
+                    ->metadata(['rule' => $this->getHumanReadableRuleName()])
+                    ->build()
+            ];
+        }
+
+        return [];
+    }
+}

--- a/CI/PHPStan/Rules/NoLegacyButtonUsagesRule.php
+++ b/CI/PHPStan/Rules/NoLegacyButtonUsagesRule.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\CI\PHPStan\Rules;
+
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class NoLegacyButtonUsagesRule extends LegacyClassUsageRule implements Rule
+{
+    protected function getHumanReadableRuleName(): string
+    {
+        return 'Legacy Button Usages';
+    }
+
+
+    protected function getForbiddenClasses(): array
+    {
+        return ['ilLinkButton'];
+    }
+}

--- a/CI/PHPStan/Rules/NoLegacyCheckboxListUsagesRule.php
+++ b/CI/PHPStan/Rules/NoLegacyCheckboxListUsagesRule.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\CI\PHPStan\Rules;
+
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class NoLegacyCheckboxListUsagesRule extends LegacyClassUsageRule implements Rule
+{
+    protected function getHumanReadableRuleName(): string
+    {
+        return 'Legacy Checkbox List Usages';
+    }
+
+
+    protected function getForbiddenClasses(): array
+    {
+        return ['ilCheckboxListOverlayGUI'];
+    }
+}

--- a/CI/PHPStan/Rules/NoLegacyModalUsagesRule.php
+++ b/CI/PHPStan/Rules/NoLegacyModalUsagesRule.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\CI\PHPStan\Rules;
+
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class NoLegacyModalUsagesRule extends LegacyClassUsageRule implements Rule
+{
+    protected function getHumanReadableRuleName(): string
+    {
+        return 'Legacy Modal Usages';
+    }
+
+
+    protected function getForbiddenClasses(): array
+    {
+        return ['ilModalGUI'];
+    }
+}

--- a/CI/PHPStan/Rules/NoLegacySelectionListUsagesRule.php
+++ b/CI/PHPStan/Rules/NoLegacySelectionListUsagesRule.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\CI\PHPStan\Rules;
+
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class NoLegacySelectionListUsagesRule extends LegacyClassUsageRule implements Rule
+{
+    protected function getHumanReadableRuleName(): string
+    {
+        return 'Legacy Advanced Selection List Usages';
+    }
+
+
+    protected function getForbiddenClasses(): array
+    {
+        return ['ilAdvancedSelectionListGUI'];
+    }
+}

--- a/CI/PHPStan/Rules/NoLegacyTableUsagesRule.php
+++ b/CI/PHPStan/Rules/NoLegacyTableUsagesRule.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\CI\PHPStan\Rules;
+
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class NoLegacyTableUsagesRule extends LegacyClassUsageRule implements Rule
+{
+    protected function getHumanReadableRuleName(): string
+    {
+        return 'Legacy Table Usages';
+    }
+
+
+    protected function getForbiddenClasses(): array
+    {
+        return ['ilTable2GUI', 'ilTableGUI'];
+    }
+}

--- a/CI/PHPStan/legacy_ui.neon
+++ b/CI/PHPStan/legacy_ui.neon
@@ -1,0 +1,41 @@
+services:
+	errorFormatter.csv:
+		class: \ILIAS\CI\PHPStan\ErrorFormatter\CSVFormatter
+rules:
+    - ILIAS\CI\PHPStan\Rules\NoLegacyButtonUsagesRule # ILIAS 9
+    - ILIAS\CI\PHPStan\Rules\NoLegacyCheckboxListUsagesRule # ILIAS 9
+    - ILIAS\CI\PHPStan\Rules\NoLegacySelectionListUsagesRule # ILIAS 9
+#    - ILIAS\CI\PHPStan\Rules\NoLegacyModalUsagesRule # ILIAS 10
+#    - ILIAS\CI\PHPStan\Rules\NoLegacyTableUsagesRule # ILIAS 10
+parameters:
+    parallel:
+        maximumNumberOfProcesses: 10
+    customRulesetUsed: true
+    bootstrapFiles:
+        - constants.php
+    excludePaths:
+        - '%currentWorkingDirectory%/vendor/*'
+        - '%currentWorkingDirectory%/Customizing/*'
+        - '%currentWorkingDirectory%/CI/*'
+        - '%currentWorkingDirectory%/data/*'
+        - '%currentWorkingDirectory%/dicto/*'
+        - '%currentWorkingDirectory%/docs/*'
+        - '%currentWorkingDirectory%/lang/*'
+        - '%currentWorkingDirectory%/node_modules/*'
+        - '%currentWorkingDirectory%/templates/*'
+        - '%currentWorkingDirectory%/xml/*'
+        - '%currentWorkingDirectory%/.github/*'
+        - '%currentWorkingDirectory%/**/mediawiki/*'
+        - '%currentWorkingDirectory%/**/Wiki/libs/*'
+        - '%currentWorkingDirectory%/**/class.ilLTIConsumerResultService.php'
+    earlyTerminatingMethodCalls:
+        ilCtrl:
+            - redirect
+            - redirectByClass
+            - redirectToURL
+        ilCtrlInterface:
+            - redirect
+            - redirectByClass
+            - redirectToURL
+        ILIAS\HTTP\RawHTTPServices:
+            - close

--- a/CI/PHPStan/run_legacy_ui_report.sh
+++ b/CI/PHPStan/run_legacy_ui_report.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+RE="(Services|Modules)"
+CONFIG=CI/PHPStan/legacy_ui.neon
+MEMORY_LIMIT=2G
+REPORT_FORMAT=csv
+REPORT_DIRECTORY=Reports
+
+# Create the report directory if it doesn't exist
+mkdir -p ${REPORT_DIRECTORY}
+
+# Check for Directory as Script-Parameter
+if [ -d "$1" ]; then
+    REPORT_DIRECTORIES=($1)
+else
+    # Find all directories matching the regex (depth 2)
+    REPORT_DIRECTORIES=($(find . -type d -maxdepth 2 -print0 |
+    xargs -0I % echo "%" |
+    grep -oE "${RE}\/.*" |
+    tr "\n" "\0" |
+    xargs -0))
+fi
+
+# Run PHPStan for each directory
+for i in "${REPORT_DIRECTORIES[@]}";
+do
+  echo "Running LUI-Report on ${i}"
+  php -dxdebug.mode=off libs/composer/vendor/bin/phpstan analyse -c "${CONFIG}" -a libs/composer/vendor/autoload.php --no-progress --no-interaction --memory-limit=${MEMORY_LIMIT} --error-format=${REPORT_FORMAT} "$i" > "${REPORT_DIRECTORY}/${i//\//_}.csv" || true;
+done
+
+cat ${REPORT_DIRECTORY}/*.csv | awk '!a[$0]++' > "${REPORT_DIRECTORY}/Summary.csv"

--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,7 @@
 			"./Modules",
 			"./libs/ilias",
 			"./CI/Rector",
+			"./CI/PHPStan",
 			"./webservice/soap",
 			"./setup/classes"
 		],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d701ac9577913f4953d8eddef9d5f024",
+    "content-hash": "b6bb60a78dee4492b4121983ec52c1d7",
     "packages": [
         {
             "name": "brick/math",
@@ -9034,16 +9034,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.8",
+            "version": "1.9.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "45411d15bf85a33b4a8ee9b75a6e82998c9adb97"
+                "reference": "e5fcc96289cf737304286a9b505fbed091f02e58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/45411d15bf85a33b4a8ee9b75a6e82998c9adb97",
-                "reference": "45411d15bf85a33b4a8ee9b75a6e82998c9adb97",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5fcc96289cf737304286a9b505fbed091f02e58",
+                "reference": "e5fcc96289cf737304286a9b505fbed091f02e58",
                 "shasum": ""
             },
             "require": {
@@ -9073,7 +9073,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.8"
+                "source": "https://github.com/phpstan/phpstan/tree/1.9.14"
             },
             "funding": [
                 {
@@ -9089,7 +9089,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-08T21:26:18+00:00"
+            "time": "2023-01-19T10:47:09+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
As just discussed in the Legacy UI project, here is the PR with the PHStan rules for the first components (to be removed with ILIAS 9).

The current report can be downloaded here: https://github.com/srsolutionsag/ILIAS/actions/runs/4044385194 (with the tree rules presented in the meeting, but Button-usages is in it).
After merging, a new Report will be generate on schedule every day (with the rules for ILIAS 9). 