### PR TITLE
Services/Repository: fix #36091

### DIFF
--- a/Services/Repository/PluginSlot/class.ilRepositoryObjectPlugin.php
+++ b/Services/Repository/PluginSlot/class.ilRepositoryObjectPlugin.php
@@ -24,14 +24,6 @@
 abstract class ilRepositoryObjectPlugin extends ilPlugin
 {
     protected ilLanguage $lng;
-    protected ilDBInterface $db;
-
-    public function __construct()
-    {
-        global $DIC;
-        $this->db = $DIC->database();
-        parent::__construct($this->db, $DIC["component.repository"], "xtst");
-    }
 
     /**
      * Only very little classes seem to care about this:


### PR DESCRIPTION
Hi @alex40724,

this fixes [#36901](https://mantis.ilias.de/view.php?id=36901). Plugins should always be created via the factory from `Services/Component`, which requires the exact interface `ilPlugin::__construct`. Also, this constructor doesn't do anything valuable anyway. `$this->db` is defined and initialized by `ilPlugin`.

Kind regards!