### PR TITLE
Setup: Make classmap retrieval more robust (`ImplementationOfInterfac…

### DIFF
--- a/src/Setup/ImplementationOfInterfaceFinder.php
+++ b/src/Setup/ImplementationOfInterfaceFinder.php
@@ -109,7 +109,17 @@ class ImplementationOfInterfaceFinder
 
 
         foreach ($this->classmap as $class_name => $file_path) {
-            $path = str_replace($this->root, "", realpath($file_path));
+            $real_path = realpath($file_path);
+            if ($real_path === false) {
+                throw new \RuntimeException(
+                    "Could not find file for class $class_name (path: $file_path). " .
+                    "Please check the composer classmap, maybe it is outdated. " .
+                    "You can regenerate it by executing 'composer du' or 'composer install' " .
+                    "(which also ensures dependencies are correctly installed) in the ILIAS root directory."
+                );
+            }
+
+            $path = str_replace($this->root, "", $real_path);
             if ($matching_path && !preg_match("#^" . $matching_path . "$#", $path)) {
                 continue;
             }


### PR DESCRIPTION
…eFinder`)

In cases where the composer autoload classmap is not up-to-date it might occur that
`\ILIAS\Setup\ImplementationOfInterfaceFinder::getAllClassNames` results in an (PHP) error and installing/updating the installation completely fails. The error occurs if there are files in the classmap which do not exist anymore.

<pre>
..
Update ILIAS
============

PHP Fatal error:  Uncaught TypeError: str_replace(): Argument #3 ($subject) must be of type array|string, bool given in /var/www/ilias/trunk/src/Setup/ImplementationOfInterfaceFinder.php:112
Stack trace:
#0 /var/www/ilias/trunk/src/Setup/ImplementationOfInterfaceFinder.php(112): str_replace()
#1 /var/www/ilias/trunk/src/Setup/ImplementationOfInterfaceFinder.php(75): ILIAS\Setup\ImplementationOfInterfaceFinder->getAllClassNames()
#2 /var/www/ilias/trunk/src/Setup/ImplementationOfAgentFinder.php(91): ILIAS\Setup\ImplementationOfInterfaceFinder->getMatchingClassNames()
#3 /var/www/ilias/trunk/src/Setup/CLI/HasAgent.php(49): ILIAS\Setup\ImplementationOfAgentFinder->getCoreAgents()
#4 /var/www/ilias/trunk/src/Setup/CLI/UpdateCommand.php(84): ILIAS\Setup\CLI\UpdateCommand->getRelevantAgent()
#5 /var/www/ilias/trunk/libs/composer/vendor/symfony/console/Command/Command.php(298): ILIAS\Setup\CLI\UpdateCommand->execute()
#6 /var/www/ilias/trunk/libs/composer/vendor/symfony/console/Application.php(1040): Symfony\Component\Console\Command\Command->run()
#7 /var/www/ilias/trunk/libs/composer/vendor/symfony/console/Application.php(301): Symfony\Component\Console\Application->doRunCommand()
#8 /var/www/ilias/trunk/libs/composer/vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun()
#9 /var/www/ilias/trunk/setup/cli.php(40): Symfony\Component\Console\Application->run()
#10 {main}
  thrown in /var/www/ilias/trunk/src/Setup/ImplementationOfInterfaceFinder.php on line 112
..
</pre>

Of course this only hides the error and we could of course debate about if a script terminating error is better than making the script more robust against these kind of situations.

IMO the best solution would be a hint like:

> Dear administrator, maybe you'll have to run "composer install" before using the setup. The following files are still in the composer classmap but could not be found anymore: [LIST_OF_FILES]

But of course this woul require to touch some more parts of the setup I think.

I don't consider this being a real bug, but maybe this change helps other developers/administrators to save some time when receiving this error.