### PR TITLE
(trunk) Migration: adapt notification about remaining steps

### DIFF
--- a/src/Setup/Objective/MigrationObjective.php
+++ b/src/Setup/Objective/MigrationObjective.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\Setup\Objective;
 

--- a/src/Setup/Objective/MigrationObjective.php
+++ b/src/Setup/Objective/MigrationObjective.php
@@ -95,11 +95,9 @@ class MigrationObjective implements Setup\Objective
         $io->inform("Preparing Migration: done.");
 
         $steps = $this->steps;
-        if ($steps === Setup\Migration::INFINITE) {
-            $steps = $this->migration->getRemainingAmountOfSteps();
-        }
-        if ($this->migration->getRemainingAmountOfSteps() < $steps) {
-            $steps = $this->migration->getRemainingAmountOfSteps();
+        $remaining = $this->migration->getRemainingAmountOfSteps();
+        if ($steps === Setup\Migration::INFINITE || $remaining < $steps) {
+            $steps = $remaining;
         }
         $io->inform("Trigger {$steps} step(s) in {$this->getLabel()}");
         $step = 0;
@@ -111,9 +109,14 @@ class MigrationObjective implements Setup\Objective
             $step++;
         }
         $io->stopProgress();
-        $remaining = $this->migration->getRemainingAmountOfSteps() - $steps;
-        $io->inform("{$remaining} step(s) remaining. Run again to proceed.");
-
+        $remaining = $this->migration->getRemainingAmountOfSteps();
+        if ($remaining == 0) {
+            $io->inform("Migration '{$key}' has no remaining steps left.");
+        }
+        else {
+            $io->inform("{$remaining} step(s) remaining. Run again to proceed.");
+        }
+        
         return $environment;
     }
 


### PR DESCRIPTION
The notification after a migration about the amount of remaining steps differentiates now between 0 or more remaining steps.
The amount of calls of getRemainingAmountOfSteps() is reduced by two.

The calculation of the remaining steps after a migration is fixed according to this commit in branch release_7:
https://github.com/ILIAS-eLearning/ILIAS/commit/8342ff2dfae9b019b3377e8c71c213801c08d59b