### PR TITLE
FileInput: Allow Multiple FileUploads in Form

### DIFF
--- a/src/UI/templates/js/Input/Field/file.js
+++ b/src/UI/templates/js/Input/Field/file.js
@@ -595,17 +595,24 @@ il.UI.Input = il.UI.Input || {};
 			let file_inputs = current_form.find(SELECTOR.file_input);
 			current_dropzone_count = file_inputs.length;
 
-			// in case multiple file-inputs were added to ONE form, they
-			// all need to be processed.
-			if (Array.isArray(file_inputs)) {
-				for (let i = 0; i < file_inputs.length; i++) {
-					let input_id = file_inputs[i].attr('id');
-					let dropzone = dropzones[input_id];
-					processRemovals(input_id, event);
-					dropzone.processQueue();
-				}
-			} else {
-				let input_id = file_inputs.attr('id');
+            if (typeof file_inputs[Symbol.iterator] === 'function') {
+                let to_process = 0;
+                for (let i = 0; i < file_inputs.length; i++) {
+                    let input_id = file_inputs[i].id;
+                    let dropzone = dropzones[input_id];
+                    processRemovals(input_id, event);
+                    to_process += dropzone.files.length;
+                    if (dropzone.files.length !== 0) {
+                        dropzone.processQueue();
+                    } else {
+                        current_dropzone++;
+                    }
+                }
+                if (to_process === 0) {
+                    current_form.submit();
+                }
+            } else {
+                let input_id = file_inputs.attr('id');
 				let dropzone = dropzones[input_id];
 				processRemovals(input_id, event);
 				if (0 !== dropzone.files.length) {
@@ -613,7 +620,7 @@ il.UI.Input = il.UI.Input || {};
 				} else {
 					current_form.submit();
 				}
-			}
+            }
 		}
 
 		/**


### PR DESCRIPTION
As part of the FR to centralize Online and Offline-Settings, I was asked to implement the necessary form elements for the Kitchensink-Forms. While doing this, I encountered the issue that it was not possible to implement multiple upload forms per form. Uploads were not processed correctly, as [they never were in an Array](https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...kergomard:9/ui/fix_file_input_multiple?expand=1#diff-2d9abcacf08b7e7e7a931e40d78ee734af912ab8af6659fa4b7a570dd349f632L600). There was an additional issue that the form was never sent. This added the lines 605 to 613.
I'm actually not sure if [this if-statement](https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...kergomard:9/ui/fix_file_input_multiple?expand=1#diff-2d9abcacf08b7e7e7a931e40d78ee734af912ab8af6659fa4b7a570dd349f632R598) is actually needed. I think we could also get rid of it and remove the code in the else-statement completely. I left it in to not break things unnecessarily.

Thank you very much,
@kergomard 