### PR TITLE
Cron: Replace `int` schedule type with `Enum`

### DIFF
--- a/Modules/BookingManager/classes/class.ilBookCronNotification.php
+++ b/Modules/BookingManager/classes/class.ilBookCronNotification.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Cron for booking manager notification
  * @author Alexander Killing <killing@leifos.de>
@@ -63,9 +65,9 @@ class ilBookCronNotification extends ilCronJob
         return $lng->txt("book_notification_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/BookingManager/classes/class.ilBookingPrefBookCron.php
+++ b/Modules/BookingManager/classes/class.ilBookingPrefBookCron.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Cron for booking pools
  * - Automatic booking for overdue pools with booking by preferences
@@ -56,9 +58,9 @@ class ilBookingPrefBookCron extends ilCronJob
         return $lng->txt("book_pref_book_cron_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/CmiXapi/classes/class.ilXapiResultsCronjob.php
+++ b/Modules/CmiXapi/classes/class.ilXapiResultsCronjob.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Class ilXapiResultsCronjob
  *
@@ -105,9 +107,9 @@ class ilXapiResultsCronjob extends ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/Course/classes/class.ilTimingsCronReminder.php
+++ b/Modules/Course/classes/class.ilTimingsCronReminder.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=0);
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -66,9 +68,9 @@ class ilTimingsCronReminder extends ilCronJob
         return $this->lng->txt('timings_reminder_notifications_info');
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/Exercise/classes/class.ilExcCronFeedbackNotification.php
+++ b/Modules/Exercise/classes/class.ilExcCronFeedbackNotification.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Cron for exercise feedback notification
  *
@@ -55,9 +57,9 @@ class ilExcCronFeedbackNotification extends ilCronJob
         return $lng->txt("exc_global_feedback_file_cron_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/Exercise/classes/class.ilExcCronReminders.php
+++ b/Modules/Exercise/classes/class.ilExcCronReminders.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Cron for exercise reminders
  *
@@ -56,9 +58,9 @@ class ilExcCronReminders extends ilCronJob
         return $lng->txt("exc_reminders_cron_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/Forum/classes/class.ilForumCronNotification.php
+++ b/Modules/Forum/classes/class.ilForumCronNotification.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Forum notifications
  * @author Michael Jansen <mjansen@databay.de>
@@ -81,9 +83,9 @@ class ilForumCronNotification extends ilCronJob
         return $this->lng->txt('cron_forum_notification_crob_desc');
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_HOURS;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/OrgUnit/classes/class.ilCronUpdateOrgUnitPaths.php
+++ b/Modules/OrgUnit/classes/class.ilCronUpdateOrgUnitPaths.php
@@ -16,6 +16,8 @@
  ********************************************************************
  */
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Class ilCronUpdateOrgUnitPaths
  * @author  Theodor Truffer <tt@studer-raimann.ch>
@@ -62,9 +64,9 @@ class ilCronUpdateOrgUnitPaths extends ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/StudyProgramme/classes/class.ilPrgInvalidateExpiredProgressesCronJob.php
+++ b/Modules/StudyProgramme/classes/class.ilPrgInvalidateExpiredProgressesCronJob.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /*
  * This invalidates a successful progress if validityOfQualification is reached.
  *
@@ -71,9 +73,9 @@ class ilPrgInvalidateExpiredProgressesCronJob extends ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_DAYS;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/StudyProgramme/classes/class.ilPrgRestartAssignmentsCronJob.php
+++ b/Modules/StudyProgramme/classes/class.ilPrgRestartAssignmentsCronJob.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  *********************************************************************/
 
 use Pimple\Container;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Re-assign users (according to restart-date).
@@ -73,9 +74,9 @@ class ilPrgRestartAssignmentsCronJob extends ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_DAYS;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/StudyProgramme/classes/class.ilPrgUpdateProgressCronJob.php
+++ b/Modules/StudyProgramme/classes/class.ilPrgUpdateProgressCronJob.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * This will set progresses to FAILED,
  * if they are past the deadline (and not successful, yet)
@@ -69,9 +71,9 @@ class ilPrgUpdateProgressCronJob extends ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_DAYS;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/StudyProgramme/classes/class.ilPrgUserNotRestartedCronJob.php
+++ b/Modules/StudyProgramme/classes/class.ilPrgUserNotRestartedCronJob.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Inform a user, that her qualification is about to expire
  */
@@ -67,9 +69,9 @@ class ilPrgUserNotRestartedCronJob extends ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_DAYS;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/StudyProgramme/classes/class.ilPrgUserRiskyToFailCronJob.php
+++ b/Modules/StudyProgramme/classes/class.ilPrgUserRiskyToFailCronJob.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -64,9 +66,9 @@ class ilPrgUserRiskyToFailCronJob extends ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_DAYS;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/Survey/classes/class.ilSurveyCronNotification.php
+++ b/Modules/Survey/classes/class.ilSurveyCronNotification.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Cron for survey notifications
  * (reminder to paricipate in the survey)
@@ -58,9 +60,9 @@ class ilSurveyCronNotification extends ilCronJob
         return $lng->txt("survey_reminder_cron_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Modules/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
+++ b/Modules/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Class ilCronFinishUnfinishedTestPasses
  * @author Guido Vollbach <gvollbach@databay.de>
@@ -77,9 +79,9 @@ class ilCronFinishUnfinishedTestPasses extends ilCronJob
         return $lng->txt("finish_unfinished_passes_desc");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): int

--- a/Modules/Test/test/ilCronFinishUnfinishedTestPassesTest.php
+++ b/Modules/Test/test/ilCronFinishUnfinishedTestPassesTest.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Class ilCronFinishUnfinishedTestPassesTest
  * @author Marvin Beym <mbeym@databay.de>
@@ -78,7 +80,7 @@ class ilCronFinishUnfinishedTestPassesTest extends ilTestBaseTestCase
     public function testGetDefaultScheduleType(): void
     {
         $this->assertEquals(
-            ilCronFinishUnfinishedTestPasses::SCHEDULE_TYPE_DAILY,
+            CronJobScheduleType::SCHEDULE_TYPE_DAILY,
             $this->testObj->getDefaultScheduleType()
         );
     }

--- a/Services/COPage/Cron/class.ilCleanCOPageHistoryCronjob.php
+++ b/Services/COPage/Cron/class.ilCleanCOPageHistoryCronjob.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  *********************************************************************/
 
 use ILIAS\COPage\History\HistoryManager;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * @author Alexander Killing <killing@leifos.de>
@@ -63,9 +64,9 @@ class ilCleanCOPageHistoryCronjob extends ilCronJob
         return $lng->txt("copg_history_cleanup_cron_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/Calendar/classes/ConsultationHours/class.ilConsultationHourCron.php
+++ b/Services/Calendar/classes/ConsultationHours/class.ilConsultationHourCron.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Reminders for consultation hours
@@ -54,9 +55,9 @@ class ilConsultationHourCron extends ilCronJob
         return $this->lng->txt("cal_ch_cron_reminder_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/Certificate/classes/class.ilCertificateCron.php
+++ b/Services/Certificate/classes/class.ilCertificateCron.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\DI\Container;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * @author  Niels Theen <ntheen@databay.de>
@@ -185,9 +186,9 @@ class ilCertificateCron extends ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_MINUTES;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/Certificate/test/ilCertificateCronTest.php
+++ b/Services/Certificate/test/ilCertificateCronTest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
@@ -468,7 +470,7 @@ class ilCertificateCronTest extends ilCertificateBaseTestCase
 
         $flexibleSchedule = $cron->getDefaultScheduleType();
 
-        $this->assertSame(2, $flexibleSchedule);
+        $this->assertSame(CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES, $flexibleSchedule);
     }
 
     public function testGetDefaultScheduleValue(): void

--- a/Services/Cron/classes/Schedule/CronJobScheduleType.php
+++ b/Services/Cron/classes/Schedule/CronJobScheduleType.php
@@ -18,19 +18,16 @@
 
 declare(strict_types=1);
 
-class ilCronServicesImpl implements ilCronServices
+namespace ILIAS\Cron\Schedule;
+
+enum CronJobScheduleType: int
 {
-    public function __construct(private readonly \ILIAS\DI\Container $dic)
-    {
-    }
-
-    public function manager(): ilCronManager
-    {
-        return $this->dic['cron.manager'];
-    }
-
-    public function repository(): ilCronJobRepository
-    {
-        return $this->dic['cron.repository'];
-    }
+    case  SCHEDULE_TYPE_DAILY = 1;
+    case  SCHEDULE_TYPE_IN_MINUTES = 2;
+    case  SCHEDULE_TYPE_IN_HOURS = 3;
+    case  SCHEDULE_TYPE_IN_DAYS = 4;
+    case  SCHEDULE_TYPE_WEEKLY = 5;
+    case  SCHEDULE_TYPE_MONTHLY = 6;
+    case  SCHEDULE_TYPE_QUARTERLY = 7;
+    case  SCHEDULE_TYPE_YEARLY = 8;
 }

--- a/Services/Cron/classes/Setup/class.ilCronDefinitionProcessor.php
+++ b/Services/Cron/classes/Setup/class.ilCronDefinitionProcessor.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Services\Logging\NullLogger;
 

--- a/Services/Cron/classes/class.ilCronHookPlugin.php
+++ b/Services/Cron/classes/class.ilCronHookPlugin.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 abstract class ilCronHookPlugin extends ilPlugin implements ilCronJobProvider
 {

--- a/Services/Cron/classes/class.ilCronJobEntities.php
+++ b/Services/Cron/classes/class.ilCronJobEntities.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 class ilCronJobEntities implements ilCronJobCollection
 {

--- a/Services/Cron/classes/class.ilCronJobEntity.php
+++ b/Services/Cron/classes/class.ilCronJobEntity.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,11 +16,15 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 class ilCronJobEntity
 {
     private string $jobId;
     private string $component;
-    private int $scheduleType;
+    private ?CronJobScheduleType $scheduleType;
     private int $scheduleValue;
     private int $jobStatus;
     private int $jobStatusUsrId;
@@ -58,7 +60,7 @@ class ilCronJobEntity
     {
         $this->jobId = (string) $record['job_id'];
         $this->component = (string) $record['component'];
-        $this->scheduleType = (int) $record['schedule_type'];
+        $this->scheduleType = is_numeric($record['schedule_type']) ? CronJobScheduleType::tryFrom((int) $record['schedule_type']) : null;
         $this->scheduleValue = (int) $record['schedule_value'];
         $this->jobStatus = (int) $record['job_status'];
         $this->jobStatusUsrId = (int) $record['job_status_user_id'];
@@ -92,7 +94,7 @@ class ilCronJobEntity
         return $this->component;
     }
 
-    public function getScheduleType(): int
+    public function getScheduleType(): ?CronJobScheduleType
     {
         return $this->scheduleType;
     }
@@ -182,7 +184,7 @@ class ilCronJobEntity
         return $this->isPlugin;
     }
 
-    public function getEffectiveScheduleType(): int
+    public function getEffectiveScheduleType(): CronJobScheduleType
     {
         $type = $this->getScheduleType();
         if (!$type || !$this->getJob()->hasFlexibleSchedule()) {

--- a/Services/Cron/classes/class.ilCronJobResult.php
+++ b/Services/Cron/classes/class.ilCronJobResult.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 class ilCronJobResult
 {

--- a/Services/Cron/classes/class.ilCronManagerGUI.php
+++ b/Services/Cron/classes/class.ilCronManagerGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,9 +16,12 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\HTTP\Wrapper\WrapperFactory;
 use ILIAS\UI\Factory;
 use ILIAS\UI\Renderer;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Class ilCronManagerGUI
@@ -189,43 +190,39 @@ class ilCronManagerGUI
         $this->tpl->setContent($a_form->getHTML());
     }
 
-    protected function getScheduleTypeFormElementName(int $scheduleTypeId): string
+    private function getScheduleTypeFormElementName(CronJobScheduleType $schedule_type): string
     {
-        return match ($scheduleTypeId) {
-            ilCronJob::SCHEDULE_TYPE_DAILY => $this->lng->txt('cron_schedule_daily'),
-            ilCronJob::SCHEDULE_TYPE_WEEKLY => $this->lng->txt('cron_schedule_weekly'),
-            ilCronJob::SCHEDULE_TYPE_MONTHLY => $this->lng->txt('cron_schedule_monthly'),
-            ilCronJob::SCHEDULE_TYPE_QUARTERLY => $this->lng->txt('cron_schedule_quarterly'),
-            ilCronJob::SCHEDULE_TYPE_YEARLY => $this->lng->txt('cron_schedule_yearly'),
-            ilCronJob::SCHEDULE_TYPE_IN_MINUTES => sprintf($this->lng->txt('cron_schedule_in_minutes'), 'x'),
-            ilCronJob::SCHEDULE_TYPE_IN_HOURS => sprintf($this->lng->txt('cron_schedule_in_hours'), 'x'),
-            ilCronJob::SCHEDULE_TYPE_IN_DAYS => sprintf($this->lng->txt('cron_schedule_in_days'), 'x'),
+        return match ($schedule_type) {
+            CronJobScheduleType::SCHEDULE_TYPE_DAILY => $this->lng->txt('cron_schedule_daily'),
+            CronJobScheduleType::SCHEDULE_TYPE_WEEKLY => $this->lng->txt('cron_schedule_weekly'),
+            CronJobScheduleType::SCHEDULE_TYPE_MONTHLY => $this->lng->txt('cron_schedule_monthly'),
+            CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY => $this->lng->txt('cron_schedule_quarterly'),
+            CronJobScheduleType::SCHEDULE_TYPE_YEARLY => $this->lng->txt('cron_schedule_yearly'),
+            CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES => sprintf($this->lng->txt('cron_schedule_in_minutes'), 'x'),
+            CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS => sprintf($this->lng->txt('cron_schedule_in_hours'), 'x'),
+            CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS => sprintf($this->lng->txt('cron_schedule_in_days'), 'x'),
+        };
+    }
+
+    protected function getScheduleValueFormElementName(CronJobScheduleType $schedule_type): string
+    {
+        return match ($schedule_type) {
+            CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES => 'smini',
+            CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS => 'shri',
+            CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS => 'sdyi',
             default => throw new InvalidArgumentException(sprintf(
                 'The passed argument %s is invalid!',
-                var_export($scheduleTypeId, true)
+                var_export($schedule_type, true)
             )),
         };
     }
 
-    protected function getScheduleValueFormElementName(int $scheduleTypeId): string
+    protected function hasScheduleValue(CronJobScheduleType $schedule_type): bool
     {
-        return match ($scheduleTypeId) {
-            ilCronJob::SCHEDULE_TYPE_IN_MINUTES => 'smini',
-            ilCronJob::SCHEDULE_TYPE_IN_HOURS => 'shri',
-            ilCronJob::SCHEDULE_TYPE_IN_DAYS => 'sdyi',
-            default => throw new InvalidArgumentException(sprintf(
-                'The passed argument %s is invalid!',
-                var_export($scheduleTypeId, true)
-            )),
-        };
-    }
-
-    protected function hasScheduleValue(int $scheduleTypeId): bool
-    {
-        return in_array($scheduleTypeId, [
-            ilCronJob::SCHEDULE_TYPE_IN_MINUTES,
-            ilCronJob::SCHEDULE_TYPE_IN_HOURS,
-            ilCronJob::SCHEDULE_TYPE_IN_DAYS
+        return in_array($schedule_type, [
+            CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES,
+            CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS,
+            CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS
         ], true);
     }
 
@@ -248,29 +245,30 @@ class ilCronManagerGUI
         if ($job->hasFlexibleSchedule()) {
             $type = new ilRadioGroupInputGUI($this->lng->txt('cron_schedule_type'), 'type');
             $type->setRequired(true);
-            $type->setValue($job_data['schedule_type']);
+            $type->setValue($job_data['schedule_type'] === null ? null : (string) $job_data['schedule_type']);
 
-            foreach ($job->getAllScheduleTypes() as $typeId) {
-                if (!in_array($typeId, $job->getValidScheduleTypes(), true)) {
+            foreach ($job->getAllScheduleTypes() as $schedule_type) {
+                if (!in_array($schedule_type, $job->getValidScheduleTypes(), true)) {
                     continue;
                 }
 
                 $option = new ilRadioOption(
-                    $this->getScheduleTypeFormElementName($typeId),
-                    (string) $typeId
+                    $this->getScheduleTypeFormElementName($schedule_type),
+                    (string) $schedule_type->value
                 );
                 $type->addOption($option);
 
-                if (in_array($typeId, $job->getScheduleTypesWithValues(), true)) {
+                if (in_array($schedule_type, $job->getScheduleTypesWithValues(), true)) {
                     $scheduleValue = new ilNumberInputGUI(
                         $this->lng->txt('cron_schedule_value'),
-                        $this->getScheduleValueFormElementName($typeId)
+                        $this->getScheduleValueFormElementName($schedule_type)
                     );
                     $scheduleValue->allowDecimals(false);
                     $scheduleValue->setRequired(true);
                     $scheduleValue->setSize(5);
-                    if ((int) $job_data['schedule_type'] === $typeId) {
-                        $scheduleValue->setValue($job_data['schedule_value']);
+                    if (is_numeric($job_data['schedule_type']) &&
+                        CronJobScheduleType::tryFrom((int) $job_data['schedule_type']) === $schedule_type) {
+                        $scheduleValue->setValue($job_data['schedule_value'] === null ? null : (string) $job_data['schedule_value']);
                     }
                     $option->addSubItem($scheduleValue);
                 }
@@ -310,7 +308,7 @@ class ilCronManagerGUI
                 }
 
                 if ($valid && $job->hasFlexibleSchedule()) {
-                    $type = (int) $form->getInput('type');
+                    $type = CronJobScheduleType::from((int) $form->getInput('type'));
                     $value = match (true) {
                         $this->hasScheduleValue($type) => (int) $form->getInput($this->getScheduleValueFormElementName($type)),
                         default => null,

--- a/Services/Cron/classes/class.ilCronManagerImpl.php
+++ b/Services/Cron/classes/class.ilCronManagerImpl.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,10 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Cron management
@@ -138,7 +140,7 @@ class ilCronManagerImpl implements ilCronManager
         } // initiate run?
         elseif ($job->isDue(
             $jobData['job_result_ts'] ? new DateTimeImmutable('@' . $jobData['job_result_ts']) : null,
-            $jobData['schedule_type'] ? (int) $jobData['schedule_type'] : null,
+            is_numeric($jobData['schedule_type']) ? CronJobScheduleType::tryFrom((int) $jobData['schedule_type']) : null,
             $jobData['schedule_value'] ? (int) $jobData['schedule_value'] : null,
             $isManualExecution
         )) {

--- a/Services/Cron/classes/class.ilCronManagerTableFilterMediator.php
+++ b/Services/Cron/classes/class.ilCronManagerTableFilterMediator.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,8 +16,11 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\UI\Component\Input\Container\Filter\Standard;
 use ILIAS\UI\Factory;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 class ilCronManagerTableFilterMediator
 {
@@ -61,14 +62,14 @@ class ilCronManagerTableFilterMediator
         $schedule = $this->uiFactory->input()->field()->select(
             $this->lng->txt('cron_schedule'),
             [
-                ilCronJob::SCHEDULE_TYPE_DAILY => $this->lng->txt('cron_schedule_daily'),
-                ilCronJob::SCHEDULE_TYPE_WEEKLY => $this->lng->txt('cron_schedule_weekly'),
-                ilCronJob::SCHEDULE_TYPE_MONTHLY => $this->lng->txt('cron_schedule_monthly'),
-                ilCronJob::SCHEDULE_TYPE_QUARTERLY => $this->lng->txt('cron_schedule_quarterly'),
-                ilCronJob::SCHEDULE_TYPE_YEARLY => $this->lng->txt('cron_schedule_yearly'),
-                ilCronJob::SCHEDULE_TYPE_IN_MINUTES => sprintf($this->lng->txt('cron_schedule_in_minutes'), 'x'),
-                ilCronJob::SCHEDULE_TYPE_IN_HOURS => sprintf($this->lng->txt('cron_schedule_in_hours'), 'x'),
-                ilCronJob::SCHEDULE_TYPE_IN_DAYS => sprintf($this->lng->txt('cron_schedule_in_days'), 'x')
+                CronJobScheduleType::SCHEDULE_TYPE_DAILY->value => $this->lng->txt('cron_schedule_daily'),
+                CronJobScheduleType::SCHEDULE_TYPE_WEEKLY->value => $this->lng->txt('cron_schedule_weekly'),
+                CronJobScheduleType::SCHEDULE_TYPE_MONTHLY->value => $this->lng->txt('cron_schedule_monthly'),
+                CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY->value => $this->lng->txt('cron_schedule_quarterly'),
+                CronJobScheduleType::SCHEDULE_TYPE_YEARLY->value => $this->lng->txt('cron_schedule_yearly'),
+                CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES->value => sprintf($this->lng->txt('cron_schedule_in_minutes'), 'x'),
+                CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS->value => sprintf($this->lng->txt('cron_schedule_in_hours'), 'x'),
+                CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS->value => sprintf($this->lng->txt('cron_schedule_in_days'), 'x')
             ]
         );
         $status = $this->uiFactory->input()->field()->select(

--- a/Services/Cron/classes/class.ilCronManagerTableGUI.php
+++ b/Services/Cron/classes/class.ilCronManagerTableGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,10 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 class ilCronManagerTableGUI extends ilTable2GUI
 {
@@ -61,26 +63,24 @@ class ilCronManagerTableGUI extends ilTable2GUI
 
     private function formatSchedule(ilCronJobEntity $entity, array $row): string
     {
-        $schedule = '';
         $schedule = match ($entity->getEffectiveScheduleType()) {
-            ilCronJob::SCHEDULE_TYPE_DAILY => $this->lng->txt('cron_schedule_daily'),
-            ilCronJob::SCHEDULE_TYPE_WEEKLY => $this->lng->txt('cron_schedule_weekly'),
-            ilCronJob::SCHEDULE_TYPE_MONTHLY => $this->lng->txt('cron_schedule_monthly'),
-            ilCronJob::SCHEDULE_TYPE_QUARTERLY => $this->lng->txt('cron_schedule_quarterly'),
-            ilCronJob::SCHEDULE_TYPE_YEARLY => $this->lng->txt('cron_schedule_yearly'),
-            ilCronJob::SCHEDULE_TYPE_IN_MINUTES => sprintf(
+            CronJobScheduleType::SCHEDULE_TYPE_DAILY => $this->lng->txt('cron_schedule_daily'),
+            CronJobScheduleType::SCHEDULE_TYPE_WEEKLY => $this->lng->txt('cron_schedule_weekly'),
+            CronJobScheduleType::SCHEDULE_TYPE_MONTHLY => $this->lng->txt('cron_schedule_monthly'),
+            CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY => $this->lng->txt('cron_schedule_quarterly'),
+            CronJobScheduleType::SCHEDULE_TYPE_YEARLY => $this->lng->txt('cron_schedule_yearly'),
+            CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES => sprintf(
                 $this->lng->txt('cron_schedule_in_minutes'),
                 $entity->getEffectiveScheduleValue()
             ),
-            ilCronJob::SCHEDULE_TYPE_IN_HOURS => sprintf(
+            CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS => sprintf(
                 $this->lng->txt('cron_schedule_in_hours'),
                 $entity->getEffectiveScheduleValue()
             ),
-            ilCronJob::SCHEDULE_TYPE_IN_DAYS => sprintf(
+            CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS => sprintf(
                 $this->lng->txt('cron_schedule_in_days'),
                 $entity->getEffectiveScheduleValue()
-            ),
-            default => $schedule,
+            )
         };
 
         return $schedule;
@@ -205,14 +205,14 @@ class ilCronManagerTableGUI extends ilTable2GUI
 
             if ($entity->getJob()->hasFlexibleSchedule()) {
                 $row['editable_schedule'] = true;
-                if (!$entity->getScheduleType()) {
+                if ($entity->getScheduleType() === null) {
                     $this->cronRepository->updateJobSchedule(
                         $entity->getJob(),
                         $entity->getEffectiveScheduleType(),
                         $entity->getEffectiveScheduleValue()
                     );
                 }
-            } elseif ($entity->getScheduleType()) {
+            } elseif ($entity->getScheduleType() !== null) {
                 $this->cronRepository->updateJobSchedule($entity->getJob(), null, null);
             }
 

--- a/Services/Cron/classes/class.ilCronStartUp.php
+++ b/Services/Cron/classes/class.ilCronStartUp.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 class ilCronStartUp
 {
     private readonly ilAuthSession $authSession;
@@ -33,7 +33,6 @@ class ilCronStartUp
 
         // TODO @see mantis 20371: To get rid of this, the authentication service has to provide a mechanism to pass the client_id
         $_GET['client_id'] = $this->client;
-        /** @noRector  */
         require_once './include/inc.header.php';
 
         if (null === $authSession) {

--- a/Services/Cron/classes/class.ilStrictCliCronManager.php
+++ b/Services/Cron/classes/class.ilStrictCliCronManager.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 class ilStrictCliCronManager implements ilCronManager
 {

--- a/Services/Cron/exceptions/class.ilCronException.php
+++ b/Services/Cron/exceptions/class.ilCronException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 class ilCronException extends ilException
 {

--- a/Services/Cron/interfaces/interface.ilCronJobCollection.php
+++ b/Services/Cron/interfaces/interface.ilCronJobCollection.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 interface ilCronJobCollection extends Countable, IteratorAggregate
 {

--- a/Services/Cron/interfaces/interface.ilCronJobProvider.php
+++ b/Services/Cron/interfaces/interface.ilCronJobProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 interface ilCronJobProvider
 {

--- a/Services/Cron/interfaces/interface.ilCronJobRepository.php
+++ b/Services/Cron/interfaces/interface.ilCronJobRepository.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,10 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 interface ilCronJobRepository
 {
     public function getJobInstanceById(string $id): ?ilCronJob;
@@ -31,9 +33,8 @@ interface ilCronJobRepository
 
     /**
      * Get cron job configuration/execution data
-     * @param array|string|null $id
-     * @param bool $withInactiveJobsIncluded
-     * @return array<int, array<string, mixed>>
+     * @param list<string>|string|null $id
+     * @return list<array<string, mixed>>
      */
     public function getCronJobData($id = null, bool $withInactiveJobsIncluded = true): array;
 
@@ -44,7 +45,6 @@ interface ilCronJobRepository
     public function createDefaultEntry(ilCronJob $job, string $component, string $class, ?string $path): void;
 
     /**
-     * @param bool $withOnlyActive
      * @return array<int, array{0: ilCronJob, 1: array<string, mixed>}>
      */
     public function getPluginJobs(bool $withOnlyActive = false): array;
@@ -60,7 +60,7 @@ interface ilCronJobRepository
 
     public function updateRunInformation(string $jobId, int $runningTimestamp, int $aliveTimestamp): void;
 
-    public function updateJobSchedule(ilCronJob $job, ?int $scheduleType, ?int $scheduleValue): void;
+    public function updateJobSchedule(ilCronJob $job, ?CronJobScheduleType $scheduleType, ?int $scheduleValue): void;
 
     public function activateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false): void;
 

--- a/Services/Cron/interfaces/interface.ilCronManager.php
+++ b/Services/Cron/interfaces/interface.ilCronManager.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 interface ilCronManager
 {

--- a/Services/Cron/interfaces/interface.ilCronServices.php
+++ b/Services/Cron/interfaces/interface.ilCronServices.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 interface ilCronServices
 {

--- a/Services/Cron/test/CronJobEntityTest.php
+++ b/Services/Cron/test/CronJobEntityTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,7 +16,10 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Class CronJobEntityTest
@@ -31,11 +32,15 @@ class CronJobEntityTest extends TestCase
      */
     private function getEntity(
         ilCronJob $job_instance = null,
-        int $schedule_type = ilCronJob::SCHEDULE_TYPE_IN_MINUTES,
+        int $schedule_type = null,
         int $schedule_value = 5,
         bool $is_plugin = false
     ): ilCronJobEntity {
         $job_instance ??= $this->createMock(ilCronJob::class);
+
+        if ($schedule_type === null) {
+            $schedule_type = CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES->value;
+        }
 
         return new ilCronJobEntity($job_instance, [
             'job_id' => 'phpunit',
@@ -99,25 +104,25 @@ class CronJobEntityTest extends TestCase
         $job_instance->method('hasFlexibleSchedule')->willReturn(true);
 
         $entity = $this->getEntity($job_instance);
-        $this->assertSame(ilCronJob::SCHEDULE_TYPE_IN_MINUTES, $entity->getEffectiveScheduleType());
+        $this->assertSame(CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES, $entity->getEffectiveScheduleType());
         $this->assertSame(5, $entity->getEffectiveScheduleValue());
 
         $another_job_instance = $this->createMock(ilCronJob::class);
         $another_job_instance->method('hasFlexibleSchedule')->willReturn(false);
-        $another_job_instance->method('getDefaultScheduleType')->willReturn(ilCronJob::SCHEDULE_TYPE_IN_HOURS);
+        $another_job_instance->method('getDefaultScheduleType')->willReturn(CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS);
         $another_job_instance->method('getDefaultScheduleValue')->willReturn(5);
 
-        $another_entity = $this->getEntity($another_job_instance, ilCronJob::SCHEDULE_TYPE_DAILY);
-        $this->assertSame(ilCronJob::SCHEDULE_TYPE_IN_HOURS, $another_entity->getEffectiveScheduleType());
+        $another_entity = $this->getEntity($another_job_instance, CronJobScheduleType::SCHEDULE_TYPE_DAILY->value);
+        $this->assertSame(CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS, $another_entity->getEffectiveScheduleType());
         $this->assertSame(5, $another_entity->getEffectiveScheduleValue());
 
         $yet_another_job_instance = $this->createMock(ilCronJob::class);
         $yet_another_job_instance->method('hasFlexibleSchedule')->willReturn(true);
-        $yet_another_job_instance->method('getDefaultScheduleType')->willReturn(ilCronJob::SCHEDULE_TYPE_IN_HOURS);
+        $yet_another_job_instance->method('getDefaultScheduleType')->willReturn(CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS);
         $yet_another_job_instance->method('getDefaultScheduleValue')->willReturn(5);
 
         $yet_another_entity = $this->getEntity($yet_another_job_instance, 0);
-        $this->assertSame(ilCronJob::SCHEDULE_TYPE_IN_HOURS, $yet_another_entity->getEffectiveScheduleType());
+        $this->assertSame(CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS, $yet_another_entity->getEffectiveScheduleType());
         $this->assertSame(5, $yet_another_entity->getEffectiveScheduleValue());
     }
 }

--- a/Services/Cron/test/CronJobManagerTest.php
+++ b/Services/Cron/test/CronJobManagerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 

--- a/Services/Cron/test/CronJobScheduleTest.php
+++ b/Services/Cron/test/CronJobScheduleTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,7 +16,10 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Class CronJobScheduleTest
@@ -32,17 +33,17 @@ class CronJobScheduleTest extends TestCase
 
     private function getJob(
         bool $has_flexible_schedule,
-        int $default_schedule_type,
+        CronJobScheduleType $default_schedule_type,
         ?int $default_schedule_value,
-        int $schedule_type,
+        CronJobScheduleType $schedule_type,
         ?int $schedule_value
     ): ilCronJob {
         $job_instance = new class ($has_flexible_schedule, $default_schedule_type, $default_schedule_value, $schedule_type, $schedule_value) extends ilCronJob {
             public function __construct(
                 private readonly bool $has_flexible_schedule,
-                private readonly int $default_schedule_type,
+                private readonly CronJobScheduleType $default_schedule_type,
                 private readonly ?int $default_schedule_value,
-                int $schedule_type,
+                CronJobScheduleType $schedule_type,
                 ?int $schedule_value
             ) {
                 $this->schedule_type = $schedule_type;
@@ -74,7 +75,7 @@ class CronJobScheduleTest extends TestCase
                 return $this->has_flexible_schedule;
             }
 
-            public function getDefaultScheduleType(): int
+            public function getDefaultScheduleType(): CronJobScheduleType
             {
                 return $this->default_schedule_type;
             }
@@ -107,154 +108,146 @@ class CronJobScheduleTest extends TestCase
 
         return [
             'Manual Run is Always Due' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_DAILY, null, ilCronJob::SCHEDULE_TYPE_DAILY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_DAILY, null, CronJobScheduleType::SCHEDULE_TYPE_DAILY, null),
                 true,
                 null,
-                ilCronJob::SCHEDULE_TYPE_DAILY,
+                CronJobScheduleType::SCHEDULE_TYPE_DAILY,
                 null,
                 true
             ],
             'Job Without Any Run is Always Due' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_DAILY, null, ilCronJob::SCHEDULE_TYPE_DAILY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_DAILY, null, CronJobScheduleType::SCHEDULE_TYPE_DAILY, null),
                 false,
                 null,
-                ilCronJob::SCHEDULE_TYPE_DAILY,
+                CronJobScheduleType::SCHEDULE_TYPE_DAILY,
                 null,
                 true
             ],
             'Daily Schedule / Did not run Today' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_DAILY, null, ilCronJob::SCHEDULE_TYPE_DAILY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_DAILY, null, CronJobScheduleType::SCHEDULE_TYPE_DAILY, null),
                 false,
                 $this->now->modify('-1 day'),
-                ilCronJob::SCHEDULE_TYPE_DAILY,
+                CronJobScheduleType::SCHEDULE_TYPE_DAILY,
                 null,
                 true
             ],
             'Daily Schedule / Did run Today' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_DAILY, null, ilCronJob::SCHEDULE_TYPE_DAILY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_DAILY, null, CronJobScheduleType::SCHEDULE_TYPE_DAILY, null),
                 false,
                 $this->now,
-                ilCronJob::SCHEDULE_TYPE_DAILY,
+                CronJobScheduleType::SCHEDULE_TYPE_DAILY,
                 null,
                 false
             ],
             'Weekly Schedule / Did not run this Week' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_WEEKLY, null, ilCronJob::SCHEDULE_TYPE_WEEKLY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null),
                 false,
                 $this->now->modify('-1 week'),
-                ilCronJob::SCHEDULE_TYPE_WEEKLY,
+                CronJobScheduleType::SCHEDULE_TYPE_WEEKLY,
                 null,
                 true
             ],
             'Weekly Schedule / Did run this Week' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_WEEKLY, null, ilCronJob::SCHEDULE_TYPE_WEEKLY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null),
                 false,
                 $this->now->modify('monday this week'),
-                ilCronJob::SCHEDULE_TYPE_WEEKLY,
+                CronJobScheduleType::SCHEDULE_TYPE_WEEKLY,
                 null,
                 false
             ],
             'Monthly Schedule / Did not run this Month' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_MONTHLY, null, ilCronJob::SCHEDULE_TYPE_MONTHLY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_MONTHLY, null, CronJobScheduleType::SCHEDULE_TYPE_MONTHLY, null),
                 false,
                 $this->now->modify('last day of last month'),
-                ilCronJob::SCHEDULE_TYPE_MONTHLY,
+                CronJobScheduleType::SCHEDULE_TYPE_MONTHLY,
                 null,
                 true
             ],
             'Monthly Schedule / Did run this Month' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_MONTHLY, null, ilCronJob::SCHEDULE_TYPE_MONTHLY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_MONTHLY, null, CronJobScheduleType::SCHEDULE_TYPE_MONTHLY, null),
                 false,
                 $this->now->modify('first day of this month'),
-                ilCronJob::SCHEDULE_TYPE_MONTHLY,
+                CronJobScheduleType::SCHEDULE_TYPE_MONTHLY,
                 null,
                 false
             ],
             'Yearly Schedule / Did not run this Year' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_YEARLY, null, ilCronJob::SCHEDULE_TYPE_YEARLY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_YEARLY, null, CronJobScheduleType::SCHEDULE_TYPE_YEARLY, null),
                 false,
                 $this->now->modify('-1 year'),
-                ilCronJob::SCHEDULE_TYPE_YEARLY,
+                CronJobScheduleType::SCHEDULE_TYPE_YEARLY,
                 null,
                 true
             ],
             'Yearly Schedule / Did run this Year' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_YEARLY, null, ilCronJob::SCHEDULE_TYPE_YEARLY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_YEARLY, null, CronJobScheduleType::SCHEDULE_TYPE_YEARLY, null),
                 false,
                 $this->now->modify('first day of January this year'),
-                ilCronJob::SCHEDULE_TYPE_YEARLY,
+                CronJobScheduleType::SCHEDULE_TYPE_YEARLY,
                 null,
                 false
             ],
             'Quarterly Schedule / Did not run this Quarter' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_QUARTERLY, null, ilCronJob::SCHEDULE_TYPE_QUARTERLY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY, null, CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY, null),
                 false,
                 $this->this_quarter_start->modify('-1 seconds'),
-                ilCronJob::SCHEDULE_TYPE_QUARTERLY,
+                CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY,
                 null,
                 true
             ],
             'Quarterly Schedule / Did run this Quarter' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_QUARTERLY, null, ilCronJob::SCHEDULE_TYPE_QUARTERLY, null),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY, null, CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY, null),
                 false,
                 $this->this_quarter_start->modify('+30 seconds'),
-                ilCronJob::SCHEDULE_TYPE_QUARTERLY,
+                CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY,
                 null,
                 false
             ],
             'Minutely Schedule / Did not run this Minute' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_IN_MINUTES, 1, ilCronJob::SCHEDULE_TYPE_IN_MINUTES, 1),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES, 1, CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES, 1),
                 false,
                 $this->now->modify('-1 minute'),
-                ilCronJob::SCHEDULE_TYPE_IN_MINUTES,
+                CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES,
                 1,
                 true
             ],
             'Minutely Schedule / Did run this Minute' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_IN_MINUTES, 1, ilCronJob::SCHEDULE_TYPE_IN_MINUTES, 1),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES, 1, CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES, 1),
                 false,
                 $this->now->modify('-30 seconds'),
-                ilCronJob::SCHEDULE_TYPE_IN_MINUTES,
+                CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES,
                 1,
                 false
             ],
             'Hourly Schedule / Did not run this Hour' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_IN_HOURS, 7, ilCronJob::SCHEDULE_TYPE_IN_HOURS, 7),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS, 7, CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS, 7),
                 false,
                 $this->now->modify('-7 hours'),
-                ilCronJob::SCHEDULE_TYPE_IN_HOURS,
+                CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS,
                 7,
                 true
             ],
             'Hourly Schedule / Did run this Hour' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_IN_HOURS, 7, ilCronJob::SCHEDULE_TYPE_IN_HOURS, 7),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS, 7, CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS, 7),
                 false,
                 $this->now->modify('-7 hours +30 seconds'),
-                ilCronJob::SCHEDULE_TYPE_IN_HOURS,
+                CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS,
                 7,
                 false
             ],
             'Every 5 Days Schedule / Did not run for 5 Days' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_IN_DAYS, 5, ilCronJob::SCHEDULE_TYPE_IN_DAYS, 5),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS, 5, CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS, 5),
                 false,
                 $this->now->modify('-5 days'),
-                ilCronJob::SCHEDULE_TYPE_IN_DAYS,
+                CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS,
                 5,
                 true
             ],
             'Every 5 Days Schedule / Did run withing the last 5 Days' => [
-                $this->getJob(true, ilCronJob::SCHEDULE_TYPE_IN_DAYS, 5, ilCronJob::SCHEDULE_TYPE_IN_DAYS, 5),
+                $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS, 5, CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS, 5),
                 false,
                 $this->now->modify('-4 days'),
-                ilCronJob::SCHEDULE_TYPE_IN_DAYS,
-                5,
-                false
-            ],
-            'Invalid Schedule Type' => [
-                $this->getJob(true, PHP_INT_MAX, 5, PHP_INT_MAX, 5),
-                false,
-                $this->now,
-                PHP_INT_MAX,
+                CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS,
                 5,
                 false
             ]
@@ -268,7 +261,7 @@ class CronJobScheduleTest extends TestCase
         ilCronJob $job_instance,
         bool $is_manual_run,
         ?DateTimeImmutable $last_run_datetime,
-        int $schedule_type,
+        CronJobScheduleType $schedule_type,
         ?int $schedule_value,
         bool $should_be_due
     ): void {
@@ -282,7 +275,7 @@ class CronJobScheduleTest extends TestCase
     public function weeklyScheduleProvider(): Generator
     {
         yield 'Different Week' => [
-            $this->getJob(true, ilCronJob::SCHEDULE_TYPE_WEEKLY, null, ilCronJob::SCHEDULE_TYPE_WEEKLY, null),
+            $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null),
             function (): DateTimeImmutable {
                 $this->now = new DateTimeImmutable('@1672570104'); // Sun Jan 01 2023 10:48:24 GMT+0000 (year: 2023 / week: 52)
 
@@ -292,7 +285,7 @@ class CronJobScheduleTest extends TestCase
         ];
 
         yield 'Same Week and Year, but different Month: December (now) and January (Last run)' => [
-            $this->getJob(true, ilCronJob::SCHEDULE_TYPE_WEEKLY, null, ilCronJob::SCHEDULE_TYPE_WEEKLY, null),
+            $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null),
             function (): DateTimeImmutable {
                 $this->now = new DateTimeImmutable('@1703669703'); // Wed Dec 27 2023 09:35:03 GMT+0000 (year: 2023 / week: 52 / month: 12)
 
@@ -302,7 +295,7 @@ class CronJobScheduleTest extends TestCase
         ];
 
         yield 'Same Week and Year and same Month: January' => [
-            $this->getJob(true, ilCronJob::SCHEDULE_TYPE_WEEKLY, null, ilCronJob::SCHEDULE_TYPE_WEEKLY, null),
+            $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null),
             function (): DateTimeImmutable {
                 $this->now = new DateTimeImmutable('@1704188103'); // Tue Jan 02 2024 09:35:03 GMT+0000 (year: 2024 / week: 1 / month: 1)
 
@@ -312,7 +305,7 @@ class CronJobScheduleTest extends TestCase
         ];
 
         yield 'Same Week (52nd), but Year Difference > 1' => [
-            $this->getJob(true, ilCronJob::SCHEDULE_TYPE_WEEKLY, null, ilCronJob::SCHEDULE_TYPE_WEEKLY, null),
+            $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null),
             function (): DateTimeImmutable {
                 $this->now = new DateTimeImmutable('@1672570104'); // Sun Jan 01 2023 10:48:24 GMT+0000 (year: 2023 / week: 52)
 
@@ -322,7 +315,7 @@ class CronJobScheduleTest extends TestCase
         ];
 
         yield 'Same Week (52nd) in different Years, but Turn of the Year' => [
-            $this->getJob(true, ilCronJob::SCHEDULE_TYPE_WEEKLY, null, ilCronJob::SCHEDULE_TYPE_WEEKLY, null),
+            $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null),
             function (): DateTimeImmutable {
                 $this->now = new DateTimeImmutable('@1672570104'); // Sun Jan 01 2023 10:48:24 GMT+0000 (year: 2023 / week: 52 / month: 1)
 
@@ -332,7 +325,7 @@ class CronJobScheduleTest extends TestCase
         ];
 
         yield 'Same Week (52nd) in different Years, but not Turn of the Year' => [
-            $this->getJob(true, ilCronJob::SCHEDULE_TYPE_WEEKLY, null, ilCronJob::SCHEDULE_TYPE_WEEKLY, null),
+            $this->getJob(true, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null, CronJobScheduleType::SCHEDULE_TYPE_WEEKLY, null),
             function (): DateTimeImmutable {
                 $this->now = new DateTimeImmutable('@1703669703'); // Wed Dec 27 2023 09:35:03 GMT+0000 (year: 2023 / week: 52 / month: 12)
 

--- a/Services/Cron/test/bootstrap.php
+++ b/Services/Cron/test/bootstrap.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,5 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 require_once 'libs/composer/vendor/autoload.php';

--- a/Services/Cron/test/ilServicesCronSuite.php
+++ b/Services/Cron/test/ilServicesCronSuite.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,9 +16,9 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-use PHPUnit\Framework\TestSuite;
+declare(strict_types=1);
 
-require_once __DIR__ . '/bootstrap.php';
+use PHPUnit\Framework\TestSuite;
 
 /**
  * Class ilServicesCronSuite

--- a/Services/FileSystem/classes/class.ilFileSystemCleanTempDirCron.php
+++ b/Services/FileSystem/classes/class.ilFileSystemCleanTempDirCron.php
@@ -18,6 +18,7 @@
 
 use ILIAS\Filesystem\DTO\Metadata;
 use ILIAS\DI\Container;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Class ilFileSystemCleanTempDirCron
@@ -81,9 +82,9 @@ class ilFileSystemCleanTempDirCron extends ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/LDAP/classes/class.ilLDAPCronSynchronization.php
+++ b/Services/LDAP/classes/class.ilLDAPCronSynchronization.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
 *
 * @author Stefan Meyer <meyer@leifos.com>
@@ -55,9 +57,9 @@ class ilLDAPCronSynchronization extends ilCronJob
         return $this->lng->txt("ldap_user_sync_cron_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/LTI/classes/class.ilLTICronOutcomeService.php
+++ b/Services/LTI/classes/class.ilLTICronOutcomeService.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Description of class class
  *
@@ -37,9 +39,9 @@ class ilLTICronOutcomeService extends ilCronJob
         $this->cronRepo = $DIC->cron()->repository();
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/Logging/classes/error/class.ilLoggerCronCleanErrorFiles.php
+++ b/Services/Logging/classes/error/class.ilLoggerCronCleanErrorFiles.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -51,9 +53,9 @@ class ilLoggerCronCleanErrorFiles extends ilCronJob
         return $this->lng->txt("log_error_file_cleanup_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_DAYS;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS;
     }
 
     public function getDefaultScheduleValue(): int

--- a/Services/Mail/classes/class.ilMailCronNotification.php
+++ b/Services/Mail/classes/class.ilMailCronNotification.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\HTTP\GlobalHttpState;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Mail notifications
@@ -68,9 +69,9 @@ class ilMailCronNotification extends ilCronJob
         );
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/Mail/classes/class.ilMailCronOrphanedMails.php
+++ b/Services/Mail/classes/class.ilMailCronOrphanedMails.php
@@ -25,6 +25,7 @@ use ILIAS\Mail\Cron\ExpiredOrOrphanedMails\ExpiredOrOrphanedMailsCollector;
 use ILIAS\Mail\Cron\ExpiredOrOrphanedMails\MailDeletionHandler;
 use ILIAS\Mail\Cron\ExpiredOrOrphanedMails\NotificationsCollector;
 use ILIAS\Mail\Cron\ExpiredOrOrphanedMails\Notifier;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Delete orphaned mails
@@ -113,18 +114,18 @@ class ilMailCronOrphanedMails extends ilCronJob
     public function getValidScheduleTypes(): array
     {
         return [
-            self::SCHEDULE_TYPE_DAILY,
-            self::SCHEDULE_TYPE_WEEKLY,
-            self::SCHEDULE_TYPE_MONTHLY,
-            self::SCHEDULE_TYPE_QUARTERLY,
-            self::SCHEDULE_TYPE_YEARLY,
-            self::SCHEDULE_TYPE_IN_DAYS
+            CronJobScheduleType::SCHEDULE_TYPE_DAILY,
+            CronJobScheduleType::SCHEDULE_TYPE_WEEKLY,
+            CronJobScheduleType::SCHEDULE_TYPE_MONTHLY,
+            CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY,
+            CronJobScheduleType::SCHEDULE_TYPE_YEARLY,
+            CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS
         ];
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/Membership/classes/Cron/class.ilMembershipCronMinMembers.php
+++ b/Services/Membership/classes/Cron/class.ilMembershipCronMinMembers.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Cron for course/group minimum members
  * @author  Jörg Lützenkirchen <luetzenkirchen@leifos.com>
@@ -51,9 +53,9 @@ class ilMembershipCronMinMembers extends ilCronJob
         return $this->lng->txt("mem_cron_min_members_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/Membership/classes/Cron/class.ilMembershipCronNotifications.php
+++ b/Services/Membership/classes/Cron/class.ilMembershipCronNotifications.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Course/group notifications
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>
@@ -61,9 +63,9 @@ class ilMembershipCronNotifications extends ilCronJob
         return $this->lng->txt("enable_course_group_notifications_desc");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/MetaData/classes/class.ilCronOerHarvester.php
+++ b/Services/MetaData/classes/class.ilCronOerHarvester.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Cron job for definition for oer harvesting
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
@@ -54,9 +56,9 @@ class ilCronOerHarvester extends ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/Search/classes/Lucene/class.ilLuceneIndexer.php
+++ b/Services/Search/classes/Lucene/class.ilLuceneIndexer.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 /* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
 * Class for indexing hmtl ,pdf, txt files and htlm Learning modules.
@@ -42,9 +43,9 @@ class ilLuceneIndexer extends ilCronJob
         return $this->lng->txt("cron_lucene_index_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/Skill/classes/class.ilSkillNotifications.php
+++ b/Services/Skill/classes/class.ilSkillNotifications.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
  */
 
 use ILIAS\Skill\Service\SkillTreeService;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Course/group skill notification
@@ -70,9 +71,9 @@ class ilSkillNotifications extends ilCronJob
         return $lng->txt("skll_skill_notification_desc");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/SystemCheck/classes/class.ilSCCronTrash.php
+++ b/Services/SystemCheck/classes/class.ilSCCronTrash.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Purge trash by cron
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
@@ -53,19 +55,19 @@ class ilSCCronTrash extends ilCronJob
         return $this->lng->txt('sysc_cron_empty_trash_desc');
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_WEEKLY;
+        return CronJobScheduleType::SCHEDULE_TYPE_WEEKLY;
     }
 
     public function getValidScheduleTypes(): array
     {
         return [
-            self::SCHEDULE_TYPE_DAILY,
-            self::SCHEDULE_TYPE_WEEKLY,
-            self::SCHEDULE_TYPE_MONTHLY,
-            self::SCHEDULE_TYPE_QUARTERLY,
-            self::SCHEDULE_TYPE_YEARLY
+            CronJobScheduleType::SCHEDULE_TYPE_DAILY,
+            CronJobScheduleType::SCHEDULE_TYPE_WEEKLY,
+            CronJobScheduleType::SCHEDULE_TYPE_MONTHLY,
+            CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY,
+            CronJobScheduleType::SCHEDULE_TYPE_YEARLY
         ];
     }
 

--- a/Services/Tracking/classes/class.ilLPCronObjectStatistics.php
+++ b/Services/Tracking/classes/class.ilLPCronObjectStatistics.php
@@ -18,6 +18,7 @@ declare(strict_types=0);
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * Cron for lp object statistics
@@ -61,9 +62,9 @@ class ilLPCronObjectStatistics extends ilCronJob
         return $this->lng->txt("trac_object_statistics_info");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/User/classes/class.ilCronDeleteInactivatedUserAccounts.php
+++ b/Services/User/classes/class.ilCronDeleteInactivatedUserAccounts.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  *********************************************************************/
 
 use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * This cron deletes user accounts by INACTIVATION period
@@ -105,9 +106,9 @@ class ilCronDeleteInactivatedUserAccounts extends ilCronJob
         );
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/User/classes/class.ilCronDeleteInactiveUserAccounts.php
+++ b/Services/User/classes/class.ilCronDeleteInactiveUserAccounts.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * This cron deletes user accounts by INACTIVITY period
  * @author Bjoern Heyser <bheyser@databay.de>
@@ -105,33 +107,33 @@ class ilCronDeleteInactiveUserAccounts extends ilCronJob
         return strpos($number, ',') || strpos($number, '.');
     }
 
-    protected function getTimeDifferenceBySchedule(int $schedule_time, int $multiplier): int
+    protected function getTimeDifferenceBySchedule(CronJobScheduleType $schedule_time, int $multiplier): int
     {
         $time_difference = 0;
 
         switch ($schedule_time) {
-            case ilCronJob::SCHEDULE_TYPE_DAILY:
+            case CronJobScheduleType::SCHEDULE_TYPE_DAILY:
                 $time_difference = 86400;
                 break;
-            case ilCronJob::SCHEDULE_TYPE_IN_MINUTES:
+            case CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES:
                 $time_difference = 60 * $multiplier;
                 break;
-            case ilCronJob::SCHEDULE_TYPE_IN_HOURS:
+            case CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS:
                 $time_difference = 3600 * $multiplier;
                 break;
-            case ilCronJob::SCHEDULE_TYPE_IN_DAYS:
+            case CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS:
                 $time_difference = 86400 * $multiplier;
                 break;
-            case ilCronJob::SCHEDULE_TYPE_WEEKLY:
+            case CronJobScheduleType::SCHEDULE_TYPE_WEEKLY:
                 $time_difference = 604800;
                 break;
-            case ilCronJob::SCHEDULE_TYPE_MONTHLY:
+            case CronJobScheduleType::SCHEDULE_TYPE_MONTHLY:
                 $time_difference = 2629743;
                 break;
-            case ilCronJob::SCHEDULE_TYPE_QUARTERLY:
+            case CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY:
                 $time_difference = 7889229;
                 break;
-            case ilCronJob::SCHEDULE_TYPE_YEARLY:
+            case CronJobScheduleType::SCHEDULE_TYPE_YEARLY:
                 $time_difference = 31556926;
                 break;
         }
@@ -154,9 +156,9 @@ class ilCronDeleteInactiveUserAccounts extends ilCronJob
         return $this->lng->txt("delete_inactive_user_accounts_desc");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int
@@ -263,7 +265,7 @@ class ilCronDeleteInactiveUserAccounts extends ilCronJob
                 $multiplier = (int) $cron_timing[0]['schedule_value'];
             }
             $time_difference = $this->getTimeDifferenceBySchedule(
-                (int) $cron_timing[0]['schedule_type'],
+                CronJobScheduleType::from((int) $cron_timing[0]['schedule_type']),
                 $multiplier
             );
         }
@@ -335,10 +337,10 @@ class ilCronDeleteInactiveUserAccounts extends ilCronJob
 
         $valid = true;
 
-        $cron_period = $this->http->wrapper()->post()->retrieve(
+        $cron_period = CronJobScheduleType::from($this->http->wrapper()->post()->retrieve(
             'type',
             $this->refinery->kindlyTo()->int()
-        );
+        ));
 
         $cron_period_custom = 0;
         $delete_period = 0;
@@ -412,26 +414,27 @@ class ilCronDeleteInactiveUserAccounts extends ilCronJob
             );
         }
 
-        if ($cron_period >= ilCronJob::SCHEDULE_TYPE_IN_DAYS && $cron_period <= ilCronJob::SCHEDULE_TYPE_YEARLY && $reminder_period > 0) {
+        if ($cron_period->value >= CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS->value &&
+            $cron_period->value <= CronJobScheduleType::SCHEDULE_TYPE_YEARLY->value && $reminder_period > 0) {
             $logic = true;
             $check_window_logic = $delete_period - $reminder_period;
-            if ($cron_period === ilCronJob::SCHEDULE_TYPE_IN_DAYS) {
+            if ($cron_period === CronJobScheduleType::SCHEDULE_TYPE_IN_DAYS) {
                 if ($check_window_logic < $cron_period_custom) {
                     $logic = false;
                 }
-            } elseif ($cron_period === ilCronJob::SCHEDULE_TYPE_WEEKLY) {
+            } elseif ($cron_period === CronJobScheduleType::SCHEDULE_TYPE_WEEKLY) {
                 if ($check_window_logic <= 7) {
                     $logic = false;
                 }
-            } elseif ($cron_period === ilCronJob::SCHEDULE_TYPE_MONTHLY) {
+            } elseif ($cron_period === CronJobScheduleType::SCHEDULE_TYPE_MONTHLY) {
                 if ($check_window_logic <= 31) {
                     $logic = false;
                 }
-            } elseif ($cron_period === ilCronJob::SCHEDULE_TYPE_QUARTERLY) {
+            } elseif ($cron_period === CronJobScheduleType::SCHEDULE_TYPE_QUARTERLY) {
                 if ($check_window_logic <= 92) {
                     $logic = false;
                 }
-            } elseif ($cron_period === ilCronJob::SCHEDULE_TYPE_YEARLY) {
+            } elseif ($cron_period === CronJobScheduleType::SCHEDULE_TYPE_YEARLY) {
                 if ($check_window_logic <= 366) {
                     $logic = false;
                 }

--- a/Services/User/classes/class.ilCronDeleteNeverLoggedInUserAccounts.php
+++ b/Services/User/classes/class.ilCronDeleteNeverLoggedInUserAccounts.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  *********************************************************************/
 
 use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 class ilCronDeleteNeverLoggedInUserAccounts extends \ilCronJob
 {
@@ -96,9 +97,9 @@ class ilCronDeleteNeverLoggedInUserAccounts extends \ilCronJob
         return $DIC->language()->txt('user_never_logged_in_info');
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): int

--- a/Services/User/classes/class.ilUserCronCheckAccounts.php
+++ b/Services/User/classes/class.ilUserCronCheckAccounts.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * This cron send notifications about expiring user accounts
  * @author  Stefan Meyer <meyer@leifos.com>
@@ -47,9 +49,9 @@ class ilUserCronCheckAccounts extends ilCronJob
         return $lng->txt("check_user_accounts_desc");
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_DAILY;
     }
 
     public function getDefaultScheduleValue(): ?int

--- a/Services/WebServices/classes/class.ilCronEcsTaskScheduler.php
+++ b/Services/WebServices/classes/class.ilCronEcsTaskScheduler.php
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 /**
  * Class ilCronEcsTaskScheduler
  *
@@ -53,9 +55,9 @@ class ilCronEcsTaskScheduler extends \ilCronJob
         return true;
     }
 
-    public function getDefaultScheduleType(): int
+    public function getDefaultScheduleType(): CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_HOURS;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS;
     }
 
     public function getDefaultScheduleValue(): ?int


### PR DESCRIPTION
Dear colleagues,

with this PR I would like to switch the PHP type representing the `Schedule Type` of a cron job from `int` to a backed enum. The usages of the public constants defined in `ilCronJob` have been marked as `deprecated` with ILIAS 8.

I changed all (core) `ilCronJob` implementations. If you have any objections, please provide feedback within the next two weeks.
Important: I did not change the license header of your files if this is already wrong.

Best regards,
@mjansenDatabay 