### PR TITLE
Fix spelling of Git

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -15,7 +15,7 @@ A general overview on our processes can be found in the [development guide](http
 
 ## Coding
 
-- [GIT introduction](https://docu.ilias.de/goto_docu_pg_15604_42.html)
+- [Git introduction](https://docu.ilias.de/goto_docu_pg_15604_42.html)
 - [Git Hooks](git-hooks.md)
 - [Accessibility Guidelines](accessibility.md): Foster an accessible user interface
 - [Accessibility Process](accessibility-process.md): Describes, who is involved, which tools the community uses and


### PR DESCRIPTION
Git, the version control system developed by Linus Torvalds, is named after the British slang word "git" ([according to Wikipedia](https://en.wikipedia.org/wiki/Git#Naming)). Git is not an acronym, hence it's not written in capital letters.