### PR TITLE
[FIX] 0036838 & 0036839 A11y improvements in File-Upload

### DIFF
--- a/src/UI/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Component/Symbol/Glyph/Glyph.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Symbol\Glyph;
 
@@ -129,4 +129,10 @@ interface Glyph extends Symbol, Clickable
     * Get a Glyph like this with an action.
     */
     public function withAction(string $action): Glyph;
+
+    /**
+     * @return bool Whether the glyph is tabbable (e.g. for screen readers). This is true if a Glyph has
+     * an action or a onClock Signal.
+     */
+    public function isTabbable(): bool;
 }

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -845,7 +845,7 @@ class Renderer extends AbstractComponentRenderer
     ): Template {
         $template->setCurrentBlock('block_file_preview');
         $template->setVariable('REMOVAL_GLYPH', $default_renderer->render(
-            $this->getUIFactory()->symbol()->glyph()->close()
+            $this->getUIFactory()->symbol()->glyph()->close()->withAction("#")
         ));
 
         if (null !== $file_info) {
@@ -860,10 +860,10 @@ class Renderer extends AbstractComponentRenderer
         // contains actual (unhidden) inputs.
         if ($file_input->hasMetadataInputs()) {
             $template->setVariable('EXPAND_GLYPH', $default_renderer->render(
-                $this->getUIFactory()->symbol()->glyph()->expand()
+                $this->getUIFactory()->symbol()->glyph()->expand()->withAction("#")
             ));
             $template->setVariable('COLLAPSE_GLYPH', $default_renderer->render(
-                $this->getUIFactory()->symbol()->glyph()->collapse()
+                $this->getUIFactory()->symbol()->glyph()->collapse()->withAction("#")
             ));
         }
 

--- a/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Glyph.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Symbol\Glyph;
 
@@ -202,5 +202,10 @@ class Glyph implements C\Symbol\Glyph\Glyph
         $clone = clone $this;
         $clone->action = $action;
         return $clone;
+    }
+
+    public function isTabbable(): bool
+    {
+        return (isset($this->triggered_signals['click']) && $this->triggered_signals['click'] !== null) || ($this->action !== null && $this->action !== "");
     }
 }

--- a/src/UI/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,12 +16,15 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Symbol\Glyph;
 
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
 use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\UI\Component;
 use ILIAS\UI\Implementation\Render\Template;
+use ILIAS\UI\Implementation\Render\ResourceRegistry;
 
 class Renderer extends AbstractComponentRenderer
 {
@@ -31,6 +32,7 @@ class Renderer extends AbstractComponentRenderer
     {
         return "tpl.glyph.standard.html";
     }
+
 
     /**
      * @inheritdocs
@@ -46,6 +48,10 @@ class Renderer extends AbstractComponentRenderer
         $tpl = $this->getTemplate($tpl_file, true, true);
 
         $tpl = $this->renderAction($component, $tpl);
+
+        if ($component->isTabbable() && !$this instanceof ButtonContextRenderer) { // Buttons are already tabbable itself
+            $tpl->touchBlock("tabbable");
+        }
 
         if ($component->isHighlighted()) {
             $tpl->touchBlock("highlighted");

--- a/src/UI/templates/default/Symbol/tpl.glyph.standard.html
+++ b/src/UI/templates/default/Symbol/tpl.glyph.standard.html
@@ -1,3 +1,3 @@
-<a class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
+<a <!-- BEGIN tabbable -->tabindex="0" <!-- END tabbable -->class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->"<!-- BEGIN with_action --> href="{ACTION}"<!-- END with_action --> aria-label="{LABEL}"<!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 {GLYPH}
 </a>

--- a/tests/UI/Component/Input/Field/FileInputTest.php
+++ b/tests/UI/Component/Input/Field/FileInputTest.php
@@ -69,6 +69,11 @@ class FileInputTest extends ILIAS_UI_TestBase
         $this->name_source = new DefNamesource();
     }
 
+    protected function brutallyTrimHTML(string $html): string
+    {
+        $html = str_replace(" />", "/>", $html);
+        return parent::brutallyTrimHTML($html);
+    }
 
     protected function buildFactory(): I\Input\Field\Factory
     {
@@ -168,10 +173,10 @@ class FileInputTest extends ILIAS_UI_TestBase
             <div class="form-group row">
                 <label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
-                    <div id="id_3" class="ui-input-file">
+                    <div id="id_4" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
+                            <button class="btn btn-link" data-action="#" id="id_3">select_files_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
                         </div>
                     </div>
@@ -195,16 +200,14 @@ class FileInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($text));
 
         $expected = $this->brutallyTrimHTML('
-            <div class="form-group row">
-                <label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
-                    <div class="help-block alert alert-danger" aria-describedby="id_3" role="alert">an_error</div>
-                    <div id="id_3" class="ui-input-file">
+                    <div class="help-block alert alert-danger" aria-describedby="id_4" role="alert">an_error</div>
+                    <div id="id_4" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
-                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                        </div>
+                            <button class="btn btn-link" data-action="#" id="id_3">select_files_from_computer</button>
+                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                     <div class="help-block">byline</div>
                 </div>
@@ -224,15 +227,13 @@ class FileInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($text));
 
         $expected = $this->brutallyTrimHTML('
-            <div class="form-group row">
-                <label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
-                    <div id="id_3" class="ui-input-file">
+                    <div id="id_4" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
-                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                        </div>
+                            <button class="btn btn-link" data-action="#" id="id_3">select_files_from_computer</button>
+                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                 </div>
             </div>
@@ -261,38 +262,28 @@ class FileInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($file_input));
 
         $expected = $this->brutallyTrimHTML('
-            <div class="form-group row">
-                <label class="control-label col-sm-4 col-md-3 col-lg-2"></label>
+            <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2"></label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
-                    <div id="id_4" class="ui-input-file">
+                    <div id="id_6" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list">
                             <div class="ui-input-file-input ui-input-dynamic-input">
-                                <div class="ui-input-file-info">
-                                    <span data-action="expand">
-                                    </span>
-                                    <span data-action="collapse">
-                                    </span>
-                                    <span data-dz-name>test file name 1</span>
-                                    <span data-dz-size>1 KB</span>
-                                    <span data-action="remove">
-                                    <a class="glyph" aria-label="close">
-                                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                                    </a>
-                                    </span>
-                                    <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                                </div>
-                                <div class="ui-input-file-metadata" style="display: none;">
-                                    <input id="id_1" type="hidden" name="name_0[form_input_0][]" value="test_file_id_1" />
-                                </div>
+                                <div class="ui-input-file-info"><span data-action="expand"></span><span
+                                        data-action="collapse"></span><span data-dz-name>test file name 1</span><span data-dz-size>1 KB</span><span
+                                        data-action="remove"><a tabindex="0" class="glyph" href="#" aria-label="close"
+                                                                id="id_1"><span class="glyphicon glyphicon-remove"
+                                                                                aria-hidden="true"></span></a></span><span
+                                        class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
+                                <div class="ui-input-file-metadata" style="display: none;"><input id="id_2" type="hidden"
+                                                                                                  name="name_0[form_input_0][]"
+                                                                                                  value="test_file_id_1" /></div>
                                 <div class="ui-input-file-input-progress-container">
                                     <div class="ui-input-file-input-progress-indicator"></div>
                                 </div>
                             </div>
                         </div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_3">select_files_from_computer</button>
-                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                        </div>
+                            <button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button>
+                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                 </div>
             </div>
@@ -324,44 +315,37 @@ class FileInputTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2">file_input</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
-                    <div id="id_6" class="ui-input-file">
+                    <div id="id_12" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list">
                             <div class="ui-input-file-input ui-input-dynamic-input">
-                                <div class="ui-input-file-info">
-                                    <span data-action="expand">
-                                    <a class="glyph" aria-label="expand_content">
-                                        <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                                    </a>
-                                    </span>
-                                    <span data-action="collapse">
-                                    <a class="glyph" aria-label="collapse_content">
-                                        <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                                    </a>
-                                    </span>
-                                    <span data-dz-name></span>
-                                    <span data-dz-size></span>
-                                    <span data-action="remove">
-                                    <a class="glyph" aria-label="close">
-                                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                                    </a>
-                                    </span>
-                                    <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                                </div>
+                                <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph" href="#"
+                                                                                              aria-label="expand_content" id="id_2"><span
+                                        class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></span><span
+                                        data-action="collapse"><a tabindex="0" class="glyph" href="#" aria-label="collapse_content"
+                                                                  id="id_3"><span class="glyphicon glyphicon-triangle-bottom"
+                                                                                  aria-hidden="true"></span></a></span><span
+                                        data-dz-name></span><span data-dz-size></span><span data-action="remove"><a tabindex="0"
+                                                                                                                    class="glyph"
+                                                                                                                    href="#"
+                                                                                                                    aria-label="close"
+                                                                                                                    id="id_1"><span
+                                        class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></span><span
+                                        class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                                 <div class="ui-input-file-metadata" style="display: none;">
-                                    <div class="form-group row">
-                                        <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">text_input</label>
-                                        <div class="col-sm-8 col-md-9 col-lg-10">
-                                            <input id="id_1" type="text" name="name_0[form_input_1][]" class="form-control form-control-sm" />
-                                        </div>
+                                    <div class="form-group row"><label for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">text_input</label>
+                                        <div class="col-sm-8 col-md-9 col-lg-10"><input id="id_4" type="text"
+                                                                                        name="name_0[form_input_1][]"
+                                                                                        class="form-control form-control-sm"/></div>
                                     </div>
-                                    <input id="id_2" type="hidden" name="name_0[form_input_2][]" value="file_id" />
-                                </div>
+                                    <input id="id_5" type="hidden" name="name_0[form_input_2][]" value="file_id"/></div>
                                 <div class="ui-input-file-input-progress-container">
                                     <div class="ui-input-file-input-progress-indicator"></div>
                                 </div>
                             </div>
                         </div>
-                        <div class="ui-input-file-input-dropzone"><button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button><span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
+                        <div class="ui-input-file-input-dropzone">
+                            <button class="btn btn-link" data-action="#" id="id_11">select_files_from_computer</button>
+                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                 </div>
             </div>
@@ -402,44 +386,35 @@ class FileInputTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2">file_input</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
-                    <div id="id_6" class="ui-input-file">
+                    <div id="id_12" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list">
                             <div class="ui-input-file-input ui-input-dynamic-input">
-                                <div class="ui-input-file-info">
-                                    <span data-action="expand">
-                                    <a class="glyph" aria-label="expand_content">
-                                        <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                                    </a>
-                                    </span>
-                                    <span data-action="collapse">
-                                    <a class="glyph" aria-label="collapse_content">
-                                        <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                                    </a>
-                                    </span>
-                                    <span data-dz-name>test file name 1</span>
-                                    <span data-dz-size>1 MB</span>
-                                    <span data-action="remove">
-                                    <a class="glyph" aria-label="close">
-                                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                                    </a>
-                                    </span>
-                                    <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                                </div>
+                                <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph" href="#"
+                                                                                              aria-label="expand_content" id="id_2"><span
+                                        class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span></a></span><span
+                                        data-action="collapse"><a tabindex="0" class="glyph" href="#" aria-label="collapse_content"
+                                                                  id="id_3"><span class="glyphicon glyphicon-triangle-bottom"
+                                                                                  aria-hidden="true"></span></a></span><span
+                                        data-dz-name>test file name 1</span><span data-dz-size>1 MB</span><span
+                                        data-action="remove"><a tabindex="0" class="glyph" href="#" aria-label="close"
+                                                                id="id_1"><span class="glyphicon glyphicon-remove"
+                                                                                aria-hidden="true"></span></a></span><span
+                                        class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                                 <div class="ui-input-file-metadata" style="display: none;">
-                                    <div class="form-group row">
-                                        <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">text_input</label>
-                                        <div class="col-sm-8 col-md-9 col-lg-10">
-                                            <input id="id_1" type="text" value="test" name="name_0[form_input_1][]" class="form-control form-control-sm" />
-                                        </div>
+                                    <div class="form-group row"><label for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">text_input</label>
+                                        <div class="col-sm-8 col-md-9 col-lg-10"><input id="id_4" type="text" value="test"
+                                                                                        name="name_0[form_input_1][]"
+                                                                                        class="form-control form-control-sm"/></div>
                                     </div>
-                                    <input id="id_2" type="hidden" name="name_0[form_input_2][]" value="test_file_id_1" />
-                                </div>
+                                    <input id="id_5" type="hidden" name="name_0[form_input_2][]" value="test_file_id_1"/></div>
                                 <div class="ui-input-file-input-progress-container">
                                     <div class="ui-input-file-input-progress-indicator"></div>
                                 </div>
                             </div>
                         </div>
-                        <div class="ui-input-file-input-dropzone"><button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button><span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
+                        <div class="ui-input-file-input-dropzone">
+                            <button class="btn btn-link" data-action="#" id="id_11">select_files_from_computer</button>
+                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                 </div>
             </div>
@@ -459,15 +434,13 @@ class FileInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($text));
 
         $expected = $this->brutallyTrimHTML('
-            <div class="form-group row">
-                <label class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>
+            <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
-                    <div id="id_3" class="ui-input-file">
+                    <div id="id_4" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
-                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                        </div>
+                            <button class="btn btn-link" data-action="#" id="id_3">select_files_from_computer</button>
+                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                 </div>
             </div>
@@ -488,12 +461,11 @@ class FileInputTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
-                    <div id="id_3" class="ui-input-file">
+                    <div id="id_4" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
-                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                        </div>
+                            <button class="btn btn-link" data-action="#" id="id_3">select_files_from_computer</button>
+                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                 </div>
             </div>

--- a/tests/UI/Component/Symbol/Glyph/GlyphTest.php
+++ b/tests/UI/Component/Symbol/Glyph/GlyphTest.php
@@ -352,7 +352,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         $css_classes = self::$canonical_css_classes[$type];
         $aria_label = self::$aria_labels[$type];
 
-        $expected = "<a class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
+        $expected = "<a tabindex=\"0\" class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\" id=\"id_1\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
         $this->assertEquals($expected, $html);
     }
 
@@ -370,8 +370,8 @@ class GlyphTest extends ILIAS_UI_TestBase
         $css_classes = self::$canonical_css_classes[$type];
         $aria_label = self::$aria_labels[$type];
 
-        $expected = "<a class=\"glyph disabled\" aria-label=\"$aria_label\" " .
-                    "aria-disabled=\"true\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
+        $expected = "<a tabindex=\"0\" class=\"glyph disabled\" aria-label=\"$aria_label\" " .
+                    "aria-disabled=\"true\" id=\"id_1\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
         $this->assertEquals($expected, $html);
     }
 
@@ -390,7 +390,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         $css_classes = self::$canonical_css_classes[G\Glyph::MAIL];
         $aria_label = self::$aria_labels[G\Glyph::MAIL];
 
-        $expected = "<a class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\">" .
+        $expected = "<a tabindex=\"0\" class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\" id=\"id_1\">" .
                     "<span class=\"$css_classes\" aria-hidden=\"true\"></span>" .
                     "<span class=\"il-counter\"><span class=\"badge badge-notify il-counter-$type\">42</span></span>" .
                     "<span class=\"il-counter-spacer\">42</span>" .
@@ -411,7 +411,7 @@ class GlyphTest extends ILIAS_UI_TestBase
 
         $css_classes = self::$canonical_css_classes[G\Glyph::MAIL];
         $aria_label = self::$aria_labels[G\Glyph::MAIL];
-        $expected = "<a class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\">" .
+        $expected = "<a tabindex=\"0\" class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\">" .
                     "<span class=\"$css_classes\" aria-hidden=\"true\"></span>" .
                     "<span class=\"il-counter\"><span class=\"badge badge-notify il-counter-status\">7</span></span>" .
                     "<span class=\"il-counter\"><span class=\"badge badge-notify il-counter-novelty\">42</span></span>" .
@@ -460,7 +460,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         $aria_label = self::$aria_labels[$type];
 
         $id = $ids[0];
-        $expected = "<a class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\" id=\"$id\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
+        $expected = "<a tabindex=\"0\" class=\"glyph\" href=\"http://www.ilias.de\" aria-label=\"$aria_label\" id=\"$id\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
         $this->assertEquals($expected, $html);
     }
 
@@ -479,7 +479,37 @@ class GlyphTest extends ILIAS_UI_TestBase
         $css_classes = self::$canonical_css_classes[$type];
         $aria_label = self::$aria_labels[$type];
 
-        $expected = "<a class=\"glyph\" href=\"http://www.ilias.de/open-source-lms-ilias/\" aria-label=\"$aria_label\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
+        $expected = "<a tabindex=\"0\" class=\"glyph\" href=\"http://www.ilias.de/open-source-lms-ilias/\" aria-label=\"$aria_label\"><span class=\"$css_classes\" aria-hidden=\"true\"></span></a>";
+        $this->assertEquals($expected, $html);
+    }
+
+    public function testTabbableGlyph(): void
+    {
+        $f = $this->getGlyphFactory();
+        $r = $this->getDefaultRenderer();
+
+        // Glyph without Action or Signal
+        $c = $f->user();
+        $expected = '<a class="glyph" aria-label="show_who_is_online"><span class="glyphicon glyphicon-user" aria-hidden="true"></span></a>';
+        $html = $this->normalizeHTML($r->render($c));
+        $this->assertEquals($expected, $html);
+
+        // Glyph with Action
+        $c = $f->user()->withAction("#");
+        $expected = '<a tabindex="0" class="glyph" href="#" aria-label="show_who_is_online" id="id_1"><span class="glyphicon glyphicon-user" aria-hidden="true"></span></a>';
+        $html = $this->normalizeHTML($r->render($c));
+        $this->assertEquals($expected, $html);
+
+        // Glyph with Signal
+        $c = $f->user()->withOnClick(new I\Signal("id_1", "click"));
+        $expected = '<a tabindex="0" class="glyph" aria-label="show_who_is_online" id="id_2"><span class="glyphicon glyphicon-user" aria-hidden="true"></span></a>';
+        $html = $this->normalizeHTML($r->render($c));
+        $this->assertEquals($expected, $html);
+
+        // Glyph with Action and Signal
+        $c = $f->user()->withAction("#")->withOnClick(new I\Signal("id_1", "click"));
+        $expected = '<a tabindex="0" class="glyph" href="#" aria-label="show_who_is_online" id="id_3"><span class="glyphicon glyphicon-user" aria-hidden="true"></span></a>';
+        $html = $this->normalizeHTML($r->render($c));
         $this->assertEquals($expected, $html);
     }
 }


### PR DESCRIPTION
This is a fix for
- https://mantis.ilias.de/view.php?id=36838
- https://mantis.ilias.de/view.php?id=36839

Currently, the glyphs for expanding and collapsing the additional fields as well as the glyph for removing a file cannot be operated with the keyboard, see the two issues.

To make these functions operable via the keyboard, the glyphs must first be accessible via tabs. Since this does not apply to all glyphs, I have introduced a withTabbable and isTabbable:

https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:fix/0036838/9/focus-fileupload-elements?expand=1#diff-8f0e178a2a3228811d6a37900f164f4665486cbb2ca479247a94baaf0e14d11aR136

This is then used in the FileInput and the JS is adapted accordingly so that, in addition to a click, an enter-key also triggers the corresponding events:

https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:fix/0036838/9/focus-fileupload-elements?expand=1#diff-2d9abcacf08b7e7e7a931e40d78ee734af912ab8af6659fa4b7a570dd349f632R176

If accepted, thus must be cherry-picked to release_8 as well.
