### PR TITLE
T&A #37034 Crash when no entry has been selected in preview and malformed error text entries are included

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assErrorText.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorText.php
@@ -650,11 +650,13 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
                     }
 
                     if ($correct_solution && !$in_passage) {
-                        $errorobject = $this->errordata[$errorcounter];
-                        if (is_object($errorobject)) {
-                            $item = strlen($errorobject->text_correct) ? $errorobject->text_correct : '&nbsp;';
+                        if (isset($this->errordata[$errorcounter])) {
+                            $errorobject = $this->errordata[$errorcounter];
+                            if (is_object($errorobject)) {
+                                $item = strlen($errorobject->text_correct) ? $errorobject->text_correct : '&nbsp;';
+                            }
+                            $errorcounter++;
                         }
-                        $errorcounter++;
                     }
                 }
 
@@ -856,14 +858,13 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
                         $inPassage = false;
                         $cur_pidx = count($passages) - 1;
                         $passages[$cur_pidx]['end_pos'] = $counter;
-
-                        $errorobject = $this->errordata[$errorcounter];
-                        if (is_object($errorobject)) {
-                            $passages[$cur_pidx]['score'] = $errorobject->points;
-                            $passages[$cur_pidx]['isError'] = true;
+                        if (isset($this->errordata[$errorcounter])) {
+                            $errorobject = $this->errordata[$errorcounter];
+                            if (is_object($errorobject)) {
+                                $passages[$cur_pidx]['score'] = $errorobject->points;
+                                $passages[$cur_pidx]['isError'] = true;
+                            }
                         }
-
-                        $errorcounter++;
                     }
 
                     $cur_pidx = count($passages) - 1;
@@ -899,6 +900,10 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
 
     protected function getPointsForSelectedPositions($positions)
     {
+        //If no position has been selected, return 0
+        if ($positions == null) {
+            return 0;
+        }
         $passages = array();
         $words = array();
         $counter = 0;
@@ -928,12 +933,13 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
                         $inPassage = false;
                         $cur_pidx = count($passages) - 1;
                         $passages[$cur_pidx]['end_pos'] = $counter;
-
-                        $errorobject = $this->errordata[$errorcounter];
-                        if (is_object($errorobject)) {
-                            $passages[$cur_pidx]['score'] = $errorobject->points;
+                        if (isset($this->errordata[$errorcounter])) {
+                            $errorobject = $this->errordata[$errorcounter];
+                            if (is_object($errorobject)) {
+                                $passages[$cur_pidx]['score'] = $errorobject->points;
+                            }
+                            $errorcounter++;
                         }
-                        $errorcounter++;
                     }
 
                     $cur_pidx = count($passages) - 1;


### PR DESCRIPTION
In a malformed question (double closing )) without initial (() the question is anaylzed without error,s, but error come when previewing the question. I modified the  getPointsForSelectedPositions($positions) to ensure the user get 0 points if no word has been selected. and getBestSelection($withPositivePointsOnly = true) to ensure the malformed closing braket does not crash the question.

An error message telling the user that at least one word must be selected would be nice to inform the user.