### PR TITLE
[FEATURE] UI: allow additional inputs for file-dropzones.

### DIFF
--- a/src/UI/Component/Dropzone/File/Factory.php
+++ b/src/UI/Component/Dropzone/File/Factory.php
@@ -20,6 +20,7 @@ namespace ILIAS\UI\Component\Dropzone\File;
 
 use ILIAS\UI\Component\Input\Field\File as FileInput;
 use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Input\Field\Input;
 
 /**
  * Describes a factory for file dropzones.
@@ -59,17 +60,19 @@ interface Factory
      *        Standard dropzones MUST offer the possibility to select files
      *        manually from the computer.
      * ---
-     * @param string $title
-     * @param string $message
-     * @param string $post_url
+     * @param string    $title
+     * @param string    $message
+     * @param string    $post_url
      * @param FileInput $file_input
+     * @param Input     $additional_input
      * @return \ILIAS\UI\Component\Dropzone\File\Standard
      */
     public function standard(
         string $title,
         string $message,
         string $post_url,
-        FileInput $file_input
+        FileInput $file_input,
+        ?Input $additional_input = null,
     ): Standard;
 
     /**
@@ -107,16 +110,18 @@ interface Factory
      *     3: Wrapper dropzones MUST NOT contain any other file dropzones.
      *     4: Wrapper dropzones MUST NOT be used in modals.
      * ---
-     * @param string $title
-     * @param string $post_url
+     * @param string                $title
+     * @param string                $post_url
      * @param Component|Component[] $content
-     * @param FileInput $file_input
+     * @param FileInput             $file_input
+     * @param Input                 $additional_input
      * @return \ILIAS\UI\Component\Dropzone\File\Wrapper
      */
     public function wrapper(
         string $title,
         string $post_url,
         $content,
-        FileInput $file_input
+        FileInput $file_input,
+        ?Input $additional_input = null,
     ): Wrapper;
 }

--- a/src/UI/Implementation/Component/Dropzone/File/Factory.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Factory.php
@@ -29,6 +29,7 @@ use ILIAS\UI\Component\Dropzone\File\Wrapper as WrapperDropzone;
 use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Component\Input\Field\File as FileInput;
 use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Input\Field\Input;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
@@ -47,32 +48,44 @@ class Factory implements FileDropzoneFactory
     /**
      * @inheritDoc
      */
-    public function standard(string $title, string $message, string $post_url, FileInput $file_input): StandardDropzone
-    {
+    public function standard(
+        string $title,
+        string $message,
+        string $post_url,
+        FileInput $file_input,
+        ?Input $additional_input = null,
+    ): StandardDropzone {
         return new Standard(
             $this->signal_generator,
             $this->field_factory,
             new FormInputNameSource(),
-            $file_input,
             $title,
             $message,
-            $post_url
+            $post_url,
+            $file_input,
+            $additional_input
         );
     }
 
     /**
      * @inheritDoc
      */
-    public function wrapper(string $title, string $post_url, $content, FileInput $file_input): WrapperDropzone
-    {
+    public function wrapper(
+        string $title,
+        string $post_url,
+        $content,
+        FileInput $file_input,
+        ?Input $additional_input = null,
+    ): WrapperDropzone {
         return new Wrapper(
             $this->signal_generator,
             $this->field_factory,
             new FormInputNameSource(),
-            $file_input,
             $title,
             $content,
-            $post_url
+            $post_url,
+            $file_input,
+            $additional_input
         );
     }
 }

--- a/src/UI/Implementation/Component/Dropzone/File/File.php
+++ b/src/UI/Implementation/Component/Dropzone/File/File.php
@@ -36,6 +36,8 @@ use ILIAS\UI\Component\ReplaceSignal;
 use ILIAS\UI\Component\Input\Container\Form\Standard;
 use ILIAS\UI\Component\Closable;
 use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Input\Field\UploadHandler;
+use ILIAS\UI\Component\Input\Field\Input;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
@@ -54,19 +56,27 @@ abstract class File implements FileDropzone
         SignalGeneratorInterface $signal_generator,
         FieldFactory $field_factory,
         NameSource $name_source,
-        FileInput $file_input,
         string $title,
-        string $post_url
+        string $post_url,
+        FileInput $file_input,
+        ?Input $additional_input
     ) {
         $this->signal_generator = $signal_generator;
         $this->clear_signal = $signal_generator->create();
+
+        if (null !== $additional_input) {
+            $inputs = [$file_input, $additional_input];
+        } else {
+            $inputs = [$file_input];
+        }
+
         $this->modal = new RoundTrip(
             $signal_generator,
             $field_factory,
             $name_source,
             $title,
             null,
-            [$file_input],
+            $inputs,
             $post_url
         );
     }

--- a/src/UI/Implementation/Component/Dropzone/File/Standard.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Standard.php
@@ -26,6 +26,7 @@ use ILIAS\UI\Component\Input\Field\File as FileInput;
 use ILIAS\UI\Component\Dropzone\File\Standard as StandardDropzone;
 use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Component\Button\Button;
+use ILIAS\UI\Component\Input\Field\Input;
 
 /**
  * @author  Thibeau Fuhrer <thibeau@sr.solutions>
@@ -39,12 +40,21 @@ class Standard extends File implements StandardDropzone
         SignalGeneratorInterface $signal_generator,
         FieldFactory $field_factory,
         NameSource $name_source,
-        FileInput $file_input,
         string $title,
         string $message,
-        string $post_url
+        string $post_url,
+        FileInput $file_input,
+        ?Input $additional_input
     ) {
-        parent::__construct($signal_generator, $field_factory, $name_source, $file_input, $title, $post_url);
+        parent::__construct(
+            $signal_generator,
+            $field_factory,
+            $name_source,
+            $title,
+            $post_url,
+            $file_input,
+            $additional_input,
+        );
         $this->message = $message;
     }
 

--- a/src/UI/Implementation/Component/Dropzone/File/Wrapper.php
+++ b/src/UI/Implementation/Component/Dropzone/File/Wrapper.php
@@ -26,6 +26,7 @@ use ILIAS\UI\Component\Dropzone\File\Wrapper as WrapperDropzone;
 use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Component\Input\Field\File as FileInput;
 use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Input\Field\Input;
 
 /**
  * @author  Thibeau Fuhrer <thibeau@sr.solutions>
@@ -38,18 +39,27 @@ class Wrapper extends File implements WrapperDropzone
     protected array $content;
 
     /**
-     * @param Component|Component[]
+     * @param Component|Component[] $content
      */
     public function __construct(
         SignalGeneratorInterface $signal_generator,
         FieldFactory $field_factory,
         NameSource $name_source,
-        FileInput $file_input,
         string $title,
         $content,
-        string $post_url
+        string $post_url,
+        FileInput $file_input,
+        ?Input $additional_input
     ) {
-        parent::__construct($signal_generator, $field_factory, $name_source, $file_input, $title, $post_url);
+        parent::__construct(
+            $signal_generator,
+            $field_factory,
+            $name_source,
+            $title,
+            $post_url,
+            $file_input,
+            $additional_input,
+        );
 
         $content = $this->toArray($content);
         $this->checkArgListElements('content', $content, [Component::class]);

--- a/src/UI/examples/Dropzone/File/Standard/with_additional_input.php
+++ b/src/UI/examples/Dropzone/File/Standard/with_additional_input.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Dropzone\File\Standard;
+
+function with_additional_input()
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    $dropzone = $factory
+        ->dropzone()->file()->standard(
+            'Upload your files here',
+            'Drag files in here to upload them!',
+            '#',
+            $factory->input()->field()->file(
+                new \ilUIAsyncDemoFileUploadHandlerGUI(),
+                'your files'
+            ),
+            $factory->input()->field()->text(
+                'Additional Input',
+                'Additional input which affects all files of this upload.'
+            )
+        )->withUploadButton(
+            $factory->button()->shy('Upload files', '#')
+        );
+
+    // please use ilCtrl to generate an appropriate link target
+    // and check it's command instead of this.
+    if ('POST' === $request->getMethod()) {
+        $dropzone = $dropzone->withRequest($request);
+        $data = $dropzone->getData();
+    } else {
+        $data = 'no results yet.';
+    }
+
+    return '<pre>' . print_r($data, true) . '</pre>' .
+        $renderer->render($dropzone);
+}

--- a/src/UI/examples/Dropzone/File/Wrapper/with_additional_input.php
+++ b/src/UI/examples/Dropzone/File/Wrapper/with_additional_input.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Dropzone\File\Wrapper;
+
+function with_additional_input()
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    $dropzone = $factory
+        ->dropzone()->file()->wrapper(
+            'Upload your files here',
+            '#',
+            $factory->messageBox()->info('Drag and drop files onto me!'),
+            $factory->input()->field()->file(
+                new \ilUIAsyncDemoFileUploadHandlerGUI(),
+                'Your files'
+            ),
+            $factory->input()->field()->text(
+                'Additional Input',
+                'Additional input which affects all files of this upload.'
+            )
+        );
+
+    // please use ilCtrl to generate an appropriate link target
+    // and check it's command instead of this.
+    if ('POST' === $request->getMethod()) {
+        $dropzone = $dropzone->withRequest($request);
+        $data = $dropzone->getData();
+    } else {
+        $data = 'no results yet.';
+    }
+
+    return '<pre>' . print_r($data, true) . '</pre>' .
+        $renderer->render($dropzone);
+}

--- a/tests/UI/Component/Dropzone/File/StandardTest.php
+++ b/tests/UI/Component/Dropzone/File/StandardTest.php
@@ -23,6 +23,9 @@ namespace ILIAS\Tests\UI\Component\Dropzone\File;
 use ILIAS\UI\Implementation\Render\JavaScriptBinding;
 use ILIAS\UI\Implementation\Component\Button\Button;
 use TestDefaultRenderer;
+use ILIAS\UI\Implementation\Component\Input\Field\Text;
+use ILIAS\UI\Implementation\Component\Input\Field\Group;
+use ILIAS\UI\Component\Input\Field\Input;
 
 /**
  * @author  Thibeau Fuhrer <thibeau@sr.solutions>
@@ -35,32 +38,22 @@ class StandardTest extends FileTestBase
         $expected_msg = 'test_msg';
         $expected_url = 'test_url';
 
-        $expected_html = $this->brutallyTrimHTML("
-            <div id=\"id_2\" class=\"ui-dropzone \">
-                <div class=\"modal fade il-modal-roundtrip\" tabindex=\"-1\" role=\"dialog\" id=\"id_1\">
-                    <div class=\"modal-dialog\" role=\"document\" data-replace-marker=\"component\">
-                        <div class=\"modal-content\">
-                            <div class=\"modal-header\">
-                                <button type=\"button\" class=\"close\" data-dismiss=\"modal\" aria-label=\"close\">
-                                    <span aria-hidden=\"true\">&times;</span>
-                                </button>
-                                <span class=\"modal-title\">$expected_title
-                                </span>
-                            </div>
-                            <div class=\"modal-body\">
-                            </div>
-                            <div class=\"modal-footer\">
-                                <button class=\"btn btn-default\" data-dismiss=\"modal\">cancel</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class=\"ui-dropzone-container\">
-                    <span class=\"ui-dropzone-message\">$expected_msg
-                    </span>
-                </div>
-            </div>
-        ");
+        $expected_html = $this->brutallyTrimHTML('
+<div id="id_4" class="ui-dropzone ">
+	<div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
+		<div class="modal-dialog" role="document" data-replace-marker="component">
+			<div class="modal-content">
+				<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="close"><span aria-hidden="true">&times;</span></button><span class="modal-title">' . $expected_title . '</span></div>
+				<div class="modal-body">
+					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">' . $this->input->getCanonicalName() . '</form>
+				</div>
+				<div class="modal-footer"><button class="btn btn-default" data-dismiss="modal">cancel</button><button class="btn btn-default" id="id_3">save</button></div>
+			</div>
+		</div>
+	</div>
+	<div class="ui-dropzone-container"><span class="ui-dropzone-message">' . $expected_msg . '</span></div>
+</div>
+        ');
 
         $dropzone = $this->factory->standard($expected_title, $expected_msg, $expected_url, $this->input);
 
@@ -73,34 +66,7 @@ class StandardTest extends FileTestBase
 
     public function testRenderStandardWithUploadButton(): void
     {
-        $expected_button_html = 'test_button';
-
-        $expected_html = $this->brutallyTrimHTML("
-            <div id=\"id_2\" class=\"ui-dropzone \">
-                <div class=\"modal fade il-modal-roundtrip\" tabindex=\"-1\" role=\"dialog\" id=\"id_1\">
-                    <div class=\"modal-dialog\" role=\"document\" data-replace-marker=\"component\">
-                        <div class=\"modal-content\">
-                            <div class=\"modal-header\">
-                                <button type=\"button\" class=\"close\" data-dismiss=\"modal\" aria-label=\"close\">
-                                    <span aria-hidden=\"true\">&times;</span>
-                                </button>
-                                <span class=\"modal-title\">
-                                </span>
-                            </div>
-                            <div class=\"modal-body\">
-                            </div>
-                            <div class=\"modal-footer\">
-                                <button class=\"btn btn-default\" data-dismiss=\"modal\">cancel</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class=\"ui-dropzone-container\">
-                    <span class=\"ui-dropzone-message\">
-                    </span> $expected_button_html
-                </div>
-            </div>
-        ");
+        $expected_button_html = md5(Button::class);
 
         $button_mock = $this->createMock(Button::class);
         $button_mock->method('getCanonicalName')->willReturn($expected_button_html);
@@ -113,6 +79,25 @@ class StandardTest extends FileTestBase
             $this->input,
         ])->render($dropzone));
 
-        $this->assertEquals($expected_html, $html);
+        $this->assertTrue(str_contains($html, $expected_button_html));
+    }
+
+    public function testRenderStandardWithAdditionalInputs(): void
+    {
+        $expected_button_html = md5(Text::class);
+
+        $additional_input = $this->createMock(Text::class);
+        $additional_input->method('getCanonicalName')->willReturn($expected_button_html);
+        $additional_input->method('isRequired')->willReturn(false);
+        $additional_input->method('withNameFrom')->willReturnSelf();
+
+        $dropzone = $this->factory->standard('', '', '', $this->input, $additional_input);
+
+        $html = $this->getDefaultRenderer(null, [
+            $this->input,
+            $additional_input,
+        ])->render($dropzone);
+
+        $this->assertTrue(str_contains($html, $expected_button_html));
     }
 }

--- a/tests/UI/Component/Dropzone/File/WrapperTest.php
+++ b/tests/UI/Component/Dropzone/File/WrapperTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Tests\UI\Component\Dropzone\File;
 
 use ILIAS\UI\Component\Legacy\Legacy;
+use ILIAS\UI\Implementation\Component\Input\Field\Text;
 
 /**
  * @author  Thibeau Fuhrer <thibeau@sr.solutions>
@@ -33,28 +34,24 @@ class WrapperTest extends FileTestBase
         $expected_url = 'test_url';
         $expected_legacy_html = 'test_legacy_html';
 
-        $expected_html = $this->brutallyTrimHTML("
-            <div id=\"id_2\" class=\"ui-dropzone ui-dropzone-wrapper\">
-                <div class=\"modal fade il-modal-roundtrip\" tabindex=\"-1\" role=\"dialog\" id=\"id_1\">
-                    <div class=\"modal-dialog\" role=\"document\" data-replace-marker=\"component\">
-                        <div class=\"modal-content\">
-                            <div class=\"modal-header\">
-                                <button type=\"button\" class=\"close\" data-dismiss=\"modal\" aria-label=\"close\">
-                                    <span aria-hidden=\"true\">&times;</span>
-                                </button>
-                                <span class=\"modal-title\">$expected_title</span>
-                            </div>
-                            <div class=\"modal-body\">
-                            </div>
-                            <div class=\"modal-footer\">
-                                <button class=\"btn btn-default\" data-dismiss=\"modal\">cancel</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class=\"ui-dropzone-container\"> $expected_legacy_html</div>
-            </div>
-        ");
+        $expected_html = $this->brutallyTrimHTML(
+            '
+<div id="id_4" class="ui-dropzone ui-dropzone-wrapper">
+	<div class="modal fade il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
+		<div class="modal-dialog" role="document" data-replace-marker="component">
+			<div class="modal-content">
+				<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="close"><span aria-hidden="true">&times;</span></button><span class="modal-title">' . $expected_title . ' </span></div>
+				<div class="modal-body">
+					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">File Field Input</form>
+				</div>
+				<div class="modal-footer"><button class="btn btn-default" data-dismiss="modal">cancel</button><button class="btn btn-default" id="id_3">save</button></div>
+			</div>
+		</div>
+	</div>
+	<div class="ui-dropzone-container"> ' . $expected_legacy_html . '</div>
+</div>
+        '
+        );
 
         $legacy_mock = $this->createMock(Legacy::class);
         $legacy_mock->method('getCanonicalName')->willReturn($expected_legacy_html);
@@ -67,5 +64,24 @@ class WrapperTest extends FileTestBase
         ])->render($dropzone));
 
         $this->assertEquals($expected_html, $html);
+    }
+
+    public function testRenderWrapperWithAdditionalInputs(): void
+    {
+        $expected_button_html = md5(Text::class);
+
+        $additional_input = $this->createMock(Text::class);
+        $additional_input->method('getCanonicalName')->willReturn($expected_button_html);
+        $additional_input->method('isRequired')->willReturn(false);
+        $additional_input->method('withNameFrom')->willReturnSelf();
+
+        $dropzone = $this->factory->standard('', '', '', $this->input, $additional_input);
+
+        $html = $this->getDefaultRenderer(null, [
+            $this->input,
+            $additional_input,
+        ])->render($dropzone);
+
+        $this->assertTrue(str_contains($html, $expected_button_html));
     }
 }


### PR DESCRIPTION
Hey all,

In light of the this [feature-request](https://docu.ilias.de/goto_docu_wiki_wpage_5318_1357.html) we need to be able to adjust the inputs of the `File\Dropzone` which appears in container-objects or -headers in the repository.

With the recent refactoring (#5203) this almost became possible, but since we don't want the copyright-selection to appear as a metadata-input for each file entry, we need to be able to pass `$additional_inputs` to the `Form` used in `File\Dropzone`s (or `Modal\Roundtrip` in the end).

We discussed on how this should be handled, because in our opinion, a `File\Dropzone` should expect a `Field\File` input explicitly, otherwise it wouldn't be a `File\Dropzone` anymore. Therefore we came up with the `$additional_inputs` as an optional array. This brings along one issue though: How do we merge the `Field\File` input into this optional array? A possible solution (which we also implemented) is mapping the `Field\File` input to the file-identifier of its `UploadHandler`. We believe with proper documentation (as written in the factory), this should be fine. However, if you have other ideas they're welcome. A nice side-effect of doing this is that now the `Field\File` input is also mapped to a key instead of just some index when retrieving data from `File\Dropzone::getData()`.

Examples are already there, unit-tests will follow.

Kind regards,
@thibsy and @lzehnder 