### PR TITLE
Staff: Fixes for Certificates view

### DIFF
--- a/Services/Certificate/classes/API/Filter/UserDataFilter.php
+++ b/Services/Certificate/classes/API/Filter/UserDataFilter.php
@@ -30,6 +30,7 @@ class UserDataFilter
     public const SORT_FIELD_USR_LASTNAME = 3;
     public const SORT_FIELD_USR_FIRSTNAME = 4;
     public const SORT_FIELD_OBJ_TITLE = 5;
+    public const SORT_FIELD_USR_EMAIL = 6;
     public const SORT_DIRECTION_ASC = 1;
     public const SORT_DIRECTION_DESC = 2;
 
@@ -41,6 +42,7 @@ class UserDataFilter
     private ?string $userLastName = null;
     private ?string $userLogin = null;
     private ?string $userEmail = null;
+    private ?string $userIdentification = null;
     /** @var int[] */
     private array $userIds = [];
     /** @var int[] */
@@ -49,6 +51,8 @@ class UserDataFilter
     private ?int $limitOffset = null;
     private ?int $limitCount = null;
     private bool $shouldIncludeDeletedObjects = true;
+    /** @var int[] */
+    private array $orgUnitIds = [];
 
     /**
      * @param int[] $usrIds
@@ -66,6 +70,16 @@ class UserDataFilter
     private function ensureValidUniqueObjIds(array $objIds): void
     {
         array_walk($objIds, static function (int $objId): void {
+            // Do nothing, use this for type safety of array values
+        });
+    }
+
+    /**
+     * @param int[] $orgUnitIds
+     */
+    private function ensureValidUniqueOrgUnitIds(array $orgUnitIds): void
+    {
+        array_walk($orgUnitIds, static function (int $orgUnitId): void {
             // Do nothing, use this for type safety of array values
         });
     }
@@ -106,6 +120,14 @@ class UserDataFilter
     {
         $clone = clone $this;
         $clone->userEmail = $emailAddress;
+
+        return $clone;
+    }
+
+    public function withUserIdentification(?string $userIdentification): self
+    {
+        $clone = clone $this;
+        $clone->userIdentification = $userIdentification;
 
         return $clone;
     }
@@ -190,6 +212,34 @@ class UserDataFilter
         return $clone;
     }
 
+    /**
+     * @param int[] $orgUnitIds
+     * @return $this
+     */
+    public function withOrgUnitIds(array $orgUnitIds): self
+    {
+        $this->ensureValidUniqueOrgUnitIds($orgUnitIds);
+
+        $clone = clone $this;
+        $clone->orgUnitIds = array_unique($orgUnitIds);
+
+        return $clone;
+    }
+
+    /**
+     * @param int[] $orgUnitIds
+     * @return $this
+     */
+    public function withAdditionalOrgUnitIds(array $orgUnitIds): self
+    {
+        $this->ensureValidUniqueOrgUnitIds($orgUnitIds);
+
+        $clone = clone $this;
+        $clone->orgUnitIds = array_unique(array_merge($clone->orgUnitIds, $orgUnitIds));
+
+        return $clone;
+    }
+
     public function getObjectTitle(): ?string
     {
         return $this->objectTitle;
@@ -230,6 +280,11 @@ class UserDataFilter
         return $this->userEmail;
     }
 
+    public function getUserIdentification(): ?string
+    {
+        return $this->userIdentification;
+    }
+
     /**
      * @return int[]
      */
@@ -244,6 +299,14 @@ class UserDataFilter
     public function getObjIds(): array
     {
         return $this->objIds;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getOrgUnitIds(): array
+    {
+        return $this->orgUnitIds;
     }
 
     public function withSortedLastNames(int $direction = self::SORT_DIRECTION_ASC): self
@@ -282,6 +345,14 @@ class UserDataFilter
     {
         $clone = clone $this;
         $clone->sorts[] = [self::SORT_FIELD_ISSUE_TIMESTAMP, $direction];
+
+        return $clone;
+    }
+
+    public function withSortedEmails(int $direction = self::SORT_DIRECTION_ASC): self
+    {
+        $clone = clone $this;
+        $clone->sorts[] = [self::SORT_FIELD_USR_EMAIL, $direction];
 
         return $clone;
     }

--- a/Services/MyStaff/classes/ListCertificates/class.ilMStListCertificates.php
+++ b/Services/MyStaff/classes/ListCertificates/class.ilMStListCertificates.php
@@ -73,10 +73,60 @@ class ilMStListCertificates
             ));
 
             if (!empty($options['filters']['user'])) {
-                $usr_data_filter = $usr_data_filter->withUserLogin($options['filters']['user']);
+                $usr_data_filter = $usr_data_filter->withUserIdentification($options['filters']['user']);
             }
             if (!empty($options['filters']['obj_title'])) {
                 $usr_data_filter = $usr_data_filter->withObjectTitle($options['filters']['obj_title']);
+            }
+            if (!empty($options['filters']['org_unit'])) {
+                $org_unit_id = (int) $options['filters']['org_unit'];
+                $usr_data_filter = $usr_data_filter->withOrgUnitIds([$org_unit_id]);
+            }
+
+            if (!empty($options['sort']['field']) && !empty($options['sort']['direction'])) {
+                if ($options['sort']['field'] === "objectTitle" && $options['sort']['direction'] === "asc") {
+                    $usr_data_filter = $usr_data_filter->withSortedObjectTitles(UserDataFilter::SORT_DIRECTION_ASC);
+                }
+                elseif ($options['sort']['field'] === "objectTitle" && $options['sort']['direction'] === "desc") {
+                    $usr_data_filter = $usr_data_filter->withSortedObjectTitles(UserDataFilter::SORT_DIRECTION_DESC);
+                }
+                elseif ($options['sort']['field'] === "issuedOnTimestamp" && $options['sort']['direction'] === "asc") {
+                    $usr_data_filter = $usr_data_filter->withSortedIssuedOnTimestamps(UserDataFilter::SORT_DIRECTION_ASC);
+                }
+                elseif ($options['sort']['field'] === "issuedOnTimestamp" && $options['sort']['direction'] === "desc") {
+                    $usr_data_filter = $usr_data_filter->withSortedIssuedOnTimestamps(UserDataFilter::SORT_DIRECTION_DESC);
+                }
+                elseif ($options['sort']['field'] === "userLogin" && $options['sort']['direction'] === "asc") {
+                    $usr_data_filter = $usr_data_filter->withSortedLogins(UserDataFilter::SORT_DIRECTION_ASC);
+                }
+                elseif ($options['sort']['field'] === "userLogin" && $options['sort']['direction'] === "desc") {
+                    $usr_data_filter = $usr_data_filter->withSortedLogins(UserDataFilter::SORT_DIRECTION_DESC);
+                }
+                elseif ($options['sort']['field'] === "userFirstName" && $options['sort']['direction'] === "asc") {
+                    $usr_data_filter = $usr_data_filter->withSortedFirstNames(UserDataFilter::SORT_DIRECTION_ASC);
+                }
+                elseif ($options['sort']['field'] === "userFirstName" && $options['sort']['direction'] === "desc") {
+                    $usr_data_filter = $usr_data_filter->withSortedFirstNames(UserDataFilter::SORT_DIRECTION_DESC);
+                }
+                elseif ($options['sort']['field'] === "userLastName" && $options['sort']['direction'] === "asc") {
+                    $usr_data_filter = $usr_data_filter->withSortedLastNames(UserDataFilter::SORT_DIRECTION_ASC);
+                }
+                elseif ($options['sort']['field'] === "userLastName" && $options['sort']['direction'] === "desc") {
+                    $usr_data_filter = $usr_data_filter->withSortedLastNames(UserDataFilter::SORT_DIRECTION_DESC);
+                }
+                elseif ($options['sort']['field'] === "userEmail" && $options['sort']['direction'] === "asc") {
+                    $usr_data_filter = $usr_data_filter->withSortedEmails(UserDataFilter::SORT_DIRECTION_ASC);
+                }
+                elseif ($options['sort']['field'] === "userEmail" && $options['sort']['direction'] === "desc") {
+                    $usr_data_filter = $usr_data_filter->withSortedEmails(UserDataFilter::SORT_DIRECTION_DESC);
+                }
+            }
+
+            if ((!empty($options['limit']['start']) || $options['limit']['start'] === 0)
+                && !empty($options['limit']['end'])
+            ) {
+                $usr_data_filter = $usr_data_filter->withLimitOffset((int) $options['limit']['start']);
+                $usr_data_filter = $usr_data_filter->withLimitCount((int) $options['limit']['end']);
             }
 
             $data = array_merge($data, $cert_api->getUserCertificateData(

--- a/Services/MyStaff/classes/ListCertificates/class.ilMStListCertificatesTableGUI.php
+++ b/Services/MyStaff/classes/ListCertificates/class.ilMStListCertificatesTableGUI.php
@@ -78,6 +78,7 @@ class ilMStListCertificatesTableGUI extends ilTable2GUI
         global $DIC;
 
         $this->setExternalSorting(true);
+        $this->setExternalSegmentation(true);
         $this->setDefaultOrderField('obj_title');
 
         $this->determineLimit();
@@ -85,7 +86,10 @@ class ilMStListCertificatesTableGUI extends ilTable2GUI
 
         $options = array(
             'filters' => $this->filter,
-            'limit' => array(),
+            'limit' => array(
+                'start' => $this->getOffset(),
+                'end' => $this->getLimit(),
+            ),
             'count' => true,
             'sort' => array(
                 'field' => $this->getOrderField(),
@@ -95,17 +99,19 @@ class ilMStListCertificatesTableGUI extends ilTable2GUI
 
         $certificates_fetcher = new ilMStListCertificates($DIC);
         $data = $certificates_fetcher->getData($options);
-        $options['limit'] = array(
-            'start' => $this->getOffset(),
-            'end' => $this->getLimit(),
-        );
-        $this->setMaxCount(count($data));
 
         // Workaround because the fillRow Method only accepts arrays
         $data = array_map(function (UserCertificateDto $it): array {
             return [$it];
         }, $data);
         $this->setData($data);
+
+        $options['limit'] = array(
+            'start' => null,
+            'end' => null,
+        );
+        $max_data = $certificates_fetcher->getData($options);
+        $this->setMaxCount(count($max_data));
     }
 
     final public function initFilter(): void
@@ -119,7 +125,9 @@ class ilMStListCertificatesTableGUI extends ilTable2GUI
 
         //user
         $item = new ilTextInputGUI(
-            $DIC->language()->txt("login"),
+            $DIC->language()->txt("login")
+            . "/" . $DIC->language()->txt("email")
+            . "/" . $DIC->language()->txt("name"),
             "user"
         );
 


### PR DESCRIPTION
Hi @mjansenDatabay 
this is a PR which fixes multiple things in the Certificates view in Staff. Most of the bugs are mentioned in [36731](https://mantis.ilias.de/view.php?id=36731) and [36732](https://mantis.ilias.de/view.php?id=36732). 
The problems were in summary:
- Filter fields were partly not working
- Table column for email was not filled
- Table sortation was not working at all
- Table navigation was not working at all

Some of the code changes had to be done in the Certificate API for Staff, so please have a look.

I will pick this to release 8 as soon as PR is merged.