### PR TITLE
Container: fix AdvMD select filters for R8 (35621)

### DIFF
--- a/Services/ADT/classes/ActiveRecord/class.ilADTActiveRecordByType.php
+++ b/Services/ADT/classes/ActiveRecord/class.ilADTActiveRecordByType.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -665,19 +666,13 @@ class ilADTActiveRecordByType
 
     /**
      * Find entries
-     * @param string $a_table
-     * @param string $a_type
-     * @param int    $a_field_id
-     * @param string $a_condition
-     * @param string $a_additional_fields
-     * @return array
      */
     public static function find(
         string $a_table,
         string $a_type,
         int $a_field_id,
         string $a_condition,
-        array $a_additional_fields = null
+        ?string $a_additional_fields = null
     ): ?array {
         global $DIC;
 

--- a/Services/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionSelect.php
+++ b/Services/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionSelect.php
@@ -49,7 +49,7 @@ class ilAdvancedMDFieldDefinitionSelect extends ilAdvancedMDFieldDefinition
 
     public function getSearchQueryParserValue(ilADTSearchBridge $a_adt_search): string
     {
-        return $a_adt_search->getADT()->getSelection();
+        return (string) $a_adt_search->getADT()->getSelection();
     }
 
     protected function initADTDefinition(): ilADTDefinition

--- a/Services/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionSelectMulti.php
+++ b/Services/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionSelectMulti.php
@@ -1,7 +1,22 @@
 <?php
 
 declare(strict_types=1);
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * AMD field type select
@@ -14,7 +29,7 @@ class ilAdvancedMDFieldDefinitionSelectMulti extends ilAdvancedMDFieldDefinition
 
     public function getSearchQueryParserValue(ilADTSearchBridge $a_adt_search): string
     {
-        return $a_adt_search->getADT()->getSelections()[0] ?? "";
+        return (string) $a_adt_search->getADT()->getSelections()[0];
     }
 
     public function getType(): int

--- a/Services/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionText.php
+++ b/Services/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionText.php
@@ -1,7 +1,22 @@
 <?php
 
 declare(strict_types=1);
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * AMD field type text
@@ -278,14 +293,14 @@ class ilAdvancedMDFieldDefinitionText extends ilAdvancedMDFieldDefinitionGroupBa
 
     public function getSearchQueryParserValue(ilADTSearchBridge $a_adt_search): string
     {
-        return $a_adt_search->getADT()->getText();
+        return (string) $a_adt_search->getADT()->getText();
     }
 
     protected function parseSearchObjects(array $a_records, array $a_object_types): array
     {
         global $DIC;
 
-        $ilDB = $DIC['ilDB'];
+        $ilDB = $DIC->database();
 
         $res = array();
 
@@ -299,8 +314,8 @@ class ilAdvancedMDFieldDefinitionText extends ilAdvancedMDFieldDefinitionGroupBa
 
         $sql = "SELECT obj_id,type" .
             " FROM object_data" .
-            " WHERE " . $ilDB->in("obj_id", array_keys($obj_ids), "", "integer") .
-            " AND " . $ilDB->in("type", $a_object_types, "", "text");
+            " WHERE " . $ilDB->in("obj_id", array_keys($obj_ids), false, "integer") .
+            " AND " . $ilDB->in("type", $a_object_types, false, "text");
         $set = $ilDB->query($sql);
         while ($row = $ilDB->fetchAssoc($set)) {
             $row["found"] = array();

--- a/Services/AdvancedMetaData/classes/class.ilAdvancedMDSearch.php
+++ b/Services/AdvancedMetaData/classes/class.ilAdvancedMDSearch.php
@@ -1,27 +1,22 @@
 <?php
 
 declare(strict_types=1);
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2006 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * @author  Stefan Meyer <meyer@leifos.com>
@@ -61,7 +56,7 @@ class ilAdvancedMDSearch extends ilAbstractSearch
     {
         $this->query_parser->parse();
 
-        $locate = null;
+        $locate = '';
         $parser_value = $this->getDefinition()->getSearchQueryParserValue($this->getSearchElement());
         if ($parser_value) {
             $this->setFields(
@@ -84,8 +79,8 @@ class ilAdvancedMDSearch extends ilAbstractSearch
 
         if (is_array($res_field)) {
             foreach ($res_field as $row) {
-                $found = is_array($row["found"]) ? $row["found"] : array();
-                $this->search_result->addEntry($row["obj_id"], $row["type"], $found);
+                $found = is_array($row["found"] ?? null) ? $row["found"] : [];
+                $this->search_result->addEntry((int) $row["obj_id"], $row["type"], $found);
             }
             return $this->search_result;
         }

--- a/Services/Container/Filter/classes/class.ilContainerFilterUtil.php
+++ b/Services/Container/Filter/classes/class.ilContainerFilterUtil.php
@@ -154,10 +154,7 @@ class ilContainerFilterUtil
                 switch ($service->advancedMetadata()->getAdvType($field->getFieldId())) {
                     case ilAdvancedMDFieldDefinition::TYPE_SELECT:
                     case ilAdvancedMDFieldDefinition::TYPE_SELECT_MULTI:
-                        $options = [];
-                        foreach ($service->advancedMetadata()->getOptions($field->getFieldId()) as $op) {
-                            $options[$op] = $op;
-                        }
+                        $options = $service->advancedMetadata()->getOptions($field->getFieldId());
                         $fields["adv_" . $field->getFieldId()] =
                             $ui->input()->field()->select($title, $options);
                         $fields_act[] = false;

--- a/Services/Container/classes/class.ilContainer.php
+++ b/Services/Container/classes/class.ilContainer.php
@@ -1172,7 +1172,11 @@ class ilContainer extends ilObject
                             $field_form->getADT()->setSelection($val);
                         }
                     }
+                    if ($field instanceof ilAdvancedMDFieldDefinitionInteger) {
+                        $field_form->getADT()->setNumber((int) $val);
+                    }
 
+                    $query_parser->setCombination(ilQueryParser::QP_COMBINATION_OR);
                     $adv_md_search = ilObjectSearchFactory::_getAdvancedMDSearchInstance($query_parser);
                     //$adv_md_search->setFilter($this->filter);	// this could be set to an array of object types
                     $adv_md_search->setDefinition($field);            // e.g. ilAdvancedMDFieldDefinitionSelectMulti


### PR DESCRIPTION
This PR is #5735 ported to R8 and trunk. It contains a bunch of additional php8 fixes in related AdvMD classes, and does not have the workaround necessary for R7.