### PR TITLE
User/Session: Allow Longer Session Ids

### DIFF
--- a/Modules/DataCollection/classes/Helpers/class.ilDclPropertyFormGUI.php
+++ b/Modules/DataCollection/classes/Helpers/class.ilDclPropertyFormGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/Modules/DataCollection/classes/Helpers/class.ilDclPropertyFormGUI.php
+++ b/Modules/DataCollection/classes/Helpers/class.ilDclPropertyFormGUI.php
@@ -51,7 +51,7 @@ class ilDclPropertyFormGUI extends ilPropertyFormGUI
         $tmp_file_name = implode(
             "~~",
             array(
-                session_id(),
+                mb_substr(session_id(), 0, 8),
                 $a_hash,
                 $a_field,
                 $a_index,

--- a/Services/User/classes/Setup/class.ilUser8DBUpdateSteps.php
+++ b/Services/User/classes/Setup/class.ilUser8DBUpdateSteps.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+class ilUser8DBUpdateSteps implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->modifyTableColumn(
+            'usr_session',
+            'session_id',
+            [
+                'type' => ilDBConstants::T_TEXT,
+                'length' => '256'
+            ]
+        );
+        $this->db->modifyTableColumn(
+            'usr_session_stats_raw',
+            'session_id',
+            [
+                'type' => ilDBConstants::T_TEXT,
+                'length' => '256'
+            ]
+        );
+        $this->db->modifyTableColumn(
+            'usr_sess_istorage',
+            'session_id',
+            [
+                'type' => ilDBConstants::T_TEXT,
+                'length' => '256'
+            ]
+        );
+    }
+}

--- a/Services/User/classes/Setup/class.ilUser8DBUpdateSteps.php
+++ b/Services/User/classes/Setup/class.ilUser8DBUpdateSteps.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,9 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
+
 class ilUser8DBUpdateSteps implements ilDatabaseUpdateSteps
 {
     protected ilDBInterface $db;

--- a/Services/User/classes/Setup/class.ilUserSetupAgent.php
+++ b/Services/User/classes/Setup/class.ilUserSetupAgent.php
@@ -53,7 +53,7 @@ class ilUserSetupAgent implements Setup\Agent
 
     public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsExecutedObjective(new ilUser8DBUpdateSteps());
     }
 
     public function getBuildArtifactObjective(): Setup\Objective
@@ -63,7 +63,7 @@ class ilUserSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilUser8DBUpdateSteps());
     }
 
     public function getMigrations(): array

--- a/Services/User/classes/class.ilObjUserFolderGUI.php
+++ b/Services/User/classes/class.ilObjUserFolderGUI.php
@@ -1143,7 +1143,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
 
         $ilUser = $DIC->user();
 
-        $importDir = 'user_import/usr_' . $ilUser->getId() . '_' . session_id();
+        $importDir = 'user_import/usr_' . $ilUser->getId() . '_' . mb_substr(session_id(), 0, 8);
 
         return $importDir;
     }


### PR DESCRIPTION
This increases the size of table-columns used for storage of the `session_id` to 256 varchars. It also shortens the value to 8 characters where it is used to generate length limited strings.
See: https://mantis.ilias.de/view.php?id=26954