### PR TITLE
Test: Fix ErrorText Behaviour

### DIFF
--- a/Modules/Test/classes/class.ilTestSkillLevelThresholdImport.php
+++ b/Modules/Test/classes/class.ilTestSkillLevelThresholdImport.php
@@ -42,10 +42,7 @@ class ilTestSkillLevelThresholdImport
      */
     protected $orderIndex = null;
 
-    /**
-     * @var integer
-     */
-    protected $threshold = null;
+    protected ?int $threshold = null;
 
     /**
      * @var string
@@ -133,7 +130,7 @@ class ilTestSkillLevelThresholdImport
      */
     public function setThreshold($threshold)
     {
-        $this->threshold = $threshold;
+        $this->threshold = (int) $threshold;
     }
 
     /**

--- a/Modules/Test/classes/class.ilTestSkillLevelThresholdXmlParser.php
+++ b/Modules/Test/classes/class.ilTestSkillLevelThresholdXmlParser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -97,12 +98,12 @@ class ilTestSkillLevelThresholdXmlParser extends ilSaxParser
         $this->curSkillTrefId = $curSkillTrefId;
     }
 
-    public function getCurSkillLevelThreshold(): ?\ilTestSkillLevelThresholdImport
+    public function getCurSkillLevelThreshold(): ?ilTestSkillLevelThresholdImport
     {
         return $this->curSkillLevelThreshold;
     }
 
-    public function setCurSkillLevelThreshold(\ilTestSkillLevelThresholdImport $curSkillLevelThreshold): void
+    public function setCurSkillLevelThreshold(?ilTestSkillLevelThresholdImport $curSkillLevelThreshold): void
     {
         $this->curSkillLevelThreshold = $curSkillLevelThreshold;
     }

--- a/Modules/Test/classes/tables/class.ilTestQuestionsTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestQuestionsTableGUI.php
@@ -194,7 +194,7 @@ class ilTestQuestionsTableGUI extends ilTable2GUI
 
         if (!$a_set['complete']) {
             $warning_icon = $this->factory->symbol()->icon()->custom(
-                ilUtil::getImagePath("icon_alert.svg"),
+                ilUtil::getImagePath('icon_alert.svg'),
                 $this->lng->txt("warning_question_not_complete")
             );
             $this->tpl->setVariable("IMAGE_WARNING", $this->renderer->render($warning_icon));

--- a/Modules/TestQuestionPool/Setup/class.ilTestQuestionPool80DBUpdateSteps.php
+++ b/Modules/TestQuestionPool/Setup/class.ilTestQuestionPool80DBUpdateSteps.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,9 @@ declare(strict_types = 1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
+
 class ilTestQuestionPool80DBUpdateSteps implements ilDatabaseUpdateSteps
 {
     protected ilDBInterface $db;
@@ -88,6 +89,37 @@ class ilTestQuestionPool80DBUpdateSteps implements ilDatabaseUpdateSteps
                 'qpl_num_range',
                 $fields,
                 'i6'
+            );
+        }
+    }
+
+    public function step_6(): void
+    {
+        if (!$this->db->tableColumnExists('qpl_a_errortext', 'position')) {
+            $this->db->addTableColumn(
+                'qpl_a_errortext',
+                'position',
+                [
+                    'type' => ilDBConstants::T_INTEGER,
+                    'length' => 2,
+                    'notnull' => false,
+                    'default' => null
+                ]
+            );
+        }
+    }
+
+    public function step_7(): void
+    {
+        if (!$this->db->tableColumnExists('qpl_qst_errortext', 'parsed_errortext')) {
+            $this->db->addTableColumn(
+                'qpl_qst_errortext',
+                'parsed_errortext',
+                [
+                    'type' => ilDBConstants::T_CLOB,
+                    'notnull' => false,
+                    'default' => null
+                ]
             );
         }
     }

--- a/Modules/TestQuestionPool/classes/class.assAnswerErrorText.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerErrorText.php
@@ -28,9 +28,10 @@ require_once './Modules/Test/classes/inc.AssessmentConstants.php';
  */
 class assAnswerErrorText
 {
-    public string $text_wrong;
-    public string $text_correct;
-    public float  $points;
+    protected string $text_wrong;
+    protected string $text_correct;
+    protected float  $points;
+    protected ?int $position;
 
     /**
      * assAnswerErrorText constructor
@@ -38,10 +39,60 @@ class assAnswerErrorText
      * @param string $text_correct Correct text
      * @param double $points       Points
      */
-    public function __construct(string $text_wrong = "", string $text_correct = "", float $points = 0.0)
-    {
+    public function __construct(
+        string $text_wrong = "",
+        string $text_correct = "",
+        float $points = 0.0,
+        ?int $position = null
+    ) {
         $this->text_wrong = $text_wrong;
         $this->text_correct = $text_correct;
         $this->points = $points;
+        $this->position = $position;
+
+        $word_array = preg_split("/\s+/", $text_wrong);
+
+        if ($word_array) {
+            $this->length = count($word_array);
+        }
+    }
+
+    public function getTextWrong(): string
+    {
+        return $this->text_wrong;
+    }
+
+    public function getTextCorrect(): string
+    {
+        return $this->text_correct;
+    }
+
+    public function getPoints(): string
+    {
+        return $this->points;
+    }
+
+    public function withPoints(float $points): self
+    {
+        $clone = clone $this;
+        $clone->points = $points;
+        return $clone;
+    }
+
+    public function getPosition(): ?int
+    {
+        return $this->position;
+    }
+
+    public function withPosition(int $position): self
+    {
+        $clone = clone $this;
+        $clone->position = $position;
+        return $clone;
+    }
+
+    public function getLength(): int
+    {
+        return $this->length;
     }
 }

--- a/Modules/TestQuestionPool/classes/class.assErrorTextGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorTextGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -33,6 +34,7 @@ require_once './Modules/Test/classes/inc.AssessmentConstants.php';
  */
 class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjustable, ilGuiAnswerScoringAdjustable
 {
+    private const DEFAULT_POINTS_WRONG = -1;
     /**
      * assErrorTextGUI constructor
      *
@@ -71,32 +73,45 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
 
     public function writeAnswerSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $errordata = $this->request->raw('errordata');
-        if ($errordata != null && is_array($errordata['key'])) {
-            $this->object->flushErrorData();
-            foreach ($errordata['key'] as $idx => $val) {
-                $this->object->addErrorData(
-                    $val,
-                    $errordata['value'][$idx],
-                    (float) str_replace(',', '.', $errordata['points'][$idx])
-                );
-            }
+        $errordata = $this->restructurePostDataForSaving($this->request->raw('errordata') ?? []);
+        $this->object->setErrorData($errordata);
+        $this->object->removeErrorDataWithoutPosition();
+    }
+
+    private function restructurePostDataForSaving(array $post): array
+    {
+        $keys = $post['key'] ?? [];
+        $restructured_array = [];
+        foreach ($keys as $key => $text_wrong) {
+            $restructured_array[] = new assAnswerErrorText(
+                $text_wrong,
+                $post['value'][$key],
+                (float) str_replace(',', '.', $post['points'][$key])
+            );
         }
+        return $restructured_array;
     }
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $questiontext = $_POST["question"];
-        $this->object->setQuestion($questiontext);
-        $this->object->setErrorText($_POST["errortext"]);
-        $points_wrong = str_replace(",", ".", $_POST["points_wrong"] ?? "0");
-        if (strlen($points_wrong) == 0) {
-            $points_wrong = -1.0;
+        $this->object->setQuestion(
+            $this->request->raw('question')
+        );
+
+        $this->object->setErrorText(
+            $this->request->raw('errortext')
+        );
+
+        $this->object->parseErrorText();
+
+        $points_wrong = str_replace(",", ".", $this->request->raw('points_wrong') ?? '');
+        if (mb_strlen($points_wrong) == 0) {
+            $points_wrong = self::DEFAULT_POINTS_WRONG;
         }
-        $this->object->setPointsWrong($points_wrong);
+        $this->object->setPointsWrong((float) $points_wrong);
 
         if (!$this->object->getSelfAssessmentEditingMode()) {
-            $this->object->setTextSize($_POST["textsize"]);
+            $this->object->setTextSize($this->request->int('textsize'));
         }
     }
 
@@ -200,7 +215,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         if (!$this->object->getSelfAssessmentEditingMode()) {
             // textsize
             $textsize = new ilNumberInputGUI($this->lng->txt("textsize"), "textsize");
-            $textsize->setValue(strlen($this->object->getTextSize()) ? $this->object->getTextSize() : 100.0);
+            $textsize->setValue(mb_strlen($this->object->getTextSize()) ? $this->object->getTextSize() : 100.0);
             $textsize->setInfo($this->lng->txt("textsize_errortext_info"));
             $textsize->setSize(6);
             $textsize->setSuffix("%");
@@ -217,7 +232,8 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     public function analyze(): void
     {
         $this->writePostData(true);
-        $this->object->setErrorData($this->object->getErrorsFromText($_POST['errortext']));
+        $this->saveTaxonomyAssignments();
+        $this->object->setErrorsFromParsedErrorText();
         $this->editQuestion();
     }
 
@@ -239,7 +255,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     public function getSolutionOutput(
         $active_id,
         $pass = null,
-        $graphicalOutput = false,
+        $graphical_output = false,
         $result_output = false,
         $show_question_only = true,
         $show_feedback = false,
@@ -250,24 +266,18 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         // get the solution of the user for the active pass or from the last pass if allowed
         $template = new ilTemplate("tpl.il_as_qpl_errortext_output_solution.html", true, true, "Modules/TestQuestionPool");
 
-        $selections = array();
-        if (($active_id > 0) && (!$show_correct_solution)) {
 
-            /* Retrieve tst_solutions entries. */
+        $selections = [
+            'user' => $this->getUsersSolutionFromPreviewOrDatabase($active_id, $pass)
+        ];
+        $selections['best'] = $this->object->getBestSelection();
+
+        $reached_points = $this->object->getPoints();
+        if ($active_id > 0 && !$show_correct_solution) {
             $reached_points = $this->object->getReachedPoints($active_id, $pass);
-            $solutions = $this->object->getSolutionValues($active_id, $pass);
-            if (is_array($solutions)) {
-                foreach ($solutions as $solution) {
-                    array_push($selections, (int) $solution['value1']);
-                }
-                $errortext_value = join(",", $selections);
-            }
-        } else {
-            $selections = $this->object->getBestSelection();
-            $reached_points = $this->object->getPoints();
         }
 
-        if ($result_output) {
+        if ($result_output === true) {
             $resulttext = ($reached_points == 1) ? "(%s " . $this->lng->txt("point") . ")" : "(%s " . $this->lng->txt("points") . ")";
             $template->setVariable("RESULT_OUTPUT", sprintf($resulttext, $reached_points));
         }
@@ -276,7 +286,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
             $template->setVariable("STYLE", " style=\"font-size: " . $this->object->getTextSize() . "%;\"");
         }
 
-        if ($show_question_text == true) {
+        if ($show_question_text === true) {
             $template->setVariable("QUESTIONTEXT", $this->object->prepareTextareaOutput($this->object->getQuestion(), true));
         }
 
@@ -284,7 +294,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
             'correct' => $this->generateCorrectnessIconsForCorrectness(self::CORRECTNESS_OK),
             'not_correct' => $this->generateCorrectnessIconsForCorrectness(self::CORRECTNESS_NOT_OK)
         ];
-        $errortext = $this->object->createErrorTextOutput($selections, $graphicalOutput, $show_correct_solution, false, $correctness_icons);
+        $errortext = $this->object->assembleErrorTextOutput($selections, $graphical_output, $show_correct_solution, false, $correctness_icons);
 
         $template->setVariable("ERRORTEXT", $errortext);
         $questionoutput = $template->get();
@@ -295,13 +305,13 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         if ($show_feedback) {
             if (!$this->isTestPresentationContext()) {
                 $fb = $this->getGenericFeedbackOutput((int) $active_id, $pass);
-                $feedback .= strlen($fb) ? $fb : '';
+                $feedback .= mb_strlen($fb) ? $fb : '';
             }
 
             $fb = $this->getSpecificFeedbackOutput(array());
-            $feedback .= strlen($fb) ? $fb : '';
+            $feedback .= mb_strlen($fb) ? $fb : '';
         }
-        if (strlen($feedback)) {
+        if (mb_strlen($feedback)) {
             $cssClass = (
                 $this->hasCorrectSolution($active_id, $pass) ?
                 ilAssQuestionFeedback::CSS_CLASS_FEEDBACK_CORRECT : ilAssQuestionFeedback::CSS_CLASS_FEEDBACK_WRONG
@@ -323,126 +333,96 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
 
     public function getPreview($show_question_only = false, $showInlineFeedback = false): string
     {
-        $selections = is_object($this->getPreviewSession()) ? (array) $this->getPreviewSession()->getParticipantsSolution() : array();
+        $selections = [
+            'user' => $this->getUsersSolutionFromPreviewOrDatabase()
+         ];
 
-        $template = new ilTemplate("tpl.il_as_qpl_errortext_output.html", true, true, "Modules/TestQuestionPool");
-        if ($this->object->getTextSize() >= 10) {
-            $template->setVariable("STYLE", " style=\"font-size: " . $this->object->getTextSize() . "%;\"");
-        }
-        $template->setVariable("QUESTIONTEXT", $this->object->prepareTextareaOutput($this->object->getQuestion(), true));
-        $errortext = $this->object->createErrorTextOutput($selections);
-        $template->setVariable("ERRORTEXT", $errortext);
-        $template->setVariable("ERRORTEXT_ID", "qst_" . $this->object->getId());
-        $questionoutput = $template->get();
-        if (!$show_question_only) {
-            // get page object output
-            $questionoutput = $this->getILIASPage($questionoutput);
-        }
-        $this->tpl->addJavascript("./Modules/TestQuestionPool/templates/default/errortext.js");
-        return $questionoutput;
+        return $this->generateQuestionOutput($selections, $show_question_only);
     }
 
     public function getTestOutput(
         $active_id,
-                // hey: prevPassSolutions - will be always available from now on
-                $pass,
-                // hey.
-                $is_postponed = false,
+        $pass,
+        $is_postponed = false,
         $use_post_solutions = false,
         $show_feedback = false
     ): string {
-        // generate the question output
+        $selections = [
+            'user' => $this->getUsersSolutionFromPreviewOrDatabase($active_id, $pass)
+         ];
+
+        return $this->outQuestionPage(
+            '',
+            $is_postponed,
+            $active_id,
+            $this->generateQuestionOutput($selections, false)
+        );
+    }
+
+    private function generateQuestionOutput($selections, $show_question_only): string
+    {
         $template = new ilTemplate("tpl.il_as_qpl_errortext_output.html", true, true, "Modules/TestQuestionPool");
-        if ($active_id) {
-            $solutions = $this->object->getTestOutputSolutions($active_id, $pass);
-            // hey.
-        }
-        $errortext_value = "";
-        $selections = array();
-        if (is_array($solutions)) {
-            foreach ($solutions as $solution) {
-                array_push($selections, $solution['value1']);
-            }
-            $errortext_value = join(",", $selections);
-        }
+
         if ($this->object->getTextSize() >= 10) {
             $template->setVariable("STYLE", " style=\"font-size: " . $this->object->getTextSize() . "%;\"");
         }
         $template->setVariable("QUESTIONTEXT", $this->object->prepareTextareaOutput($this->object->getQuestion(), true));
-        $errortext = $this->object->createErrorTextOutput($selections);
-        $this->ctrl->setParameterByClass($this->getTargetGuiClass(), 'errorvalue', '');
+        $errortext = $this->object->assembleErrorTextOutput($selections);
+        if ($this->getTargetGuiClass() !== null) {
+            $this->ctrl->setParameterByClass($this->getTargetGuiClass(), 'errorvalue', '');
+        }
         $template->setVariable("ERRORTEXT", $errortext);
         $template->setVariable("ERRORTEXT_ID", "qst_" . $this->object->getId());
-        $template->setVariable("ERRORTEXT_VALUE", $errortext_value);
+        $template->setVariable("ERRORTEXT_VALUE", join(',', $selections['user']));
 
+        $this->tpl->addOnLoadCode('il.test.player.errortext.init()');
+        $this->tpl->addJavascript('./Modules/TestQuestionPool/templates/default/errortext.js');
         $questionoutput = $template->get();
-        //if (!$show_question_only) {
-        // get page object output
-        $questionoutput = $this->getILIASPage($questionoutput);
-        //}
-        $this->tpl->addJavascript("./Modules/TestQuestionPool/templates/default/errortext.js");
-        $questionoutput = $template->get();
-        $pageoutput = $this->outQuestionPage("", $is_postponed, $active_id, $questionoutput);
-        return $pageoutput;
+
+        if ($show_question_only) {
+            return $questionoutput;
+        }
+
+        return $this->getILIASPage($questionoutput);
     }
 
-    public function getSpecificFeedbackOutput(array $userSolution): string
+    private function getUsersSolutionFromPreviewOrDatabase(int $active_id = 0, ?int $pass = null): array
     {
-        $selection = $this->object->getBestSelection(false);
+        if (is_object($this->getPreviewSession())) {
+            return (array) $this->getPreviewSession()->getParticipantsSolution();
+        }
 
+        if ($active_id > 0) {
+            $selections = [];
+            $solutions = $this->object->getTestOutputSolutions($active_id, $pass ?? 0);
+            foreach ($solutions as $solution) {
+                $selections[] = $solution['value1'];
+            }
+            return $selections;
+        }
+
+        return [];
+    }
+
+    public function getSpecificFeedbackOutput(array $user_solution): string
+    {
         if (!$this->object->feedbackOBJ->specificAnswerFeedbackExists()) {
             return '';
         }
 
         $feedback = '<table class="test_specific_feedback"><tbody>';
-
-        $elements = array();
-        foreach (preg_split("/[\n\r]+/", $this->object->getErrorText()) as $line) {
-            $elements = array_merge($elements, preg_split("/\s+/", $line));
-        }
-
-        $matchedIndexes = array();
-
-        $i = 0;
-        foreach ($selection as $index => $answer) {
-            $element = array();
-            foreach ($answer as $answerPartIndex) {
-                $element[] = $elements[$answerPartIndex];
-            }
-
-            $element = implode(' ', $element);
-            $element = str_replace(array('((', '))', '#'), array('', '', ''), $element);
-
-            $ordinal = $index + 1;
-
+        $elements = $this->object->getErrorData();
+        foreach ($elements as $index => $element) {
             $feedback .= '<tr>';
-
-            $feedback .= '<td class="text-nowrap">' . $ordinal . '. ' . $element . ':</td>';
-
-            foreach ($this->object->getErrorData() as $idx => $ans) {
-                /** @var assAnswerErrorText $ans */
-                if (isset($matchedIndexes[$idx])) {
-                    continue;
-                }
-
-                if (preg_match('/' . preg_quote($ans->text_wrong, '/') . '/', $element)) {
-                    $fb = $this->object->feedbackOBJ->getSpecificAnswerFeedbackTestPresentation(
-                        $this->object->getId(),
-                        0,
-                        $idx
-                    );
-
-                    $feedback .= '<td>' . $fb . '</td>';
-
-                    $matchedIndexes[$idx] = $idx;
-
-                    break;
-                }
-            }
+            $feedback .= '<td class="text-nowrap">' . $index . '. ' . $element->getTextWrong() . ':</td>';
+            $feedback .= '<td>' . $this->object->feedbackOBJ->getSpecificAnswerFeedbackTestPresentation(
+                $this->object->getId(),
+                0,
+                $index
+            ) . '</td>';
 
             $feedback .= '</tr>';
         }
-
         $feedback .= '</tbody></table>';
 
         return $this->object->prepareTextareaOutput($feedback, true);
@@ -459,7 +439,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
      */
     public function getAfterParticipationSuppressionAnswerPostVars(): array
     {
-        return array();
+        return [];
     }
 
     /**
@@ -473,7 +453,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
      */
     public function getAfterParticipationSuppressionQuestionPostVars(): array
     {
-        return array();
+        return [];
     }
 
     /**
@@ -486,7 +466,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     {
         $errortext = $this->object->getErrorText();
 
-        $passdata = array(); // Regroup answers into units of passes.
+        $passdata = []; // Regroup answers into units of passes.
         foreach ($relevant_answers as $answer_chosen) {
             $passdata[$answer_chosen['active_fi'] . '-' . $answer_chosen['pass']][$answer_chosen['value2']][] = $answer_chosen['value1'];
         }
@@ -500,37 +480,33 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         return $html;
     }
 
-    public function getAnswersFrequency($relevantAnswers, $questionIndex): array
+    public function getAnswersFrequency($relevant_answers, $question_index): array
     {
-        $answersByActiveAndPass = array();
+        $answers_by_active_and_pass = [];
 
-        foreach ($relevantAnswers as $row) {
+        foreach ($relevant_answers as $row) {
             $key = $row['active_fi'] . ':' . $row['pass'];
 
-            if (!isset($answersByActiveAndPass[$key])) {
-                $answersByActiveAndPass[$key] = array();
+            if (!isset($answers_by_active_and_pass[$key])) {
+                $answers_by_active_and_pass[$key] = ['user' => []];
             }
 
-            if (!isset($answersByActiveAndPass[$key][$row['value2']])) {
-                $answersByActiveAndPass[$key][$row['value2']] = array();
-            }
-
-            $answersByActiveAndPass[$key][$row['value2']][] = $row['value1'];
+            $answers_by_active_and_pass[$key]['user'][] = $row['value1'];
         }
 
-        $answers = array();
+        $answers = [];
 
-        foreach ($answersByActiveAndPass as $ans) {
-            $errorText = $this->object->createErrorTextOutput($ans);
-            $errorMd5 = md5($errorText);
+        foreach ($answers_by_active_and_pass as $answer) {
+            $error_text = $this->object->assembleErrorTextOutput($answer);
+            $error_text_hashed = md5($error_text);
 
-            if (!isset($answers[$errorMd5])) {
-                $answers[$errorMd5] = array(
-                    'answer' => $errorText, 'frequency' => 0
-                );
+            if (!isset($answers[$error_text_hashed])) {
+                $answers[$error_text_hashed] = [
+                    'answer' => $error_text, 'frequency' => 0
+                ];
             }
 
-            $answers[$errorMd5]['frequency']++;
+            $answers[$error_text_hashed]['frequency']++;
         }
 
         return array_values($answers);
@@ -540,19 +516,19 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     {
         // error terms
         include_once "./Modules/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php";
-        $errordata = new ilAssErrorTextCorrectionsInputGUI($this->lng->txt("errors"), "errordata");
+        $errordata = new ilAssErrorTextCorrectionsInputGUI($this->lng->txt('errors'), 'errordata');
         $errordata->setKeyName($this->lng->txt('text_wrong'));
         $errordata->setValueName($this->lng->txt('text_correct'));
         $errordata->setValues($this->object->getErrorData());
         $form->addItem($errordata);
 
         // points for wrong selection
-        $points_wrong = new ilNumberInputGUI($this->lng->txt("points_wrong"), "points_wrong");
+        $points_wrong = new ilNumberInputGUI($this->lng->txt('points_wrong'), 'points_wrong');
         $points_wrong->allowDecimals(true);
         $points_wrong->setMaxValue(0);
         $points_wrong->setMaxvalueShouldBeLess(true);
         $points_wrong->setValue($this->object->getPointsWrong());
-        $points_wrong->setInfo($this->lng->txt("points_wrong_info"));
+        $points_wrong->setInfo($this->lng->txt('points_wrong_info'));
         $points_wrong->setSize(6);
         $points_wrong->setRequired(true);
         $form->addItem($points_wrong);
@@ -563,15 +539,16 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
      */
     public function saveCorrectionsFormProperties(ilPropertyFormGUI $form): void
     {
+        $existing_errordata = $this->object->getErrorData();
         $this->object->flushErrorData();
-        foreach ($form->getItemByPostVar('errordata')->getValues() as $idx => $errAnswer) {
-            $this->object->addErrorData(
-                $errAnswer->text_wrong,
-                $errAnswer->text_correct,
-                $errAnswer->points
+        $new_errordata = $this->request->raw('errordata');
+        $errordata = [];
+        foreach ($new_errordata['points'] as $index => $points) {
+            $errordata[$index] = $existing_errordata[$index]->withPoints(
+                (float) str_replace(',', '.', $points)
             );
         }
-
+        $this->object->setErrorData($errordata);
         $this->object->setPointsWrong((float) str_replace(',', '.', $form->getInput('points_wrong')));
     }
 }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentList.php
@@ -287,12 +287,12 @@ class ilAssQuestionSkillAssignmentList
 
     public function getNumAssignsBySkill($skillBaseId, $skillTrefId)
     {
-        return $this->numAssignsBySkill[$this->buildSkillKey($skillBaseId, $skillTrefId)];
+        return $this->numAssignsBySkill[$this->buildSkillKey($skillBaseId, $skillTrefId)] ?? null;
     }
 
     public function getMaxPointsBySkill($skillBaseId, $skillTrefId)
     {
-        return $this->maxPointsBySkill[$this->buildSkillKey($skillBaseId, $skillTrefId)];
+        return $this->maxPointsBySkill[$this->buildSkillKey($skillBaseId, $skillTrefId)] ?? null;
     }
 
     public function hasSkillsAssignedLowerThanBarrier(): bool

--- a/Modules/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -28,7 +29,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     protected $key_size = 20;
     protected $value_size = 20;
     protected $key_maxlength = 255;
-    protected $value_maxlength = 255;
+    protected $value_maxlength = 150;
     protected $key_name = "";
     protected $value_name = "";
 
@@ -212,7 +213,6 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
         }
         $max_points = 0;
 
-
         if (is_array($foundvalues) && count($foundvalues) > 0) {
             // check answers
             if (is_array($foundvalues['key']) && is_array($foundvalues['value'])) {
@@ -270,22 +270,22 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
         $i = 0;
         foreach ($this->values as $value) {
             if (is_object($value)) {
-                if (strlen($value->text_wrong)) {
+                if (strlen($value->getTextWrong())) {
                     $tpl->setCurrentBlock("prop_key_propval");
-                    $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput($value->text_wrong));
+                    $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput($value->getTextWrong()));
                     $tpl->parseCurrentBlock();
                 }
-                if (strlen($value->text_correct)) {
+                if (strlen($value->getTextCorrect())) {
                     $tpl->setCurrentBlock("prop_value_propval");
                     $tpl->setVariable(
                         "PROPERTY_VALUE",
-                        ilLegacyFormElementsUtil::prepareFormOutput($value->text_correct)
+                        ilLegacyFormElementsUtil::prepareFormOutput($value->getTextCorrect())
                     );
                     $tpl->parseCurrentBlock();
                 }
-                if (strlen($value->points)) {
+                if (strlen($value->getPoints())) {
                     $tpl->setCurrentBlock("prop_points_propval");
-                    $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput($value->points));
+                    $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput($value->getPoints()));
                     $tpl->parseCurrentBlock();
                 }
             }

--- a/Modules/TestQuestionPool/classes/export/qti12/class.assErrorTextExport.php
+++ b/Modules/TestQuestionPool/classes/export/qti12/class.assErrorTextExport.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -76,14 +77,26 @@ class assErrorTextExport extends assQuestionExport
         $a_xml_writer->xmlElement("fieldentry", null, $this->object->getErrorText());
         $a_xml_writer->xmlEndTag("qtimetadatafield");
         $a_xml_writer->xmlStartTag("qtimetadatafield");
+        $a_xml_writer->xmlElement("fieldlabel", null, "parsederrortext");
+        $a_xml_writer->xmlElement("fieldentry", null, serialize($this->object->getParsedErrorText()));
+        $a_xml_writer->xmlEndTag("qtimetadatafield");
+        $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "textsize");
         $a_xml_writer->xmlElement("fieldentry", null, $this->object->getTextSize());
         $a_xml_writer->xmlEndTag("qtimetadatafield");
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "errordata");
-        $serialized = array();
+        $serialized = [];
         foreach ($this->object->getErrorData() as $data) {
-            array_push($serialized, array($data->text_correct, $data->text_wrong, $data->points));
+            array_push(
+                $serialized,
+                [
+                    $data->getTextCorrect(),
+                    $data->getTextWrong(),
+                    $data->getPoints(),
+                    $data->getPosition()
+                ]
+            );
         }
         $a_xml_writer->xmlElement("fieldentry", null, serialize($serialized));
         $a_xml_writer->xmlEndTag("qtimetadatafield");

--- a/Modules/TestQuestionPool/classes/feedback/class.ilAssErrorTextFeedback.php
+++ b/Modules/TestQuestionPool/classes/feedback/class.ilAssErrorTextFeedback.php
@@ -27,9 +27,6 @@
 class ilAssErrorTextFeedback extends ilAssMultiOptionQuestionFeedback
 {
     /**
-     * returns the answer options mapped by answer index
-     * (overwrites parent method from ilAssMultiOptionQuestionFeedback)
-     *
      * @return string[] $answerOptionsByAnswerIndex
      */
     public function getAnswerOptionsByAnswerIndex(): array
@@ -38,16 +35,13 @@ class ilAssErrorTextFeedback extends ilAssMultiOptionQuestionFeedback
     }
 
     /**
-     * builds an answer option label from given (mixed type) index and answer
-     * (overwrites parent method from ilAssMultiOptionQuestionFeedback)
-     * @param integer $index
-     * @param mixed $answer
+     * @param assAnswerErrorText $answer
      */
     protected function buildAnswerOptionLabel(int $index, $answer): string
     {
         $caption = $ordinal = $index + 1;
-        $caption .= '. <br />"' . $answer->text_wrong . '" =&gt; ';
-        $caption .= '"' . $answer->text_correct . '"';
+        $caption .= '. <br />"' . $answer->getTextWrong() . '" =&gt; ';
+        $caption .= '"' . $answer->getTextCorrect() . '"';
         $caption .= '</i>';
 
         return $caption;

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php
@@ -32,7 +32,7 @@ class ilAssErrorTextCorrectionsInputGUI extends ilErrorTextWizardInputGUI
             include_once "./Modules/TestQuestionPool/classes/class.assAnswerErrorText.php";
             if (is_array($a_value['points'])) {
                 foreach ($this->values as $idx => $key) {
-                    $this->values[$idx]->points = (
+                    $this->values[$idx] = $this->values[$idx]->withPoints(
                         str_replace(",", ".", $a_value['points'][$idx])
                     );
                 }
@@ -42,39 +42,25 @@ class ilAssErrorTextCorrectionsInputGUI extends ilErrorTextWizardInputGUI
 
     public function checkInput(): bool
     {
-        global $DIC;
-        $lng = $DIC['lng'];
-
-        if (is_array($_POST[$this->getPostVar()])) {
-            $_POST[$this->getPostVar()] = ilArrayUtil::stripSlashesRecursive($_POST[$this->getPostVar()]);
-        }
         $foundvalues = $_POST[$this->getPostVar()];
 
-        if (is_array($foundvalues)) {
-            if (is_array($foundvalues['points'])) {
-                foreach ($foundvalues['points'] as $val) {
-                    if ($this->getRequired() && (strlen($val)) == 0) {
-                        $this->setAlert($lng->txt("msg_input_is_required"));
-                        return false;
-                    }
-                    if (!is_numeric(str_replace(",", ".", $val))) {
-                        $this->setAlert($lng->txt("form_msg_numeric_value_required"));
-                        return false;
-                    }
-                    if ((float) $val <= 0) {
-                        $this->setAlert($lng->txt("positive_numbers_required"));
-                        return false;
-                    }
-                }
-            } else {
-                if ($this->getRequired()) {
-                    $this->setAlert($lng->txt("msg_input_is_required"));
-                    return false;
-                }
+        if (!isset($foundvalues['points'])
+            || !is_array($foundvalues['points'])) {
+            $this->setAlert($this->lng->txt("msg_input_is_required"));
+            return false;
+        }
+
+        foreach ($foundvalues['points'] as $val) {
+            if ($this->getRequired() && (strlen($val)) == 0) {
+                $this->setAlert($this->lng->txt("msg_input_is_required"));
+                return false;
             }
-        } else {
-            if ($this->getRequired()) {
-                $this->setAlert($lng->txt("msg_input_is_required"));
+            if (!is_numeric(str_replace(",", ".", $val))) {
+                $this->setAlert($this->lng->txt("form_msg_numeric_value_required"));
+                return false;
+            }
+            if ((float) $val <= 0) {
+                $this->setAlert($this->lng->txt("positive_numbers_required"));
                 return false;
             }
         }
@@ -91,13 +77,13 @@ class ilAssErrorTextCorrectionsInputGUI extends ilErrorTextWizardInputGUI
         $i = 0;
         foreach ($this->values as $value) {
             $tpl->setCurrentBlock("prop_points_propval");
-            $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput($value->points));
+            $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput($value->getPoints()));
             $tpl->parseCurrentBlock();
 
             $tpl->setCurrentBlock("row");
 
-            $tpl->setVariable("TEXT_WRONG", ilLegacyFormElementsUtil::prepareFormOutput($value->text_wrong));
-            $tpl->setVariable("TEXT_CORRECT", ilLegacyFormElementsUtil::prepareFormOutput($value->text_correct));
+            $tpl->setVariable("TEXT_WRONG", ilLegacyFormElementsUtil::prepareFormOutput($value->getTextWrong()));
+            $tpl->setVariable("TEXT_CORRECT", ilLegacyFormElementsUtil::prepareFormOutput($value->getTextCorrect()));
 
             $class = ($i % 2 == 0) ? "even" : "odd";
             if ($i == 0) {

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php
@@ -62,12 +62,18 @@ class assErrorTextImport extends assQuestionImport
         $this->object->setObjId($questionpool_id);
         $this->object->setPointsWrong($item->getMetadataEntry("points_wrong"));
         $this->object->setErrorText($item->getMetadataEntry("errortext"));
+        $parsed_error_text = $item->getMetadataEntry("parsederrortext");
+        if ($parsed_error_text !== null) {
+            $this->object->setParsedErrorText(unserialize($parsed_error_text));
+        }
         $this->object->setTextSize($item->getMetadataEntry("textsize"));
         $errordata = unserialize($item->getMetadataEntry("errordata"), ["allowed_classes" => false]);
         if (is_array($errordata)) {
+            $errordata_answers_array = [];
             foreach ($errordata as $data) {
-                $this->object->addErrorData($data[1], $data[0] ?? '', $data[2]);
+                $errordata_answers_array[] = new assAnswerErrorText($data[1], $data[0] ?? '', $data[2], $data[3] ?? null);
             }
+            $this->object->setErrorData($errordata_answers_array);
         }
         // additional content editing mode information
         $this->object->setAdditionalContentEditingMode(

--- a/Modules/TestQuestionPool/templates/default/errortext.js
+++ b/Modules/TestQuestionPool/templates/default/errortext.js
@@ -1,29 +1,44 @@
-$().ready(function() {
-	$('div.errortext a').on('click', function(e) {
-		var $elm = $(this);
+(function () {
+    let errortext = () => {
+        let init = () => {
+            let errortext = document.querySelectorAll('div.errortext a');
+            errortext.forEach((elem) => {
+                elem.addEventListener('click', click_function);
+            });
+        };
 
-		if($elm.hasClass('ilc_qetitem_ErrorTextItem'))
-		{
-            $elm.removeClass('ilc_qetitem_ErrorTextItem');
-            $elm.addClass('ilc_qetitem_ErrorTextSelected');
-		}
-		else if($elm.hasClass('ilc_qetitem_ErrorTextSelected'))
-		{
-            $elm.removeClass('ilc_qetitem_ErrorTextSelected');
-            $elm.addClass('ilc_qetitem_ErrorTextItem');
-			
-		}
+        let click_function = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
 
-		var context  = $elm.closest('.errortext');
-		var selected = [];
-		context.find('a').each(function(i) {
-			if ($(this).hasClass('ilc_qetitem_ErrorTextSelected')) {
-				selected.push(i);
-			}
-		});
-		context.find('input[type=hidden]').val(selected.join(','));
+            let context  = e.target.closest('.errortext');
+            let class_list = e.target.classList;
 
-		e.preventDefault();
-		e.stopPropagation();
-	});
-});
+            if (class_list.contains('ilc_qetitem_ErrorTextItem')) {
+                class_list.remove('ilc_qetitem_ErrorTextItem');
+                class_list.add('ilc_qetitem_ErrorTextSelected');
+            } else if (class_list.contains('ilc_qetitem_ErrorTextSelected')) {
+                class_list.remove('ilc_qetitem_ErrorTextSelected');
+                class_list.add('ilc_qetitem_ErrorTextItem');
+            }
+
+            let selected = [];
+            context.querySelectorAll('a').forEach((e,i) => {
+                if (e.classList.contains('ilc_qetitem_ErrorTextSelected')) {
+                    selected.push(i);
+                }
+            });
+            context.querySelector('input[type=hidden]').value = selected.join(',');
+        };
+
+        let public_interface = {
+            init
+        };
+        return public_interface;
+    };
+
+    il = il || {};
+    il.test = il.test || {};
+    il.test.player = il.test.player || {};
+    il.test.player.errortext = errortext();
+}());

--- a/Modules/TestQuestionPool/templates/default/tpl.prop_errortextwizardinput.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.prop_errortextwizardinput.html
@@ -11,7 +11,7 @@
 <!-- BEGIN row -->
 			<tr class="{ROW_CLASS}">
 				<td>
-					<input class="form-control" type="text" size="{KEY_SIZE}" id="{KEY_ID}" maxlength="{KEY_MAXLENGTH}" name="{POST_VAR}[key][{ROW_NUMBER}]" <!-- BEGIN prop_key_propval -->value="{PROPERTY_VALUE}" <!-- END prop_key_propval -->{DISABLED_KEY}/>
+					<input class="form-control" type="text" size="{KEY_SIZE}" id="{KEY_ID}" maxlength="{KEY_MAXLENGTH}" name="{POST_VAR}[key][{ROW_NUMBER}]" <!-- BEGIN prop_key_propval -->value="{PROPERTY_VALUE}" <!-- END prop_key_propval -->readonly />
 				</td>
 				<td>
 					<input class="form-control" type="text" size="{VALUE_SIZE}" id="{VALUE_ID}" maxlength="{VALUE_MAXLENGTH}" name="{POST_VAR}[value][{ROW_NUMBER}]" <!-- BEGIN prop_value_propval -->value="{PROPERTY_VALUE}" <!-- END prop_value_propval -->{DISABLED_VALUE}/>

--- a/Modules/TestQuestionPool/test/assAnswerErrorTextTest.php
+++ b/Modules/TestQuestionPool/test/assAnswerErrorTextTest.php
@@ -42,7 +42,7 @@ class assAnswerErrorTextTest extends assBaseTestCase
         $instance = new assAnswerErrorText('errortext');
 
         // Assert
-        $this->assertTrue(true);
+        $this->assertInstanceOf(assAnswerErrorText::class, $instance);
     }
 
 
@@ -55,14 +55,33 @@ class assAnswerErrorTextTest extends assBaseTestCase
         $instance = new assAnswerErrorText(
             'errortext',
             'correcttext',
-            1
+            0.01,
+            21
         );
 
         // Assert
-        $this->assertTrue(true);
+        $this->assertInstanceOf(assAnswerErrorText::class, $instance);
     }
 
-    public function test_setGetPoints_valid(): void
+    public function test_instantiateObjectFullHasCorrectValues(): void
+    {
+
+        $instance = new assAnswerErrorText(
+            'errortext',
+            'correcttext',
+            0.01,
+            21
+        );
+
+        $this->assertInstanceOf(assAnswerErrorText::class, $instance);
+        $this->assertEquals('errortext', $instance->getTextWrong());
+        $this->assertEquals('correcttext', $instance->getTextCorrect());
+        $this->assertEquals(0.01, $instance->getPoints());
+        $this->assertEquals(21, $instance->getPosition());
+        $this->assertEquals(1, $instance->getLength());
+    }
+
+    public function test_withPoints_valid(): void
     {
         //$this->markTestIncomplete('Testing an uncommitted feature.');
         // Arrange
@@ -71,55 +90,26 @@ class assAnswerErrorTextTest extends assBaseTestCase
         $expected = 0.01;
 
         // Act
-        $instance->points = $expected;
-        $actual = $instance->points;
+        $instance_with_points = $instance->withPoints($expected);
+        $actual = $instance_with_points->getPoints();
 
         // Assert
         $this->assertEquals($actual, $expected);
     }
 
-    public function test_setGetTextCorrect(): void
+    public function test_withPosition_valid(): void
     {
+        //$this->markTestIncomplete('Testing an uncommitted feature.');
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assAnswerErrorText.php';
         $instance = new assAnswerErrorText('errortext');
-        $expected = 'Correct text';
+        $expected = 21;
 
         // Act
-        $instance->text_correct = $expected;
-        $actual = $instance->text_correct;
+        $instance_with_position = $instance->withPosition($expected);
+        $actual = $instance_with_position->getPosition();
 
         // Assert
         $this->assertEquals($actual, $expected);
-    }
-
-    public function test_setGetTextWrong_valid(): void
-    {
-        // Arrange
-        require_once './Modules/TestQuestionPool/classes/class.assAnswerErrorText.php';
-        $instance = new assAnswerErrorText('errortext');
-        $expected = 'Errortext';
-
-        // Act
-        $instance->text_wrong = $expected;
-        $actual = $instance->text_wrong;
-
-        // Assert
-        $this->assertEquals($actual, $expected);
-    }
-
-    public function test_setTextWrong_invalid(): void
-    {
-        // Arrange
-        require_once './Modules/TestQuestionPool/classes/class.assAnswerErrorText.php';
-        $instance = new assAnswerErrorText('errortext');
-        $expected = '';
-
-        // Act
-        $instance->text_wrong = $expected;
-        $actual = $instance->text_wrong;
-
-        // Assert
-        $this->assertEquals($expected, $actual);
     }
 }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1091,6 +1091,7 @@ assessment#:#qpl_skl_sub_tab_quest_assign#:#Fragen-Kompetenz-Zuordnung
 assessment#:#qpl_skl_sub_tab_usages#:#Vergabehäufigkeit
 assessment#:#qpl_sync_quest_skl_assigns_confirmation#:#Die Frage wurde aus einem anderen Magazinobjekt eingefügt. Soll die aktuelle Konfiguration von Kompetenzzuweisungen auf das Original der Frage übertragen werden?
 assessment#:#qpl_tab_competences#:#Kompetenzen
+assessment#:#qst_error_text_too_long#:#Einer oder mehrere der als fehlerhaft markierten Textelemente ist zu lang. Die maximale Länge für ein als fehlerhaft markiertes Textelement ist 150 Zeichen.
 assessment#:#qst_essay_allready_written_words#:#Bereits geschriebene Wörter:
 assessment#:#qst_essay_chars_remaining#:#Noch übrige Zeichen:
 assessment#:#qst_essay_wordcounter_enabled#:#Wörter zählen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1091,6 +1091,7 @@ assessment#:#qpl_skl_sub_tab_quest_assign#:#Question/Competence Assignment
 assessment#:#qpl_skl_sub_tab_usages#:#Assignment Frequency
 assessment#:#qpl_sync_quest_skl_assigns_confirmation#:#The question was inserted from another repository object. Should the question's original be updated with the current config of competence assignments?
 assessment#:#qpl_tab_competences#:#Competences
+assessment#:#qst_error_text_too_long#:#One or more text elements marked as erroneous are too long. The maximum size for a text element marked as erroneous is 150 characters:
 assessment#:#qst_essay_allready_written_words#:#Already entered words:
 assessment#:#qst_essay_chars_remaining#:#Remaining characters:
 assessment#:#qst_essay_wordcounter_enabled#:#Count Words


### PR DESCRIPTION
This PR is just in case somebody wants to look through the whole shenanigans, while we test the surface. 
It is rather encompasing, but actually started as a fix for: https://mantis.ilias.de/view.php?id=28393

But I didn't believe it useful to just tackle this and as we are still early in the cylce, this is a
refactoring of the ErrorText-Question.

It:
- Moves the parsing of the test to the creation time.
- It introduces saved positions for correct answers.
- It removes all jQuery and improves JS.
- It makes error-passages work in Learning Modules.
- It splits up the huge parsing functions into small, named functions.