### PR TITLE
TinyMCE/Logging: Use appropriate HTTP header when requesting JSON

### DIFF
--- a/Services/RTE/templates/default/tpl.tinymce.js
+++ b/Services/RTE/templates/default/tpl.tinymce.js
@@ -140,6 +140,7 @@ function UploadHandler(blobInfo, success, failure, progress) {
     var xhr, formData;
     var uploadUrl = './node_modules/tinymce/plugins/ilimgupload/imgupload.php?obj_id=' + obj_id + '&obj_type=' + obj_type + '&update=' + image_update;
     xhr = new XMLHttpRequest();
+    xhr.setRequestHeader('Accept', 'application/json');
     xhr.open('POST', uploadUrl);
     //xhr.withCredentials = settings.credentials;
     xhr.upload.onprogress = function(e) {

--- a/Services/RTE/templates/default/tpl.tinymce_frm_post.js
+++ b/Services/RTE/templates/default/tpl.tinymce_frm_post.js
@@ -117,6 +117,7 @@ function UploadHandler(blobInfo, success, failure, progress) {
     var uploadUrl = './node_modules/tinymce/plugins/ilimgupload/imgupload.php?obj_id=' + obj_id + '&obj_type=' + obj_type + '&update=' + image_update;
     xhr = new XMLHttpRequest();
     xhr.open('POST', uploadUrl);
+    xhr.setRequestHeader('Accept', 'application/json');
     //xhr.withCredentials = settings.credentials;
     xhr.upload.onprogress = function(e) {
         progress(e.loaded / e.total * 100);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=37167

This PR adds the HTTP `Accept` request header when uploading an image in the `TinyMCE` `ilimgupload` plugin. The client always expects the response to be a JSON document, so it should state this.