### PR TITLE
UI: Fix Representation of Minutes in JS

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -50,6 +50,7 @@ class Renderer extends AbstractComponentRenderer
         'l' => 'dddd',
         'D' => 'dd',
         'S' => 'o',
+        'i' => 'mm',
         'W' => '',
         'm' => 'MM',
         'F' => 'MMMM',


### PR DESCRIPTION
Maybe I'm also doing something wrong, but I was unable to fill a Duration-Input with Time correctly without this change.