### PR TITLE
refactor NotificationProvider

### DIFF
--- a/Services/Notifications/classes/Model/ilNotificationConfig.php
+++ b/Services/Notifications/classes/Model/ilNotificationConfig.php
@@ -47,6 +47,8 @@ class ilNotificationConfig
     protected int $visibleForSeconds = 0;
     private array $handlerParams = [];
 
+    private string $provider_key = '';
+
     public function __construct(string $type)
     {
         $this->type = $type;
@@ -291,5 +293,15 @@ class ilNotificationConfig
     public function unsetHandlerParam(string $name): void
     {
         unset($this->handlerParams[$name]);
+    }
+
+    public function setProviderKey(string $key): void
+    {
+        $this->provider_key = $key;
+    }
+
+    public function getProviderKey(): string
+    {
+        return $this->provider_key;
     }
 }

--- a/Services/Notifications/classes/Setup/ilNotificationUpdateSteps.php
+++ b/Services/Notifications/classes/Setup/ilNotificationUpdateSteps.php
@@ -168,4 +168,15 @@ class ilNotificationUpdateSteps implements ilDatabaseUpdateSteps
         );
 
     }
+
+    public function step_10(): void
+    {
+        if (!$this->db->tableColumnExists('notification_osd', 'provider_key')) {
+            $this->db->addTableColumn("notification_osd", "provider_key", [
+                "type" => "text",
+                "notnull" => false,
+                "default" => ''
+            ]);
+        }
+    }
 }

--- a/Services/Notifications/classes/ilNotificationOSDHandler.php
+++ b/Services/Notifications/classes/ilNotificationOSDHandler.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Notifications;
 
+use ILIAS\GlobalScreen\Scope\Notification\Provider\AbstractNotificationProvider;
+use ILIAS\Notifications\Model\ilNotificationConfig;
 use ILIAS\Notifications\Model\ilNotificationObject;
 use ILIAS\Notifications\Model\OSD\ilOSDNotificationObject;
 use ILIAS\Notifications\Repository\ilNotificationOSDRepository;
@@ -69,14 +71,31 @@ class ilNotificationOSDHandler extends ilNotificationHandler
         return $notifications;
     }
 
+    /**
+     * @depracated
+     */
     public function deleteStaleNotificationsForUserAndType(int $user_id, string $type): void
     {
-        $this->repo->deleteStaleNotificationsForUserAndType($user_id, $type, $this->clock->now()->getTimestamp());
+        $this->repo->deleteStaleOSDNotificationsForUserAndType($user_id, $type, $this->clock->now()->getTimestamp());
+    }
+
+    public function deleteStaleOSDNotificationsForUserAndType(int $user_id, string $type): void
+    {
+        $this->repo->deleteStaleOSDNotificationsForUserAndType($user_id, $type, $this->clock->now()->getTimestamp());
     }
 
     public function removeNotification(int $notification_osd_id): bool
     {
         return $this->repo->deleteOSDNotificationById($notification_osd_id);
+    }
+
+    public function removeProviderNotification(AbstractNotificationProvider $provider, string $provider_key, int $user_id = 0): bool
+    {
+        return $this->repo->deleteOSDNotificationByProviderKey(
+            $provider->getType(),
+            $provider_key,
+            $user_id
+        );
     }
 
     private function appendParamToLink(string $link, string $param, int $value): string

--- a/Services/Notifications/test/notifications/ilNotificationOSDTest.php
+++ b/Services/Notifications/test/notifications/ilNotificationOSDTest.php
@@ -151,18 +151,4 @@ class ilNotificationOSDTest extends ilNotificationsBaseTest
         $this->assertCount(0, $this->handler->getOSDNotificationsForUser($this->user->getId()));
         $this->assertFalse($this->handler->removeNotification(3));
     }
-
-    public function testCreateMultipleUniqueNotifications(): void
-    {
-        $this->createDBFunctionCalls(3, 0, 0, 3);
-        $config = new \ILIAS\Notifications\Model\ilNotificationConfig('who_is_online');
-        $config->setTitleVar('Unique Test Notification');
-        $config->setShortDescriptionVar('This is a unqiue test notification');
-        $test_obj = new \ILIAS\Notifications\Model\ilNotificationObject($config, $this->user);
-        $this->handler->notify($test_obj);
-        $this->handler->notify($test_obj);
-        $this->handler->notify($test_obj);
-
-        $this->assertCount(1, $this->database);
-    }
 }

--- a/Services/User/classes/class.ilPublicUserProfileGUI.php
+++ b/Services/User/classes/class.ilPublicUserProfileGUI.php
@@ -196,10 +196,6 @@ class ilPublicUserProfileGUI implements ilCtrlBaseClassInterface
                 }
                 // no break
             case 'ilbuddysystemgui':
-                $osd_id = $this->profile_request->getOsdId();
-                if ($osd_id > 0) {
-                    ilNotificationOSDHandler::removeNotification($osd_id);
-                }
                 $gui = new ilBuddySystemGUI();
                 $ilCtrl->setReturn($this, 'view');
                 $ilCtrl->forwardCommand($gui);

--- a/src/GlobalScreen/Scope/Notification/Provider/AbstractNotificationProvider.php
+++ b/src/GlobalScreen/Scope/Notification/Provider/AbstractNotificationProvider.php
@@ -23,6 +23,10 @@ use ILIAS\DI\Container;
 use ILIAS\GlobalScreen\Identification\IdentificationProviderInterface;
 use ILIAS\GlobalScreen\Provider\AbstractProvider;
 use ILIAS\GlobalScreen\Scope\Notification\Factory\NotificationFactory;
+use ILIAS\Notifications\ilNotificationOSDHandler;
+use ILIAS\Notifications\Model\ilNotificationConfig;
+use ILIAS\Notifications\Model\OSD\ilOSDNotificationObject;
+use ILIAS\Notifications\Repository\ilNotificationOSDRepository;
 
 /**
  * Interface AbstractNotificationProvider
@@ -30,18 +34,66 @@ use ILIAS\GlobalScreen\Scope\Notification\Factory\NotificationFactory;
  */
 abstract class AbstractNotificationProvider extends AbstractProvider implements NotificationProvider
 {
+    protected const NOTIFICATION_TYPE = 'none';
+    protected const MUTED_UNTIL_PREFERENCE_KEY = '';
+
     protected Container $dic;
     protected IdentificationProviderInterface $if;
     protected NotificationFactory $notification_factory;
+    protected ilNotificationOSDHandler $osd_handler;
 
     /**
      * @inheritDoc
      */
-    public function __construct(Container $dic)
+    public function __construct(Container $dic = null)
     {
+        if ($dic === null) {
+            global $DIC;
+            $dic = $DIC;
+        }
         parent::__construct($dic);
         $this->notification_factory = $this->globalScreen()->notifications()->factory();
         $this->if = $this->globalScreen()->identification()->core($this);
+        $this->osd_handler = new ilNotificationOSDHandler(new ilNotificationOSDRepository($this->dic->database()));
+    }
+
+    final public function getType(): string
+    {
+        return $this::NOTIFICATION_TYPE;
+    }
+
+    final public function removeOSDNotificationsByProviderKey(string $provider_key, int $user_id = 0): void
+    {
+        $this->osd_handler->removeProviderNotification($this, $provider_key, $user_id);
+    }
+
+    /**
+     * @return ilOSDNotificationObject[]
+     */
+    final public function getUserOSDNotifications(): array
+    {
+        return $this->osd_handler->getOSDNotificationsForUser(
+            $this->dic->user()->getId(),
+            true,
+            time() - (int) ($this->dic->user()->getPref(self::MUTED_UNTIL_PREFERENCE_KEY) ?? 0),
+            $this::NOTIFICATION_TYPE
+        );
+    }
+
+    final public function deleteStaleNotifications(): void
+    {
+        $this->osd_handler->deleteStaleOSDNotificationsForUserAndType(
+            $this->dic->user()->getId(),
+            $this::NOTIFICATION_TYPE
+        );
+    }
+
+    final public function getNotificationConfig(): ilNotificationConfig
+    {
+        $config = new ilNotificationConfig($this::NOTIFICATION_TYPE);
+        $config->setValidForSeconds(ilNotificationConfig::TTL_LONG);
+        $config->setVisibleForSeconds(ilNotificationConfig::DEFAULT_TTS);
+        return $config;
     }
 
     /**


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=36967

The Notification Service has no knowledge about how to handle the persistence of OSD Notification.
This causes that, rn, the only option to remove a OSD Notification is by decay or with a direct interaction of the Notifications presentation, but not by its caused event.
This poses a problem since most Notification have mutliple events which should cause the removal of the notification (e.g. Contact Request canceled, ignored and approved) which mostly can be accessed not only over the UI but also can be caused by link etc.
Therefore the Notification System should oblige the creating sources to handle their Notifications and only should validate their scope of action.

This refactores the OSD Notification System to outsource the persistence of OSD Notification to the providing sources.
- It ensures that the handling source only acts in its own scope.
- It provides a key to for authetification and handling of created Notifications and enabled the deletion and cleanup of them.

_The PRs for the target components will follow soon_