### PR TITLE
UI: force ltr rendering of breadcrumbs

### DIFF
--- a/src/UI/templates/default/Breadcrumbs/tpl.breadcrumbs.html
+++ b/src/UI/templates/default/Breadcrumbs/tpl.breadcrumbs.html
@@ -1,9 +1,11 @@
 <nav aria-label="{ARIA_LABEL}" class="breadcrumb_wrapper">
-	<div class="breadcrumb">
-		<!-- BEGIN crumbs -->
-		<span class="crumb">
-			{CRUMB}
+	<div class="breadcrumb"> <!-- this here exists to put ellipsis on the right side via rtl-rendering --!>
+		<span> <!-- this here exists to force rendering of words in ltr order... --!>
+			<!-- BEGIN crumbs -->
+			<span class="crumb">
+				{CRUMB}
+			</span>
+			<!-- END crumbs -->
 		</span>
-		<!-- END crumbs -->
 	</div>
 </nav>

--- a/templates/default/070-components/UI-framework/Breadcrumbs/_ui-component_breadcrumbs.scss
+++ b/templates/default/070-components/UI-framework/Breadcrumbs/_ui-component_breadcrumbs.scss
@@ -20,25 +20,29 @@
 		padding: ($il-padding-small-vertical * 2);
 		padding-left: $il-standard-page-content-padding;
 
-		span.crumb a {
-			color: $il-standard-page-breadcrumbs-color;
-			&:hover {
-				color: $il-standard-page-breadcrumbs-active-color;
-			}
-			&:focus {
-				border: $il-focus-outline-inner;
+		span {
+			direction: ltr;
+
+			span.crumb a {
+				color: $il-standard-page-breadcrumbs-color;
+				&:hover {
+					color: $il-standard-page-breadcrumbs-active-color;
+				}
+				&:focus {
+					border: $il-focus-outline-inner;
 				
-				&::after {
-					content: none;
+					&::after {
+						content: none;
+					}
 				}
 			}
-		}
 
-		&>span+span:before {
-			content: $il-standard-page-breadcrumbs-seperator;
-			color: $il-standard-page-breadcrumbs-divider-color;
-			padding: 8px 10px;
-			font-family: "il-icons";
+			&>span+span:before {
+				content: $il-standard-page-breadcrumbs-seperator;
+				color: $il-standard-page-breadcrumbs-divider-color;
+				padding: 8px 10px;
+				font-family: "il-icons";
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi everyone,

this shows a fix I found to solve [#37062](https://mantis.ilias.de/view.php?id=37062), which documents that for some time safari rendered the words in the breadcrumbs in reverse order. For some time I thought, that the behaviour of safari documented in the ticket was actually correct. After reading up again on LTR/RTL (left-to-right/right-to-left) text rendering, I do not think so anymore. So we won't need that fix anymore, IMO. But: I think this is highlights some interesting insights on LTR/RTL text rendering, so I still open this PR to document the insights in case any LTR/RTL-discussions ever comes up again.

If someone wants to go deeper, the [w3c on *Structural markup and right-to-left text in HTML*](https://www.w3.org/International/questions/qa-html-dir) and [the basics on Unicode Bidirectional Algorithm](https://www.w3.org/International/articles/inline-bidi-markup/uba-basics) are very interesting and understandable reads. Major takeaways for me is: If we want to move towards being RTL ready, we should avoid `left` and `right` in our CSS and use `start` and `end` instead.

But lets look into this issue now. We begin by describing the status quo. We are looking at the breadcrumbs, that `repository > category 1 > category 2 > my course` thingy somewhere at the top of page. When building it, we wanted to avoid linebreaks in the breadcrumb section in case the breadcrumbs get longer then the available width. There is a very convenient css-feature to do this: [the ellipsis](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow?retiredLocale=de). But sadly, it would appear at the right side of the breadcrumb, which, sadly, would skip the important part of the breadcrumb. Luckily, there is a well [known hack to accomplish this by using RTL rendering](https://davidwalsh.name/css-ellipsis-left). This worked very well for some time, until the ticket was posted.

Some wording regarding bidirectional text: Text has a base direction, which by default is assumed to be left to right. This base direction can be changed with the css "direction" attribute or the html "dir" attribute. Which is what the ellipsis hack uses. The base direction determines, well, where the text starts and the direction in which it flows. This is fine, for text that only needs one direction. But: There is text that contains both directions. E.g., when I quote an arabic word in arabic script in an english text. Unicode defines a direction for every character and bidirectional rendering can use this to combine characters with the same direction into a directional run. This is why the words in the breadcrumbs are rendered in the correct direction, even though the base direction is RTL.

This is also the reason that I initially thought that safari was indeed correct with its rendering. The single words need to be rendered ltr (and indeed are) but the overall text is RTL, hence the words are sorted in backwards. But things are a little bit more complicated: Unicode also knows "neutral" characters, that do not have a natural direction (e.g. spaces and dots). If these characters are surrounded by other characters that have a direction, the characters are combined into one directional run. Hence safari was wrong indeed to sort the words from rtl, since they only are separated by neutral characters. A miss interpretation of neutral characters might also have been the bug that was fixed in safari.

The fix proposed here would have forced the correct word order by changing the base direction of the breadcrumbs again. Hence, it produces the desired behaviour: the ellipsis appears on the left (as we declare an RTL text), but the RTL only contains one LTR section with the actual breadcrumb. This fix might come in handy again once someone uses titles that contain arabic characters, because neutral characters copy the base direction once they are in between characters of different directions.

I hope this was comprehensive and useful =)

Best wishes