### PR TITLE
Fix spelling of “GitHub”

### DIFF
--- a/docs/development/file-handling.md
+++ b/docs/development/file-handling.md
@@ -309,5 +309,5 @@ The legacy varaints should no longer be used because they always presuppose that
 
 # Contribute
 If there is anything wrong or missing here, or if there are any uncertainties, please open a ticket in Mantis (https://mantis.ilias.de). Errors or missing content in the documentation are treated as bugs.
-If someone wants to write this example in "pretty", i.e. use UI components etc., I'm happy about a pull request on Github!
+If someone wants to write this example in "pretty", i.e. use UI components etc., I'm happy about a pull request on GitHub!
 

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -18,7 +18,7 @@ source code. The system is complex for new developers and they need to know the 
 in the development guide.
  
 Communication among developers that are working on a specific component needs to be assured. Final decision about 
-getting write access to the ILIAS development system (Github) is handled by the product manager.
+getting write access to the ILIAS development system (GitHub) is handled by the product manager.
  
 ILIAS is currently maintained by three types of Maintainerships:
 

--- a/docs/development/review.md
+++ b/docs/development/review.md
@@ -51,7 +51,7 @@ We adapted this slightly by bundling questions, suggestions and change requests 
 the reactions up front.
 
 ## Inline Comments
-Github makes it very easy to leave inline comments. However, in the past, we observed, that large
+GitHub makes it very easy to leave inline comments. However, in the past, we observed, that large
 numbers of inline comments make a review hard to read and understand. We therefore propose
 only the leave inline comments for trivial directly actionable suggestions and change request, that
 do not need an rational (E.g. *Change Request: typo in word actionalbe*).

--- a/src/UI/examples/Dropdown/Standard/with_buttons_and_links.php
+++ b/src/UI/examples/Dropdown/Standard/with_buttons_and_links.php
@@ -11,7 +11,7 @@ function with_buttons_and_links()
     $renderer = $DIC->ui()->renderer();
 
     $items = array(
-        $f->button()->shy("Github", "https://www.github.com"),
+        $f->button()->shy("GitHub", "https://www.github.com"),
         $f->link()->standard("ILIAS", "https://www.ilias.de")->withOpenInNewViewport(true)
     );
     return $renderer->render($f->dropdown()->standard($items)->withLabel("Actions"));

--- a/templates/Readme.md
+++ b/templates/Readme.md
@@ -27,7 +27,7 @@ npm install -g sass
 
 or
 
-Download [Dart SASS from Github](https://github.com/sass/dart-sass/releases/) and add it to the machine's PATH.
+Download [Dart SASS from GitHub](https://github.com/sass/dart-sass/releases/) and add it to the machine's PATH.
 
 If you want to create system styles throught frontend, make sure, that your webserver
 has the permission to read and execute your newly installed sass compiler.
@@ -64,7 +64,7 @@ To create a new skin, first add a new subdirectory to directory
 `Customizing/global/skin`, e.g. `Customizing/global/skin/myskin`.
 
 In the future, we will provide a base System Style based on the
-default Delos that you can download from Github and place here.
+default Delos that you can download from GitHub and place here.
 
 #### Step 2: Create template.xml File
 

--- a/tests/UI/Component/Dropdown/DropdownTest.php
+++ b/tests/UI/Component/Dropdown/DropdownTest.php
@@ -53,7 +53,7 @@ class DropdownTest extends ILIAS_UI_TestBase
     public function test_with_items(): void
     {
         $f = $this->getFactory();
-        $link = new I\Component\Link\Standard("Link to Github", "http://www.github.com");
+        $link = new I\Component\Link\Standard("Link to GitHub", "http://www.github.com");
         $c = $f->standard(array(
             new I\Component\Button\Shy("ILIAS", "https://www.ilias.de"),
             new I\Component\Button\Shy("GitHub", "https://www.github.com"),

--- a/tests/UI/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/tests/UI/Component/Panel/PanelSecondaryLegacyTest.php
@@ -106,7 +106,7 @@ class PanelSecondaryLegacyTest extends ILIAS_UI_TestBase
         $legacy = $this->getUIFactory()->legacy("Legacy content");
         $actions = $this->getUIFactory()->dropdown()->standard(array(
             $this->getUIFactory()->button()->shy("ILIAS", "https://www.ilias.de"),
-            $this->getUIFactory()->button()->shy("Github", "https://www.github.com")
+            $this->getUIFactory()->button()->shy("GitHub", "https://www.github.com")
         ));
 
         $secondary_panel = $this->getUIFactory()->legacyPanel("title", $legacy)
@@ -182,7 +182,7 @@ class PanelSecondaryLegacyTest extends ILIAS_UI_TestBase
         $legacy = $this->getUIFactory()->legacy("Legacy content");
         $actions = $this->getUIFactory()->dropdown()->standard(array(
             $this->getUIFactory()->button()->shy("ILIAS", "https://www.ilias.de"),
-            $this->getUIFactory()->button()->shy("Github", "https://www.github.com")
+            $this->getUIFactory()->button()->shy("GitHub", "https://www.github.com")
         ));
 
         $sec = $this->getUIFactory()->legacyPanel("Title", $legacy)->withActions($actions);
@@ -196,7 +196,7 @@ class PanelSecondaryLegacyTest extends ILIAS_UI_TestBase
 		<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="id_3" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu" > <span class="caret"></span></button>
 			<ul id="id_3_menu" class="dropdown-menu">
 				<li><button class="btn btn-link" data-action="https://www.ilias.de" id="id_1">ILIAS</button></li>
-				<li><button class="btn btn-link" data-action="https://www.github.com" id="id_2">Github</button></li>
+				<li><button class="btn btn-link" data-action="https://www.github.com" id="id_2">GitHub</button></li>
 			</ul>
 		</div>
 	</div>

--- a/tests/UI/Component/Panel/PanelSecondaryListingTest.php
+++ b/tests/UI/Component/Panel/PanelSecondaryListingTest.php
@@ -142,7 +142,7 @@ class PanelSecondaryListingTest extends ILIAS_UI_TestBase
     {
         $actions = $this->getUIFactory()->dropdown()->standard(array(
             $this->getUIFactory()->button()->shy("ILIAS", "https://www.ilias.de"),
-            $this->getUIFactory()->button()->shy("Github", "https://www.github.com")
+            $this->getUIFactory()->button()->shy("GitHub", "https://www.github.com")
         ));
 
         $sec = $this->getUIFactory()->panelSecondary()->listing("Title", array())->withActions($actions);
@@ -156,7 +156,7 @@ class PanelSecondaryListingTest extends ILIAS_UI_TestBase
 		<div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="id_3" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu"> <span class="caret"></span></button>
 			<ul id="id_3_menu" class="dropdown-menu">
 				<li><button class="btn btn-link" data-action="https://www.ilias.de" id="id_1">ILIAS</button></li>
-				<li><button class="btn btn-link" data-action="https://www.github.com" id="id_2">Github</button></li>
+				<li><button class="btn btn-link" data-action="https://www.github.com" id="id_2">GitHub</button></li>
 			</ul>
 		</div>
 	</div>

--- a/tests/UI/Component/ViewControl/ViewControlTest.php
+++ b/tests/UI/Component/ViewControl/ViewControlTest.php
@@ -29,12 +29,12 @@ class ViewControlTest extends ILIAS_UI_TestBase
 {
     protected array $actions = [
         "ILIAS" => "http://www.ilias.de",
-        "Github" => "http://www.github.com"
+        "GitHub" => "http://www.github.com"
     ];
 
     protected string $aria_label = "Mode View Controler";
     protected string $role = "group";
-    protected string $active = "Github";
+    protected string $active = "GitHub";
 
     public function getViewControlFactory(): I\Component\ViewControl\Factory
     {


### PR DESCRIPTION
This is just a small capitalization fix for “GitHub” throughout our source tree (not in the parts which we import from external projects).

I have verified that the changed tests still pass.