### PR TITLE
Session: avoid accessing unused db table event_files (31608)

### DIFF
--- a/Modules/Session/classes/class.ilObjSession.php
+++ b/Modules/Session/classes/class.ilObjSession.php
@@ -913,7 +913,12 @@ class ilObjSession extends ilObject
     public function initFiles()
     {
         include_once('./Modules/Session/classes/class.ilSessionFile.php');
-        $this->files = ilSessionFile::_readFilesByEvent($this->getEventId());
+        /**
+         * BT 31608: ilSessionFile is an unused remnant of a previous refactoring.
+         *  It will be removed in R9, and as a minimally invasive performance
+         *  fix disabled in R7 and R8.
+         */
+        //$this->files = ilSessionFile::_readFilesByEvent($this->getEventId());
     }
     
     


### PR DESCRIPTION
The database table `event_files` is an unused remnant of a previous refactoring. This PR makes a minimally invasive change to avoid accessing it (in lieu of introducing an additional index as suggested in [31608](https://mantis.ilias.de/view.php?id=31608)). I'll provide a separate PR for the trunk to remove the table and some other leftover stuff in `Session` altogether, so this PR should only be merged to R7 and R8.