### PR TITLE
User: Use argon2id hashes if supported (ILIAS 9)

### DIFF
--- a/Services/User/classes/Setup/class.ilUserDB90.php
+++ b/Services/User/classes/Setup/class.ilUserDB90.php
@@ -53,4 +53,23 @@ class ilUserDB90 implements ilDatabaseUpdateSteps
             );
         }
     }
+
+    /**
+     * Modifies the 'passwd' field in table 'usr_data' to accept longer passwords
+     */
+    public function step_2(): void
+    {
+        if (!$this->db->tableColumnExists('usr_data', 'passwd')) {
+            $this->db->modifyTableColumn(
+                'usr_data',
+                'passwd',
+                [
+                    'type'    => 'text',
+                    'length'  => 100,
+                    'notnull' => false,
+                    'default' => null
+                ]
+            );
+        }
+    }
 }

--- a/Services/User/classes/class.ilUserPasswordEncoderFactory.php
+++ b/Services/User/classes/class.ilUserPasswordEncoderFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,22 +16,19 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-/**
- * Class ilUserPasswordEncoderFactory
- * @author  Michael Jansen <mjansen@databay.de>
- * @package ServicesUser
- */
+declare(strict_types=1);
+
 class ilUserPasswordEncoderFactory
 {
-    protected ?string $defaultEncoder = null;
+    private ?string $default_encoder = null;
     /** @var array<string, ilPasswordEncoder> Array of supported encoders */
-    protected array $encoders = [];
+    private array $supported_encoders = [];
 
     /**
-     * @param array $config
+     * @param array<string, mixed> $config
      * @throws ilPasswordException
      */
-    public function __construct(array $config = []) // Missing array type.
+    public function __construct(array $config = [])
     {
         if (!empty($config)) {
             foreach ($config as $key => $value) {
@@ -49,13 +44,14 @@ class ilUserPasswordEncoderFactory
     }
 
     /**
-     * @param array $config
-     * @return ilPasswordEncoder[]
+     * @param array<string, mixed> $config
+     * @return list<ilPasswordEncoder>
      * @throws ilPasswordException
      */
-    protected function getValidEncoders(array $config): array // Missing array type.
+    private function getEncoders(array $config): array
     {
         return [
+            new ilArgon2idPasswordEncoder($config),
             new ilBcryptPhpPasswordEncoder($config),
             new ilBcryptPasswordEncoder($config),
             new ilMd5PasswordEncoder(),
@@ -63,108 +59,80 @@ class ilUserPasswordEncoderFactory
     }
 
     /**
-     * @param array $config
+     * @param array<string, mixed> $config
      * @throws ilPasswordException
      */
-    protected function initEncoders(array $config): void // Missing array type.
+    private function initEncoders(array $config): void
     {
-        $this->encoders = [];
+        $this->supported_encoders = [];
 
-        $encoders = $this->getValidEncoders($config);
+        $encoders = $this->getEncoders($config);
         foreach ($encoders as $encoder) {
             if ($encoder->isSupportedByRuntime()) {
-                $this->encoders[$encoder->getName()] = $encoder;
+                $this->supported_encoders[$encoder->getName()] = $encoder;
             }
         }
     }
 
     public function getDefaultEncoder(): ?string
     {
-        return $this->defaultEncoder;
+        return $this->default_encoder;
     }
 
-    public function setDefaultEncoder(string $defaultEncoder): void
+    public function setDefaultEncoder(string $default_encoder): void
     {
-        $this->defaultEncoder = $defaultEncoder;
+        $this->default_encoder = $default_encoder;
     }
 
     /**
      * @return array<string, ilPasswordEncoder>
      */
-    public function getEncoders(): array
+    public function getSupportedEncoders(): array
     {
-        return $this->encoders;
+        return $this->supported_encoders;
     }
 
     /**
-     * @param ilPasswordEncoder[] $encoders
+     * @param list<ilPasswordEncoder> $supported_encoders
      * @throws ilUserException
      */
-    public function setEncoders(array $encoders): void
+    public function setSupportedEncoders(array $supported_encoders): void
     {
-        $this->encoders = [];
-        foreach ($encoders as $encoder) {
-            if (!($encoder instanceof ilPasswordEncoder)) {
+        $this->supported_encoders = [];
+        foreach ($supported_encoders as $encoder) {
+            if (!($encoder instanceof ilPasswordEncoder) || !$encoder->isSupportedByRuntime()) {
                 throw new ilUserException(sprintf(
                     'One of the passed encoders is not valid: %s.',
-                    json_encode($encoder, JSON_THROW_ON_ERROR)
+                    print_r($encoder, true)
                 ));
             }
-            $this->encoders[$encoder->getName()] = $encoder;
+            $this->supported_encoders[$encoder->getName()] = $encoder;
         }
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getSupportedEncoderNames(): array
     {
-        return array_keys($this->getEncoders());
+        return array_keys($this->getSupportedEncoders());
     }
 
     /**
-     * @param string $name
-     * @param bool $get_default_on_mismatch
-     * @return ilPasswordEncoder
      * @throws ilUserException
      */
-    public function getEncoderByName(string $name, bool $get_default_on_mismatch = false): ilPasswordEncoder
+    public function getEncoderByName(string $name): ilPasswordEncoder
     {
-        if (!isset($this->encoders[$name])) {
-            if (!$get_default_on_mismatch) {
-                throw new ilUserException(sprintf('The encoder "%s" was not configured.', $name));
-            } elseif (!$this->getDefaultEncoder()) {
+        if (!isset($this->supported_encoders[$name])) {
+            if (!$this->getDefaultEncoder()) {
                 throw new ilUserException('No default encoder specified, fallback not possible.');
-            } elseif (!isset($this->encoders[$this->getDefaultEncoder()])) {
+            } elseif (!isset($this->supported_encoders[$this->getDefaultEncoder()])) {
                 throw new ilUserException("No default encoder found for name: '{$this->getDefaultEncoder()}'.");
             }
 
-            return $this->encoders[$this->getDefaultEncoder()];
+            return $this->supported_encoders[$this->getDefaultEncoder()];
         }
 
-        return $this->encoders[$name];
-    }
-
-    /**
-     * @param string $encoded
-     * @param array $matchers An key/value pair callback functions (accepting the encoded password) assigned to the respective encoder name
-     * @return ilPasswordEncoder
-     * @throws ilUserException
-     */
-    public function getFirstEncoderForEncodedPasswordAndMatchers(string $encoded, array $matchers): ilPasswordEncoder
-    {
-        foreach ($this->getEncoders() as $encoder) {
-            foreach ($matchers as $encoderName => $callback) {
-                if (
-                    is_callable($callback) &&
-                    $encoder->getName() === $encoderName &&
-                    $callback($encoded) === true
-                ) {
-                    return $encoder;
-                }
-            }
-        }
-
-        return $this->getEncoderByName($this->getDefaultEncoder());
+        return $this->supported_encoders[$name];
     }
 }

--- a/Services/User/test/ilObjUserPasswordTest.php
+++ b/Services/User/test/ilObjUserPasswordTest.php
@@ -29,11 +29,6 @@ require_once 'Services/User/classes/class.ilObjUser.php';
 require_once 'Services/User/exceptions/class.ilUserException.php';
 require_once 'Services/User/test/ilUserBaseTest.php';
 
-/**
- * Class ilObjUserPasswordTest
- * @author  Michael Jansen <mjansen@databay.de>
- * @package ServicesUser
- */
 class ilObjUserPasswordTest extends ilUserBaseTest
 {
     private const PASSWORD = 'password';
@@ -367,7 +362,7 @@ class ilObjUserPasswordTest extends ilUserBaseTest
         $factory = new ilUserPasswordEncoderFactory([
             'data_directory' => $this->getTestDirectoryUrl()
         ]);
-        $this->assertInstanceOf('ilUserPasswordEncoderFactory', $factory);
+        $this->assertInstanceOf(ilUserPasswordEncoderFactory::class, $factory);
     }
 
     /**
@@ -383,14 +378,16 @@ class ilObjUserPasswordTest extends ilUserBaseTest
         ]);
         $this->assertEquals('md5', $factory->getDefaultEncoder());
 
-        $encoder = $this->getMockBuilder(ilBasePasswordEncoder::class)->disableOriginalConstructor()->getMock();
+        $encoder = $this->createMock(ilPasswordEncoder::class);
         $encoder->expects($this->atLeastOnce())->method('getName')->willReturn('mockencoder');
+        $encoder->expects($this->atLeastOnce())->method('isSupportedByRuntime')->willReturn(true);
 
-        $second_mockencoder = $this->getMockBuilder(ilBasePasswordEncoder::class)->disableOriginalConstructor()->getMock();
+        $second_mockencoder = $this->createMock(ilPasswordEncoder::class);
         $second_mockencoder->expects($this->atLeastOnce())->method('getName')->willReturn('second_mockencoder');
+        $second_mockencoder->expects($this->atLeastOnce())->method('isSupportedByRuntime')->willReturn(true);
 
-        $factory->setEncoders([$encoder, $second_mockencoder]);
-        $this->assertCount(2, $factory->getEncoders());
+        $factory->setSupportedEncoders([$encoder, $second_mockencoder]);
+        $this->assertCount(2, $factory->getSupportedEncoders());
         $this->assertCount(2, $factory->getSupportedEncoderNames());
         $this->assertCount(
             0,
@@ -406,28 +403,13 @@ class ilObjUserPasswordTest extends ilUserBaseTest
      * @throws ilPasswordException
      * @throws ilUserException
      */
-    /*
-    public function testFactoryRaisesAnExceptionIfAnUnsupportedEncoderWasInjected() : void
+    public function testFactoryRaisesAnExceptionIfAnUnsupportedEncoderWasInjected(): void
     {
         $this->assertException(ilUserException::class);
         $factory = new ilUserPasswordEncoderFactory([
             'data_directory' => $this->getTestDirectoryUrl()
         ]);
-        $factory->setEncoders(['phpunit']);
-    }*/
-
-    /**
-     * @throws ilPasswordException
-     * @throws ilUserException
-     */
-    public function testExceptionIsRaisedIfAnUnsupportedEncoderIsRequestedFromFactory(): void
-    {
-        $this->assertException(ilUserException::class);
-        $factory = new ilUserPasswordEncoderFactory([
-            'default_password_encoder' => 'md5',
-            'data_directory' => $this->getTestDirectoryUrl()
-        ]);
-        $factory->getEncoderByName('phpunit');
+        $factory->setSupportedEncoders(['phpunit']);
     }
 
     /**
@@ -440,7 +422,7 @@ class ilObjUserPasswordTest extends ilUserBaseTest
         $factory = new ilUserPasswordEncoderFactory([
             'data_directory' => $this->getTestDirectoryUrl()
         ]);
-        $factory->getEncoderByName('phpunit', true);
+        $factory->getEncoderByName('phpunit');
     }
 
     /**
@@ -454,7 +436,7 @@ class ilObjUserPasswordTest extends ilUserBaseTest
             'default_password_encoder' => 'phpunit',
             'data_directory' => $this->getTestDirectoryUrl()
         ]);
-        $factory->getEncoderByName('phpunit', true);
+        $factory->getEncoderByName('phpunit');
     }
 
     /**
@@ -466,13 +448,14 @@ class ilObjUserPasswordTest extends ilUserBaseTest
     {
         $encoder = $this->getMockBuilder(ilBasePasswordEncoder::class)->disableOriginalConstructor()->getMock();
         $encoder->expects($this->atLeastOnce())->method('getName')->willReturn('mockencoder');
+        $encoder->expects($this->atLeastOnce())->method('isSupportedByRuntime')->willReturn(true);
 
         $factory = new ilUserPasswordEncoderFactory([
             'default_password_encoder' => $encoder->getName(),
             'data_directory' => $this->getTestDirectoryUrl()
         ]);
-        $factory->setEncoders([$encoder]);
-        $this->assertEquals($encoder, $factory->getEncoderByName('phpunit', true));
+        $factory->setSupportedEncoders([$encoder]);
+        $this->assertEquals($encoder, $factory->getEncoderByName('phpunit'));
     }
 
     /**
@@ -484,12 +467,13 @@ class ilObjUserPasswordTest extends ilUserBaseTest
     {
         $encoder = $this->getMockBuilder(ilBasePasswordEncoder::class)->disableOriginalConstructor()->getMock();
         $encoder->expects($this->atLeastOnce())->method('getName')->willReturn('mockencoder');
+        $encoder->expects($this->atLeastOnce())->method('isSupportedByRuntime')->willReturn(true);
 
         $factory = new ilUserPasswordEncoderFactory([
             'default_password_encoder' => $encoder->getName(),
             'data_directory' => $this->getTestDirectoryUrl()
         ]);
-        $factory->setEncoders([$encoder]);
-        $this->assertEquals($encoder, $factory->getEncoderByName('mockencoder', true));
+        $factory->setSupportedEncoders([$encoder]);
+        $this->assertEquals($encoder, $factory->getEncoderByName('mockencoder'));
     }
 }


### PR DESCRIPTION
See: https://docu.ilias.de/goto_docu_wiki_wpage_6330_1357.html

This PR changes the `User Password Manager` by using `argonid` as the desired password hashing algorithm for local user passwords.

We used configuration parameters based on the OWASP recommendation.

The default/fallback algorithm is still 'bcrypt', because it is available on every PHP compilation, which might not be the case for `argon2id` (most distributions do, and I added this dependency to the installation documentation of ILIAS, but who knows ...).