### PR TITLE
T&A 0037197: hint created when entering invalid input for points

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionHintGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionHintGUI.php
@@ -98,7 +98,7 @@ class ilAssQuestionHintGUI extends ilAssQuestionHintAbstractGUI
         $lng = $DIC['lng'];
         $ilCtrl = $DIC['ilCtrl'];
 
-        if ($form instanceof ilPropertyFormGUI) {
+        if ($form instanceof ilPropertyFormGUI && !$this->request->isset('hint_id')) {
             $form->setValuesByPost();
         } elseif ($this->request->isset('hint_id') && (int) $this->request->raw('hint_id')) {
             $questionHint = new ilAssQuestionHint();
@@ -269,6 +269,9 @@ class ilAssQuestionHintGUI extends ilAssQuestionHintAbstractGUI
                 $areaInp->setValue($questionHint->getText());
             }
 
+            if ($this->request->isset('hint_points') && !is_numeric($this->request->raw('hint_points'))){
+                $numInp->setAlert($lng->txt('err_no_numeric_value'));
+            }
             $numInp->setValue($questionHint->getPoints());
 
             $hiddenInp->setValue($questionHint->getId());


### PR DESCRIPTION
Ticket:
https://mantis.ilias.de/view.php?id=37197 hint created when entering invalid input for points

Problem:
When saving an invalid value in the point deduction field for a question hint, the control flow switched from the form with a questionHint object to an empty form, used to create new hints.

Solution:
Small fix in the control flow when a questionHint object is set.
Added a alert for non-numeric values. However here I'm a bit unhappy, because I belive checkInput should ususally handle this?


As always, let me know how to improve a solution or if I missed something.