### PR TITLE
UI/Input/Field/Duration: allow same dates for start and end

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Duration.php
+++ b/src/UI/Implementation/Component/Input/Field/Duration.php
@@ -93,7 +93,7 @@ class Duration extends Group implements C\Input\Field\Duration
             if (is_null($v)) {
                 return true;
             }
-            return $v['start'] < $v['end'];
+            return $v['start'] <= $v['end'];
         };
 
         $from_before_until = $this->refinery->custom()->constraint($is_ok, $error);


### PR DESCRIPTION
UI Input 'Duration' fails when start and end are equal; however, I cannot see a good reason for this (anymore).