### PR TITLE
fix mail adress read with globale settings set

### DIFF
--- a/Services/Mail/classes/class.ilMailOptions.php
+++ b/Services/Mail/classes/class.ilMailOptions.php
@@ -78,9 +78,7 @@ class ilMailOptions
         }
         $this->mailTransportSettings = $mailTransportSettings;
 
-        if ($this->settings->get('show_mail_settings') === '1') {
-            $this->read();
-        }
+        $this->read();
     }
 
     /**
@@ -121,26 +119,28 @@ class ilMailOptions
         );
         $row = $this->db->fetchObject($res);
         if ($row !== null) {
-            $this->isCronJobNotificationEnabled = (bool) $row->cronjob_notification;
-            $this->signature = (string) $row->signature;
-            $this->linebreak = (int) $row->linebreak;
-            $this->incomingType = (int) $row->incoming_type;
-            $this->emailAddressMode = (int) $row->mail_address_option;
+            if ($this->settings->get('show_mail_settings') === '1') {
+                $this->isCronJobNotificationEnabled = (bool) $row->cronjob_notification;
+                $this->signature = (string) $row->signature;
+                $this->linebreak = (int) $row->linebreak;
+                $this->incomingType = (int) $row->incoming_type;
+                $this->emailAddressMode = (int) $row->mail_address_option;
 
-            if (false === filter_var(
-                $this->incomingType,
-                FILTER_VALIDATE_INT,
-                ['options' => ['min_range' => self::INCOMING_LOCAL, 'max_range' => self::INCOMING_BOTH]]
-            )) {
-                $this->incomingType = self::INCOMING_LOCAL;
-            }
+                if (false === filter_var(
+                        $this->incomingType,
+                        FILTER_VALIDATE_INT,
+                        ['options' => ['min_range' => self::INCOMING_LOCAL, 'max_range' => self::INCOMING_BOTH]]
+                    )) {
+                    $this->incomingType = self::INCOMING_LOCAL;
+                }
 
-            if (false === filter_var(
-                $this->emailAddressMode,
-                FILTER_VALIDATE_INT,
-                ['options' => ['min_range' => self::FIRST_EMAIL, 'max_range' => self::BOTH_EMAIL]]
-            )) {
-                $this->emailAddressMode = self::FIRST_EMAIL;
+                if (false === filter_var(
+                        $this->emailAddressMode,
+                        FILTER_VALIDATE_INT,
+                        ['options' => ['min_range' => self::FIRST_EMAIL, 'max_range' => self::BOTH_EMAIL]]
+                    )) {
+                    $this->emailAddressMode = self::FIRST_EMAIL;
+                }
             }
 
             $this->firstEmailAddress = (string) $row->email;

--- a/Services/Mail/test/ilMailOptionsTest.php
+++ b/Services/Mail/test/ilMailOptionsTest.php
@@ -1,62 +1,80 @@
-<?php declare(strict_types=1);
+<?php
 
 /* Copyright (c) 1998-2017 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+declare(strict_types=1);
+
 /**
- * Class ilMailOptionsTest
- * @author Niels Theen <ntheen@databay.de>
- * @author Michael Jansen <mjansen@databay.de>
+ * @author Ingmar Szmais <iszmais@databay.de>
  */
 class ilMailOptionsTest extends ilMailBaseTest
 {
-    /**
-     * @throws ReflectionException
-     */
-    public function testConstructor() : void
-    {
-        $userId = 1;
+    /** @var MockObject */
+    protected $setting;
+    /** @var sdtClass */
+    protected $object;
 
-        $database = $this->getMockBuilder(ilDBInterface::class)
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->database = $this->getMockBuilder(ilDBInterface::class)
                          ->getMock();
         $queryMock = $this->getMockBuilder(ilDBStatement::class)
                           ->getMock();
 
-        $object = $this->getMockBuilder(stdClass::class)->getMock();
-        $object->cronjob_notification = false;
-        $object->signature = 'smth';
-        $object->linebreak = false;
-        $object->incoming_type = 1;
-        $object->mail_address_option = 0;
-        $object->email = 'test@test.com';
-        $object->second_email = 'ilias@ilias.com';
+        $this->object = new stdClass();
+        $this->object->cronjob_notification = false;
+        $this->object->signature = 'smth';
+        $this->object->linebreak = 0;
+        $this->object->incoming_type = 1;
+        $this->object->mail_address_option = 0;
+        $this->object->email = 'test@test.com';
+        $this->object->second_email = 'ilias@ilias.com';
 
-        $database->expects($this->once())->method('fetchObject')->willReturn($object);
-        $database->expects($this->once())->method('queryF')->willReturn($queryMock);
-        $database->method('replace')->willReturn(0);
+        $this->database->expects($this->once())->method('fetchObject')->willReturn($this->object);
+        $this->database->expects($this->once())->method('queryF')->willReturn($queryMock);
+        $this->database->method('replace')->willReturn(0);
+        $this->setGlobalVariable('ilDB', $this->database);
 
-        $this->setGlobalVariable('ilDB', $database);
+        $this->settings = $this->getMockBuilder(ilSetting::class)->disableOriginalConstructor()->getMock();
+    }
 
-        $settings = $this->getMockBuilder(ilSetting::class)->disableOriginalConstructor()->onlyMethods([
-            'set',
-            'get'
-        ])->getMock();
-        $this->setGlobalVariable('ilSetting', $settings);
+    public function testConstructor() : void
+    {
+        $this->settings->expects($this->exactly(3))->method('get')->willReturnMap(
+            [
+                ['mail_incoming_mail', '', ''],
+                ['mail_address_option', '', ''],
+                ['show_mail_settings', false, '0']
+            ]
+        );
+        $this->setGlobalVariable('ilSetting', $this->settings);
 
-        $mailOptions = new class($userId) extends ilMailOptions {
-            public function read() : void
-            {
-                parent::read();
-            }
-        };
+        $mailOptions = new ilMailOptions(1);
 
-        $this->assertEquals('', $mailOptions->getSignature());
-        $this->assertEquals(ilMailOptions::INCOMING_LOCAL, $mailOptions->getIncomingType());
-        $this->assertEquals(ilMailOptions::DEFAULT_LINE_BREAK, $mailOptions->getLinebreak());
-        $this->assertEquals(false, $mailOptions->isCronJobNotificationEnabled());
-        $mailOptions->read();
-        $this->assertEquals($object->signature, $mailOptions->getSignature());
-        $this->assertEquals($object->incoming_type, $mailOptions->getIncomingType());
-        $this->assertEquals($object->linebreak, $mailOptions->getLinebreak());
-        $this->assertEquals($object->cronjob_notification, $mailOptions->isCronJobNotificationEnabled());
+        $this->assertSame('', $mailOptions->getSignature());
+        $this->assertSame(ilMailOptions::INCOMING_LOCAL, $mailOptions->getIncomingType());
+        $this->assertSame(ilMailOptions::DEFAULT_LINE_BREAK, $mailOptions->getLinebreak());
+        $this->assertFalse($mailOptions->isCronJobNotificationEnabled());
+    }
+
+    public function testConstructorWithUserSettings() : void
+    {
+        $this->settings->expects($this->exactly(3))->method('get')->willReturnMap(
+                    [
+                        ['mail_incoming_mail', '', ''],
+                        ['mail_address_option', '', ''],
+                        ['show_mail_settings', false, '1']
+                    ]
+                );
+        $this->setGlobalVariable('ilSetting', $this->settings);
+
+        $mailOptions = new ilMailOptions(1);
+
+        $this->assertSame($this->object->signature, $mailOptions->getSignature());
+        $this->assertSame($this->object->incoming_type, $mailOptions->getIncomingType());
+        $this->assertSame($this->object->linebreak, $mailOptions->getLinebreak());
+        $this->assertSame($this->object->cronjob_notification, $mailOptions->isCronJobNotificationEnabled());
     }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=36590

Fixes a bug caused in https://github.com/ILIAS-eLearning/ILIAS/pull/4881 where the user mail adress was not read properly when the user mail settings where disabled.