### PR TITLE
[FIX] Survey: surveys are now in the repository context (GS).

### DIFF
--- a/Modules/Survey/classes/class.ilObjSurveyGUI.php
+++ b/Modules/Survey/classes/class.ilObjSurveyGUI.php
@@ -83,7 +83,11 @@ class ilObjSurveyGUI extends ilObjectGUI
 
         // this class will be treated as a baseclass in most cases, therefore
         // we need to claim the repository context manually. see #37010
-        $DIC->globalScreen()->tool()->context()->claim()->repository();
+        if (!$DIC->globalScreen()->tool()->context()->stack()->hasMatch(
+            $DIC->globalScreen()->tool()->context()->collection()->repository()
+        )) {
+            $DIC->globalScreen()->tool()->context()->claim()->repository();
+        }
     }
     
     public function executeCommand()

--- a/Modules/Survey/classes/class.ilObjSurveyGUI.php
+++ b/Modules/Survey/classes/class.ilObjSurveyGUI.php
@@ -80,6 +80,10 @@ class ilObjSurveyGUI extends ilObjectGUI
         $this->invitation_manager = new Participants\InvitationsManager();
 
         parent::__construct("", (int) $_GET["ref_id"], true, false);
+
+        // this class will be treated as a baseclass in most cases, therefore
+        // we need to claim the repository context manually. see #37010
+        $DIC->globalScreen()->tool()->context()->claim()->repository();
     }
     
     public function executeCommand()


### PR DESCRIPTION
Hi @alex40724

This should fix the issue mentioned in https://mantis.ilias.de/view.php?id=37010, where surveys are not part of the repository context.

Kind regards,
@thibsy 