### PR TITLE
Bugfix 0036354 text subset question with levenshtein distance is broken

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestion.php
@@ -487,7 +487,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
                 break;
         }
 
-        // run answers against Levenshtein2 methods
+        // run answers against Levenshtein methods
         foreach ($answerwords as $a_original) {
             if (isset($transformation) && $transformation->transform($a_original) >= 0) {
                 return true;

--- a/Modules/TestQuestionPool/classes/class.assTextSubset.php
+++ b/Modules/TestQuestionPool/classes/class.assTextSubset.php
@@ -452,9 +452,10 @@ class assTextSubset extends assQuestion implements ilObjQuestionScoringAdjustabl
             if ($this->answers[$key]->getPoints() <= 0) {
                 continue;
             }
+            $value = html_entity_decode($value); #SB
             switch ($textrating) {
                 case TEXTGAP_RATING_CASEINSENSITIVE:
-                    if (strcmp(ilStr::strToLower(html_entity_decode($value)), ilStr::strToLower($answer)) == 0) {
+                    if (strcmp(ilStr::strToLower($value), ilStr::strToLower($answer)) == 0) { #SB
                         return $key;
                     }
                     break;

--- a/src/Refinery/String/Transformation/LevenshteinTransformation.php
+++ b/src/Refinery/String/Transformation/LevenshteinTransformation.php
@@ -118,6 +118,9 @@ class LevenshteinTransformation implements Transformation
             }
             $cost_matrix[$i + 1] = $current_row;
         }
+        if ($cost_matrix[$primary_string_length][$secondary_string_length] > $this->maximum_distance && $this->maximum_distance != 0) {
+            return -1.0;
+        }
         return $cost_matrix[$primary_string_length][$secondary_string_length];
     }
 

--- a/tests/Refinery/String/LevenshteinTest.php
+++ b/tests/Refinery/String/LevenshteinTest.php
@@ -94,6 +94,13 @@ class LevenshteinTest extends TestCase
         $this->assertEquals(2.0, $transformation->transform(496));
     }
 
+    public function testNoMaxEscapeButOverTheLimit()
+    {
+        $transformation = $this->group->levenshtein()->standard("Juni", 2);
+
+        $this->assertEquals(-1, $transformation->transform("Januar"));
+    }
+
     // Numerical
     public function testCustomCostsMixed()
     {


### PR DESCRIPTION
Hello,

https://mantis.ilias.de/view.php?id=36354

Refinery code:
I missed a code path, when implementing the escape sequences of the levenshtein distances. This is now fixed thanks to mbecker with a general control before a success is returned.

T&A Code:
This also fixes an issue with HTML-entities  in the text subset question
