### PR TITLE
[FIX] 0036499: Failed test: Abbruch des Hochladens

### DIFF
--- a/src/UI/templates/js/Input/Field/file.js
+++ b/src/UI/templates/js/Input/Field/file.js
@@ -208,6 +208,7 @@ il.UI.Input = il.UI.Input || {};
 				let file_preview = file_id_input.closest(SELECTOR.file_list_entry);
 
 				if (file_preview) {
+					file_preview.find(SELECTOR.removal_glyph).hide();
 					let progressContainer = file_preview.find(SELECTOR.progress_container);
 					let progressIndicator = file_preview.find(SELECTOR.progress_indicator);
 					let number = Math.round(progress);
@@ -674,6 +675,7 @@ il.UI.Input = il.UI.Input || {};
 		 * @param {jQuery} container
 		 */
 		let displayErrorMessage = function (message, container) {
+			container.find(SELECTOR.removal_glyph).show();
 			container.find(SELECTOR.error_message).html(message);
 			container.find(SELECTOR.progress_indicator).addClass('error');
 		}


### PR DESCRIPTION
This is a relatively small fix, unfortunately you can't cancel the upload when uploading large files. So that you don't have the impression that you can cancel the upload with a click on the X, it is hidden by the PR.

see https://mantis.ilias.de/view.php?id=36499