### PR TITLE
UI: Add optional custom constraint to Input::withRequired()

### DIFF
--- a/src/UI/Component/Input/Field/FormInput.php
+++ b/src/UI/Component/Input/Field/FormInput.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,12 +15,14 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Input\Field;
 
 use ILIAS\UI\Component\JavaScriptBindable;
 use ILIAS\UI\Component\OnUpdateable;
 use Closure;
+use ILIAS\Refinery\Constraint;
 
 /**
  * This describes inputs that can be used in forms.
@@ -60,10 +60,14 @@ interface FormInput extends Input, JavaScriptBindable, OnUpdateable
 
     /**
      * Get an input like this, but set the field to be required (or not).
+     * With the optional $required_constraint, you can REPLACE the default
+     * constraint that is checked if $is_required is true
+     * (see getConstraintForRequirement() on Input/Field implementations).
+     * A custom constraint SHOULD be explained in the byline of the input.
      *
      * @return static
      */
-    public function withRequired(bool $is_required);
+    public function withRequired(bool $is_required, ?Constraint $requirement_constraint = null);
 
     /**
      * Is this input disabled?

--- a/src/UI/Implementation/Component/Input/Field/Checkbox.php
+++ b/src/UI/Implementation/Component/Input/Field/Checkbox.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -41,6 +40,10 @@ class Checkbox extends Input implements C\Input\Field\Checkbox, C\Changeable, C\
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return null;
     }
 

--- a/src/UI/Implementation/Component/Input/Field/ColorPicker.php
+++ b/src/UI/Implementation/Component/Input/Field/ColorPicker.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -68,6 +67,10 @@ class ColorPicker extends Input implements C\Input\Field\ColorPicker
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return $this->refinery->string()->hasMinLength(4);
     }
 

--- a/src/UI/Implementation/Component/Input/Field/DateTime.php
+++ b/src/UI/Implementation/Component/Input/Field/DateTime.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -184,6 +183,10 @@ class DateTime extends Input implements C\Input\Field\DateTime
 
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return $this->refinery->string()->hasMinLength(1)
             ->withProblemBuilder(fn ($txt, $value) => $txt("datetime_required"));
     }

--- a/src/UI/Implementation/Component/Input/Field/Duration.php
+++ b/src/UI/Implementation/Component/Input/Field/Duration.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -24,6 +23,7 @@ use ILIAS\UI\Component as C;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\DateFormat\DateFormat;
 use ILIAS\Refinery as Refinery;
+use ILIAS\Refinery\Constraint;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use DateTimeImmutable;
@@ -283,8 +283,12 @@ class Duration extends Group implements C\Input\Field\Duration
     /**
      * @inheritdoc
      */
-    protected function getConstraintForRequirement(): ?Refinery\Custom\Constraint
+    protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return null;
     }
 

--- a/src/UI/Implementation/Component/Input/Field/File.php
+++ b/src/UI/Implementation/Component/Input/Field/File.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -182,6 +181,10 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
 
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return $this->refinery->custom()->constraint(
             function ($value) {
                 return (is_array($value) && count($value) > 0);

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -72,10 +71,10 @@ class Group extends Input implements C\Input\Field\Group
         return $clone;
     }
 
-    public function withRequired(bool $is_required): C\Input\Field\Input
+    public function withRequired(bool $is_required, ?Constraint $requirement_constraint = null): C\Input\Field\Input
     {
-        $clone = parent::withRequired($is_required);
-        $clone->inputs = array_map(fn ($i) => $i->withRequired($is_required), $this->inputs);
+        $clone = parent::withRequired($is_required, $requirement_constraint);
+        $clone->inputs = array_map(fn ($i) => $i->withRequired($is_required, $requirement_constraint), $this->inputs);
         return $clone;
     }
 

--- a/src/UI/Implementation/Component/Input/Field/Input.php
+++ b/src/UI/Implementation/Component/Input/Field/Input.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -51,6 +50,7 @@ abstract class Input implements C\Input\Field\Input, FormInputInternal
     protected string $label;
     protected ?string $byline;
     protected bool $is_required = false;
+    protected ?Constraint $requirement_constraint = null;
     protected bool $is_disabled = false;
 
     /**
@@ -147,10 +147,11 @@ abstract class Input implements C\Input\Field\Input, FormInputInternal
     /**
      * @inheritdoc
      */
-    public function withRequired(bool $is_required)
+    public function withRequired(bool $is_required, ?Constraint $requirement_constraint = null)
     {
         $clone = clone $this;
         $clone->is_required = $is_required;
+        $clone->requirement_constraint = ($is_required) ? $requirement_constraint : null;
         return $clone;
     }
 

--- a/src/UI/Implementation/Component/Input/Field/Link.php
+++ b/src/UI/Implementation/Component/Input/Field/Link.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -96,6 +95,10 @@ class Link extends Group implements C\Input\Field\Link
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return null;
     }
 }

--- a/src/UI/Implementation/Component/Input/Field/MultiSelect.php
+++ b/src/UI/Implementation/Component/Input/Field/MultiSelect.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -82,6 +81,10 @@ class MultiSelect extends Input implements C\Input\Field\MultiSelect
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return $this->refinery->custom()->constraint(
             fn ($value) => is_array($value) && count($value) > 0,
             "Empty"

--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -67,6 +66,10 @@ class Numeric extends Input implements C\Input\Field\Numeric
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return $this->refinery->numeric()->isNumeric();
     }
 

--- a/src/UI/Implementation/Component/Input/Field/OptionalGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/OptionalGroup.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -42,6 +41,10 @@ class OptionalGroup extends Group implements Field\OptionalGroup
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return null;
     }
 
@@ -56,10 +59,10 @@ class OptionalGroup extends Group implements Field\OptionalGroup
         return parent::isClientSideValueOk($value);
     }
 
-    public function withRequired($is_required): Field\Input
+    public function withRequired($is_required, ?Constraint $requirement_constraint = null): Field\Input
     {
         /** @noinspection PhpIncompatibleReturnTypeInspection */
-        return Input::withRequired($is_required);
+        return Input::withRequired($is_required, $requirement_constraint);
     }
 
     public function isRequired(): bool

--- a/src/UI/Implementation/Component/Input/Field/Password.php
+++ b/src/UI/Implementation/Component/Input/Field/Password.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -71,6 +70,10 @@ class Password extends Input implements C\Input\Field\Password, Triggerable
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return $this->refinery->string()->hasMinLength(1);
     }
 

--- a/src/UI/Implementation/Component/Input/Field/Radio.php
+++ b/src/UI/Implementation/Component/Input/Field/Radio.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -59,6 +58,10 @@ class Radio extends Input implements C\Input\Field\Radio
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return null;
     }
 

--- a/src/UI/Implementation/Component/Input/Field/Select.php
+++ b/src/UI/Implementation/Component/Input/Field/Select.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -71,6 +70,10 @@ class Select extends Input implements C\Input\Field\Select
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return $this->refinery->logical()->sequential([
             $this->refinery->to()->string(),
             $this->refinery->string()->hasMinLength(1)

--- a/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -58,6 +57,10 @@ class SwitchableGroup extends Group implements Field\SwitchableGroup
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return null;
     }
 
@@ -72,9 +75,9 @@ class SwitchableGroup extends Group implements Field\SwitchableGroup
         return array_key_exists($value, $this->inputs);
     }
 
-    public function withRequired($is_required): Field\Input
+    public function withRequired($is_required, ?Constraint $requirement_constraint = null): Field\Input
     {
-        return Input::withRequired($is_required);
+        return Input::withRequired($is_required, $requirement_constraint);
     }
 
     /**

--- a/src/UI/Implementation/Component/Input/Field/Tag.php
+++ b/src/UI/Implementation/Component/Input/Field/Tag.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -117,6 +116,10 @@ class Tag extends Input implements FormInputInternal, C\Input\Field\Tag
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return $this->refinery->logical()->sequential([
             $this->refinery->logical()->not($this->refinery->null()),
             $this->refinery->string()->hasMinLength(1)

--- a/src/UI/Implementation/Component/Input/Field/Text.php
+++ b/src/UI/Implementation/Component/Input/Field/Text.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -89,6 +88,10 @@ class Text extends Input implements C\Input\Field\Text
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return $this->refinery->string()->hasMinLength(1);
     }
 

--- a/src/UI/Implementation/Component/Input/Field/Textarea.php
+++ b/src/UI/Implementation/Component/Input/Field/Textarea.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -113,6 +112,10 @@ class Textarea extends Input implements C\Input\Field\Textarea
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         if ($this->min_limit) {
             return $this->refinery->string()->hasMinLength($this->min_limit);
         }

--- a/src/UI/Implementation/Component/Input/Field/Url.php
+++ b/src/UI/Implementation/Component/Input/Field/Url.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
@@ -114,6 +113,10 @@ class Url extends Input implements C\Input\Field\Url
      */
     protected function getConstraintForRequirement(): ?Constraint
     {
+        if ($this->requirement_constraint !== null) {
+            return $this->requirement_constraint;
+        }
+
         return $this->refinery->custom()->constraint(self::getURIChecker(), 'Not an URI');
     }
 

--- a/src/UI/examples/Input/with_required.php
+++ b/src/UI/examples/Input/with_required.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input;
+
+/**
+ * Example showing the use of the withRequired() method
+ */
+function with_required()
+{
+    //Step 0: Declare dependencies
+    global $DIC;
+    $ui = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    // Step 1: define the text field and make it a required field,
+    // i.e. checking for its default requirement constraint
+    // (for text fields: value must have a minimum length of 1)
+    $text_input = $ui->input()->field()->text("Enter a name", "And make it a good one!");
+    $text_input = $text_input->withRequired(true);
+
+    //Step 2: define form and form actions
+    $form = $ui->input()->container()->form()->standard('#', [ $text_input]);
+
+    //Step 3: implement some form data processing.
+    if ($request->getMethod() == "POST") {
+        $form = $form->withRequest($request);
+        $result = $form->getData();
+    } else {
+        $result = "No result yet.";
+    }
+
+    //Step 4: Render the checkbox with the enclosing form.
+    return
+        "<pre>" . print_r($result, true) . "</pre><br/>" .
+        $renderer->render($form);
+}

--- a/src/UI/examples/Input/with_required_custom_constraint.php
+++ b/src/UI/examples/Input/with_required_custom_constraint.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input;
+
+/**
+ * Example showing the use of the withRequired() method
+ * with a custom constraint that replaces the default requirement constraint.
+ * A custom constraint SHOULD be explained in the byline of the input.
+ */
+function with_required_custom_constraint()
+{
+    //Step 0: Declare dependencies
+    global $DIC;
+    $ui = $DIC->ui()->factory();
+    $refinery = $DIC->refinery();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    // Step 1: define the text field, make it a required field
+    // and add a custom constraint
+    $text_input = $ui->input()->field()->text("Enter a name", "Needs to start with an H");
+    $custom_constraint = $refinery->custom()->constraint(function ($value) {
+        return (substr($value, 0, 1) === 'H') ? true : false;
+    }, "Name does not start with an H");
+    $text_input = $text_input->withRequired(true, $custom_constraint);
+
+    //Step 2: define form and form actions
+    $form = $ui->input()->container()->form()->standard('#', [ $text_input]);
+
+    //Step 3: implement some form data processing.
+    if ($request->getMethod() == "POST") {
+        $form = $form->withRequest($request);
+        $result = $form->getData();
+    } else {
+        $result = "No result yet.";
+    }
+
+    //Step 4: Render the checkbox with the enclosing form.
+    return
+        "<pre>" . print_r($result, true) . "</pre><br/>" .
+        $renderer->render($form);
+}

--- a/tests/UI/Component/Input/Field/InputTest.php
+++ b/tests/UI/Component/Input/Field/InputTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 require_once(__DIR__ . "/../../../../../libs/composer/vendor/autoload.php");
 require_once(__DIR__ . "/../../../Base.php");
@@ -167,6 +166,19 @@ class InputTest extends ILIAS_UI_TestBase
         $this->assertTrue($input->isRequired());
         $input = $input->withRequired(false);
         $this->assertFalse($input->isRequired());
+    }
+
+    public function test_withRequired_and_custom_constraint(): void
+    {
+        $custom_constraint = $this->refinery->custom()->constraint(
+            function ($value) {
+                return (substr($value, 0, 1) === 'H') ? true : false;
+            },
+            "Your name does not start with an H"
+        );
+        $input = $this->input->withRequired(true, $custom_constraint);
+        $this->assertTrue($input->isRequired());
+        $this->assertEquals($input->requirement_constraint, $custom_constraint);
     }
 
     public function test_withDisabled(): void
@@ -552,24 +564,20 @@ class InputTest extends ILIAS_UI_TestBase
     public function test_withInput_requirement_constraint(): void
     {
         $name = "name_0";
-        $value = "value";
-        $error = "an error";
+        $value = "Adam";
+        $error = "Your name does not start with an H";
         $input = $this->input->withNameFrom($this->name_source);
         $values = new DefInputData([$name => $value]);
-
-        $input->requirement_constraint = $this->refinery->custom()->constraint(function () {
-            return false;
-        }, $error);
-
-        $input2 = $input->withRequired(true)->withInput($values);
+        $custom_constraint = $this->refinery->custom()->constraint(
+            function ($value) {
+                return (substr($value, 0, 1) === 'H') ? true : false;
+            },
+            $error
+        );
+        $input2 = $input->withRequired(true, $custom_constraint)->withInput($values);
         $res = $input2->getContent();
-
         $this->assertInstanceOf(Result::class, $res);
-        $this->assertTrue($res->isError());
-        $this->assertEquals($error, $res->error());
-
-        $this->assertNotSame($input, $input2);
-        $this->assertEquals($value, $input2->getValue());
+        $this->assertFalse($res->isOk());
         $this->assertEquals($error, $input2->getError());
     }
 
@@ -581,11 +589,11 @@ class InputTest extends ILIAS_UI_TestBase
         $input = $this->input->withNameFrom($this->name_source);
         $values = new DefInputData([$name => $value]);
 
-        $input->requirement_constraint = $this->refinery->custom()->constraint(function () {
+        $custom_constraint = $this->refinery->custom()->constraint(function () {
             return false;
         }, $error);
 
-        $input2 = $input->withRequired(true)->withRequired(false)->withInput($values);
+        $input2 = $input->withRequired(true, $custom_constraint)->withRequired(false)->withInput($values);
         $res = $input2->getContent();
 
         $this->assertInstanceOf(Result::class, $res);


### PR DESCRIPTION
The constraints for Inputs that are marked `withRequired(true)` are currently only visible inside the code of the individual implementations and differ depending on the type of field. To give developers better control on which constraints are checked, we have added a new parameter to `withRequired()` that allows us to REPLACE the default constraint with a custom constraint (instead of just being able to ADD more constraints with `withAdditionalTransformation()`).

The two added examples should make it more obvious how `withRequired()` is working with and without an additional constraint. Looking forward to your feedback!

_( This is based on a proposal by @klees )_