### PR TITLE
[FIX] UI: OptionalGroup now is only required if explicitly set.

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/OptionalGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/OptionalGroup.php
@@ -51,6 +51,11 @@ class OptionalGroup extends Group implements Field\OptionalGroup
         return Input::withRequired($is_required);
     }
 
+    public function isRequired(): bool
+    {
+        return $this->is_required;
+    }
+
     /**
      * @inheritdoc
      * @return OptionalGroup

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -241,7 +241,7 @@ class Renderer extends AbstractComponentRenderer
         $dependant_group_html = $default_renderer->render($component->getInputs());
 
         $this->maybeDisable($component, $tpl);
-        return $this->wrapInFormContext($component, $tpl->get(), "", $dependant_group_html);
+        return $this->wrapInFormContext($component, $tpl->get(), $id, $dependant_group_html);
     }
 
     protected function renderSwitchableGroup(F\SwitchableGroup $component, RendererInterface $default_renderer) : string

--- a/src/UI/examples/Input/Field/OptionalGroup/with_required_sub_inputs.php
+++ b/src/UI/examples/Input/Field/OptionalGroup/with_required_sub_inputs.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Example showing how an optional group (of inputs) which shows, that
+ * the optional input will not be required even though it's sub inputs
+ * are.
+ */
+function with_required_sub_inputs()
+{
+    global $DIC;
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    $optional_group = $factory->input()->field()->optionalGroup([
+        $factory->input()->field()->text(
+            'this input is required',
+            'but only if the optional group is checked'
+        )->withRequired(true)
+    ], 'this input is not required');
+
+    $form = $factory->input()->container()->form()->standard('#', [$optional_group]);
+
+    if ("POST" === $request->getMethod()) {
+        $form = $form->withRequest($request);
+        $result = $form->getData();
+    } else {
+        $result = "No result yet.";
+    }
+
+    return "<pre>" . print_r($result, true) . "</pre>" . $renderer->render($form);
+}

--- a/tests/UI/Component/Input/Field/OptionalGroupInputTest.php
+++ b/tests/UI/Component/Input/Field/OptionalGroupInputTest.php
@@ -95,6 +95,19 @@ class OptionalGroupInputTest extends ILIAS_UI_TestBase
         $this->assertNotSame($this->optional_group, $new_group);
     }
 
+    public function testThatOptionalGroupIsNotRequiredBecauseOfItsChildren(): void
+    {
+        $this->assertNotSame($this->child1, $this->child2);
+        $this->child1->method('isRequired')->willReturn(true);
+        $this->child2->method('isRequired')->willReturn(true);
+
+        $new_group = $this->optional_group;
+
+        $this->assertEquals([$this->child1, $this->child2], $new_group->getInputs());
+        $this->assertInstanceOf(OptionalGroup::class, $new_group);
+        $this->assertFalse($new_group->isRequired());
+    }
+
     public function testOptionalGroupMayOnlyHaveInputChildren()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
Hi folks,

I noticed that `OptionalGroup`s are required if any of it's sub-inputs are, like in normal `Group`s.

This behaviour is IMO not quite as expected, because the sub-inputs should only be required **after** the `OptionalGroup` was checked, or if set explicitly (why-so-ever one would do this).

This PR therefore adds:
- a fix for this issue by overriding `Group::isRequired()`
- a fix for yet another issue, where the label of the optional group was not pointing to it's checkbox input.
- an example for the expected behaviour of required `OptionalGroup`s.
- a unit-test for the expected behaviour of required `OptionalGroup`s.

If you feel different about this behaviour let me know.

Kind regards
@thibsy