### PR TITLE
Properly handle input from user defined fields

### DIFF
--- a/Services/Registration/classes/class.ilAccountRegistrationGUI.php
+++ b/Services/Registration/classes/class.ilAccountRegistrationGUI.php
@@ -436,10 +436,11 @@ class ilAccountRegistrationGUI
         $user_defined_fields = ilUserDefinedFields::_getInstance();
         $defs = $user_defined_fields->getRegistrationDefinitions();
         $udf = [];
-        foreach ($_POST as $k => $v) {
-            if (strpos($k, "udf_") === 0) {
-                $f = substr($k, 4);
-                $udf[$f] = $v;
+        foreach ($defs as $definition) {
+            $f = "udf_" . $definition['field_id'];
+            $item = $this->form->getItemByPostVar($f);
+            if ($item && !$item->getDisabled()) {
+                $udf[$definition['field_id']] = $this->form->getInput($f);
             }
         }
         $this->userObj->setUserDefinedData($udf);

--- a/Services/Registration/classes/class.ilAccountRegistrationGUI.php
+++ b/Services/Registration/classes/class.ilAccountRegistrationGUI.php
@@ -145,7 +145,7 @@ class ilAccountRegistrationGUI
             $fprop = ilCustomUserFieldsHelper::getInstance()->getFormPropertyForDefinition(
                 $definition,
                 true,
-                $user_defined_data['f_' . $field_id] ?? null
+                $user_defined_data['f_' . $field_id] ?? ''
             );
             if ($fprop instanceof ilFormPropertyGUI) {
                 $custom_fields['udf_' . $definition['field_id']] = $fprop;

--- a/Services/User/classes/class.ilCustomUserFieldsHelper.php
+++ b/Services/User/classes/class.ilCustomUserFieldsHelper.php
@@ -90,7 +90,7 @@ class ilCustomUserFieldsHelper
     public function getFormPropertyForDefinition(
         array $definition,
         bool $a_changeable = true,
-        ?string $a_default_value = null
+        string $a_default_value = null
     ): ?ilFormPropertyGUI {
         $fprop = null;
 

--- a/Services/User/classes/class.ilCustomUserFieldsHelper.php
+++ b/Services/User/classes/class.ilCustomUserFieldsHelper.php
@@ -90,7 +90,7 @@ class ilCustomUserFieldsHelper
     public function getFormPropertyForDefinition(
         array $definition,
         bool $a_changeable = true,
-        string $a_default_value = null
+        ?string $a_default_value = null
     ): ?ilFormPropertyGUI {
         $fprop = null;
 
@@ -136,7 +136,11 @@ class ilCustomUserFieldsHelper
                 // should be a plugin
                 foreach ($this->getActivePlugins() as $plugin) {
                     if ($plugin->getDefinitionType() == $definition['field_type']) {
-                        $fprop = $plugin->getFormPropertyForDefinition($definition, $a_changeable);
+                        $fprop = $plugin->getFormPropertyForDefinition(
+                            $definition,
+                            $a_changeable,
+                            $a_default_value
+                        );
                         break;
                     }
                 }

--- a/Services/User/classes/class.ilUDFDefinitionPlugin.php
+++ b/Services/User/classes/class.ilUDFDefinitionPlugin.php
@@ -49,13 +49,12 @@ abstract class ilUDFDefinitionPlugin extends ilPlugin
     ): void;
 
     /**
-     * Get form property for definition
      * Context: edit user; registration; edit user profile
-     * @param mixed $a_default_value
      */
     abstract public function getFormPropertyForDefinition(
         array $definition,
-        $a_default_value = null
+        bool $a_changeable = true,
+        ?string $a_default_value = null
     ): ilFormPropertyGUI;
 
 


### PR DESCRIPTION
This PR makes it so that input from user defined fields is read out using `getInput` instead of directly from post. This is needed for user defined fields (e.g. of a type from a UDFDefinition plugin) to be able to clean up their input after submission without directly writing into post.

In Addition, this PR also fixes a small mismatch in the signature of `ilUDFDefinitionPlugin::getFormPropertyForDefinition`.

As far as I can see this also needs to be merged to trunk, let me know if you want me to handle that, or if you want a second PR.