### PR TITLE
Search: Context Sensitive Search - Suggestions from ILIAS (11578)

### DIFF
--- a/Services/Search/classes/class.ilMainMenuSearchGUI.php
+++ b/Services/Search/classes/class.ilMainMenuSearchGUI.php
@@ -98,6 +98,7 @@ class ilMainMenuSearchGUI
         if ($ilUser->getId() != ANONYMOUS_USER_ID && ilSearchSettings::getInstance()->isLuceneUserSearchEnabled()) {
             $this->tpl->setCurrentBlock('usr_search');
             $this->tpl->setVariable('TXT_USR_SEARCH', $this->lng->txt('search_users'));
+            $this->tpl->setVariable('USER_SEARCH_ID', ilSearchController::TYPE_USER_SEARCH);
             $this->tpl->parseCurrentBlock();
         }
         
@@ -106,6 +107,8 @@ class ilMainMenuSearchGUI
         $this->tpl->setVariable('BTN_SEARCH', $this->lng->txt('search'));
         $this->tpl->setVariable('SEARCH_INPUT_LABEL', $this->lng->txt('search_field'));
         $this->tpl->setVariable('AC_DATASOURCE', "ilias.php?baseClass=ilSearchController&cmd=autoComplete");
+        $this->tpl->setVariable('AC_ROOT_ID', ROOT_FOLDER_ID);
+        $this->tpl->setVariable('AC_USER_SEARCH_ID', ilSearchController::TYPE_USER_SEARCH);
         
         $this->tpl->setVariable('IMG_MM_SEARCH', ilUtil::img(
             ilUtil::getImagePath("icon_seas.svg"),

--- a/Services/Search/templates/default/tpl.main_menu_search.html
+++ b/Services/Search/templates/default/tpl.main_menu_search.html
@@ -15,7 +15,7 @@
 				<input type="radio" name="root_id" value="{REF_ID}" id="ilmmsc"/> <label for="ilmmsc"> {TXT_CURRENT_POSITION}</label><br />
 				<!-- END position_rep -->
 				<!-- BEGIN usr_search -->
-				<input type="radio" name="root_id" value="-1" id="ilmmsu"/> <label for="ilmmsu"> {TXT_USR_SEARCH}</label>
+				<input type="radio" name="root_id" value="{USER_SEARCH_ID}" id="ilmmsu"/> <label for="ilmmsu"> {TXT_USR_SEARCH}</label>
 				<!-- END usr_search -->
 				<!-- BEGIN position_hid --><input type="hidden" name="root_id" value="{ROOT_ID_HID}"/><!-- END position_hid -->
 			</fieldset>
@@ -56,6 +56,7 @@
 
                     $("#ilMMSearchMenu input[type='radio']").change(function () {
                         $("#main_menu_search").focus();
+						$("#main_menu_search").autocomplete("enable");
 
                         /* close current search */
                         $("#main_menu_search").autocomplete("close");
@@ -64,6 +65,11 @@
 
                         var orig_datasource = "{AC_DATASOURCE}";
                         var type_val = $('input[name=root_id]:checked', '#mm_search_form').val();
+
+						if (type_val !== "{AC_ROOT_ID}" && type_val !== "{AC_USER_SEARCH_ID}") {
+							$("#main_menu_search").autocomplete("disable");
+							return;
+						}
 
                         $("#main_menu_search").autocomplete("option",
                             {


### PR DESCRIPTION
This PR fixes [11578](https://mantis.ilias.de/view.php?id=11578) by disabling autocomplete in the main menu search when 'At Current Position' is selected as 'Search Area'.