### PR TITLE
[FIX] UI: required file inputs will work now.

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/File.php
+++ b/src/UI/Implementation/Component/Input/Field/File.php
@@ -45,7 +45,14 @@ class File extends Input implements C\Input\Field\File
 
     protected function getConstraintForRequirement()
     {
-        return $this->refinery->string();
+        return $this->refinery->custom()->constraint(
+            function ($value) {
+                return (is_array($value) && count($value) > 0);
+            },
+            function ($txt, $value) {
+                return $txt("msg_no_file");
+            },
+        );
     }
 
     protected function isClientSideValueOk($value) : bool


### PR DESCRIPTION
Hi all,

I noticed that `ILIAS\UI\Implementation\Component\Input\Field\File::getConstraintForRequirement()` returns a `ILIAS\Refinery\String\Group` instead of a `Constraint`. This PR introduces a proper constraint, similar as done in trunk (see [here](https://github.com/ILIAS-eLearning/ILIAS/blob/f75bea22c088dcdd24c2daa7eca811b04b54be8c/src/UI/Implementation/Component/Input/Field/File.php#L132)).

Kind regards,
@thibsy 