### PR TITLE
[37418] Fix missing tools if mainMenu has no items

### DIFF
--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
@@ -113,6 +113,7 @@ class StandardPagePartProvider implements PagePartProvider
     public function getMainBar() : ?MainBar
     {
         $this->gs->collector()->mainmenu()->collectOnce();
+        $this->gs->collector()->tool()->collectOnce();
         if (!$this->gs->collector()->mainmenu()->hasVisibleItems()
             && !$this->gs->collector()->tool()->hasVisibleItems()) {
             return null;


### PR DESCRIPTION
Hello,

if the main menu has no items there are no tools visible.

The collector for the tools is still empty because collect wasnt called yet. This PR fixes this and the tools are visible if there are no menu items. 

Greetings
Purhur