### PR TITLE
Add bitwise or, and to formula question

### DIFF
--- a/Services/Math/classes/class.EvalMath.php
+++ b/Services/Math/classes/class.EvalMath.php
@@ -338,10 +338,9 @@ class EvalMath
         }
     
         $stack = new EvalMathStack;
-        
         foreach ($tokens as $token) { // nice and easy
             // if the token is a binary operator, pop two values off the stack, do the operation, and push the result back on
-            if (in_array($token, array('+', '-', '*', '/', '^'))) {
+            if (in_array($token, array('+', '-', '*', '/', '^','&','|'))) {
                 if (is_null($op2 = $stack->pop())) {
                     return $this->trigger("internal error");
                 }
@@ -363,6 +362,10 @@ class EvalMath
                                             $stack->push(ilMath::_div($op1, $op2)); break;
                                         case '^':
                                             $stack->push(ilMath::_pow($op1, $op2)); break;
+                                        case '&':
+                                            $stack->push(ilMath::_and($op1, $op2)); break;
+                                        case '|':
+                                            $stack->push(ilMath::_or($op1, $op2)); break;
                 }
                 // if the token is a unary operator, pop one value off the stack, do the operation, and push it back on
             } elseif ($token == "_") {

--- a/Services/Math/classes/class.ilMath.php
+++ b/Services/Math/classes/class.ilMath.php
@@ -49,7 +49,6 @@ class ilMath
     public static function _mod($operand, $modulu)
     {
         $adapter = static::getDefaultAdapter();
-
         return $adapter->mod($operand, $modulu);
     }
 
@@ -77,6 +76,35 @@ class ilMath
         $adapter = static::getDefaultAdapter();
 
         return $adapter->pow($left_operand, $right_operand, $scale);
+    }
+
+    /**
+     * @param int|float $left_operand
+     * @param int|float $right_operand
+     * @return mixed
+     */
+    public static function _and($left_operand, $right_operand)
+    {
+        return $left_operand & $right_operand;
+    }
+
+    /**
+     * @param int|float $left_operand
+     * @param int|float $right_operand
+     * @return mixed
+     */
+    public static function _or($left_operand, $right_operand)
+    {
+        return $left_operand | $right_operand;
+    }
+
+    /**
+     * @param int|float $operand
+     * @return mixed
+     */
+    public static function _not($operand)
+    {
+        return ~$operand;
     }
 
     /**

--- a/Services/Math/classes/class.ilMath.php
+++ b/Services/Math/classes/class.ilMath.php
@@ -100,15 +100,6 @@ class ilMath
 
     /**
      * @param int|float $operand
-     * @return mixed
-     */
-    public static function _not($operand)
-    {
-        return ~$operand;
-    }
-
-    /**
-     * @param int|float $operand
      * @param int $scale
      * @return mixed
      */

--- a/Services/Math/test/ilMathTest.php
+++ b/Services/Math/test/ilMathTest.php
@@ -33,6 +33,22 @@ class ilMathTest extends TestCase
     }
 
     /**
+     * @dataProvider andData
+     */
+    public function testAnd($a, $b, $result)
+    {
+        $this->assertEquals($result, ilMath::_and($a, $b));
+    }
+
+    /**
+     * @dataProvider orData
+     */
+    public function testOr($a, $b, $result)
+    {
+        $this->assertEquals($result, ilMath::_or($a, $b));
+    }
+
+    /**
      * @return array
      */
     public function gcdData()
@@ -40,6 +56,26 @@ class ilMathTest extends TestCase
         return [
             ['1254', '5298', '6'],
             ['41414124', '41414124', '41414124']
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function andData()
+    {
+        return [
+            ['11', '2', '2']
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function orData()
+    {
+        return [
+            ['3', '2', '3']
         ];
     }
 }

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -804,7 +804,7 @@ assessment#:#for#:#for
 assessment#:#forcejs#:#Force JavaScript output for test questions
 assessment#:#form_msg_area_missing_points#:#Please enter points for all areas.
 assessment#:#formula#:#Formula
-assessment#:#fq_formula_desc#:#You may enter predefined variables ($v1 to $vn), defined results (e.g. $r1), braces for expressions, mathematical operators  + (addition), - (subtraction), * (multiplication), / (division), ^ (nth power), & (logical and), | (logical or), the constants ‘pi’ for pi and ‘e’ for euler's constant, as well as the functions ‘sin’, ‘sinh’, ‘arcsin’, ‘asin’, ‘arcsinh’, ‘asinh’, ‘cos’, ‘cosh’, ‘arccos’, ‘acos’, ‘arccosh’, ‘acosh’, ‘tan’, ‘tanh’, ‘arctan’, ‘atan’, ‘arctanh’, ‘atanh’, ‘sqrt’, ‘abs’, ‘ln’ and ‘log’.
+assessment#:#fq_formula_desc#:#You may enter predefined variables ($v1 to $vn), defined results (e.g. $r1), braces for expressions, mathematical operators  + (addition), - (subtraction), * (multiplication), / (division), ^ (nth power), & (bitwise and), | (bitwise or), the constants ‘pi’ for pi and ‘e’ for euler's constant, as well as the functions ‘sin’, ‘sinh’, ‘arcsin’, ‘asin’, ‘arcsinh’, ‘asinh’, ‘cos’, ‘cosh’, ‘arccos’, ‘acos’, ‘arccosh’, ‘acosh’, ‘tan’, ‘tanh’, ‘arctan’, ‘atan’, ‘arctanh’, ‘atanh’, ‘sqrt’, ‘abs’, ‘ln’ and ‘log’.
 assessment#:#fq_no_restriction_info#:#Both decimals and fractions are accepted as input.
 assessment#:#fq_precision_info#:#Enter the number of desired decimal places.
 assessment#:#fq_question_desc#:#You can define variables by inserting $v1, $v2 ... $vn, results by inserting $r1, $r2 .... $rn at the desired position in the question text. Click on the button ‘Parse Question’ to create editing forms for variables and results.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -804,7 +804,7 @@ assessment#:#for#:#for
 assessment#:#forcejs#:#Force JavaScript output for test questions
 assessment#:#form_msg_area_missing_points#:#Please enter points for all areas.
 assessment#:#formula#:#Formula
-assessment#:#fq_formula_desc#:#You may enter predefined variables ($v1 to $vn), defined results (e.g. $r1), braces for expressions, mathematical operators  + (addition), - (subtraction), * (multiplication), / (division), ^ (nth power), the constants ‘pi’ for pi and ‘e’ for euler's constant, as well as the functions ‘sin’, ‘sinh’, ‘arcsin’, ‘asin’, ‘arcsinh’, ‘asinh’, ‘cos’, ‘cosh’, ‘arccos’, ‘acos’, ‘arccosh’, ‘acosh’, ‘tan’, ‘tanh’, ‘arctan’, ‘atan’, ‘arctanh’, ‘atanh’, ‘sqrt’, ‘abs’, ‘ln’ and ‘log’.
+assessment#:#fq_formula_desc#:#You may enter predefined variables ($v1 to $vn), defined results (e.g. $r1), braces for expressions, mathematical operators  + (addition), - (subtraction), * (multiplication), / (division), ^ (nth power), & (logical and), | (logical or), the constants ‘pi’ for pi and ‘e’ for euler's constant, as well as the functions ‘sin’, ‘sinh’, ‘arcsin’, ‘asin’, ‘arcsinh’, ‘asinh’, ‘cos’, ‘cosh’, ‘arccos’, ‘acos’, ‘arccosh’, ‘acosh’, ‘tan’, ‘tanh’, ‘arctan’, ‘atan’, ‘arctanh’, ‘atanh’, ‘sqrt’, ‘abs’, ‘ln’ and ‘log’.
 assessment#:#fq_no_restriction_info#:#Both decimals and fractions are accepted as input.
 assessment#:#fq_precision_info#:#Enter the number of desired decimal places.
 assessment#:#fq_question_desc#:#You can define variables by inserting $v1, $v2 ... $vn, results by inserting $r1, $r2 .... $rn at the desired position in the question text. Click on the button ‘Parse Question’ to create editing forms for variables and results.


### PR DESCRIPTION
This PR adds bitwise AND and OR operators to formula questions. 

& and | are added as two new binary operators

_Why this addition?_
To simplify the and operation in formulas from
`(-1)^($v1+$v2)/-2+0.5` to `$v1 & $v2`