### PR TITLE
Fix undefined array key in `ilObjectAccess::canBeDelivered`

### DIFF
--- a/Services/Object/classes/class.ilObjectAccess.php
+++ b/Services/Object/classes/class.ilObjectAccess.php
@@ -117,10 +117,11 @@ class ilObjectAccess implements ilWACCheckingClass
     {
         global $ilAccess;
 
-        preg_match("/\\/obj_([\\d]*)\\//uism", $ilWACPath->getPath(), $results);
-        foreach (ilObject2::_getAllReferences((int) $results[1]) as $ref_id) {
-            if ($ilAccess->checkAccess('visible', '', $ref_id) || $ilAccess->checkAccess('read', '', $ref_id)) {
-                return true;
+        if (preg_match("/\\/obj_([\\d]*)\\//uism", $ilWACPath->getPath(), $results)) {
+            foreach (ilObject2::_getAllReferences((int) $results[1]) as $ref_id) {
+                if ($ilAccess->checkAccess('visible', '', $ref_id) || $ilAccess->checkAccess('read', '', $ref_id)) {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds a check in In the `ilObjectAccess::canBeDelivered` if the regular expression matched the given path, to prevent accessing an undefined array key (`$results[1]`).