### PR TITLE
css word-break in workflow listing, fixes long titles in learning sequence toc - mantis 37291

### DIFF
--- a/src/UI/templates/default/Listing/workflow.less
+++ b/src/UI/templates/default/Listing/workflow.less
@@ -1,3 +1,6 @@
+.il-workflow {
+	word-break: break-word;
+}
 .il-workflow-header {
 	// margin-bottom:  @il-slate-content-padding;
 	// height: @il-top-bar-height;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8804,6 +8804,9 @@ fieldset[disabled] .il-table-presentation-viewcontrols .btn-default.engaged.focu
 .il-table-data .header.cell {
   font-weight: bold;
 }
+.il-workflow {
+  word-break: break-word;
+}
 .il-workflow-header .il-workflow-title {
   background-color: #f0f0f0;
   color: #4c6586;


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=37291

# Issue

Long titles in learning sequence table of content overflow indefinitely.

This is actually the behavior of the UI component workflow listing.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/a4888d2b-ef90-4d5b-ae3c-ad3c5aa2472f)

# Changes

Long strings inside the UI workflow listing are now forced to break (using `word-break: break-word;`) even if `hyphens: auto` wouldn't add a break.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/00878f32-8660-4d67-a656-82bd18f61468)

# Related

The page content shows the same problem (see heading in the screenshots). This should be tackled separately and with careful consideration for the scope of the change as it could negatively impact tables.