### PR TITLE
casting arg #1 of str_pad() to 'string'

### DIFF
--- a/Services/Object/classes/class.ilObjectDefinition.php
+++ b/Services/Object/classes/class.ilObjectDefinition.php
@@ -71,7 +71,7 @@ class ilObjectDefinition
                 "rbac" => $rec["rbac"],
                 "group" => $rec["grp"],
                 "system" => $rec["system"],
-                "default_pos" => "9999" . str_pad($rec["default_pos"], 4, "0", STR_PAD_LEFT), // "unassigned" group
+                "default_pos" => "9999" . str_pad((string) $rec["default_pos"], 4, "0", STR_PAD_LEFT), // "unassigned" group
                 "sideblock" => $rec["sideblock"],
                 'export' => $rec['export'],
                 'repository' => $rec['repository'],


### PR DESCRIPTION
occured TypeError using PHP 8.1 for ILIAS 9.0_alpha:

TypeError thrown with message "str_pad(): Argument #1 ($string) must be of type string, int given"

Stacktrace:
#7 TypeError in /srv/www/9/trunk9/Services/Object/classes/class.ilObjectDefinition.php:74 
#6 str_pad in /srv/www/9/trunk9/Services/Object/classes/class.ilObjectDefinition.php:74 
[...]