### PR TITLE
EmployeeTalk: failing DBUpdateStep 4

### DIFF
--- a/Modules/OrgUnit/classes/Positions/Operation/class.ilOrgUnitOperationContextDBRepository.php
+++ b/Modules/OrgUnit/classes/Positions/Operation/class.ilOrgUnitOperationContextDBRepository.php
@@ -30,9 +30,9 @@ class ilOrgUnitOperationContextDBRepository implements OrgUnitOperationContextRe
 
     public function get(string $context, ?string $parent_context): ilOrgUnitOperationContext
     {
-        $context = $this->find($context);
-        if ($context) {
-            return $context;
+        $found_context = $this->find($context);
+        if ($found_context) {
+            return $found_context;
         }
 
         $parent_id = 0;
@@ -45,7 +45,7 @@ class ilOrgUnitOperationContextDBRepository implements OrgUnitOperationContextRe
         }
 
         $context = (new ilOrgUnitOperationContext())
-            ->withContext($context->getContext())
+            ->withContext($context)
             ->withParentContextId($parent_id);
         $this->store($context);
 


### PR DESCRIPTION
During installation of a new client step 4 of class.ilEmployeeTalkDBUpdateSteps: 
https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/Modules/EmployeeTalk/classes/Setup/class.ilEmployeeTalkDBUpdateSteps.php#L105 
fails on trying to register 'etal' as a new context.

The reason is an attempted access on $context as an object of class ilOrgUnitOperationContext here: 
https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/Modules/OrgUnit/classes/Positions/Operation/class.ilOrgUnitOperationContextDBRepository.php#L48
$context is always null if processing reaches this point of code due to be overwrittten at the beginning of the function.

The PR fixes this failure for me, but check the proposed change CAREFULLY before merging!