### PR TITLE
UI: Allow dedicated names for inputs in a filter

### DIFF
--- a/src/UI/Implementation/Component/Input/Container/Filter/Filter.php
+++ b/src/UI/Implementation/Component/Input/Container/Filter/Filter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Container\Filter;
 
@@ -89,6 +88,7 @@ abstract class Filter implements C\Input\Container\Filter\Filter, CI\Input\NameS
      * For the implementation of NameSource.
      */
     private int $count = 0;
+    private array $used_names = [];
 
 
     /**
@@ -259,6 +259,23 @@ abstract class Filter implements C\Input\Container\Filter\Filter, CI\Input\NameS
         $this->count++;
 
         return $name;
+    }
+
+    /**
+     * Implementation of NameSource
+     * for using dedicated names in filter fields
+     */
+    public function getNewDedicatedName(string $dedicated_name): string
+    {
+        if ($dedicated_name == 'filter_input') {
+            return $this->getNewName();
+        }
+        if (in_array($dedicated_name, $this->used_names)) {
+            return $dedicated_name . '_' . $this->count++;
+        } else {
+            $this->used_names[] = $dedicated_name;
+            return $dedicated_name;
+        }
     }
 
     /**

--- a/tests/UI/Component/Input/Container/Filter/StandardFilterTest.php
+++ b/tests/UI/Component/Input/Container/Filter/StandardFilterTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 require_once(__DIR__ . "/../../../../../../libs/composer/vendor/autoload.php");
 require_once(__DIR__ . "/../../../../Base.php");
@@ -674,5 +673,33 @@ EOT;
 EOT;
 
         $this->assertHTMLEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
+    }
+
+    public function test_dedicated_names(): void
+    {
+        $f = $this->buildFactory();
+        $if = $this->buildInputFactory();
+        $inputs = [
+            $if->text("Title")->withDedicatedName('title'),
+            $if->select("Selection", ["one" => "One", "two" => "Two", "three" => "Three"])->withDedicatedName('selection'),
+            $if->multiSelect("Multi Selection", ["one" => "Num One", "two" => "Num Two", "three" => "Num Three"])
+        ];
+        $filter = $f->standard(
+            "#",
+            "#",
+            "#",
+            "#",
+            "#",
+            "#",
+            $inputs,
+            [true, true, true],
+            true,
+            true
+        );
+
+        $inputs = $filter->getInputs();
+        $this->assertEquals('filter_input_0/title', $inputs[0]->getName());
+        $this->assertEquals('filter_input_0/selection', $inputs[1]->getName());
+        $this->assertEquals('filter_input_0/filter_input_1', $inputs[2]->getName());
     }
 }


### PR DESCRIPTION
This is a followup for #5711 and allows dedicated names for inputs inside a filter component, as this implements its own namesource and did not implement `getNewDedicatedName()` yet.