### PR TITLE
Bugfix 0037173: Column layout in help slate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@
 /Customizing/clients
 virtual-data
 /libs/composer/vendor
-libs/bower/bower_components
 /node_modules/**/.cache
 
 # /dicto

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@
 /Customizing/clients
 virtual-data
 /libs/composer/vendor
+libs/bower/bower_components
 /node_modules/**/.cache
 
 # /dicto

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -15942,6 +15942,56 @@ div.il_SearchFragment {
 #ilHelpText .ilc_list_u_BulletedList .ilc_list_o_NumberedList {
   padding-left: 15px;
 }
+#ilHelpText .col-xs-1,
+#ilHelpText .col-sm-1,
+#ilHelpText .col-md-1,
+#ilHelpText .col-lg-1,
+#ilHelpText .col-xs-2,
+#ilHelpText .col-sm-2,
+#ilHelpText .col-md-2,
+#ilHelpText .col-lg-2,
+#ilHelpText .col-xs-3,
+#ilHelpText .col-sm-3,
+#ilHelpText .col-md-3,
+#ilHelpText .col-lg-3,
+#ilHelpText .col-xs-4,
+#ilHelpText .col-sm-4,
+#ilHelpText .col-md-4,
+#ilHelpText .col-lg-4,
+#ilHelpText .col-xs-5,
+#ilHelpText .col-sm-5,
+#ilHelpText .col-md-5,
+#ilHelpText .col-lg-5,
+#ilHelpText .col-xs-6,
+#ilHelpText .col-sm-6,
+#ilHelpText .col-md-6,
+#ilHelpText .col-lg-6,
+#ilHelpText .col-xs-7,
+#ilHelpText .col-sm-7,
+#ilHelpText .col-md-7,
+#ilHelpText .col-lg-7,
+#ilHelpText .col-xs-8,
+#ilHelpText .col-sm-8,
+#ilHelpText .col-md-8,
+#ilHelpText .col-lg-8,
+#ilHelpText .col-xs-9,
+#ilHelpText .col-sm-9,
+#ilHelpText .col-md-9,
+#ilHelpText .col-lg-9,
+#ilHelpText .col-xs-10,
+#ilHelpText .col-sm-10,
+#ilHelpText .col-md-10,
+#ilHelpText .col-lg-10,
+#ilHelpText .col-xs-11,
+#ilHelpText .col-sm-11,
+#ilHelpText .col-md-11,
+#ilHelpText .col-lg-11,
+#ilHelpText .col-xs-12,
+#ilHelpText .col-sm-12,
+#ilHelpText .col-md-12,
+#ilHelpText .col-lg-12 {
+  width: 100%;
+}
 a#ilHelpClose {
   display: block;
   float: right;
@@ -20017,4 +20067,3 @@ table.mceToolbar td {
     width: auto !important;
   }
 }
-/*# sourceMappingURL=delos.css.map */

--- a/templates/default/less/Services/Help/delos.less
+++ b/templates/default/less/Services/Help/delos.less
@@ -25,6 +25,11 @@
 #ilHelpText .ilc_list_u_BulletedList .ilc_list_o_NumberedList {
 	padding-left: 15px;
 }
+#ilHelpText {
+    .col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
+        width: 100%;
+    }
+}
 
 a#ilHelpClose {
 	display: block;


### PR DESCRIPTION
Hi,

the online help learning module is to be revised and made visually attractive. The goal of the review is that the learning module is not only used in the help slate, but also used as a manual/handout. To do this, the pages are restructured using column layouts. f I create a column layout with 4 columns, they are displayed side by side on large screen. On mobile devices the columns are displayed below each other. This is also true for the Help Slate.

However, the size of the help slate ALWAYS corresponds to the mobile view, regardless of the screen size of the end device. For this reason, columns within the slate should always be displayed one below the other. 

See discussion: https://mantis.ilias.de/view.php?id=37173

Best regrards, 
Enrico