### PR TITLE
#36506: moved styles from wrongly nested img to icon classes

### DIFF
--- a/src/UI/templates/default/Symbol/icon.less
+++ b/src/UI/templates/default/Symbol/icon.less
@@ -12,14 +12,11 @@
 
 	&.small {
 		height: @il-icon-size-small;
+		width: @il-icon-size-small;
 		line-height: @il-icon-size-small;
 		.abbreviation {
 			font-size: ceil(@il-icon-size-small * 0.4);
 			width: @il-icon-size-small;
-		}
-		img {
-			width: @il-icon-size-small;
-			height: @il-icon-size-small;
 		}
 	}
 	&.medium {
@@ -29,9 +26,6 @@
 			font-size: ceil(@il-icon-size-medium * 0.4);
 			width: @il-icon-size-medium;
 		}
-		img {
-			height: @il-icon-size-medium;
-		}
 	}
 	&.large {
 		height: @il-icon-size-large;
@@ -39,19 +33,13 @@
 		.abbreviation {
 			font-size: ceil(@il-icon-size-large * 0.4);
 		}
-		img {
-			height: @il-icon-size-large;
-		}
 	}
 	&.responsive {
 		width: 100%;
+		height: auto;
 		line-height: @il-icon-size-medium;
 		.abbreviation {
 			font-size: ceil(@il-icon-size-medium * 0.4);
-		}
-		img {
-			width: 100%;
-			height: auto;
 		}
 	}
 


### PR DESCRIPTION
The corrupted generation of a PDF from test results came from the missing 'with' style of icons for 'ok' and 'not ok'.

On 10.02.2021 the icon template was changed from a div with enclosed img to a pure div:
src/UI/templates/default/Symbol/tpl.icon.html

The corresponding less file, however, still used img elements to set the width. These styles were ignored since the icon classes are now directly added to the img tag. The fix removes the obsolete img nestings and adds their styles directly to the classes.

This sets the with for small icons to the predefined size. Large and medium icons didn't have a 'with' setting. I don't know if this is intended. The KS description says:
'Images used for Custom Icons SHOULD have equal width and height (=be quadratic) in order not to be distorted.'
