### PR TITLE
Fix for missing background-color

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -11457,6 +11457,7 @@ the il- variable in your less code and not the boostrap variable in your less co
 .il-maincontrols-metabar .il-link.link-bulky {
   font-size: 0.625rem;
   line-height: 0.83125rem;
+  background: #F5F5F5;
 }
 .il-maincontrols-mainbar .btn-bulky:focus, .il-maincontrols-mainbar .btn-bulky:active,
 .il-maincontrols-mainbar .il-link.link-bulky:focus,


### PR DESCRIPTION
Fix for https://mantis.ilias.de/view.php?id=37096

I added a minimal lighter color for the submenu for better overview.


Before:
![image](https://user-images.githubusercontent.com/1473674/232227175-2c06d927-391c-4224-8f9e-41efa73b004a.png)


After:
![image](https://user-images.githubusercontent.com/1473674/232227159-a7cdfdf8-1b6d-4554-8f4f-e647e31af04c.png)
