### PR TITLE
Test: Update processing time on time-restricted tests without page reload

### DIFF
--- a/Modules/Test/classes/class.ilObjTestAccess.php
+++ b/Modules/Test/classes/class.ilObjTestAccess.php
@@ -541,7 +541,7 @@ class ilObjTestAccess extends ilObjectAccess implements ilConditionHandling
                 );
                 if ($result->numRows()) {
                     $row = $ilDB->fetchAssoc($result);
-                    if (trim($row['clientip']) != "") {
+                    if ($row['clientip'] !== null && trim($row['clientip']) != "") {
                         $row['clientip'] = preg_replace("/[^0-9.?*,:]+/", "", $row['clientip']);
                         $row['clientip'] = str_replace(".", "\\.", $row['clientip']);
                         $row['clientip'] = str_replace(array("?","*",","), array("[0-9]","[0-9]*","|"), $row['clientip']);

--- a/Modules/Test/classes/class.ilTestPasswordChecker.php
+++ b/Modules/Test/classes/class.ilTestPasswordChecker.php
@@ -81,7 +81,7 @@ class ilTestPasswordChecker
 
     public function wrongUserEnteredPasswordExist(): bool
     {
-        if (!strlen($this->getUserEnteredPassword())) {
+        if ($this->getUserEnteredPassword() && $this->getUserEnteredPassword() === '') {
             return false;
         }
 

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1404,7 +1404,22 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         } else {
             $template->setVariable("REDIRECT_URL", "");
         }
+        $template->setVariable("CHECK_URL", $this->ctrl->getLinkTarget($this, 'checkWorkingTime', '', true));
         $this->tpl->addOnLoadCode($template->get());
+    }
+
+    /**
+     * This is asynchronously called by tpl.workingtime.js to check for
+     * changes in the user's processing time for a test. This includes
+     * extra time added during the test, as this is checked by
+     * ilObjTest::getProcessingTimeInSeconds(). The Javascript side
+     * then updates the test timer without needing to reload the test page.
+     */
+    public function checkWorkingTimeCmd(): void
+    {
+        $active_id = $this->testSession->getActiveId();
+        echo (string) $this->object->getProcessingTimeInSeconds($active_id);
+        exit;
     }
 
     protected function showSideList($presentationMode, $currentSequenceElement)

--- a/Modules/Test/classes/class.ilTestServiceGUI.php
+++ b/Modules/Test/classes/class.ilTestServiceGUI.php
@@ -666,7 +666,7 @@ class ilTestServiceGUI
 
         $invited_user = array_pop($this->object->getInvitedUsers($user_id));
         $title_client = '';
-        if ($invited_user != null && strlen($invited_user["clientip"])) {
+        if ($invited_user["clientip"] !== null && strlen($invited_user["clientip"])) {
             $template->setCurrentBlock("client_ip");
             $template->setVariable("TXT_CLIENT_IP", $this->lng->txt("client_ip"));
             $template->setVariable("VALUE_CLIENT_IP", $invited_user["clientip"]);

--- a/Modules/Test/templates/default/tpl.workingtime.js
+++ b/Modules/Test/templates/default/tpl.workingtime.js
@@ -24,7 +24,8 @@
 		timeleft = "{STRING_TIMELEFT}",
 		redirectUrl = "{REDIRECT_URL}",
 		and = "{AND}",
-		time_left_span;
+		time_left_span,
+		check_url = "{CHECK_URL}";
 
 		<!-- BEGIN enddate -->
 			test_end = (new Date({ENDYEAR}, {ENDMONTH}, {ENDDAY}, {ENDHOUR}, {ENDMINUTE}, {ENDSECOND})).getTime() / 1000;
@@ -147,10 +148,35 @@
 		setWorkingTime();
 	}
 
+	/**
+	 * This is invoked every 30 secs to check if the
+	 * allocated time for time-restricted tests has been
+	 * changed during the test and update the timer
+	 * accordingly.
+	 */
+	function checkWorkingTime() {
+		$.ajax({
+		    type: 'GET',
+		    url: check_url,
+		    dataType: 'text',
+		    timeout: 1000
+		})
+		.done((response) => {
+			if (response > 0) {
+				test_time_sec = response % 60;
+				test_time_min = (response - test_time_sec) / 60;
+				setWorkingTime();
+			};
+		})
+		.fail();
+
+	}
+
 	$(function() {
 		time_left_span = $('#timeleft');
 		tick();
 		interval = w.setInterval(tick, 1000);
+		w.setInterval(checkWorkingTime, 30000);
 	});
 
 }(window, jQuery));


### PR DESCRIPTION
Refering to the first part of https://mantis.ilias.de/view.php?id=22536#c75295 :
When extra time is added to time-restricted tests while the test is running, the timer for the participant is not updated unless the page is reloaded. This can lead to triggering the auto-submit too early without adding the extra time. 

This PR adds a polling method every 30 seconds that checks for the correct processing time (including extra time) and updates the timer accordingly. I have decided against just checking this before finally auto-submitting the test (as proposed in Mantis), as the participant might get irritated if the extra time is only displayed at the last second. 
This way, the update happens no more than 30 seconds after the proctor has added extra time via the dashboard. If you feel that the additional load of polling every 30 seconds is too much, the timing can of course be changed.

The second commit should be cherry-pickable for ILIAS 7 and 8 as well, the first one just contains some small fixes for PHP 8.1 and is only valid for trunk. The second part of the Mantis ticket (change of password during a test) will be handled separately in a future PR.