### PR TITLE
UI presentation table - fix overlap of box and header into action btn

### DIFF
--- a/src/UI/templates/default/Table/table.less
+++ b/src/UI/templates/default/Table/table.less
@@ -69,9 +69,15 @@
 
     .il-table-presentation-actions {
         margin: 5px 0;
+        // if there is an action, row header text should not run over action button
+        &:not(:empty) + .il-table-presentation-row-header {
+            max-width: calc(100% - 120px);
+        }
     }
 
     .il-table-presentation-row-header {
+        // if there is no sub headline, a min-height is needed so further fields box doesn't overlap with action button - Mantis 36531
+        min-height: @font-size-h4 * 2;
         h4 {
             font-size: @font-size-h4;
             font-weight: normal;

--- a/src/UI/templates/default/Table/table.less
+++ b/src/UI/templates/default/Table/table.less
@@ -71,7 +71,7 @@
         margin: 5px 0;
         // if there is an action, row header text should not run over action button
         &:not(:empty) + .il-table-presentation-row-header {
-            max-width: calc(100% - 120px);
+            max-width: calc(100% - 11rem);
         }
     }
 

--- a/src/UI/templates/default/Table/tpl.presentationrow.html
+++ b/src/UI/templates/default/Table/tpl.presentationrow.html
@@ -11,10 +11,8 @@
 
 
 	<div class="il-table-presentation-row-contents">
-
-		<div class="il-table-presentation-actions">
-			<!-- BEGIN button -->{BUTTON}<br><!-- END button -->
-		</div>
+		<!-- has to be in one line so :empty selector can check if there is a button in this div -->
+		<div class="il-table-presentation-actions"><!-- BEGIN button -->{BUTTON}<br><!-- END button --></div>
 
 		<div class="il-table-presentation-row-header">
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8718,6 +8718,12 @@ fieldset[disabled] .il-table-presentation-viewcontrols .btn-default.engaged.focu
 .il-table-presentation-row .il-table-presentation-actions {
   margin: 5px 0;
 }
+.il-table-presentation-row .il-table-presentation-actions:not(:empty) + .il-table-presentation-row-header {
+  max-width: calc(100% - 120px);
+}
+.il-table-presentation-row .il-table-presentation-row-header {
+  min-height: 34px;
+}
 .il-table-presentation-row .il-table-presentation-row-header h4 {
   font-size: 17px;
   font-weight: normal;
@@ -10336,9 +10342,6 @@ footer {
 }
 .il-maincontrols-footer .il-footer-permanent-url {
   margin-right: 5px;
-}
-.il-maincontrols-footer .il-footer-permanent-url > a {
-  color: white;
 }
 .il-maincontrols-footer .il-footer-text {
   margin-right: 5px;
@@ -20168,4 +20171,3 @@ table.mceToolbar td {
   border: 1px solid #dddddd;
   border-radius: 0.25em;
 }
-/*# sourceMappingURL=delos.css.map */

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8719,7 +8719,7 @@ fieldset[disabled] .il-table-presentation-viewcontrols .btn-default.engaged.focu
   margin: 5px 0;
 }
 .il-table-presentation-row .il-table-presentation-actions:not(:empty) + .il-table-presentation-row-header {
-  max-width: calc(100% - 120px);
+  max-width: calc(100% - 11rem);
 }
 .il-table-presentation-row .il-table-presentation-row-header {
   min-height: 34px;


### PR DESCRIPTION
# Issues

Mantis: https://mantis.ilias.de/view.php?id=36531

The action button or dropdown is overlapped by other elements of the presentation table...

...when there is no sub-headline:

![image](https://user-images.githubusercontent.com/59924129/227916889-72a91b74-787f-460f-9c67-e2e35a007d60.png)

...when the headline is very long:

![image](https://user-images.githubusercontent.com/59924129/227917084-3cb68a1a-d0cf-4cdc-8217-5bc705011ef7.png)

This happens because the action div is removed from the document flow with `position: absolute` so other elements cannot respect its space.

While I am guilty of having worked like this in the past to stick dropdowns and buttons to top right corners of containers with this method, I currently believe that placing these elements within the flow of a flex- or grid-layout is the more stable solution as nothing can ever overlap into the action's place. I would like to propose a refactoring of the presentation table as a flex-layout for Ilias 9 for consideration (maybe the CSS squad is a good place to discuss this?).

For now, this PR contains a less invasive temporary fix.

# Fix

This fix contains...
* a min-height for the header to make sure the box always starts below the action
* a limited width if the action is not empty, so header text cannot run into the action

![image](https://user-images.githubusercontent.com/59924129/227921063-1df8a491-3b6b-4c54-b2b9-4823c2b2d55c.png)

Note that for the `:not(:empty)`selector to work, the action div has to be written as one line with no spaces in the html template.