### PR TITLE
Mail, 36487: encode and space ILIAS_URL's client id.

### DIFF
--- a/Services/Mail/classes/class.ilMailTemplateContext.php
+++ b/Services/Mail/classes/class.ilMailTemplateContext.php
@@ -162,7 +162,8 @@ abstract class ilMailTemplateContext
             case 'ilias_url' === $placeholder_id:
                 $resolved = $this->envHelper->getHttpPath()
                     . '/login.php?client_id='
-                    . $this->envHelper->getClientId();
+                    . rawurlencode($this->envHelper->getClientId())
+                    . ' ';
                 break;
 
             case 'installation_name' === $placeholder_id:

--- a/Services/Mail/classes/class.ilMailTemplateContext.php
+++ b/Services/Mail/classes/class.ilMailTemplateContext.php
@@ -160,10 +160,7 @@ abstract class ilMailTemplateContext
                 break;
 
             case 'ilias_url' === $placeholder_id:
-                $resolved = $this->envHelper->getHttpPath()
-                    . '/login.php?client_id='
-                    . rawurlencode($this->envHelper->getClientId())
-                    . ' ';
+                $resolved = $this->envHelper->getHttpPath() . ' ';
                 break;
 
             case 'installation_name' === $placeholder_id:


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=36487

I'm a little unsure about this one; 
the placeholder [ILIAS_URL] is resolved to ilUtil::_getHttpPath() . '/login.php?client_id=' . CLIENT_ID;
A HTML-Mail will then be refined by String/MakeClickable;
the Text to transform is
`'http://ilias.de/login.php?client_id=test8: .....' `
and will be resolved to
`<a href="http://ilias.de/login.php?client_id=test8:">.....`
Also, when there is a space in the client id: 
`'http://ilias.de/login.php?client_id=test 8: .....' `will lead to `<a href="http://ilias.de/login.php?client_id=test"> 8: .....`

This PR encodes the client_id and adds a space after the placeholder, so that the transformation will produce a valid link.