### PR TITLE
[FIX] UI: `Roundtrip` and `Interruptive` should no longer be translated

### DIFF
--- a/Modules/Blog/Exercise/class.ilBlogExerciseGUI.php
+++ b/Modules/Blog/Exercise/class.ilBlogExerciseGUI.php
@@ -188,7 +188,7 @@ class ilBlogExerciseGUI
 
         if ($tooltip) {
             $modal = $ui->factory()->modal()->roundtrip($lng->txt("exc_instruction"), $ui->factory()->legacy($tooltip))
-                ->withCancelButtonLabel("close");
+                ->withCancelButtonLabel($lng->txt("close"));
             $elements[] = $modal;
             $buttons[] = $ui->factory()->button()->standard($lng->txt("exc_instruction"), '#')
                 ->withOnClick($modal->getShowSignal());

--- a/Modules/BookingManager/Reservations/class.ilBookingReservationsTableGUI.php
+++ b/Modules/BookingManager/Reservations/class.ilBookingReservationsTableGUI.php
@@ -728,7 +728,7 @@ class ilBookingReservationsTableGUI extends ilTable2GUI
         if ($this->showMessages() && $a_set["message"] !== "") {
             $c = $this->gui->modal(
                 $this->lng->txt("book_message"),
-                "close"
+                $this->lng->txt("close")
             )
                 ->legacy(nl2br($a_set["message"]))
                 ->getTriggerButtonComponents(

--- a/Modules/CmiXapi/classes/class.ilCmiXapiStatementsTableGUI.php
+++ b/Modules/CmiXapi/classes/class.ilCmiXapiStatementsTableGUI.php
@@ -179,7 +179,7 @@ class ilCmiXapiStatementsTableGUI extends ilTable2GUI
         return $f->modal()->roundtrip(
             'Raw Statement',
             $f->legacy('<pre>' . $data['statement'] . '</pre>')
-        )->withCancelButtonLabel('close');
+        )->withCancelButtonLabel($this->language->txt('close'));
     }
 
     protected function getUsername(ilCmiXapiUser $cmixUser): string

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -5618,7 +5618,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
                                 $this->lng->txt('forums_info_delete_post'),
                             $url
                         )->withActionButtonLabel(
-                            str_contains($url, 'deletePostingDraft') ? 'deletePostingDraft' : 'deletePosting'
+                            $this->lng->txt(str_contains($url, 'deletePostingDraft') ? 'deletePostingDraft' : 'deletePosting')
                         );
 
                         $deleteAction = $this->uiFactory->button()->shy($this->lng->txt($lng_id), '#')->withOnClick(

--- a/Modules/Portfolio/Exercise/class.ilPortfolioExerciseGUI.php
+++ b/Modules/Portfolio/Exercise/class.ilPortfolioExerciseGUI.php
@@ -226,7 +226,7 @@ class ilPortfolioExerciseGUI
 
         if ($tooltip) {
             $modal = $ui->factory()->modal()->roundtrip($lng->txt("exc_instruction"), $ui->factory()->legacy($tooltip))
-                ->withCancelButtonLabel("close");
+                ->withCancelButtonLabel($lng->txt("close"));
             $elements[] = $modal;
             $buttons[] = $ui->factory()->button()->standard($lng->txt("exc_instruction"), '#')
                 ->withOnClick($modal->getShowSignal());

--- a/Services/AdministrativeNotification/classes/class.ilADNNotificationTableGUI.php
+++ b/Services/AdministrativeNotification/classes/class.ilADNNotificationTableGUI.php
@@ -141,7 +141,7 @@ class ilADNNotificationTableGUI extends ilTable2GUI
                                $action
                            )
                            ->withAffectedItems([$i])
-                           ->withActionButtonLabel($cmd);
+                           ->withActionButtonLabel($this->lng->txt($cmd));
     }
 
     public function getHTML(): string

--- a/Services/Badge/classes/class.ilBadgeProfileGUI.php
+++ b/Services/Badge/classes/class.ilBadgeProfileGUI.php
@@ -141,7 +141,7 @@ class ilBadgeProfileGUI
             $modal = $this->factory->modal()->roundtrip(
                 $badge["title"],
                 $this->factory->legacy($badge["renderer"]->renderModalContent())
-            )->withCancelButtonLabel("ok");
+            )->withCancelButtonLabel($this->lng->txt("ok"));
             $image = $this->factory->image()->responsive(ilWACSignedPath::signFile($badge["image"]), $badge["name"])
                 ->withAction($modal->getShowSignal());
 

--- a/Services/Badge/classes/class.ilBadgeRenderer.php
+++ b/Services/Badge/classes/class.ilBadgeRenderer.php
@@ -51,7 +51,7 @@ class ilBadgeRenderer
         $modal = $this->factory->modal()->roundtrip(
             $this->badge->getTitle(),
             $this->factory->legacy($this->renderModalContent())
-        )->withCancelButtonLabel("ok");
+        )->withCancelButtonLabel($this->lng->txt("ok"));
         $components[] = $modal;
 
         $image_path = ilWACSignedPath::signFile($this->badge->getImagePath());

--- a/Services/Calendar/classes/class.ilCalendarViewGUI.php
+++ b/Services/Calendar/classes/class.ilCalendarViewGUI.php
@@ -273,7 +273,7 @@ class ilCalendarViewGUI
                 $modal = $this->ui_factory->modal()->roundtrip(
                     $modal_title,
                     $this->ui_factory->legacy($content)
-                )->withCancelButtonLabel("close");
+                )->withCancelButtonLabel($this->lng->txt("close"));
                 echo $this->ui_renderer->renderAsync($modal);
             }
         }

--- a/Services/Mail/classes/class.ilMailTemplateTableGUI.php
+++ b/Services/Mail/classes/class.ilMailTemplateTableGUI.php
@@ -135,7 +135,7 @@ class ilMailTemplateTableGUI extends ilTable2GUI
                     $this->lng->txt('mail_tpl_sure_delete_entry'),
                     $this->ctrl->getFormAction($this->getParentObject(), 'deleteTemplate')
                 )->withActionButtonLabel(
-                    'deleteTemplate'
+                    $this->lng->txt('deleteTemplate')
                 );
 
             $this->uiComponents[] = $deleteModal;

--- a/Services/MainMenu/classes/Administration/class.ilMMSubItemTableGUI.php
+++ b/Services/MainMenu/classes/Administration/class.ilMMSubItemTableGUI.php
@@ -222,7 +222,7 @@ class ilMMSubItemTableGUI extends ilTable2GUI
                                  $this->lng->txt(ilMMSubItemGUI::CMD_CONFIRM_MOVE),
                                  $action
                              )
-                             ->withActionButtonLabel(ilMMSubItemGUI::CMD_MOVE)
+                             ->withActionButtonLabel($this->lng->txt(ilMMSubItemGUI::CMD_MOVE))
                              ->withAffectedItems([$ditem]);
                 $items[] = $factory->button()->shy(
                     $this->lng->txt(ilMMSubItemGUI::CMD_MOVE . '_to_top_item'),

--- a/Services/Tasks/classes/class.ilPDTasksBlockGUI.php
+++ b/Services/Tasks/classes/class.ilPDTasksBlockGUI.php
@@ -199,7 +199,7 @@ class ilPDTasksBlockGUI extends ilBlockGUI
             $lng->txt("task_details"),
             $factory->legacy($info_screen->getHTML())
         )
-            ->withCancelButtonLabel("close");
+            ->withCancelButtonLabel($lng->txt("close"));
         $button1 = $factory->button()->shy($a_set["title"], '#')
             ->withOnClick($modal->getShowSignal());
 

--- a/Services/TermsOfService/classes/Document/class.ilTermsOfServiceDocumentTableGUI.php
+++ b/Services/TermsOfService/classes/Document/class.ilTermsOfServiceDocumentTableGUI.php
@@ -200,7 +200,7 @@ class ilTermsOfServiceDocumentTableGUI extends ilTermsOfServiceTableGUI
                 $this->lng->txt('tos_sure_delete_documents_s'),
                 $this->ctrl->getFormAction($this->getParentObject(), 'deleteDocument')
             )
-            ->withActionButtonLabel('deleteDocument');
+            ->withActionButtonLabel($this->lng->txt('deleteDocument'));
 
         $deleteBtn = $this->uiFactory
             ->button()
@@ -255,7 +255,7 @@ class ilTermsOfServiceDocumentTableGUI extends ilTermsOfServiceTableGUI
                     $this->lng->txt('tos_doc_sure_detach_crit'),
                     $this->ctrl->getFormAction($this->getParentObject(), 'detachCriterionAssignment')
                 )
-                ->withActionButtonLabel('detachCriterionAssignment');
+                ->withActionButtonLabel($this->lng->txt('detachCriterionAssignment'));
 
             $deleteBtn = $this->uiFactory
                 ->button()

--- a/src/UI/Component/Modal/Interruptive.php
+++ b/src/UI/Component/Modal/Interruptive.php
@@ -53,21 +53,20 @@ interface Interruptive extends Modal
     public function withAffectedItems(array $items): Interruptive;
 
     /**
-     * Get the label of the action button in the footer
+     * Get the custom label of the action button in the footer.
      */
-    public function getActionButtonLabel(): string;
+    public function getActionButtonLabel(): ?string;
 
     /**
      * Get a modal like this with the action button labeled
      * according to the parameter.
-     * The label will be translated.
      */
     public function withActionButtonLabel(string $action_label): Interruptive;
 
     /**
-     * Get the label of the cancel button in the footer
+     * Get the custom label of the cancel button in the footer.
      */
-    public function getCancelButtonLabel(): string;
+    public function getCancelButtonLabel(): ?string;
 
     /**
      * Get a modal like this with the cancel button labeled

--- a/src/UI/Component/Modal/RoundTrip.php
+++ b/src/UI/Component/Modal/RoundTrip.php
@@ -48,15 +48,15 @@ interface RoundTrip extends Modal, Standard
     public function getActionButtons(): array;
 
     /**
-     * Get the label of the cancel button in the footer, as language key
+     * Get the custom label of the cancel button in the footer.
      */
-    public function getCancelButtonLabel(): string;
+    public function getCancelButtonLabel(): ?string;
 
     /**
      * Get a modal like this with the provided action buttons in the footer.
      * Note that the footer always contains a cancel button closing the modal as last button in the footer (on the right).
      *
-     * @param array Button\Button[] $buttons
+     * @param Button\Button[] $buttons
      */
     public function withActionButtons(array $buttons): RoundTrip;
 

--- a/src/UI/Implementation/Component/Dropzone/File/File.php
+++ b/src/UI/Implementation/Component/Dropzone/File/File.php
@@ -162,7 +162,7 @@ abstract class File implements FileDropzone
         return $this->modal->getActionButtons();
     }
 
-    public function getCancelButtonLabel(): string
+    public function getCancelButtonLabel(): ?string
     {
         return $this->modal->getCancelButtonLabel();
     }

--- a/src/UI/Implementation/Component/Modal/Interruptive.php
+++ b/src/UI/Implementation/Component/Modal/Interruptive.php
@@ -31,8 +31,8 @@ class Interruptive extends Modal implements M\Interruptive
     protected array $items = array();
     protected string $title;
     protected string $message;
-    protected string $action_button_label = 'delete';
-    protected string $cancel_button_label = 'cancel';
+    protected ?string $action_button_label = null;
+    protected ?string $cancel_button_label = null;
     protected string $form_action;
 
     public function __construct(
@@ -91,7 +91,7 @@ class Interruptive extends Modal implements M\Interruptive
     /**
      * @inheritdoc
      */
-    public function getActionButtonLabel(): string
+    public function getActionButtonLabel(): ?string
     {
         return $this->action_button_label;
     }
@@ -110,7 +110,7 @@ class Interruptive extends Modal implements M\Interruptive
     /**
      * @inheritdoc
      */
-    public function getCancelButtonLabel(): string
+    public function getCancelButtonLabel(): ?string
     {
         return $this->cancel_button_label;
     }

--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -150,9 +150,8 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable('KEY_VALUE_ITEMS', $key_value_items);
         }
 
-        $tpl->setVariable('ACTION_BUTTON_LABEL', $this->txt($modal->getActionButtonLabel()));
-        $tpl->setVariable('ACTION_BUTTON', $modal->getActionButtonLabel());
-        $tpl->setVariable('CANCEL_BUTTON_LABEL', $this->txt($modal->getCancelButtonLabel()));
+        $tpl->setVariable('ACTION_BUTTON_LABEL', $modal->getActionButtonLabel() ?? $this->txt('delete'));
+        $tpl->setVariable('CANCEL_BUTTON_LABEL', $modal->getCancelButtonLabel() ?? $this->txt('cancel'));
         return $tpl->get();
     }
 
@@ -209,7 +208,7 @@ class Renderer extends AbstractComponentRenderer
 
             // render submit in modal footer.
             $submit = $this->getUIFactory()->button()->standard(
-                $modal->getSubmitCaption(),
+                $modal->getSubmitCaption() ?? $this->txt('save'),
                 ''
             )->withOnClick($modal->getForm()->getSubmitSignal());
             $tpl->setCurrentBlock('with_submit');
@@ -217,7 +216,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
 
-        $tpl->setVariable('CANCEL_BUTTON_LABEL', $this->txt($modal->getCancelButtonLabel()));
+        $tpl->setVariable('CANCEL_BUTTON_LABEL', $modal->getCancelButtonLabel() ?? $this->txt('cancel'));
         return $tpl->get();
     }
 

--- a/src/UI/Implementation/Component/Modal/RoundTrip.php
+++ b/src/UI/Implementation/Component/Modal/RoundTrip.php
@@ -55,8 +55,8 @@ class RoundTrip extends Modal implements M\RoundTrip
     protected Signal $submit_signal;
     protected FormWithoutSubmitButton $form;
     protected string $title;
-    protected string $cancel_button_label = 'cancel';
-    protected string $submit_button_label = 'save';
+    protected ?string $cancel_button_label = null;
+    protected ?string $submit_button_label = null;
 
     /**
      * @param Component[]|Component|null $content
@@ -134,7 +134,7 @@ class RoundTrip extends Modal implements M\RoundTrip
     /**
      * @inheritdoc
      */
-    public function getCancelButtonLabel(): string
+    public function getCancelButtonLabel(): ?string
     {
         return $this->cancel_button_label;
     }

--- a/src/UI/examples/Modal/Interruptive/with_custom_labels.php
+++ b/src/UI/examples/Modal/Interruptive/with_custom_labels.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Modal\Interruptive;
+
+/**
+ * An example showing how you can set a custom label for the
+ * modals action- and cancel-button.
+ */
+function with_custom_labels()
+{
+    global $DIC;
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $modal = $factory->modal()->interruptive(
+        'Interrupting something',
+        'Am I interrupting you?',
+        '#'
+    )->withActionButtonLabel(
+        'Yeah you do!'
+    )->withCancelButtonLabel(
+        'Nah, not really'
+    );
+
+    $trigger = $factory->button()->standard('I will interrupt you', $modal->getShowSignal());
+
+    return $renderer->render([$modal, $trigger]);
+}

--- a/src/UI/examples/Modal/RoundTrip/with_custom_labels.php
+++ b/src/UI/examples/Modal/RoundTrip/with_custom_labels.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Modal\RoundTrip;
+
+/**
+ * An example showing how you can set a custom label for the
+ * modals cancel-button.
+ */
+function with_custom_labels()
+{
+    global $DIC;
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $modal = $factory->modal()->roundtrip(
+        'Showing something off',
+        [
+            $factory->messageBox()->info('I am something.'),
+        ]
+    )->withCancelButtonLabel(
+        'wow, that was something'
+    );
+
+    $trigger = $factory->button()->standard('I will show you something', $modal->getShowSignal());
+
+    return $renderer->render([$modal, $trigger]);
+}

--- a/src/UI/templates/default/Modal/tpl.interruptive.html
+++ b/src/UI/templates/default/Modal/tpl.interruptive.html
@@ -26,8 +26,10 @@
 					<!-- END with_key_value_items -->
 				</div>
 				<div class="modal-footer">
-					<input type="submit" class="btn btn-primary" value="{ACTION_BUTTON_LABEL}" name="cmd[{ACTION_BUTTON}]">
-					<button class="btn btn-default" data-dismiss="modal">{CANCEL_BUTTON_LABEL}</button>
+					<input type="submit" class="btn btn-primary" value="{ACTION_BUTTON_LABEL}"/>
+					<button class="btn btn-default" data-dismiss="modal" aria-label="{CLOSE_LABEL}">
+						{CANCEL_BUTTON_LABEL}
+					</button>
 				</div>
 			</div>
 		</form>

--- a/tests/UI/Component/Modal/InterruptiveTest.php
+++ b/tests/UI/Component/Modal/InterruptiveTest.php
@@ -141,8 +141,8 @@ EOT;
         $expected_end = <<<EOT
 				</div>
 				<div class="modal-footer">
-					<input type="submit" class="btn btn-primary" value="delete" name="cmd[delete]">
-					<button class="btn btn-default" data-dismiss="modal">cancel</button>
+					<input type="submit" class="btn btn-primary" value="delete"/>
+					<button class="btn btn-default" data-dismiss="modal" aria-label="close">cancel</button>
 				</div>
 			</div>
 		</form>


### PR DESCRIPTION
Hi all,

Please note that this PR contains a feature which has yet to be merged, see #5203. After the PR has been merged I will rebase this one again. Now to the issue at hand (second commit):

I noticed when using `Interruptive::withActionButtonLabel()`, `Interruptive::withCancelButtonLabel()` and `Roundtrip::withCancelButtonLabel()` a language variable has been expected. Since we'd like to keep things consistent I recommend to remove this behaviour and only translate **default values** (if no custom label was provided) while rendering. Otherwise, we mix up expecting language variables and translated strings which confuses the consumer. This was IMO inconsistent because when creating UI components we always expect translated strings instead of language variables, which would be the vast majority.

The change for cancel-labels is not exactly a breaking-change, as the same strings will still be displayed, they might just not be translated anymore. I checked the usages and there are not many places these labels are set, from which many even use the default string anyways.

What might be a breaking-change is that I removed the `Interruptive`s `name` attribute, where the language-variable of `Interruptive::withActionButtonLabel()` has been used as a command (so `$_POST['cmd']` contained this value). This wasn't great anyways, since any change of `ilCtrl` in regards to the request-parameters would break this. Instead, we should build proper links for the action in the first place, which as the maintainer of `ilCtrl` I strongly endorse anyways :). Furhtermore, it seemed odd that the action-label should serve as the command. I checked the usages of this method as well and the change might break up to 6 cases, which can easily be resolved though.

I will commit the according changes here as well once this PR has been approved.

Kind regards,
@thibsy 