### PR TITLE
T&A 0037170 Processing the feedback of an Ordering Question (Vertical)  in the question pool leads to errors

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionFeedbackEditingGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionFeedbackEditingGUI.php
@@ -205,8 +205,9 @@ class ilAssQuestionFeedbackEditingGUI
 
         if ($form->checkInput()) {
             $this->feedbackOBJ->saveGenericFormProperties($form);
-            $this->feedbackOBJ->saveSpecificFormProperties($form);
-
+            if ($this->questionOBJ->hasSpecificFeedback()){
+                $this->feedbackOBJ->saveSpecificFormProperties($form);
+            }
             $this->questionOBJ->cleanupMediaObjectUsage();
             $this->questionOBJ->updateTimestamp();
 


### PR DESCRIPTION
Ticket:
https://mantis.ilias.de/view.php?id=37170 Bearbeiten der Rückmeldung einer Anordnungsfrage vertikal im Fragenpool führt zu Fehler

Problem:
Answer-specific feedback has been removed for: long menu, text, and ordered questions. Based on Mantis ticket: https://mantis.ilias.de/view.php?id=35726
However, the questions still attempted to save the now removed specific feedback.

Solution:
Verify that specific feedback is enabled for the current question type before saving.

As always, let me know how I can improve the suggested solution or if I missed something.