### PR TITLE
Trunk: Add showing error message when test was already finished

### DIFF
--- a/Modules/Test/classes/class.ilTestOutputGUI.php
+++ b/Modules/Test/classes/class.ilTestOutputGUI.php
@@ -567,8 +567,22 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
         }
     }
 
+    protected function handleCheckTestPassValid() : void
+    {
+        global $DIC;
+        $testObj = new ilObjTest($this->ref_id, true);
+
+        $participants = $testObj->getActiveParticipantList();
+        $participant = $participants->getParticipantByUsrId($DIC->user()->getId());
+        if (!$participant || !$participant->hasUnfinishedPasses()) {
+            $this->tpl->setOnScreenMessage('failure', $this->lng->txt("tst_current_pass_no_longer_valid"), true);
+            $this->backToInfoScreenCmd();
+        }
+    }
+
     protected function nextQuestionCmd()
     {
+        $this->handleCheckTestPassValid();
         $lastSequenceElement = $this->getCurrentSequenceElement();
         $nextSequenceElement = $this->testSequence->getNextSequence($lastSequenceElement);
 
@@ -588,6 +602,8 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
 
     protected function previousQuestionCmd()
     {
+        $this->handleCheckTestPassValid();
+
         $sequenceElement = $this->testSequence->getPreviousSequence(
             $this->getCurrentSequenceElement()
         );

--- a/Modules/Test/classes/class.ilTestOutputGUI.php
+++ b/Modules/Test/classes/class.ilTestOutputGUI.php
@@ -575,7 +575,7 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
         $participants = $testObj->getActiveParticipantList();
         $participant = $participants->getParticipantByUsrId($DIC->user()->getId());
         if (!$participant || !$participant->hasUnfinishedPasses()) {
-            $this->tpl->setOnScreenMessage('failure', $this->lng->txt("tst_current_pass_no_longer_valid"), true);
+            $this->tpl->setOnScreenMessage('failure', $this->lng->txt("tst_current_run_no_longer_valid"), true);
             $this->backToInfoScreenCmd();
         }
     }

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -750,6 +750,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
     public function finishTestCmd($requires_confirmation = true)
     {
+        $this->handleCheckTestPassValid();
         ilSession::clear("tst_next");
 
         $active_id = $this->testSession->getActiveId();

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1364,7 +1364,7 @@ assessment#:#tst_count_correct_solutions#:#Nur vollständig richtig beantwortete
 assessment#:#tst_count_correct_solutions_desc#:#Vollständige und richtige Antworten erhalten die maximale Punktzahl. In allen anderen Fällen gibt es 0 Punkte. Dies gilt auch für Fragen, die Punkte für Teilantworten vorsehen.
 assessment#:#tst_count_partial_solutions#:#Auch teilweise falsch beantwortete Fragen ergeben Punkte
 assessment#:#tst_count_partial_solutions_desc#:#Bei einigen Fragetypen können für korrekt gegebene Teilantworten Punkte erzielt werden. Diese werden aufsummiert. Dies betrifft die Fragetypen Multiple Choice, KPrim, Mehrfachauswahl in Imagemaps, Fehler / Worte markieren und Zuordnungsfrage.
-assessment#:#tst_current_pass_no_longer_valid#:#Ihr aktueller Test Durchlauf ist nicht mehr gültig. <br>Er wurde wahrscheinlich bereits abgeschlossen oder von einem Tutor beendet.
+assessment#:#tst_current_run_no_longer_valid#:#Ihr aktueller Testdurchlauf ist nicht mehr gültig. <br>Er wurde wahrscheinlich bereits abgeschlossen oder von einem Tutor beendet.
 assessment#:#tst_default_settings#:#Persönliche Standardeinstellungen
 assessment#:#tst_defaults_applied#:#Die ausgewählten Standardeinstellungen wurden angewendet.
 assessment#:#tst_defaults_apply_not_possible#:#ILIAS konnte die ausgewählten Standardeinstellungen nicht auf diesen Test anwenden! Eventuell enthält dieser Test bereits Teilnehmerdatensätze, die verhindern, dass bestimmte Standardeinstellungen übernommen werden können.

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1949,6 +1949,7 @@ assessment#:#tst_wf_info_optional_question#:#Diese Frage gehört zu einem bereit
 assessment#:#tst_you_have_to_answer_this_question#:#Diese Frage muss beantwortet werden, um den Test beenden zu können.
 assessment#:#tst_your_answer_was#:#Sie haben die folgende Antwort gegeben
 assessment#:#tst_your_answers#:#Dies sind die Antworten, die Sie zu den folgenden Fragen gegeben haben. Bitte kontrollieren Sie Ihre Antworten und senden Sie diese dann ab.
+assessment#:#tst_current_pass_no_longer_valid#:#Ihr aktueller Test Durchlauf ist nicht mehr gültig. <br>Er wurde wahrscheinlich bereits abgeschlossen oder von einem Tutor beendet.
 assessment#:#un_add_category#:#Kategorie hinzufügen
 assessment#:#un_add_unit#:#Einheit hinzufügen
 assessment#:#un_cat_deletion_errors_f#:#Die folgenden Kategorien können nicht gelöscht werden:
@@ -2000,7 +2001,6 @@ assessment#:#without_solutions_participants#:#Teilnehmer ohne Antworten
 assessment#:#worked_through#:#Bearbeitet
 assessment#:#working_time#:#Bearbeitungsdauer
 assessment#:#you_received_a_of_b_points#:#Sie haben %s von %s möglichen Punkten erreicht.
-assessment#:#tst_current_pass_no_longer_valid#:#Ihr aktueller Test Durchlauf ist nicht mehr gültig. <br>Er wurde wahrscheinlich bereits abgeschlossen oder von einem Tutor beendet.
 auth#:#auth_account_code#:#Code
 auth#:#auth_account_code_info#:#Um Ihr Anmeldekonto zu reaktivieren, können Sie einen ILIAS-Anmeldekonten-Code benutzen.
 auth#:#auth_account_code_title#:#Anmeldekonten-Code

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2000,6 +2000,7 @@ assessment#:#without_solutions_participants#:#Teilnehmer ohne Antworten
 assessment#:#worked_through#:#Bearbeitet
 assessment#:#working_time#:#Bearbeitungsdauer
 assessment#:#you_received_a_of_b_points#:#Sie haben %s von %s möglichen Punkten erreicht.
+assessment#:#tst_current_pass_no_longer_valid#:#Ihr aktueller Test Durchlauf ist nicht mehr gültig. <br>Er wurde wahrscheinlich bereits abgeschlossen oder von einem Tutor beendet.
 auth#:#auth_account_code#:#Code
 auth#:#auth_account_code_info#:#Um Ihr Anmeldekonto zu reaktivieren, können Sie einen ILIAS-Anmeldekonten-Code benutzen.
 auth#:#auth_account_code_title#:#Anmeldekonten-Code

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1364,6 +1364,7 @@ assessment#:#tst_count_correct_solutions#:#Nur vollständig richtig beantwortete
 assessment#:#tst_count_correct_solutions_desc#:#Vollständige und richtige Antworten erhalten die maximale Punktzahl. In allen anderen Fällen gibt es 0 Punkte. Dies gilt auch für Fragen, die Punkte für Teilantworten vorsehen.
 assessment#:#tst_count_partial_solutions#:#Auch teilweise falsch beantwortete Fragen ergeben Punkte
 assessment#:#tst_count_partial_solutions_desc#:#Bei einigen Fragetypen können für korrekt gegebene Teilantworten Punkte erzielt werden. Diese werden aufsummiert. Dies betrifft die Fragetypen Multiple Choice, KPrim, Mehrfachauswahl in Imagemaps, Fehler / Worte markieren und Zuordnungsfrage.
+assessment#:#tst_current_pass_no_longer_valid#:#Ihr aktueller Test Durchlauf ist nicht mehr gültig. <br>Er wurde wahrscheinlich bereits abgeschlossen oder von einem Tutor beendet.
 assessment#:#tst_default_settings#:#Persönliche Standardeinstellungen
 assessment#:#tst_defaults_applied#:#Die ausgewählten Standardeinstellungen wurden angewendet.
 assessment#:#tst_defaults_apply_not_possible#:#ILIAS konnte die ausgewählten Standardeinstellungen nicht auf diesen Test anwenden! Eventuell enthält dieser Test bereits Teilnehmerdatensätze, die verhindern, dass bestimmte Standardeinstellungen übernommen werden können.
@@ -1949,7 +1950,6 @@ assessment#:#tst_wf_info_optional_question#:#Diese Frage gehört zu einem bereit
 assessment#:#tst_you_have_to_answer_this_question#:#Diese Frage muss beantwortet werden, um den Test beenden zu können.
 assessment#:#tst_your_answer_was#:#Sie haben die folgende Antwort gegeben
 assessment#:#tst_your_answers#:#Dies sind die Antworten, die Sie zu den folgenden Fragen gegeben haben. Bitte kontrollieren Sie Ihre Antworten und senden Sie diese dann ab.
-assessment#:#tst_current_pass_no_longer_valid#:#Ihr aktueller Test Durchlauf ist nicht mehr gültig. <br>Er wurde wahrscheinlich bereits abgeschlossen oder von einem Tutor beendet.
 assessment#:#un_add_category#:#Kategorie hinzufügen
 assessment#:#un_add_unit#:#Einheit hinzufügen
 assessment#:#un_cat_deletion_errors_f#:#Die folgenden Kategorien können nicht gelöscht werden:

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2001,6 +2001,7 @@ assessment#:#without_solutions_participants#:#Participants without solutions
 assessment#:#worked_through#:#Worked Through
 assessment#:#working_time#:#Working Time
 assessment#:#you_received_a_of_b_points#:#You received %s of %s possible points
+assessment#:#tst_current_pass_no_longer_valid#:#Your current Test Pass is no longer valid. <br>It was probably already completed or finished by a Tutor.
 auth#:#auth_account_code#:#Code
 auth#:#auth_account_code_info#:#To re-activate your account you can use an ILIAS account code.
 auth#:#auth_account_code_title#:#Account Code

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1950,6 +1950,7 @@ assessment#:#tst_wf_info_optional_question#:#This question relates to an already
 assessment#:#tst_you_have_to_answer_this_question#:#You have to answer this question to be able to finish the test.
 assessment#:#tst_your_answer_was#:#Your answer was
 assessment#:#tst_your_answers#:#These are your answers given to the following questions.
+assessment#:#tst_current_pass_no_longer_valid#:#Your current Test Pass is no longer valid. <br>It was probably already completed or finished by a Tutor.
 assessment#:#un_add_category#:#Add Category
 assessment#:#un_add_unit#:#Add Unit
 assessment#:#un_cat_deletion_errors_f#:#Cannot delete certain categories:
@@ -2001,7 +2002,6 @@ assessment#:#without_solutions_participants#:#Participants without solutions
 assessment#:#worked_through#:#Worked Through
 assessment#:#working_time#:#Working Time
 assessment#:#you_received_a_of_b_points#:#You received %s of %s possible points
-assessment#:#tst_current_pass_no_longer_valid#:#Your current Test Pass is no longer valid. <br>It was probably already completed or finished by a Tutor.
 auth#:#auth_account_code#:#Code
 auth#:#auth_account_code_info#:#To re-activate your account you can use an ILIAS account code.
 auth#:#auth_account_code_title#:#Account Code

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1364,7 +1364,7 @@ assessment#:#tst_count_correct_solutions#:#Only Correct and Complete Answers Sco
 assessment#:#tst_count_correct_solutions_desc#:#Participants score either the maximum number of points for a fully correct and complete answer or 0 points in every other case. This is also valid for questions that define points for partial answers.
 assessment#:#tst_count_partial_solutions#:#Incomplete or Partly Wrong Answers Score Points
 assessment#:#tst_count_partial_solutions_desc#:#When a question defines points for partial answers, points for correctly provided partial answers are added up: Participants can score points for incomplete or partly wrong answers on these questions.
-assessment#:#tst_current_pass_no_longer_valid#:#Your current Test Pass is no longer valid. <br>It was probably already completed or finished by a Tutor.
+assessment#:#tst_current_run_no_longer_valid#:#Your current test run is no longer valid. <br>It was probably completed already or finished by a tutor.
 assessment#:#tst_default_settings#:#Personal Default Settings
 assessment#:#tst_defaults_applied#:#The selected test defaults have been applied.
 assessment#:#tst_defaults_apply_not_possible#:#ILIAS could not apply the selected test defaults to this test! Maybe this test already contains participant data sets.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1364,6 +1364,7 @@ assessment#:#tst_count_correct_solutions#:#Only Correct and Complete Answers Sco
 assessment#:#tst_count_correct_solutions_desc#:#Participants score either the maximum number of points for a fully correct and complete answer or 0 points in every other case. This is also valid for questions that define points for partial answers.
 assessment#:#tst_count_partial_solutions#:#Incomplete or Partly Wrong Answers Score Points
 assessment#:#tst_count_partial_solutions_desc#:#When a question defines points for partial answers, points for correctly provided partial answers are added up: Participants can score points for incomplete or partly wrong answers on these questions.
+assessment#:#tst_current_pass_no_longer_valid#:#Your current Test Pass is no longer valid. <br>It was probably already completed or finished by a Tutor.
 assessment#:#tst_default_settings#:#Personal Default Settings
 assessment#:#tst_defaults_applied#:#The selected test defaults have been applied.
 assessment#:#tst_defaults_apply_not_possible#:#ILIAS could not apply the selected test defaults to this test! Maybe this test already contains participant data sets.
@@ -1950,7 +1951,6 @@ assessment#:#tst_wf_info_optional_question#:#This question relates to an already
 assessment#:#tst_you_have_to_answer_this_question#:#You have to answer this question to be able to finish the test.
 assessment#:#tst_your_answer_was#:#Your answer was
 assessment#:#tst_your_answers#:#These are your answers given to the following questions.
-assessment#:#tst_current_pass_no_longer_valid#:#Your current Test Pass is no longer valid. <br>It was probably already completed or finished by a Tutor.
 assessment#:#un_add_category#:#Add Category
 assessment#:#un_add_unit#:#Add Unit
 assessment#:#un_cat_deletion_errors_f#:#Cannot delete certain categories:


### PR DESCRIPTION
Mantis Ticket: https://mantis.ilias.de/view.php?id=36512

- Clicking on the `Finish Test`, `Next question` or `Previous question` button will now show an error message if the user has no unfinished passes currently (meaning it was already finished from somewhere/someone else.