### PR TITLE
[FIX] 0036605: Updating ILIAS without MathJax config not possible

### DIFF
--- a/Services/MathJax/classes/Setup/class.ilMathJaxConfigCheckedObjective.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxConfigCheckedObjective.php
@@ -1,25 +1,28 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 
 class ilMathJaxConfigCheckedObjective implements Setup\Objective
 {
-    protected \ilMathJaxSetupConfig $setup_config;
+    protected ?\ilMathJaxSetupConfig $setup_config = null;
 
     public function __construct(?\ilMathJaxSetupConfig $setup_config = null)
     {
@@ -96,7 +99,7 @@ class ilMathJaxConfigCheckedObjective implements Setup\Objective
             }
         }
         if ($change
-            && isset($this->setup_config)
+            && $this->setup_config !== null
             && in_array($this->setup_config->getConfig()->getClientScriptUrl(), $outdated)
         ) {
             $interaction->inform("Please change the URL in the setup.json to avoid this message in the next update.");


### PR DESCRIPTION
This fixes an issue described in https://mantis.ilias.de/view.php?id=36605