### PR TITLE
Calendar: Fix handling of incoming date in `ilDateTimeInputGUI`

### DIFF
--- a/Services/Form/classes/class.ilDateTimeInputGUI.php
+++ b/Services/Form/classes/class.ilDateTimeInputGUI.php
@@ -32,6 +32,8 @@ class ilDateTimeInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableF
      * @var bool
      */
     protected $side_by_side = true;
+    /** @var ilDateTime|null */
+    protected $valid_incoming_datetime = null;
 
     /**
     * Constructor
@@ -166,9 +168,13 @@ class ilDateTimeInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableF
     */
     public function setValueByArray($a_values)
     {
-        $incoming = $a_values[$this->getPostVar()];
-        $this->setDate(ilCalendarUtil::parseIncomingDate($incoming, $this->getDatePickerTimeFormat()));
-                
+        if ($this->valid_incoming_datetime !== null) {
+            $this->setDate($this->valid_incoming_datetime);
+        } else {
+            $incoming = $a_values[$this->getPostVar()];
+            $this->setDate(ilCalendarUtil::parseIncomingDate($incoming, $this->getDatePickerTimeFormat()));
+        }
+
         foreach ($this->getSubItems() as $item) {
             $item->setValueByArray($a_values);
         }
@@ -231,6 +237,7 @@ class ilDateTimeInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableF
                 $post_format = $this->getShowTime()
                     ? IL_CAL_DATETIME
                     : IL_CAL_DATE;
+                $this->valid_incoming_datetime = $this->getDate();
                 $_POST[$this->getPostVar()] = $this->getDate()->get($post_format);
             } else {
                 $_POST[$this->getPostVar()] = null;


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=37383

This PR fixes an issue with the `ilDateTimeInputGUI` in case the container form is **invalid**.

Let's suppose the following settings are given:
* Global timezone in the ILIAS calendar administration: An arbitrary timezone
* User timezone: Europe/Berlin

Let's further suppose the user enters/selects the following datetime string with the calendar picker in the user interface:
* 25.05.2023 09:00

In ILIAS 7, the problem is:
1. In `\ilDateTimeInputGUI::checkInput` the HTTP POST variable (initially: `25.05.2023 09:00`) is mutated by setting a normalized datetime string (with an applied UTC timezone) when `$_POST[$this->getPostVar()] = $this->getDate()->get($post_format);` is called.
2. As a result, the value in $_POST changes from `25.05.2023 09:00` (Europe/Berlin) to `25.05.2023 07:00` (UTC). `\ilDateTimeInputGUI::$date` is a `ilDateTime` instance with an internal `DateTime` set to `2023-05-25 09:00:00.000000` with `Europe/Berlin` as the interpreted timezone.
3. If the containing form is invalid an the consumer calls `$form->setValuesByPost();`
4. The `$incoming` datetime string (`25.05.2023 07:00`) is parsed again. `\ilDateTimeInputGUI::$date` is  now a  `ilDateTime` instance with an internal `DateTime` set to `2023-05-25 07:00:00.000000` with `Europe/Berlin` as the interpreted timezone. So the offset is now 2 hours.
5. This datetime string is now rendered in the user interface, which is wrong.

This seems to be **not** an issue for ILIAS >= 8.x.