### PR TITLE
Refinery: Prevent parser tests from failing when Xdebug is enabled (>=PHP8.1)

### DIFF
--- a/tests/Data/LanguageTagTest.php
+++ b/tests/Data/LanguageTagTest.php
@@ -32,8 +32,8 @@ class LanguageTagTest extends TestCase
         $this->assertInstanceOf(LanguageTag::class, $tag);
     }
 
-        /**
-     * @dataProvider parseProvider
+    /**
+     * @dataProvider saveToRun
      */
     public function testParse(string $input, bool $isOk): void
     {
@@ -44,24 +44,28 @@ class LanguageTagTest extends TestCase
         $this->assertInstanceOf(LanguageTag::class, $tag);
     }
 
-    public function parseProvider(): array
+    /**
+     * @dataProvider risky
+     */
+    public function testRisky(string $input, bool $isOk): void
+    {
+        $this->testParse($input, $isOk);
+    }
+
+    public function saveToRun(): array
     {
         return [
             ['de', true],
             ['d$', false],
             ['aa-111', true],
-            ['aa-7-123abc-abc-a-12', true],
-            ['aa-b1b1b-6a8b-cccccc', true],
             ['aa-b1b1b', true],
             ['aa-bb', true],
-            ['aa-bbb-ccc-1111-ccccc-b1b1b', true],
             ['aa-bbb-ccc-ddd', true],
             ['aa-bbb', true],
             ['aa-bbbb-cc', true],
             ['aa-bbbb', true],
             ['aa-x-1234ab-d', true],
             ['aa', true],
-            ['aaa-bbb-ccc-ddd-abcd-123-abc123-0abc-b-01-abc123-x-01ab-abc12', true],
             ['aaa-bbb-ccc', true],
             ['aaaa', true],
             ['aaaaa', true],
@@ -72,28 +76,22 @@ class LanguageTagTest extends TestCase
             ['ar-afb', true],
             ['art-lojban', true],
             ['ast', true],
-            ['az-Arab-x-AZE-derbend', true],
             ['az-Latn', true],
             ['cel-gaulish', true],
             ['cmn-Hans-CN', true],
             ['de-CH-1901', true],
-            ['de-CH-x-phonebk', true],
-            ['de-DE-u-co-phonebk', true],
             ['de-DE', true],
             ['de-Qaaa', true],
             ['de', true],
             ['en-GB-oed', true],
-            ['en-US-u-islamcal', true],
             ['en-US-x-twain', true],
             ['en-US', true],
-            ['en-a-myext-b-another', true],
             ['en', true],
             ['es-005', true],
             ['es-419', true],
             ['fr-CA', true],
             ['fr', true],
             ['hak', true],
-            ['hy-Latn-IT-arevela', true],
             ['i-ami', true],
             ['i-bnn', true],
             ['i-default', true],
@@ -111,7 +109,6 @@ class LanguageTagTest extends TestCase
             ['mas', true],
             ['no-bok', true],
             ['no-nyn', true],
-            ['qaa-Qaaa-QM-x-southern', true],
             ['sgn-BE-FR', true],
             ['sgn-BE-NL', true],
             ['sgn-CH-DE', true],
@@ -127,7 +124,6 @@ class LanguageTagTest extends TestCase
             ['x-111-aaaaa-BBB', true],
             ['x-whatever', true],
             ['yue-HK', true],
-            ['zh-CN-a-myext-x-private', true],
             ['zh-Hans-CN', true],
             ['zh-Hans', true],
             ['zh-Hant-HK', true],
@@ -140,6 +136,31 @@ class LanguageTagTest extends TestCase
             ['zh-xiang', true],
             ['zh-yue-HK', true],
             ['zh-yue', true],
+        ];
+    }
+
+    public function risky(): array
+    {
+        if (function_exists('xdebug_info') && ((int) ini_get('xdebug.max_nesting_level')) < 780) {
+            $this->markTestSkipped(sprintf(
+                'You are running under Xdebug. To be able to run all tests xdebug.max_nesting_level must be at least 780 (Currently %d).',
+                (int) ini_get('xdebug.max_nesting_level')
+            ));
+        }
+
+        return [
+            ['aa-bbb-ccc-1111-ccccc-b1b1b', true],
+            ['aaa-bbb-ccc-ddd-abcd-123-abc123-0abc-b-01-abc123-x-01ab-abc12', true],
+            ['az-Arab-x-AZE-derbend', true],
+            ['de-CH-x-phonebk', true],
+            ['de-DE-u-co-phonebk', true],
+            ['en-US-u-islamcal', true],
+            ['en-a-myext-b-another', true],
+            ['hy-Latn-IT-arevela', true],
+            ['qaa-Qaaa-QM-x-southern', true],
+            ['aa-7-123abc-abc-a-12', true],
+            ['aa-b1b1b-6a8b-cccccc', true],
+            ['zh-CN-a-myext-x-private', true],
         ];
     }
 }

--- a/tests/Refinery/Parser/ABNF/BrickTest.php
+++ b/tests/Refinery/Parser/ABNF/BrickTest.php
@@ -205,6 +205,16 @@ class BrickTest extends TestCase
         }
     }
 
+    private function breakIntoPieces(int $x, string $break_me): array
+    {
+        $len = (int) floor(strlen($break_me) / $x);
+
+        return array_map(
+            fn ($i) => substr($break_me, $i * $len, $len),
+            range(0, $x - !(strlen($break_me) % $x))
+        );
+    }
+
     public function characterProvider(): array
     {
         $alpha = array_fill(ord('a'), ord('z') - ord('a') + 1, '');
@@ -214,12 +224,17 @@ class BrickTest extends TestCase
         $alpha = implode('', $alpha);
         $alpha .= strtoupper($alpha);
 
+        // Circumvent error when running this test with Xdebug. The default value of xdebug.max_nesting_level will kill the test.
+        $alpha_parts = $this->breakIntoPieces(3, $alpha);
+
         $digits = '1234567890';
 
         return [
             'Accepts all digits.' => ['digit', $digits, true],
             'Accepts no characters from a-z or A-Z.' => ['digit', $alpha, false],
-            'Accepts characters from a-z and A-Z.' => ['alpha', $alpha, true],
+            'Accepts characters from a-z and A-Z (Part 1).' => ['alpha', $alpha_parts[0], true],
+            'Accepts characters from a-z and A-Z (Part 2).' => ['alpha', $alpha_parts[1], true],
+            'Accepts characters from a-z and A-Z (Part 3).' => ['alpha', $alpha_parts[2], true],
             'Accepts no digits.' => ['alpha', $digits, false],
         ];
     }

--- a/tests/Refinery/Parser/ABNF/PrimitivesTest.php
+++ b/tests/Refinery/Parser/ABNF/PrimitivesTest.php
@@ -115,7 +115,7 @@ class PrimitivesTest extends TestCase
 
     public function testUntilSuccess(): void
     {
-        $success_after = 300;
+        $success_after = 20;
         $primitives = new Primitives();
         $called = 0;
         $end_called = 0;
@@ -138,7 +138,7 @@ class PrimitivesTest extends TestCase
 
     public function testUntilChildFails(): void
     {
-        $fail_after = 134;
+        $fail_after = 20;
         $primitives = new Primitives();
         $called = 0;
         $end_called = 0;


### PR DESCRIPTION
The parser tests are adjusted so they can pass successfully with the default value of Xdebug's `max_nestining_level` (which is `256`).

The parser tests (Brick and Primitives) are now using smaller values for the tests so they won't exceed `256`. Previously loops up to 300 where used, which resulted in a call stack between 2000 and 3000 :)

As I don't want to remove the language tag tests they are now marked as _skipped_ when Xdebug is enabled and `max_nesting_level` is below `780`. Additionally they are skipped in the data provider, not in the test itself, so that only one message is shown to the user instead of 12 (If this is not preferred I will adjust this PR).


Interestingly all these tests run fine with PHP8.**0** + Xdebug.

_Tested with PHP8.0, 8.1 and 8.2._