### PR TITLE
T&A 0036799 Akkordion content printed

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -13368,12 +13368,6 @@ img.ilSmallIcon {
   height: 0px;
   display: none;
 }
-@media print {
-  .ilAccHideContent {
-    height: auto !important;
-    width: auto !important;
-  }
-}
 div.ilc_va_icont_VAccordICont {
   overflow: visible !important;
 }
@@ -20032,5 +20026,9 @@ table.mceToolbar td {
   }
   a[href]:after {
     content: "";
+  }
+  .ilAccHideContent {
+    height: auto !important;
+    width: auto !important;
   }
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -13368,6 +13368,11 @@ img.ilSmallIcon {
   height: 0px;
   display: none;
 }
+@media print {
+  .ilAccHideContent {
+    display: none !important;
+  }
+}
 div.ilc_va_icont_VAccordICont {
   overflow: visible !important;
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -13370,7 +13370,8 @@ img.ilSmallIcon {
 }
 @media print {
   .ilAccHideContent {
-    display: none !important;
+    height: auto !important;
+    width: auto !important;
   }
 }
 div.ilc_va_icont_VAccordICont {

--- a/templates/default/less/Services/Accordion/delos.less
+++ b/templates/default/less/Services/Accordion/delos.less
@@ -44,7 +44,8 @@
 
 @media print {
 	.ilAccHideContent {
-		display: none !important;
+		height: auto !important;
+		width: auto !important;
 	}
 }
 

--- a/templates/default/less/Services/Accordion/delos.less
+++ b/templates/default/less/Services/Accordion/delos.less
@@ -42,13 +42,6 @@
 	display: none;
 }
 
-@media print {
-	.ilAccHideContent {
-		height: auto !important;
-		width: auto !important;
-	}
-}
-
 .il_VAccordionContentDef, .il_HAccordionContentDef {
     > div {
         //overflow: auto;

--- a/templates/default/less/Services/Accordion/delos.less
+++ b/templates/default/less/Services/Accordion/delos.less
@@ -42,6 +42,12 @@
 	display: none;
 }
 
+@media print {
+	.ilAccHideContent {
+		display: none !important;
+	}
+}
+
 .il_VAccordionContentDef, .il_HAccordionContentDef {
     > div {
         //overflow: auto;

--- a/templates/default/less/print.less
+++ b/templates/default/less/print.less
@@ -126,5 +126,11 @@
   a[href]:after {
     content: "";
   }
+
+  .ilAccHideContent {
+    height: auto !important;
+    width: auto !important;
+  }
+
 }
 


### PR DESCRIPTION
Issue:
https://mantis.ilias.de/view.php?id=36799

Problem:
The content of a page accordion element in a question gets printed regardless if visible in the preview.


Solution:
Add a media printing rule to the css to prevent unopened accordion panels from printing their content.


As always, let me know where this solution needs further improvement.