### PR TITLE
Database Update Steps to convert whole database to UTF8MB4

### DIFF
--- a/Services/Database/classes/Setup/class.ilDatabaseUTF8MB4Agent.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUTF8MB4Agent.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup;
+
+class ilDatabaseUTF8MB4Agent extends Setup\Agent\NullAgent
+{
+    public function getUpdateObjective(\ILIAS\Setup\Config $config = null): \ILIAS\Setup\Objective
+    {
+        return new \ilDatabaseUpdateStepsExecutedObjective(new ilDatabaseUTF8MB4UpdateSteps());
+    }
+
+    public function getStatusObjective(\ILIAS\Setup\Metrics\Storage $storage): \ILIAS\Setup\Objective
+    {
+        return new \ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilDatabaseUTF8MB4UpdateSteps());
+    }
+}

--- a/Services/Database/classes/Setup/class.ilDatabaseUTF8MB4UpdateSteps.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUTF8MB4UpdateSteps.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
+ * Class ilDatabaseUTF8MB4UpdateSteps
+ * Contains update steps to convert the database, all tables and columns to UTF8MB4
+ *
+ * @author Sven Dyhr <sven.dyhr@tik.uni-stuttgart.de>
+ */
+class ilDatabaseUTF8MB4UpdateSteps implements \ilDatabaseUpdateSteps
+{
+    protected \ilDBInterface $db;
+    private string $charset;
+    private string $collation;
+    private string $dbName;
+
+    public function prepare(\ilDBInterface $db): void
+    {
+        $this->db = $db;
+        $this->dbName = $this->db->getDbName();
+        $this->charset = "utf8mb4";
+        $this->collation = $this->selectCollation();
+    }
+
+    /**
+     * Checks if the database supports utf8mb4_unicode_520_ci and if so returns it.
+     * Should be the case for MariaDB 10.x & MySQL 5.7 and 8.0
+     *
+     * utf8mb4_unicode_ci is returned as fallback
+     *
+     * @return string   Contains the collation used for conversion.
+     */
+    private function selectCollation(): string
+    {
+        $q = "SHOW COLLATION WHERE COLLATION LIKE 'utf8mb4_unicode_520_ci'";
+        if ($this->db->query($q)->fetch()) {
+            return "utf8mb4_unicode_520_ci";
+        }
+        return "utf8mb4_unicode_ci";
+    }
+
+    /**
+     * Fetches all tables of the database.
+     *
+     * ilDBInterface provides the method "listTables", but it ignores sequence tables.
+     * Since all tables should be converted, a separate function is necessary.
+     *
+     * @return array    An array containing names of all tables of the database.
+     */
+    private function getTables(): array
+    {
+        $q = "SHOW TABLES FROM $this->dbName";
+        $statement = $this->db->query($q);
+        $tables = [];
+        while ($data = $statement->fetch()) {
+            $tables[] = array_values($data)[0];
+        }
+        return $tables;
+    }
+
+    /**
+     * Fetches the character set and collation of the database.
+     *
+     * @return array|false  False if the query does not return any data,
+     *                      an array with keys charset and collation.
+     */
+    private function getCharsetDB(): array|false
+    {
+        $q = "SELECT DEFAULT_CHARACTER_SET_NAME as charset, " .
+             "DEFAULT_COLLATION_NAME as collation " .
+             "FROM information_schema.SCHEMATA " .
+             "WHERE SCHEMA_NAME = '$this->dbName'";
+        return $this->db->query($q)->fetch();
+    }
+
+    /**
+     * Fetches the character set and collation of a given table.
+     *
+     * @param string $table The table whose character set and collation are to be fetched
+     * @return array|false  False if the given table does not exist, otherwise an array
+     *                      with keys charset and collation
+     */
+    private function getCharsetTable(string $table): array|false
+    {
+        if (!$this->db->tableExists($table)) {
+            return false;
+        }
+        $q = "SELECT CCSA.CHARACTER_SET_NAME AS charset, " .
+             "TABLE_COLLATION AS collation " .
+             "FROM information_schema.TABLES AS T " .
+             "JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS CCSA " .
+             "WHERE T.TABLE_COLLATION = CCSA.COLLATION_NAME " .
+             "AND TABLE_SCHEMA='$this->dbName' AND TABLE_NAME='$table'";
+        return $this->db->query($q)->fetch();
+    }
+
+    /**
+     * Fetches all information about a given column of a given table.
+     *
+     * @param string $table     The table containing the column
+     * @param string $column    The column whose information are to be retrieved
+     * @return array|false      False if the given table does not exist or does not contain the
+     *                          given column, otherwise an array containing the metadata
+     */
+    private function getColumnMetadata(string $table, string $column): array|false
+    {
+        if (!$this->db->tableExists($table) || !$this->db->tableColumnExists($table, $column)) {
+            return false;
+        }
+        $q = "SELECT * FROM information_schema.COLUMNS WHERE table_schema = '$this->dbName' " .
+             "AND table_name = '$table' AND column_name = '$column'";
+        return $this->db->query($q)->fetch();
+    }
+
+    /**
+     * Converts a given column of a table to a new column type
+     *
+     * @param string      $table    The table containing the column
+     * @param string      $column   The column whose type is to be changed
+     * @param string      $type     The new type of the column
+     */
+    private function convertColumn(string $table, string $column, string $type): void
+    {
+        //do nothing if table or column does not exist
+        if (!$this->db->tableExists($table) || !$this->db->tableColumnExists($table, $column)) {
+            return;
+        }
+
+        $data = $this->getColumnMetadata($table, $column);
+        // do nothing if column doesn't have a collation (non text fields)
+        if (is_null($data["CHARACTER_SET_NAME"])) {
+            return;
+        }
+        // do nothing if column already has the new character set AND type
+        if ($data["CHARACTER_SET_NAME"] === $this->charset && $data["COLUMN_TYPE"] === $type) {
+            return;
+        }
+
+        $constraint = ($data["IS_NULLABLE"] === "YES") ? "NULL" : "NOT NULL";
+        if (!is_null($data["COLUMN_DEFAULT"])) {
+            $constraint .= " DEFAULT {$data['COLUMN_DEFAULT']}";
+        }
+
+        $q = "ALTER TABLE $table CHANGE $column $column $type " .
+             "CHARACTER SET $this->charset COLLATE $this->collation $constraint";
+        $this->db->manipulate($q);
+    }
+
+    /**
+     * Converts the character set of the database itself
+     */
+    private function convertCharsetDatabase(): void
+    {
+        $db_info = $this->getCharsetDB();
+
+        if ($db_info === false || $db_info["charset"] === $this->charset) {
+            return;
+        }
+        $q = "ALTER DATABASE $this->dbName " .
+             "CHARACTER SET = $this->charset " .
+             "COLLATE = $this->collation";
+        $this->db->manipulate($q);
+    }
+
+    /**
+     * Converts the character set of all tables of the database
+     */
+    private function convertCharsetTables(): void
+    {
+        $tables = $this->getTables();
+        foreach ($tables as $table) {
+            $table_info = $this->getCharsetTable($table);
+            if ($table_info === false || $table_info["charset"] === $this->charset) {
+                continue;
+            }
+            $q = "ALTER TABLE $table CONVERT TO " .
+                 "CHARACTER SET $this->charset COLLATE $this->collation";
+            $this->db->manipulate($q);
+        }
+    }
+
+    /**
+     * Takes care of some special cases that would throw errors due to byte limit
+     */
+    private function convertCharsetColumnsSpecialCases(): void
+    {
+        $cases = array(
+            "event" => array("description", "location", "tutor_name", "details"),
+            "crs_settings" => array("syllabus", "contact_consultation", "important", "target_group")
+        );
+        foreach ($cases as $table => $columns) {
+            foreach ($columns as $column) {
+                $this->convertColumn($table, $column, "text");
+            }
+        }
+    }
+
+    public function step_1(): void
+    {
+        $this->convertCharsetDatabase();
+    }
+
+    public function step_2(): void
+    {
+        $this->convertCharsetColumnsSpecialCases();
+    }
+
+    public function step_3(): void
+    {
+        $this->convertCharsetTables();
+    }
+}


### PR DESCRIPTION
### Motivation
With current versions of MySQL and MariaDB, the character set `utf8` is an alias for `utf8mb3`. It uses up to three bytes per character to encode text. At the moment, ILIAS only supports utf8mb3.

The following points are incentives to convert the database to a more modern character set:

- `utf8mb3` only supports Basic Multilingual Plane (BMP), `utf8mb4` also supports supplementary characters
- According to the MySQL 8.0 documentation, `utf8mb3` is deprecated and is expected to be removed in future MySQL versions

### Implemented changes
This pull request implements database update steps to convert the character set of the ILIAS database itself, all tables and text containing columns to `utf8mb4`.

With the current state, most tables are converted without problems. Two tables have to be altered manually and feedback of the maintainer is required (see below). This is also implemented here and will either be kept or edited after feedback is received. In addition, there is a db update class in the trunk branch that leads to an index prefix that is too long causing the steps to stop.

No exception handling is implemented, as the database update should actually fail if a conversion step fails.

### Additional feedback or actions required from maintainers

#### Service: ResourceStorage (@chfsx)
⚠️ This causes the update or setup to fail and needs to be resolved before merging. 
- Affected Class: [ilResourceStorageDB90](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/Services/ResourceStorage/classes/Setup/DB/class.ilResourceStorageDB90.php)
- For the primary key, the columns `rid`, `revision`, `definition_id` and `variant` are used.
  - in total, an integer of length `8` and text of length `64 + 64 + 768 = 896`
  - with 4 bytes per character, the text part alone allocates at least `3584` bytes
  - with DYNAMIC row format of InnoDB, only up to `3072` bytes are supported for index prefixes

#### Module: Course (@smeyer-ilias)
- Affected database table: `crs_settings`
- The maximum row size of MySQL is `65535` bytes. The affected table contains four columns of type `varchar` and length `4000`, which sums up to `64000` bytes with the usage of `utf8mb4`. With the remaining columns, the row exceeds the limit and an error is thrown
- Columns with type `varchar(4000)` in this context are:
  - syllabus
  - contact_consultation
  - important
  - target_group
- To fix this issue, the affected four columns could be converted to type `text` which is stored in overflow pages.
- The necessary update steps are implemented in the function `convertCharsetColumnsSpecialCases`. 

#### Module: Session (@smeyer-ilias)
- Affected database table: `event`
- Same problem as with table crs_settings of Course above.
- Columns with type `varchar(4000)` in this context are:
  - description
  - location
  - tutor_name
  - details