### PR TITLE
#37025 don't show instant response 

### DIFF
--- a/Modules/Test/classes/class.ilTestOutputGUI.php
+++ b/Modules/Test/classes/class.ilTestOutputGUI.php
@@ -318,7 +318,12 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
             $instantResponse = true;
         } else {
             $presentationMode = ilTestPlayerAbstractGUI::PRESENTATION_MODE_EDIT;
-            $instantResponse = $this->getInstantResponseParameter();
+            // #37025 don't show instant response if a request for it should fix the answer and answer is not yet fixed
+            if ($this->object->isInstantFeedbackAnswerFixationEnabled()) {
+                $instantResponse = false;
+            } else {
+                $instantResponse = $this->getInstantResponseParameter();
+            }
         }
         // fau.
 

--- a/Modules/Test/classes/class.ilTestPlayerDynamicQuestionSetGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerDynamicQuestionSetGUI.php
@@ -579,7 +579,12 @@ class ilTestPlayerDynamicQuestionSetGUI extends ilTestPlayerAbstractGUI
                 $instantResponse = true;
                 $presentationMode = ilTestPlayerAbstractGUI::PRESENTATION_MODE_VIEW;
             } else {
-                $instantResponse = $this->getInstantResponseParameter();
+                // #37025 don't show instant response if a request for it should fix the answer and answer is not yet fixed
+                if ($this->object->isInstantFeedbackAnswerFixationEnabled()) {
+                    $instantResponse = false;
+                } else {
+                    $instantResponse = $this->getInstantResponseParameter();
+                }
                 $presentationMode = ilTestPlayerAbstractGUI::PRESENTATION_MODE_EDIT;
             }
             // fau.


### PR DESCRIPTION
Don't show an instant response if a request for the instant response should fix the answer and the answer is not yet fixed.