### PR TITLE
[FIX] CI: applied PSR-12 standard for union-types and bitwise operator `|`

### DIFF
--- a/CI/PHP-CS-Fixer/code-format.php_cs
+++ b/CI/PHP-CS-Fixer/code-format.php_cs
@@ -24,7 +24,7 @@ return (new PhpCsFixer\Config())
         'strict_param' => false,
         'concat_space' => ['spacing' => 'one'],
         'function_typehint_space' => true,
-        'binary_operator_spaces' => ['operators' => ['|' => 'single_space']],
-        'types_spaces' => ['space' => 'single'],
+        'binary_operator_spaces' => ['default' => 'single_space'],
+        // 'types_spaces' => ['space' => 'single'],
 	])
 	->setFinder($finder);

--- a/CI/PHP-CS-Fixer/code-format.php_cs
+++ b/CI/PHP-CS-Fixer/code-format.php_cs
@@ -23,6 +23,8 @@ return (new PhpCsFixer\Config())
         '@PSR12' => true,
         'strict_param' => false,
         'concat_space' => ['spacing' => 'one'],
-        'function_typehint_space' => true
+        'function_typehint_space' => true,
+        'binary_operator_spaces' => ['operators' => ['|' => 'single_space']],
+        'types_spaces' => ['space' => 'single'],
 	])
 	->setFinder($finder);

--- a/docs/development/code-style-configs/php-storm.xml
+++ b/docs/development/code-style-configs/php-storm.xml
@@ -1,4 +1,4 @@
-<code_scheme name="ILIAS 9 Coding Style 8/2022" version="175">
+<code_scheme name="ILIAS 9 Coding Style 5/2023" version="176">
   <option name="LINE_SEPARATOR" value="&#10;" />
   <PHPCodeStyleSettings>
     <option name="ALIGN_PHPDOC_PARAM_NAMES" value="true" />
@@ -13,7 +13,6 @@
     <option name="BLANK_LINES_AFTER_OPENING_TAG" value="1" />
     <option name="KEEP_BLANK_LINES_AFTER_LBRACE" value="0" />
     <option name="NEW_LINE_AFTER_PHP_OPENING_TAG" value="true" />
-    <option name="SPACES_AROUND_PIPE_IN_UNION_TYPE" value="true"/>
     <option name="ATTRIBUTES_WRAP" value="2" />
     <option name="PARAMETERS_ATTRIBUTES_WRAP" value="2" />
   </PHPCodeStyleSettings>
@@ -26,6 +25,7 @@
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
     <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+    <option name="SPACE_AROUND_BITWISE_OPERATORS" value="true" />
     <option name="SPACE_AFTER_TYPE_CAST" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />

--- a/docs/development/code-style-configs/php-storm.xml
+++ b/docs/development/code-style-configs/php-storm.xml
@@ -13,6 +13,7 @@
     <option name="BLANK_LINES_AFTER_OPENING_TAG" value="1" />
     <option name="KEEP_BLANK_LINES_AFTER_LBRACE" value="0" />
     <option name="NEW_LINE_AFTER_PHP_OPENING_TAG" value="true" />
+    <option name="SPACES_AROUND_PIPE_IN_UNION_TYPE" value="true"/>
     <option name="ATTRIBUTES_WRAP" value="2" />
     <option name="PARAMETERS_ATTRIBUTES_WRAP" value="2" />
   </PHPCodeStyleSettings>
@@ -25,7 +26,6 @@
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
     <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
-    <option name="SPACE_AROUND_BITWISE_OPERATORS" value="false" />
     <option name="SPACE_AFTER_TYPE_CAST" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />


### PR DESCRIPTION
Hi all,

I recently discovered a small deviation between our code-style to the PSR-12 standard.

According to PSR-12 code-style we must follow these rules:
- [operators](https://www.php-fig.org/psr/psr-12/#62-binary-operators): all bitwise operators incl. `|` must be surrounded by single spaces.
- [catch structure](https://www.php-fig.org/psr/psr-12/#56-try-catch-finally): the `|` must be surrounded by single spaces when expecting multiple exceptions.

**However**, I could not find anything about using the `|` operator for union types. According to the two rules above, I made the assumption that the operator must also be surrounded by single spaces in this scenario. IMO it's important that we define how union types should be handled, so we don't start mixing up `a | b` vs `a|b`. Concretely, this
```php
function f(float|int $x): float|int
{
    $y = true|false;

    try {
    } catch (LogicException|InvalidArgumentException $z) {
    }
}
```
becomes
```php
function f(float | int $x): float | int
{
    $y = true | false;

    try {
    } catch (LogicException | InvalidArgumentException $z) {
    }
}
```

The PR changes the configuration for PHPStorm and the PHP-CS-Fixer, so the surrounding spaces are now always expected. I believe this might be announced or even discussed at the JF.

Kind regards,
@thibsy 