### PR TITLE
Fix crs to course typo

### DIFF
--- a/Modules/Course/classes/class.ilObjCourse.php
+++ b/Modules/Course/classes/class.ilObjCourse.php
@@ -75,7 +75,7 @@ class ilObjCourse extends ilContainer implements ilMembershipRegistrationCodes
     /**
      * @var bool
      */
-    protected $crs_start_time_indication = false;
+    protected $course_start_time_indication = false;
 
     /**
      * @var \ilDateTime | null


### PR DESCRIPTION
Hi
 I've noticed a typo in the property name: in two methods this variable is referred to as `course_start_time_indication` instead of `crs_start_time_indication`.