### PR TITLE
RootFolder: Change Function For Icon

### DIFF
--- a/Modules/RootFolder/classes/class.ilObjRootFolderGUI.php
+++ b/Modules/RootFolder/classes/class.ilObjRootFolderGUI.php
@@ -279,7 +279,7 @@ class ilObjRootFolderGUI extends ilContainerGUI
         );
 
 
-        $this->showCustomIconsEditing(1, $form, false);
+        $form = $obj_service->commonSettings()->legacyForm($form, $this->object)->addIcon();
 
         $form = $obj_service->commonSettings()->legacyForm($form, $this->object)->addTitleIconVisibility();
 
@@ -312,26 +312,8 @@ class ilObjRootFolderGUI extends ilContainerGUI
             // list presentation
             $this->saveListPresentation($form);
 
-            if ($ilSetting->get('custom_icons')) {
-                global $DIC;
-                /** @var ilObjectCustomIconFactory $customIconFactory */
-                $customIconFactory = $DIC['object.customicons.factory'];
-                $customIcon = $customIconFactory->getByObjId($this->object->getId(), $this->object->getType());
-
-                /** @var ilImageFileInputGUI $item */
-                $fileData = (array) $form->getInput('cont_icon');
-                $item = $form->getItemByPostVar('cont_icon');
-
-                if ($item->getDeletionFlag()) {
-                    $customIcon->remove();
-                }
-
-                if ($fileData['tmp_name']) {
-                    $customIcon->saveFromHttpRequest();
-                }
-            }
-
             // custom icon
+            $obj_service->commonSettings()->legacyForm($form, $this->object)->saveIcon();
             $obj_service->commonSettings()->legacyForm($form, $this->object)->saveTitleIconVisibility();
 
             // BEGIN ChangeEvent: Record update

--- a/Services/Object/classes/class.ilObjectGUI.php
+++ b/Services/Object/classes/class.ilObjectGUI.php
@@ -1612,45 +1612,6 @@ class ilObjectGUI
     }
 
     /**
-     * show edit section of custom icons for container
-     */
-    protected function showCustomIconsEditing(
-        $input_colspan = 1,
-        ilPropertyFormGUI $form = null,
-        $as_section = true
-    ): void {
-        if ($this->settings->get("custom_icons")) {
-            if ($form) {
-                $customIcon = $this->custom_icon_factory->getByObjId($this->object->getId(), $this->object->getType());
-
-                if ($as_section) {
-                    $title = new ilFormSectionHeaderGUI();
-                    $title->setTitle($this->lng->txt("icon_settings"));
-                } else {
-                    $title = new ilCustomInputGUI($this->lng->txt("icon_settings"), "");
-                }
-                $form->addItem($title);
-
-                $caption = $this->lng->txt("cont_custom_icon");
-                $icon = new ilImageFileInputGUI($caption, "cont_icon");
-
-                $icon->setSuffixes($customIcon->getSupportedFileExtensions());
-                $icon->setUseCache(false);
-                if ($customIcon->exists()) {
-                    $icon->setImage($customIcon->getFullPath());
-                } else {
-                    $icon->setImage('');
-                }
-                if ($as_section) {
-                    $form->addItem($icon);
-                } else {
-                    $title->addSubItem($icon);
-                }
-            }
-        }
-    }
-
-    /**
      * Redirect after creation, see https://docu.ilias.de/goto_docu_wiki_wpage_5035_1357.html
      * Should be overwritten and redirect to settings screen.
      */


### PR DESCRIPTION
Hi @alex40724 
While cleaning up the custom icons forms in `ilObject` I found this strange function that produces a broken out put and is only used in one place. Can we get rid of it please?
The changes in `ilObjectGUI` are most obviously fine with my, so if you agree you can just merge, ...or give me a thumbs up and I will take care of it.

Thank you and best,
@kergomard 