### PR TITLE
Portfolio: fix copying of AdvMD when creating from template (36565)

### DIFF
--- a/Modules/Portfolio/Page/class.ilPCAMDForm.php
+++ b/Modules/Portfolio/Page/class.ilPCAMDForm.php
@@ -136,8 +136,9 @@ class ilPCAMDForm extends ilPageContent
                 $nodes = $xpath->query("//AMDForm");
                 foreach ($nodes as $node) {
                     $old_ids = explode(",", (string) $node->getAttribute("RecordIds"));
+                    // 36565: do not overwrite RecordIds that are not mapped
                     $new_ids = array_map(static function ($i) use ($mappings, $key) {
-                        return $mappings[$key][(int) $i] ?? null;
+                        return $mappings[$key][(int) $i] ?? $i;
                     }, $old_ids);
                     $new_ids = implode(",", $new_ids);
                     if ($new_ids !== "") {

--- a/Modules/Portfolio/classes/class.ilObjPortfolioBase.php
+++ b/Modules/Portfolio/classes/class.ilObjPortfolioBase.php
@@ -410,6 +410,13 @@ abstract class ilObjPortfolioBase extends ilObject2
         $copy_id = ilCopyWizardOptions::_allocateCopyId();
         ilAdvancedMDValues::_cloneValues($copy_id, $a_source->getId(), $a_target->getId());
 
+        // copy selection of global optional sets
+        ilAdvancedMDRecord::saveObjRecSelection(
+            $a_target->getId(),
+            'pfpg',
+            ilAdvancedMDRecord::getObjRecSelection($a_source->getId(), 'pfpg')
+        );
+
         // fix metadata record type assignment
         // e.g. if portfolio is created from template
         // we need to change this from prtt to prtf


### PR DESCRIPTION
This PR fixes a couple of issues with advanced metadata sets not surviving the creation of a Portfolio from a template, including [36565](https://mantis.ilias.de/view.php?id=0036565).