### PR TITLE
Fix #36637 Handle invalid discovery url

### DIFF
--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettingsGUI.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectSettingsGUI.php
@@ -394,13 +394,21 @@ class ilOpenIdConnectSettingsGUI
                     $discoveryURL = null;
                     break;
             }
-            $invalid_scopes = !is_null($discoveryURL) ? $this->settings->validateScopes($discoveryURL, (array) $scopes) : [];
+            $validation_result = !is_null($discoveryURL) ? $this->settings->validateScopes($discoveryURL, (array) $scopes) : [];
 
-            if (!empty($invalid_scopes)) {
-                $this->mainTemplate->setOnScreenMessage(
-                    'failure',
-                    sprintf($this->lng->txt('auth_oidc_settings_invalid_scopes'), implode(",", $invalid_scopes))
-                );
+            if (!empty($validation_result)) {
+                if (ilOpenIdConnectSettings::VALIDATION_ISSUE_INVALID_SCOPE === $validation_result[0]) {
+                    $this->mainTemplate->setOnScreenMessage(
+                        'failure',
+                        sprintf($this->lng->txt('auth_oidc_settings_invalid_scopes'), implode(",", $validation_result[1]))
+                    );
+                } else {
+                    $this->mainTemplate->setOnScreenMessage(
+                        'failure',
+                        sprintf($this->lng->txt('auth_oidc_settings_discovery_error'), $validation_result[1])
+                    );
+
+                }
                 $form->setValuesByPost();
                 $this->settings($form);
                 return;

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2047,6 +2047,7 @@ auth#:#auth_oidc_settings_custom_session_duration_option#:#Eigene Sitzungsdauer
 auth#:#auth_oidc_settings_custom_session_duration_type#:#Einstellungen zur Sitzungsdauer
 auth#:#auth_oidc_settings_default_role#:#Rollenzuordnung
 auth#:#auth_oidc_settings_default_role_info#:#Bitte wählen Sie eine globale Rolle für neu anzulegende ILIAS-Benutzer aus!
+auth#:#auth_oidc_settings_discovery_error#:#Die Discovery URL konnte nicht abgerufen werden. Fehler: %s
 auth#:#auth_oidc_settings_discovery_url#:#Discovery URL des Providers
 auth#:#auth_oidc_settings_img#:#Bild
 auth#:#auth_oidc_settings_img_file_info#:#Laden Sie ein Bild hoch das auf der Anmeldeseite angezeigt werden soll. Das Bild verlinkt automatisch auf das OpenId Connect Anmeldeskript.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2048,6 +2048,7 @@ auth#:#auth_oidc_settings_custom_session_duration_option#:#Duration of Own Sessi
 auth#:#auth_oidc_settings_custom_session_duration_type#:#Session Duration Settings
 auth#:#auth_oidc_settings_default_role#:#Role Assignment
 auth#:#auth_oidc_settings_default_role_info#:#Please select a global role for the ILIAS user accounts that will be created for users who have authenticated themselves using OpenID Connect.
+auth#:#auth_oidc_settings_discovery_error#:#Retrieving the Discovery URL failed with: %s
 auth#:#auth_oidc_settings_discovery_url#:#Discovery URL of the provider
 auth#:#auth_oidc_settings_img#:#Image
 auth#:#auth_oidc_settings_img_file_info#:#Upload an image that you would like to have shown on the login page. The image will link automatically to the OpenID Connect login script.


### PR DESCRIPTION
Handle error in case the discovery url provided does not return a 200 http status code. In this case, display error to user.