### PR TITLE
Test: Fix Wrong Link to Statistics in Pool  37226

### DIFF
--- a/Modules/TestQuestionPool/classes/tables/class.ilQuestionBrowserTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilQuestionBrowserTableGUI.php
@@ -411,7 +411,7 @@ class ilQuestionBrowserTableGUI extends ilTable2GUI
                 }
                 if (strcmp($c, 'statistics') == 0) {
                     $this->tpl->setCurrentBlock('statistics');
-                    $this->tpl->setVariable("LINK_ASSESSMENT", $this->ctrl->getLinkTargetByClass($class, "assessment"));
+                    $this->tpl->setVariable("LINK_ASSESSMENT", $this->ctrl->getLinkTargetByClass('ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_STATISTICS));
                     $this->tpl->setVariable("TXT_ASSESSMENT", $this->lng->txt("statistics"));
                     include_once "./Services/Utilities/classes/class.ilUtil.php";
                     $this->tpl->setVariable("IMG_ASSESSMENT", ilUtil::getImagePath("assessment.gif", "Modules/TestQuestionPool"));


### PR DESCRIPTION
This is a simple cherry-pick from this commit: 
https://github.com/ILIAS-eLearning/ILIAS/commit/b6e306aac33db46b4487674d85885c31c075df3f

It will fix this issue also on ilias7
 https://mantis.ilias.de/view.php?id=37226