### PR TITLE
Services/Component: Ignore dot files and non-directories in plugin scan

### DIFF
--- a/Services/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
@@ -36,10 +36,16 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
         foreach (["Modules", "Services"] as $type) {
             $components = $this->scanDir(static::BASE_PATH . $type);
             foreach ($components as $component) {
+                if ($this->isDotFile($component)
+                    || ! $this->isDir(static::BASE_PATH . "$type/$component")) continue;
                 $slots = $this->scanDir(static::BASE_PATH . "$type/$component");
                 foreach ($slots as $slot) {
+                    if ($this->isDotFile($slot)
+                        || ! $this->isDir(static::BASE_PATH . "$type/$component/$slot")) continue;
                     $plugins = $this->scanDir(static::BASE_PATH . "$type/$component/$slot");
                     foreach ($plugins as $plugin) {
+                        if ($this->isDotFile($plugin)
+                            || ! $this->isDir(static::BASE_PATH . "$type/$component/$slot/$plugin")) continue;
                         $this->addPlugin($data, $type, $component, $slot, $plugin);
                     }
                 }
@@ -116,6 +122,16 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
     protected function fileExists(string $path): bool
     {
         return file_exists($path) && is_file($path);
+    }
+
+    protected function isDir(string $dir): bool
+    {
+        return file_exists($dir) && is_dir($dir);
+    }
+
+    protected function isDotFile(string $file): bool
+    {
+        return ( substr($file, 0, 1) === '.' );
     }
 
     protected function buildPluginPath(string $type, string $component, string $slot, string $plugin): string

--- a/Services/Component/test/Setup/ilComponentBuildPluginInfoObjectiveTest.php
+++ b/Services/Component/test/Setup/ilComponentBuildPluginInfoObjectiveTest.php
@@ -44,6 +44,18 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
             {
                 return parent::scanDir($dir);
             }
+            protected function isDir(string $dir): bool
+            {
+                return true;
+            }
+            public function _isDir(string $dir): bool
+            {
+                return parent::isDir($dir);
+            }
+            public function _isDotFile(string $file): bool
+            {
+                return parent::isDotFile($file);
+            }
             protected function buildPluginPath(string $type, string $component, string $slot, string $plugin): string
             {
                 return $this->test->files[parent::buildPluginPath($type, $component, $slot, $plugin)];
@@ -81,7 +93,7 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
             "Services" => ["Service1"],
             "Modules/Module1" => ["Slot1", "Slot2"],
             "Modules/Module2" => [],
-            "Services/Service1" => ["Slot3"]
+            "Services/Service1" => ["Slot3",".DS_Store"] // .DS_Store should be skipped
         ];
 
         $this->builder->build();
@@ -127,6 +139,21 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
                 ["artifacts", ".DS_Store"] // .DS_Store is a macOS artifact which is not relevant for the test.
             )
         );
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testIsDir(): void
+    {
+        // Use the component directory, because this should be mostly stable.
+        $expected = true;
+        $actual = $this->builder->_isDir(__DIR__ . "/../..");
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testIsDotFile(): void
+    {
+        $expected = true;
+        $actual = $this->builder->_isDotFile(".DS_Store");
         $this->assertEquals($expected, $actual);
     }
 


### PR DESCRIPTION
This is a follow-up for #5548 and implements the change as suggested by @klees in the comments.

I also tried solving this via `src/Filesystem/Finder`, as that would ignore dot files by default and make scanning for only directories a bit easier. But as this objective is achieved when building artifacts (e.g. via `composer du`), the global $DIC is not initialised and therefore the Filesystem is not available at `$DIC->filesystem()`.

I considered doing the initialisation of the Filesystem manually in the Objective, but after going through its setup in `ilInitialisation::initIlias()`, I found it depends on a Factory which then depends on a FilenameSanitizer and that depends on reading the ILIAS settings ... so I gave up :)

If anybody has an idea on how to make accessing `src/Filesystem` inside the Objective easier, I would like to hear your input on this.