### PR TITLE
T&A #32195: Specific Feedback for Each Answer provided: Not necessa…

### DIFF
--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2278,7 +2278,6 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
     }
     // fau;
 
-
     /**
      * @see ilAssQuestionPreviewGUI::handleInstantResponseRendering()
      */
@@ -2343,8 +2342,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
             if ($questionGui->hasInlineFeedback()) {
                 // Don't jump to the feedback below the question if some feedback is shown within the question
                 $jump_to_response = false;
-            }
-            elseif ($this->populateSpecificFeedbackBlock($questionGui)) {
+            } elseif ($this->populateSpecificFeedbackBlock($questionGui)) {
                 $response_available = true;
                 $jump_to_response = true;
             }
@@ -2352,7 +2350,11 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
         $this->populateFeedbackBlockHeader($jump_to_response);
         if (!$response_available) {
-            $this->populateFeedbackMissingMessage();
+            if ($questionGui->hasInlineFeedback()) {
+                $this->populateFeedbackBlockMessage($this->lng->txt('tst_feedback_is_given_inline'));
+            } else {
+                $this->populateFeedbackBlockMessage($this->lng->txt('tst_feedback_not_available_for_answer'));
+            }
         }
     }
 
@@ -2369,10 +2371,10 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         $this->tpl->parseCurrentBlock();
     }
 
-    protected function populateFeedbackMissingMessage()
+    protected function populateFeedbackBlockMessage(string $a_message)
     {
-        $this->tpl->setCurrentBlock('instant_response_missing');
-        $this->tpl->setVariable('INSTANT_RESPONSE_MISSING', $this->lng->txt('tst_feedback_not_available_for_answer'));
+        $this->tpl->setCurrentBlock('instant_response_message');
+        $this->tpl->setVariable('INSTANT_RESPONSE_MESSAGE', $a_message);
         $this->tpl->parseCurrentBlock();
     }
 

--- a/Modules/Test/templates/default/tpl.il_as_tst_output.html
+++ b/Modules/Test/templates/default/tpl.il_as_tst_output.html
@@ -49,9 +49,9 @@
 						<!-- END inst_resp_id -->><h2 class="ilc_page_title_PageTitle">{INSTANT_RESPONSE_HEADER}</h2>
 					</div>
 					<!-- END instant_response_header -->
-					<!-- BEGIN instant_response_missing -->
-					<p>{INSTANT_RESPONSE_MISSING}</p>
-					<!-- END instant_response_missing -->
+					<!-- BEGIN instant_response_message -->
+					<p>{INSTANT_RESPONSE_MESSAGE}</p>
+					<!-- END instant_response_message -->
 					<!-- BEGIN received_points_information -->
 					<p>{RECEIVED_POINTS_INFORMATION}</p>
 					<!-- END received_points_information -->

--- a/Modules/Test/templates/default/tpl.il_as_tst_output.html
+++ b/Modules/Test/templates/default/tpl.il_as_tst_output.html
@@ -49,6 +49,9 @@
 						<!-- END inst_resp_id -->><h2 class="ilc_page_title_PageTitle">{INSTANT_RESPONSE_HEADER}</h2>
 					</div>
 					<!-- END instant_response_header -->
+					<!-- BEGIN instant_response_missing -->
+					<p>{INSTANT_RESPONSE_MISSING}</p>
+					<!-- END instant_response_missing -->
 					<!-- BEGIN received_points_information -->
 					<p>{RECEIVED_POINTS_INFORMATION}</p>
 					<!-- END received_points_information -->

--- a/Modules/Test/templates/default/tpl.tst_player_response_modal.html
+++ b/Modules/Test/templates/default/tpl.tst_player_response_modal.html
@@ -3,6 +3,9 @@
 <!-- BEGIN instant_response_header -->
 <div<!-- BEGIN inst_resp_id --> id="{INSTANT_RESPONSE_FOCUS_ID}"<!-- END inst_resp_id -->><h1 class="ilc_page_title_PageTitle">{INSTANT_RESPONSE_HEADER}</h1></div>
 <!-- END instant_response_header -->
+<!-- BEGIN instant_response_missing -->
+<p>{INSTANT_RESPONSE_MISSING}</p>
+<!-- END instant_response_missing -->
 <!-- BEGIN received_points_information -->
 <p>{RECEIVED_POINTS_INFORMATION}</p>
 <!-- END received_points_information -->

--- a/Modules/Test/templates/default/tpl.tst_player_response_modal.html
+++ b/Modules/Test/templates/default/tpl.tst_player_response_modal.html
@@ -3,9 +3,9 @@
 <!-- BEGIN instant_response_header -->
 <div<!-- BEGIN inst_resp_id --> id="{INSTANT_RESPONSE_FOCUS_ID}"<!-- END inst_resp_id -->><h1 class="ilc_page_title_PageTitle">{INSTANT_RESPONSE_HEADER}</h1></div>
 <!-- END instant_response_header -->
-<!-- BEGIN instant_response_missing -->
-<p>{INSTANT_RESPONSE_MISSING}</p>
-<!-- END instant_response_missing -->
+<!-- BEGIN instant_response_message -->
+<p>{INSTANT_RESPONSE_MESSAGE}</p>
+<!-- END instant_response_message -->
 <!-- BEGIN received_points_information -->
 <p>{RECEIVED_POINTS_INFORMATION}</p>
 <!-- END received_points_information -->

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -347,17 +347,28 @@ class ilAssQuestionPreviewGUI
             if ($this->questionGUI->hasInlineFeedback()) {
                 // Don't jump to the feedback below the question if some feedback is shown within the question
                 $jump_to_response = false;
-            }
-            else if ($this->populateSpecificQuestionFeedback($tpl)) {
-                $response_available = true;
-                $jump_to_response = true;
+            } else {
+                if ($this->populateSpecificQuestionFeedback($tpl)) {
+                    $response_available = true;
+                    $jump_to_response = true;
+                }
             }
         }
 
         if ($response_required) {
             $this->populateInstantResponseHeader($tpl, $jump_to_response);
             if (!$response_available) {
-                $this->populateInstantResponseMissing($tpl);
+                if ($this->questionGUI->hasInlineFeedback()) {
+                    $this->populateInstantResponseMessage(
+                        $tpl,
+                        $this->lng->txt('tst_feedback_is_given_inline')
+                    );
+                } else {
+                    $this->populateInstantResponseMessage(
+                        $tpl,
+                        $this->lng->txt('tst_feedback_not_available_for_answer')
+                    );
+                }
             }
         }
     }
@@ -576,10 +587,10 @@ class ilAssQuestionPreviewGUI
         $tpl->parseCurrentBlock();
     }
 
-    protected function populateInstantResponseMissing(ilTemplate $tpl)
+    protected function populateInstantResponseMessage(ilTemplate $tpl, string $a_message)
     {
-        $tpl->setCurrentBlock('instant_response_missing');
-        $tpl->setVariable('INSTANT_RESPONSE_MISSING', $this->lng->txt('tst_feedback_not_available_for_answer'));
+        $tpl->setCurrentBlock('instant_response_message');
+        $tpl->setVariable('INSTANT_RESPONSE_MESSAGE', $a_message);
         $tpl->parseCurrentBlock();
     }
 

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -310,42 +310,55 @@ class ilAssQuestionPreviewGUI
         $this->questionGUI->assessment();
     }
 
+    /**
+     * @see ilTestPlayerAbstractGUI::populateInstantResponseBlocks()
+     */
     protected function handleInstantResponseRendering(ilTemplate $tpl)
     {
-        $renderHeader = false;
-        $renderAnchor = false;
+        $response_required = false;
+        $response_available = false;
+        $jump_to_response = false;
 
         if ($this->isShowReachedPointsRequired()) {
             $this->populateReachedPointsOutput($tpl);
-            $renderAnchor = true;
-            $renderHeader = true;
+            $response_required = true;
+            $response_available = true;
+            $jump_to_response = true;
         }
 
         if ($this->isShowBestSolutionRequired()) {
             $this->populateSolutionOutput($tpl);
-            $renderAnchor = true;
-            $renderHeader = true;
+            $response_required = true;
+            $response_available = true;
+            $jump_to_response = true;
         }
 
         if ($this->isShowGenericQuestionFeedbackRequired()) {
-            $this->populateGenericQuestionFeedback($tpl);
-            $renderAnchor = true;
-            $renderHeader = true;
-        }
-
-        if ($this->isShowSpecificQuestionFeedbackRequired()) {
-            $renderHeader = true;
-
-            if ($this->questionGUI->hasInlineFeedback()) {
-                $renderAnchor = false;
-            } else {
-                $this->populateSpecificQuestionFeedback($tpl);
-                $renderAnchor = true;
+            $response_required = true;
+            if ($this->populateGenericQuestionFeedback($tpl)) {
+                $response_available = true;
+                $jump_to_response = true;
             }
         }
 
-        if ($renderHeader) {
-            $this->populateInstantResponseHeader($tpl, $renderAnchor);
+        if ($this->isShowSpecificQuestionFeedbackRequired()) {
+            $response_required = true;
+
+            if ($this->questionGUI->hasInlineFeedback()) {
+                // Don't jump to the feedback below the question if some feedback is shown within the question
+                $jump_to_response = false;
+            }
+            else if ($this->populateSpecificQuestionFeedback($tpl)) {
+                $response_available = true;
+                $jump_to_response = true;
+            }
+        }
+
+        if ($response_required) {
+            $this->populateInstantResponseHeader($tpl, $jump_to_response);
+            if (!$response_available) {
+                $this->populateInstantResponseMissing($tpl);
+            }
         }
     }
 
@@ -507,7 +520,11 @@ class ilAssQuestionPreviewGUI
         return $this->ctrl->getHTML($navGUI);
     }
 
-    private function populateGenericQuestionFeedback(ilTemplate $tpl)
+    /**
+     * Populate the block for an instant generic feedback
+     * @return bool     true, if there is some feedback populated
+     */
+    private function populateGenericQuestionFeedback(ilTemplate $tpl) : bool
     {
         if ($this->questionOBJ->isPreviewSolutionCorrect($this->previewSession)) {
             $feedback = $this->questionGUI->getGenericFeedbackOutputForCorrectSolution();
@@ -522,18 +539,28 @@ class ilAssQuestionPreviewGUI
             $tpl->setVariable('GENERIC_FEEDBACK', $feedback);
             $tpl->setVariable('ILC_FB_CSS_CLASS', $cssClass);
             $tpl->parseCurrentBlock();
+            return true;
         }
+        return false;
     }
 
-    private function populateSpecificQuestionFeedback(ilTemplate $tpl)
+    /**
+     * Populate the block for an instant specific feedback
+     * @return bool     true, if there is some feedback populated
+     */
+    private function populateSpecificQuestionFeedback(ilTemplate $tpl) : bool
     {
         $fb = $this->questionGUI->getSpecificFeedbackOutput(
             (array) $this->previewSession->getParticipantsSolution()
         );
 
-        $tpl->setCurrentBlock('instant_feedback_specific');
-        $tpl->setVariable('ANSWER_FEEDBACK', $fb);
-        $tpl->parseCurrentBlock();
+        if (!empty($fb)) {
+            $tpl->setCurrentBlock('instant_feedback_specific');
+            $tpl->setVariable('ANSWER_FEEDBACK', $fb);
+            $tpl->parseCurrentBlock();
+            return true;
+        }
+        return false;
     }
 
     protected function populateInstantResponseHeader(ilTemplate $tpl, $withFocusAnchor)
@@ -546,6 +573,13 @@ class ilAssQuestionPreviewGUI
 
         $tpl->setCurrentBlock('instant_response_header');
         $tpl->setVariable('INSTANT_RESPONSE_HEADER', $this->lng->txt('tst_feedback'));
+        $tpl->parseCurrentBlock();
+    }
+
+    protected function populateInstantResponseMissing(ilTemplate $tpl)
+    {
+        $tpl->setCurrentBlock('instant_response_missing');
+        $tpl->setVariable('INSTANT_RESPONSE_MISSING', $this->lng->txt('tst_feedback_not_available_for_answer'));
         $tpl->parseCurrentBlock();
     }
 

--- a/Modules/TestQuestionPool/templates/default/tpl.qpl_question_preview.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.qpl_question_preview.html
@@ -4,7 +4,10 @@
 		{QUESTION_OUTPUT}
 		<!-- BEGIN instant_response_header -->
 			<div<!-- BEGIN inst_resp_id --> id="{INSTANT_RESPONSE_FOCUS_ID}"<!-- END inst_resp_id -->><h2 class="ilc_page_title_PageTitle">{INSTANT_RESPONSE_HEADER}</h2></div>
-		<!-- END instant_response_header -->
+	<!-- END instant_response_header -->
+		<!-- BEGIN instant_response_missing -->
+			<p>{INSTANT_RESPONSE_MISSING}</p>
+		<!-- END instant_response_missing -->
 		<!-- BEGIN instant_feedback_generic -->
 			<div class="{ILC_FB_CSS_CLASS}">{GENERIC_FEEDBACK}</div>
 		<!-- END instant_feedback_generic -->

--- a/Modules/TestQuestionPool/templates/default/tpl.qpl_question_preview.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.qpl_question_preview.html
@@ -5,9 +5,9 @@
 		<!-- BEGIN instant_response_header -->
 			<div<!-- BEGIN inst_resp_id --> id="{INSTANT_RESPONSE_FOCUS_ID}"<!-- END inst_resp_id -->><h2 class="ilc_page_title_PageTitle">{INSTANT_RESPONSE_HEADER}</h2></div>
 	<!-- END instant_response_header -->
-		<!-- BEGIN instant_response_missing -->
-			<p>{INSTANT_RESPONSE_MISSING}</p>
-		<!-- END instant_response_missing -->
+		<!-- BEGIN instant_response_message -->
+			<p>{INSTANT_RESPONSE_MESSAGE}</p>
+		<!-- END instant_response_message -->
 		<!-- BEGIN instant_feedback_generic -->
 			<div class="{ILC_FB_CSS_CLASS}">{GENERIC_FEEDBACK}</div>
 		<!-- END instant_feedback_generic -->

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1439,7 +1439,7 @@ assessment#:#tst_failed#:#Durchgefallen
 assessment#:#tst_failed_imp_qst_skl_assign#:#Die Zuweisungen der Fragen zu folgenden Kompetenzen konnte durch den Import nicht hergestellt werden. Die entsprechenden Kompetenzen konnten im hiesigen System nicht identifiziert werden.
 assessment#:#tst_failed_imp_skl_thresholds#:#Der Import der Schwellenwerte für folgende Kompetenzen wurde übersprungen, weil die zugehörige Kompetenz im lokalen System eine abweichende Liste von Ausprägungen aufweist.
 assessment#:#tst_feedback#:#Rückmeldung
-assessment#:#tst_feedback_is_given_inline#:#Die Rückmeldung wird bei Ihrer Antwort angezeigt.
+assessment#:#tst_feedback_is_given_inline#:#Die Rückmeldung wird direkt unter Ihrer Antwort angezeigt.
 assessment#:#tst_feedback_not_available_for_answer#:#Für Ihre Antwort ist keine Rückmeldung verfügbar.
 assessment#:#tst_filter_lifecycle_enabled#:#Filter „Lebenszyklus“ verwenden
 assessment#:#tst_filter_question_type#:#Fragentyp

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1440,6 +1440,7 @@ assessment#:#tst_failed_imp_qst_skl_assign#:#Die Zuweisungen der Fragen zu folge
 assessment#:#tst_failed_imp_skl_thresholds#:#Der Import der Schwellenwerte für folgende Kompetenzen wurde übersprungen, weil die zugehörige Kompetenz im lokalen System eine abweichende Liste von Ausprägungen aufweist.
 assessment#:#tst_feedback#:#Rückmeldung
 assessment#:#tst_feedback_not_available_for_answer#:#Für Ihre Antwort ist keine Rückmeldung verfügbar.
+assessment#:#tst_feedback_is_given_inline#:#Die Rückmeldung wird bei Ihrer Antwort angezeigt.
 assessment#:#tst_filter_lifecycle_enabled#:#Filter „Lebenszyklus“ verwenden
 assessment#:#tst_filter_question_type#:#Fragentyp
 assessment#:#tst_filter_question_type_enabled#:#Fragentyp Filter verwenden

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1439,6 +1439,7 @@ assessment#:#tst_failed#:#Durchgefallen
 assessment#:#tst_failed_imp_qst_skl_assign#:#Die Zuweisungen der Fragen zu folgenden Kompetenzen konnte durch den Import nicht hergestellt werden. Die entsprechenden Kompetenzen konnten im hiesigen System nicht identifiziert werden.
 assessment#:#tst_failed_imp_skl_thresholds#:#Der Import der Schwellenwerte für folgende Kompetenzen wurde übersprungen, weil die zugehörige Kompetenz im lokalen System eine abweichende Liste von Ausprägungen aufweist.
 assessment#:#tst_feedback#:#Rückmeldung
+assessment#:#tst_feedback_not_available_for_answer#:#Für Ihre Antwort ist keine Rückmeldung verfügbar.
 assessment#:#tst_filter_lifecycle_enabled#:#Filter „Lebenszyklus“ verwenden
 assessment#:#tst_filter_question_type#:#Fragentyp
 assessment#:#tst_filter_question_type_enabled#:#Fragentyp Filter verwenden

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1439,8 +1439,8 @@ assessment#:#tst_failed#:#Durchgefallen
 assessment#:#tst_failed_imp_qst_skl_assign#:#Die Zuweisungen der Fragen zu folgenden Kompetenzen konnte durch den Import nicht hergestellt werden. Die entsprechenden Kompetenzen konnten im hiesigen System nicht identifiziert werden.
 assessment#:#tst_failed_imp_skl_thresholds#:#Der Import der Schwellenwerte für folgende Kompetenzen wurde übersprungen, weil die zugehörige Kompetenz im lokalen System eine abweichende Liste von Ausprägungen aufweist.
 assessment#:#tst_feedback#:#Rückmeldung
-assessment#:#tst_feedback_not_available_for_answer#:#Für Ihre Antwort ist keine Rückmeldung verfügbar.
 assessment#:#tst_feedback_is_given_inline#:#Die Rückmeldung wird bei Ihrer Antwort angezeigt.
+assessment#:#tst_feedback_not_available_for_answer#:#Für Ihre Antwort ist keine Rückmeldung verfügbar.
 assessment#:#tst_filter_lifecycle_enabled#:#Filter „Lebenszyklus“ verwenden
 assessment#:#tst_filter_question_type#:#Fragentyp
 assessment#:#tst_filter_question_type_enabled#:#Fragentyp Filter verwenden

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1440,8 +1440,8 @@ assessment#:#tst_failed#:#Failed
 assessment#:#tst_failed_imp_qst_skl_assign#:#The question's assignments to the following competences could not be created. The according competences could not be identified within the local system.
 assessment#:#tst_failed_imp_skl_thresholds#:#The Import of thresholds for the following competences were skipped, because the according competences within the local system are configured with a different list of levels.
 assessment#:#tst_feedback#:#Feedback
-assessment#:#tst_feedback_not_available_for_answer#:#There is no feedback available for your answer.
 assessment#:#tst_feedback_is_given_inline#:#The feedback is given in your answer.
+assessment#:#tst_feedback_not_available_for_answer#:#There is no feedback available for your answer.
 assessment#:#tst_filter_lifecycle_enabled#:#Use Lifecycle as Filter
 assessment#:#tst_filter_question_type#:#Question Type
 assessment#:#tst_filter_question_type_enabled#:#Use Question Type as Filter

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1440,7 +1440,7 @@ assessment#:#tst_failed#:#Failed
 assessment#:#tst_failed_imp_qst_skl_assign#:#The question's assignments to the following competences could not be created. The according competences could not be identified within the local system.
 assessment#:#tst_failed_imp_skl_thresholds#:#The Import of thresholds for the following competences were skipped, because the according competences within the local system are configured with a different list of levels.
 assessment#:#tst_feedback#:#Feedback
-assessment#:#tst_feedback_is_given_inline#:#The feedback is given in your answer.
+assessment#:#tst_feedback_is_given_inline#:#The feedback will be displayed along with your answer.
 assessment#:#tst_feedback_not_available_for_answer#:#There is no feedback available for your answer.
 assessment#:#tst_filter_lifecycle_enabled#:#Use Lifecycle as Filter
 assessment#:#tst_filter_question_type#:#Question Type

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1440,6 +1440,7 @@ assessment#:#tst_failed#:#Failed
 assessment#:#tst_failed_imp_qst_skl_assign#:#The question's assignments to the following competences could not be created. The according competences could not be identified within the local system.
 assessment#:#tst_failed_imp_skl_thresholds#:#The Import of thresholds for the following competences were skipped, because the according competences within the local system are configured with a different list of levels.
 assessment#:#tst_feedback#:#Feedback
+assessment#:#tst_feedback_not_available_for_answer#:#There is no feedback available for your answer.
 assessment#:#tst_filter_lifecycle_enabled#:#Use Lifecycle as Filter
 assessment#:#tst_filter_question_type#:#Question Type
 assessment#:#tst_filter_question_type_enabled#:#Use Question Type as Filter

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1441,6 +1441,7 @@ assessment#:#tst_failed_imp_qst_skl_assign#:#The question's assignments to the f
 assessment#:#tst_failed_imp_skl_thresholds#:#The Import of thresholds for the following competences were skipped, because the according competences within the local system are configured with a different list of levels.
 assessment#:#tst_feedback#:#Feedback
 assessment#:#tst_feedback_not_available_for_answer#:#There is no feedback available for your answer.
+assessment#:#tst_feedback_is_given_inline#:#The feedback is given in your answer.
 assessment#:#tst_filter_lifecycle_enabled#:#Use Lifecycle as Filter
 assessment#:#tst_filter_question_type#:#Question Type
 assessment#:#tst_filter_question_type_enabled#:#Use Question Type as Filter


### PR DESCRIPTION
…ry "Feedback" Headline visible

Proposal:
Instead of hiding the headline (which would result in no visible action after clicking 'check'), a message is shown: 'There is no feedback available for your answer.' The message is always shown if the content under the headline would be empty.

Mantis: https://mantis.ilias.de/view.php?id=32195