### PR TITLE
EmployeeTalk: fix talks in calendar

### DIFF
--- a/Services/Calendar/classes/AppointmentPresentation/class.ilAppointmentPresentationEmployeeTalkGUI.php
+++ b/Services/Calendar/classes/AppointmentPresentation/class.ilAppointmentPresentationEmployeeTalkGUI.php
@@ -35,7 +35,7 @@ class ilAppointmentPresentationEmployeeTalkGUI extends ilAppointmentPresentation
         array $a_appointment,
         ?ilInfoScreenGUI $a_info_screen,
         ?ilToolbarGUI $a_toolbar,
-        Item $a_list_item
+        ?Item $a_list_item
     ) {
         parent::__construct($a_appointment, $a_info_screen, $a_toolbar, $a_list_item);
 

--- a/Services/Calendar/classes/class.ilCalendarCategories.php
+++ b/Services/Calendar/classes/class.ilCalendarCategories.php
@@ -425,6 +425,14 @@ class ilCalendarCategories
         $this->readSelectedCategories(ilParticipants::_getMembershipByType($this->user_id, ['crs']));
         $this->readSelectedCategories(ilParticipants::_getMembershipByType($this->user_id, ['grp']));
 
+        $repository = new IliasDBEmployeeTalkSeriesRepository($this->user, $this->db);
+        $talks = $repository->findByOwnerAndEmployee();
+        $talkIds = array_map(function (ilObjEmployeeTalkSeries $item) {
+            return $item->getId();
+        }, $talks);
+
+        $this->readSelectedCategories($talkIds, 0, false);
+
         $this->addSubitemCalendars();
     }
 
@@ -484,6 +492,14 @@ class ilCalendarCategories
         $this->readSelectedCategories($groups);
         $this->readSelectedCategories($exercises);
 
+        $repository = new IliasDBEmployeeTalkSeriesRepository($this->user, $this->db);
+        $talks = $repository->findByOwnerAndEmployee();
+        $talkIds = array_map(function (ilObjEmployeeTalkSeries $item) {
+            return $item->getId();
+        }, $talks);
+
+        $this->readSelectedCategories($talkIds, 0, false);
+
         $this->addSubitemCalendars();
     }
 
@@ -541,8 +557,6 @@ class ilCalendarCategories
             $this->readSelectedCategories(array($this->root_obj_id), $this->root_ref_id);
         }
 
-        $this->addSubitemCalendars();
-
         if (!$a_container_only) {
             $this->readSelectedCategories(ilParticipants::_getMembershipByType($this->user_id, ['crs']));
             $this->readSelectedCategories(ilParticipants::_getMembershipByType($this->user_id, ['grp']));
@@ -555,6 +569,8 @@ class ilCalendarCategories
 
             $this->readSelectedCategories($talkIds, 0, false);
         }
+
+        $this->addSubitemCalendars();
     }
 
     public function readSingleCalendar(int $a_cat_id): void

--- a/Services/Calendar/classes/class.ilCalendarCategories.php
+++ b/Services/Calendar/classes/class.ilCalendarCategories.php
@@ -424,14 +424,11 @@ class ilCalendarCategories
 
         $this->readSelectedCategories(ilParticipants::_getMembershipByType($this->user_id, ['crs']));
         $this->readSelectedCategories(ilParticipants::_getMembershipByType($this->user_id, ['grp']));
-
-        $repository = new IliasDBEmployeeTalkSeriesRepository($this->user, $this->db);
-        $talks = $repository->findByOwnerAndEmployee();
-        $talkIds = array_map(function (ilObjEmployeeTalkSeries $item) {
-            return $item->getId();
-        }, $talks);
-
-        $this->readSelectedCategories($talkIds, 0, false);
+        $this->readSelectedCategories(
+            $this->lookupRelevantTalkSeriesIds(),
+            0,
+            false
+        );
 
         $this->addSubitemCalendars();
     }
@@ -491,14 +488,11 @@ class ilCalendarCategories
         $this->readSelectedCategories($sessions);
         $this->readSelectedCategories($groups);
         $this->readSelectedCategories($exercises);
-
-        $repository = new IliasDBEmployeeTalkSeriesRepository($this->user, $this->db);
-        $talks = $repository->findByOwnerAndEmployee();
-        $talkIds = array_map(function (ilObjEmployeeTalkSeries $item) {
-            return $item->getId();
-        }, $talks);
-
-        $this->readSelectedCategories($talkIds, 0, false);
+        $this->readSelectedCategories(
+            $this->lookupRelevantTalkSeriesIds(),
+            0,
+            false
+        );
 
         $this->addSubitemCalendars();
     }
@@ -560,14 +554,11 @@ class ilCalendarCategories
         if (!$a_container_only) {
             $this->readSelectedCategories(ilParticipants::_getMembershipByType($this->user_id, ['crs']));
             $this->readSelectedCategories(ilParticipants::_getMembershipByType($this->user_id, ['grp']));
-
-            $repository = new IliasDBEmployeeTalkSeriesRepository($this->user, $this->db);
-            $talks = $repository->findByOwnerAndEmployee();
-            $talkIds = array_map(function (ilObjEmployeeTalkSeries $item) {
-                return $item->getId();
-            }, $talks);
-
-            $this->readSelectedCategories($talkIds, 0, false);
+            $this->readSelectedCategories(
+                $this->lookupRelevantTalkSeriesIds(),
+                0,
+                false
+            );
         }
 
         $this->addSubitemCalendars();
@@ -944,6 +935,18 @@ class ilCalendarCategories
                 $this->categories_info[$cat_id]['subitem_obj_ids'] = array();
             }
         }
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function lookupRelevantTalkSeriesIds(): array
+    {
+        $repository = new IliasDBEmployeeTalkSeriesRepository($this->user, $this->db);
+        $talks = $repository->findByOwnerAndEmployee();
+        return array_map(function (ilObjEmployeeTalkSeries $item) {
+            return $item->getId();
+        }, $talks);
     }
 
     /**

--- a/Services/Calendar/classes/class.ilCalendarSelectionBlockGUI.php
+++ b/Services/Calendar/classes/class.ilCalendarSelectionBlockGUI.php
@@ -330,7 +330,12 @@ class ilCalendarSelectionBlockGUI extends ilBlockGUI
 
     protected function renderItem(array $a_set, ilTemplate $a_tpl): void
     {
-        if (strlen((string) $a_set['path'])) {
+        $obj_type = ilObject::_lookupType($a_set['obj_id']);
+
+        if (
+            strlen((string) $a_set['path']) &&
+            $this->obj_def->isAllowedInRepository($obj_type)
+        ) {
             $a_tpl->setCurrentBlock('calendar_path');
             $a_tpl->setVariable('ADD_PATH_INFO', $a_set['path']);
             $a_tpl->parseCurrentBlock();
@@ -365,7 +370,7 @@ class ilCalendarSelectionBlockGUI extends ilBlockGUI
                 $this->ctrl->setParameterByClass('ilcalendarpresentationgui', 'backpd', 1);
             }
             $this->ctrl->setParameterByClass('ilcalendarpresentationgui', 'ref_id', $a_set['ref_id']);
-            switch (ilObject::_lookupType($a_set['obj_id'])) {
+            switch ($obj_type) {
                 case 'crs':
                     $link = $this->ctrl->getLinkTargetByClass(
                         [
@@ -419,15 +424,14 @@ class ilCalendarSelectionBlockGUI extends ilBlockGUI
                 break;
 
             case ilCalendarCategory::TYPE_OBJ:
-                $type = ilObject::_lookupType($a_set['obj_id']);
-                $a_tpl->setVariable('IMG_SRC', ilUtil::getImagePath('icon_' . $type . '.svg'));
-                $a_tpl->setVariable('IMG_ALT', $this->lng->txt('cal_type_' . $type));
+                $img_type = $obj_type === 'tals' ? 'etal' : $obj_type;
+                $a_tpl->setVariable('IMG_SRC', ilUtil::getImagePath('icon_' . $img_type . '.svg'));
+                $a_tpl->setVariable('IMG_ALT', $this->lng->txt('cal_type_' . $obj_type));
                 break;
 
             case ilCalendarCategory::TYPE_BOOK:
-                $type = ilObject::_lookupType($a_set['obj_id']);
                 $a_tpl->setVariable('IMG_SRC', ilUtil::getImagePath('icon_book.svg'));
-                $a_tpl->setVariable('IMG_ALT', $this->lng->txt('cal_type_' . $type));
+                $a_tpl->setVariable('IMG_ALT', $this->lng->txt('cal_type_' . $obj_type));
                 break;
 
             case ilCalendarCategory::TYPE_CH:

--- a/Services/Calendar/classes/class.ilCalendarSelectionBlockGUI.php
+++ b/Services/Calendar/classes/class.ilCalendarSelectionBlockGUI.php
@@ -280,6 +280,11 @@ class ilCalendarSelectionBlockGUI extends ilBlockGUI
      */
     protected function buildPath($a_ref_id): string
     {
+        $obj_type = ilObject::_lookupType($a_ref_id, true);
+        if (!$this->obj_def->isAllowedInRepository($obj_type)) {
+            return '';
+        }
+
         $path_arr = $this->tree->getPathFull($a_ref_id, ROOT_FOLDER_ID);
         $counter = 0;
         unset($path_arr[count($path_arr) - 1]);
@@ -330,12 +335,7 @@ class ilCalendarSelectionBlockGUI extends ilBlockGUI
 
     protected function renderItem(array $a_set, ilTemplate $a_tpl): void
     {
-        $obj_type = ilObject::_lookupType($a_set['obj_id']);
-
-        if (
-            strlen((string) $a_set['path']) &&
-            $this->obj_def->isAllowedInRepository($obj_type)
-        ) {
+        if (strlen((string) $a_set['path'])) {
             $a_tpl->setCurrentBlock('calendar_path');
             $a_tpl->setVariable('ADD_PATH_INFO', $a_set['path']);
             $a_tpl->parseCurrentBlock();
@@ -362,6 +362,7 @@ class ilCalendarSelectionBlockGUI extends ilBlockGUI
         }
         $a_tpl->setVariable('BGCOLOR', $a_set['color']);
 
+        $obj_type = ilObject::_lookupType($a_set['obj_id']);
         if (
             ($a_set['type'] == ilCalendarCategory::TYPE_OBJ) &&
             $a_set['ref_id']


### PR DESCRIPTION
This PR makes it so that talks show up in the calendars of employee and superior, both in the Repository and in the Personal Workspace. It also suppresses the presentation of breadcrumbs in 'Calendar Selection' for objects not allowed in the Repository.