### PR TITLE
Fixed problems that caused ILIAS 8 to crash when setting up ECS.

### DIFF
--- a/Services/WebServices/ECS/classes/Setup/class.ilECSAgent.php
+++ b/Services/WebServices/ECS/classes/Setup/class.ilECSAgent.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup;
+
+class ilECSAgent extends Setup\Agent\NullAgent
+{
+    public function getUpdateObjective(\ILIAS\Setup\Config $config = null) : \ILIAS\Setup\Objective
+    {
+        return new \ilDatabaseUpdateStepsExecutedObjective(new ilECSDBUpdateSteps());
+    }
+
+    public function getStatusObjective(\ILIAS\Setup\Metrics\Storage $storage) : \ILIAS\Setup\Objective
+    {
+        return new \ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilECSDBUpdateSteps());
+    }
+}

--- a/Services/WebServices/ECS/classes/Setup/class.ilECSDBUpdateSteps.php
+++ b/Services/WebServices/ECS/classes/Setup/class.ilECSDBUpdateSteps.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+class ilECSDBUpdateSteps implements \ilDatabaseUpdateSteps
+{
+    protected \ilDBInterface $db;
+
+    public function prepare(\ilDBInterface $db) : void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        if($this->db->tableColumnExists('ecs_server', 'polling_time')) {
+            $this->db->dropTableColumn('ecs_server', 'polling_time');
+        }
+    }
+}

--- a/Services/WebServices/ECS/classes/class.ilECSSetting.php
+++ b/Services/WebServices/ECS/classes/class.ilECSSetting.php
@@ -2,19 +2,21 @@
 
 declare(strict_types=1);
 
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
 /**
 * @author Stefan Meyer <smeyer.ilias@gmx.de>
@@ -568,7 +570,7 @@ class ilECSSetting
             $this->db->quote($this->getProtocol(), 'integer') . ', ' .
             $this->db->quote($this->getServer(), 'text') . ', ' .
             $this->db->quote($this->getPort(), 'integer') . ', ' .
-            $this->db->quote($this->getAuthType(), 'integer') . ', ' .
+            $this->db->quote($this->getAuthType(), 'integer') . ', '
             $this->db->quote($this->getClientCertPath(), 'text') . ', ' .
             $this->db->quote($this->getCACertPath(), 'text') . ', ' .
             $this->db->quote($this->getKeyPath(), 'text') . ', ' .

--- a/Services/WebServices/ECS/classes/class.ilECSSetting.php
+++ b/Services/WebServices/ECS/classes/class.ilECSSetting.php
@@ -51,7 +51,6 @@ class ilECSSetting
     private ?string $cert_serial_number = '';
     private string $key_path = '';
     private string $key_password = '';
-    private int $polling = 0;
     private int $import_id = 0;
     private int $global_role = 0;
     private int $duration = 0;
@@ -561,7 +560,7 @@ class ilECSSetting
         $this->server_id = $this->db->nextId('ecs_server');
         $this->db->manipulate(
             'INSERT INTO ecs_server (server_id,active,title,protocol,server,port,auth_type,client_cert_path,ca_cert_path,' .
-            'key_path,key_password,cert_serial,polling_time,import_id,global_role,econtent_rcp,user_rcp,approval_rcp,duration,auth_user,auth_pass) ' .
+            'key_path,key_password,cert_serial,import_id,global_role,econtent_rcp,user_rcp,approval_rcp,duration,auth_user,auth_pass) ' .
             'VALUES (' .
             $this->db->quote($this->getServerId(), 'integer') . ', ' .
             $this->db->quote((int) $this->isEnabled(), 'integer') . ', ' .

--- a/Services/WebServices/ECS/classes/class.ilECSSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSSettingsGUI.php
@@ -2,19 +2,21 @@
 
 declare(strict_types=1);
 
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
 /**
  *

--- a/Services/WebServices/ECS/classes/class.ilECSSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSSettingsGUI.php
@@ -519,8 +519,8 @@ class ilECSSettingsGUI
         $this->settings->setEnabledStatus((bool) $_POST['active']);
         $this->settings->setTitle(ilUtil::stripSlashes($_POST['title']));
         $this->settings->setServer(ilUtil::stripSlashes($_POST['server']));
-        $this->settings->setPort(ilUtil::stripSlashes($_POST['port']));
-        $this->settings->setProtocol(ilUtil::stripSlashes($_POST['protocol']));
+        $this->settings->setPort((int) ilUtil::stripSlashes($_POST['port']));
+        $this->settings->setProtocol((int) ilUtil::stripSlashes($_POST['protocol']));
         $this->settings->setClientCertPath(ilUtil::stripSlashes($_POST['client_cert']));
         $this->settings->setCACertPath(ilUtil::stripSlashes($_POST['ca_cert']));
         $this->settings->setKeyPath(ilUtil::stripSlashes($_POST['key_path']));


### PR DESCRIPTION
- Integers were expected for port and protocol, but strings are passed => casting added
- Removed unused polling time from class attributes, SQL statement and DB