### PR TITLE
Use refactored notification provider functions

### DIFF
--- a/Services/Badge/GlobalScreen/BadgeToastProvider.php
+++ b/Services/Badge/GlobalScreen/BadgeToastProvider.php
@@ -21,14 +21,10 @@ declare(strict_types=1);
 namespace ILIAS\Badge\GlobalScreen;
 
 use ILIAS\GlobalScreen\Scope\Toast\Provider\AbstractToastProvider;
-use ILIAS\Notifications\Repository\ilNotificationOSDRepository;
 use ILIAS\UI\Component\Symbol\Icon\Standard;
-use ILIAS\Notifications\ilNotificationOSDHandler;
 
 class BadgeToastProvider extends AbstractToastProvider
 {
-    public const NOTIFICATION_TYPE = 'badge_received';
-
     public function getToasts(): array
     {
         $toasts = [];
@@ -37,14 +33,7 @@ class BadgeToastProvider extends AbstractToastProvider
             return $toasts;
         }
 
-        $osd_notification_handler = new ilNotificationOSDHandler(new ilNotificationOSDRepository($this->dic->database()));
-
-        foreach ($osd_notification_handler->getOSDNotificationsForUser(
-            $this->dic->user()->getId(),
-            true,
-            0,
-            self::NOTIFICATION_TYPE
-        ) as $badge_issued_info) {
+        foreach ((new BadgeNotificationProvider($this->dic))->getUserOSDNotifications() as $badge_issued_info) {
             $toast = $this->getDefaultToast(
                 $badge_issued_info->getObject()->title,
                 $this->dic->ui()->factory()->symbol()->icon()->standard(Standard::BDGA, 'badge')

--- a/Services/Badge/classes/class.ilBadgeHandler.php
+++ b/Services/Badge/classes/class.ilBadgeHandler.php
@@ -27,6 +27,8 @@ use ILIAS\Badge\GlobalScreen\BadgeNotificationProvider;
  */
 class ilBadgeHandler
 {
+    public const BADGES = 'badges';
+
     protected ilComponentRepository $component_repository;
     protected ilDBInterface $db;
     protected ilTree $tree;
@@ -480,6 +482,8 @@ class ilBadgeHandler
         array $a_user_map,
         int $a_parent_ref_id = null
     ): void {
+        $provider = new BadgeNotificationProvider();
+
         $badges = [];
 
         foreach ($a_user_map as $user_id => $badge_ids) {
@@ -541,14 +545,14 @@ class ilBadgeHandler
                     $url = new ilNotificationLink(new ilNotificationParameter('badge_notification_badges_goto', [], 'badge'), $url);
                     $osd_params = ["badge_list" => implode(", ", $user_badges)];
 
-                    $notification = new ilNotificationConfig(BadgeNotificationProvider::NOTIFICATION_TYPE);
+                    $notification = $provider->getNotificationConfig();
                     $notification->setTitleVar("badge_notification_subject", [], "badge");
                     $notification->setShortDescriptionVar("badge_notification_osd", $osd_params, "badge");
                     $notification->setLongDescriptionVar("");
                     $notification->setLinks([$url]);
                     $notification->setIconPath(ilUtil::getImagePath('icon_bdga.svg'));
-                    $notification->setValidForSeconds(ilNotificationConfig::TTL_SHORT);
-                    $notification->setVisibleForSeconds(ilNotificationConfig::DEFAULT_TTS);
+                    $notification->setProviderKey(self::BADGES);
+
                     $notification->notifyByUsers([$user_id]);
                 }
             }


### PR DESCRIPTION
**DEPENDS ON https://github.com/ILIAS-eLearning/ILIAS/pull/5698**

With the merge of the depending PR the usage of OSDNotifcation obliges the Service to handle the cleanup of its own notifications. Therefore the refactored Notification System provider a new feature trough the NotifcationProvider from wich this service heritages, to delete your own Notifcation with a safe named key.

You can set that key within your Notification config with the function `setProviderKey()`

If an event causes the Notification to be irelevant it can be deleted by that key with a new function in your NotificationProvider Inehitance `removeOSDNotificationsByProviderKey()` wich optional recieves a user ID to remove this OSD for on user. Otherwise its removed for all users.

Further you can cleanup all old notifications with the function `deleteStaleNotifications()`. I encourage you to do so if your service produces a lot of notifications.