### PR TITLE
[FIX] checks must not update composer dependecies

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -27,9 +27,9 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer update && composer install --no-interaction --no-progress
+        run: composer install --no-interaction --no-progress
 
-      - name: PHP Unit Test 
+      - name: PHP Unit Test
         run: CI/PHPUnit/run_tests.sh
         env:
           GHRUN: "yes"


### PR DESCRIPTION
The github action `check` did update the composer dependecies on each run, this leads to wrong versions such as PHPUnit (which fails all tests currently).

Additionally I changes the checkout depth to 1.

This PR is for documentation and information purposes, I will merge it immediately and also cherry-pick it in the release branches.