### PR TITLE
Object: Refactor AutoRating

### DIFF
--- a/Modules/File/classes/Processors/class.ilObjFileAbstractProcessor.php
+++ b/Modules/File/classes/Processors/class.ilObjFileAbstractProcessor.php
@@ -83,6 +83,8 @@ abstract class ilObjFileAbstractProcessor implements ilObjFileProcessorInterface
         if ($create_reference) {
             $file_obj->createReference();
         }
+
+        $file_obj->processAutoRating();
         $this->gui_object->putObjectInTree($file_obj, $parent_id);
 
         return $file_obj;

--- a/Modules/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -273,9 +273,6 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
                 $newObj->applyDidacticTemplate($dtpl);
             }
 
-            // auto rating
-            $this->handleAutoRating($newObj);
-
             $this->afterSave($newObj);
 
             return;
@@ -504,8 +501,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
             if ($dtpl) {
                 $newObj->applyDidacticTemplate($dtpl);
             }
-            // auto rating
-            $gui->handleAutoRating($newObj);
+
             $newObj->setProviderId($provider->getId());
             $newObj->setProvider($provider);
             // custom params

--- a/Modules/Wiki/classes/class.ilObjWikiGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiGUI.php
@@ -883,7 +883,8 @@ class ilObjWikiGUI extends ilObjectGUI
         if ($a_mode === "create") {
             $values["rating_new"] = true;
 
-            $values["rating_overall"] = $this->object->hasAutoRating();
+            $parent = ilObjectFactory::getInstanceByRefId($this->requested_ref_id);
+            $values["rating_overall"] = $parent->selfOrParentWithRatingEnabled();
         } else {
             $values["online"] = $this->object->getOnline();
             $values["title"] = $this->object->getTitle();

--- a/Modules/Wiki/classes/class.ilObjWikiGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiGUI.php
@@ -883,7 +883,7 @@ class ilObjWikiGUI extends ilObjectGUI
         if ($a_mode === "create") {
             $values["rating_new"] = true;
 
-            $values["rating_overall"] = ilObject::hasAutoRating("wiki", $this->requested_ref_id);
+            $values["rating_overall"] = $this->object->hasAutoRating();
         } else {
             $values["online"] = $this->object->getOnline();
             $values["title"] = $this->object->getTitle();

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -64,6 +64,8 @@ class ilObject
     protected string $import_id = "";
     protected bool $register = false;	// registering required for object? set to true to implement a subscription interface
 
+    private bool $process_auto_reating = false;
+
 
     /**
     * @var array contains all child objects of current object
@@ -135,6 +137,14 @@ class ilObject
         return ($this->call_by_reference) ? true : $this->referenced;
     }
 
+    /**
+     *
+     * @deprecated: This function will be removed asap.
+     */
+    public function processAutoRating(): void
+    {
+        $this->process_auto_reating = true;
+    }
 
     public function read(): void
     {
@@ -1797,7 +1807,7 @@ class ilObject
 
     protected function handleAutoRating(): void
     {
-        if ($this->getRefId() !== 0
+        if ($this->process_auto_reating
             && $this->hasAutoRating()
             && method_exists($this, "setRating")
         ) {

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1818,7 +1818,6 @@ class ilObject
 
     protected function hasAutoRating(): bool
     {
-        $tree = $this->tree;
         $ref_id = $this->getRefId();
         $type = $this->type;
 
@@ -1826,6 +1825,13 @@ class ilObject
             return false;
         }
 
+        return $this->selfOrParentWithRatingEnabled();
+    }
+
+    public function selfOrParentWithRatingEnabled(): bool
+    {
+        $tree = $this->tree;
+        $ref_id = $this->getRefId();
         $parent_ref_id = $tree->checkForParentType($ref_id, "grp");
         if (!$parent_ref_id) {
             $parent_ref_id = $tree->checkForParentType($ref_id, "crs");

--- a/Services/Object/classes/class.ilObject2GUI.php
+++ b/Services/Object/classes/class.ilObject2GUI.php
@@ -826,12 +826,4 @@ abstract class ilObject2GUI extends ilObjectGUI
         $plink->setIncludePermanentLinkText(false);
         return $plink->getHTML();
     }
-
-    protected function handleAutoRating(ilObject $new_obj): void
-    {
-        // only needed in repository
-        if ($this->id_type == self::REPOSITORY_NODE_ID) {
-            parent::handleAutoRating($new_obj);
-        }
-    }
 }

--- a/Services/Object/classes/class.ilObjectGUI.php
+++ b/Services/Object/classes/class.ilObjectGUI.php
@@ -835,7 +835,6 @@ class ilObjectGUI
                 $newObj->applyDidacticTemplate($dtpl);
             }
 
-            $this->handleAutoRating($newObj);
             $this->afterSave($newObj);
         }
 
@@ -1609,20 +1608,6 @@ class ilObjectGUI
     protected function enableDragDropFileUpload(): void
     {
         $this->tpl->setFileUploadRefId($this->ref_id);
-    }
-
-    /**
-     * Activate rating automatically if parent container setting
-     */
-    protected function handleAutoRating(ilObject $new_obj): void
-    {
-        if (
-            ilObject::hasAutoRating($new_obj->getType(), $new_obj->getRefId()) &&
-            method_exists($new_obj, "setRating")
-        ) {
-            $new_obj->setRating(true);
-            $new_obj->update();
-        }
     }
 
     /**

--- a/Services/Object/classes/class.ilObjectGUI.php
+++ b/Services/Object/classes/class.ilObjectGUI.php
@@ -826,6 +826,7 @@ class ilObjectGUI
             $newObj->setType($this->requested_new_type);
             $newObj->setTitle($form->getInput("title"));
             $newObj->setDescription($form->getInput("desc"));
+            $newObj->processAutoRating();
             $newObj->create();
 
             $this->putObjectInTree($newObj);


### PR DESCRIPTION
Couldn't we move the whole auto-rating stuff to `ilObject::putInTree()`? This to me looks far more logical. It changes the behavior slightly, as this would also set the notifications, when an object with auto-rating is linked.

See: https://mantis.ilias.de/view.php?id=34112