### PR TITLE
Migrate DCL files from File-Objects to direct Access

### DIFF
--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordFieldModel.php
@@ -188,7 +188,7 @@ class ilDclBaseRecordFieldModel
      */
     public function deserializeData($value)
     {
-        $deserialize = json_decode($value, true);
+        $deserialize = json_decode($value ?? '', true);
         if (is_array($deserialize)) {
             return $deserialize;
         }

--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordModel.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordModel.php
@@ -13,8 +13,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 use ILIAS\Notes\Service;
 
@@ -628,10 +627,6 @@ class ilDclBaseRecordModel
 
         $this->loadRecordFields();
         foreach ($this->recordfields as $recordfield) {
-            if ($recordfield->getField()->getDatatypeId() == ilDclDatatype::INPUTFORMAT_FILE) {
-                $this->deleteFile((int)$recordfield->getValue());
-            }
-
             if ($recordfield->getField()->getDatatypeId() == ilDclDatatype::INPUTFORMAT_MOB) {
                 $this->deleteMob((int)$recordfield->getValue());
             }

--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclDatatype.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclDatatype.php
@@ -13,8 +13,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
  * Class ilDclDatatype
@@ -34,7 +33,7 @@ class ilDclDatatype
     public const INPUTFORMAT_REFERENCE = 3;
     public const INPUTFORMAT_BOOLEAN = 4;
     public const INPUTFORMAT_DATETIME = 5;
-    public const INPUTFORMAT_FILE = 6;
+    public const INPUTFORMAT_FILEUPLOAD = 6;
     public const INPUTFORMAT_RATING = 7;
     public const INPUTFORMAT_ILIAS_REF = 8;
     public const INPUTFORMAT_MOB = 9;
@@ -43,6 +42,7 @@ class ilDclDatatype
     public const INPUTFORMAT_PLUGIN = 12;
     public const INPUTFORMAT_TEXT_SELECTION = 14;
     public const INPUTFORMAT_DATE_SELECTION = 15;
+    public const INPUTFORMAT_FILE = 16;
 
     protected int $id = 0;
     protected string $title = "";

--- a/Modules/DataCollection/classes/Fields/File/class.ilDclFileFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/File/class.ilDclFileFieldModel.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ilDclFileFieldModel extends ilDclBaseFieldModel
+{
+    public function getRecordQuerySortObject(
+        string $direction = "asc",
+        bool $sort_by_status = false
+    ): ?ilDclRecordQueryObject {
+        $join_str = "LEFT JOIN il_dcl_record_field AS sort_record_field_{$this->getId()} ON (sort_record_field_{$this->getId()}.record_id = record.id AND sort_record_field_{$this->getId()}.field_id = "
+            . $this->db->quote($this->getId(), 'integer') . ") ";
+        $join_str .= "LEFT JOIN il_dcl_stloc{$this->getStorageLocation()}_value AS sort_stloc_{$this->getId()} ON (sort_stloc_{$this->getId()}.record_field_id = sort_record_field_{$this->getId()}.id) ";
+        $join_str .= "LEFT JOIN il_resource_revision AS sort_object_data_{$this->getId()} ON (sort_object_data_{$this->getId()}.rid = sort_stloc_{$this->getId()}.value) ";
+        $select_str = " sort_object_data_{$this->getId()}.title AS field_{$this->getId()},";
+
+        $record_query = new ilDclRecordQueryObject();
+        $record_query->setSelectStatement($select_str);
+        $record_query->setJoinStatement($join_str);
+        $record_query->setOrderStatement("field_{$this->getId()} " . $direction);
+
+        return $record_query;
+    }
+
+    public function allowFilterInListView(): bool
+    {
+        return false;
+    }
+
+    public function getValidFieldProperties(): array
+    {
+        return [ilDclBaseFieldModel::PROP_SUPPORTED_FILE_TYPES];
+    }
+
+    public function getSupportedExtensions(): array
+    {
+        if (!$this->hasProperty(ilDclBaseFieldModel::PROP_SUPPORTED_FILE_TYPES)) {
+            return [];
+        }
+
+        $file_types = $this->getProperty(ilDclBaseFieldModel::PROP_SUPPORTED_FILE_TYPES);
+
+        return $this->parseSupportedExtensions($file_types);
+    }
+
+    protected function parseSupportedExtensions(string $input_value): array
+    {
+        $supported_extensions = explode(",", $input_value);
+
+        $trim_function = function ($value) {
+            return trim(trim(strtolower($value)), ".");
+        };
+
+        return array_map($trim_function, $supported_extensions);
+    }
+}

--- a/Modules/DataCollection/classes/Fields/File/class.ilDclFileFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/File/class.ilDclFileFieldRepresentation.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ilDclFileFieldRepresentation extends ilDclBaseFieldRepresentation
+{
+    public function getInputField(
+        ilPropertyFormGUI $form,
+        ?int $record_id = null
+    ): ?ilFormPropertyGUI {
+        $input = new ilFileInputGUI(
+            $this->getField()->getTitle(),
+            'field_' . $this->getField()->getId()
+        );
+
+        $supported_suffixes = $this->getField()->getSupportedExtensions();
+        if (!empty($supported_suffixes)) {
+            $input->setSuffixes($supported_suffixes);
+        }
+
+        $input->setAllowDeletion(true);
+        $this->requiredWorkaroundForInputField($input, $record_id); // TODO CHeck
+
+        return $input;
+    }
+
+    private function requiredWorkaroundForInputField(
+        ilFileInputGUI $input,
+        ?int $record_id
+    ): void {
+        if ($record_id !== null) {
+            $record = ilDclCache::getRecordCache($record_id);
+        }
+
+        $this->setupInputField($input, $this->getField());
+
+        //WORKAROUND
+        // If field is from type file: if it's required but already has a value it is no longer required as the old value is taken as default without the form knowing about it.
+        if ($record_id !== null && $record->getId()) {
+            $field_value = $record->getRecordFieldValue((int)$this->getField()->getId());
+            if ($field_value) {
+                $input->setRequired(false);
+            }
+        }
+        // If this is an ajax request to return the form, input files are currently not supported
+        if ($this->ctrl->isAsynch()) {
+            $input->setDisabled(true);
+        }
+    }
+
+    protected function buildFieldCreationInput(
+        ilObjDataCollection $dcl,
+        string $mode = 'create'
+    ): ilRadioOption {
+        $opt = parent::buildFieldCreationInput($dcl, $mode);
+
+        $prop_filetype = new ilTextInputGUI(
+            $this->lng->txt('dcl_supported_filetypes'),
+            'prop_' . ilDclBaseFieldModel::PROP_SUPPORTED_FILE_TYPES
+        );
+        $prop_filetype->setInfo($this->lng->txt('dcl_supported_filetypes_desc'));
+
+        $opt->addSubItem($prop_filetype);
+
+        return $opt;
+    }
+}

--- a/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordFieldModel.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\ResourceStorage\Revision\Revision;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ilDclFileRecordFieldModel extends ilDclBaseRecordFieldModel
+{
+    use ilDclFileFieldHelper;
+
+    private const FILE_TMP_NAME = 'tmp_name';
+    private const FILE_NAME = "name";
+    private const FILE_TYPE = "type";
+
+    private \ILIAS\ResourceStorage\Services $irss;
+    private ilDataCollectionStakeholder $stakeholder;
+    private \ILIAS\FileUpload\FileUpload $upload;
+
+    public function __construct(ilDclBaseRecordModel $record, ilDclBaseFieldModel $field)
+    {
+        global $DIC;
+        parent::__construct($record, $field);
+        $this->stakeholder = new ilDataCollectionStakeholder();
+        $this->irss = $DIC->resourceStorage();
+        $this->upload = $DIC->upload();
+    }
+
+    public function getRecordRepresentation(): ?ilDclBaseRecordRepresentation
+    {
+        return new ilDclFileRecordPresentation($this);
+    }
+
+    public function parseValue($value)
+    {
+        if ($value === -1) { // marked for deletion.
+            return null;
+        }
+
+        $file = $value;
+
+        // Some general Request Information
+        $has_record_id = $this->http->wrapper()->query()->has('record_id');
+        $is_confirmed = $this->http->wrapper()->post()->has('save_confirmed');
+        $has_save_confirmation = ($this->getRecord()->getTable()->getSaveConfirmation() && !$has_record_id);
+
+        if (
+            is_array($file)
+            && isset($file[self::FILE_TMP_NAME])
+            && $file[self::FILE_TMP_NAME] !== ""
+            && (!$has_save_confirmation || $is_confirmed)
+        ) {
+            if ($has_save_confirmation) {
+                $ilfilehash = $this->http->wrapper()->post()->retrieve(
+                    'ilfilehash',
+                    $this->refinery->kindlyTo()->string()
+                );
+
+                $move_file = ilDclPropertyFormGUI::getTempFilename(
+                    $ilfilehash,
+                    'field_' . $this->getField()->getId(),
+                    $file[self::FILE_NAME],
+                    $file[self::FILE_TYPE]
+                );
+
+                $file_stream = ILIAS\Filesystem\Stream\Streams::ofResource(fopen($move_file, 'rb'));
+            } else {
+                $move_file = $file[self::FILE_TMP_NAME];
+
+                if (false === $this->upload->hasBeenProcessed()) {
+                    $this->upload->process();
+                }
+
+                if (false === $this->upload->hasUploads()) {
+                    throw new ilException($this->lng->txt('upload_error_file_not_found'));
+                }
+
+                $file_stream = Streams::ofResource(fopen($move_file, 'rb'));
+            }
+
+            $file_title = $file[self::FILE_NAME] ?? basename($move_file);
+
+            // Storing the File to the IRSS
+            $existing_value = $this->getValueForRepresentation();
+            if (
+                is_string($existing_value)
+                && ($rid = $this->irss->manage()->find($existing_value)) !== null
+            ) {
+                // Append to existing RID
+                $this->irss->manage()->appendNewRevisionFromStream(
+                    $rid,
+                    $file_stream,
+                    $this->stakeholder,
+                    $file_title
+                );
+            } else {
+                // Create new RID
+                $rid = $this->irss->manage()->stream(
+                    $file_stream,
+                    $this->stakeholder,
+                    $file_title
+                );
+            }
+
+            return $rid->serialize();
+        } else {
+            // handover for save-confirmation
+            if (is_array($file) && isset($file[self::FILE_TMP_NAME]) && $file[self::FILE_TMP_NAME] != "") {
+                return $file;
+            } else {
+                return $this->getValue();
+            }
+        }
+
+        return null;
+    }
+
+    public function addHiddenItemsToConfirmation(ilConfirmationGUI $confirmation): void
+    {
+        if (is_array($this->getValue())) {
+            foreach ($this->getValue() as $key => $value) {
+                $confirmation->addHiddenItem('field_' . $this->field->getId() . '[' . $key . ']', $value);
+            }
+        }
+    }
+
+    public function delete(): void
+    {
+        if (($rid = $this->valueToRID($this->value)) !== null) {
+            $this->irss->manage()->remove(
+                $rid,
+                $this->stakeholder
+            );
+        }
+
+        parent::delete();
+    }
+
+    public function setValue($value, bool $omit_parsing = false): void
+    {
+        $this->loadValue();
+
+        if (!$omit_parsing) {
+            $temporary = $this->parseValue($value);
+            $current = $this->value;
+            if ($temporary !== false) {
+                $this->value = $temporary;
+                if (
+                    $current
+                    && $current !== $temporary
+                    && ($rid = $this->valueToRID($value)) !== null
+                ) {
+                    $this->irss->manage()->remove(
+                        $rid,
+                        $this->stakeholder
+                    );
+                }
+            }
+        } else {
+            $this->value = $value;
+        }
+    }
+
+    public function parseExportValue($value)
+    {
+        return $this->valueToFileTitle($value);
+    }
+
+    public function parseSortingValue($value, bool $link = true)
+    {
+        return $this->valueToFileTitle($value);
+    }
+
+    public function afterClone(): void
+    {
+        $field = ilDclCache::getCloneOf($this->getField()->getId(), ilDclCache::TYPE_FIELD);
+        $record = ilDclCache::getCloneOf($this->getRecord()->getId(), ilDclCache::TYPE_RECORD);
+        $record_field = ilDclCache::getRecordFieldCache($record, $field);
+
+        if (!$record_field || !$record_field->getValue()) {
+            return;
+        }
+        $current = $this->valueToCurrentRevision($record_field->getValue());
+        if ($current !== null) {
+            $new_rid = $this->irss->manage()->clone($current->getIdentification());
+            $this->setValue($new_rid->serialize());
+            $this->doUpdate();
+        }
+    }
+}

--- a/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordPresentation.php
+++ b/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordPresentation.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ilDclFileRecordPresentation extends ilDclBaseRecordRepresentation
+{
+    use ilDclFileFieldHelper;
+
+    private \ILIAS\ResourceStorage\Services $irss;
+
+    public function __construct(ilDclBaseRecordFieldModel $record_field)
+    {
+        global $DIC;
+        parent::__construct($record_field);
+        $this->irss = $DIC->resourceStorage();
+    }
+
+    public function getSingleHTML(?array $options = null, bool $link = true): string
+    {
+        return $this->getHTML(true, $options ?? []);
+    }
+
+    public function getHTML(bool $link = true, array $options = []): string
+    {
+        $rid_string = $this->record_field->getValue();
+
+        if ($rid_string === null || is_array($rid_string)) {
+            return '';
+        }
+
+        $title = $this->valueToFileTitle($rid_string);
+
+        if ($title === '') {
+            return $this->lng->txt('file_not_found');
+        }
+
+        if ($link) {
+            $download_link = $this->buildDownloadLink();
+
+            return '<a href="' . $download_link . '">' . $title . '</a>';
+        }
+
+        return $title;
+    }
+
+    public function parseFormInput($value)
+    {
+        if ($value === null || is_array($value)) {
+            return '';
+        }
+        return $this->valueToFileTitle($value);
+    }
+
+    private function buildDownloadLink(): string
+    {
+        $record_field = $this->getRecordField();
+
+        $this->ctrl->setParameterByClass(
+            ilDclRecordListGUI::class,
+            "record_id",
+            $record_field->getRecord()->getId()
+        );
+        $this->ctrl->setParameterByClass(
+            ilDclRecordListGUI::class,
+            "field_id",
+            $record_field->getField()->getId()
+        );
+        return $this->ctrl->getLinkTargetByClass(
+            ilDclRecordListGUI::class,
+            "sendFile"
+        );
+    }
+}

--- a/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordPresentation.php
+++ b/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordPresentation.php
@@ -26,12 +26,14 @@ class ilDclFileRecordPresentation extends ilDclBaseRecordRepresentation
     use ilDclFileFieldHelper;
 
     private \ILIAS\ResourceStorage\Services $irss;
+    private \ILIAS\DI\UIServices $ui_services;
 
     public function __construct(ilDclBaseRecordFieldModel $record_field)
     {
         global $DIC;
         parent::__construct($record_field);
         $this->irss = $DIC->resourceStorage();
+        $this->ui_services = $DIC->ui();
     }
 
     public function getSingleHTML(?array $options = null, bool $link = true): string
@@ -54,9 +56,12 @@ class ilDclFileRecordPresentation extends ilDclBaseRecordRepresentation
         }
 
         if ($link) {
-            $download_link = $this->buildDownloadLink();
+            $link_component = $this->ui_services->factory()->link()->standard(
+                $title,
+                $this->buildDownloadLink()
+            );
 
-            return '<a href="' . $download_link . '">' . $title . '</a>';
+            return $this->ui_services->renderer()->render($link_component);
         }
 
         return $title;

--- a/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordQueryObject.php
+++ b/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordQueryObject.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ilDclFileRecordQueryObject extends ilDclRecordQueryObject
+{
+    public function applyCustomSorting(
+        ilDclBaseFieldModel $field,
+        array $all_records,
+        string $direction = 'asc'
+    ): array {
+        return $all_records;
+    }
+}

--- a/Modules/DataCollection/classes/Fields/File/trait.ilDclFileFieldHelper.php
+++ b/Modules/DataCollection/classes/Fields/File/trait.ilDclFileFieldHelper.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\ResourceStorage\Manager\Manager;
+use ILIAS\ResourceStorage\Revision\Revision;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+use ILIAS\ResourceStorage\Resource\StorableResource;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+trait ilDclFileFieldHelper
+{
+    private function valueToRID(?string $value): ?ResourceIdentification
+    {
+        if ($value !== null && ($rid = $this->irss->manage()->find($value)) !== null) {
+            return $rid;
+        }
+        return null;
+    }
+
+    private function valueToFileTitle(?string $value): string
+    {
+        return $this->valueToCurrentRevision($value)?->getTitle() ?? '';
+    }
+
+    private function valueToCurrentRevision(?string $value): ?Revision
+    {
+        $rid = $this->valueToRID($value);
+        if ($rid !== null) {
+            return $this->irss->manage()->getCurrentRevision($rid);
+        }
+
+        return null;
+    }
+
+    private function valueToResource(?string $value): ?StorableResource
+    {
+        $rid = $this->valueToRID($value);
+        if ($rid !== null) {
+            return $this->irss->manage()->getResource($rid);
+        }
+
+        return null;
+    }
+}

--- a/Modules/DataCollection/classes/Fields/Fileupload/class.ilDclFileuploadFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Fileupload/class.ilDclFileuploadFieldModel.php
@@ -13,13 +13,10 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
- * Class ilDclBooleanFieldModel
- * @author  Michael Herren <mh@studer-raimann.ch>
- * @version 1.0.0
+ * @deprecated use new type ilDCLFileFieldModel instead
  */
 class ilDclFileuploadFieldModel extends ilDclBaseFieldModel
 {

--- a/Modules/DataCollection/classes/Fields/Fileupload/class.ilDclFileuploadFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Fileupload/class.ilDclFileuploadFieldRepresentation.php
@@ -13,23 +13,18 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
- * Class ilDclFileuploadFieldRepresentaion
- * @author  Michael Herren <mh@studer-raimann.ch>
- * @version 1.0.0
+ * @deprecated
  */
 class ilDclFileuploadFieldRepresentation extends ilDclBaseFieldRepresentation
 {
     public function getInputField(ilPropertyFormGUI $form, ?int $record_id = null): ilFileInputGUI
     {
         $input = new ilFileInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
-        $input->setSuffixes($this->getField()->getSupportedExtensions());
-        $input->setAllowDeletion(true);
-
-        $this->requiredWorkaroundForInputField($input, $record_id);
+        $input->setInfo($this->lng->txt('fileupload_not_migrated'));
+        $input->setDisabled(true);
 
         return $input;
     }
@@ -60,7 +55,7 @@ class ilDclFileuploadFieldRepresentation extends ilDclBaseFieldRepresentation
      * @return array|string|null
      * @throws Exception
      */
-    public function addFilterInputFieldToTable(ilTable2GUI $table)
+    public function addFilterInputFieldToTable(ilTable2GUI $table) //todo
     {
         $input = $table->addFilterItemByMetaType(
             "filter_" . $this->getField()->getId(),
@@ -78,7 +73,7 @@ class ilDclFileuploadFieldRepresentation extends ilDclBaseFieldRepresentation
     /**
      * @param string $filter
      */
-    public function passThroughFilter(ilDclBaseRecordModel $record, $filter): bool
+    public function passThroughFilter(ilDclBaseRecordModel $record, $filter): bool //todo
     {
         $value = $record->getRecordFieldValue($this->getField()->getId());
         $pass = false;

--- a/Modules/DataCollection/classes/Fields/Fileupload/class.ilDclFileuploadRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Fileupload/class.ilDclFileuploadRecordFieldModel.php
@@ -20,10 +20,7 @@ use ILIAS\FileUpload\MimeType;
 use ILIAS\Filesystem\Stream\Streams;
 
 /**
- * Class ilDclBaseFieldModel
- * @author  Stefan Wanzenried <sw@studer-raimann.ch>
- * @author  Fabian Schmid <fs@studer-raimann.ch>
- * @version $Id:
+ * @deprecated
  */
 class ilDclFileuploadRecordFieldModel extends ilDclBaseRecordFieldModel
 {

--- a/Modules/DataCollection/classes/Fields/Fileupload/class.ilDclFileuploadRecordRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Fileupload/class.ilDclFileuploadRecordRepresentation.php
@@ -16,9 +16,7 @@
  *********************************************************************/
 
 /**
- * Class ilDclFileuploadRecordRepresentation
- * @author  Michael Herren <mh@studer-raimann.ch>
- * @version 1.0.0
+ * @deprecated
  */
 class ilDclFileuploadRecordRepresentation extends ilDclBaseRecordRepresentation
 {
@@ -27,53 +25,7 @@ class ilDclFileuploadRecordRepresentation extends ilDclBaseRecordRepresentation
      */
     public function getHTML(bool $link = true, array $options = []): string
     {
-        $value = $this->getRecordField()->getValue();
-
-        // the file is only temporary uploaded. Still need to be confirmed before stored
-        $has_ilfilehash = $this->http->wrapper()->post()->has('ilfilehash');
-        if (is_array($value) && $has_ilfilehash) {
-            $ilfilehash = $this->http->wrapper()->post()->retrieve('ilfilehash', $this->refinery->kindlyTo()->string());
-            $this->ctrl->setParameterByClass("ildclrecordlistgui", "ilfilehash", $ilfilehash);
-            $this->ctrl->setParameterByClass(
-                "ildclrecordlistgui",
-                "field_id",
-                $this->getRecordField()->getField()->getId()
-            );
-
-            return '<a href="' . $this->ctrl->getLinkTargetByClass(
-                "ildclrecordlistgui",
-                "sendFile"
-            ) . '">' . $value['name'] . '</a>';
-        } else {
-            if (!ilObject2::_exists((int)$value) || ilObject2::_lookupType($value, false) != "file") {
-                return "";
-            }
-        }
-
-        $file_obj = new ilObjFile($value, false);
-        $this->ctrl->setParameterByClass(
-            "ildclrecordlistgui",
-            "record_id",
-            $this->getRecordField()->getRecord()->getId()
-        );
-        $this->ctrl->setParameterByClass(
-            "ildclrecordlistgui",
-            "field_id",
-            $this->getRecordField()->getField()->getId()
-        );
-
-        $html = '<a href="' . $this->ctrl->getLinkTargetByClass(
-            "ildclrecordlistgui",
-            "sendFile"
-        ) . '">' . $file_obj->getFileName() . '</a>';
-
-        $preview= new ilObjFilePreviewRendererGUI($file_obj->getId());
-        if ($preview->has()) {
-            $html = '<div id="' . $wrapper_html_id . '">' . $html;
-            $html .= $preview->getRenderedTriggerComponents(false) . '</div>';
-        }
-
-        return $html;
+        return $this->lng->txt('fileupload_not_migrated');
     }
 
     /**

--- a/Modules/DataCollection/classes/Fields/NReference/class.ilDclNReferenceRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/NReference/class.ilDclNReferenceRecordFieldModel.php
@@ -13,8 +13,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
  * @author Oskar Truffer <ot@studer-raimann.ch>
@@ -83,7 +82,7 @@ class ilDclNReferenceRecordFieldModel extends ilDclReferenceRecordFieldModel
             $supported_internal_types = array(
                 ilDclDatatype::INPUTFORMAT_ILIAS_REF,
                 ilDclDatatype::INPUTFORMAT_MOB,
-                ilDclDatatype::INPUTFORMAT_FILE,
+                ilDclDatatype::INPUTFORMAT_FILEUPLOAD,
             );
 
             $supported_types = array_merge(
@@ -118,7 +117,7 @@ class ilDclNReferenceRecordFieldModel extends ilDclReferenceRecordFieldModel
                     $query .= " INNER JOIN object_data AS ilias_object ON ilias_object.obj_id = ilias_ref.obj_id ";
                     break;
                 case ilDclDatatype::INPUTFORMAT_MOB:
-                case ilDclDatatype::INPUTFORMAT_FILE:
+                case ilDclDatatype::INPUTFORMAT_FILEUPLOAD:
                     $query .= " INNER JOIN object_data AS ilias_object ON ilias_object.obj_id =  stlocRef.value ";
                     break;
             }

--- a/Modules/DataCollection/classes/Fields/Reference/class.ilDclReferenceFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Reference/class.ilDclReferenceFieldModel.php
@@ -13,8 +13,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
  * Class ilDclReferenceFieldModel
@@ -116,7 +115,7 @@ class ilDclReferenceFieldModel extends ilDclBaseFieldModel
         $ref_field = $this->getFieldRef();
 
         return !($ref_field->getDatatypeId() == ilDclDatatype::INPUTFORMAT_MOB
-            || $ref_field->getDatatypeId() == ilDclDatatype::INPUTFORMAT_FILE);
+            || $ref_field->getDatatypeId() == ilDclDatatype::INPUTFORMAT_FILEUPLOAD);
     }
 
     public function getFieldRef(): ilDclBaseFieldModel

--- a/Modules/DataCollection/classes/Fields/Reference/class.ilDclReferenceFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Reference/class.ilDclReferenceFieldRepresentation.php
@@ -13,8 +13,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
  * Class ilDclTextFieldRepresentation
@@ -53,7 +52,7 @@ class ilDclReferenceFieldRepresentation extends ilDclBaseFieldRepresentation
         foreach ($reftable->getRecords() as $record) {
             // If the referenced field is MOB or FILE, we display the filename in the dropdown
             switch ($reffield->getDatatypeId()) {
-                case ilDclDatatype::INPUTFORMAT_FILE:
+                case ilDclDatatype::INPUTFORMAT_FILEUPLOAD:
                     $file_obj = new ilObjFile($record->getRecordFieldValue($fieldref), false);
                     $options[$record->getId()] = $file_obj->getFileName();
                     break;

--- a/Modules/DataCollection/classes/Fields/class.ilDclFieldFactory.php
+++ b/Modules/DataCollection/classes/Fields/class.ilDclFieldFactory.php
@@ -13,8 +13,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
  * Class ilDclFieldFactory
@@ -246,6 +245,12 @@ class ilDclFieldFactory
                 $fieldtype = self::$default_prefix . ucfirst(self::parseDatatypeTitle($datatype->getTitle()));
             }
             self::$field_type_cache[$datatype->getId()][$field->getId()] = $fieldtype;
+        } elseif ($field->getDatatypeId() == ilDclDatatype::INPUTFORMAT_FILEUPLOAD) {
+            // This is for legacy reasons. The fileupload field was replaced with ilDclDatatype::INPUTFORMAT_FILE in
+            // ILIAS 9, but must be available for one more release, since there might be records with this field type
+            // which have not et been migrated.
+            $fieldtype = self::$default_prefix . ucfirst('Fileupload');
+            self::$field_type_cache[$field->getDatatypeId()] = $fieldtype;
         } else {
             $fieldtype = self::$default_prefix . ucfirst(self::parseDatatypeTitle($datatype->getTitle()));
             self::$field_type_cache[$datatype->getId()] = $fieldtype;
@@ -297,6 +302,29 @@ class ilDclFieldFactory
                     ucfirst(self::parseDatatypeTitle($datatype->getTitle()))
                 );
             }
+        } elseif ($field->getDatatypeId() == ilDclDatatype::INPUTFORMAT_FILEUPLOAD) {
+            // This is for legacy reasons. The fileupload field was replaced with ilDclDatatype::INPUTFORMAT_FILE in
+            // ILIAS 9, but must be available for one more release, since there might be records with this field type
+            // which have not et been migrated.
+            $class_path = sprintf(
+                self::$field_base_path_patter,
+                ucfirst(self::parseDatatypeTitle('Fileupload'))
+            );
+
+            $class_name = sprintf(
+                'class.' . self::$default_prefix . '%s.php',
+                sprintf(
+                    $class_pattern,
+                    ucfirst('Fileupload'),
+                )
+            );
+
+            $return = $class_path . $class_name;
+            if ($field->getId() != null) {
+                self::$class_path_cache[$field->getId()][$class_pattern] = $return;
+            }
+
+            return $return;
         } else {
             $class_path = sprintf(
                 self::$field_base_path_patter,

--- a/Modules/DataCollection/classes/Setup/class.ilDataCollectionDBUpdateSteps9.php
+++ b/Modules/DataCollection/classes/Setup/class.ilDataCollectionDBUpdateSteps9.php
@@ -27,44 +27,64 @@ class ilDataCollectionDBUpdateSteps9 implements \ilDatabaseUpdateSteps
 
     public function step_1(): void
     {
-        $this->db->manipulate("UPDATE il_dcl_tableview " .
+        $this->db->manipulate(
+            "UPDATE il_dcl_tableview " .
             "SET description=" . $this->db->quote("", "text") .
-            "WHERE description is null");
-        $this->db->modifyTableColumn("il_dcl_tableview", "description", [ 'notnull' => true,
-              'default' => '']);
+            "WHERE description is null"
+        );
+        $this->db->modifyTableColumn("il_dcl_tableview", "description", [
+            'notnull' => true,
+            'default' => ''
+        ]);
     }
 
     public function step_2(): void
     {
-        $this->db->manipulate("UPDATE il_dcl_tview_set " .
+        $this->db->manipulate(
+            "UPDATE il_dcl_tview_set " .
             "SET in_filter=0 " .
-            "WHERE in_filter is null");
-        $this->db->manipulate("UPDATE il_dcl_tview_set " .
+            "WHERE in_filter is null"
+        );
+        $this->db->manipulate(
+            "UPDATE il_dcl_tview_set " .
             "SET visible=0 " .
-            "WHERE visible is null");
-        $this->db->manipulate("UPDATE il_dcl_tview_set " .
+            "WHERE visible is null"
+        );
+        $this->db->manipulate(
+            "UPDATE il_dcl_tview_set " .
             "SET filter_changeable=0 " .
-            "WHERE filter_changeable is null");
-        $this->db->modifyTableColumn("il_dcl_tview_set", "in_filter", [ 'notnull' => true,
-                                                                          'default' => 0]);
-        $this->db->modifyTableColumn("il_dcl_tview_set", "visible", [ 'notnull' => true,
-                                                                        'default' => 0]);
-        $this->db->modifyTableColumn("il_dcl_tview_set", "filter_changeable", [ 'notnull' => true,
-                                                                      'default' => 0]);
+            "WHERE filter_changeable is null"
+        );
+        $this->db->modifyTableColumn("il_dcl_tview_set", "in_filter", [
+            'notnull' => true,
+            'default' => 0
+        ]);
+        $this->db->modifyTableColumn("il_dcl_tview_set", "visible", [
+            'notnull' => true,
+            'default' => 0
+        ]);
+        $this->db->modifyTableColumn("il_dcl_tview_set", "filter_changeable", [
+            'notnull' => true,
+            'default' => 0
+        ]);
     }
 
     public function step_3(): void
     {
-        $this->db->manipulate("UPDATE il_dcl_tfield_set " .
+        $this->db->manipulate(
+            "UPDATE il_dcl_tfield_set " .
             "SET exportable=0 " .
-            "WHERE exportable is null");
-        $this->db->modifyTableColumn("il_dcl_tfield_set", "exportable", [ 'notnull' => true,
-                                                                        'default' => 0]);
+            "WHERE exportable is null"
+        );
+        $this->db->modifyTableColumn("il_dcl_tfield_set", "exportable", [
+            'notnull' => true,
+            'default' => 0
+        ]);
     }
 
     public function step_4(): void
     {
-        $this->db->modifyTableColumn("il_dcl_stloc3_value", "value", [ 'notnull' => false]);
+        $this->db->modifyTableColumn("il_dcl_stloc3_value", "value", ['notnull' => false]);
     }
 
     public function step_5(): void
@@ -75,5 +95,25 @@ class ilDataCollectionDBUpdateSteps9 implements \ilDatabaseUpdateSteps
         if (!$this->db->indexExistsByFields('il_dcl_tview_set', array('tableview_id'))) {
             $this->db->addIndex('il_dcl_tview_set', array('tableview_id'), 'i1');
         }
+    }
+
+    public function step_6(): void
+    {
+        $this->db->insert("il_dcl_datatype", [
+            'id' => ['integer', ilDclDatatype::INPUTFORMAT_FILE],
+            'title' => ['text', 'file'],
+            'ildb_type' => ['text', 'text'],
+            'storage_location' => ['integer', 1], // string-storage location
+            'sort' => ['integer', 75], // legacy + 5
+        ]);
+    }
+
+    public function step_7(): void
+    {
+        $this->db->manipulateF(
+            "DELETE FROM il_dcl_datatype WHERE id = %s",
+            ['integer'],
+            [defined(ilDclDatatype::class . '::INPUTFORMAT_FILEUPLOAD') ? ilDclDatatype::INPUTFORMAT_FILEUPLOAD : 6]
+        );
     }
 }

--- a/Modules/DataCollection/classes/Setup/class.ilDataCollectionSetupAgent.php
+++ b/Modules/DataCollection/classes/Setup/class.ilDataCollectionSetupAgent.php
@@ -19,10 +19,17 @@
 use ILIAS\Setup;
 use ILIAS\Setup\Objective;
 
-class ilDataCollectionAgent extends Setup\Agent\NullAgent
+class ilDataCollectionSetupAgent extends Setup\Agent\NullAgent
 {
     public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
     {
         return new \ilDatabaseUpdateStepsExecutedObjective(new ilDataCollectionDBUpdateSteps9());
+    }
+
+    public function getMigrations(): array
+    {
+        return [
+            new ilDataCollectionStorageMigration()
+        ];
     }
 }

--- a/Modules/DataCollection/classes/Setup/class.ilDataCollectionStorageMigration.php
+++ b/Modules/DataCollection/classes/Setup/class.ilDataCollectionStorageMigration.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ilDataCollectionStorageMigration implements \ILIAS\Setup\Migration
+{
+    public const DEFAULT_AMOUNT_OF_STEPS = 10000;
+
+    protected ilResourceStorageMigrationHelper $helper;
+
+    /**
+     * @inheritDoc
+     */
+    public function getLabel(): string
+    {
+        return "Migration of DataCollection files to the Resource Storage Service.";
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDefaultAmountOfStepsPerRun(): int
+    {
+        return self::DEFAULT_AMOUNT_OF_STEPS;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPreconditions(\ILIAS\Setup\Environment $environment): array
+    {
+        return ilResourceStorageMigrationHelper::getPreconditions();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function prepare(\ILIAS\Setup\Environment $environment): void
+    {
+        $this->helper = new ilResourceStorageMigrationHelper(
+            new ilDataCollectionStakeholder(),
+            $environment
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function step(\ILIAS\Setup\Environment $environment): void
+    {
+        $integer_storage = "il_dcl_stloc2_value";
+        $string_storage = "il_dcl_stloc1_value";
+        $db = $this->helper->getDatabase();
+
+        // Find next field with a fileupload datatype.
+
+        $legacy_file_field = $db->fetchObject(
+            $db->query(
+                "SELECT * FROM il_dcl_field AS field WHERE datatype_id = 6 LIMIT 1;"
+            )
+        );
+
+        // Loop through all records of the field.
+        $legacy_file_records = $db->queryF(
+            "SELECT * FROM il_dcl_record_field AS record_field WHERE record_field.field_id = %s;",
+            ['integer'],
+            [$legacy_file_field->id]
+        );
+        while ($record = $db->fetchObject($legacy_file_records)) {
+            // Get the file id from the storage.
+            $legacy_file_record = $db->fetchObject(
+                $db->queryF(
+                    "SELECT id, rid, file_id, record_field_id 
+                    FROM $integer_storage AS storage 
+                    JOIN file_data AS file ON file.file_id = storage.value
+                    WHERE storage.record_field_id = %s;",
+                    ['integer'],
+                    [$record->id]
+                )
+            );
+
+            // Store RID as new value in string storage.
+            $rid = $legacy_file_record->rid;
+            $db->insert($string_storage, [
+                'id' => ['integer', $db->nextId($string_storage)],
+                'record_field_id' => ['integer', (int) $legacy_file_record->record_field_id],
+                'value' => ['text', $rid],
+            ]);
+
+            // Remove file_id from integer storage.
+            $db->manipulateF(
+                "DELETE FROM $integer_storage WHERE id = %s;",
+                ['integer'],
+                [(int) $legacy_file_record->id]
+            );
+
+            // Switch Stakeholder
+            $this->helper->moveResourceToNewStakeholderAndOwner(
+                new ResourceIdentification($rid),
+                new ilObjFileStakeholder(),
+                $this->helper->getStakeholder()
+            );
+
+            // Delete File-object
+            try {
+                $file_id = (int) $legacy_file_record->file_id;
+                $db->manipulateF(
+                    "DELETE FROM file_data WHERE file_id = %s",
+                    ['integer'],
+                    [$file_id]
+                );
+                $db->manipulateF(
+                    "DELETE FROM history WHERE obj_id = %s",
+                    ['integer'],
+                    [(int) $legacy_file_record->id]
+                );
+                $db->manipulateF(
+                    "DELETE FROM object_data WHERE obj_id = %s AND type = %s",
+                    ['integer', 'text'],
+                    [(int) $legacy_file_record->id, 'file']
+                );
+            } catch (Exception $e) {
+                continue;
+            }
+        }
+
+        // update datatype of legacy entry, so it now reads from string-storage.
+        $db->update("il_dcl_field", [
+            'datatype_id' => ['integer', ilDclDatatype::INPUTFORMAT_FILE],
+        ], [
+            'id' => ['integer', (int) $legacy_file_field->id],
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRemainingAmountOfSteps(): int
+    {
+        $legacy_file_field_amount = $this->helper->getDatabase()->fetchObject(
+            $this->helper->getDatabase()->query(
+                "SELECT COUNT(field.id) AS amount FROM il_dcl_field AS field WHERE field.datatype_id = 6;"
+            )
+        );
+
+        return (int) $legacy_file_field_amount?->amount;
+    }
+}

--- a/Modules/DataCollection/classes/Table/class.ilDclTable.php
+++ b/Modules/DataCollection/classes/Table/class.ilDclTable.php
@@ -14,8 +14,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
  * Class ilDclBaseFieldModel
@@ -561,7 +560,7 @@ class ilDclTable
             ilDclDatatype::INPUTFORMAT_MOB,
             ilDclDatatype::INPUTFORMAT_REFERENCELIST,
             ilDclDatatype::INPUTFORMAT_REFERENCE,
-            ilDclDatatype::INPUTFORMAT_FILE,
+            ilDclDatatype::INPUTFORMAT_FILEUPLOAD,
             ilDclDatatype::INPUTFORMAT_RATING,
         );
 

--- a/Modules/DataCollection/classes/class.ilDataCollectionDataSet.php
+++ b/Modules/DataCollection/classes/class.ilDataCollectionDataSet.php
@@ -13,8 +13,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
  * DataCollection dataset class
@@ -408,7 +407,7 @@ class ilDataCollectionDataSet extends ilDataSet
                                 $value = ($new_mob_id) ? (int) $new_mob_id : null;
                                 $this->import_temp_new_mob_ids[] = $new_mob_id;
                                 break;
-                            case ilDclDatatype::INPUTFORMAT_FILE:
+                            case ilDclDatatype::INPUTFORMAT_FILEUPLOAD:
                                 $new_file_id = $a_mapping->getMapping('Modules/File', 'file', $a_rec['value']);
                                 $value = ($new_file_id) ? (int) $new_file_id : null;
                                 break;

--- a/Modules/DataCollection/classes/class.ilDataCollectionExporter.php
+++ b/Modules/DataCollection/classes/class.ilDataCollectionExporter.php
@@ -13,8 +13,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
  * Class ilDataCollectionExporter
@@ -71,7 +70,7 @@ class ilDataCollectionExporter extends ilXmlExporter
     public function getXmlExportHeadDependencies(string $a_entity, string $a_target_release, array $a_ids): array
     {
         $dependencies = array(
-            ilDclDatatype::INPUTFORMAT_FILE => array(
+            ilDclDatatype::INPUTFORMAT_FILEUPLOAD => array(
                 'component' => 'Modules/File',
                 'entity' => 'file',
                 'ids' => array(),
@@ -105,8 +104,8 @@ class ilDataCollectionExporter extends ilXmlExporter
 
         // Return external dependencies/IDs if there are any
         $return = array();
-        if (count($dependencies[ilDclDatatype::INPUTFORMAT_FILE]['ids'])) {
-            $return[] = $dependencies[ilDclDatatype::INPUTFORMAT_FILE];
+        if (count($dependencies[ilDclDatatype::INPUTFORMAT_FILEUPLOAD]['ids'])) {
+            $return[] = $dependencies[ilDclDatatype::INPUTFORMAT_FILEUPLOAD];
         }
         if (count($dependencies[ilDclDatatype::INPUTFORMAT_MOB]['ids'])) {
             $return[] = $dependencies[ilDclDatatype::INPUTFORMAT_MOB];

--- a/Modules/DataCollection/classes/class.ilDataCollectionStakeholder.php
+++ b/Modules/DataCollection/classes/class.ilDataCollectionStakeholder.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ilDataCollectionStakeholder extends \ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder
+{
+    private int $owner;
+
+    public function __construct()
+    {
+        global $DIC;
+
+        $this->owner = $DIC->isDependencyAvailable('user') ? $DIC->user()->getId() : 6;
+    }
+
+    public function getId(): string
+    {
+        return "dcl_uploads";
+    }
+
+    public function getOwnerOfNewResources(): int
+    {
+        return $this->owner;
+    }
+}

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -8464,10 +8464,10 @@ dcl#:#dcl_field_title_change_warning#:#Sie haben den Titel des Feldes geändert.
 dcl#:#dcl_field_title_unique#:#Es existiert bereits ein Feld mit diesem Titel. Titel muss eindeutig sein.
 dcl#:#dcl_field_visible#:#Sichtbar
 dcl#:#dcl_fieldtitle#:#Feldtitel
+dcl#:#dcl_file#:#Datei-Upload
+dcl#:#dcl_file_desc#:#Möglichkeit zum Hochladen beliebiger Dateien, die per Link heruntergeladen werden können
 dcl#:#dcl_file_format_description#:#Die Import-Datei muss im Excel-Format .xlsx vorliegen, mit den zu importierenden Daten auf der ersten Seite. In der ersten Zeile müssen die exakten Namen der Felder stehen (inklusive Grossschreibung) und in den folgenden Zeilen die Werte der zu importierenden Datensatzeinträge. Es wird empfohlen, jeden Import zuerst zu simulieren. Für den Import von mehrfachen Einträgen bei Auswahlmenü-Feldern und Referenzfeldern werden Semikolon und/oder Komma als Trenner akzeptiert.
 dcl#:#dcl_file_not_readable#:#Die Datei konnte nicht gelesen werden. Bitte verwenden Sie das .xlsx-Dateiformat.
-dcl#:#dcl_fileupload#:#Datei-Upload
-dcl#:#dcl_fileupload_desc#:#Möglichkeit zum Hochladen beliebiger Dateien, die per Link heruntergeladen werden können
 dcl#:#dcl_filter#:#Im Filter verfügbar
 dcl#:#dcl_filter_changeable#:#Filter änderbar
 dcl#:#dcl_formula#:#Formel
@@ -8664,6 +8664,7 @@ dcl#:#dcl_wrong_length#:#Der eingegebene Text ist zu lang.
 dcl#:#dcl_wrong_regex#:#Der eingegebene Text passt nicht zur Spezifikation dieses Feldes (Regulärer Ausdruck).
 dcl#:#dlc_xls_async_export#:#Asynchroner XLSX export
 dcl#:#fieldtitle_allow_chars#:#Nicht Erlaubte Zeichen: %s
+dcl#:#fileupload_not_migrated#:#Die Datei wurde noch nicht migriert und kann nicht angezeigt werden. Bitte wenden Sie sich an Ihre System-Administration.
 didactic#:#activate_exclusive_template#:#Standard ausgrauen
 didactic#:#activate_exclusive_template_info#:#Die Standard-Vorlage wird überall dort ausgegraut, wo diese didaktische Vorlage aktiv ist.
 didactic#:#activate_local_didactic_template#:#Gültigkeitsbereich

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8465,10 +8465,10 @@ dcl#:#dcl_field_title_change_warning#:#You changed the title of the field hence 
 dcl#:#dcl_field_title_unique#:#There exists already a field with this title. Title must be unique.
 dcl#:#dcl_field_visible#:#Visible
 dcl#:#dcl_fieldtitle#:#Field Title
+dcl#:#dcl_file#:#Fileupload
+dcl#:#dcl_file_desc#:#Field to upload arbitrary files. They can be downloaded with a link.
 dcl#:#dcl_file_format_description#:#The file needs to be an excel .XLSX file with the data you want to import on the first sheet. In the first row there have to be exactly the names of the fields (case sensitive) you want to import and in the following rows you can add the values. It is strongly recommended to simulate your import first. When importing reference or selection fields with multi selection, commas and/or semicolons can be used as delimiters.
 dcl#:#dcl_file_not_readable#:#The file could not be read. Please make sure to upload an XLSX file.
-dcl#:#dcl_fileupload#:#Fileupload
-dcl#:#dcl_fileupload_desc#:#Field to upload arbitrary files. They can be downloaded with a link.
 dcl#:#dcl_filter#:#Available in filter
 dcl#:#dcl_filter_changeable#:#Filter changeable
 dcl#:#dcl_formula#:#Formula
@@ -8665,6 +8665,7 @@ dcl#:#dcl_wrong_length#:#The text you entered is to long.
 dcl#:#dcl_wrong_regex#:#The text you entered does not match the specification for this field (Regular Expression).
 dcl#:#dlc_xls_async_export#:#Asynchronous XLSX-Export
 dcl#:#fieldtitle_allow_chars#:#Not allowed chars: %s
+dcl#:#fileupload_not_migrated#:#File has not yet been migration and cannot be displayed. Please contact your System-Administrator.
 didactic#:#activate_exclusive_template#:#Grey Out Default
 didactic#:#activate_exclusive_template_info#:#The standard template won't be available wherever this template is active.
 didactic#:#activate_local_didactic_template#:#Scope of Application


### PR DESCRIPTION
This PR detaches the user uploads in the datacollection from the ilObjFile and uses the IRSS directly. Due to the migration to ILIAS 7, these files are already in the storage service, but were previously accessed via ilObjFile.

The PR again provides a migration. As long as this has not been executed, the files in DataCollections cannot be used (the old field type FileUpload has been modified so that it only displays information about the missing migration). A new field type "File" was added, which saves new files directly in the storage service without diversions via ilObjFile. 

If you have any questions, please contact me at any time. We can also discuss this via Discord, for example.

https://docu.ilias.de/goto_docu_wiki_wpage_6727_1357.html 