### PR TITLE
Add "Whos is online" toast provider for GS

### DIFF
--- a/Services/Awareness/GlobalScreen/WhoIsOnlineToastProvider.php
+++ b/Services/Awareness/GlobalScreen/WhoIsOnlineToastProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Awareness\GlobalScreen;
+
+use ILIAS\GlobalScreen\Scope\Toast\Provider\AbstractToastProvider;
+use ILIAS\Notifications\Repository\ilNotificationOSDRepository;
+use ILIAS\UI\Component\Symbol\Icon\Standard;
+use ILIAS\Notifications\ilNotificationOSDHandler;
+
+class WhoIsOnlineToastProvider extends AbstractToastProvider
+{
+    public const NOTIFICATION_TYPE = 'who_is_online';
+
+    public function getToasts(): array
+    {
+        $toasts = [];
+
+        if (0 === $this->dic->user()->getId() || $this->dic->user()->isAnonymous()) {
+            return $toasts;
+        }
+
+        $osd_notification_handler = new ilNotificationOSDHandler(new ilNotificationOSDRepository($this->dic->database()));
+
+        $toast = null;
+        foreach ($osd_notification_handler->getOSDNotificationsForUser(
+            $this->dic->user()->getId(),
+            true,
+            0,
+            self::NOTIFICATION_TYPE
+        ) as $invitation) {
+            if ($toast === null && count($invitation->getObject()->links) > 0) {
+                $toast = $this->getDefaultToast(
+                    $invitation->getObject()->title,
+                    $this->dic->ui()->factory()->symbol()->icon()->standard(Standard::AWRA, 'who_is_online')
+                );
+            }
+            foreach ($invitation->getObject()->links as $link) {
+                $toast = $toast->withAdditionalLink($this->dic->ui()->factory()->link()->standard(
+                    $link->getTitle(),
+                    $link->getUrl()
+                ));
+            }
+        }
+        if ($toast !== null) {
+            $toasts[] = $toast;
+        }
+
+        return $toasts;
+    }
+}

--- a/Services/User/Settings/classes/class.ilUserPrivacySettingsGUI.php
+++ b/Services/User/Settings/classes/class.ilUserPrivacySettingsGUI.php
@@ -132,7 +132,7 @@ class ilUserPrivacySettingsGUI
     /**
      * Is awareness tool setting visible
      */
-    protected function isAwarnessSettingVisible(): bool
+    protected function isAwarenessSettingVisible(): bool
     {
         $awrn_set = new ilSetting("awrn");
 
@@ -203,7 +203,7 @@ class ilUserPrivacySettingsGUI
     protected function populateWithAwarenessSettingsSection(
         array &$formSections
     ): void {
-        if (!$this->isAwarnessSettingVisible()) {
+        if (!$this->isAwarenessSettingVisible()) {
             return;
         }
 
@@ -388,7 +388,7 @@ class ilUserPrivacySettingsGUI
             $form = $form->withRequest($request);
             $formData = $form->getData();
 
-            if ($this->isAwarnessSettingVisible() && $this->workWithUserSetting("hide_own_online_status")) {
+            if ($this->isAwarenessSettingVisible() && $this->workWithUserSetting("hide_own_online_status")) {
                 $val = $formData["hide_own_online_status"] ?? 'x';
                 if ($val == "x") {
                     $val = "";

--- a/src/UI/Factory.php
+++ b/src/UI/Factory.php
@@ -867,7 +867,7 @@ interface Factory
      *   rivals:
      *     OSD notification: OSD notification are of the similar purpose as toast but arent a component ATM(26.04.2021).
      *        Therefore toast suppose to replace and unify this UI violation.
-     *     Message Box: The Message Box it primarily used to catch the users awarness for serious problems or error and
+     *     Message Box: The Message Box it primarily used to catch the users awareness for serious problems or error and
      *        is therefore more intrusive or even used to interrupt the users workflow, while toast will provide some
      *        less serious information which can be optional ignored by  the user.
      *     System Info: System Info is used for system specific information without temporal dependencies, while toast


### PR DESCRIPTION
Due to changes made inside the load of toast an provider interface was established to porvide the initial toasts without another request: https://github.com/ILIAS-eLearning/ILIAS/pull/5121

Therefore every provider of toast is obliged to provide a new toast Provider if his service want to add toast to the page.
ATM this only applies to initial toast but will probably be extended to all toast in near future.

This PR is an Proposal for toast inside your Service. Feel free to use and manipulate this template to your fitting and provide a PR for Trunk.
If you dont want to provide Toast with your Service feel free to cloase this PR.