### PR TITLE
Fix #36081: Antworten mit Umlauten für "Begriffe benennen" 

### DIFF
--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -1224,6 +1224,11 @@ ilias.questions.showCorrectAnswers =function(a_id) {
 					{
 						correct_answer = correct_answer.toLowerCase();
 					}
+
+					// decode the HTML entity encoding of the correct answer
+					var parsed = new DOMParser().parseFromString(correct_answer, "text/html");
+					correct_answer =  parsed.documentElement.textContent;
+
 					if(correct_answer == answer)
 					{
 						found = true;

--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -495,6 +495,11 @@ ilias.questions.assTextSubset = function(a_id) {
 		for (var c=0;c<questions[a_id].correct_answers.length;c++)
 		{
 			var correct_answer = questions[a_id].correct_answers[c]["answertext"];
+
+			// decode the HTML entity encoding of the correct answer
+			var parsed = new DOMParser().parseFromString(correct_answer, "text/html");
+			correct_answer =  parsed.documentElement.textContent;
+
 			if(questions[a_id].matching_method == "ci")
 			{
 				correct_answer = correct_answer.toLowerCase();


### PR DESCRIPTION
Correct answers are provided with encoded HTML entities. The fix decodes these before they are compared with the user input.