### PR TITLE
Test: Avoid data loss when changing password mid-test

### DIFF
--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1793,7 +1793,6 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
         if (!$this->passwordChecker->isPasswordProtectionPageRedirectRequired()) {
             $this->testSession->setPasswordChecked(true);
-            $this->testSession->saveToDb();
             return;
         }
 

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1777,11 +1777,23 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
     protected function handlePasswordProtectionRedirect()
     {
+        /**
+         * The test password is only checked once per session
+         * to avoid errors during autosave if the password is
+         * changed during a running test.
+         * See Mantis #22536 for more details.
+         */
+        if ($this->testSession->isPasswordChecked() === true) {
+            return;
+        }
+
         if ($this->ctrl->getNextClass() == 'iltestpasswordprotectiongui') {
             return;
         }
 
         if (!$this->passwordChecker->isPasswordProtectionPageRedirectRequired()) {
+            $this->testSession->setPasswordChecked(true);
+            $this->testSession->saveToDb();
             return;
         }
 

--- a/Modules/Test/classes/class.ilTestSession.php
+++ b/Modules/Test/classes/class.ilTestSession.php
@@ -179,8 +179,7 @@ class ilTestSession
                     'tstamp' => ['integer', time() - 10],
                     'last_finished_pass' => ['integer', $this->getLastFinishedPass()],
                     'last_started_pass' => ['integer', $this->getPass()],
-                    'objective_container' => ['integer', $this->getObjectiveOrientedContainerId()],
-                    'pw_checked' => ['integer', ($this->passwordChecked === true) ? 1 : 0]
+                    'objective_container' => ['integer', $this->getObjectiveOrientedContainerId()]
                 ],
                 [
                     'active_id' => ['integer', $this->getActiveId()]
@@ -205,8 +204,7 @@ class ilTestSession
                         'tstamp' => ['integer', time() - 10],
                         'last_finished_pass' => ['integer', $this->getLastFinishedPass()],
                         'last_started_pass' => ['integer', $this->getPass()],
-                        'objective_container' => ['integer', $this->getObjectiveOrientedContainerId()],
-                        'pw_checked' => ['integer', ($this->passwordChecked === true) ? 1 : 0]
+                        'objective_container' => ['integer', $this->getObjectiveOrientedContainerId()]
                     ]
                 );
                 $this->active_id = $next_id;
@@ -256,7 +254,6 @@ class ilTestSession
             $this->submitted = ($row["submitted"]) ? true : false;
             $this->submittedTimestamp = $row["submittimestamp"];
             $this->tstamp = $row["tstamp"];
-            $this->passwordChecked = ($row["pw_checked"] === 1) ? true : false;
 
             $this->setLastStartedPass($row['last_started_pass']);
             $this->setLastFinishedPass($row['last_finished_pass']);
@@ -289,7 +286,6 @@ class ilTestSession
             $this->submitted = ($row["submitted"]) ? true : false;
             $this->submittedTimestamp = $row["submittimestamp"];
             $this->tstamp = $row["tstamp"];
-            $this->passwordChecked = ($row["pw_checked"] === 1) ? true : false;
 
             $this->setLastStartedPass($row['last_started_pass']);
             $this->setLastFinishedPass($row['last_finished_pass']);
@@ -538,20 +534,21 @@ class ilTestSession
 
     public function isPasswordChecked(): bool
     {
-        return $this->passwordChecked;
+        if (ilSession::get('pw_checked_' . $this->active_id) === null) {
+            return false;
+        }
+        return ilSession::get('pw_checked_' . $this->active_id);
     }
 
     public function setPasswordChecked(bool $value): void
     {
-        $this->passwordChecked = $value;
+        ilSession::set('pw_checked_' . $this->active_id, $value);
     }
 
     /**
      * @var null|bool
      */
     private $reportableResultsAvailable = null;
-
-    private $passwordChecked = false;
 
     /**
      * @param ilObjTest $testOBJ

--- a/Modules/Test/classes/class.ilTestSession.php
+++ b/Modules/Test/classes/class.ilTestSession.php
@@ -179,7 +179,8 @@ class ilTestSession
                     'tstamp' => ['integer', time() - 10],
                     'last_finished_pass' => ['integer', $this->getLastFinishedPass()],
                     'last_started_pass' => ['integer', $this->getPass()],
-                    'objective_container' => ['integer', $this->getObjectiveOrientedContainerId()]
+                    'objective_container' => ['integer', $this->getObjectiveOrientedContainerId()],
+                    'pw_checked' => ['integer', ($this->passwordChecked === true) ? 1 : 0]
                 ],
                 [
                     'active_id' => ['integer', $this->getActiveId()]
@@ -204,7 +205,8 @@ class ilTestSession
                         'tstamp' => ['integer', time() - 10],
                         'last_finished_pass' => ['integer', $this->getLastFinishedPass()],
                         'last_started_pass' => ['integer', $this->getPass()],
-                        'objective_container' => ['integer', $this->getObjectiveOrientedContainerId()]
+                        'objective_container' => ['integer', $this->getObjectiveOrientedContainerId()],
+                        'pw_checked' => ['integer', ($this->passwordChecked === true) ? 1 : 0]
                     ]
                 );
                 $this->active_id = $next_id;
@@ -254,6 +256,7 @@ class ilTestSession
             $this->submitted = ($row["submitted"]) ? true : false;
             $this->submittedTimestamp = $row["submittimestamp"];
             $this->tstamp = $row["tstamp"];
+            $this->passwordChecked = ($row["pw_checked"] === 1) ? true : false;
 
             $this->setLastStartedPass($row['last_started_pass']);
             $this->setLastFinishedPass($row['last_finished_pass']);
@@ -286,6 +289,7 @@ class ilTestSession
             $this->submitted = ($row["submitted"]) ? true : false;
             $this->submittedTimestamp = $row["submittimestamp"];
             $this->tstamp = $row["tstamp"];
+            $this->passwordChecked = ($row["pw_checked"] === 1) ? true : false;
 
             $this->setLastStartedPass($row['last_started_pass']);
             $this->setLastFinishedPass($row['last_finished_pass']);
@@ -532,10 +536,22 @@ class ilTestSession
         return $this->getUserId() == ANONYMOUS_USER_ID;
     }
 
+    public function isPasswordChecked(): bool
+    {
+        return $this->passwordChecked;
+    }
+
+    public function setPasswordChecked(bool $value): void
+    {
+        $this->passwordChecked = $value;
+    }
+
     /**
      * @var null|bool
      */
     private $reportableResultsAvailable = null;
+
+    private $passwordChecked = false;
 
     /**
      * @param ilObjTest $testOBJ

--- a/Modules/Test/test/ilTestSessionTest.php
+++ b/Modules/Test/test/ilTestSessionTest.php
@@ -158,7 +158,9 @@ class ilTestSessionTest extends ilTestBaseTestCase
 
     public function testPasswordChecked(): void
     {
+        $this->testObj->active_id = 20;
         $this->testObj->setPasswordChecked(true);
+        $this->assertTrue(ilSession::get('pw_checked_20'));
         $this->assertTrue($this->testObj->isPasswordChecked());
     }
 }

--- a/Modules/Test/test/ilTestSessionTest.php
+++ b/Modules/Test/test/ilTestSessionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 /**
  * Class ilTestSessionTest
@@ -155,5 +154,11 @@ class ilTestSessionTest extends ilTestBaseTestCase
 
         $this->testObj->setUserId(ANONYMOUS_USER_ID);
         $this->assertTrue($this->testObj->isAnonymousUser());
+    }
+
+    public function testPasswordChecked(): void
+    {
+        $this->testObj->setPasswordChecked(true);
+        $this->assertTrue($this->testObj->isPasswordChecked());
     }
 }


### PR DESCRIPTION
Refering to the second part of https://mantis.ilias.de/view.php?id=22536#c75295 :
When a test password is changed during a running test, every participant has to re-enter the password again. If the page is not reloaded (e.g. for essay questions), this mechanism is not triggered and autosaving as well as auto-submitting the test will fail. 

As proposed, the password will now just be checked **once** per test session and the session will be flagged as "authenticated". This allows autosave and auto-submit to work as expected. New test sessions will still require the changed password.

~~This PR adds a new field to the test session table (_tst_active_) for persistence, so it might just be viable for trunk.~~ It also handles an edge case that should not happen regularly.
