### PR TITLE
Services/Logging: Add PSR-3 README. Add `$context` parameter for `ilLogger`

### DIFF
--- a/Modules/Test/test/tables/ilTestVerificationTableGUITest.php
+++ b/Modules/Test/test/tables/ilTestVerificationTableGUITest.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\Services\Logging\NullLogger;
+
 /**
  * Class ilTestVerificationTableGUITest
  * @author Marvin Beym <mbeym@databay.de>
@@ -53,40 +55,12 @@ class ilTestVerificationTableGUITest extends ilTestBaseTestCase
 
             public static function getRootLogger(): ilLogger
             {
-                return new class () extends ilLogger {
-                    public function __construct()
-                    {
-                    }
-
-                    public function write(string $a_message, $a_level = ilLogLevel::INFO): void
-                    {
-                    }
-
-                    public function info(string $a_message): void
-                    {
-                    }
-
-                    public function debug(string $a_message, array $a_context = array()): void
-                    {
-                    }
-                };
+                return new NullLogger();
             }
 
             public static function getLogger(string $a_component_id): ilLogger
             {
-                return new class () extends ilLogger {
-                    public function __construct()
-                    {
-                    }
-
-                    public function write(string $a_message, $a_level = ilLogLevel::INFO): void
-                    {
-                    }
-
-                    public function debug(string $a_message, array $a_context = array()): void
-                    {
-                    }
-                };
+                return new NullLogger();
             }
         });
 

--- a/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\DI;
+use ILIAS\Services\Logging\NullLogger;
 
 class ilComponentActivatePluginsObjective implements Setup\Objective
 {
@@ -126,29 +127,7 @@ class ilComponentActivatePluginsObjective implements Setup\Objective
         $GLOBALS["DIC"]["ilDB"] = $db;
         $GLOBALS["DIC"]["ilIliasIniFile"] = $ini;
         $GLOBALS["DIC"]["ilClientIniFile"] = $client_ini;
-        $GLOBALS["DIC"]["ilLog"] = new class() extends ilLogger {
-            public function __construct()
-            {
-            }
-            public function write(string $a_message, $a_level = ilLogLevel::INFO): void
-            {
-            }
-            public function info(string $a_message): void
-            {
-            }
-            public function warning(string $a_message): void
-            {
-            }
-            public function error(string $a_message): void
-            {
-            }
-            public function debug(string $a_message, array $a_context = []): void
-            {
-            }
-            public function dump($a_variable, int $a_level = ilLogLevel::INFO): void
-            {
-            }
-        };
+        $GLOBALS["DIC"]["ilLog"] = new NullLogger();
         $GLOBALS["DIC"]["ilLoggerFactory"] = new class() extends ilLoggerFactory {
             public function __construct()
             {

--- a/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\Setup;
 use ILIAS\DI;
 use ILIAS\Setup\Objective\ClientIdReadObjective;
+use ILIAS\Services\Logging\NullLogger;
 
 class ilComponentInstallPluginObjective implements Setup\Objective
 {
@@ -131,29 +132,7 @@ class ilComponentInstallPluginObjective implements Setup\Objective
         $GLOBALS["DIC"]["ilDB"] = $db;
         $GLOBALS["DIC"]["ilIliasIniFile"] = $ini;
         $GLOBALS["DIC"]["ilClientIniFile"] = $client_ini;
-        $GLOBALS["DIC"]["ilLog"] = new class() extends ilLogger {
-            public function __construct()
-            {
-            }
-            public function write(string $a_message, $a_level = ilLogLevel::INFO): void
-            {
-            }
-            public function info(string $a_message): void
-            {
-            }
-            public function warning(string $a_message): void
-            {
-            }
-            public function error(string $a_message): void
-            {
-            }
-            public function debug(string $a_message, array $a_context = []): void
-            {
-            }
-            public function dump($a_variable, int $a_level = ilLogLevel::INFO): void
-            {
-            }
-        };
+        $GLOBALS["DIC"]["ilLog"] = new NullLogger();
         $GLOBALS["DIC"]["ilLoggerFactory"] = new class() extends ilLoggerFactory {
             public function __construct()
             {

--- a/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\Setup;
 use ILIAS\DI;
 use ILIAS\Setup\Objective\ClientIdReadObjective;
+use ILIAS\Services\Logging\NullLogger;
 
 class ilComponentUpdatePluginObjective implements Setup\Objective
 {
@@ -134,80 +135,8 @@ class ilComponentUpdatePluginObjective implements Setup\Objective
         $GLOBALS["ilDB"] = $db;
         $GLOBALS["DIC"]["ilIliasIniFile"] = $ini;
         $GLOBALS["DIC"]["ilClientIniFile"] = $client_ini;
-        $GLOBALS["DIC"]["ilLogger"] = new class () extends ilLogger {
-            public function __construct()
-            {
-            }
-            public function isHandling(int $a_level): bool
-            {
-                return true;
-            }
-            public function log(string $a_message, int $a_level = ilLogLevel::INFO): void
-            {
-            }
-            public function dump($a_variable, int $a_level = ilLogLevel::INFO): void
-            {
-            }
-            public function debug(string $a_message, array $a_context = array()): void
-            {
-            }
-            public function info(string $a_message): void
-            {
-            }
-            public function notice(string $a_message): void
-            {
-            }
-            public function warning(string $a_message): void
-            {
-            }
-            public function error(string $a_message): void
-            {
-            }
-            public function critical(string $a_message): void
-            {
-            }
-            public function alert(string $a_message): void
-            {
-            }
-            public function emergency(string $a_message): void
-            {
-            }
-            public function write(string $a_message, $a_level = ilLogLevel::INFO): void
-            {
-            }
-            public function writeLanguageLog(string $a_topic, string $a_lang_key): void
-            {
-            }
-            public function logStack(?int $a_level = null, string $a_message = ''): void
-            {
-            }
-            public function writeMemoryPeakUsage(int $a_level): void
-            {
-            }
-        };
-        $GLOBALS["DIC"]["ilLog"] = new class () extends ilLog {
-            public function __construct()
-            {
-            }
-            public function write(string $a_msg, $a_log_level = ilLogLevel::INFO): void
-            {
-            }
-            public function info($msg): void
-            {
-            }
-            public function warning($msg): void
-            {
-            }
-            public function error($msg): void
-            {
-            }
-            public function debug($msg, $a = []): void
-            {
-            }
-            public function dump($a_var, ?int $a_log_level = ilLogLevel::INFO): void
-            {
-            }
-        };
+        $GLOBALS["DIC"]["ilLogger"] = new NullLogger();
+        $GLOBALS["DIC"]["ilLog"] = new NullLogger();
         $GLOBALS["DIC"]["ilLoggerFactory"] = new class () extends ilLoggerFactory {
             public function __construct()
             {

--- a/Services/Cron/classes/Setup/class.ilCronDefinitionProcessor.php
+++ b/Services/Cron/classes/Setup/class.ilCronDefinitionProcessor.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-use Monolog\Logger;
+use ILIAS\Services\Logging\NullLogger;
 
 class ilCronDefinitionProcessor implements ilComponentDefinitionProcessor
 {
@@ -38,77 +38,7 @@ class ilCronDefinitionProcessor implements ilComponentDefinitionProcessor
         $this->cronRepository = new ilCronJobRepositoryImpl(
             $this->db,
             $setting,
-            new class () extends ilLogger {
-                public function __construct()
-                {
-                }
-
-                public function isHandling(int $a_level): bool
-                {
-                    return false;
-                }
-
-                public function log(string $a_message, int $a_level = ilLogLevel::INFO): void
-                {
-                }
-
-                public function dump($a_variable, int $a_level = ilLogLevel::INFO): void
-                {
-                }
-
-                public function debug(string $a_message, array $a_context = []): void
-                {
-                }
-
-                public function info(string $a_message): void
-                {
-                }
-
-                public function notice(string $a_message): void
-                {
-                }
-
-                public function warning(string $a_message): void
-                {
-                }
-
-                public function error(string $a_message): void
-                {
-                }
-
-                public function critical(string $a_message): void
-                {
-                }
-
-                public function alert(string $a_message): void
-                {
-                }
-
-                public function emergency(string $a_message): void
-                {
-                }
-
-                /** @noinspection PhpInconsistentReturnPointsInspection */
-                public function getLogger(): Logger
-                {
-                }
-
-                public function write(string $a_message, $a_level = ilLogLevel::INFO): void
-                {
-                }
-
-                public function writeLanguageLog(string $a_topic, string $a_lang_key): void
-                {
-                }
-
-                public function logStack(?int $a_level = null, string $a_message = ''): void
-                {
-                }
-
-                public function writeMemoryPeakUsage(int $a_level): void
-                {
-                }
-            },
+            new NullLogger(),
             $componentRepository,
             $componentFactory
         );

--- a/Services/Language/classes/Setup/class.ilPluginLanguageUpdatedObjective.php
+++ b/Services/Language/classes/Setup/class.ilPluginLanguageUpdatedObjective.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\DI;
+use ILIAS\Services\Logging\NullLogger;
 
 class ilPluginLanguageUpdatedObjective implements Setup\Objective
 {
@@ -115,57 +116,7 @@ class ilPluginLanguageUpdatedObjective implements Setup\Objective
         $GLOBALS["ilDB"] = $db;
         $GLOBALS["DIC"]["ilIliasIniFile"] = $ini;
         $GLOBALS["DIC"]["ilClientIniFile"] = $client_ini;
-        $GLOBALS["DIC"]["ilLog"] = new class () extends ilLogger {
-            public function __construct()
-            {
-            }
-            public function isHandling(int $a_level): bool
-            {
-                return true;
-            }
-            public function log(string $a_message, int $a_level = ilLogLevel::INFO): void
-            {
-            }
-            public function dump($a_variable, int $a_level = ilLogLevel::INFO): void
-            {
-            }
-            public function debug(string $a_message, array $a_context = array()): void
-            {
-            }
-            public function info(string $a_message): void
-            {
-            }
-            public function notice(string $a_message): void
-            {
-            }
-            public function warning(string $a_message): void
-            {
-            }
-            public function error(string $a_message): void
-            {
-            }
-            public function critical(string $a_message): void
-            {
-            }
-            public function alert(string $a_message): void
-            {
-            }
-            public function emergency(string $a_message): void
-            {
-            }
-            public function write(string $a_message, $a_level = ilLogLevel::INFO): void
-            {
-            }
-            public function writeLanguageLog(string $a_topic, string $a_lang_key): void
-            {
-            }
-            public function logStack(?int $a_level = null, string $a_message = ''): void
-            {
-            }
-            public function writeMemoryPeakUsage(int $a_level): void
-            {
-            }
-        };
+        $GLOBALS["DIC"]["ilLog"] = new NullLogger();
         $GLOBALS["DIC"]["ilLoggerFactory"] = new class () extends ilLoggerFactory {
             public function __construct()
             {

--- a/Services/Logging/README.md
+++ b/Services/Logging/README.md
@@ -1,0 +1,18 @@
+# How to use the logging service
+
+The ilLogger exposes the placeholder feature given by the monolog bundle, which implements a PSR-3 compliant logger interface.
+
+Placeholders should be used to allow escaping of user input just as `$database->quote(...)` is used to escape user input in SQL queries.
+
+### Example usage
+
+```php
+$logger->debug('Lorem ipsum {foo} dolor {bar}.', [
+    'foo' => 'Lorem',
+    'bar' => 'ipsum',
+]);
+```
+
+## Further reading
+
+Please read the [PSR-3 Specification](https://www.php-fig.org/psr/psr-3/) for further information.

--- a/Services/Logging/classes/NullLogger.php
+++ b/Services/Logging/classes/NullLogger.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Services\Logging;
+
+use ilLogger;
+use ilLogLevel;
+use Monolog\Logger;
+use Exception;
+
+class NullLogger extends ilLogger
+{
+    public function __construct()
+    {
+    }
+
+    public function isHandling(int $level): bool
+    {
+        return true;
+    }
+
+    public function log(string $message, int $level = ilLogLevel::INFO, array $context = []): void
+    {
+    }
+
+    public function dump($value, int $level = ilLogLevel::INFO): void
+    {
+    }
+
+    public function debug(string $message, array $context = []): void
+    {
+    }
+
+    public function info(string $message, array $context = []): void
+    {
+    }
+
+    public function notice(string $message, array $context = []): void
+    {
+    }
+
+    public function warning(string $message, array $context = []): void
+    {
+    }
+
+    public function error(string $message, array $context = []): void
+    {
+    }
+
+    public function critical(string $message, array $context = []): void
+    {
+    }
+
+    public function alert(string $message, array $context = []): void
+    {
+    }
+
+    public function emergency(string $message, array $context = []): void
+    {
+    }
+
+    /** @noinspection \PhpInconsistentReturnPointsInspection */
+    public function getLogger(): Logger
+    {
+        throw new Exception('Can not return monolog logger from a null logger.');
+    }
+
+    public function write(string $message, $level = ilLogLevel::INFO, array $context = []): void
+    {
+    }
+
+    public function writeLanguageLog(string $topic, string $lang_key): void
+    {
+    }
+
+    public function logStack(?int $level = null, string $message = '', array $context = []): void
+    {
+    }
+
+    public function writeMemoryPeakUsage(int $level): void
+    {
+    }
+}

--- a/Services/Logging/classes/class.ilLogger.php
+++ b/Services/Logging/classes/class.ilLogger.php
@@ -1,10 +1,22 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
-
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
-
-include_once __DIR__ . '/../../../libs/composer/vendor/autoload.php';
 
 use Monolog\Logger;
 use Monolog\Processor\MemoryPeakUsageProcessor;
@@ -15,75 +27,68 @@ use Monolog\Processor\MemoryPeakUsageProcessor;
  */
 abstract class ilLogger
 {
-    private Logger $logger;
-
-    public function __construct(Logger $logger)
+    public function __construct(private readonly Logger $logger)
     {
-        $this->logger = $logger;
     }
 
     /**
      * Check whether current logger is handling a log level
      */
-    public function isHandling(int $a_level): bool
+    public function isHandling(int $level): bool
     {
-        return $this->getLogger()->isHandling($a_level);
+        return $this->getLogger()->isHandling($level);
     }
 
-    public function log(string $a_message, int $a_level = ilLogLevel::INFO): void
+    public function log(string $message, int $level = ilLogLevel::INFO, array $context = []): void
     {
-        $this->getLogger()->log($a_level, $a_message);
+        $this->getLogger()->log($level, $message, $context);
     }
 
-    /**
-     * @param  mixed $a_variable
-     * @param int    $a_level
-     * @return void
-     */
-    public function dump($a_variable, int $a_level = ilLogLevel::INFO): void
+    public function dump($value, int $level = ilLogLevel::INFO): void
     {
-        $this->log((string) print_r($a_variable, true), $a_level);
+        $this->log('{dump}', $level, [
+            'dump' => print_r($value, true),
+        ]);
     }
 
-    public function debug(string $a_message, array $a_context = array()): void
+    public function debug(string $message, array $context = []): void
     {
-        $this->getLogger()->debug($a_message, $a_context);
+        $this->getLogger()->debug($message, $context);
     }
 
-    public function info(string $a_message): void
+    public function info(string $message, array $context = []): void
     {
-        $this->getLogger()->info($a_message);
+        $this->getLogger()->info($message, $context);
     }
 
-    public function notice(string $a_message): void
+    public function notice(string $message, array $context = []): void
     {
-        $this->getLogger()->notice($a_message);
+        $this->getLogger()->notice($message, $context);
     }
 
-    public function warning(string $a_message): void
+    public function warning(string $message, array $context = []): void
     {
-        $this->getLogger()->warning($a_message);
+        $this->getLogger()->warning($message, $context);
     }
 
-    public function error(string $a_message): void
+    public function error(string $message, array $context = []): void
     {
-        $this->getLogger()->error($a_message);
+        $this->getLogger()->error($message, $context);
     }
 
-    public function critical(string $a_message): void
+    public function critical(string $message, array $context = []): void
     {
-        $this->getLogger()->critical($a_message);
+        $this->getLogger()->critical($message, $context);
     }
 
-    public function alert(string $a_message): void
+    public function alert(string $message, array $context = []): void
     {
-        $this->getLogger()->alert($a_message);
+        $this->getLogger()->alert($message, $context);
     }
 
-
-    public function emergency(string $a_message): void
+    public function emergency(string $message, array $context = []): void
     {
-        $this->getLogger()->emergency($a_message);
+        $this->getLogger()->emergency($message, $context);
     }
 
     public function getLogger(): Logger
@@ -95,41 +100,39 @@ abstract class ilLogger
      * write log message
      * @deprecated since version 5.1
      * @see ilLogger->info(), ilLogger()->debug(), ...
-     *
-     * @param int $_level
      */
-    public function write(string $a_message, $a_level = ilLogLevel::INFO): void
+    public function write(string $message, $level = ilLogLevel::INFO, array $context = []): void
     {
-        if (!in_array($a_level, ilLogLevel::getLevels())) {
-            $a_level = ilLogLevel::INFO;
+        if (!in_array($level, ilLogLevel::getLevels())) {
+            $level = ilLogLevel::INFO;
         }
-        $this->getLogger()->log((int) $a_level, $a_message);
+        $this->getLogger()->log((int) $level, $message, $context);
     }
 
     /**
      * Write language log
      * @deprecated since version 5.1
      */
-    public function writeLanguageLog(string $a_topic, string $a_lang_key): void
+    public function writeLanguageLog(string $topic, string $lang_key): void
     {
-        $this->getLogger()->debug("Language (" . $a_lang_key . "): topic -" . $a_topic . "- not present");
+        $this->getLogger()->debug("Language (" . $lang_key . "): topic -" . $topic . "- not present");
     }
 
-    public function logStack(?int $a_level = null, string $a_message = ''): void
+    public function logStack(?int $level = null, string $message = '', array $context = []): void
     {
-        if (is_null($a_level)) {
-            $a_level = ilLogLevel::INFO;
+        if (is_null($level)) {
+            $level = ilLogLevel::INFO;
         }
 
-        if (!in_array($a_level, ilLogLevel::getLevels())) {
-            $a_level = ilLogLevel::INFO;
+        if (!in_array($level, ilLogLevel::getLevels())) {
+            $level = ilLogLevel::INFO;
         }
 
 
         try {
-            throw new \Exception($a_message);
+            throw new Exception($message);
         } catch (Exception $ex) {
-            $this->getLogger()->log($a_level, $a_message . "\n" . $ex->getTraceAsString());
+            $this->getLogger()->log($level, $message . "\n" . $ex->getTraceAsString(), $context);
         }
     }
 
@@ -137,10 +140,10 @@ abstract class ilLogger
      * Write memory peak usage
      * Automatically called at end of script
      */
-    public function writeMemoryPeakUsage(int $a_level): void
+    public function writeMemoryPeakUsage(int $level): void
     {
         $this->getLogger()->pushProcessor(new MemoryPeakUsageProcessor());
-        $this->getLogger()->log($a_level, 'Memory usage: ');
+        $this->getLogger()->log($level, 'Memory usage: ');
         $this->getLogger()->popProcessor();
     }
 }

--- a/Services/Logging/classes/extensions/class.ilLineFormatter.php
+++ b/Services/Logging/classes/extensions/class.ilLineFormatter.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/* Copyright (c) 1998-2014 ILIAS open source, Extended GPL, see docs/LICENSE */
+declare(strict_types=1);
 
 use Monolog\Formatter\LineFormatter as LineFormatter;
 
@@ -23,6 +37,9 @@ class ilLineFormatter extends LineFormatter
             $record["message"] = $record["extra"]["trace"] . " " . $record["message"];
             $record["extra"] = array();
         }
+
+        $record['context'] = [];
+
         return parent::format($record);
     }
 }

--- a/Services/Logging/classes/public/class.ilLoggerFactory.php
+++ b/Services/Logging/classes/public/class.ilLoggerFactory.php
@@ -27,6 +27,7 @@ use Monolog\Handler\FingersCrossedHandler;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use ILIAS\DI\Container;
+use Monolog\Processor\PsrLogMessageProcessor;
 
 /**
  * Logging factory
@@ -237,6 +238,8 @@ class ilLoggerFactory
         // append trace
         $logger->pushProcessor(new ilTraceProcessor(ilLogLevel::DEBUG));
 
+        // Interpolate context variables.
+        $logger->pushProcessor(new PsrLogMessageProcessor());
 
         // register new logger
         $this->loggers[$a_component_id] = new ilComponentLogger($logger);


### PR DESCRIPTION
This PR exposes the `$context` parameter of the monolog logger for the `ilLogger` and placeholder interpolation for a logged message (PSR-3).
A short description on how and why is provided within a `README.md`.

Furthermore this PR replaces all occurrences of an anonymous class to create a dummy `ilLogger` with an actual `NullLogger` class.

See: https://peakd.com/hive-168588/@crell/using-psr-3-placeholders-properly