### PR TITLE
[PROPOSAL] Add npm install to composer install and update commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,10 @@
 		],
 		"post-install-cmd": [
 			"@php libs/composer/rmdirs.php",
-			"[ $COMPOSER_DEV_MODE -eq 0 ] && npm install --omit=dev --ignore-scripts || npm install --ignore-scripts"
+			"[ $COMPOSER_DEV_MODE -eq 0 ] && npm ci --omit=dev --ignore-scripts || npm ci --ignore-scripts"
 		],
 		"post-update-cmd": [
-			"@php libs/composer/rmdirs.php",
-			"[ $COMPOSER_DEV_MODE -eq 0 ] && npm update --omit=dev --ignore-scripts || npm update --ignore-scripts"
+			"@php libs/composer/rmdirs.php"
 		],
 		"test-php-all": [
 			"./libs/composer/vendor/bin/phpunit -c ./Services/PHPUnit/config/PhpUnitConfig.xml --colors=always --disallow-todo-tests"

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,12 @@
 			"@php setup/cli.php build-artifacts --yes"
 		],
 		"post-install-cmd": [
-			"@php libs/composer/rmdirs.php"
+			"@php libs/composer/rmdirs.php",
+			"[ $COMPOSER_DEV_MODE -eq 0 ] && npm install --omit=dev --ignore-scripts || npm install --ignore-scripts"
 		],
 		"post-update-cmd": [
-			"@php libs/composer/rmdirs.php"
+			"@php libs/composer/rmdirs.php",
+			"[ $COMPOSER_DEV_MODE -eq 0 ] && npm update --omit=dev --ignore-scripts || npm update --ignore-scripts"
 		],
 		"test-php-all": [
 			"./libs/composer/vendor/bin/phpunit -c ./Services/PHPUnit/config/PhpUnitConfig.xml --colors=always --disallow-todo-tests"


### PR DESCRIPTION
In addition to https://github.com/ILIAS-eLearning/ILIAS/pull/5128 i propose to combine the npm install/update with the corrosponding composer commands.

This removes one step for admins and devs to setup/update an ilias installation. It also respects the --no-dev argument. 


PS:
If someone is has some better bash skills for the --no-dev/--omit=dev flag and is able to merge the command in one line this would improve the change a lot. But i dont know how to bash ;)