### PR TITLE
LSO: Disable multi-download for LSO

### DIFF
--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -226,6 +226,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
         $this->lng->loadLanguageModule($this->obj_type);
 
         $this->data_factory = new Data\Factory();
+        $this->multi_download_enabled = false;
 
         $this->ref_id = $this->request_wrapper->retrieve("ref_id", $this->refinery->kindlyTo()->int());
         parent::__construct([], $this->ref_id, true, false);

--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 use ILIAS\Repository\Clipboard\ClipboardManager;
 use ILIAS\DI\UIServices;
@@ -2238,7 +2237,8 @@ class ilObjectListGUI
             return;
         }
 
-        if ($this->getContainerObject() instanceof ilContainerGUI) {
+        if ($this->getContainerObject() instanceof ilContainerGUI
+            && $this->getContainerObject()->isMultiDownloadEnabled()) {
             $this->ctrl->setParameter($this->getContainerObject(), "type", "");
             $this->ctrl->setParameter($this->getContainerObject(), "item_ref_id", "");
             $this->ctrl->setParameter($this->getContainerObject(), "active_node", "");


### PR DESCRIPTION
I had a look at https://mantis.ilias.de/view.php?id=36631 and tried to figure out how to disable the header action "**Download Mulitple Objects**" just for the Learning Sequence. After some research, it looks to me as if `ilContainerGUI::multi_download_enabled` is ignored by `ilObjectListGUI::insertMultiDownloadCommand` (which inserts the Action button) and so there is no way to disable this option on a per container basis (as far as I can tell).

This PR adds a check to `ilObjectListGUI::insertMultiDownloadCommand` to see if multi-downloads are enabled for an `ilContainerGUI`. The downside with this is that the default value of `ilContainerGUI::multi_download_enabled` is `false` right now and thus the "**Download Mulitple Objects**" action disappears unless it is explicitly set to `true`. Therefore I'm putting this up for discussion, in case I'm missing some other option here to disable multi-downloads for a single container.

Looking forward to your feedback.
