### PR TITLE
Fix PHP error for "Create Question" when a question plugin is active

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionTypeOrderer.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionTypeOrderer.php
@@ -145,13 +145,13 @@ class ilAssQuestionTypeOrderer
      */
     public function fixQuestionTypeOrderSortCallback($a, $b): int
     {
-        if (self::$flippedQuestionTypeOrder[ $a['type_tag'] ] > self::$flippedQuestionTypeOrder[ $b['type_tag'] ]) {
+        if (!isset(self::$flippedQuestionTypeOrder[ $a['type_tag'] ])) {
             return 1;
-        } elseif (!isset(self::$flippedQuestionTypeOrder[ $a['type_tag'] ])) {
+        } elseif (!isset(self::$flippedQuestionTypeOrder[ $b['type_tag'] ])) {
+            return -1;
+        } elseif (self::$flippedQuestionTypeOrder[ $a['type_tag'] ] > self::$flippedQuestionTypeOrder[ $b['type_tag'] ]) {
             return 1;
         } elseif (self::$flippedQuestionTypeOrder[ $a['type_tag'] ] < self::$flippedQuestionTypeOrder[ $b['type_tag'] ]) {
-            return -1;
-        } elseif (!isset(self::$flippedQuestionTypeOrder[ $b['type_tag'] ])) {
             return -1;
         }
 


### PR DESCRIPTION
When a question type plugin is activated, the "Create Question" in a question pools brings an array access error. Solved by checking the keyss first.