### PR TITLE
Object/Container: Move Adopt Content

### DIFF
--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=0);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=0);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=0);
 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;

--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -112,6 +112,7 @@ class ilObjCourseGUI extends ilContainerGUI
         $this->checkPermission('read', 'view');
         if ($this->view_manager->isAdminView()) {
             parent::renderObject();
+            $this->addAdoptContentLinkToToolbar();
             return;
         }
 

--- a/Modules/Group/classes/class.ilObjGroupGUI.php
+++ b/Modules/Group/classes/class.ilObjGroupGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;

--- a/Modules/Group/classes/class.ilObjGroupGUI.php
+++ b/Modules/Group/classes/class.ilObjGroupGUI.php
@@ -434,8 +434,9 @@ class ilObjGroupGUI extends ilContainerGUI
             'grp'
         );
 
-        if ($this->getAdminMode() === self::ADMIN_MODE_SETTINGS) {
-            parent::viewObject();
+        if ($this->view_manager->isAdminView()) {
+            parent::renderObject();
+            $this->addAdoptContentLinkToToolbar();
             return;
         }
 

--- a/Services/Container/classes/class.ilContainerGUI.php
+++ b/Services/Container/classes/class.ilContainerGUI.php
@@ -330,7 +330,7 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
 
     protected function showPossibleSubObjects(): void
     {
-        if ($this->isActiveAdministrationPanel() || $this->isActiveOrdering()) {
+        if ($this->isActiveOrdering()) {
             return;
         }
         $gui = new ilObjectAddNewItemGUI($this->object->getRefId());
@@ -517,19 +517,6 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                         'download'
                     );
                 }
-            }
-            if ($this->object->getType() === 'crs' || $this->object->getType() === 'grp') {
-                if ($this->object->gotItems()) {
-                    $toolbar->addSeparator();
-                }
-
-                $toolbar->addButton(
-                    $this->lng->txt('cntr_adopt_content'),
-                    $this->ctrl->getLinkTargetByClass(
-                        'ilObjectCopyGUI',
-                        'adoptContent'
-                    )
-                );
             }
 
             $main_tpl->addAdminPanelToolbar(

--- a/Services/Object/classes/class.ilObjectGUI.php
+++ b/Services/Object/classes/class.ilObjectGUI.php
@@ -780,17 +780,15 @@ class ilObjectGUI
 
     protected function addAdoptContentLinkToToolbar(): void
     {
-        if ($this->object->getType() === 'crs' || $this->object->getType() === 'grp') {
-            $this->toolbar->addComponent(
-                $this->ui->factory()->link()->standard(
-                    $this->lng->txt('cntr_adopt_content'),
-                    $this->ctrl->getLinkTargetByClass(
-                        'ilObjectCopyGUI',
-                        'adoptContent'
-                    )
+        $this->toolbar->addComponent(
+            $this->ui->factory()->link()->standard(
+                $this->lng->txt('cntr_adopt_content'),
+                $this->ctrl->getLinkTargetByClass(
+                    'ilObjectCopyGUI',
+                    'adoptContent'
                 )
-            );
-        }
+            )
+        );
     }
 
     /**

--- a/Services/Object/classes/class.ilObjectGUI.php
+++ b/Services/Object/classes/class.ilObjectGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\HTTP\Wrapper\ArrayBasedRequestWrapper;

--- a/Services/Object/classes/class.ilObjectGUI.php
+++ b/Services/Object/classes/class.ilObjectGUI.php
@@ -778,6 +778,21 @@ class ilObjectGUI
     {
     }
 
+    protected function addAdoptContentLinkToToolbar(): void
+    {
+        if ($this->object->getType() === 'crs' || $this->object->getType() === 'grp') {
+            $this->toolbar->addComponent(
+                $this->ui->factory()->link()->standard(
+                    $this->lng->txt('cntr_adopt_content'),
+                    $this->ctrl->getLinkTargetByClass(
+                        'ilObjectCopyGUI',
+                        'adoptContent'
+                    )
+                )
+            );
+        }
+    }
+
     /**
      * cancel create action and go back to repository parent
      */


### PR DESCRIPTION
Hi @alex40724 
This PR moves Adopt Content to the Toolbar [as it was requested by the Jour Fixe](https://docu.ilias.de/goto_docu_wiki_wpage_5268_1357.html). After some thinking, I think this is the most elegant way to do it right now, opening up opportunities for the future.

I think we could actually mostly backport this to ILIAS 8, we should then just change the Link for a Button (I can do that, if you like). I think this also makes the behavior across Objects more consistent.

Best,
@kergomard 