### PR TITLE
Memberships: Prevent integrity constraint issues

### DIFF
--- a/Modules/Course/classes/class.ilCourseParticipants.php
+++ b/Modules/Course/classes/class.ilCourseParticipants.php
@@ -152,7 +152,12 @@ class ilCourseParticipants extends ilParticipants
                 $ilDB->quote(0, 'integer') . ", " .
                 $ilDB->quote(0, 'integer') . ", " .
                 $ilDB->quote($origin, 'integer') . ", " .
-                $ilDB->quote($origin_ts, 'integer') . ")";
+                $ilDB->quote($origin_ts, 'integer') . ")
+                ON DUPLICATE KEY UPDATE
+                    passed = VALUES(passed),
+                    origin = VALUES(origin),
+                    origin_ts = VALUES(origin_ts)
+            ";
         }
         if (strlen($update_query)) {
             $ilDB->manipulate($update_query);

--- a/Services/Membership/classes/class.ilParticipant.php
+++ b/Services/Membership/classes/class.ilParticipant.php
@@ -446,7 +446,7 @@ abstract class ilParticipant
                 $this->db->quote($a_usr_id, 'integer') . ", " .
                 $this->db->quote(0, 'integer') . ", " .
                 $this->db->quote(0, 'integer') .
-                ")";
+                ") ON DUPLICATE KEY UPDATE notification = VALUES(notification)";
         }
         $this->db->manipulate($query);
     }

--- a/Services/Membership/classes/class.ilParticipants.php
+++ b/Services/Membership/classes/class.ilParticipants.php
@@ -757,7 +757,7 @@ abstract class ilParticipants
                 $this->ilDB->quote($a_usr_id, 'integer') . ", " .
                 $this->ilDB->quote(0, 'integer') . ", " .
                 $this->ilDB->quote(0, 'integer') .
-                ")";
+                ") ON DUPLICATE KEY UPDATE blocked = VALUES(blocked)";
         }
         $res = $this->ilDB->manipulate($query);
     }
@@ -812,7 +812,7 @@ abstract class ilParticipants
                 $this->ilDB->quote($a_usr_id, 'integer') . ", " .
                 $this->ilDB->quote(0, 'integer') . ", " .
                 $this->ilDB->quote(0, 'integer') .
-                ")";
+                ") ON DUPLICATE KEY UPDATE notification = VALUES(notification)";
         }
         $res = $this->ilDB->manipulate($query);
     }


### PR DESCRIPTION
If you monitor the log of ILIAS installations with many concurrent users, you often find dozens of integrity constraint violations for the `object_members` table.

These `duplicate key` issues are caused by race conditons. This commit makes the state modifying SQL statements more robust and prevents that exceptions or  `WSOD` (white screen of death) are shown to the user. I added a `ON DUPLICATE KEY UPDATE`  clause (possible, because we do not support `Oracle` or `Postgres` anymore) which updates only the relevant field(s) if the tuple already exists.

Important:

> The use of VALUES() to refer to the new row and columns is deprecated beginning with MySQL 8.0.20, and is subject to removal in a future version of MySQL. Instead, use row and column aliases, as described in the next few paragraphs of this section.
> 
> Beginning with MySQL 8.0.19, it is possible to use an alias for the row, with, optionally, one or more of its columns to be inserted, following the VALUES or SET clause, and preceded by the AS keyword. Using the row alias new, the statement shown previously using VALUES() to access the new column values can be written in the form shown here:
> 
> 

See: https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html