### PR TITLE
T&A 0036944: Mark Schema: 'Official Form'

### DIFF
--- a/Modules/Test/classes/tables/class.ilMarkSchemaTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilMarkSchemaTableGUI.php
@@ -119,7 +119,7 @@ class ilMarkSchemaTableGUI extends ilTable2GUI
         $official_name->setSize(20);
         $official_name->setDisabled(!$this->object->canEditMarks());
         $official_name->setMaxLength(50);
-        $official_name->setValue($a_set['mark_official']);
+        $official_name->setValue($row['mark_official']);
 
         $percentage = new ilNumberInputGUI('', 'mark_percentage_' . $row['mark_id']);
         $percentage->allowDecimals(true);


### PR DESCRIPTION
Ticket:
https://mantis.ilias.de/view.php?id=36944

Symptom:
in the Settings -> Mark Schema, the table column Official Form didn't show any information.

Problem:
Refactoring mistake 

Checked the solution on:
ILIAS 7, since described as only ILIAS 7 bug, see ticket.

Note:
The second bug, described in the comments of the ticket, occurs when no value is saved for a Mark Schema table row.   Easy to produce when you save by default nothing to the database for the Official Form name. However, with this fix, an empty failed message is now rather a willing result than a system error.

As always, let me know where this solution needs further improvement.

