### PR TITLE
Add Mail toast provider for GS

### DIFF
--- a/Services/Mail/classes/Provider/MailToastProvider.php
+++ b/Services/Mail/classes/Provider/MailToastProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Mail\Provider;
+
+use ILIAS\GlobalScreen\Scope\Toast\Provider\AbstractToastProvider;
+use ILIAS\Notifications\Repository\ilNotificationOSDRepository;
+use ILIAS\UI\Component\Symbol\Icon\Standard;
+use ILIAS\Notifications\ilNotificationOSDHandler;
+
+class MailToastProvider extends AbstractToastProvider
+{
+    public const NOTIFICATION_TYPE = 'mail';
+
+    public function getToasts(): array
+    {
+        $toasts = [];
+
+        if (0 === $this->dic->user()->getId() || $this->dic->user()->isAnonymous()) {
+            return $toasts;
+        }
+
+        $osd_notification_handler = new ilNotificationOSDHandler(new ilNotificationOSDRepository($this->dic->database()));
+
+        foreach ($osd_notification_handler->getOSDNotificationsForUser(
+            $this->dic->user()->getId(),
+            true,
+            0,
+            self::NOTIFICATION_TYPE
+        ) as $invitation) {
+            $toast = $this->toast_factory->standard(
+                $invitation->getObject()->title,
+                $this->dic->ui()->factory()->symbol()->icon()->standard(Standard::MAIL, 'mail')
+            )->withDescription($invitation->getObject()->shortDescription);
+            foreach ($invitation->getObject()->links as $link) {
+                $toast = $toast->withAdditionalLink(
+                    $this->dic->ui()->factory()->link()->standard(
+                        $link->getTitle(),
+                        $link->getUrl()
+                    )
+                );
+            }
+            $toasts[] = $toast;
+        }
+
+        return $toasts;
+    }
+}


### PR DESCRIPTION
Due to changes made inside the load of toast an provider interface was established to porvide the initial toasts without another request: https://github.com/ILIAS-eLearning/ILIAS/pull/5121

Therefore every provider of toast is obliged to provide a new toast Provider if his service want to add toast to the page.
ATM this only applies to initial toast but will probably be extended to all toast in near future.

This PR is an Proposal for toast inside your Service. Feel free to use and manipulate this template to your fitting and provide a PR for Trunk.
If you dont want to provide Toast with your Service feel free to cloase this PR.