### PR TITLE
T&A Bugfix #0036503 Empty Instant Feedback

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -495,15 +495,7 @@ class ilAssQuestionPreviewGUI
             $cssClass = ilAssQuestionFeedback::CSS_CLASS_FEEDBACK_WRONG;
         }
 
-        if (str_contains($feedback, '<!--COPage-PageTop-->')) {
-            $start_tag = '<!--COPage-PageTop-->';
-            $end_tag = '<div style="clear:both;"><!--Break-->';
-            $content = substr($feedback, strpos($feedback, $start_tag) + strlen($start_tag), strpos($feedback, $end_tag) - strpos($feedback, $start_tag) - strlen($start_tag));
-        } else {
-            $content = $feedback;
-        }
-
-        if ($content !== '') {
+        if ($feedback !== '') {
             $tpl->setCurrentBlock('instant_feedback_generic');
             $tpl->setVariable('GENERIC_FEEDBACK', $feedback);
             $tpl->setVariable('ILC_FB_CSS_CLASS', $cssClass);

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -495,7 +495,15 @@ class ilAssQuestionPreviewGUI
             $cssClass = ilAssQuestionFeedback::CSS_CLASS_FEEDBACK_WRONG;
         }
 
-        if (strlen($feedback)) {
+        if (str_contains($feedback, '<!--COPage-PageTop-->')) {
+            $start_tag = '<!--COPage-PageTop-->';
+            $end_tag = '<div style="clear:both;"><!--Break-->';
+            $content = substr($feedback, strpos($feedback, $start_tag) + strlen($start_tag), strpos($feedback, $end_tag) - strpos($feedback, $start_tag) - strlen($start_tag));
+        } else {
+            $content = $feedback;
+        }
+
+        if ($content !== '') {
             $tpl->setCurrentBlock('instant_feedback_generic');
             $tpl->setVariable('GENERIC_FEEDBACK', $feedback);
             $tpl->setVariable('ILC_FB_CSS_CLASS', $cssClass);

--- a/Modules/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
+++ b/Modules/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
@@ -95,6 +95,17 @@ abstract class ilAssQuestionFeedback
                 $this->getGenericFeedbackPageObjectType(),
                 $this->getGenericFeedbackPageObjectId($questionId, $solutionCompleted)
             );
+
+            $doc = new DOMDocument('1.0', 'UTF-8');
+            if (@$doc->loadHTML('<html><body>' . $genericFeedbackTestPresentationHTML . '</body></html>')) {
+                $xpath = new DOMXPath($doc);
+                $nodes_after_comments = $xpath->query('//comment()/following-sibling::*[1]');
+                foreach ($nodes_after_comments as $node_after_comments) {
+                    if (trim($node_after_comments->nodeValue) === '') {
+                        return '';
+                    }
+                }
+            }
         } else {
             $genericFeedbackTestPresentationHTML = $this->getGenericFeedbackContent($questionId, $solutionCompleted);
         }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=36503

$feedback contains a hidden link "Vertiefungswissen verbergen" and a modal called "Vollbild" which for me did not contain anything

```
<a class="small" id="ilPageShowAdvContent" style="display:none; text-align:right;" href="#">\<span>Vertiefungswissen anzeigen</span><span>Vertiefungswissen verbergen</span></a>
<!--COPage-PageTop--><div class="ilc_Paragraph ilc_text_block_Standard">Good job<!--Break--></div><div style="clear:both;"><!--Break--></div><script></script>

<div class='il-copg-mob-fullscreen-modal'><div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="il_ui_fw_642d6ed854dd58_82531420">
	<div class="modal-dialog" role="document" data-replace-marker="component">
		<div class="modal-content">
			<div class="modal-header">
				<button type="button" class="close" data-dismiss="modal" aria-label="Schließen"><span aria-hidden="true">&times;</span></button>
				<span class="modal-title">Vollbild</span>
			</div>
			<div class="modal-body">
				
				<iframe class='il-copg-mob-fullscreen' id='il-copg-mob-fullscreen-qfbg-1783'></iframe>
				
				
			</div>
			<div class="modal-footer">
				
				<button class="btn btn-default" data-dismiss="modal" aria-label="Schließen">Abbrechen</button>
				
			</div>
		</div>
	</div>
</div></div>
```

An empty copage looks as follows:

```
<!--COPage-PageTop--><div style="clear:both;"><!--Break--></div><script></script>
```

So for detecting if the CoPage is empty i made this hacky PR
This is open for discussion to find better solutions.