### PR TITLE
T&A Bugfix #0031276: Cannot add copied questions

### DIFF
--- a/Modules/Test/Service/class.InternalRequestService.php
+++ b/Modules/Test/Service/class.InternalRequestService.php
@@ -70,6 +70,11 @@ class InternalRequestService
         return $this->int('q_id');
     }
 
+    public function getQuestionIds(): array
+    {
+        return $this->intArray('q_id');
+    }
+
     public function getCallingTest(): int
     {
         return $this->int('calling_test');

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -3365,7 +3365,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
                 $clone = assQuestion::instantiateQuestionGUI($new_id);
                 $clone->object->setObjId($this->object->getId());
-                $clone->object->saveToDb();
+                $clone->object->saveToDb($new_id);
 
                 $this->object->insertQuestion($this->test_question_set_config_factory->getQuestionSetConfig(), $new_id, true);
 

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -3335,10 +3335,10 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
             $this->ctrl->redirect($this, "infoScreen");
         }
 
-        if ($this->testrequest->raw('q_id') && !is_array($this->testrequest->raw('q_id'))) {
-            $ids = array($this->testrequest->raw('q_id'));
-        } elseif ($this->testrequest->raw('q_id')) {
-            $ids = $this->testrequest->raw('q_id');
+        if ($this->testrequest->hasQuestionId() && !is_array($this->testrequest->raw('q_id'))) {
+            $ids = [$this->testrequest->getQuestionId()];
+        } elseif ($this->testrequest->getQuestionIds()) {
+            $ids = $this->testrequest->getQuestionIds();
         } else {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('copy_no_questions_selected'), true);
             $this->ctrl->redirect($this, 'questions');

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -3365,7 +3365,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
                 $clone = assQuestion::instantiateQuestionGUI($new_id);
                 $clone->object->setObjId($this->object->getId());
-                $clone->object->saveToDb($new_id);
+                $clone->object->saveToDb();
 
                 $this->object->insertQuestion($this->test_question_set_config_factory->getQuestionSetConfig(), $new_id, true);
 

--- a/Modules/Test/classes/tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestQuestionBrowserTableGUI.php
@@ -483,7 +483,7 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
     private function getQuestionInstanceTypeFilter(): string
     {
         if ($this->fetchModeParameter() === self::MODE_BROWSE_TESTS) {
-            return ilAssQuestionList::QUESTION_INSTANCE_TYPE_DUPLICATES;
+            return ilAssQuestionList::QUESTION_INSTANCE_TYPE_ALL;
         }
 
         return ilAssQuestionList::QUESTION_INSTANCE_TYPE_ORIGINALS;

--- a/Modules/Test/classes/tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestQuestionBrowserTableGUI.php
@@ -481,11 +481,7 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
 
     private function getQuestionInstanceTypeFilter(): string
     {
-        if ($this->fetchModeParameter() === self::MODE_BROWSE_TESTS) {
-            return ilAssQuestionList::QUESTION_INSTANCE_TYPE_DUPLICATES;
-        }
-
-        return ilAssQuestionList::QUESTION_INSTANCE_TYPE_ORIGINALS;
+        return ilAssQuestionList::QUESTION_INSTANCE_TYPE_ALL;
     }
 
     /**

--- a/Modules/Test/classes/tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestQuestionBrowserTableGUI.php
@@ -473,6 +473,7 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
         }
 
         $questionList->setParentObjIdsFilter($parentObjectIds);
+        $questionList->setParentObjectType($this->getQuestionParentObjectType());
 
         $questionList->load();
 
@@ -481,7 +482,11 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
 
     private function getQuestionInstanceTypeFilter(): string
     {
-        return ilAssQuestionList::QUESTION_INSTANCE_TYPE_ALL;
+        if ($this->fetchModeParameter() === self::MODE_BROWSE_TESTS) {
+            return ilAssQuestionList::QUESTION_INSTANCE_TYPE_DUPLICATES;
+        }
+
+        return ilAssQuestionList::QUESTION_INSTANCE_TYPE_ORIGINALS;
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -1688,7 +1688,7 @@ abstract class assQuestion
                 "nr_of_tries" => array("integer", $this->getDefaultNrOfTries()), // #10771
                 "complete" => array("text", $complete),
                 "created" => array("integer", time()),
-                "original_id" => array("integer", null),
+                "original_id" => array("integer", $next_id),
                 "tstamp" => array("integer", $tstamp),
                 "external_id" => array("text", $this->getExternalId()),
                 'add_cont_edit_mode' => array('text', $this->getAdditionalContentEditingMode())
@@ -1739,6 +1739,7 @@ abstract class assQuestion
                 "points" => array("float", $this->getMaximumPoints()),
                 "nr_of_tries" => array("integer", $this->getNrOfTries()),
                 "tstamp" => array("integer", time()),
+                "original_id" => array("integer", ($original_id != -1) ? $original_id : $this->getOriginalId()),
                 'complete' => array('integer', $this->isComplete()),
                 "external_id" => array("text", $this->getExternalId())
             ), array(

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -1688,7 +1688,7 @@ abstract class assQuestion
                 "nr_of_tries" => array("integer", $this->getDefaultNrOfTries()), // #10771
                 "complete" => array("text", $complete),
                 "created" => array("integer", time()),
-                "original_id" => array("integer", $next_id),
+                "original_id" => array("integer", null),
                 "tstamp" => array("integer", $tstamp),
                 "external_id" => array("text", $this->getExternalId()),
                 'add_cont_edit_mode' => array('text', $this->getAdditionalContentEditingMode())
@@ -1739,7 +1739,6 @@ abstract class assQuestion
                 "points" => array("float", $this->getMaximumPoints()),
                 "nr_of_tries" => array("integer", $this->getNrOfTries()),
                 "tstamp" => array("integer", time()),
-                "original_id" => array("integer", ($original_id != -1) ? $original_id : $this->getOriginalId()),
                 'complete' => array('integer', $this->isComplete()),
                 "external_id" => array("text", $this->getExternalId())
             ), array(

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -126,6 +126,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 
     public const QUESTION_INSTANCE_TYPE_ORIGINALS = 'QST_INSTANCE_TYPE_ORIGINALS';
     public const QUESTION_INSTANCE_TYPE_DUPLICATES = 'QST_INSTANCE_TYPE_DUPLICATES';
+    public const QUESTION_INSTANCE_TYPE_ALL = 'QST_INSTANCE_TYPE_ALL';
     private $questionInstanceTypeFilter = self::QUESTION_INSTANCE_TYPE_ORIGINALS;
 
     private $includeQuestionIdsFilter = null;
@@ -428,6 +429,10 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             case self::QUESTION_INSTANCE_TYPE_DUPLICATES:
 
                 return 'qpl_questions.original_id IS NOT NULL';
+            case self::QUESTION_INSTANCE_TYPE_ALL:
+            default:
+
+                return null;
         }
 
         return null;

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -427,8 +427,6 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
                 return 'qpl_questions.original_id IS NULL';
 
             case self::QUESTION_INSTANCE_TYPE_DUPLICATES:
-
-                return 'qpl_questions.original_id IS NOT NULL';
             case self::QUESTION_INSTANCE_TYPE_ALL:
             default:
 

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -519,6 +519,18 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 			";
         }
 
+        if ($this->getParentObjectType() === 'tst') {
+            $tableJoin .= "
+            			LEFT JOIN	qpl_questions origquest
+			ON			origquest.question_id = qpl_questions.original_id
+			";
+
+            $tableJoin .= "
+            						INNER JOIN	tst_test_question tstquest
+			ON			tstquest.question_fi = qpl_questions.question_id
+			";
+        }
+
         if ($this->getAnswerStatusActiveId()) {
             $tableJoin .= "
 				LEFT JOIN	tst_test_result

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -423,13 +423,11 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
     {
         switch ($this->getQuestionInstanceTypeFilter()) {
             case self::QUESTION_INSTANCE_TYPE_ORIGINALS:
-
                 return 'qpl_questions.original_id IS NULL';
-
             case self::QUESTION_INSTANCE_TYPE_DUPLICATES:
+                return 'qpl_questions.original_id IS NOT NULL';
             case self::QUESTION_INSTANCE_TYPE_ALL:
             default:
-
                 return null;
         }
 

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -517,11 +517,6 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 
         if ($this->getParentObjectType() === 'tst') {
             $tableJoin .= "
-            			LEFT JOIN	qpl_questions origquest
-			ON			origquest.question_id = qpl_questions.original_id
-			";
-
-            $tableJoin .= "
             						INNER JOIN	tst_test_question tstquest
 			ON			tstquest.question_fi = qpl_questions.question_id
 			";


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=31276

@mbecker-databay  The "add from other test" feature did list only copied courses when filtering for a specific test and only original courses with no test filter
Changed the behaviour so that always all tests are shown
If thats not the intended behaviour please notify me