### PR TITLE
T&A: Bugfix #36142: Type error when direct Importing an XML file when TinyMCE Image is included in original question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -782,7 +782,9 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             $newObj->setPermissions($this->qplrequest->getRefId());
         }
 
-        if (is_file(ilSession::get("qpl_import_dir") . '/' . ilSession::get("qpl_import_subdir") . "/manifest.xml")) {
+        if (is_string(ilSession::get("qpl_import_dir")) && is_string(ilSession::get("qpl_import_subdir")) && is_file(
+                ilSession::get("qpl_import_dir") . '/' . ilSession::get("qpl_import_subdir") . "/manifest.xml"
+            )) {
             ilSession::set("qpl_import_idents", $this->qplrequest->raw("ident"));
 
             $fileName = ilSession::get("qpl_import_subdir") . '.zip';

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -1747,9 +1747,11 @@ class ilQTIParser extends ilSaxParser
             }
         }
         if (!$this->matimage->getEmbedded() && strlen($this->matimage->getUri())) {
-            $this->matimage->setContent(
-                (string) @file_get_contents(dirname($this->xml_file) . '/' . $this->matimage->getUri())
-            );
+            $img_string = @file_get_contents(dirname($this->xml_file) . '/' . $this->matimage->getUri());
+
+            if (is_string($img_string)) {
+                $this->matimage->setContent($img_string);
+            }
         }
     }
 

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -1747,7 +1747,9 @@ class ilQTIParser extends ilSaxParser
             }
         }
         if (!$this->matimage->getEmbedded() && strlen($this->matimage->getUri())) {
-            $this->matimage->setContent(@file_get_contents(dirname($this->xml_file) . '/' . $this->matimage->getUri()));
+            $this->matimage->setContent(
+                (string) @file_get_contents(dirname($this->xml_file) . '/' . $this->matimage->getUri())
+            );
         }
     }
 


### PR DESCRIPTION
Ensures no type error is raised when:

Steps would be like:

0a) Create a pool or test
0b) Therein create a question with TinyMCE and include some media (i.e. an image) in the question and/or answer text
1) Export the test or pool
2) Extract the "_qti_" labeled XML-file from the top level of the export ZIP-file
3) On the question list of any given pool click the "Import" button
4a) Select the 'qti'-XML-file from step 2) and click the "Upload" button
4b) On the following 'Import' screen click the "Import" button