### PR TITLE
Object: Remove Object Cloning from Creation Dialog

### DIFF
--- a/Modules/File/classes/class.ilObjFileGUI.php
+++ b/Modules/File/classes/class.ilObjFileGUI.php
@@ -329,7 +329,6 @@ class ilObjFileGUI extends ilObject2GUI
         // repository only
         if ($this->id_type !== self::WORKSPACE_NODE_ID) {
             $forms[self::CFORM_IMPORT] = $this->initImportForm(ilObjFile::OBJECT_TYPE);
-            $forms[self::CFORM_CLONE] = $this->fillCloneTemplate(null, ilObjFile::OBJECT_TYPE);
         }
 
         return $forms;

--- a/Modules/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -88,9 +88,6 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
             $forms[self::CFORM_CUSTOM_NEW] = $this->initCustomCreateForm($a_new_type);
         }
 
-        //$forms[self::CFORM_IMPORT] = $this->initImportForm($a_new_type), // no import yet
-        $forms[self::CFORM_CLONE] = $this->fillCloneTemplate(null, $a_new_type);
-
         return $forms;
     }
 

--- a/Modules/MediaCast/classes/class.ilObjMediaCastGUI.php
+++ b/Modules/MediaCast/classes/class.ilObjMediaCastGUI.php
@@ -215,8 +215,7 @@ class ilObjMediaCastGUI extends ilObjectGUI
     protected function initCreationForms(string $new_type): array
     {
         $forms = array(self::CFORM_NEW => $this->initCreateForm($new_type),
-                self::CFORM_IMPORT => $this->initImportForm($new_type),
-                self::CFORM_CLONE => $this->fillCloneTemplate(null, $new_type));
+                self::CFORM_IMPORT => $this->initImportForm($new_type));
 
         return $forms;
     }

--- a/Modules/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
+++ b/Modules/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
@@ -256,8 +256,6 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
         $this->initUploadForm();
         $forms[self::CFORM_IMPORT] = $this->form;
 
-        $forms[self::CFORM_CLONE] = $this->fillCloneTemplate(null, $a_new_type);
-
         return $forms;
     }
 

--- a/Modules/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
+++ b/Modules/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
@@ -1,21 +1,19 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
- *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
- *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
+ */
 
 /**
 * SCORM Learning Modules
@@ -251,7 +249,7 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
      */
     protected function initCreationForms(string $a_new_type): array
     {
-        $forms = array();
+        $forms = [];
 
         $this->initUploadForm();
         $forms[self::CFORM_IMPORT] = $this->form;

--- a/Modules/Wiki/classes/class.ilObjWikiGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiGUI.php
@@ -320,8 +320,7 @@ class ilObjWikiGUI extends ilObjectGUI
         $this->getSettingsFormValues("create");
 
         $forms = array(self::CFORM_NEW => $this->form_gui,
-                self::CFORM_IMPORT => $this->initImportForm($new_type),
-                self::CFORM_CLONE => $this->fillCloneTemplate(null, $new_type));
+                self::CFORM_IMPORT => $this->initImportForm($new_type));
 
         return $forms;
     }

--- a/Services/Object/classes/class.ilObject2GUI.php
+++ b/Services/Object/classes/class.ilObject2GUI.php
@@ -503,10 +503,6 @@ abstract class ilObject2GUI extends ilObjectGUI
     {
         parent::redirectToRefId($ref_id, $cmd);
     }
-    final protected function fillCloneTemplate(?string $tpl_varname, string $type): ?ilPropertyFormGUI
-    {
-        return parent::fillCloneTemplate($tpl_varname, $type);
-    }
 
     //	private function setAdminTabs() { return parent::setAdminTabs(); }
     //	final public function getAdminTabs() { return parent::getAdminTabs(); }

--- a/Services/Object/classes/class.ilObjectGUI.php
+++ b/Services/Object/classes/class.ilObjectGUI.php
@@ -649,48 +649,33 @@ class ilObjectGUI
             }
         }
 
-        // no accordion if there is just one form
-        if (sizeof($forms) == 1) {
-            $form_type = key($forms);
-            $forms = array_shift($forms);
+        $acc = new ilAccordionGUI();
+        $acc->setBehaviour(ilAccordionGUI::FIRST_OPEN);
+        $cnt = 1;
+        foreach ($forms as $form_type => $cf) {
+            $htpl = new ilTemplate("tpl.creation_acc_head.html", true, true, "Services/Object");
 
-            // see bug #0016217
+            // using custom form titles (used for repository plugins)
+            $form_title = "";
             if (method_exists($this, "getCreationFormTitle")) {
                 $form_title = $this->getCreationFormTitle($form_type);
-                if ($form_title != "") {
-                    $forms->setTitle($form_title);
-                }
             }
-            return $forms->getHTML();
-        } else {
-            $acc = new ilAccordionGUI();
-            $acc->setBehaviour(ilAccordionGUI::FIRST_OPEN);
-            $cnt = 1;
-            foreach ($forms as $form_type => $cf) {
-                $htpl = new ilTemplate("tpl.creation_acc_head.html", true, true, "Services/Object");
-
-                // using custom form titles (used for repository plugins)
-                $form_title = "";
-                if (method_exists($this, "getCreationFormTitle")) {
-                    $form_title = $this->getCreationFormTitle($form_type);
-                }
-                if (!$form_title) {
-                    $form_title = $cf->getTitle();
-                }
-
-                // move title from form to accordion
-                $htpl->setVariable("TITLE", $this->lng->txt("option") . " " . $cnt . ": " . $form_title);
-                $cf->setTitle('');
-                $cf->setTitleIcon('');
-                $cf->setTableWidth("100%");
-
-                $acc->addItem($htpl->get(), $cf->getHTML());
-
-                $cnt++;
+            if (!$form_title) {
+                $form_title = $cf->getTitle();
             }
 
-            return "<div class='ilCreationFormSection'>" . $acc->getHTML() . "</div>";
+            // move title from form to accordion
+            $htpl->setVariable("TITLE", $this->lng->txt("option") . " " . $cnt . ": " . $form_title);
+            $cf->setTitle('');
+            $cf->setTitleIcon('');
+            $cf->setTableWidth("100%");
+
+            $acc->addItem($htpl->get(), $cf->getHTML());
+
+            $cnt++;
         }
+
+        return "<div class='ilCreationFormSection'>" . $acc->getHTML() . "</div>";
     }
 
     protected function initCreateForm(string $new_type): ilPropertyFormGUI

--- a/Services/Object/classes/class.ilObjectGUI.php
+++ b/Services/Object/classes/class.ilObjectGUI.php
@@ -630,8 +630,7 @@ class ilObjectGUI
     {
         $forms = [
             self::CFORM_NEW => $this->initCreateForm($new_type),
-            self::CFORM_IMPORT => $this->initImportForm($new_type),
-            self::CFORM_CLONE => $this->fillCloneTemplate(null, $new_type)
+            self::CFORM_IMPORT => $this->initImportForm($new_type)
         ];
 
         return $forms;
@@ -1426,29 +1425,6 @@ class ilObjectGUI
         $class = strtolower("ilObj" . $class_name . "GUI");
         $this->ctrl->setParameterByClass("ilrepositorygui", "ref_id", $ref_id);
         $this->ctrl->redirectByClass(array("ilrepositorygui", $class), $cmd);
-    }
-
-    /**
-     * Fill object clone template
-     * This method can be called from any object GUI class that wants to offer object cloning.
-     *
-     * @param ?string template variable name that will be filled
-     * @param string type of new object
-     * @return ?ilPropertyFormGUI
-     */
-    protected function fillCloneTemplate(?string $tpl_name, string $type): ?ilPropertyFormGUI
-    {
-        $cp = new ilObjectCopyGUI($this);
-        $cp->setType($type);
-        $target = $this->request_wrapper->has("ref_id")
-            ? $this->request_wrapper->retrieve("ref_id", $this->refinery->kindlyTo()->int())
-            : 0;
-        $cp->setTarget($target);
-        if ($tpl_name) {
-            $cp->showSourceSearch($tpl_name);
-        }
-
-        return $cp->showSourceSearch(null);
     }
 
     /**

--- a/Services/Repository/PluginSlot/class.ilObjectPluginGUI.php
+++ b/Services/Repository/PluginSlot/class.ilObjectPluginGUI.php
@@ -242,9 +242,6 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
         if ($this->supportsExport()) {
             $forms[self::CFORM_IMPORT] = $this->initImportForm($new_type);
         }
-        if ($this->supportsCloning()) {
-            $forms[self::CFORM_CLONE] = $this->fillCloneTemplate(null, $new_type);
-        }
 
         return $forms;
     }


### PR DESCRIPTION
This implements [_Abandon Copying from Create Dialogue_](https://docu.ilias.de/goto.php?target=wiki_1357_Abandon_Copying_from_Create_Dialogue) and removes the copy-option from the creation-dialog of objects.

As the function has been overridden in a few places, here it is as a PR. Thank you @chfsx , @Uwe-Kohnle , and @alex40724  for a quick thumbs up.

This also changes the presentation of Single Entries. We always show them in an accordion now, as it otherwise looks very broken.
Now:
![grafik](https://user-images.githubusercontent.com/13102171/229105831-b93dc8d2-d9db-4c55-9ce0-11b16f80ee0e.png)
Compared to before:
![grafik](https://user-images.githubusercontent.com/13102171/229105934-0bb01301-82b2-4820-b94a-3d372ce1cf1f.png)
