### PR TITLE
UI, Mainbar: 37282, slate(cookie) still enganged after redirect

### DIFF
--- a/src/UI/templates/js/MainControls/dist/mainbar.js
+++ b/src/UI/templates/js/MainControls/dist/mainbar.js
@@ -271,8 +271,8 @@ var mainbar = function() {
         }
         mb.model.actions.initMoreButton(mb.renderer.calcAmountOfButtons());
         let state = mb.model.getState();
-        mb.persistence.storePageState(state.any_entry_engaged || state.tools_engaged);
         mb.renderer.render(state);
+        mb.persistence.store(state);
     },
     init_mobile = function() {
         var mb = il.UI.maincontrols.mainbar;
@@ -685,8 +685,7 @@ var persistence = function() {
 
     public_interface = {
         read: readStates,
-        store: storeStates,
-        storePageState : storePageState
+        store: storeStates
     };
 
     return public_interface;

--- a/src/UI/templates/js/MainControls/dist/mainbar.js
+++ b/src/UI/templates/js/MainControls/dist/mainbar.js
@@ -270,7 +270,9 @@ var mainbar = function() {
             }
         }
         mb.model.actions.initMoreButton(mb.renderer.calcAmountOfButtons());
-        mb.renderer.render(mb.model.getState());
+        let state = mb.model.getState();
+        mb.persistence.storePageState(state.any_entry_engaged || state.tools_engaged);
+        mb.renderer.render(state);
     },
     init_mobile = function() {
         var mb = il.UI.maincontrols.mainbar;
@@ -436,8 +438,8 @@ var model = function() {
             if(!state.entries[entry_id]) { //tools
                 return true;
             }
-            var hops = entry_id.split(':');
-                state.entries;
+            var hops = entry_id.split(':'),
+                entries = state.entries;
             while (hops.length > 1) {
                 entry_id = hops.join(':');
                 if(!state.entries[entry_id].engaged) {
@@ -683,7 +685,8 @@ var persistence = function() {
 
     public_interface = {
         read: readStates,
-        store: storeStates
+        store: storeStates,
+        storePageState : storePageState
     };
 
     return public_interface;
@@ -980,17 +983,12 @@ var renderer = function($) {
                 someting_to_focus_on = $('#' + dom_id.slate)
                     .children().first()
                     .children().first();
-            console.log("here we go.");
-
             someting_to_focus_on_if_listing = someting_to_focus_on.children().first().children().first();
             if(someting_to_focus_on[0]) {
                 if(!someting_to_focus_on.is(":focusable")) { //cannot focus w/o index
                     someting_to_focus_on.attr('tabindex', '-1');
-                    console.log("first entry no focusable");
                     if(someting_to_focus_on_if_listing[0]
                       && someting_to_focus_on_if_listing.is(":focusable")) { //cannot focus w/o index
-                        console.log("sub entry focusable");
-
                         someting_to_focus_on_if_listing[0].focus();
                     }
                 } else {

--- a/src/UI/templates/js/MainControls/src/mainbar.main.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.main.js
@@ -271,8 +271,8 @@ var mainbar = function() {
         }
         mb.model.actions.initMoreButton(mb.renderer.calcAmountOfButtons());
         let state = mb.model.getState();
-        mb.persistence.storePageState(state.any_entry_engaged || state.tools_engaged);
         mb.renderer.render(state);
+        mb.persistence.store(state);
     },
     init_mobile = function() {
         var mb = il.UI.maincontrols.mainbar;

--- a/src/UI/templates/js/MainControls/src/mainbar.main.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.main.js
@@ -270,7 +270,9 @@ var mainbar = function() {
             }
         }
         mb.model.actions.initMoreButton(mb.renderer.calcAmountOfButtons());
-        mb.renderer.render(mb.model.getState());
+        let state = mb.model.getState();
+        mb.persistence.storePageState(state.any_entry_engaged || state.tools_engaged);
+        mb.renderer.render(state);
     },
     init_mobile = function() {
         var mb = il.UI.maincontrols.mainbar;

--- a/src/UI/templates/js/MainControls/src/mainbar.persistence.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.persistence.js
@@ -113,8 +113,7 @@ var persistence = function() {
 
     public_interface = {
         read: readStates,
-        store: storeStates,
-        storePageState : storePageState
+        store: storeStates
     };
 
     return public_interface;

--- a/src/UI/templates/js/MainControls/src/mainbar.persistence.js
+++ b/src/UI/templates/js/MainControls/src/mainbar.persistence.js
@@ -113,7 +113,8 @@ var persistence = function() {
 
     public_interface = {
         read: readStates,
-        store: storeStates
+        store: storeStates,
+        storePageState : storePageState
     };
 
     return public_interface;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=37282

When a tool is active, the cookie il_mb_slates is set to "engaged"; this state is not lost (and shouldn't be) when redirecting.
However, the new page maybe has no more tools.

The entirely correct way woul be to first close slates and then redirect; this fix just re-writes the state after first calculation, which will result in the described behavior occuring _once_ only.