### PR TITLE
grand anonym session only when public section is enabled

### DIFF
--- a/Services/Authentication/classes/class.ilAuthSession.php
+++ b/Services/Authentication/classes/class.ilAuthSession.php
@@ -111,12 +111,14 @@ class ilAuthSession
      */
     public function logout()
     {
+        global $DIC;
+
         $this->getLogger()->debug('Logout called for: ' . $this->getUserId());
         session_regenerate_id(true);
         session_destroy();
 
         $this->init();
-        $this->setAuthenticated(true, ANONYMOUS_USER_ID);
+        $this->setAuthenticated($DIC->settings()->get('pub_section'), ANONYMOUS_USER_ID);
     }
     
     /**


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=36712

This only creates a anonymous sesssion when the public section is enabled since all other section wich an unlgogged user should have acces to are veryfied somewhere else  ( see ilInitialisation::blockedAuthentication())