### PR TITLE
PasswordAssistance: Remove `session_*` function calls

### DIFF
--- a/Services/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/Services/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -291,14 +291,7 @@ class ilPasswordAssistanceGUI
 
         require_once 'include/inc.pwassist_session_handler.php';
 
-        // Create a new session id
-        // #9700 - this didn't do anything before?!
-        // db_set_save_handler();
-        if (session_status() !== PHP_SESSION_ACTIVE) {
-            session_start();
-        }
         $pwassist_session['pwassist_id'] = db_pwassist_create_id();
-        session_destroy();
         db_pwassist_session_write(
             $pwassist_session['pwassist_id'],
             3600,


### PR DESCRIPTION
This PR removes the `session_*` function calls from the password assistance. These function calls are not required anymore.

**!!!Important!!!**: If #6030 is merged, this PR here can be closed