### PR TITLE
UI: Cleanup for UI Input components

### DIFF
--- a/src/UI/Component/Input/Field/Factory.php
+++ b/src/UI/Component/Input/Field/Factory.php
@@ -58,7 +58,7 @@ interface Factory
      * @param string|null $byline
      * @return    \ILIAS\UI\Component\Input\Field\Text
      */
-    public function text(string $label, string $byline = null): Text;
+    public function text(string $label, ?string $byline = null): Text;
 
     /**
      * ---
@@ -84,7 +84,7 @@ interface Factory
      * @param string|null $byline
      * @return    \ILIAS\UI\Component\Input\Field\Numeric
      */
-    public function numeric(string $label, string $byline = null): Numeric;
+    public function numeric(string $label, ?string $byline = null): Numeric;
 
     /**
      * ---
@@ -104,9 +104,10 @@ interface Factory
      * ---
      * @param array<mixed,\ILIAS\UI\Component\Input\Field\FormInput> $inputs
      * @param string                                                 $label
+     * @param string|null                                            $byline
      * @return    \ILIAS\UI\Component\Input\Field\Group
      */
-    public function group(array $inputs, string $label = ''): Group;
+    public function group(array $inputs, string $label = '', ?string $byline = null): Group;
 
     /**
      * ---
@@ -130,9 +131,11 @@ interface Factory
      *      accept by the Jour Fixe.
      * ---
      * @param array<mixed,\ILIAS\UI\Component\Input\Field\FormInput> $inputs
+     * @param string                                                 $label
+     * @param string|null                                            $byline
      * @return    \ILIAS\UI\Component\Input\Field\OptionalGroup
      */
-    public function optionalGroup(array $inputs, string $label, string $byline = null): OptionalGroup;
+    public function optionalGroup(array $inputs, string $label, ?string $byline = null): OptionalGroup;
 
     /**
      * ---
@@ -155,10 +158,12 @@ interface Factory
      *      of a subsetting by a date or number. These exceptions MUST individually
      *      accepted by the Jour Fixe.
      * ---
-     * @param array<mixed,\ILIAS\UI\Component\Input\Field\FormInput> $input
+     * @param array<mixed,\ILIAS\UI\Component\Input\Field\FormInput> $inputs
+     * @param string                                                 $label
+     * @param string|null                                            $byline
      * @return    \ILIAS\UI\Component\Input\Field\SwitchableGroup
      */
-    public function switchableGroup(array $inputs, string $label, string $byline = null): SwitchableGroup;
+    public function switchableGroup(array $inputs, string $label, ?string $byline = null): SwitchableGroup;
 
     /**
      * ---
@@ -195,11 +200,11 @@ interface Factory
      *       In doubt consistency SHOULD be prioritized over accuracy in titles.
      * ---
      * @param array<mixed,\ILIAS\UI\Component\Input\Field\FormInput> $inputs
-     * @param string|null                                            $label
-     * @param string                                                 $byline
+     * @param string                                                 $label
+     * @param string|null                                            $byline
      * @return    \ILIAS\UI\Component\Input\Field\Section
      */
-    public function section(array $inputs, string $label, string $byline = null): Section;
+    public function section(array $inputs, string $label, ?string $byline = null): Section;
 
     /**
      * ---
@@ -225,9 +230,11 @@ interface Factory
      *     1: The checkbox’s identifier MUST always state something positive.
      *
      * ---
+     * @param string      $label
+     * @param string|null $byline
      * @return    \ILIAS\UI\Component\Input\Field\Checkbox
      */
-    public function checkbox(string $label, string $byline = null): Checkbox;
+    public function checkbox(string $label, ?string $byline = null): Checkbox;
 
 
     /**
@@ -280,13 +287,13 @@ interface Factory
      *     5: The tags provided SHOULD NOT have long titles (50 characters).
      *
      * ---
-     * @param string   $label
-     * @param string   $byline
-     * @param string[] $tags  List of tags to select from, given as a list of texts
-     *                        such as [ 'Interesting', 'Boring', 'Animating', 'Repetitious' ]
+     * @param string      $label
+     * @param string[]    $tags  List of tags to select from, given as a list of texts
+     *                           such as [ 'Interesting', 'Boring', 'Animating', 'Repetitious' ]
+     * @param string|null $byline
      * @return    \ILIAS\UI\Component\Input\Field\Tag
      */
-    public function tag(string $label, array $tags, string $byline = null): Tag;
+    public function tag(string $label, array $tags, ?string $byline = null): Tag;
 
     /**
      * ---
@@ -328,7 +335,7 @@ interface Factory
      * @param string|null $byline
      * @return    \ILIAS\UI\Component\Input\Field\Password
      */
-    public function password(string $label, string $byline = null): Password;
+    public function password(string $label, ?string $byline = null): Password;
 
     /**
      * ---
@@ -358,13 +365,12 @@ interface Factory
      *     2: First Option MAY be selectable when the field is not required.
      *
      * ---
-     * @param $label   string defines the label.
-     * @param $options array<string,string> with the select options as key-value pairs.
-     * @param $byline  string
-     *
+     * @param string               $label
+     * @param array<string,string> $options with the select options as key-value pairs.
+     * @param string|null          $byline
      * @return \ILIAS\UI\Component\Input\Field\Select
      */
-    public function select(string $label, array $options, string $byline = null): Select;
+    public function select(string $label, array $options, ?string $byline = null): Select;
 
     /**
      * ---
@@ -408,7 +414,7 @@ interface Factory
      * @param string|null $byline
      * @return    \ILIAS\UI\Component\Input\Field\Textarea
      */
-    public function textarea(string $label, string $byline = null): Textarea;
+    public function textarea(string $label, ?string $byline = null): Textarea;
 
     /**
      * ---
@@ -450,7 +456,7 @@ interface Factory
      * @param string|null $byline
      * @return    \ILIAS\UI\Component\Input\Field\Radio
      */
-    public function radio(string $label, string $byline = null): Radio;
+    public function radio(string $label, ?string $byline = null): Radio;
 
     /**
      * ---
@@ -489,10 +495,10 @@ interface Factory
      * ---
      * @param string               $label
      * @param array<string,string> $options with the select options as value=>label.
-     * @param string               $byline
+     * @param string|null          $byline
      * @return \ILIAS\UI\Component\Input\Field\MultiSelect
      */
-    public function multiSelect(string $label, array $options, string $byline = null): MultiSelect;
+    public function multiSelect(string $label, array $options, ?string $byline = null): MultiSelect;
 
     /**
      * ---
@@ -520,11 +526,11 @@ interface Factory
      *     1: When used as a time-only input, the glyph MUST be Time Glyph.
      *
      * ---
-     * @param string $label defines the label.
-     * @param string $byline
+     * @param string      $label
+     * @param string|null $byline
      * @return \ILIAS\UI\Component\Input\Field\DateTime
      */
-    public function dateTime(string $label, string $byline = null): DateTime;
+    public function dateTime(string $label, ?string $byline = null): DateTime;
 
     /**
      * ---
@@ -547,11 +553,11 @@ interface Factory
      *     1: When used with time-only inputs, the glyph MUST be Time Glyph.
      *
      * ---
-     * @param string $label defines the label.
-     * @param string $byline
+     * @param string      $label
+     * @param string|null $byline
      * @return \ILIAS\UI\Component\Input\Field\Duration
      */
-    public function duration(string $label, string $byline = null): Duration;
+    public function duration(string $label, ?string $byline = null): Duration;
 
     /**
      * ---
@@ -584,7 +590,7 @@ interface Factory
      *
      * ---
      * @param UploadHandler $handler
-     * @param string        $label defines the label.
+     * @param string        $label
      * @param string|null   $byline
      * @param Input|null    $metadata_input
      * @return \ILIAS\UI\Component\Input\Field\File
@@ -592,7 +598,7 @@ interface Factory
     public function file(
         UploadHandler $handler,
         string $label,
-        string $byline = null,
+        ?string $byline = null,
         Input $metadata_input = null
     ): File;
 
@@ -623,7 +629,7 @@ interface Factory
      * @param string|null $byline
      * @return \ILIAS\UI\Component\Input\Field\Url
      */
-    public function url(string $label, string $byline = null): Url;
+    public function url(string $label, ?string $byline = null): Url;
 
     /**
      * ---
@@ -651,7 +657,7 @@ interface Factory
      * @param string|null $byline
      * @return \ILIAS\UI\Component\Input\Field\Link
      */
-    public function link(string $label, string $byline = null): Link;
+    public function link(string $label, ?string $byline = null): Link;
 
     /**
      * ---
@@ -695,10 +701,9 @@ interface Factory
      *        As with all Inputs, the Color Picker Input MUST be operable by only using inputs.
      *        If HTML5 Standards are used, it is the responsibility of the Browser to provide this functionality.
      * ---
-     *
-     * @param string $label
+     * @param string      $label
      * @param string|null $byline
      * @return \ILIAS\UI\Component\Input\Field\ColorPicker
-     * */
-    public function colorPicker(string $label, string $byline=null): ColorPicker;
+     */
+    public function colorPicker(string $label, ?string $byline = null): ColorPicker;
 }

--- a/src/UI/Implementation/Component/Input/Field/ColorPicker.php
+++ b/src/UI/Implementation/Component/Input/Field/ColorPicker.php
@@ -43,7 +43,7 @@ class ColorPicker extends Input implements C\Input\Field\ColorPicker
         Data\Factory $datafactory,
         Refinery $refinery,
         string $label,
-        string $byline
+        ?string $byline
     ) {
         parent::__construct(
             $datafactory,

--- a/src/UI/Implementation/Component/Input/Field/Factory.php
+++ b/src/UI/Implementation/Component/Input/Field/Factory.php
@@ -58,7 +58,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function text(string $label, string $byline = null): Field\Text
+    public function text(string $label, ?string $byline = null): Field\Text
     {
         return new Text($this->data_factory, $this->refinery, $label, $byline);
     }
@@ -66,7 +66,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function numeric(string $label, string $byline = null): Field\Numeric
+    public function numeric(string $label, ?string $byline = null): Field\Numeric
     {
         return new Numeric($this->data_factory, $this->refinery, $label, $byline);
     }
@@ -74,7 +74,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function group(array $inputs, string $label = '', $byline = ''): Field\Group
+    public function group(array $inputs, string $label = '', ?string $byline = null): Field\Group
     {
         return new Group($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
@@ -82,7 +82,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function optionalGroup(array $inputs, string $label, string $byline = null): Field\OptionalGroup
+    public function optionalGroup(array $inputs, string $label, ?string $byline = null): Field\OptionalGroup
     {
         return new OptionalGroup($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
@@ -90,7 +90,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function switchableGroup(array $inputs, string $label, string $byline = null): Field\SwitchableGroup
+    public function switchableGroup(array $inputs, string $label, ?string $byline = null): Field\SwitchableGroup
     {
         return new SwitchableGroup($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
@@ -98,7 +98,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function section(array $inputs, $label, $byline = null): Field\Section
+    public function section(array $inputs, string $label, ?string $byline = null): Field\Section
     {
         return new Section($this->data_factory, $this->refinery, $this->lng, $inputs, $label, $byline);
     }
@@ -106,7 +106,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function checkbox(string $label, string $byline = null): Field\Checkbox
+    public function checkbox(string $label, ?string $byline = null): Field\Checkbox
     {
         return new Checkbox($this->data_factory, $this->refinery, $label, $byline);
     }
@@ -114,7 +114,7 @@ class Factory implements Field\Factory
     /**
      * @inheritDoc
      */
-    public function tag(string $label, array $tags, string $byline = null): Field\Tag
+    public function tag(string $label, array $tags, ?string $byline = null): Field\Tag
     {
         return new Tag($this->data_factory, $this->refinery, $label, $byline, $tags);
     }
@@ -122,7 +122,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function password(string $label, string $byline = null): Field\Password
+    public function password(string $label, ?string $byline = null): Field\Password
     {
         return new Password($this->data_factory, $this->refinery, $label, $byline, $this->signal_generator);
     }
@@ -130,7 +130,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function select(string $label, array $options, string $byline = null): Field\Select
+    public function select(string $label, array $options, ?string $byline = null): Field\Select
     {
         return new Select($this->data_factory, $this->refinery, $label, $options, $byline);
     }
@@ -138,7 +138,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function textarea(string $label, string $byline = null): Field\Textarea
+    public function textarea(string $label, ?string $byline = null): Field\Textarea
     {
         return new Textarea($this->data_factory, $this->refinery, $label, $byline);
     }
@@ -146,7 +146,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function radio(string $label, string $byline = null): Field\Radio
+    public function radio(string $label, ?string $byline = null): Field\Radio
     {
         return new Radio($this->data_factory, $this->refinery, $label, $byline);
     }
@@ -154,7 +154,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function multiSelect(string $label, array $options, string $byline = null): Field\MultiSelect
+    public function multiSelect(string $label, array $options, ?string $byline = null): Field\MultiSelect
     {
         return new MultiSelect($this->data_factory, $this->refinery, $label, $options, $byline);
     }
@@ -162,7 +162,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function dateTime(string $label, string $byline = null): Field\DateTime
+    public function dateTime(string $label, ?string $byline = null): Field\DateTime
     {
         return new DateTime($this->data_factory, $this->refinery, $label, $byline);
     }
@@ -170,7 +170,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function duration(string $label, string $byline = null): Field\Duration
+    public function duration(string $label, ?string $byline = null): Field\Duration
     {
         return new Duration($this->data_factory, $this->refinery, $this->lng, $this, $label, $byline);
     }
@@ -181,16 +181,25 @@ class Factory implements Field\Factory
     public function file(
         UploadHandler $handler,
         string $label,
-        string $byline = null,
+        ?string $byline = null,
         Input $metadata_input = null
     ): Field\File {
-        return new File($this->lng, $this->data_factory, $this->refinery, $this->upload_limit_resolver, $handler, $label, $metadata_input, $byline);
+        return new File(
+            $this->lng,
+            $this->data_factory,
+            $this->refinery,
+            $this->upload_limit_resolver,
+            $handler,
+            $label,
+            $metadata_input,
+            $byline
+        );
     }
 
     /**
      * @inheritdoc
      */
-    public function url(string $label, string $byline = null): Field\Url
+    public function url(string $label, ?string $byline = null): Field\Url
     {
         return new Url($this->data_factory, $this->refinery, $label, $byline);
     }
@@ -198,7 +207,7 @@ class Factory implements Field\Factory
     /**
      * @inheritdoc
      */
-    public function link(string $label, string $byline = null): Field\Link
+    public function link(string $label, ?string $byline = null): Field\Link
     {
         return new Link($this->data_factory, $this->refinery, $this->lng, $this, $label, $byline);
     }
@@ -214,7 +223,7 @@ class Factory implements Field\Factory
     /**
      * @inheritDoc
      */
-    public function colorpicker(string $label, string $byline = null): Field\ColorPicker
+    public function colorpicker(string $label, ?string $byline = null): Field\ColorPicker
     {
         return new ColorPicker($this->data_factory, $this->refinery, $label, $byline);
     }

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -57,7 +57,7 @@ class Group extends Input implements C\Input\Field\Group
         ilLanguage $lng,
         array $inputs,
         string $label,
-        string $byline = null
+        ?string $byline = null
     ) {
         parent::__construct($data_factory, $refinery, $label, $byline);
         $this->checkArgListElements("inputs", $inputs, InputInternal::class);

--- a/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -47,7 +47,7 @@ class SwitchableGroup extends Group implements Field\SwitchableGroup
         ilLanguage $lng,
         array $inputs,
         string $label,
-        string $byline = null
+        ?string $byline = null
     ) {
         $this->checkArgListElements("inputs", $inputs, Group::class);
         parent::__construct($data_factory, $refinery, $lng, $inputs, $label, $byline);

--- a/tests/UI/Component/Input/Container/Form/FormTest.php
+++ b/tests/UI/Component/Input/Container/Form/FormTest.php
@@ -91,7 +91,7 @@ class FormTest extends ILIAS_UI_TestBase
 
     protected function buildFactory(): Input\Container\Form\Factory
     {
-        return new Input\Container\Form\Factory($this->buildInputFactory(), new DefNamesource());
+        return new Input\Container\Form\Factory($this->buildInputFactory());
     }
 
     protected function buildInputFactory(): Input\Field\Factory
@@ -483,5 +483,4 @@ class FormTest extends ILIAS_UI_TestBase
         $form = new ConcreteForm($this->buildInputFactory(), new DefNamesource(), $inputs);
         $this->assertTrue($form->hasRequiredInputs());
     }
-
 }

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -64,7 +64,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
 {
     protected function buildFactory(): I\Input\Container\Form\Factory
     {
-        return new I\Input\Container\Form\Factory($this->buildInputFactory(), new InputNameSource());
+        return new I\Input\Container\Form\Factory($this->buildInputFactory());
     }
 
     protected function buildInputFactory(): I\Input\Field\Factory

--- a/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
@@ -425,7 +425,6 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
                         <div class="help-block">some field</div>
                     </div>
                 </div>
-                <div class="help-block"></div>
             </div>
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_g2_opt" name="" value="g2" /><label for="id_1_g2_opt"></label>
@@ -436,7 +435,6 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
                         <div class="help-block">some other field</div>
                     </div>
                 </div>
-                <div class="help-block"></div>
             </div>
         </div>
         <div class="help-block">byline</div>
@@ -472,7 +470,6 @@ EOT;
                         <div class="help-block">some field</div>
                     </div>
                 </div>
-                <div class="help-block"></div>
             </div>
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_g2_opt" name="" value="g2" checked="checked" /><label for="id_1_g2_opt"></label>
@@ -483,7 +480,6 @@ EOT;
                         <div class="help-block">some other field</div>
                     </div>
                 </div>
-                <div class="help-block"></div>
             </div>
         </div>
         <div class="help-block">byline</div>
@@ -531,7 +527,6 @@ EOT;
                         <div class="help-block">some field</div>
                     </div>
                 </div>
-                <div class="help-block"></div>
             </div>
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_1_opt" name="" value="1" checked="checked" /><label for="id_1_1_opt"></label>
@@ -542,7 +537,6 @@ EOT;
                         <div class="help-block">some other field</div>
                     </div>
                 </div>
-                <div class="help-block"></div>
             </div>
 
             <div class="form-control form-control-sm il-input-radiooption">


### PR DESCRIPTION
These changes have been moved from PR #5711, as they came up during its development, but are not directly related:
- Added better type hinting and unified PHPDocs for `Form` and `Input` factories
- Removed unused parameters from test
- Corrected default value for group byline to null in factory (-> also removes empty DIV from render, see test)