### PR TITLE
[FIX] UI: file input will now call file-removal endpoint.

### DIFF
--- a/src/UI/templates/js/Input/Field/file.js
+++ b/src/UI/templates/js/Input/Field/file.js
@@ -84,6 +84,7 @@ il.UI.Input = il.UI.Input || {};
 				clone.attr('data-file-id', new_file_id);
 
 				files.file_id = new_file_id;
+				files.is_existing = true;
 
 				$(container).append(clone);
 			};


### PR DESCRIPTION
Hi all,

I noticed that the file-removal endpoint of `ILIAS\UI\Component\Input\Field\UploadHandler` when using file inputs is never called, even though files are successfully uploaded.

This is due to [this](https://github.com/ILIAS-eLearning/ILIAS/blob/d0dff3d405a9ea95a847df9106a0a24f1dc4b4ca/src/UI/templates/js/Input/Field/file.js#L132) if-statement, which checked an attribute that's never set. This PR fixes the issue by setting this attribute in the success hook after a file has been successfully uploaded.

Kind regards,
@thibsy 