### PR TITLE
EmployeeTalk: fix icons

### DIFF
--- a/Modules/EmployeeTalk/classes/Provider/MyStaffListEntryProvider.php
+++ b/Modules/EmployeeTalk/classes/Provider/MyStaffListEntryProvider.php
@@ -58,7 +58,10 @@ final class MyStaffListEntryProvider extends AbstractStaticMainMenuProvider
 
         $title = $this->dic->language()->txt("mm_org_etal");
         $action = "ilias.php?baseClass=ilAdministrationGUI&ref_id=" . ilObjOrgUnit::getRootOrgRefId() . "&cmd=jump";
-        $icon = $this->dic->ui()->factory()->symbol()->icon()->standard('etal', $title);
+        $icon = $this->dic->ui()->factory()->symbol()->icon()->custom(
+            \ilUtil::getImagePath('icon_etal.svg'),
+            $title
+        );
 
         $items[] = $this->mainmenu->link($this->employeeTalkTemplateIdentifier)
                                   ->withAlwaysAvailable(false)

--- a/Modules/EmployeeTalk/classes/Talk/class.ilEmployeeTalkMyStaffListGUI.php
+++ b/Modules/EmployeeTalk/classes/Talk/class.ilEmployeeTalkMyStaffListGUI.php
@@ -66,6 +66,7 @@ final class ilEmployeeTalkMyStaffListGUI implements ControlFlowCommandHandler
         $this->refinery = $container->refinery();
         $this->controlFlow = $container->ctrl();
         $this->ui->mainTemplate()->setTitle($container->language()->txt('mm_org_etal'));
+        $this->ui->mainTemplate()->setTitleIcon(ilUtil::getImagePath('icon_etal.svg'));
         $this->currentUser = $container->user();
         $this->repository = new IliasDBEmployeeTalkRepository($container->database());
     }

--- a/Modules/OrgUnit/classes/Provider/OrgUnitMainBarProvider.php
+++ b/Modules/OrgUnit/classes/Provider/OrgUnitMainBarProvider.php
@@ -86,7 +86,7 @@ class OrgUnitMainBarProvider extends AbstractStaticMainMenuProvider
 
         $title = $this->dic->language()->txt("mm_talk_template", "");
         $action = "ilias.php?baseClass=ilAdministrationGUI&ref_id=" . ilObjTalkTemplateAdministration::getRootRefId() . "&cmd=jump";
-        $icon = $this->dic->ui()->factory()->symbol()->icon()->standard('etal', $title);
+        $icon = $this->dic->ui()->factory()->symbol()->icon()->standard('tala', $title);
         $linkEmployeeTalkTemplates = $this->mainmenu->link($this->employeeTalkTemplateIdentifier)
                                                     ->withAlwaysAvailable(true)
                                                     ->withAction($action)

--- a/src/UI/Component/Symbol/Icon/Standard.php
+++ b/src/UI/Component/Symbol/Icon/Standard.php
@@ -178,4 +178,5 @@ interface Standard extends Icon
     public const CON = 'con';	    //Conversaion
     public const GCON = 'gcon';	    //Group Conversaion
     public const FILS = 'fils';	    //File System Service
+    public const TALA = 'tala';	    //Employee Talk Template Admin
 }

--- a/src/UI/Implementation/Component/Symbol/Icon/Standard.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Standard.php
@@ -172,7 +172,8 @@ class Standard extends Icon implements C\Symbol\Icon\Standard
         self::NOTA,
         self::GCON,
         self::CON,
-        self::FILS
+        self::FILS,
+        self::TALA
     ];
 
     public function __construct(string $name, string $label, string $size, bool $is_disabled)

--- a/templates/default/images/icon_etal.svg
+++ b/templates/default/images/icon_etal.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 320 320" style="enable-background:new 0 0 320 320;" xml:space="preserve">
+<style type="text/css">
+	.st0{clip-path:url(#SVGID_00000124868157462803041610000007608160386584962474_);fill:#4C6586;}
+</style>
+<g>
+	<defs>
+		<rect id="SVGID_1_" width="320" height="320"/>
+	</defs>
+	<clipPath id="SVGID_00000123404383005134731350000015603087900512629685_">
+		<use xlink:href="#SVGID_1_"  style="overflow:visible;"/>
+	</clipPath>
+	<path style="clip-path:url(#SVGID_00000123404383005134731350000015603087900512629685_);fill:#4C6586;" d="M250,270
+		c0,2.8-2.2,5-5,5H75c-2.8,0-5-2.2-5-5V60c0-2.8,2.2-5,5-5h24.8v15h-15v190h150V70h-15V55H245c2.8,0,5,2.2,5,5V270z M212.8,132.9
+		l-40.6,54.4l-0.4,0l0,0l-31.6-28.5l11.4-12.7l17.8,16.1l29.8-39.6L212.8,132.9z M204.8,80h-90V50h22.7v-1c0-7.7,6.3-14,14-14h17
+		c7.7,0,14,6.3,14,14v1h22.3V80z M107.2,120h15v15h-15V120z M122.2,190h-15v-15h15V190z M107.2,147.5h15v15h-15V147.5z"/>
+</g>
+</svg>


### PR DESCRIPTION
This PR fixes a bunch of icons in EmployeeTalk, see [35564](https://mantis.ilias.de/view.php?id=35564). For some reason one is hiding in `Modules\OrgUnit`. I also added the icon for the EmployeeTalk Templates Administration to the standard KS icons. I'm not quite sure what the criteria are there, but that one seems to fit.

I also noticed that there is no icon yet for the Employee Talk objects themselves. I added a preliminary one to this PR (just the template icon inverted, as for Portfolios). If there is a good reason to not add a new icon I could also reuse existing ones, but I'd  prefer having a separate icon to distinguish between templates and the real thing.
(I hope you are the right person to tag for icons @matthiaskunkel, if not feel free to reassign.)