### PR TITLE
T&A: fixes #36855

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -10176,13 +10176,12 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             $user = $feedback_old['finalized_by_usr_id'];
             $finalized_time = $feedback_old['finalized_tstamp'];
         }
-        if ($finalized == false || $finalized == NULL) {
 
+        if ($finalized === false) {
             $update_default['finalized_evaluation'] = ['integer', 0];
             $update_default['finalized_by_usr_id'] = ['integer', 0];
             $update_default['finalized_tstamp'] = ['integer', 0];
-        }
-       elseif ($finalized == true) {
+        } elseif ($finalized === true) {
             $update_default['finalized_evaluation'] = ['integer', 1];
             $update_default['finalized_by_usr_id'] = ['integer', $user];
             $update_default['finalized_tstamp'] = ['integer', $finalized_time];

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -10176,19 +10176,18 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             $user = $feedback_old['finalized_by_usr_id'];
             $finalized_time = $feedback_old['finalized_tstamp'];
         }
+        if ($finalized == false || $finalized == NULL) {
 
-        if ($finalized === true || $feedback_old['finalized_evaluation'] == 1) {
-            if (!array_key_exists('evaluated', $_POST)) {
-                $update_default['finalized_evaluation'] = ['integer', 0];
-                $update_default['finalized_by_usr_id'] = ['integer', 0];
-                $update_default['finalized_tstamp'] = ['integer', 0];
-            } else {
-                $update_default['finalized_evaluation'] = ['integer', 1];
-                $update_default['finalized_by_usr_id'] = ['integer', $user];
-                $update_default['finalized_tstamp'] = ['integer', $finalized_time];
-            }
+            $update_default['finalized_evaluation'] = ['integer', 0];
+            $update_default['finalized_by_usr_id'] = ['integer', 0];
+            $update_default['finalized_tstamp'] = ['integer', 0];
         }
-
+       elseif ($finalized == true) {
+            $update_default['finalized_evaluation'] = ['integer', 1];
+            $update_default['finalized_by_usr_id'] = ['integer', $user];
+            $update_default['finalized_tstamp'] = ['integer', $finalized_time];
+        }
+        
         $ilDB->insert('tst_manual_fb', $update_default);
     }
 

--- a/Modules/Test/classes/class.ilTestScoringGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringGUI.php
@@ -288,7 +288,7 @@ class ilTestScoringGUI extends ilTestServiceGUI
         foreach ($questionGuiList as $questionId => $questionGui) {
             $reachedPoints = $form->getItemByPostVar("question__{$questionId}__points")->getValue();
 
-            $finalized = $form->getItemByPostVar("{$questionId}__evaluated")->getchecked();
+            $finalized = (bool) $form->getItemByPostVar("{$questionId}__evaluated")->getchecked();
 
             // fix #35543: save manual points only if they differ from the existing points
             // this prevents a question being set to "answered" if only feedback is entered

--- a/Modules/Test/classes/class.ilTestScoringGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringGUI.php
@@ -431,8 +431,8 @@ class ilTestScoringGUI extends ilTestServiceGUI
             $questionSolution = $questionGUI->getSolutionOutput($activeId, $pass, false, false, true, false, false, true);
             $bestSolution = $questionGUI->object->getSuggestedSolutionOutput();
             $feedback = $this->object->getSingleManualFeedback($activeId, $questionId, $pass);
-
-                if(isset($feedback['finalized_evaluation']) && $feedback['finalized_evaluation'] == 1){
+            $disabled = false;
+            if (isset($feedback['finalized_evaluation']) && $feedback['finalized_evaluation'] == 1) {
                 $disabled = true;
             }
         

--- a/Modules/Test/classes/class.ilTestScoringGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringGUI.php
@@ -288,6 +288,8 @@ class ilTestScoringGUI extends ilTestServiceGUI
         foreach ($questionGuiList as $questionId => $questionGui) {
             $reachedPoints = $form->getItemByPostVar("question__{$questionId}__points")->getValue();
 
+            $finalized = $form->getItemByPostVar("{$questionId}__evaluated")->getchecked();
+
             // fix #35543: save manual points only if they differ from the existing points
             // this prevents a question being set to "answered" if only feedback is entered
             $oldPoints = assQuestion::_getReachedPoints($activeId, $questionId, $pass);
@@ -308,8 +310,8 @@ class ilTestScoringGUI extends ilTestServiceGUI
                 false,
                 ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment")
             );
-                    
-            $this->object->saveManualFeedback($activeId, $questionId, $pass, $feedback);
+
+            $this->object->saveManualFeedback($activeId, $questionId, $pass, $feedback, $finalized, true);
 
             $notificationData[$questionId] = array(
                 'points' => $reachedPoints, 'feedback' => $feedback
@@ -428,6 +430,11 @@ class ilTestScoringGUI extends ilTestServiceGUI
             $questionHeader = sprintf($lng->txt('tst_manscoring_question_section_header'), $questionGUI->object->getTitle());
             $questionSolution = $questionGUI->getSolutionOutput($activeId, $pass, false, false, true, false, false, true);
             $bestSolution = $questionGUI->object->getSuggestedSolutionOutput();
+            $feedback = $this->object->getSingleManualFeedback($activeId, $questionId, $pass);
+
+                if(isset($feedback['finalized_evaluation']) && $feedback['finalized_evaluation'] == 1){
+                $disabled = true;
+            }
         
             $sect = new ilFormSectionHeaderGUI();
             $sect->setTitle($questionHeader . ' [' . $this->lng->txt('question_id_short') . ': ' . $questionGUI->object->getId() . ']');
@@ -450,6 +457,9 @@ class ilTestScoringGUI extends ilTestServiceGUI
             if ($initValues) {
                 $text->setValue(assQuestion::_getReachedPoints($activeId, $questionId, $pass));
             }
+            if($disabled){
+                $text->setDisabled($disabled);
+            }
             $form->addItem($text);
             
             $nonedit = new ilNonEditableValueGUI($lng->txt('tst_manscoring_input_max_points_for_question'), "question__{$questionId}__maxpoints");
@@ -463,7 +473,17 @@ class ilTestScoringGUI extends ilTestServiceGUI
             if ($initValues) {
                 $area->setValue($this->object->getSingleManualFeedback($activeId, $questionId, $pass)['feedback']);
             }
+            if($disabled){
+                $area->setDisabled($disabled);
+            }
             $form->addItem($area);
+
+            $check = new ilCheckboxInputGUI($lng->txt('finalized_evaluation'), "{$questionId}__evaluated");
+            if ($disabled) {
+                $check->setChecked(true);
+            }
+            $form->addItem($check);
+
             if (strlen(trim($bestSolution))) {
                 $cust = new ilCustomInputGUI($lng->txt('tst_show_solution_suggested'));
                 $cust->setHtml($bestSolution);


### PR DESCRIPTION
This is a fix for https://mantis.ilias.de/view.php?id=36855

I added an extra checkbox "Scoring completed" under "Scoring by Participant" for each question.
When "Scoring completed" is checked, you cant edit that question neither under "Scoring by Question" or "Scoring by Participant". 
![Bildschirmfoto 2023-03-23 um 10 46 39](https://user-images.githubusercontent.com/41621260/227165105-3360b173-b1f6-4ce1-91bc-621156c08016.png)
