### PR TITLE
Database: Show `InnoDb` migration errors

### DIFF
--- a/Services/Database/classes/PDO/class.ilDBPdoMySQL.php
+++ b/Services/Database/classes/PDO/class.ilDBPdoMySQL.php
@@ -69,17 +69,16 @@ abstract class ilDBPdoMySQL extends ilDBPdo
         );
     }
 
-    public function migrateTableToEngine(string $table_name, string $engine = ilDBConstants::MYSQL_ENGINE_INNODB): bool
+    public function migrateTableToEngine(string $table_name, string $engine = ilDBConstants::MYSQL_ENGINE_INNODB): void
     {
         try {
             $this->pdo->exec("ALTER TABLE {$table_name} ENGINE={$engine}");
             if ($this->sequenceExists($table_name)) {
                 $this->pdo->exec("ALTER TABLE {$table_name}_seq ENGINE={$engine}");
             }
-        } catch (Exception $e) {
-            return false;
+        } catch (PDOException $e) {
+            throw new ilDatabaseException($e->getMessage());
         }
-        return true;
     }
 
     /**

--- a/Services/Database/classes/Setup/class.ilMysqlMyIsamToInnoDbMigration.php
+++ b/Services/Database/classes/Setup/class.ilMysqlMyIsamToInnoDbMigration.php
@@ -79,11 +79,16 @@ class ilMysqlMyIsamToInnoDbMigration implements Migration
     {
         $rows = $this->getNonInnoDBTables();
         $table_name = array_pop($rows);
-        if (is_string($table_name) && strlen($table_name) > 0) {
-            $migration = $this->database->migrateTableToEngine($table_name);
-        }
-        if (isset($migration) && $migration === false) {
-            throw new ilException("The migration of the following tables did throw errors, please resolve the problem before you continue: \n" . $table_name);
+
+        if (is_string($table_name) && $table_name !== '') {
+            try {
+                $this->database->migrateTableToEngine($table_name);
+            } catch (\ilDatabaseException $e) {
+                throw new ilException(
+                    "The migration of the following tables did throw errors, " .
+                    "please resolve the problem before you continue: \n" . $table_name . " -> " . $e->getMessage()
+                );
+            }
         }
     }
 

--- a/Services/Database/interfaces/interface.ilDBPdoInterface.php
+++ b/Services/Database/interfaces/interface.ilDBPdoInterface.php
@@ -37,7 +37,7 @@ interface ilDBPdoInterface extends ilDBInterface
 
     public function escapePattern(string $text): string;
 
-    public function migrateTableToEngine(string $table_name, string $engine = ilDBConstants::MYSQL_ENGINE_INNODB): bool;
+    public function migrateTableToEngine(string $table_name, string $engine = ilDBConstants::MYSQL_ENGINE_INNODB): void;
     /**
      * @return array of failed tables
      */


### PR DESCRIPTION
While executing the migrations on a local ILIAS installation I received an error while migration table `personal_pc_clipboard`. The actual problem was not shown, so I suggest to print the exception message with this PR.

The actual issue was:

> An undefined Database Exception occured. SQLSTATE[42000]: Syntax error or access      
         violation: 1067 Invalid default value for 'insert_time' 

If approved, this should be cherry-picked to `release_8` as  well.