### PR TITLE
Refactored Notifications to match GS Refactorement

### DIFF
--- a/Services/Notifications/classes/Provider/NotificationToastProvider.php
+++ b/Services/Notifications/classes/Provider/NotificationToastProvider.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Notifications\Provider;
+
+use ILIAS\Badge\GlobalScreen\BadgeNotificationProvider;
+use ILIAS\Chatroom\GlobalScreen\ChatInvitationNotificationProvider;
+use ILIAS\Contact\Provider\ContactNotificationProvider;
+use ILIAS\GlobalScreen\Identification\IdentificationInterface;
+use ILIAS\GlobalScreen\Scope\Toast\Provider\AbstractToastProvider;
+use ILIAS\Notifications\ilNotificationOSDHandler;
+use ILIAS\Notifications\Repository\ilNotificationOSDRepository;
+use ILIAS\UI\Implementation\Component\Symbol\Icon\Icon;
+use ILIAS\UI\Implementation\Component\Symbol\Icon\Standard;
+use ILIAS\UI\Implementation\Component\Toast\Toast;
+use ilSetting;
+use function Sabre\Xml\Deserializer\functionCaller;
+
+/**
+ * @author Ingmar Szmais <iszmais@databay.de>
+ */
+class NotificationToastProvider extends AbstractToastProvider
+{
+    /**
+     * @inheritDoc
+     */
+    public function getToasts(): array
+    {
+        $settings = new ilSetting('notifications');
+        $toasts = [];
+
+        if (
+            $settings->get('enable_osd', '0') !== '1' ||
+            0 === $this->dic->user()->getId() ||
+            $this->dic->user()->isAnonymous()
+        ) {
+            return $toasts;
+        }
+
+        $osd_repository = new ilNotificationOSDRepository($this->dic->database());
+        $osd_notification_handler = new ilNotificationOSDHandler($osd_repository);
+
+        foreach ($osd_notification_handler->getOSDNotificationsForUser(
+            $this->dic->user()->getId(),
+            true,
+            time() - ($this->dic->http()->request()->getQueryParams()['max_age'] ?? time())
+        ) as $notification) {
+            $type = $notification->getType();
+            $toast = $this->toast_factory
+                ->standard(
+                    $this->if->identifier((string) $notification->getId()),
+                    $notification->getObject()->title
+                )
+                ->withIcon($this->getIconByType($notification->getType()))
+                ->withDescription($notification->getObject()->shortDescription)
+                ->withVanishTime((int) $settings->get('osd_vanish', (string) Toast::DEFAULT_VANISH_TIME))
+                ->withDelayTime((int) $settings->get('osd_delay', (string) Toast::DEFAULT_DELAY_TIME))
+                ->withClosedCallable(static function () use ($osd_repository, $notification) {
+                    $osd_repository->deleteOSDNotificationById($notification->getId());
+                });
+
+            foreach ($notification->getObject()->links as $link) {
+                $toast = $toast->withAdditionToastAction(
+                    $this->toast_factory->action(
+                        $link->getTitle(),
+                        $link->getTitle(),
+                        function () use ($link, $osd_repository, $notification): void {
+                            $osd_repository->deleteOSDNotificationById($notification->getId());
+                            $this->dic->ctrl()->redirectToURL($link->getUrl());
+                        }
+                    )
+                );
+            }
+            $toasts[] = $toast;
+        }
+
+        return $toasts;
+    }
+
+    protected function getIconByType(string $type): Icon
+    {
+        $name = 'default';
+        switch ($type) {
+            case BadgeNotificationProvider::NOTIFICATION_TYPE:
+                $name = Standard::BDGA;
+                break;
+            case ChatInvitationNotificationProvider::NOTIFICATION_TYPE:
+                $name = Standard::CHTA;
+                break;
+            case ContactNotificationProvider::NOTIFICATION_TYPE:
+                $name = Standard::CADM;
+                break;
+        }
+        return $this->dic->ui()->factory()->symbol()->icon()->standard($name, $type);
+    }
+}

--- a/Services/Notifications/classes/Repository/ilNotificationOSDRepository.php
+++ b/Services/Notifications/classes/Repository/ilNotificationOSDRepository.php
@@ -158,13 +158,18 @@ class ilNotificationOSDRepository implements ilNotificationOSDRepositoryInterfac
         );
     }
 
-    public function deleteStaleNotificationsForUserAndType(int $user_id, string $type, int $until_timestamp): void
+    public function deleteStaleOSDNotificationsForUserAndType(string $povider_type, int $user_id, int $until_timestamp): void
     {
-        $query = 'DELETE FROM ' . ilNotificationSetupHelper::$tbl_notification_osd_handler . ' WHERE usr_id = %s AND type = %s AND time_added < %s';
+        $query = 'DELETE FROM ' . ilNotificationSetupHelper::$tbl_notification_osd_handler . ' WHERE type = %s AND usr_id = %s AND time_added < %s';
         $this->database->manipulateF(
             $query,
-            [ilDBConstants::T_INTEGER, ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER],
-            [$user_id, $type, $until_timestamp]
+            [ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER],
+            [$povider_type, $user_id, $until_timestamp]
         );
+    }
+
+    public function deleteAllOSDNotifications(): void
+    {
+        $this->database->manipulate('TRUNCATE TABLE ' . ilNotificationSetupHelper::$tbl_notification_osd_handler);
     }
 }

--- a/Services/Notifications/classes/class.ilNotificationGUI.php
+++ b/Services/Notifications/classes/class.ilNotificationGUI.php
@@ -108,7 +108,11 @@ class ilNotificationGUI implements ilCtrlBaseClassInterface
     public function getOSDNotificationsObject(): void
     {
         ilSession::enableWebAccessWithoutSession(true);
-        $toasts = $this->dic->globalScreen()->collector()->toasts()->getToasts();
+        $toasts = [];
+        foreach ($this->dic->globalScreen()->collector()->toasts()->getToasts() as $toast) {
+            $renderer = $toast->getRenderer();
+            $toasts[] = $renderer->getToastComponentForItem($toast);
+        }
 
         $this->dic->http()->saveResponse(
             $this->dic->http()->response()

--- a/Services/Notifications/classes/class.ilObjNotificationAdminGUI.php
+++ b/Services/Notifications/classes/class.ilObjNotificationAdminGUI.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  *********************************************************************/
 
 use ILIAS\DI\Container;
+use ILIAS\Notifications\Repository\ilNotificationOSDRepository;
 use ILIAS\UI\Component\Input\Container\Form\Form;
 
 /**
@@ -100,6 +101,8 @@ class ilObjNotificationAdminGUI extends ilObjectGUI
         $data = $form->getData();
         if (isset($data['osd']) && is_array($data['osd'])) {
             if (!isset($data['osd']['enable_osd'])) {
+                global $DIC;
+                $DIC->notifications()->system()->clear('osd');
                 $settings->deleteAll();
                 $settings->set('enable_osd', '0');
             } else {

--- a/Services/Notifications/classes/ilNotificationHandler.php
+++ b/Services/Notifications/classes/ilNotificationHandler.php
@@ -32,4 +32,8 @@ abstract class ilNotificationHandler
     public function showSettings($form): void
     {
     }
+
+    public function clear(): void
+    {
+    }
 }

--- a/Services/Notifications/classes/ilNotificationOSDHandler.php
+++ b/Services/Notifications/classes/ilNotificationOSDHandler.php
@@ -69,12 +69,20 @@ class ilNotificationOSDHandler extends ilNotificationHandler
         return $notifications;
     }
 
+    /**
+     * @deprecated
+     */
     public function deleteStaleNotificationsForUserAndType(int $user_id, string $type): void
     {
-        $this->repo->deleteStaleNotificationsForUserAndType($user_id, $type, $this->clock->now()->getTimestamp());
+        $this->repo->deleteStaleOSDNotificationsForUserAndType($type, $user_id, $this->clock->now()->getTimestamp());
     }
 
-    public function removeNotification(int $notification_osd_id): bool
+    public function deleteStaleOSDNotificationsForUser(string $provider, int $user_id): void
+    {
+        $this->repo->deleteStaleOSDNotificationsForUserAndType($provider, $user_id, $this->clock->now()->getTimestamp());
+    }
+
+    public function removeOSDNotification(int $notification_osd_id): bool
     {
         return $this->repo->deleteOSDNotificationById($notification_osd_id);
     }
@@ -87,5 +95,10 @@ class ilNotificationOSDHandler extends ilNotificationHandler
             $link .= '?' . $param . '=' . $value;
         }
         return $link;
+    }
+
+    public function clear(): void
+    {
+        $this->repo->deleteAllOSDNotifications();
     }
 }

--- a/Services/Notifications/classes/ilNotificationSystem.php
+++ b/Services/Notifications/classes/ilNotificationSystem.php
@@ -30,6 +30,9 @@ use ilRbacReview;
  */
 class ilNotificationSystem
 {
+    /**
+     * @var ilNotificationHandler[][]
+     */
     private array $handler = [];
     private string $defaultLanguage = 'en';
     private ilRbacReview $rbacReview;
@@ -178,6 +181,19 @@ class ilNotificationSystem
     {
         if ($users) {
             ilNotificationDatabaseHandler::enableListeners($module, $ref_id, $users);
+        }
+    }
+
+    public function clear(string $channel = ''): void
+    {
+        $channels = $this->handler;
+        if ($channel !== '') {
+            $channels = [$this->handler[$channel]] ?? [];
+        }
+        foreach ($channels as $c) {
+            foreach ($c as $handler) {
+                $handler->clear();
+            }
         }
     }
 }

--- a/Services/Notifications/templates/default/notifications.js
+++ b/Services/Notifications/templates/default/notifications.js
@@ -43,7 +43,7 @@ var OSDNotifier, OSDNotifications = settings => {
     };
 
     const poll = (container) => {
-        let lastRequest = 0;
+        let lastRequest = parseInt(new Date().getTime() / 1000);
 
         return () => {
             const time = parseInt(new Date().getTime() / 1000);

--- a/Services/Notifications/test/notifications/ilNotificationOSDTest.php
+++ b/Services/Notifications/test/notifications/ilNotificationOSDTest.php
@@ -141,7 +141,7 @@ class ilNotificationOSDTest extends ilNotificationsBaseTest
         $notifications = $this->handler->getOSDNotificationsForUser($this->user->getId());
 
         $this->assertCount(1, $notifications);
-        $this->assertTrue($this->handler->removeNotification($notifications[0]->getId()));
+        $this->assertTrue($this->handler->removeOSDNotification($notifications[0]->getId()));
         $this->assertCount(0, $this->handler->getOSDNotificationsForUser($this->user->getId()));
     }
 
@@ -149,20 +149,6 @@ class ilNotificationOSDTest extends ilNotificationsBaseTest
     {
         $this->createDBFunctionCalls(0, 2, 2, 0);
         $this->assertCount(0, $this->handler->getOSDNotificationsForUser($this->user->getId()));
-        $this->assertFalse($this->handler->removeNotification(3));
-    }
-
-    public function testCreateMultipleUniqueNotifications(): void
-    {
-        $this->createDBFunctionCalls(3, 0, 0, 3);
-        $config = new \ILIAS\Notifications\Model\ilNotificationConfig('who_is_online');
-        $config->setTitleVar('Unique Test Notification');
-        $config->setShortDescriptionVar('This is a unqiue test notification');
-        $test_obj = new \ILIAS\Notifications\Model\ilNotificationObject($config, $this->user);
-        $this->handler->notify($test_obj);
-        $this->handler->notify($test_obj);
-        $this->handler->notify($test_obj);
-
-        $this->assertCount(1, $this->database);
+        $this->assertFalse($this->handler->removeOSDNotification(3));
     }
 }

--- a/Services/User/classes/class.ilPublicUserProfileGUI.php
+++ b/Services/User/classes/class.ilPublicUserProfileGUI.php
@@ -196,10 +196,6 @@ class ilPublicUserProfileGUI implements ilCtrlBaseClassInterface
                 }
                 // no break
             case 'ilbuddysystemgui':
-                $osd_id = $this->profile_request->getOsdId();
-                if ($osd_id > 0) {
-                    ilNotificationOSDHandler::removeNotification($osd_id);
-                }
                 $gui = new ilBuddySystemGUI();
                 $ilCtrl->setReturn($this, 'view');
                 $ilCtrl->forwardCommand($gui);


### PR DESCRIPTION
Adapt the Notifications service to the new Gs Handling of Toast and Notifications https://github.com/ILIAS-eLearning/ILIAS/pull/5121 and establishes a central Toast Provider for notification-based toasts (excluding "Who is online?")

Further more this offers following Improvements and Bugfixes:
- Notifications a now loange crawled asyncrounously when they are part of the initial page load
- Deactivation of Notifications inside the Administration clear all OSD Notifications
- Notifications are now removed when the Toast