### PR TITLE
Add intl as dependency

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -73,7 +73,7 @@ For best results we recommend:
   * PHP 8.0
   * Apache 2.4.x with `mod_php`
   * ImageMagick 6.8+
-  * php-gd, php-xml, php-mysql, php-mbstring
+  * php-gd, php-xml, php-mysql, php-mbstring, php-intl
   * OpenJDK 11
   * zip, unzip
   * Node.js: 14 (LTS)
@@ -209,7 +209,7 @@ systemctl restart httpd.service
 ### PHP Installation and Configuration
 
 Refer to the to documentation of your installation to install either PHP 7.4 to
-PHP 8.0 including packages for gd, mysql, mbstring, curl, dom, zip and xml.
+PHP 8.0 including packages for gd, mysql, mbstring, curl, dom, zip, intl and xml.
 
 To check if the installation was successfull create the file `/var/www/html/phpinfo.php`
 with the following contents:


### PR DESCRIPTION
Installiert man ILIAS 8 mit PHP 8.0 steht in der Anleitung nicht, dass PHP-INTL gebraucht wird. Hat man das nicht installiert, erscheint folgender Fehler:

```
PHP Fatal error:  Uncaught Error: Class "Normalizer" not found in /usr/share/php/Symfony/Component/Console/Helper/Helper.php:65
Stack trace:
#0 /usr/share/php/Symfony/Component/Console/Helper/ProgressBar.php(383): Symfony\Component\Console\Helper\Helper::width()
#1 /usr/share/php/Symfony/Component/Console/Helper/ProgressBar.php(322): Symfony\Component\Console\Helper\ProgressBar->setMaxSteps()
#2 /usr/share/php/Composer/Util/Loop.php(89): Symfony\Component\Console\Helper\ProgressBar->start()
#3 /usr/share/php/Composer/Installer/InstallationManager.php(497): Composer\Util\Loop->wait()
#4 /usr/share/php/Composer/Installer/InstallationManager.php(362): Composer\Installer\InstallationManager->waitOnPromises()
#5 /usr/share/php/Composer/Installer/InstallationManager.php(282): Composer\Installer\InstallationManager->downloadAndExecuteBatch()
#6 /usr/share/php/Composer/Installer.php(754): Composer\Installer\InstallationManager->execute()
#7 /usr/share/php/Composer/Installer.php(281): Composer\Installer->doInstall()
#8 /usr/share/php/Composer/Command/InstallCommand.php(139): Composer\Installer->run()
#9 /usr/share/php/Symfony/Component/Console/Command/Command.php(298): Composer\Command\InstallCommand->execute()
#10 /usr/share/php/Symfony/Component/Console/Application.php(1015): Symfony\Component\Console\Command\Command->run()
#11 /usr/share/php/Symfony/Component/Console/Application.php(299): Symfony\Component\Console\Application->doRunCommand()
#12 /usr/share/php/Composer/Console/Application.php(336): Symfony\Component\Console\Application->doRun()
#13 /usr/share/php/Symfony/Component/Console/Application.php(171): Composer\Console\Application->doRun()
#14 /usr/share/php/Composer/Console/Application.php(131): Symfony\Component\Console\Application->run()
#15 /usr/bin/composer(84): Composer\Console\Application->run()
#16 {main}
  thrown in /usr/share/php/Symfony/Component/Console/Helper/Helper.php on line 65
```