### PR TITLE
[FIX] CI: fixed arrow-function spacing for PHP-CS-Fixer.

### DIFF
--- a/CI/PHP-CS-Fixer/code-format.php_cs
+++ b/CI/PHP-CS-Fixer/code-format.php_cs
@@ -24,6 +24,7 @@ return (new PhpCsFixer\Config())
         'strict_param' => false,
         'concat_space' => ['spacing' => 'one'],
         'function_typehint_space' => true,
+        'function_declaration' => ['closure_fn_spacing' => 'none'],
         'binary_operator_spaces' => ['default' => 'single_space'],
         // 'types_spaces' => ['space' => 'single'],
 	])


### PR DESCRIPTION
Hi all,

According to PER, arrow-functions or the `fn` keyword must not be followed by a space character. See https://www.php-fig.org/per/coding-style/#71-short-closures for more info.

With the current configuration for the PHP-CS-Fixer however, this space has been added up till now. I have also checked with the PHPStorm code-style, which already did this correctly.

Kind regards,
@thibsy 