### PR TITLE
Setup: Added Github installation Workflow for PHP 7.3/7.4

### DIFF
--- a/.github/workflows/install-check-release_7-7.3.yml
+++ b/.github/workflows/install-check-release_7-7.3.yml
@@ -1,0 +1,47 @@
+name: install-check-release_7-7.3
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+jobs:
+  installation:
+    runs-on: ubuntu-20.04
+    outputs:
+      all: ${{ steps.changes.outputs.all }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [7.3]
+    env:
+      DB_DATABASE: ilias
+      DB_USER: root
+      DB_PASSWORD: root
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: release_7
+
+      - name: Copy config file to location outside webroot
+        run: |
+          cp CI/install-check/ilias-ci-config.json ../ilias-ci-config.json
+
+      - name: Start MySQL Service and switch to legacy authentication for PHP7.3
+        run: |
+          sudo /etc/init.d/mysql start
+          mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';" -uroot -proot
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, gd, json, readline, xsl, xml, mysql
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --no-dev
+
+      - name: Perform setup
+        run: |
+          php setup/setup.php install -y ../ilias-ci-config.json

--- a/.github/workflows/install-check-release_7-7.4.yml
+++ b/.github/workflows/install-check-release_7-7.4.yml
@@ -1,0 +1,46 @@
+name: install-check-release_7-7.4
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+jobs:
+  installation:
+    runs-on: ubuntu-20.04
+    outputs:
+      all: ${{ steps.changes.outputs.all }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [7.4]
+    env:
+      DB_DATABASE: ilias
+      DB_USER: root
+      DB_PASSWORD: root
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: release_7
+
+      - name: Copy config file to location outside webroot
+        run: |
+          cp CI/install-check/ilias-ci-config.json ../ilias-ci-config.json
+
+      - name: Start MySQL Service
+        run: |
+          sudo /etc/init.d/mysql start
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, gd, json, readline, xsl, xml, mysql
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --no-dev
+
+      - name: Perform setup
+        run: |
+          php setup/setup.php install -y ../ilias-ci-config.json

--- a/CI/install-check/ilias-ci-config.json
+++ b/CI/install-check/ilias-ci-config.json
@@ -1,0 +1,55 @@
+{
+  "common" : {
+    "client_id" : "ilias",
+    "master_password" : "123456",
+    "server_timezone" : "gmt"
+  },
+  "database" : {
+    "user" : "root",
+    "database" : "ilias",
+    "type" : "innodb",
+    "create_database" : true,
+    "password" : "root"
+  },
+  "filesystem" : {
+    "data_dir" : "/home/runner/work/ILIAS/data/"
+  },
+  "systemfolder" : {
+    "client" : {
+      "name" : "ilias",
+      "description" : "ILIAS",
+      "institution" : "ILIAS e.V."
+    },
+    "contact" : {
+      "firstname" : "Laura",
+      "lastname" : "Herzog",
+      "email" : "laura.herzog@concepts-and-training.de"
+    }
+  },
+  "language" : {
+    "default_language" : "en"
+  },
+  "http" : {
+    "path" : "http://localhost"
+  },
+  "logging" : {
+    "enable" : true,
+    "path_to_logfile" : "/home/runner/work/ILIAS/ILIAS/logs/ilias.log",
+    "errorlog_dir" : "/home/runner/work/ILIAS/ILIAS/logs/"
+  },
+  "utilities" : {
+    "path_to_convert" : "/usr/bin/convert",
+    "path_to_zip" : "/usr/bin/zip",
+    "path_to_unzip" : "/usr/bin/unzip"
+  },
+  "virusscanner" : {
+    "virusscanner" : "none"
+  },
+  "webservices" : {
+    "soap_user_administration" : false,
+    "soap_wsdl_path" : "http://127.0.0.1/webservice/soap/server.php?wsdl",
+    "soap_connect_timeout" : 10,
+    "rpc_server_host" : "127.0.0.1",
+    "rpc_server_port" : "11111"
+  }
+}


### PR DESCRIPTION
This adds Github installation workflows for PHP 7.3 and 7.4 to `release_7` (see also #5893 and #5896 ).

_(Note: The combination of MySQL 8.0 and PHP 7.3 needed an additional tweak to change the authentication to mysql_native_password which is included in the workflow file.)_