### PR TITLE
Fix #36866: getObjectsForOwner() needs to be static

### DIFF
--- a/Services/Object/classes/class.ilObjectFactory.php
+++ b/Services/Object/classes/class.ilObjectFactory.php
@@ -39,7 +39,7 @@ class ilObjectFactory
      * @param unknown_type $owner_id
      * @return unknown
      */
-    public function getObjectsForOwner($object_type, $owner_id)
+    public static function getObjectsForOwner($object_type, $owner_id)
     {
         global $DIC;
 


### PR DESCRIPTION
As `getObjectsForOwner()` is in a factory, I assume that it should be a static method. That's also how it's been invoked.

There are only static calls to this method in the entire code base:

```
ajcay@dev:/ilias$ grep -r "getObjectsForOwner"
Services/Object/classes/class.ilObjectFactory.php:    public function getObjectsForOwner($object_type, $owner_id)
webservice/soap/classes/class.ilSoapGroupAdministration.php:            $owned_objects = ilObjectFactory::getObjectsForOwner("grp", $user_id);
webservice/soap/classes/class.ilSoapCourseAdministration.php:            $owned_objects = ilObjectFactory::getObjectsForOwner("crs", $user_id);
```

Fixes https://mantis.ilias.de/view.php?id=36866