### PR TITLE
(7x) Migration: adapt notification about remaining steps

### DIFF
--- a/src/Setup/Objective/MigrationObjective.php
+++ b/src/Setup/Objective/MigrationObjective.php
@@ -87,11 +87,9 @@ class MigrationObjective implements Setup\Objective
         $io->inform("Preparing Migration: done.");
 
         $steps = $this->steps;
-        if ($steps === Setup\Migration::INFINITE) {
-            $steps = $this->migration->getRemainingAmountOfSteps();
-        }
-        if ($this->migration->getRemainingAmountOfSteps() < $steps) {
-            $steps = $this->migration->getRemainingAmountOfSteps();
+        $remaining = $this->migration->getRemainingAmountOfSteps();
+        if ($steps === Setup\Migration::INFINITE || $remaining < $steps) {
+            $steps = $remaining;
         }
         $io->inform("Trigger {$steps} step(s) in {$this->getLabel()}");
         $step = 0;
@@ -104,7 +102,12 @@ class MigrationObjective implements Setup\Objective
         }
         $io->stopProgress();
         $remaining = $this->migration->getRemainingAmountOfSteps();
-        $io->inform("{$remaining} step(s) remaining. Run again to proceed.");
+        if ($remaining == 0) {
+            $io->inform("Migration '{$key}' has no remaining steps left.");
+        }
+        else {
+            $io->inform("{$remaining} step(s) remaining. Run again to proceed.");
+        }
 
         return $environment;
     }


### PR DESCRIPTION
The notification after a migration about the amount of remaining steps differentiates now between 0 or more remaining steps. 
The amount of calls of getRemainingAmountOfSteps() is reduced by two.