### PR TITLE
[PROPOSAL] UI: `Form` compatibility for `Interruptive` modals.

### DIFF
--- a/src/UI/Component/Modal/Interruptive.php
+++ b/src/UI/Component/Modal/Interruptive.php
@@ -21,13 +21,14 @@ declare(strict_types=1);
 namespace ILIAS\UI\Component\Modal;
 
 use ILIAS\UI\Component\Modal\InterruptiveItem\InterruptiveItem;
+use ILIAS\UI\Component\Input\Container\Form\Standard;
 
 /**
  * Interface Interruptive
  *
  * @package ILIAS\UI\Component\Modal
  */
-interface Interruptive extends Modal
+interface Interruptive extends Standard, Modal
 {
     /**
      * Get the message of this modal, displayed below the modals title
@@ -38,31 +39,6 @@ interface Interruptive extends Modal
      * Get the title of this modal
      */
     public function getTitle(): string;
-
-    /**
-     * Get a modal like this submitting the form to the given form action
-     */
-    public function withFormAction(string $form_action): Interruptive;
-
-    /**
-     * Get a modal like this listing the given items in the content section below the message.
-     * The IDs of the interruptive items are sent via POST to the form action of this modal.
-     *
-     * @param InterruptiveItem[] $items
-     */
-    public function withAffectedItems(array $items): Interruptive;
-
-    /**
-     * Get the label of the action button in the footer
-     */
-    public function getActionButtonLabel(): string;
-
-    /**
-     * Get a modal like this with the action button labeled
-     * according to the parameter.
-     * The label will be translated.
-     */
-    public function withActionButtonLabel(string $action_label): Interruptive;
 
     /**
      * Get the label of the cancel button in the footer
@@ -82,9 +58,4 @@ interface Interruptive extends Modal
      * @return InterruptiveItem[]
      */
     public function getAffectedItems(): array;
-
-    /**
-     * Get the form action where the action button is sending the IDs of the affected items
-     */
-    public function getFormAction(): string;
 }

--- a/src/UI/Component/Modal/InterruptiveItem/InterruptiveItem.php
+++ b/src/UI/Component/Modal/InterruptiveItem/InterruptiveItem.php
@@ -20,14 +20,14 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Modal\InterruptiveItem;
 
-use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Input\Field\HasDynamicInputs;
 
 /**
  * Interface InterruptiveItem
  *
  * Represents an item to be displayed inside an interruptive modal
  */
-interface InterruptiveItem extends Component
+interface InterruptiveItem extends HasDynamicInputs
 {
     /**
      * Return an ID of the item


### PR DESCRIPTION
## Current Situation

### Reusability

`Interruptive` modals have no client-side functionality which enables the reusability of them. Consider the following scenario: There is a table with multiple entries (or rows), which all have an action `Dropdown`. Several `Button`s of each `Dropdown` will trigger a "dangerous" action. 

The current implementation of this scenario will render an `Interruptive` modal for each of these dangerous actions for each entry. We can already slim down the implementation by rendering "dummy" `Interruptive` modals, which are replaced by their `withAsyncRenderUrl`, instead of actual ones, so they can share an endpoint which provides (sort of) the same `Interruptive` on each request. This still leads to much HTML needing to be rendered, since every modal could potentially be requested. The new `Data` table already does reuse one modal for all actions, but it still makes requests to replace the modal content.

This produces more network traffic, which would be fine, if it weren't unnecessary. The solution to this problem is not quite trivial though, but if the component provided client-side functionality to fill an `Interruptive`s affected items, this could get rid of asynchronous rendering altogether for this scenario.

### Submissions

An `Interruptive` modal contains several affected items (`InterruptiveItems`), which are identified by an ID. These items will be submitted via POST. Currently, there is no way of knowing how the affected items must be retrieved from the request-body, right now the key `interruptive_items` is hardcoded. Therefore, current implementations cannot define their own key for the request-body and use some magic string that could change at any time and break the endpoint.

The component can also not be provided with a `ServerRequestInterface`, like `Form`s, to obtain the submitted items with e.g. `getData()`. Thus, making implementations somewhat fragile.

## Solution

The first problem (reusability) points into the direction of dynamic inputs (`HasDynamicInputs`), which allows the client to render a template of an input on-demand. A template in this case would be an `InterruptiveItem`, whose ID would be used for submission. This also leads to the latter problem, which points to the behaviour of a `Form`. If `Interruptive` modals behaved like `Form`s, it would be way more robust because the consumer would not need to worry about retrieving the affected items from `$_POST`.

A possible solution would be:
- `InterruptiveItem` extends `Input\HasDynamicInputs`, so a template for client-side rendering can be used.
- `Interruptive` extends `Form\Standard`, so the modal can be treated in the same manner.
- `Interruptive` becomes a decorator for a `FormWithNoSubmitButton`, just like `Roundtrip`.
- `Interruptive` does only accept `InterruptiveItem`s as inputs, which need to be provided in the constructor.
- `modal.js` is extended by a public function to trigger the rendering process of a dynamic inputs (`InterruptiveItem`s)

There is currently an open discussion about displaying multiple `InterruptiveItems` inside the modal, which can be selected or not with an according `Checkbox`. The checkbox would decide whether the item should be considered on submission or not. If the `InterruptiveItem` already extends the `HasDynamicInput` and therefore `Input` interface, this looks also quite approachable:
- `Checkbox` is extended to accept another `Component` (or something more explicit) with e.g. `withAdditionalContent()`, which is displayed besides the checkbox-element.
- `SelectableItem` as new `InterruptiveItem` which returns a `Checkbox::withAdditionalContent()` as `getTemplateForDynamicInputs()`.
