### PR TITLE
Cron: Allow local auth. only (without password)

### DIFF
--- a/Services/Authentication/classes/Provider/class.ilAuthProviderCliFactory.php
+++ b/Services/Authentication/classes/Provider/class.ilAuthProviderCliFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilAuthProviderCliFactory extends ilAuthProviderFactory
+{
+    public function getProviders(ilAuthCredentials $credentials): array
+    {
+        return [
+            $this->getProviderByAuthMode($credentials, ilAuthUtils::AUTH_LOCAL)
+        ];
+    }
+
+    public function getProviderByAuthMode(ilAuthCredentials $credentials, $a_authmode): ?ilAuthProviderInterface
+    {
+        switch ((int) $a_authmode) {
+            case ilAuthUtils::AUTH_LOCAL:
+                /** @var ilAuthProviderDatabase $provider */
+                $provider = parent::getProviderByAuthMode($credentials, $a_authmode);
+                return $provider->withoutPasswordVerification();
+
+            default:
+                throw new ilCronException("The cron CLI script supports local authentication only.");
+        }
+    }
+}

--- a/Services/Authentication/classes/Provider/class.ilAuthProviderFactory.php
+++ b/Services/Authentication/classes/Provider/class.ilAuthProviderFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,19 +16,12 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-/**
- * Auth provider factory
- *
- * @author Stefan Meyer <smeyer.ilias@gmx.de>
- *
- */
+declare(strict_types=1);
+
 class ilAuthProviderFactory
 {
     private ilLogger $logger;
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         global $DIC;
@@ -38,22 +29,22 @@ class ilAuthProviderFactory
     }
 
     /**
-     * Get provider
+     * @return list<ilAuthProviderInterface>
      */
     public function getProviders(ilAuthCredentials $credentials): array
     {
         // Fixed provider selection;
         if ($credentials->getAuthMode() !== '') {
             $this->logger->debug('Returning fixed provider for auth mode: ' . $credentials->getAuthMode());
-            return array(
+            return [
                 $this->getProviderByAuthMode($credentials, $credentials->getAuthMode())
-            );
+            ];
         }
 
         $auth_determination = ilAuthModeDetermination::_getInstance();
         $sequence = $auth_determination->getAuthModeSequence($credentials->getUsername());
 
-        $providers = array();
+        $providers = [];
         foreach ($sequence as $position => $authmode) {
             $provider = $this->getProviderByAuthMode($credentials, $authmode);
             if ($provider instanceof ilAuthProviderInterface) {
@@ -64,7 +55,7 @@ class ilAuthProviderFactory
     }
 
     /**
-     * Get provider by auth mode
+     * @param string|int $a_authmode
      */
     public function getProviderByAuthMode(ilAuthCredentials $credentials, $a_authmode): ?ilAuthProviderInterface
     {
@@ -120,6 +111,7 @@ class ilAuthProviderFactory
                 }
                 break;
         }
+
         return null;
     }
 }

--- a/Services/Cron/README.md
+++ b/Services/Cron/README.md
@@ -7,6 +7,8 @@ described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 **Table of Contents**
 * [ilCronJobResult](#ilCronJobResult)
+* [Cron Job Execution](#cron-job-execution)
+* [Permission Context](#permission-context)
 
 ## ilCronJobResult
 
@@ -64,3 +66,22 @@ public function run() : ilCronJobResult
 
 A message SHOULD be added additionally.
 If given, this message will be displayed in the cron job overview table.
+
+
+# Cron Job Execution
+
+In order to execute the cron job manager, the following command MUST be used:
+
+```shell
+/usr/bin/php [PATH_TO_ILIAS]/cron/cron.php run-jobs <user> <client_id>
+```
+
+The `<user>` MUST be a valid (but arbitrary) user account of the ILIAS installation.
+The `<client_id>` MUST be the client id of the ILIAS installation.
+
+## Permission Context
+
+Implementations of `ilCronJob` MUST NOT rely on specific permissions (e.g. RBAC).
+Generally said, there MUST NOT be any expectations regarding given permissions
+at all in the context of a cron job. Please keep this in mind when you structure
+your code layers.

--- a/Services/Cron/classes/CLI/App.php
+++ b/Services/Cron/classes/CLI/App.php
@@ -18,12 +18,20 @@
 
 declare(strict_types=1);
 
-chdir(__DIR__);
-chdir('..');
+namespace ILIAS\Cron\CLI;
 
-require_once './libs/composer/vendor/autoload.php';
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 
-$cron = new ILIAS\Cron\CLI\App(
-    new ILIAS\Cron\CLI\Commands\RunActiveJobsCommand()
-);
-$cron->run();
+class App extends Application
+{
+    public const NAME = "The ILIAS cron job script";
+
+    public function __construct(Command ...$commands)
+    {
+        parent::__construct(self::NAME);
+        foreach ($commands as $c) {
+            $this->add($c);
+        }
+    }
+}

--- a/Services/Cron/classes/CLI/Commands/RunActiveJobsCommand.php
+++ b/Services/Cron/classes/CLI/Commands/RunActiveJobsCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Cron\CLI\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Style\StyleInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use ilCronStartUp;
+use Exception;
+use ilStrictCliCronManager;
+
+class RunActiveJobsCommand extends Command
+{
+    protected static $defaultName = 'run-jobs';
+
+    /** @var OutputInterface|StyleInterface */
+    private $style;
+
+    protected function configure(): void
+    {
+        $this->setDescription('Runs cron jobs depending on the respective schedule');
+
+        $this->addArgument('user', InputArgument::REQUIRED, 'The ILIAS user the script is executed with');
+        $this->addArgument('client_id', InputArgument::REQUIRED, 'The ILIAS client_id');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->style = new SymfonyStyle($input, $output);
+
+        $cron = new ilCronStartUp(
+            $input->getArgument('client_id'),
+            $input->getArgument('user')
+        );
+
+        try {
+            $cron->authenticate();
+
+            $this->withAuthenticated($input, $output);
+
+            $this->style->success('Success');
+
+            return 0;
+        } catch (Exception $e) {
+            $this->style->error($e->getMessage());
+            $this->style->error($e->getTraceAsString());
+
+            return 1;
+        } finally {
+            $cron->logout();
+        }
+    }
+
+    private function withAuthenticated(InputInterface $input, OutputInterface $output): void
+    {
+        global $DIC;
+
+        $strictCronManager = new ilStrictCliCronManager(
+            $DIC->cron()->manager()
+        );
+        $strictCronManager->runActiveJobs($DIC->user());
+    }
+}

--- a/Services/Cron/classes/class.ilCronStartUp.php
+++ b/Services/Cron/classes/class.ilCronStartUp.php
@@ -21,18 +21,17 @@ declare(strict_types=1);
 class ilCronStartUp
 {
     private readonly ilAuthSession $authSession;
+    private bool $authenticated = false;
 
     public function __construct(
         private readonly string $client,
         private readonly string $username,
-        private readonly string $password,
         ?ilAuthSession $authSession = null
     ) {
         /** @noRector  */
-        require_once './Services/Context/classes/class.ilContext.php';
         ilContext::init(ilContext::CONTEXT_CRON);
 
-        // @see mantis 20371: To get rid of this, the authentication service has to provide a mechanism to pass the client_id
+        // TODO @see mantis 20371: To get rid of this, the authentication service has to provide a mechanism to pass the client_id
         $_GET['client_id'] = $this->client;
         /** @noRector  */
         require_once './include/inc.header.php';
@@ -46,49 +45,46 @@ class ilCronStartUp
 
 
     /**
-     * Start authentication
      * @throws ilCronException if authentication failed.
      */
     public function authenticate(): bool
     {
         $credentials = new ilAuthFrontendCredentials();
         $credentials->setUsername($this->username);
-        $credentials->setPassword($this->password);
-
-        $provider_factory = new ilAuthProviderFactory();
-        $providers = $provider_factory->getProviders($credentials);
 
         $status = ilAuthStatus::getInstance();
 
         $frontend_factory = new ilAuthFrontendFactory();
         $frontend_factory->setContext(ilAuthFrontendFactory::CONTEXT_CLI);
 
+        $provider_factory = new ilAuthProviderCliFactory();
+
         $frontend = $frontend_factory->getFrontend(
             $this->authSession,
             $status,
             $credentials,
-            $providers
+            $provider_factory->getProviders($credentials)
         );
 
         $frontend->authenticate();
 
         switch ($status->getStatus()) {
             case ilAuthStatus::STATUS_AUTHENTICATED:
+                $this->authenticated = true;
                 ilLoggerFactory::getLogger('auth')->debug('Authentication successful; Redirecting to starting page.');
                 return true;
-
 
             case ilAuthStatus::STATUS_AUTHENTICATION_FAILED:
             default:
                 throw new ilCronException($status->getTranslatedReason());
         }
-
-        return true;
     }
 
     public function logout(): void
     {
-        ilSession::setClosingContext(ilSession::SESSION_CLOSE_USER);
-        $this->authSession->logout();
+        if ($this->authenticated) {
+            ilSession::setClosingContext(ilSession::SESSION_CLOSE_USER);
+            $this->authSession->logout();
+        }
     }
 }


### PR DESCRIPTION
This PR changes the CLI cron script of ILIAS by ...

- ... only trying a local authentication (so no more LDAP auth. etc.) - it is more a `Lookup` and not an authentication anymore ...
- ... therefore don't requiring a raw password to be provided as an argument in the PHP CLI process anymore
- ... using `Symfony Console` (similar to the setup). IMO this is a good foundation for possible future ehancements in the `Cron` component of ILIAS (e.g. introduce a command to run a specific job only etc.).

Depending on the JF decision I would like to integrate this in `release_8` as well.