### PR TITLE
invalid return value for new memcache node

### DIFF
--- a/Services/GlobalCache/classes/class.ilMemcacheNodesRepository.php
+++ b/Services/GlobalCache/classes/class.ilMemcacheNodesRepository.php
@@ -54,7 +54,7 @@ class ilMemcacheNodesRepository implements NodeRepository
         int $weight
     ): Node {
         $node = new Node($host, $port, $weight);
-        if ($this->db === null) {
+        if ($this->db != null) {
             $next_id = $this->db->nextId(self::TABLE_NAME);
             $this->db->insert(self::TABLE_NAME, [
                 "id" => ["integer", $next_id],

--- a/Services/GlobalCache/classes/class.ilMemcacheNodesRepository.php
+++ b/Services/GlobalCache/classes/class.ilMemcacheNodesRepository.php
@@ -55,17 +55,17 @@ class ilMemcacheNodesRepository implements NodeRepository
     ): Node {
         $node = new Node($host, $port, $weight);
         if ($this->db === null) {
-            return $node;
+            $next_id = $this->db->nextId(self::TABLE_NAME);
+            $this->db->insert(self::TABLE_NAME, [
+                "id" => ["integer", $next_id],
+                "status" => ["integer", true],
+                "host" => ["text", $node->getHost()],
+                "port" => ["integer", $node->getPort()],
+                "weight" => ["integer", $node->getWeight()],
+                "flush_needed" => ["integer", false]
+            ]);
         }
-        $next_id = $this->db->nextId(self::TABLE_NAME);
-        $this->db->insert(self::TABLE_NAME, [
-            "id" => ["integer", $next_id],
-            "status" => ["integer", true],
-            "host" => ["text", $node->getHost()],
-            "port" => ["integer", $node->getPort()],
-            "weight" => ["integer", $node->getWeight()],
-            "flush_needed" => ["integer", false]
-        ]);
+        return $node;
     }
 
     public function getNodes(): array


### PR DESCRIPTION
Error thrown when installing a new ILIAS instance having a memcache node configured (respectively: updating with a new memcache node):

 [ERROR] ilMemcacheNodesRepository::create(): Return value must be of type ILIAS\Cache\Nodes\Node, none returned