### PR TITLE
T&A Added missing lang var

### DIFF
--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1811,6 +1811,8 @@ assessment#:#tst_results_grading_opt_show_status_desc#:#Information on the ‘Pa
 assessment#:#tst_results_overview#:#Pass Overview of the Test Results
 assessment#:#tst_results_print_best_solution#:#Best Solution
 assessment#:#tst_results_print_best_solution_info#:#Additionally for each question the best possible solution will be displayed.
+assessment#:#tst_results_print_best_solution_singlepage#:#Best Solution
+assessment#:#tst_results_print_best_solution_singlepage_info#:#Additionally for each question the best possible solution will be displayed.
 assessment#:#tst_results_tax_filters#:#Result Filter
 assessment#:#tst_resume_dyn_test_with_cur_quest_sel#:#Resume Test with Current Question Selection
 assessment#:#tst_resume_test#:#Resume the Test


### PR DESCRIPTION
These 2 have still missed after the changes from @nhaagen.

After the single page result view should be abandoned with ILIAS 9, there is no need to cherry-pick this to Trunk.