### PR TITLE
T&A 0029121: Cloze question: Answer cannot be added in post-correction 

### DIFF
--- a/Modules/Test/classes/class.ilTestCorrectionsGUI.php
+++ b/Modules/Test/classes/class.ilTestCorrectionsGUI.php
@@ -314,6 +314,7 @@ class ilTestCorrectionsGUI
 
     protected function addAnswer()
     {
+        require_once("Modules/TestQuestionPool/classes/forms/class.ilAddAnswerFormBuilder.php");
         $form_builder = new ilAddAnswerFormBuilder($this, $this->ui->factory(), $this->refinery, $this->language, $this->ctrl);
 
         $form = $form_builder->buildAddAnswerForm()

--- a/Modules/TestQuestionPool/classes/class.assClozeTest.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeTest.php
@@ -2018,7 +2018,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         }
 
         foreach ($gap->getItems($this->randomGroup->dontShuffle()) as $item) {
-            if ($item->getAnswertext() == $answerOptionValue) {
+            if ($item->getAnswertext() === $answerOptionValue) {
                 return false;
             }
         }

--- a/Modules/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
@@ -163,6 +163,7 @@ class ilAnswerFrequencyStatisticTableGUI extends ilTable2GUI
 
     protected function buildAddAnswerAction($data): string
     {
+        require_once("Modules/TestQuestionPool/classes/forms/class.ilAddAnswerFormBuilder.php");
         $ui_factory = $this->ui->factory();
         $ui_renderer = $this->ui->renderer();
 


### PR DESCRIPTION
Ticket:
https://mantis.ilias.de/view.php?id=29121

Symptom:
Answers for a question of a clozed question test, couldn't be added to the pool of correct solutions.

Problem:
The decision process relied on loose comparison of the existing and new solution.
Loose comparison type juggles the strings to a numeric, and therefore they are seen as equals.

Solution:
Switch to strict comparison. 
Example:
'01' == '1' -> True 
'01' === '1' -> False

Note:
TextSubset questions already uses strict comparison in this code path


tested the solution on:
ILIAS 7 
ILIAS 8 needed additional class call fixing


As always, let me know where this solution needs further improvement.