### PR TITLE
Logging: Respect HTTP header and disable console logging for JSON req…

### DIFF
--- a/Services/Logging/classes/public/class.ilLoggerFactory.php
+++ b/Services/Logging/classes/public/class.ilLoggerFactory.php
@@ -121,11 +121,20 @@ class ilLoggerFactory
             return false;
         }
 
+        if (isset($_SERVER['HTTP_ACCEPT']) && strpos($_SERVER['HTTP_ACCEPT'], 'text/html') !== false) {
+            // If the client expects HTML, allow console logging
+            return true;
+        }
+
+        if (isset($_SERVER['HTTP_ACCEPT']) && strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false) {
+            // If the client expects JSON, don't use console logging: https://mantis.ilias.de/view.php?id=37167
+            return false;
+        }
+
         if ((isset($_GET['cmdMode']) && $_GET['cmdMode'] === 'asynch') || (
             isset($GLOBALS['DIC']['http']) &&
             strtolower($GLOBALS['DIC']->http()->request()->getServerParams()['HTTP_X_REQUESTED_WITH'] ?? '') === 'xmlhttprequest'
         )) {
-            // In theory, we could analyze the HTTP_ACCEPT header and return true for text/html
             return false;
         }
 


### PR DESCRIPTION
…uests

This PR adds additional criteria (see also: #4840) to the browser console logging handler determination. If a HTTP client expects a JSON response by sending a corresponding `Accept` HTTP request header, the `ilLoggerFactory` MUST NOT attach the browser console handler. This currently results in a `<script>...</script>` string being appended to the JSON response string.

https://mantis.ilias.de/view.php?id=37167

If approved, this MUST be cherry-picked to `release_8` and `trunk` as well.