### PR TITLE
WAC: Error if filename contains Umlaute/Sonderzeichen

### DIFF
--- a/Services/WebAccessChecker/classes/class.ilWACPath.php
+++ b/Services/WebAccessChecker/classes/class.ilWACPath.php
@@ -135,6 +135,9 @@ class ilWACPath
         $re = '/' . self::REGEX . '/';
         preg_match($re, $path, $result);
 
+        $url_parts = parse_url($path);
+        $result['path_without_query'] = $url_parts['path'];
+
         foreach ($result as $k => $v) {
             if (is_numeric($k)) {
                 unset($result[$k]);
@@ -557,8 +560,7 @@ class ilWACPath
      */
     public function getCleanURLdecodedPath()
     {
-        $path = explode("?", (string) $this->path); // removing everything behind ?
-        $path_to_file = rawurldecode($path[0]);
+        $path_to_file = rawurldecode($this->getPathWithoutQuery());
 
         return $path_to_file;
     }

--- a/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
+++ b/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
@@ -128,7 +128,7 @@ class ilWebAccessChecker
 
         // Check if Path is within accepted paths
         if ($this->getPathObject()->getModuleType() !== 'rs') {
-            $path = realpath($this->getPathObject()->getPathWithoutQuery());
+            $path = realpath($this->getPathObject()->getCleanURLdecodedPath());
             $data_dir = realpath(CLIENT_WEB_DIR);
             if (strpos($path, $data_dir) !== 0) {
                 return false;


### PR DESCRIPTION
Huhu,

ich mach das mal auf Deutsch weil der PR wohl ehh an dich @chfsx geht.

https://github.com/ILIAS-eLearning/ILIAS/commit/d6509a177d107aaa9e20d3fec55fe74c9593eb8b Mit diesem Commit müssen die Pathes die benutzt werden urldecoded sein. Sonst steht im Pfad die URL Encodeden % Werte und `realpath` gibt false zurück.

Ich bin mir jetzt nicht sicher ob die Stelle die ich ganz oben im Konstruktor gewählt habe die beste ist. Der Impact ist ja relativ groß, aber sollte innerhalb vom WAC nicht grundsätzlich mit normalen Dateipfaden gearbeitet werden? 

Alternativ funktionieren Umlaute (und Sonderzeichen) im Pfad auch wenn das `urldecode` direkt vor dem neuem `realpath` gemacht wird. Dann hätte es sicherlich weniger Impact woanders. 

Ich hab es in 7 gefixt aber betrifft dann bestimmt alle Versionen. 

Viele Grüße
