### PR TITLE
GlobalScreen/MetaBar: Prevent accessing uninitialized property

### DIFF
--- a/src/GlobalScreen/Scope/MetaBar/Factory/LinkItem.php
+++ b/src/GlobalScreen/Scope/MetaBar/Factory/LinkItem.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -29,7 +30,7 @@ use ILIAS\UI\Component\Symbol\Symbol;
  */
 class LinkItem extends AbstractChildItem implements isItem, hasTitle, hasSymbol, isChild
 {
-    protected ?Symbol $symbol;
+    protected ?Symbol $symbol = null;
     protected string $title = "";
     protected string $action = "";
 


### PR DESCRIPTION
This PR initializes the `ILIAS\GlobalScreen\Scope\MetaBar\Factory\LinkItem::$symbol` with `null` to prevent an error when calling `LinkItem::hasSymbol` when no Symbol is set.