### PR TITLE
Setup: Fix Github installation workflow (#37261)

### DIFF
--- a/.github/workflows/install-check-trunk.yml
+++ b/.github/workflows/install-check-trunk.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           ref: trunk
 
+      - name: Copy config file to location outside webroot
+        run: |
+           cp CI/install-check/ilias-ci-config.json ../ilias-ci-config.json
+
       - name: Start MySQL Service
         run: |
            sudo /etc/init.d/mysql start
@@ -39,4 +43,4 @@ jobs:
 
       - name: Perform setup
         run: |
-           php setup/setup.php install -y CI/install-check/ilias-ci-config.json
+           php setup/setup.php install -y ../ilias-ci-config.json

--- a/CI/install-check/ilias-ci-config.json
+++ b/CI/install-check/ilias-ci-config.json
@@ -7,7 +7,7 @@
     "database" : {
         "user" : "root",
         "database" : "ilias",
-        "type" : "mysql",
+        "type" : "innodb",
         "create_database" : true,
         "password" : "root"
     },


### PR DESCRIPTION
The Github workflow for testing the installation failed, because the referenced config.json was located inside the webroot. This is now fixed by coyping the file to a location outside of webroot before performing the setup.

**Please note**: The workflow will still fail until the included fix to the config file (`CI/install-check/ilias-ci-config.json`) is merged into trunk, as the code is checked out from there during the workflow run.

_(PS: In my test runs, another (probably unrelated) error happened during installation which leads to the setup failing. If this just happens during the workflow run, we'll have to tackle it separately.)_