### PR TITLE
Bug fix mantis report 37208

### DIFF
--- a/Services/AccessControl/classes/class.ilRoleXmlImporter.php
+++ b/Services/AccessControl/classes/class.ilRoleXmlImporter.php
@@ -151,7 +151,7 @@ class ilRoleXmlImporter
         foreach ($role->operations as $sxml_operations) {
             foreach ($sxml_operations as $sxml_op) {
                 $ops_group = (string) $sxml_op['group'];
-                $ops_id = (int) $operations[trim((string) $sxml_op)];
+                $ops_id = (int) ($operations[trim((string) $sxml_op)] ?? 0);
                 $ops = trim((string) $sxml_op);
 
                 if ($ops_group && $ops_id) {


### PR DESCRIPTION
Prevents error messages when unknown rbac_operations occur in the role operations array.