### PR TITLE
UI KS Feature: Standard Listing Panel gets ViewControls

### DIFF
--- a/src/UI/Component/Panel/Listing/Standard.php
+++ b/src/UI/Component/Panel/Listing/Standard.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Panel\Listing;
 

--- a/src/UI/Component/Panel/Listing/Standard.php
+++ b/src/UI/Component/Panel/Listing/Standard.php
@@ -20,10 +20,12 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Panel\Listing;
 
+use ILIAS\UI\Component\ViewControl\HasViewControls;
+
 /**
  * Interface Standard
  * @package ILIAS\UI\Component\Panel\Listing
  */
-interface Standard extends Listing
+interface Standard extends Listing, HasViewControls
 {
 }

--- a/src/UI/Implementation/Component/Panel/Listing/Listing.php
+++ b/src/UI/Implementation/Component/Panel/Listing/Listing.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Panel\Listing;
 

--- a/src/UI/Implementation/Component/Panel/Listing/Renderer.php
+++ b/src/UI/Implementation/Component/Panel/Listing/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Panel\Listing;
 

--- a/src/UI/Implementation/Component/Panel/Listing/Renderer.php
+++ b/src/UI/Implementation/Component/Panel/Listing/Renderer.php
@@ -24,6 +24,7 @@ use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
 use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Component\Item\Group;
+use ILIAS\UI\Implementation\Render\Template as Template;
 
 class Renderer extends AbstractComponentRenderer
 {
@@ -44,6 +45,8 @@ class Renderer extends AbstractComponentRenderer
     {
         $tpl = $this->getTemplate("tpl.listing_standard.html", true, true);
 
+        $tpl = $this->parseHeader($component, $default_renderer, $tpl);
+
         foreach ($component->getItemGroups() as $group) {
             if ($group instanceof Group) {
                 $tpl->setCurrentBlock("group");
@@ -52,16 +55,34 @@ class Renderer extends AbstractComponentRenderer
             }
         }
 
-        $title = $component->getTitle();
-        $tpl->setVariable("LIST_TITLE", $title);
-
-        // actions
-        $actions = $component->getActions();
-        if ($actions !== null) {
-            $tpl->setVariable("ACTIONS", $default_renderer->render($actions));
-        }
-
         return $tpl->get();
+    }
+
+    protected function parseHeader(
+        C\Panel\Listing\Standard $component,
+        RendererInterface $default_renderer,
+        Template $tpl
+    ): Template {
+        $title = $component->getTitle();
+        $actions = $component->getActions();
+        $view_controls = $component->getViewControls();
+
+        if ($title !== "" || $actions || $view_controls) {
+            $tpl->setVariable("TITLE", $title);
+            if ($actions) {
+                $tpl->setVariable("ACTIONS", $default_renderer->render($actions));
+            }
+            if ($view_controls) {
+                foreach ($view_controls as $view_control) {
+                    $tpl->setCurrentBlock("view_controls");
+                    $tpl->setVariable("VIEW_CONTROL", $default_renderer->render($view_control));
+                    $tpl->parseCurrentBlock();
+                }
+            }
+            $tpl->setCurrentBlock("heading");
+            $tpl->parseCurrentBlock();
+        }
+        return $tpl;
     }
 
     /**

--- a/src/UI/Implementation/Component/Panel/Listing/Standard.php
+++ b/src/UI/Implementation/Component/Panel/Listing/Standard.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Panel\Listing;
 

--- a/src/UI/Implementation/Component/Panel/Listing/Standard.php
+++ b/src/UI/Implementation/Component/Panel/Listing/Standard.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Panel\Listing;
 
 use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component\ViewControl\HasViewControls;
 
 /**
  * Class Panel
@@ -28,4 +29,5 @@ use ILIAS\UI\Component as C;
  */
 class Standard extends Listing implements C\Panel\Listing\Standard
 {
+    use HasViewControls;
 }

--- a/src/UI/Implementation/Component/Panel/Standard.php
+++ b/src/UI/Implementation/Component/Panel/Standard.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Panel;
 

--- a/src/UI/templates/default/Panel/tpl.listing_standard.html
+++ b/src/UI/templates/default/Panel/tpl.listing_standard.html
@@ -1,4 +1,16 @@
 <div class="panel il-panel-listing-std-container clearfix">
-<h2>{LIST_TITLE}</h2>{ACTIONS}
-<!-- BEGIN group -->{ITEM_GROUP}<!-- END group -->
+    <!-- BEGIN heading -->
+    <div class="panel-heading ilHeader">
+        <h2>{TITLE}</h2>
+        {ACTIONS}
+        <!-- BEGIN view_controls -->
+        {VIEW_CONTROL}
+        <!-- END view_controls -->
+    </div>
+    <!-- END heading -->
+    <div class="panel-body">
+        <!-- BEGIN group -->
+        {ITEM_GROUP}
+        <!-- END group -->
+    </div>
 </div>

--- a/tests/UI/Component/Panel/PanelListingTest.php
+++ b/tests/UI/Component/Panel/PanelListingTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 require_once(__DIR__ . "/../../../../libs/composer/vendor/autoload.php");
 require_once(__DIR__ . "/../../Base.php");
@@ -109,7 +109,9 @@ class PanelListingTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
 <div class="panel il-panel-listing-std-container clearfix">
-  <h2>title</h2>
+<div class="panel-heading ilHeader">
+<h2>title</h2></div>
+<div class="panel-body">
   <div class="il-item-group">
     <h3>Subtitle 1</h3>
     <div class="il-item-group-items">
@@ -140,6 +142,7 @@ class PanelListingTest extends ILIAS_UI_TestBase
     </div>
   </div>
 </div>
+</div>
 EOT;
         $this->assertHTMLEquals(
             $this->brutallyTrimHTML($expected),
@@ -166,11 +169,15 @@ EOT;
 
         $expected = <<<EOT
 <div class="panel il-panel-listing-std-container clearfix">
+<div class="panel-heading ilHeader">
 <h2>title</h2><div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="id_3" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu"> <span class="caret"></span></button>
 <ul id="id_3_menu" class="dropdown-menu">
 	<li><button class="btn btn-link" data-action="https://www.ilias.de" id="id_1">ILIAS</button></li>
 	<li><button class="btn btn-link" data-action="https://www.github.com" id="id_2">GitHub</button></li>
 </ul>
+</div>
+</div>
+<div class="panel-body">            
 </div>
 </div>
 EOT;


### PR DESCRIPTION
While implementing https://docu.ilias.de/goto_docu_wiki_wpage_7503_1357.html (PR https://github.com/ILIAS-eLearning/ILIAS/pull/5804) we discovered that Standard Listing Panels do not have the option to render ViewControls like Mode/Sortation and Pagination.
The Dashboard will however need these ViewControls in the Standard Listing Panel to move the options out of the Action Menu and render them to the Panels header section