### PR TITLE
[FIX] UI: fixed access before initialization error in Table\Presentation

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16743,6 +16743,7 @@ ui#:#ui_link_url#:#URL
 ui#:#ui_md_input_edit#:#Bearbeiten
 ui#:#ui_md_input_view#:#Vorschau
 ui#:#ui_numeric_only#:#Bitte geben sie eine ganze Zahl ein.
+ui#:#ui_table_no_records#:#Keine Einträge
 ui#:#ui_tag_required#:#Bitte geben sie mindestens ein Tag ein.
 ui#:#ui_transcription#:#Abschrift
 user#:#all_roles_has_starting_point#:#Alle Rollen mit definierter Startseite

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16740,6 +16740,7 @@ ui#:#ui_link_url#:#URL
 ui#:#ui_md_input_edit#:#Edit
 ui#:#ui_md_input_view#:#View
 ui#:#ui_numeric_only#:#Please insert a whole number.
+ui#:#ui_table_no_records#:#No records
 ui#:#ui_tag_required#:#Please insert at least one tag.
 ui#:#ui_transcription#:#Transcript
 user#:#all_roles_has_starting_point#:#All the roles have starting points

--- a/src/UI/Implementation/Component/Table/Presentation.php
+++ b/src/UI/Implementation/Component/Table/Presentation.php
@@ -39,7 +39,7 @@ class Presentation extends Table implements T\Presentation
      */
     private array $environment = [];
 
-    private array $records;
+    private array $records = [];
     protected Signal $signal_toggle_all;
 
     public function __construct(

--- a/src/UI/examples/Table/Data/without_data.php
+++ b/src/UI/examples/Table/Data/without_data.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Table\Data;
+
+use ILIAS\UI\Component\Table\DataRetrieval;
+use ILIAS\UI\Component\Table\DataRowBuilder;
+use ILIAS\Data\Range;
+use ILIAS\Data\Order;
+use Generator;
+
+/**
+ * Example showing a data table without any data and hence no entries, which
+ * will automatically display an according message.
+ */
+function without_data(): string
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $empty_retrieval = new class () implements DataRetrieval {
+        public function getRows(
+            DataRowBuilder $row_builder,
+            array $visible_column_ids,
+            Range $range,
+            Order $order,
+            ?array $filter_data,
+            ?array $additional_parameters
+        ): Generator {
+            yield from [];
+        }
+
+        public function getTotalRowCount(?array $filter_data, ?array $additional_parameters): ?int
+        {
+            return null;
+        }
+    };
+
+    $table = $factory->table()->data(
+        'Empty Data Table',
+        [
+            'col1' => $factory->table()->column()->text('Column 1'),
+            'col2' => $factory->table()->column()->number('Column 2'),
+        ],
+        $empty_retrieval
+    );
+
+    return $renderer->render($table);
+}

--- a/src/UI/examples/Table/Presentation/without_data.php
+++ b/src/UI/examples/Table/Presentation/without_data.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Table\Presentation;
+
+use ILIAS\UI\Component\Table\PresentationRow;
+use ILIAS\UI\Factory;
+
+/**
+ * Example showing a presentation table without any data and hence no entries, which
+ * will automatically display an according message.
+ */
+function without_data(): string
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $minimal_mapping = static fn(
+        PresentationRow $row,
+        mixed $record,
+        Factory $ui_factory,
+        mixed $environment
+    ): PresentationRow => $row;
+
+    $table = $factory->table()->presentation(
+        'Empty Presentation Table',
+        [$factory->viewControl()->mode(['All' => '#'], '')],
+        $minimal_mapping
+    );
+
+    // Note: this is an optional call, it should merely demonstrate that we have
+    // an empty table.
+    $table->withData([]);
+
+    return $renderer->render($table);
+}

--- a/src/UI/templates/default/Table/tpl.datacell.html
+++ b/src/UI/templates/default/Table/tpl.datacell.html
@@ -5,13 +5,13 @@
 <!-- END rowselection_cell -->
 
 <!-- BEGIN cell -->
-<td class="c-table-data__cell c-table-data__cell--{COL_TYPE} <!-- BEGIN highlighted --> c-table-data__cell--highlighted<!-- END highlighted -->" role="gridcell" aria-colindex="{COL_INDEX}" tabindex="-1">
+<td class="c-table-data__cell c-table-data__cell--{COL_TYPE} <!-- BEGIN highlighted --> c-table-data__cell--highlighted<!-- END highlighted -->" role="gridcell" aria-colindex="{COL_INDEX}" <!-- BEGIN with_col_span -->colspan="{COL_SPAN}"<!-- END with_col_span --> tabindex="-1">
 	<span class="c-table-data__cell__col-title">{CELL_COL_TITLE}: </span>{CELL_CONTENT}
 </td>
 <!-- END cell -->
 
 <!-- BEGIN rowaction_cell -->
 <td class="c-table-data__cell c-table-data__rowaction" role="gridcell" tabindex="-1">
-		{ACTION_CONTENT}
+	{ACTION_CONTENT}
 </td>
 <!-- END rowaction_cell -->

--- a/src/UI/templates/default/Table/tpl.presentationrow_empty.html
+++ b/src/UI/templates/default/Table/tpl.presentationrow_empty.html
@@ -1,0 +1,5 @@
+<div class="il-table-presentation-row row">
+    <div class="il-table-presentation-row-header">
+        {CONTENT}
+    </div>
+</div>

--- a/tests/UI/Component/Table/DataRendererTest.php
+++ b/tests/UI/Component/Table/DataRendererTest.php
@@ -389,4 +389,45 @@ EOT;
         $expected = $this->brutallyTrimHTML($expected);
         $this->assertEquals($expected, $actual);
     }
+
+    public function testRenderEmptyDataCell(): void
+    {
+        $data = new class () implements Component\Table\DataRetrieval {
+            public function getRows(
+                Component\Table\DataRowBuilder $row_builder,
+                array $visible_column_ids,
+                Data\Range $range,
+                Data\Order $order,
+                ?array $filter_data,
+                ?array $additional_parameters
+            ): Generator {
+                yield from [];
+            }
+
+            public function getTotalRowCount(?array $filter_data, ?array $additional_parameters): ?int
+            {
+                return null;
+            }
+        };
+
+        $columns = [
+            'f1' => $this->getUIFactory()->table()->column()->text('f1'),
+            'f2' => $this->getUIFactory()->table()->column()->text('f2'),
+            'f3' => $this->getUIFactory()->table()->column()->text('f3'),
+            'f4' => $this->getUIFactory()->table()->column()->text('f4'),
+            'f5' => $this->getUIFactory()->table()->column()->text('f5'),
+        ];
+
+        $table = $this->getUIFactory()->table()->data('', $columns, $data);
+
+        $html = $this->getDefaultRenderer()->render($table);
+
+        $translation = $this->getLanguage()->txt('ui_table_no_records');
+        $column_count = count($columns);
+
+        // check that the empty cell is stretched over all columns.
+        $this->assertTrue(str_contains($html, "colspan=\"$column_count\""));
+        // check that the cell contains the default message.
+        $this->assertTrue(str_contains($html, $translation));
+    }
 }

--- a/tests/UI/Component/Table/PresentationTest.php
+++ b/tests/UI/Component/Table/PresentationTest.php
@@ -61,31 +61,6 @@ class PresentationTest extends ILIAS_UI_TestBase
         $this->assertEquals(array('dk' => 'dv'), $pt->getData());
     }
 
-    public function testBareTableRendering(): void
-    {
-        $r = $this->getDefaultRenderer();
-        $f = $this->getFactory();
-        $pt = $f->presentation('title', [], function (): void {
-        });
-        $expected = <<<EXP
-        <div class="il-table-presentation" id="id_3">
-            <h3 class="ilHeader">title</h3>
-            <div class="il-table-presentation-viewcontrols">
-                <div class="btn-group">
-                    <button class="btn btn-default" id="id_1">presentation_table_expand</button>
-                    <button class="btn btn-default" id="id_2">presentation_table_collapse</button>
-                </div>
-            </div>
-            <div class="il-table-presentation-data"></div>
-        </div>
-EXP;
-
-        $this->assertHTMLEquals(
-            $this->brutallyTrimHTML($expected),
-            $this->brutallyTrimHTML($r->render($pt->withData([])))
-        );
-    }
-
     public function testRowConstruction(): void
     {
         $f = $this->getFactory();
@@ -308,5 +283,18 @@ EXP;
             $this->brutallyTrimHTML($expected),
             $this->brutallyTrimHTML($this->brutallyTrimSignals($actual))
         );
+    }
+
+    public function testRenderEmptyTableEntry(): void
+    {
+        $mapping = fn(PresentationRow $row, mixed $record, \ILIAS\UI\Factory $ui_factory, mixed $environment) => $row;
+
+        $table = $this->getFactory()->presentation('', [], $mapping);
+
+        $html = $this->getDefaultRenderer()->render($table);
+
+        $translation = $this->getLanguage()->txt('ui_table_no_records');
+
+        $this->assertTrue(str_contains($html, $translation));
     }
 }


### PR DESCRIPTION
Hi all,

I noticed that rendering a `Table\Presentation` component without calling `::withData()` on it throws an error because the `$records` property is accessed before initialization.

I've fixed this by initializing the value by default, so `::withData()` stays an optional method call, and supplied an according unit-test for this behaviour. This should be picked for release_8 as well if accepted.

Kind regards,
@thibsy 