### PR TITLE
[FEATURE] CI: improved copyright-checker

### DIFF
--- a/CI/Copyright-Checker/copyright-checker.sh
+++ b/CI/Copyright-Checker/copyright-checker.sh
@@ -37,7 +37,7 @@ function is_copyright_valid() {
   local file="${1}"
 
   if ! [ -f "${file}" ]; then
-    printf "Internal Error: please provide is_copyright_valid with a valid file.\n"
+    printf "Internal Error (is_copyright_valid): ${file} is not a valid file.\n"
     exit 1
   fi
 
@@ -79,18 +79,18 @@ function is_copyright_valid() {
 }
 
 # DESC: prints all .php and .js files of the provided directory,
-#       ignoring the /libs folders.
+#       ignoring the /libs and /node_modules folders.
 #
 # ARGS: [<string>] directory to scan
 function get_supported_files_of_dir() {
   local directory="${1}"
 
   if ! [ -d "${directory}" ]; then
-    printf "Internal Error: please provide get_supported_files_of_dir with a valid directory.\n"
+    printf "Internal Error (get_supported_files_of_dir): ${directory} is not a valid directory.\n"
     exit 1
   fi
 
-  find "${directory}" \( -name "*.php" -or -name "*.js" \) -and -not -path "./libs*"
+  find "${directory}" \( -name "*.php" -or -name "*.js" \) ! -path "*/node_modules/*" ! -path "*/libs/*"
 }
 
 # DESC: returns 0 if the given path is located in the examples
@@ -100,6 +100,12 @@ function get_supported_files_of_dir() {
 function is_ui_example() {
   local file="${1}"
 
+  if ! [ -f "${file}" ]; then
+    printf "Internal Error (is_ui_example): ${file} is not a valid file.\n"
+    exit 1
+  fi
+
+  file="$(realpath ${file})"
   if [[ "${file}" == *"src/UI/examples"* ]]; then
     return 0
   fi
@@ -139,10 +145,10 @@ function perform_copyright_check() {
 
   local exit_status=0
   for file in ${files[@]}; do
-    is_copyright_valid "$(pwd)/${file}"
+    is_copyright_valid "${file}"
     local is_valid="${?}"
 
-    is_ui_example "$(pwd)/${file}"
+    is_ui_example "${file}"
     local is_example="${?}"
 
     # invert the copyright-check for UI examples, because we

--- a/CI/Copyright-Checker/copyright-checker.sh
+++ b/CI/Copyright-Checker/copyright-checker.sh
@@ -1,140 +1,168 @@
 #!/bin/bash
 
-# Copyright Checker
+# This file is part of ILIAS, a powerful learning management system
+# published by ILIAS open source e-Learning e.V.
 #
-# Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE
+# ILIAS is licensed with the GPL-3.0,
+# see https://www.gnu.org/licenses/gpl-3.0.en.html
+# You should have received a copy of said license along with the
+# source code, too.
 #
-# Author Laura Herzog <laura.herzog@concepts-and-training.de>
+# If this is not the case or you just want to try ILIAS, you'll find
+# us at:
+# https://www.ilias.de
+# https://github.com/ILIAS-eLearning
+
+# This script will be used to check files for the official ILIAS
+# copyright license header (the content of which is also above).
 #
-# This tool checks the changes files in the current pull request
-# to determine if the copyright lines are at the correct place.
-# Only works with php files.
+# @author Thibeau Fuhrer <thibeau@sr.solutions>
+# @version 1.0.0
 
-source CI/Import/Functions.sh
+# the ${IFS} is a constant used by bash to explode output into arrays.
+# this assignment changes the default-behaviour to only split strings
+# into arrays on linebreaks instead of (almost) all whitespace chars.
+IFS=$'\n'
 
-STRINGTOCHECK="/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/"
+# DESC: checks if the given file contains the official ILIAS copyright
+#       license header at the beginning of its content.
+#
+#       NOTE that this function does not check the copyright-ending
+#       deliberately, because developers have been using multiple
+#       different variations. This also leaves the option to maybe
+#       add some further document-level comment beneath.
+#
+# ARGS: [<string>] file to check
+function is_copyright_valid() {
+  local file="${1}"
 
-STRINGTOCHECK="$(echo -e "${STRINGTOCHECK}" | tr -d '[:space:]')"
-STRINGTOCHECK="$(echo -e "${STRINGTOCHECK}" | tr -d '*')"
-STRINGTOCHECK="$(echo -e "${STRINGTOCHECK}" | tr -d '/')"
-
-# get the files from this PR to the last head
-if [[ -z ${GHRUN} ]]
-then
-  CHANGED_FILES=$(find . -path ./libs -prune -o -type f -name '*.php')
-else
-  CHANGED_FILES=$(get_changed_files)
-fi
-
-echo "Scanning changed files for copyright notice ..."
-
-FILES=()
-COUNTER=0
-for PHPFILE in $CHANGED_FILES;
-do
-  FELONE="$(pwd)/$PHPFILE"
-
-  if [ ! -f "$FELONE" ]; then
-    continue
+  if ! [ -f "${file}" ]; then
+    printf "Internal Error: please provide is_copyright_valid with a valid file.\n"
+    exit 1
   fi
 
-  if [[ $FELONE == "./libs" ]]; then
-    continue
+  local copyright_lines=(
+    "/**"
+    " * This file is part of ILIAS, a powerful learning management system"
+    " * published by ILIAS open source e-Learning e.V."
+    " *"
+    " * ILIAS is licensed with the GPL-3.0,"
+    " * see https://www.gnu.org/licenses/gpl-3.0.en.html"
+    " * You should have received a copy of said license along with the"
+    " * source code, too."
+    " *"
+    " * If this is not the case or you just want to try ILIAS, you'll find"
+    " * us at:"
+    " * https://www.ilias.de"
+    " * https://github.com/ILIAS-eLearning"
+  )
+
+  local file_extension="${file##*.}"
+  local offset=1
+
+  # since PSR-12 the php files will contain the copyright license as
+  # document-level comment, which starts on line 3.
+  if [ "php" = "${file_extension}" ]; then
+    offset=3
   fi
 
-  if [[ $FELONE == "./src/UI/examples" ]]; then
-    continue
-  fi
-
-  # check for php extension
-  if [ ! ${FELONE: -4} == ".php" ]; then
-    continue
-  fi
-
-  LINE1=$(sed -n 1p ${FELONE})
-  LINE2=$(sed -n 2p ${FELONE})
-  LINE3=$(sed -n 3p ${FELONE})
-  LINE4=$(sed -n 4p ${FELONE})
-  LINE5=$(sed -n 5p ${FELONE})
-
-  if [[ ${LINE2} == *"/**"* ]]
-  then
-    START=2
-  elif [[ -z ${LINE2} ]]
-  then
-    if [[ ${LINE3} == *"/**"* ]]
-    then
-      START=3
-    elif [[ ${LINE3} == *"declare(strict_types=1);"* ]] && [[ -z ${LINE4} ]] && [[ ${LINE5} == *"/**"* ]]
-    then
-      START=5
+  for copyright_line in "${copyright_lines[@]}"; do
+    local line_to_check="$(sed "${offset}q;d" "${file}")"
+    if ! [ "${copyright_line}" = "${line_to_check}" ]; then
+      return 1
     fi
-  fi
 
-  if [[ -z ${START} ]]
-  then
-    FILES+=("Start of file not as expected in $PHPFILE")
-    if [[ -z ${GHRUN} ]]
-    then
-      echo -ne "F"
-    fi
-  else
-    COUNTER=0
-    COPYLINE=""
-    while IFS= read -r LINE
-    do
-      let COUNTER=COUNTER+1
-      if (( ${COUNTER} >= START )) && (( ${COUNTER} <= START+12 ))
-      then
-        COPYLINE+="${LINE}"
-      fi
-    done < "${FELONE}"
-
-    COPYLINE="$(echo -e "${COPYLINE}" | tr -d '[:space:]')"
-    COPYLINE="$(echo -e "${COPYLINE}" | tr -d '*')"
-    COPYLINE="$(echo -e "${COPYLINE}" | tr -d '/')"
-
-    if [[ "${COPYLINE}" == "${STRINGTOCHECK}" ]]
-    then
-      if [[ -z ${GHRUN} ]]
-      then
-        echo -ne "."
-      fi
-      continue
-    else
-      FILES+=("Copyright not as expected in $PHPFILE")
-      if [[ -z ${GHRUN} ]]
-      then
-        echo -ne "F"
-      fi
-    fi
-  fi
-done
-
-cd $DIR
-AMOUNTFILES=${#FILES[@]}
-echo -ne "\n"
-echo "Scan complete. Found $AMOUNTFILES incidents."
-if [ "$AMOUNTFILES" -gt "0" ]; then
-  for (( i=0; i<${AMOUNTFILES}; i++ ));
-  do
-    LINE=${FILES[$i]}
-    echo ${LINE}
+    offset=$((1 + ${offset}))
   done
-  exit 1
+
+  return 0
+}
+
+# DESC: prints all .php and .js files of the provided directory,
+#       ignoring the /libs folders.
+#
+# ARGS: [<string>] directory to scan
+function get_supported_files_of_dir() {
+  local directory="${1}"
+
+  if ! [ -d "${directory}" ]; then
+    printf "Internal Error: please provide get_supported_files_of_dir with a valid directory.\n"
+    exit 1
+  fi
+
+  find "${directory}" \( -name "*.php" -or -name "*.js" \) -and -not -path "./libs*"
+}
+
+# DESC: returns 0 if the given path is located in the examples
+#       directory, 1 otherwise
+#
+# ARGS: [<string>] file path to check
+function is_ui_example() {
+  local file="${1}"
+
+  if [[ "${file}" == *"src/UI/examples"* ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+# DESC: main function of this script, which executes the copyright-
+#       check for either all or the provided file(s).
+#       if any of the checked files are invalid they are printed to
+#       stdout.
+#
+# ARGS: [...<string>] file(s) to check, defaults to all or changed
+#                     files (from git).
+function perform_copyright_check() {
+  local files=()
+  while [ 1 -le ${#} ]; do
+    local file="${1}"
+
+    if [ -d "${file}" ]; then
+      files+=($(get_supported_files_of_dir "${file}"))
+    elif [ -f "${file}" ]; then
+      files+=("${file}")
+    else
+      printf "Error: ${file} is not a valid file or directory.\n"
+      exit 1
+    fi
+
+    shift 1>/dev/null
+  done
+
+  if [ 0 -eq ${#files[@]} ]; then
+    [ -z "${GHRUN}" ] &&
+      files=($(get_supported_files_of_dir "$(pwd)")) ||
+      files=($(get_changed_files))
+  fi
+
+  local exit_status=0
+  for file in ${files[@]}; do
+    is_copyright_valid "$(pwd)/${file}"
+    local is_valid="${?}"
+
+    is_ui_example "$(pwd)/${file}"
+    local is_example="${?}"
+
+    # invert the copyright-check for UI examples, because we
+    # don't want them to have too much content.
+    if ([ 0 -eq ${is_example} ] && [ 0 -eq ${is_valid} ]) ||
+      ([ 1 -eq ${is_example} ] && [ 1 -eq ${is_valid} ]); then
+      printf "copyright is not as expected in %s\n" "${file}"
+      exit_status=1
+    fi
+  done
+
+  return ${exit_status}
+}
+
+# this helper is only required if we are in a GitHub-run.
+if ! [ -z "${GHRUN}" ]; then
+  source "$(pwd)/CI/Import/Functions.sh"
 fi
-exit 0
+
+# run script with all supplied arguments and exit with the status code
+# of the function call.
+perform_copyright_check "${@}"
+exit "${?}"

--- a/CI/Copyright-Checker/copyright-checker.sh
+++ b/CI/Copyright-Checker/copyright-checker.sh
@@ -145,6 +145,12 @@ function perform_copyright_check() {
 
   local exit_status=0
   for file in ${files[@]}; do
+    # remove this theck once JavaScript files are properly
+    # supported as well (concept for minified scripts).
+    if [[ ${file} == *".js" ]]; then
+      continue
+    fi
+
     is_copyright_valid "${file}"
     local is_valid="${?}"
 

--- a/CI/Import/Functions.sh
+++ b/CI/Import/Functions.sh
@@ -11,7 +11,7 @@ function get_changed_files() {
     CHANGED_FILES=$(git diff-tree --name-only --diff-filter=ACMRT --no-commit-id -r ${GH_SHA} | grep -e '.php$' -e '.js$')
   else
     URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files"
-    CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep -e '.php$' -e '.js$')
+    CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep -e '\.php$' -e '\.js$')
   fi
   echo ${CHANGED_FILES}
 }

--- a/CI/Import/Functions.sh
+++ b/CI/Import/Functions.sh
@@ -8,10 +8,10 @@ function get_changed_files() {
 
   if [[ -z ${PR_NUMBER} ]]
   then
-    CHANGED_FILES=$(git diff-tree --name-only --diff-filter=ACMRT --no-commit-id -r ${GH_SHA} | grep '.php')
+    CHANGED_FILES=$(git diff-tree --name-only --diff-filter=ACMRT --no-commit-id -r ${GH_SHA} | grep -e '.php$' -e '.js$')
   else
     URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files"
-    CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep '.php')
+    CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep -e '.php$' -e '.js$')
   fi
   echo ${CHANGED_FILES}
 }


### PR DESCRIPTION
Hey all,

As you all know our CI workflow will check changed files (according to git) for a valid ILIAS copyright license header when committing to the repository or creating a PR.

You may also know that we **don't** want said copyright-header in the examples of UI components. Therefore, many PRs that adjust or introduce UI examples will fail the workflows because of this.

With this PR I inverted the check for files located in `src/UI/examples/`, so the workflow will now fail **if there is** a copyright-header.

When improving this script I also noticed a few flaws:
1. `echo` has been used over `printf`, which lead to problems on macOS
2. the logic did not enforce PSR-12 file-level doc-blocks (see [here](https://www.php-fig.org/psr/psr-12/#3-declare-statements-namespace-and-import-statements))
3. whitespace (`[:space:]`), `/` and `*` characters were stripped before comparison

Especially point 3 is crucial, because this means developers could have made any change they liked as long as it only affected these characters. Hence, this would have been a valid copyright-license until now:
```php
/**
 *ThisfileispartofILIAS,apowerfullearningmanagementsystem
 *publishedbyILIASopensourcee-Learninge.V.
 ********************************************************
 *ILIASislicensedwiththeGPL-3.0,
 *seehttps://www.gnu.org/licenses/gpl-3.0.en.html
 *Youshouldhavereceivedacopyofsaidlicensealongwiththe
 *sourcecode,too.
 */////////////////////////////////////////////////////*
 /*IfthisisnotthecaseoryoujustwanttotryILIAS,you'llfind
 *usat:
 *https://www.ilias.de
 *https://github.com/ILIAS-eLearning*/
```
This version of the copyright-check will compare all lines of the comment without altering it, so any adjustment will fail the workflow. The check will stop at line 13 of the comment (the repository URL) intentionally, because there are currently several versions of how the copyright-header will end. Some comments fill the line with `*` characters, others just close it directly with `*/`. This does not only serve as a "workaround" of sorts, because this also leaves the option for _actual_ file-level doc-blocks, which could be written beneath the copyright-header now. Starting a new comment would violate the PSR-12 standard. For this reason, PHP-files are also searched from line 3, which means the PSR-12 file-level doc-block will be enforced from now on. The check can also be applied to any other file now, whereas the starting line will be 1.

This also brings me to a new feature: the check can now be applied to one or more files or directories (which are traversed recursively) if supplied as arguments. So e.g. this will perform the copy-right check on all UI examples:
```bash
sh CI/Copyright-Checker/copyright-checker.sh "src/UI/examples"
```
Without arguments, this script defaults to either:
a) local: all files of the current directory (`$(pwd)`), or
b) GitHub: all changed files of the current PR or commit.

---

Another part of this PR is the consideration of JavaScript files. I find it inconsistent to only enforce the ILIAS copyright license header for PHP files, when JavaScript files are written by ILIAS developers as well. This is why I also made a small adjustment to the retrieval of files in the copyright-checker, so `*.js` files are now considered.

As previously mentioned JavaScript files will be checked from line 1, which means the file-level doc-block will be expected at the beginning of the file. According to our JavaScript code-style ([Airbnb](https://github.com/airbnb/javascript)) there's no rule for file-level comments and there is no "PSR" standard like there is for PHP. So I've decided to implement this behaviour.

Kind regards
@thibsy
