### PR TITLE
Changed lang var used for column title for Contributors

### DIFF
--- a/Modules/Wiki/classes/class.ilWikiContributorsTableGUI.php
+++ b/Modules/Wiki/classes/class.ilWikiContributorsTableGUI.php
@@ -43,7 +43,7 @@ class ilWikiContributorsTableGUI extends ilTable2GUI
 
         $this->addColumn("", "", "1");
         //$this->addColumn("", "", "1");
-        $this->addColumn($lng->txt("wiki_contributor"), "", "33%");
+        $this->addColumn($lng->txt("wiki_contributors"), "", "33%");
         $this->addColumn($lng->txt("wiki_page_changes"), "", "33%");
         $this->addColumn($lng->txt("wiki_grading"), "", "33%");
         $this->setEnableHeader(true);


### PR DESCRIPTION
The working group for gendermainstreaming the German language file would like to replace the column title "Mitwirkende/r" in the related table for contributors of a wiki and to use only the plural version "Mitwirkende". Instead of changing the lang var, this PR substitutes the used lang var #wiki_contributor# by #wiki_contributors#. This avoids to have two lang vars with the same meening. #wiki_contributor# will removed by the language manager when this PR has been accepted.