### PR TITLE
Footer goto link: Use plain link instead of button with JS

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -3757,7 +3757,6 @@ common#:#copy_all#:#Alle kopieren
 common#:#copy_n_of_suffix#:#- Kopie (%1$s)
 common#:#copy_of#:#Kopie von
 common#:#copy_of_suffix#:#- Kopie
-common#:#copy_perma_link#:#Link zu dieser Seite kopieren
 common#:#copy_selected_items#:#Kopieren
 common#:#count#:#Anzahl
 common#:#country#:#Land

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -3758,7 +3758,6 @@ common#:#copy_all#:#Copy all
 common#:#copy_n_of_suffix#:#- Copy (%1$s)
 common#:#copy_of#:#Copy of
 common#:#copy_of_suffix#:#- Copy
-common#:#copy_perma_link#:#Copy Permanent Link
 common#:#copy_selected_items#:#Copy
 common#:#count#:#Count
 common#:#country#:#Country

--- a/src/UI/Implementation/Component/MainControls/Renderer.php
+++ b/src/UI/Implementation/Component/MainControls/Renderer.php
@@ -34,7 +34,6 @@ use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\Data\URI;
 use ILIAS\UI\Implementation\Render\ResourceRegistry;
 use LogicException;
-use Closure;
 
 class Renderer extends AbstractComponentRenderer
 {
@@ -332,8 +331,8 @@ class Renderer extends AbstractComponentRenderer
 
         $id = $this->bindJavaScript($component);
         $tpl->setVariable('ID', $id);
-        $tpl->setVariable('ID_HEADLINE', $id."_headline");
-        $tpl->setVariable('ID_DESCRIPTION', $id."_description");
+        $tpl->setVariable('ID_HEADLINE', $id . "_headline");
+        $tpl->setVariable('ID_DESCRIPTION', $id . "_description");
 
         return $tpl->get();
     }
@@ -440,11 +439,10 @@ class Renderer extends AbstractComponentRenderer
         $perm_url = $component->getPermanentURL();
         if ($perm_url instanceof URI) {
             $url = $perm_url->__toString();
-            $button = $this->getUIFactory()
-                           ->button()
-                           ->shy($this->txt('copy_perma_link'), $url)
-                           ->withAdditionalOnLoadCode($this->permanentJS($url));
-            $tpl->setVariable('PERMANENT', $default_renderer->render($button));
+            $link = $this->getUIFactory()
+                         ->link()
+                         ->standard($this->txt('perma_link'), $url);
+            $tpl->setVariable('PERMANENT', $default_renderer->render($link));
         }
         return $tpl->get();
     }
@@ -473,21 +471,5 @@ class Renderer extends AbstractComponentRenderer
             ModeInfo::class,
             Component\MainControls\SystemInfo::class
         );
-    }
-
-    private function permanentJS(string $url): Closure
-    {
-        $url = json_encode($url);
-        return static function (string $id) use ($url): string {
-            return "document.getElementById('$id').addEventListener('click', function(event){
-                    if (window.navigator.clipboard) {
-                        window.navigator.clipboard.writeText($url);
-                        event.stopImmediatePropagation();
-                        return false;
-                    } else {
-                        console.warn('Cannot copy link to clipboard. Please note that the clipboard is only available in secure contexts (HTTPS). See https://developer.mozilla.org/en-US/docs/Web/API/Clipboard for more information.');
-                    }
-                });";
-        };
     }
 }

--- a/templates/default/070-components/UI-framework/MainControls/_ui-component_footer.scss
+++ b/templates/default/070-components/UI-framework/MainControls/_ui-component_footer.scss
@@ -51,15 +51,6 @@ footer{
 
 	.il-footer-permanent-url {
 		margin-right: $il-margin-xs-horizontal;
-
-		label {
-			margin-right: $il-margin-xs-horizontal;
-
-			color: $il-main-color;
-			&:hover{
-				text-decoration: underline;
-			}
-		}
 	}
 
 	.il-footer-text {

--- a/tests/UI/Component/MainControls/FooterTest.php
+++ b/tests/UI/Component/MainControls/FooterTest.php
@@ -153,9 +153,9 @@ class FooterTest extends ILIAS_UI_TestBase
                 return new I\Listing\Factory();
             }
 
-            public function button(): C\Button\Factory
+            public function link(): C\Link\Factory
             {
-                return new I\Button\Factory();
+                return new I\Link\Factory();
             }
         };
     }
@@ -226,7 +226,7 @@ EOT;
         $expected = <<<EOT
         <div class="il-maincontrols-footer">
             <div class="il-footer-content">
-                <div class="il-footer-permanent-url"><button class="btn btn-link" data-action="http://www.ilias.de/goto.php?target=xxx_123" id="id_1">copy_perma_link</button>
+                <div class="il-footer-permanent-url"><a href="http://www.ilias.de/goto.php?target=xxx_123">perma_link</a>
                 </div>
 
                 <div class="il-footer-text">footer text</div>


### PR DESCRIPTION
Follow up to PR: #5301
With this PR the footer permanent link will be rendered as a plain link without any JS attached. The Label will show _Permanent Link_.