### PR TITLE
OrgU: Fix for Mantis #37176

### DIFF
--- a/Modules/OrgUnit/classes/Webservices/SOAP/Base.php
+++ b/Modules/OrgUnit/classes/Webservices/SOAP/Base.php
@@ -49,9 +49,11 @@ abstract class Base extends ilSoapAdministration implements ilSoapMethod
 
     public function __construct()
     {
-        $dic = \ilOrgUnitLocalDIC::dic();
-        $this->positionRepo =  $dic["repo.Positions"];
-        $this->assignmentRepo = $dic["repo.UserAssignments"];
+        if (! isset($_GET["wsdl"])) {
+            $dic = \ilOrgUnitLocalDIC::dic();
+            $this->positionRepo = $dic["repo.Positions"];
+            $this->assignmentRepo = $dic["repo.UserAssignments"];
+        }
 
         parent::__construct();
     }


### PR DESCRIPTION
Do not include local DIC when WSDL is requested, because ILIAS is not initialized and the global $DIC is not available.
(see https://mantis.ilias.de/view.php?id=37176)