### PR TITLE
Use refactored notification provider functions

### DIFF
--- a/Modules/Chatroom/GlobalScreen/ChatInvitationToastProvider.php
+++ b/Modules/Chatroom/GlobalScreen/ChatInvitationToastProvider.php
@@ -21,15 +21,10 @@ declare(strict_types=1);
 namespace ILIAS\Chatroom\GlobalScreen;
 
 use ILIAS\GlobalScreen\Scope\Toast\Provider\AbstractToastProvider;
-use ILIAS\Notifications\Repository\ilNotificationOSDRepository;
 use ILIAS\UI\Component\Symbol\Icon\Standard;
-use ILIAS\Notifications\ilNotificationOSDHandler;
 
 class ChatInvitationToastProvider extends AbstractToastProvider
 {
-    public const MUTED_UNTIL_PREFERENCE_KEY = 'chatinv_nc_muted_until';
-    public const NOTIFICATION_TYPE = 'chat_invitation';
-
     public function getToasts(): array
     {
         $toasts = [];
@@ -38,14 +33,7 @@ class ChatInvitationToastProvider extends AbstractToastProvider
             return $toasts;
         }
 
-        $osd_notification_handler = new ilNotificationOSDHandler(new ilNotificationOSDRepository($this->dic->database()));
-
-        foreach ($osd_notification_handler->getOSDNotificationsForUser(
-            $this->dic->user()->getId(),
-            true,
-            time() - $this->dic->user()->getPref(self::MUTED_UNTIL_PREFERENCE_KEY),
-            self::NOTIFICATION_TYPE
-        ) as $invitation) {
+        foreach ((new ChatInvitationNotificationProvider($this->dic))->getUserOSDNotifications() as $invitation) {
             $toast = $this->getDefaultToast(
                 $invitation->getObject()->title,
                 $this->dic->ui()->factory()->symbol()->icon()->standard(Standard::CHTA, 'chat_invitations')

--- a/Modules/Chatroom/classes/class.ilChatroom.php
+++ b/Modules/Chatroom/classes/class.ilChatroom.php
@@ -31,6 +31,8 @@ use ILIAS\Chatroom\GlobalScreen\ChatInvitationNotificationProvider;
  */
 class ilChatroom
 {
+    public const CHAT_INVITATION = 'chat_invitation';
+
     private static string $settingsTable = 'chatroom_settings';
     private static string $historyTable = 'chatroom_history';
     private static string $userTable = 'chatroom_users';
@@ -843,6 +845,7 @@ class ilChatroom
         int $subScope = 0,
         string $invitationLink = ''
     ): void {
+        $provider = new ChatInvitationNotificationProvider();
         $links = [];
 
         if ($gui && $invitationLink === '') {
@@ -887,16 +890,14 @@ class ilChatroom
                 $bodyParams['room_name'] .= ' - ' . self::lookupPrivateRoomTitle($subScope);
             }
 
-            $notification = new ilNotificationConfig(ChatInvitationNotificationProvider::NOTIFICATION_TYPE);
+            $notification = $provider->getNotificationConfig();
             $notification->setTitleVar('chat_invitation', $bodyParams, 'chatroom');
             $notification->setShortDescriptionVar('chat_invitation_short', $bodyParams, 'chatroom');
             $notification->setLongDescriptionVar('chat_invitation_long', $bodyParams, 'chatroom');
             $notification->setLinks($links);
             $notification->setIconPath('templates/default/images/icon_chtr.svg');
-            $notification->setValidForSeconds(ilNotificationConfig::TTL_LONG);
-            $notification->setVisibleForSeconds(ilNotificationConfig::DEFAULT_TTS);
-
             $notification->setHandlerParam('mail.sender', (string) $sender_id);
+            $notification->setProviderKey(self::CHAT_INVITATION);
 
             $notification->notifyByUsers([$recipient_id]);
         }


### PR DESCRIPTION
**DEPENDS ON https://github.com/ILIAS-eLearning/ILIAS/pull/5698**

With the merge of the depending PR the usage of OSDNotifcation obliges the Service to handle the cleanup of its own notifications. Therefore the refactored Notification System provider a new feature trough the NotifcationProvider from wich this service heritages, to delete your own Notifcation with a safe named key.

You can set that key within your Notification config with the function `setProviderKey()`

If an event causes the Notification to be irelevant it can be deleted by that key with a new function in your NotificationProvider Inehitance `removeOSDNotificationsByProviderKey()` wich optional recieves a user ID to remove this OSD for on user. Otherwise its removed for all users.

Further you can cleanup all old notifications with the function `deleteStaleNotifications()`. I encourage you to do so if your service produces a lot of notifications.
