### PR TITLE
Setup: Revised Github installation Workflow for PHP 7.4/8.0

### DIFF
--- a/.github/workflows/install-check-release_8-7.4.yml
+++ b/.github/workflows/install-check-release_8-7.4.yml
@@ -1,11 +1,11 @@
-name: install-check-trunk
+name: install-check-release_8-7.4
 on:
   schedule:
     - cron: "0 12 * * *"
   workflow_dispatch:
 jobs:
   installation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       all: ${{ steps.changes.outputs.all }}
     strategy:
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: trunk
+          ref: release_8
 
       - name: Copy config file to location outside webroot
         run: |
@@ -34,12 +34,12 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, gd, json, readline, xsl
-          tools: composer:v1
+          extensions: dom, curl, libxml, mbstring, zip, gd, json, readline, xsl, xml, mysql
+          tools: composer:v2
           coverage: none
 
       - name: Install dependencies
-        run: composer install --no-interaction --no-progress
+        run: composer install --no-interaction --no-progress --no-dev
 
       - name: Perform setup
         run: |

--- a/.github/workflows/install-check-release_8-8.0.yml
+++ b/.github/workflows/install-check-release_8-8.0.yml
@@ -1,17 +1,17 @@
-name: install-check-release_7
+name: install-check-release_8-8.0
 on:
   schedule:
     - cron: "0 12 * * *"
   workflow_dispatch:
 jobs:
   installation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       all: ${{ steps.changes.outputs.all }}
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4]
+        php: [8.0]
     env:
       DB_DATABASE: ilias
       DB_USER: root
@@ -20,7 +20,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: release_7
+          ref: release_8
+
+      - name: Copy config file to location outside webroot
+        run: |
+           cp CI/install-check/ilias-ci-config.json ../ilias-ci-config.json
 
       - name: Start MySQL Service
         run: |
@@ -30,13 +34,13 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, gd, json, readline, xsl
-          tools: composer:v1
+          extensions: dom, curl, libxml, mbstring, zip, gd, json, readline, xsl, xml, mysql
+          tools: composer:v2
           coverage: none
 
       - name: Install dependencies
-        run: composer install --no-interaction --no-progress
+        run: composer install --no-interaction --no-progress --no-dev
 
       - name: Perform setup
         run: |
-           php setup/setup.php install -y CI/install-check/ilias-ci-config.json
+           php setup/setup.php install -y ../ilias-ci-config.json


### PR DESCRIPTION
Same as #5893 (minus the NPM), but for `release_8` and PHP versions 7.4 and 8.0.