### PR TITLE
Test: fix statistics tab selecting wrong pass (37163)

### DIFF
--- a/Modules/Test/classes/class.ilTestEvaluationUserData.php
+++ b/Modules/Test/classes/class.ilTestEvaluationUserData.php
@@ -398,9 +398,9 @@ class ilTestEvaluationUserData
         foreach ($this->passes as $pass) {
             $reached = $this->getReachedPointsInPercentForPass($pass->getPass());
 
-            if ($reached > $bestpoints
-                && ($pass->areObligationsAnswered() || !$obligationsAnsweredPassExists)
-                && !isset($bestpass)) {
+            if (($reached > $bestpoints
+                && ($pass->areObligationsAnswered() || !$obligationsAnsweredPassExists))
+                || !isset($bestpass)) {
                 $bestpoints = $reached;
                 $bestpass = $pass->getPass();
             }


### PR DESCRIPTION
This PR fixes [37163](https://mantis.ilias.de/view.php?id=37163). Please have a quick look @fneumann, but I think the behavior should match what you intended in [this commit](https://github.com/ILIAS-eLearning/ILIAS/commit/2e8bcf0d94a22484ecdecd47f65b28c1449e5664).