### PR TITLE
T&A Solves #36836

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assErrorText.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorText.php
@@ -52,16 +52,17 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     }
 
     /**
-    * Returns true, if a single choice question is complete for use
+    * Returns true, if an error text question is complete for use
     *
-    * @return boolean True, if the single choice question is complete for use, otherwise false
+    * @return boolean True, if the error text question is complete for use, otherwise false
     */
     public function isComplete()
     {
         if (strlen($this->title)
             && ($this->author)
             && ($this->question)
-            && ($this->getMaximumPoints() > 0)) {
+            && ($this->getMaximumPoints() > 0)
+            && (!empty($this->getErrorData()) || !empty($this->getErrorsFromText($_POST['errortext'])))) {
             return true;
         } else {
             return false;

--- a/Modules/TestQuestionPool/classes/class.assErrorTextGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorTextGUI.php
@@ -115,7 +115,15 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
 
         $this->populateQuestionSpecificFormPart($form);
 
-        if (count($this->object->getErrorData()) || $checkonly) {
+        if ($save || $checkonly) {
+            $this->writePostData(true);
+            $this->object->setErrorData($this->object->getErrorsFromText($_POST['errortext']));
+            if (empty($this->object->getErrorData())) {
+                ilUtil::sendFailure($this->lng->txt('errortext_info'), true);
+            }
+        }
+
+        if (count($this->object->getErrorData())) {
             $this->populateAnswerSpecificFormPart($form);
         }
 


### PR DESCRIPTION
With this changes, questions with no errors in the error text are saved as incomplete, and user gets the information message as an error (Please enter the error text. To mark a word as an error please insert a hash sign (#) in front of the word. To mark a group of words as an error please encapsulate the words group between double brackets (i.e.: here is ((an example)) of it). If you press the "Analyze Error Text" button, all marked words will be extracted for further processing.) 

