### PR TITLE
UI: OptionalGroup Set `$null_value_was_explicitly_set` correctly in `withInput`

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/OptionalGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/OptionalGroup.php
@@ -112,6 +112,10 @@ class OptionalGroup extends Group implements Field\OptionalGroup
                 return $clone;
             }
         }
-        return parent::withInput($input);
+
+        $clone = parent::withInput($input);
+        // If disabled keep, else false, because the null case is already handled.
+        $clone->null_value_was_explicitly_set = $this->isDisabled() && $this->null_value_was_explicitly_set;
+        return $clone;
     }
 }


### PR DESCRIPTION
This PR fixes the following issue in the `OptionalGroup`:

When changing from a `null` value to a `non null` value via `OptionalGroup::withInput(...)` the property `$null_value_was_explicitly_set` is not updated correctly (It retains the previous value).
This causes the `OptionalGroup` to still show the `null` state when rendered.

This problem exists also in release_6 and release_7 (as this is a small issue, I'm not sure if it needs to get fixed there too).