### PR TITLE
Use refactored notification provider functions

### DIFF
--- a/Services/Contact/BuddySystem/classes/class.ilBuddySystemNotification.php
+++ b/Services/Contact/BuddySystem/classes/class.ilBuddySystemNotification.php
@@ -29,6 +29,8 @@ use ILIAS\Contact\Provider\ContactNotificationProvider;
  */
 class ilBuddySystemNotification
 {
+    public const CONTACT_REQUEST = 'contact_request';
+
     protected ilObjUser $sender;
     protected ilSetting $settings;
     /** @var int[] */
@@ -62,13 +64,13 @@ class ilBuddySystemNotification
 
     public function send(): void
     {
+        $provider = new ContactNotificationProvider();
+
         foreach ($this->getRecipientIds() as $usr_id) {
             $user = new ilObjUser($usr_id);
 
             $recipientLanguage = ilLanguageFactory::_getLanguage($user->getLanguage());
             $recipientLanguage->loadLanguageModule('buddysystem');
-
-            $notification = new ilNotificationConfig(ContactNotificationProvider::NOTIFICATION_TYPE);
 
             $personalProfileLink = $recipientLanguage->txt('buddy_noti_cr_profile_not_published');
             if ($this->hasPublicProfile($this->sender->getId())) {
@@ -117,14 +119,16 @@ class ilBuddySystemNotification
                 'REQUESTING_USER' => ilUserUtil::getNamePresentation($this->sender->getId()),
                 'PERSONAL_PROFILE_LINK' => $personalProfileLink,
             ];
+
+            $notification = $provider->getNotificationConfig();
             $notification->setTitleVar('buddy_notification_contact_request', [], 'buddysystem');
             $notification->setShortDescriptionVar('buddy_notification_contact_request_short', $bodyParams, 'buddysystem');
             $notification->setLongDescriptionVar('buddy_notification_contact_request_long', $bodyParams, 'buddysystem');
             $notification->setLinks($links);
-            $notification->setValidForSeconds(ilNotificationConfig::TTL_LONG);
-            $notification->setVisibleForSeconds(ilNotificationConfig::DEFAULT_TTS);
             $notification->setIconPath('templates/default/images/icon_usr.svg');
             $notification->setHandlerParam('mail.sender', (string) ANONYMOUS_USER_ID);
+            $notification->setProviderKey(self::CONTACT_REQUEST);
+
             $notification->notifyByUsers([$user->getId()]);
         }
     }

--- a/Services/Contact/classes/Provider/ContactNotificationProvider.php
+++ b/Services/Contact/classes/Provider/ContactNotificationProvider.php
@@ -41,8 +41,8 @@ use ILIAS\Notifications\ilNotificationOSDHandler;
  */
 class ContactNotificationProvider extends AbstractNotificationProvider
 {
-    public const MUTED_UNTIL_PREFERENCE_KEY = 'bs_nc_muted_until';
-    public const NOTIFICATION_TYPE = 'buddysystem_request';
+    protected const NOTIFICATION_TYPE = 'buddysystem_request';
+    protected const MUTED_UNTIL_PREFERENCE_KEY = 'bs_nc_muted_until';
 
     private function getIdentifier(string $id): IdentificationInterface
     {
@@ -123,8 +123,6 @@ class ContactNotificationProvider extends AbstractNotificationProvider
                 )
             ]);
 
-        $osd_notification_handler = new ilNotificationOSDHandler(new ilNotificationOSDRepository($this->dic->database()));
-
         $group = $factory
             ->standardGroup($this->getIdentifier('contact_bucket_group'))
             ->withTitle($this->dic->language()->txt('nc_contact_requests_headline'))
@@ -132,13 +130,10 @@ class ContactNotificationProvider extends AbstractNotificationProvider
                 $factory->standard($this->getIdentifier('contact_bucket'))
                     ->withNotificationItem($notificationItem)
                     ->withClosedCallable(
-                        function () use ($osd_notification_handler): void {
+                        function (): void {
                             $this->dic->user()->writePref(self::MUTED_UNTIL_PREFERENCE_KEY, (string) time());
 
-                            $osd_notification_handler->deleteStaleNotificationsForUserAndType(
-                                $this->dic->user()->getId(),
-                                self::NOTIFICATION_TYPE
-                            );
+                            $this->deleteStaleNotifications();
                         }
                     )->withNewAmount(1)
             );

--- a/Services/Contact/classes/Provider/ContactToastProvider.php
+++ b/Services/Contact/classes/Provider/ContactToastProvider.php
@@ -21,14 +21,10 @@ declare(strict_types=1);
 namespace ILIAS\Contact\Provider;
 
 use ILIAS\GlobalScreen\Scope\Toast\Provider\AbstractToastProvider;
-use ILIAS\Notifications\Repository\ilNotificationOSDRepository;
 use ILIAS\UI\Component\Symbol\Icon\Standard;
-use ILIAS\Notifications\ilNotificationOSDHandler;
 
 class ContactToastProvider extends AbstractToastProvider
 {
-    public const NOTIFICATION_TYPE = 'buddysystem_request';
-
     public function getToasts(): array
     {
         $toasts = [];
@@ -37,14 +33,7 @@ class ContactToastProvider extends AbstractToastProvider
             return $toasts;
         }
 
-        $osd_notification_handler = new ilNotificationOSDHandler(new ilNotificationOSDRepository($this->dic->database()));
-
-        foreach ($osd_notification_handler->getOSDNotificationsForUser(
-            $this->dic->user()->getId(),
-            true,
-            0,
-            self::NOTIFICATION_TYPE
-        ) as $contact_request_info) {
+        foreach ((new ContactNotificationProvider($this->dic))->getUserOSDNotifications() as $contact_request_info) {
             $toast = $this->getDefaultToast(
                 $contact_request_info->getObject()->title,
                 $this->dic->ui()->factory()->symbol()->icon()->standard(Standard::CADM, 'buddysystem_request')


### PR DESCRIPTION
**DEPENDS ON https://github.com/ILIAS-eLearning/ILIAS/pull/5698**

With the merge of the depending PR the usage of OSDNotifcation obliges the Service to handle the cleanup of its own notifications. Therefore the refactored Notification System provider a new feature trough the NotifcationProvider from wich this service heritages, to delete your own Notifcation with a safe named key.

You can set that key within your Notification config with the function `setProviderKey()`

If an event causes the Notification to be irelevant it can be deleted by that key with a new function in your NotificationProvider Inehitance `removeOSDNotificationsByProviderKey()` wich optional recieves a user ID to remove this OSD for on user. Otherwise its removed for all users.

Further you can cleanup all old notifications with the function `deleteStaleNotifications()`. I encourage you to do so if your service produces a lot of notifications.