### PR TITLE
T&A Bugfix #0026320: Test generates empty data before password input

### DIFF
--- a/Modules/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
+++ b/Modules/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
@@ -208,6 +208,19 @@ class ilCronFinishUnfinishedTestPasses extends ilCronJob
     {
         $processLocker = $this->processLockerFactory->withContextId((int) $active_id)->getLocker();
 
+        $testSession = new ilTestSession();
+        $testSession->loadFromDb($active_id);
+
+        $test = new ilObjTest($obj_id, false);
+
+        assQuestion::_updateTestPassResults(
+            $active_id,
+            $testSession->getPass(),
+            $test->areObligationsEnabled(),
+            null,
+            $obj_id
+        );
+
         $pass_finisher = new ilTestPassFinishTasks($active_id, $obj_id);
         $pass_finisher->performFinishTasks($processLocker);
 

--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -1981,8 +1981,20 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         $participantData->load($this->object->getTestId());
 
         if (in_array($activeId, $participantData->getActiveIds())) {
+            $testSession = new ilTestSession();
+            $testSession->loadFromDb($activeId);
+
+            assQuestion::_updateTestPassResults(
+                $activeId,
+                $testSession->getPass(),
+                $this->object->areObligationsEnabled(),
+                null,
+                $this->object->getId()
+            );
+
             $this->finishTestPass($activeId, $this->object->getId());
         }
+
 
         $this->redirectBackToParticipantsScreen();
     }
@@ -2010,8 +2022,20 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
                 continue;
             }
 
+            $testSession = new ilTestSession();
+            $testSession->loadFromDb($participant->getActiveId());
+
+            assQuestion::_updateTestPassResults(
+                $participant->getActiveId(),
+                $testSession->getPass(),
+                $this->object->areObligationsEnabled(),
+                null,
+                $this->object->getId()
+            );
+
             $this->finishTestPass($participant->getActiveId(), $this->object->getId());
         }
+
 
         $this->redirectBackToParticipantsScreen();
     }

--- a/Modules/Test/classes/class.ilTestPassFinishTasks.php
+++ b/Modules/Test/classes/class.ilTestPassFinishTasks.php
@@ -45,6 +45,14 @@ class ilTestPassFinishTasks
     {
         $testSession = $this->testSession;
 
+        assQuestion::_updateTestPassResults(
+            $testSession->getActiveId(),
+            $testSession->getPass(),
+            false,
+            null,
+            $testSession->getTestId()
+        );
+
         $processLocker->executeTestFinishOperation(function () use ($testSession) {
             if (!$testSession->isSubmitted()) {
                 $testSession->setSubmitted();

--- a/Modules/Test/classes/class.ilTestPassFinishTasks.php
+++ b/Modules/Test/classes/class.ilTestPassFinishTasks.php
@@ -45,14 +45,6 @@ class ilTestPassFinishTasks
     {
         $testSession = $this->testSession;
 
-        assQuestion::_updateTestPassResults(
-            $testSession->getActiveId(),
-            $testSession->getPass(),
-            false,
-            null,
-            $testSession->getTestId()
-        );
-
         $processLocker->executeTestFinishOperation(function () use ($testSession) {
             if (!$testSession->isSubmitted()) {
                 $testSession->setSubmitted();


### PR DESCRIPTION
Quick fix for: https://mantis.ilias.de/view.php?id=26320
Contrary to the JF decision, i just prevented data generation before password input.
Generating data only on manual finish has huge impact on test execution

Cherry-pick for 7&8 as well