### PR TITLE
32716: Certificate cannot be downloaded at Organization/Staff List

### DIFF
--- a/Services/Certificate/classes/User/class.ilUserCertificateGUI.php
+++ b/Services/Certificate/classes/User/class.ilUserCertificateGUI.php
@@ -313,7 +313,7 @@ class ilUserCertificateGUI
     {
         global $DIC;
 
-        $user = $DIC->user();
+        $user = $this->user;
         $language = $DIC->language();
 
         $pdfGenerator = new ilPdfGenerator($this->userCertificateRepository);


### PR DESCRIPTION
Hi @mjansenDatabay 
This is a fix for [32716](https://mantis.ilias.de/view.php?id=32716) (and maybe some other occurrences of `download()`).
Please cherry-pick to `release_8` and `release_7` when accepted.