### PR TITLE
allow some secure tags for lang vars

### DIFF
--- a/Services/Language/classes/class.ilObjLanguageExtGUI.php
+++ b/Services/Language/classes/class.ilObjLanguageExtGUI.php
@@ -394,7 +394,7 @@ class ilObjLanguageExtGUI extends ilObjectGUI
                 // avoid line breaks
                 $value = preg_replace("/(\015\012)|(\015)|(\012)/", "<br />", $value);
                 $value = str_replace("<<", "«",$value);
-                $value = ilUtil::stripSlashes($value);
+                $value = ilUtil::stripSlashes($value, true, "<a><br><u>");
                 $save_array[$key] = $value;
 
                 // the comment has the key of the language with the suffix


### PR DESCRIPTION
Since shortly before the call of stripSlashes line breaks are replaced by the br-tag, but those were then removed again directly afterwards, I have now adapted this so that both the br-tags, as well as 2 other tags, which were otherwise simply deleted out, are passed as allowed tags. These are included in the secureTags.