### PR TITLE
CI: Let Captain Hook Just Fix the Coding Style

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -36,7 +36,7 @@
         "conditions": []
       },
       {
-        "action": "libs/composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --config=./CI/PHP-CS-Fixer/code-format.php_cs --using-cache=no --dry-run -vvv {$STAGED_FILES|of-type:php}",
+        "action": "libs/composer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --config=./CI/PHP-CS-Fixer/code-format.php_cs --using-cache=no -vvv {$STAGED_FILES|of-type:php} && git add {$STAGED_FILES|of-type:php}",
         "options": [],
         "conditions": [
           {


### PR DESCRIPTION
Hi folks,

could we please allow Captain Hook to just fix the coding style? Currently it only complains about non-compliance to the coding style and then I go on and fix the style by running that same command (minus a `--dry-run`) again. If we'd just allow Captain Hook to fix the style I (and presumably others as well...) will have one step less in my workflow and the style will end up fixed anyway.

Best wishes!

