### PR TITLE
Forum: Default view is saved in a separate session key

### DIFF
--- a/Modules/Forum/classes/Request/ilForumRequestTrait.php
+++ b/Modules/Forum/classes/Request/ilForumRequestTrait.php
@@ -24,23 +24,18 @@ trait ilForumRequestTrait
 {
     private function retrieveIntOrZeroFrom(ArrayBasedRequestWrapper $wrapper, string $param): int
     {
-        $value = 0;
         if ($wrapper->has($param)) {
-            $value = $wrapper->retrieve(
+            return $wrapper->retrieve(
                 $param,
                 $this->refinery->byTrying([
                     $this->refinery->kindlyTo()->int(),
-                    $this->refinery->custom()->transformation(static function ($value): int {
-                        if ($value === '') {
-                            return 0;
-                        }
-
-                        return $value;
-                    })
+                    $this->refinery->custom()->transformation(
+                        static fn ($value): int => $value === '' ? 0 : $value
+                    )
                 ])
             );
         }
 
-        return $value;
+        return 0;
     }
 }

--- a/Modules/Forum/classes/class.ilForumSettingsGUI.php
+++ b/Modules/Forum/classes/class.ilForumSettingsGUI.php
@@ -323,8 +323,9 @@ class ilForumSettingsGUI implements ilForumObjectConstants
 
         // BUGFIX FOR 11271
 
-        if (ilSession::get('viewmode')) {
-            ilSession::set('viewmode', $default_view);
+        $view_mode = 'viewmode_' . $this->parent_obj->getObject()->getId();
+        if (ilSession::get($view_mode)) {
+            ilSession::set($view_mode, $default_view);
         }
 
         if ($this->settings->get('enable_anonymous_fora') || $this->parent_obj->objProperties->isAnonymized()) {

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -202,9 +202,9 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
         }
 
         if ($subtree_nodes !== [] && $this->objCurrentPost->getId() > 0) {
-            $isCurrentPostingInPage = array_filter($pagedPostings, function (ilForumPost $posting): bool {
-                return $posting->getId() === $this->objCurrentPost->getId();
-            });
+            $isCurrentPostingInPage = array_filter($pagedPostings, fn (ilForumPost $posting): bool => (
+                $posting->getId() === $this->objCurrentPost->getId()
+            ));
 
             if ([] === $isCurrentPostingInPage) {
                 $pageOfCurrentPosting = 0;
@@ -2885,13 +2885,14 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
     public function checkUsersViewMode(): void
     {
         $this->selectedSorting = $this->objProperties->getDefaultView();
+        $view_mode = 'viewmode_' . $this->getObject()->getId();
 
-        if (in_array((int) ilSession::get('viewmode'), [
+        if (in_array((int) ilSession::get($view_mode), [
             ilForumProperties::VIEW_TREE,
             ilForumProperties::VIEW_DATE_ASC,
             ilForumProperties::VIEW_DATE_DESC
         ], true)) {
-            $this->selectedSorting = ilSession::get('viewmode');
+            $this->selectedSorting = ilSession::get($view_mode);
         }
 
         if (
@@ -2909,7 +2910,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
             $this->selectedSorting = $this->objProperties->getDefaultView();
         }
 
-        ilSession::set('viewmode', $this->selectedSorting);
+        ilSession::set($view_mode, $this->selectedSorting);
     }
 
     public function resetLimitedViewObject(): void


### PR DESCRIPTION
Fix mantis bug: https://mantis.ilias.de/view.php?id=37201
The session key is prefix with the object id to distinguish between different forum objects. 