### PR TITLE
[ECS] Fix TypeError on deleting ECS

### DIFF
--- a/Services/WebServices/ECS/classes/class.ilECSSettingsGUI.php
+++ b/Services/WebServices/ECS/classes/class.ilECSSettingsGUI.php
@@ -253,7 +253,7 @@ class ilECSSettingsGUI
      */
     protected function doDelete(): void
     {
-        $this->initSettings($_REQUEST['server_id']);
+        $this->initSettings((int) $_REQUEST['server_id']);
         $this->settings->delete();
         $this->tpl->setOnScreenMessage('success', $this->lng->txt('ecs_setting_deleted'), true);
         $this->ctrl->redirect($this, 'overview');


### PR DESCRIPTION
Deleting an ECS in ILIAS 8 triggers a TypeError. Added missing type casting in doDelete() 