### PR TITLE
UI: Abandoning FileRemovalURL

### DIFF
--- a/Modules/File/classes/Icons/class.ilIconUploadHandlerGUI.php
+++ b/Modules/File/classes/Icons/class.ilIconUploadHandlerGUI.php
@@ -99,28 +99,6 @@ class ilIconUploadHandlerGUI extends AbstractCtrlAwareUploadHandler
         return new BasicHandlerResult($this->getFileIdentifierParameterName(), $status, $rid, $message);
     }
 
-    protected function getRemoveResult(string $rid): HandlerResult
-    {
-        $id = $this->storage->manage()->find($rid);
-        if ($id !== null) {
-            $rev = $this->storage->manage()->getCurrentRevision($id);
-            $rev_num = $rev->getVersionNumber();
-            $this->storage->manage()->removeRevision($id, $rev_num);
-            return new BasicHandlerResult(
-                $this->getFileIdentifierParameterName(),
-                HandlerResult::STATUS_OK,
-                $rid,
-                'file deleted'
-            );
-        }
-        return new BasicHandlerResult(
-            $this->getFileIdentifierParameterName(),
-            HandlerResult::STATUS_FAILED,
-            $rid,
-            'file not found'
-        );
-    }
-
     public function getInfoResult(string $rid): ?FileInfoResult
     {
         $id = $this->storage->manage()->find($rid);

--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
@@ -89,7 +89,6 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
                 $this->$cmd();
                 break;
             case AbstractCtrlAwareUploadHandler::CMD_UPLOAD:
-            case AbstractCtrlAwareUploadHandler::CMD_REMOVE:
             case AbstractCtrlAwareUploadHandler::CMD_INFO:
                 parent::executeCommand();
                 break;
@@ -347,21 +346,6 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
             $message = $result->getStatus()->getMessage();
         }
 
-        return new BasicHandlerResult($this->getFileIdentifierParameterName(), $status, $identifier, $message);
-    }
-
-    protected function getRemoveResult(string $identifier): HandlerResult
-    {
-        $resource_id = $this->irss->manage()->find($identifier);
-        if($resource_id) {
-            $this->irss->manage()->remove($resource_id, $this->stakeholder);
-            $status = HandlerResult::STATUS_OK;
-            $message = $this->lng->txt('iass_file_deleted');
-        } else {
-            $status = HandlerResult::STATUS_FAILED;
-            $identifier = '';
-            $message = 'no resource to delete';
-        }
         return new BasicHandlerResult($this->getFileIdentifierParameterName(), $status, $identifier, $message);
     }
 

--- a/Services/FileServices/README.md
+++ b/Services/FileServices/README.md
@@ -28,7 +28,6 @@ The simplest variant is to address your `UploadHandler` via ilCtrl. For this the
 
 ```php
 abstract protected function getUploadResult() : HandlerResult;
-abstract protected function getRemoveResult(string $identifier) : HandlerResult;
 abstract public function getInfoResult(string $identifier) : ?FileInfoResult;
 abstract public function getInfoForExistingFiles(array $file_ids) : array;
 ```
@@ -79,29 +78,11 @@ An example would be:
 The `$identifier` in a BasicHandlerResult is the value that is then returned as a string value in the form processing after the form is submitted (e. g. `$form->getData();`, see documentation for `\ILIAS\UI\Component\Input\Container\Form\Form`).
 
 #### getRemoveResult
-To remove files that a user has dropped into a file input (and thus have already been processed), he clicks on the (X) in the form field. An asynchronous request is sent to the delete URL, and the identifier of the desired file is sent as a parameter. This is received as a parameter in the method. The method is responsible for deleting this file. In the case of the ResourceStorageService this can be done very simply as follows:
+This function has been removed, because the premature removal of files leads to follow-up problems. 
+Please see the discussion on https://mantis.ilias.de/view.php?id=37161 and https://github.com/ILIAS-eLearning/ILIAS/pull/5807 for more details.
+Please use the storage service for handling the removal of files.
 
-```php
-    protected function getRemoveResult(string $identifier) : HandlerResult
-    {
-        if (null !== ($id = $this->storage->manage()->find($identifier))) {
-            $this->storage->manage()->remove($id, $this->stakeholder);
-            $status = HandlerResult::STATUS_OK;
-            $message = "file removal OK";
-        } else {
-            $status = HandlerResult::STATUS_OK;
-            $message = "file with identifier '$identifier' doesn't exist, nothing to do.";
-        }
 
-        return new BasicHandlerResult(
-            $this->getFileIdentifierParameterName(), 
-            $status, 
-            $identifier, 
-            $message
-        );
-    } 
-```
-If you do not use the storage service, you are responsible for the deletion.
 
 #### getInfoResult
 Here a file input or dropzone can request information about an existing file, e.g. if the form field with `->withValue()` already contains a file. Example with the ResourceStorageService:

--- a/Services/FileServices/classes/UploadService/class.ilCtrlAwareStorageUploadHandler.php
+++ b/Services/FileServices/classes/UploadService/class.ilCtrlAwareStorageUploadHandler.php
@@ -1,7 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 declare(strict_types=1);
-
 
 use ILIAS\Filesystem\Stream\Streams;
 use ILIAS\FileUpload\FileUpload;
@@ -14,20 +28,6 @@ use ILIAS\FileUpload\DTO\UploadResult;
 use ILIAS\FileUpload\Handler\BasicHandlerResult;
 use ILIAS\FileUpload\Handler\BasicFileInfoResult;
 use ILIAS\FileUpload\Handler\AbstractCtrlAwareUploadHandler;
-
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 
 /**
  * Class ilCtrlAwareStorageUploadHandler
@@ -69,20 +69,6 @@ class ilCtrlAwareStorageUploadHandler extends AbstractCtrlAwareUploadHandler
             $identifier = '';
             $status = HandlerResult::STATUS_FAILED;
             $message = $result->getStatus()->getMessage();
-        }
-
-        return new BasicHandlerResult($this->getFileIdentifierParameterName(), $status, $identifier, $message);
-    }
-
-    protected function getRemoveResult(string $identifier): HandlerResult
-    {
-        if (null !== ($id = $this->storage->manage()->find($identifier))) {
-            $this->storage->manage()->remove($id, $this->stakeholder);
-            $status = HandlerResult::STATUS_OK;
-            $message = "file removal OK";
-        } else {
-            $status = HandlerResult::STATUS_OK;
-            $message = "file with identifier '$identifier' doesn't exist, nothing to do.";
         }
 
         return new BasicHandlerResult($this->getFileIdentifierParameterName(), $status, $identifier, $message);

--- a/Services/MainMenu/classes/Administration/class.ilMMUploadHandlerGUI.php
+++ b/Services/MainMenu/classes/Administration/class.ilMMUploadHandlerGUI.php
@@ -1,5 +1,20 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 declare(strict_types=1);
 
 use ILIAS\FileUpload\DTO\UploadResult;
@@ -64,19 +79,6 @@ class ilMMUploadHandlerGUI extends AbstractCtrlAwareUploadHandler
         }
 
         return new BasicHandlerResult($this->getFileIdentifierParameterName(), $status, $identifier, $message);
-    }
-
-
-    protected function getRemoveResult(string $identifier): HandlerResultInterface
-    {
-        $id = $this->storage->manage()->find($identifier);
-        if ($id !== null) {
-            $this->storage->manage()->remove($id, $this->stakeholder);
-
-            return new BasicHandlerResult($this->getFileIdentifierParameterName(), HandlerResultInterface::STATUS_OK, $identifier, 'file deleted');
-        } else {
-            return new BasicHandlerResult($this->getFileIdentifierParameterName(), HandlerResultInterface::STATUS_FAILED, $identifier, 'file not found');
-        }
     }
 
 

--- a/Services/MetaData/classes/Settings/Copyright/class.ilMDCopyrightImageUploadHandlerGUI.php
+++ b/Services/MetaData/classes/Settings/Copyright/class.ilMDCopyrightImageUploadHandlerGUI.php
@@ -78,16 +78,6 @@ class ilMDCopyrightImageUploadHandlerGUI extends AbstractCtrlAwareUploadHandler
         );
     }
 
-    protected function getRemoveResult(string $identifier): HandlerResult
-    {
-        return new BasicHandlerResult(
-            $this->getFileIdentifierParameterName(),
-            HandlerResult::STATUS_OK,
-            $identifier,
-            'asynchronous removal blocked'
-        );
-    }
-
     public function getInfoResult(string $identifier): ?FileInfoResult
     {
         if (null !== ($id = $this->storage->manage()->find($identifier))) {

--- a/Services/Object/classes/Properties/AdditionalProperties/Icon/class.ilObjectCustomIconUploadHandlerGUI.php
+++ b/Services/Object/classes/Properties/AdditionalProperties/Icon/class.ilObjectCustomIconUploadHandlerGUI.php
@@ -99,24 +99,6 @@ class ilObjectCustomIconUploadHandlerGUI extends AbstractCtrlAwareUploadHandler 
         );
     }
 
-    protected function getRemoveResult(string $file_name): HandlerResult
-    {
-        if ($this->has_access === false) {
-            return $this->getAccessFailureResult(
-                $this->getFileIdentifierParameterName(),
-                $file_name,
-                $this->language
-            );
-        }
-
-        return new BasicHandlerResult(
-            $this->getFileIdentifierParameterName(),
-            HandlerResult::STATUS_OK,
-            $file_name,
-            'There is nothing to do here.'
-        );
-    }
-
     public function getInfoResult(string $file_name): ?FileInfoResult
     {
         if ($this->has_access === false) {

--- a/Services/Object/classes/Properties/CoreProperties/TileImage/class.ilObjectTileImageUploadHandlerGUI.php
+++ b/Services/Object/classes/Properties/CoreProperties/TileImage/class.ilObjectTileImageUploadHandlerGUI.php
@@ -123,24 +123,6 @@ class ilObjectTileImageUploadHandlerGUI extends AbstractCtrlAwareUploadHandler i
         );
     }
 
-    protected function getRemoveResult(string $identifier): HandlerResult
-    {
-        if ($this->has_access === false) {
-            return $this->getAccessFailureResult(
-                $this->getFileIdentifierParameterName(),
-                $identifier,
-                $this->language
-            );
-        }
-
-        return new BasicHandlerResult(
-            $this->getFileIdentifierParameterName(),
-            HandlerResult::STATUS_OK,
-            $identifier,
-            "We just don't do anything here."
-        );
-    }
-
     public function getInfoResult(string $identifier): ?FileInfoResult
     {
         if (null !== ($id = $this->storage->manage()->find($identifier))) {

--- a/Services/Repository/Service/Form/class.ilRepoStandardUploadHandlerGUI.php
+++ b/Services/Repository/Service/Form/class.ilRepoStandardUploadHandlerGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 use ILIAS\FileUpload\Handler\AbstractCtrlAwareUploadHandler;
 use ILIAS\FileUpload\Handler\FileInfoResult;
@@ -74,15 +73,6 @@ class ilRepoStandardUploadHandlerGUI extends AbstractCtrlAwareUploadHandler
         return $this->ctrl->getLinkTargetByClass($this->getCtrlPath(), self::CMD_INFO);
     }
 
-
-    /**
-     * @inheritDoc
-     */
-    public function getFileRemovalURL(): string
-    {
-        return $this->ctrl->getLinkTargetByClass($this->getCtrlPath(), self::CMD_REMOVE);
-    }
-
     protected function debug(string $mess): void
     {
         if (!is_null($this->log)) {
@@ -116,16 +106,6 @@ class ilRepoStandardUploadHandlerGUI extends AbstractCtrlAwareUploadHandler
             $this->debug("has no upload...");
         }
         return $result;
-    }
-
-    protected function getRemoveResult(string $identifier): HandlerResult
-    {
-        return new BasicHandlerResult(
-            $this->getFileIdentifierParameterName(),
-            HandlerResult::STATUS_OK,
-            $identifier,
-            ''
-        );
     }
 
     public function getInfoResult(string $identifier): ?FileInfoResult

--- a/Services/Skill/Profile/class.ilSkillProfileUploadHandlerGUI.php
+++ b/Services/Skill/Profile/class.ilSkillProfileUploadHandlerGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +14,8 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+declare(strict_types=1);
 
 use ILIAS\FileUpload\DTO\UploadResult;
 use ILIAS\FileUpload\Handler\AbstractCtrlAwareUploadHandler;
@@ -67,18 +65,6 @@ class ilSkillProfileUploadHandlerGUI extends AbstractCtrlAwareUploadHandler
         }
 
         return new BasicHandlerResult($this->getFileIdentifierParameterName(), $status, $identifier, $message);
-    }
-
-    protected function getRemoveResult(string $identifier): HandlerResultInterface
-    {
-        $id = $this->storage->manage()->find($identifier);
-        if ($id !== null) {
-            $this->storage->manage()->remove($id, $this->stakeholder);
-
-            return new BasicHandlerResult($this->getFileIdentifierParameterName(), HandlerResultInterface::STATUS_OK, $identifier, 'file deleted');
-        } else {
-            return new BasicHandlerResult($this->getFileIdentifierParameterName(), HandlerResultInterface::STATUS_FAILED, $identifier, 'file not found');
-        }
     }
 
     public function getInfoResult(string $identifier): ?FileInfoResult

--- a/Services/UI/classes/class.ilUIAsyncDemoFileUploadHandler.php
+++ b/Services/UI/classes/class.ilUIAsyncDemoFileUploadHandler.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 declare(strict_types=1);
-
-/* Copyright (c) 2021 Thibeau Fuhrer <thibeau@sr.solutions> Extended GPL, see docs/LICENSE */
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
@@ -24,16 +37,6 @@ class ilUIAsyncDemoFileUploadHandler extends ilUIDemoFileUploadHandlerGUI
         return $this->ctrl->getLinkTargetByClass(
             [ilUIPluginRouterGUI::class, self::class],
             self::CMD_INFO,
-            null,
-            true
-        );
-    }
-
-    public function getFileRemovalURL(): string
-    {
-        return $this->ctrl->getLinkTargetByClass(
-            [ilUIPluginRouterGUI::class, self::class],
-            self::CMD_REMOVE,
             null,
             true
         );

--- a/Services/UI/classes/class.ilUIAsyncDemoFileUploadHandlerGUI.php
+++ b/Services/UI/classes/class.ilUIAsyncDemoFileUploadHandlerGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +14,8 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+declare(strict_types=1);
 
 /**
  * @ilCtrl_isCalledBy ilUIAsyncDemoFileUploadHandlerGUI: ilUIPluginRouterGUI
@@ -40,16 +38,6 @@ class ilUIAsyncDemoFileUploadHandlerGUI extends ilUIDemoFileUploadHandlerGUI
         return $this->ctrl->getLinkTargetByClass(
             [ilUIPluginRouterGUI::class, self::class],
             self::CMD_INFO,
-            null,
-            true
-        );
-    }
-
-    public function getFileRemovalURL(): string
-    {
-        return $this->ctrl->getLinkTargetByClass(
-            [ilUIPluginRouterGUI::class, self::class],
-            self::CMD_REMOVE,
             null,
             true
         );

--- a/Services/UI/classes/class.ilUIDemoFileUploadHandlerGUI.php
+++ b/Services/UI/classes/class.ilUIDemoFileUploadHandlerGUI.php
@@ -47,21 +47,6 @@ class ilUIDemoFileUploadHandlerGUI extends AbstractCtrlAwareUploadHandler
         return $this->ctrl->getLinkTargetByClass([ilUIPluginRouterGUI::class, self::class], self::CMD_INFO);
     }
 
-
-    /**
-     * @inheritDoc
-     */
-    public function getFileRemovalURL(): string
-    {
-        return $this->ctrl->getLinkTargetByClass(
-            [ilUIPluginRouterGUI::class, self::class],
-            self::CMD_REMOVE,
-            null,
-            false
-        );
-    }
-
-
     /**
      * @inheritDoc
      */
@@ -79,15 +64,6 @@ class ilUIDemoFileUploadHandlerGUI extends AbstractCtrlAwareUploadHandler
         $status = HandlerResult::STATUS_OK;
         $identifier = md5(random_bytes(65));
         $message = 'Everything ok';
-
-        return new BasicHandlerResult($this->getFileIdentifierParameterName(), $status, $identifier, $message);
-    }
-
-
-    protected function getRemoveResult(string $identifier): HandlerResult
-    {
-        $status = HandlerResult::STATUS_OK;
-        $message = 'File Deleted';
 
         return new BasicHandlerResult($this->getFileIdentifierParameterName(), $status, $identifier, $message);
     }

--- a/src/FileUpload/Handler/AbstractCtrlAwareIRSSUploadHandler.php
+++ b/src/FileUpload/Handler/AbstractCtrlAwareIRSSUploadHandler.php
@@ -131,25 +131,6 @@ abstract class AbstractCtrlAwareIRSSUploadHandler extends AbstractCtrlAwareUploa
         return $this->ctrl->getLinkTargetByClass($this->class_path, self::CMD_INFO, null, true);
     }
 
-    public function getFileRemovalURL(): string
-    {
-        return $this->ctrl->getLinkTargetByClass($this->class_path, self::CMD_REMOVE, null, true);
-    }
-
-    protected function getRemoveResult(string $identifier): HandlerResult
-    {
-        if (null !== ($id = $this->irss->manage()->find($identifier))) {
-            $this->irss->manage()->remove($id, $this->stakeholder);
-            $status = HandlerResult::STATUS_OK;
-            $message = "file removal OK";
-        } else {
-            $status = HandlerResult::STATUS_OK;
-            $message = "file with identifier '$identifier' doesn't exist, nothing to do.";
-        }
-
-        return new BasicHandlerResult($this->getFileIdentifierParameterName(), $status, $identifier, $message);
-    }
-
     public function getInfoResult(string $identifier): ?FileInfoResult
     {
         if (null !== ($id = $this->irss->manage()->find($identifier))) {

--- a/src/FileUpload/Handler/AbstractCtrlAwareUploadHandler.php
+++ b/src/FileUpload/Handler/AbstractCtrlAwareUploadHandler.php
@@ -1,5 +1,20 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 declare(strict_types=1);
 
 namespace ILIAS\FileUpload\Handler;
@@ -9,19 +24,6 @@ use ILIAS\FileUpload\FileUpload;
 use ILIAS\HTTP\Services as HttpServices;
 use ilCtrl;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 /**
  * Class ilCtrlAwareUploadHandler
  *
@@ -30,7 +32,6 @@ use ilCtrl;
 abstract class AbstractCtrlAwareUploadHandler implements ilCtrlAwareUploadHandler
 {
     protected const CMD_UPLOAD = 'upload';
-    protected const CMD_REMOVE = 'remove';
     protected const CMD_INFO = 'info';
 
     protected HttpServices $http;
@@ -84,11 +85,14 @@ abstract class AbstractCtrlAwareUploadHandler implements ilCtrlAwareUploadHandle
 
 
     /**
-     * @inheritDoc
+     * @deprecated This function has been removed together with getRemoveResult(),
+     * because the premature removal of files leads to follow-up problems.
+     * Please see the discussion on https://mantis.ilias.de/view.php?id=37161 and
+     * https://github.com/ILIAS-eLearning/ILIAS/pull/5807 for more details.
      */
-    public function getFileRemovalURL(): string
+    final public function getFileRemovalURL(): string
     {
-        return $this->ctrl->getLinkTargetByClass([static::class], self::CMD_REMOVE);
+        throw new \ilException('AbstractCtrlAwareUploadHandler::getFileRemovalURL() -> Deprecated function, please do not use!');
     }
 
     protected function readChunkedInformation(): void
@@ -124,12 +128,6 @@ abstract class AbstractCtrlAwareUploadHandler implements ilCtrlAwareUploadHandle
                     );
                 }
                 break;
-            case self::CMD_REMOVE:
-                // here you delete the previously uploaded file again, you know
-                // which file to delete since you defined what 'my_file_id' is.
-                $file_identifier = $this->http->request()->getQueryParams()[$this->getFileIdentifierParameterName()];
-                $content = json_encode($this->getRemoveResult($file_identifier));
-                break;
             case self::CMD_INFO:
                 // here you give info about an already existing file
                 // return a JsonEncoded \ILIAS\FileUpload\Handler\FileInfoResult
@@ -150,7 +148,16 @@ abstract class AbstractCtrlAwareUploadHandler implements ilCtrlAwareUploadHandle
     abstract protected function getUploadResult(): HandlerResult;
 
 
-    abstract protected function getRemoveResult(string $identifier): HandlerResult;
+    /**
+     * @deprecated This function has been removed together with getFileRemovalURL(),
+     * because the premature removal of files leads to follow-up problems.
+     * Please see the discussion on https://mantis.ilias.de/view.php?id=37161 and
+     * https://github.com/ILIAS-eLearning/ILIAS/pull/5807 for more details.
+     */
+    final protected function getRemoveResult(string $identifier): HandlerResult
+    {
+        throw new \ilException('AbstractCtrlAwareUploadHandler::getRemoveResult() -> Deprecated function, please do not use!');
+    }
 
 
     abstract public function getInfoResult(string $identifier): ?FileInfoResult;
@@ -162,5 +169,4 @@ abstract class AbstractCtrlAwareUploadHandler implements ilCtrlAwareUploadHandle
     {
         return false;
     }
-
 }

--- a/src/UI/Component/Input/Field/UploadHandler.php
+++ b/src/UI/Component/Input/Field/UploadHandler.php
@@ -45,15 +45,6 @@ interface UploadHandler
      */
     public function getUploadURL(): string;
 
-
-    /**
-     * @return string of the URL where in GUI deleted files are handled. The URL
-     * is called by POST with a field with name from getFileIdentifierParameterName()
-     * and the FileID of the deleted file.
-     */
-    public function getFileRemovalURL(): string;
-
-
     /**
      * @return string of the URL where in GUI existing files are handled. The URL
      * is called by GET with a field with name from getFileIdentifierParameterName()

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -968,7 +968,6 @@ class Renderer extends AbstractComponentRenderer
                         il.UI.Input.File.init(
                             '$id',
                             '{$input->getUploadHandler()->getUploadURL()}',
-                            '{$input->getUploadHandler()->getFileRemovalURL()}',
                             '{$input->getUploadHandler()->getFileIdentifierParameterName()}',
                             $current_file_count,
                             {$input->getMaxFiles()},

--- a/src/UI/templates/js/Input/Field/file.js
+++ b/src/UI/templates/js/Input/Field/file.js
@@ -105,7 +105,6 @@ il.UI.Input = il.UI.Input || {};
 		/**
 		 * @param {string} input_id
 		 * @param {string} upload_url
-		 * @param {string} removal_url
 		 * @param {string} file_identifier
 		 * @param {int} current_file_count
 		 * @param {int} max_file_amount
@@ -117,7 +116,6 @@ il.UI.Input = il.UI.Input || {};
 		let init = function (
 			input_id,
 			upload_url,
-			removal_url,
 			file_identifier,
 			current_file_count,
 			max_file_amount,
@@ -161,7 +159,6 @@ il.UI.Input = il.UI.Input || {};
 					parallelUploads: 1,
 					current_file_count: current_file_count,
 					file_identifier: file_identifier,
-					removal_url: removal_url,
 					input_id: input_id,
 					chunking: should_upload_be_chunked,
 					forceChunking: should_upload_be_chunked,
@@ -582,27 +579,6 @@ il.UI.Input = il.UI.Input || {};
 			}
 		}
 
-		let processRemovals = function (input_id, event) {
-			let file_to_remove = removal_items[input_id];
-			let dropzone = dropzones[input_id];
-			for (let i = 0, i_max = file_to_remove.length; i < i_max; i++) {
-				let file_id = file_to_remove[i];
-				$.ajax({
-					type: 'GET',
-					url: dropzone.options.removal_url,
-					data: {
-						[dropzone.options.file_identifier]: file_id,
-					},
-					success: json_response => {
-
-					},
-					error: json_response => {
-
-					},
-				});
-			}
-		}
-
 		let processCurrentFormDropzones = function (event) {
 			// retrieve all file inputs of the current form.
 			let file_inputs = current_form.find(SELECTOR.file_input);
@@ -613,7 +589,6 @@ il.UI.Input = il.UI.Input || {};
                 for (let i = 0; i < file_inputs.length; i++) {
                     let input_id = file_inputs[i].id;
                     let dropzone = dropzones[input_id];
-                    processRemovals(input_id, event);
                     to_process += dropzone.files.length;
                     if (dropzone.files.length !== 0) {
                         dropzone.processQueue();
@@ -627,7 +602,6 @@ il.UI.Input = il.UI.Input || {};
             } else {
                 let input_id = file_inputs.attr('id');
 				let dropzone = dropzones[input_id];
-				processRemovals(input_id, event);
 				if (0 !== dropzone.files.length) {
 					dropzone.processQueue();
 				} else {

--- a/tests/UI/Component/Input/Field/FileInputTest.php
+++ b/tests/UI/Component/Input/Field/FileInputTest.php
@@ -102,11 +102,6 @@ class FileInputTest extends ILIAS_UI_TestBase
                 return 'uploadurl';
             }
 
-            public function getFileRemovalURL(): string
-            {
-                return 'removalurl';
-            }
-
             /**
              * @inheritDoc
              */


### PR DESCRIPTION
This PR removes `getFileRemovalURL()` and the associated `getRemoveResult()` from `Input/Field/UploadHandler` as well as their implementations, as proposed by @klees on #5807 and Mantis [#37161](https://mantis.ilias.de/view.php?id=37161). It also contains a small fix for the handling of `withInput()` on Dynamic Inputs.