### PR TITLE
UI docs ITCSS proposal wording, link to guide

### DIFF
--- a/src/UI/docu/sass-itcss-concepts.md
+++ b/src/UI/docu/sass-itcss-concepts.md
@@ -1,17 +1,16 @@
-# Proposal: Use frameworkless SASS for the UI-Framework
+# Frameworkless SASS and ITCSS
 
-We hereby propose to the JF to move the style code of the UI-Framework from LESS
-to SASS. We propose to get rid of the framework dependency to Bootstrap completely
-during that move. We furthermore propose to introduce a certain structure-model
-for the SASS-code based on a customized version of Inverted Triangle CSS (ITCSS).
-This new guideline will superseed the current LESS Guideline. We ask the JF to
-express its general support for that move so we can be confident to go on to
-make more detailed plans to get us there. We furthermore request the JF to ask
-questions or state constraints for our endeavor so we can look into them for a
-next iteration.
+This concept outlines how we strive to make ILIAS style code more modern and
+easier to maintain using frameworkless SASS and ITCSS. Large parts of this have
+been put into practice during a style code refactoring for ILIAS 9.
 
-We try to lay out the plan in more detail in the following.
+Read this document to find out
+* why big changes were made to the style code and
+* what strategic decisions will influence ongoing and future projects.
 
+A more practical guide with rules and recommendations on how to work with the
+ILIAS style code when developing or building System Style skins can be found
+here: [SCSS Coding Guidelines](../../../templates/Guidelines_SCSS-Coding.md)
 
 ## Why use SASS instead of LESS?
 
@@ -26,7 +25,7 @@ compiler (running on node.js) did not recieve any updates since 2017, so it seem
 to be a good time to move to SASS as well.
 
 
-## Why only move the UI-Framework?
+## Why we expect to implement new best practices in the UI Framework first?
 
 The UI-Framework is meant to provide UI components for all other components of
 ILIAS, with the ultimate goal that other components do not contain any custom
@@ -100,7 +99,7 @@ out there that we indeed might want to use to solve specific UI problems for us.
 is a proposal to structure complex and big code bases for style sheet code. The
 layers are imagined to form a triangle, where the topmost layer has the biggest
 reach but least specificity and explicitness. We decided to use that model after
-an extensive research in proposals for style code architecture . During our
+an extensive research in proposals for style code architecture. During our
 discussion of the various models, we found that a customized version of ITCSS
 should allow us to build a structured code base for our style code that neatly
 fits the requirements of different groups of its prospective users and the idea
@@ -109,22 +108,16 @@ and implementation of the UI framework.
 
 ## Which guidelines do you propose?
 
-TL/DR: The [complete guideline](#guidelines-for-an-itcss-oriented-scss-structure-for-ilias)
-including some examples can be found beneath this text. We propose to structure
-our style code according to ITCSS using eight layers:
-1. settings
-2. dependencies
-3. tools
-4. normalize
-5. layout
-6. elements
-7. components
-8. hacks and tweaks
+The currently binding guidelines for ILIAS version 9 and later can be found here: 
+[SCSS Coding Guidelines](../../../templates/Guidelines_SCSS-Coding.md)
+
+They include a detailed description of each ITCSS layer, naming conventions and
+best practices for Sass.
 
 
 ## Why do we need such a complex style code structure for SASS?
 
-The proposed structure tries to fit the actual complexity and requirements that
+The chosen structure tries to fit the actual complexity and requirements that
 our style code bears. The complexity mostly arrises due to the huge variety of UI
 components and combinations thereof, in conjunction with the sizeable group of
 developers working on and using them. The guidelines attempts to provide a structure
@@ -141,37 +134,10 @@ contains a lot complexity and problems in and on itself. The goal of the guideli
 is to make them manageable but won't make them disappear.
 
 
-## Why can't we reuse the current LESS-Guidelines for SASS?
-
-The current guidelines were in fact intended to be a first version of guidelines
-for style code and were meant to be extended step by step (see JF decision
-regarding that guideline). We in fact should recognize that these guidelines only
-target a very small portion of the actual problems that arise when building and
-maintaining style code for a complex and manifold UI. The proposal we make here
-targets the general structure of our style code, while the LESS-guidelines were
-mostly concerned with the way that actual less code is written and layed out. We
-plan to add corresponding guidelines to our current proposal as well and will
-revisit the current LESS-guidelines when doing so. But we think that there are
-more important questions to ponder before doing so. 
-
-
-## Can you outline how you would want to proceed?
-
-If the JF supports our general idea and direction, as of this proposal here, we
-plan to actually apply the model we layed out to (some of) the existing components
-in the UI framework. We expect that this will spawn questions and insights that
-will lead to refinements and clarifications of the guidelines as proposed here,
-as well as induce a discussion about issues and rules on a more detailed level,
-such as naming conventions, documentation requirements and layout of code. This
-will also allow us to investigate how and where we would want to use the syntactic
-and functional possibilities of SASS. This hopefully should lead to a refined
-guideline and a PR for the UI framework that we will take to the JF again, for
-discussions and/or approval.
-
-
-# Guidelines for an ITCSS-oriented SCSS structure for ILIAS
+# The ITCSS-oriented SCSS structure for ILIAS
 
 SASS in ILIAS is structured according to an adapted version of the [Inverted Triangle CSS (ITCSS) Model](https://www.xfive.co/blog/itcss-scalable-maintainable-css-architecture/).
+
 The general idea is to separate the SCSS codebase in several layers and arrange
 it in a way that goes from general to specific, so that specific SCSS can use
 code from more general layers. This model serves different purposes:
@@ -190,120 +156,5 @@ code from more general layers. This model serves different purposes:
 * It uses separate folders for each layer of the triangle respectively ITCSS section.
 * It provides namespaces that make it easy to understand the purpose of a SCSS-snippet.
 
-ILIAS uses a custom set of ITCSS-layers, which is structured as such (from general to specific):
-
-
-## Settings
-
-The Settings-layer only contains global variables that will be used throughout the
-whole system. People that only need minimal changes to the ILIAS skin to create
-their custom skin should be able to do this easily by changing values here. It
-should contain all global variables related to colors, fonts, font-sizes and
-spacings. Local variables that belong to lower layers are defined based on values
-from these global variables.
-
-Examples:
-* Choose fonts for different purposes.
-* Choose a color palette.
-* Choose general sizing and spacing for the skin.
-
-
-## Dependencies
-
-The Dependencies-layer contains files pulled in from other projects. Dependencies
-should only be added after careful consideration whether the benefits outweigh the
-risks. The dependencies are added here as complete packages to make updating them
-easy. Instead of adding complete packages to our css as a framework, we use
-dependencies as libraries in the lower layers.
-
-Examples:
-* Bootstrap...
-* ...
-
-
-## Tools
-
-The Tools-layer defines mixins, extensible classes, media queries and animations
-that are used in lower layers of the SCSS. The tools are used in various other
-sections in the SCSS, provide uniform definitions for common concepts and problems,
-and thus foster visual homogenity in the system. They substantiate variables from
-the Settings into more concrete concepts.
-
-Examples:
-* Use colors from the Settings to define a common look for errors.
-* Turn screen sizes from the Settings to concrete media queries.
-* Provide parametrized mixins for common styling problems.
-
-
-## Normalize
-
-The Normalize-layer contains styles that normalize browser behaviour by resetting
-browser defaults for page and element rendering.
-
-Examples:
-* Set general line-heights for texts.
-* Remove paddings and margins.
-* Remove browser specific stylings.
-
-
-## Layout
-
-The Layout-layer contains classes and mixins that define the positioning and spacing
-of components relative to each other. Base classes for extensions or mixins from
-this layer are used in the components. That means: Whenever positioning and spacing
-needs to be coordinated between various components the code should be contained
-here. If a positioning or spacing can be defined internally in a component or solely
-be based on global variables, it should go into the component layer.
-
-Examples:
-* The layout of the complete ILIAS-page is implemented via a CSS-grid/flexbox and
-  coordinates different individual components.
-* The spacing of Bulky Buttons and Bulky Links in Menues needs to be coordinated.
-* Close Button in Tool Slate and the Collapse Button in Slates should be on the
-  same vertical line.
-
-
-## Elements
-
-The Elements-layer contains the basic styling of all unclassed HTML-elements. It
-provides a visual baseline for more specific components. This is the first layer
-that contains actual styling that is visual for end user. This layer will use
-variables from the Settings extensively. It captures commonalities among components
-that allows them to use unclassed HTML-elements and to only add classes and specific
-styling if strictly required.
-
-Examples:
-* Define the bullets that are used in lists.
-* Define a general look for links.
-* Define how headline-elements use variables for fonts and sizes.
-
-
-## Components
-
-The Component-layer contains css-classes for the single components in the UI-framework
-and determines the individual look of each UI-component. It is expected that this
-mostly mixes and combines stuff from the upper layers to classes to be slapped
-onto html from UI-Components. Colors, sizes and fonts may not be set on this layer
-but only be referenced via global variables or indirectly via base classes or mixins
-from other layers. This layer should only define its own CSS-properties or overwrite
-styles from the Elements-Layer if strictly required.
-
-Examples:
-* Build a class to assign color and positions of label to Primary Button by using
-  some mixins from Tools and global variables.
-* Build a class for the panel to set background color, border and font-style based
-  on mixins from Tools and global variables.
-
-Non-Examples:
-* Define font-families or sizes for some component. This is supposed to be done in
-  the Settings-layer.
-
-
-## Hacks and Tweaks
-
-This layer should be empty. But as every developer knows: sometimes we cannot solve
-a problem right away and we need a hack or tweak that temporarily fixes the issue.
-This is the layer where this code goes. Styles that affect very specific locations
-in the DOM or override some specific CSS inherited from somewhere go here.
-`!important` is only permitted here. Every bit of code that is contained here
-should be considered a smell that is worth fixing.
+The custom set of layers that we ended up implementing are described in detail as part
+of the [SCSS Coding Guidelines](../../../templates/Guidelines_SCSS-Coding.md).

--- a/templates/Guidelines_SCSS-Coding.md
+++ b/templates/Guidelines_SCSS-Coding.md
@@ -12,6 +12,8 @@ The following guidelines will help you to
 
 Code contributions to the ILIAS repository containing style code will be reviewed according to the rules and recommendations defined here.
 
+If you are interested why we decided to make big changes to the style code for ILIAS version 9 and up, you can find out more in this concept: [Using frameworkless SASS and ITCSS](../src/UI/docu/sass-itcss-concepts.md)
+
 ## SASS in SCSS syntax generates CSS
 
 Sass/CSS is responsible for the design of the website. Instead of directly writing CSS code and many repeating patterns by hand, we are using the Sass pre-processor to generate the CSS code for ILIAS.
@@ -19,6 +21,8 @@ Sass/CSS is responsible for the design of the website. Instead of directly writi
 Sass extends the CSS language, adding features that allow advanced variables, mixins, functions and many other techniques that allow you to make CSS that is more maintainable, themable and expendable (see: [sass-lang.com](http://sass-lang.com/)).
 
 The Sass pre-processor compiles the entry point delos.scss and all connected files to the one delos.css file which can then be rendered by the browser.
+
+Please use the most recent **Dart Sass** version (**not** Ruby Sass) that can be downloaded from [the official GitHub repository](https://github.com/sass/dart-sass/releases).
 
 You should consult the [official Sass Documentation](https://sass-lang.com/documentation/) to make use of the advantages of Sass.
 
@@ -30,6 +34,8 @@ You should consult the [official Sass Documentation](https://sass-lang.com/docum
 * You MUST NOT make changes to the compiled delos.css manually.
 * Delos.scss MUST only contain imports and no other Sass logic at all.
 
+If you are interested, you can read more about why we switched preprocessors from LESS to Sass here.
+
 ## HTML
 
 HTML templates are only responsible for a well structured HTML document, which displays the bare content of the website and nothing else.
@@ -40,7 +46,6 @@ They can be found in `src/UI/templates/default` for modern UI components or in `
 * New class names MUST follow the naming convention outlined in this document.
 * You MUST NOT use style attributes like style, align, border, cellpadding, cellspacing font, nowrap, valign, width, height and similar in HTML templates.
 * You MUST NOT use `&nbsp;`, `<br>`, `<br/>` or similar means to create space.
-
 
 
 # ITCSS structure


### PR DESCRIPTION
The ITCSS proposal document and the Guidelines for SCSS Coding were repeating the same information from different angles. With this PR each document was refined to have its own focus:

* **Using frameworkless SASS and ITCSS** is about why the big changes to the style code had to be made and what overarching strategy guides ongoing and future delos projects
* **Guidelines SCSS Coding** is about the detailed rules and best practices any contributions to the style code have to follow.

This should make more clear how these two documents build on each other instead of presenting the same or rivaling information. Each one now links to the other one and states its purpose and scope in comparison.