### PR TITLE
Add setting approval for toast provider

### DIFF
--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
@@ -31,6 +31,7 @@ use ILIAS\UI\Component\MainControls\MainBar;
 use ILIAS\UI\Component\MainControls\MetaBar;
 use ILIAS\UI\Component\MainControls\Slate\Combined;
 use ILIAS\UI\Component\Toast\Container as TContainer;
+use ilSetting;
 use ilUserUtil;
 use ilUtil;
 use ILIAS\GlobalScreen\Services;
@@ -269,10 +270,13 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getToastContainer(): TContainer
+    public function getToastContainer(): ?TContainer
     {
-        $toast_container = $this->ui->factory()->toast()->container();
+        if ((new ilSetting('notifications'))->get('enable_osd') !== '1') {
+            return null;
+        }
 
+        $toast_container = $this->ui->factory()->toast()->container();
         foreach ($this->gs->collector()->toasts()->getToasts() as $toast) {
             $toast_container = $toast_container->withAdditionalToast($toast);
         }


### PR DESCRIPTION
_There is no own Mantis ticket for this Bug but a comment:_
https://mantis.ilias.de/view.php?id=36967#c91762

ATM the Global settings on Notifications are ignored for Toast.
This PR fixes that bug by adding a approval wihc was lost due to the last refactoring of the toasts.