### PR TITLE
StandardPage Modification: strict StandardPage return types

### DIFF
--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
@@ -68,7 +68,7 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getContent(): ?Legacy
+    public function getContent(): Legacy
     {
         return $this->content ?? $this->ui->factory()->legacy("");
     }
@@ -76,12 +76,9 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getMetaBar(): ?MetaBar
+    public function getMetaBar(): MetaBar
     {
         $this->gs->collector()->metaBar()->collectOnce();
-        if (!$this->gs->collector()->metaBar()->hasItems()) {
-            return null;
-        }
         $f = $this->ui->factory();
         $meta_bar = $f->mainControls()->metaBar();
 
@@ -99,14 +96,9 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getMainBar(): ?MainBar
+    public function getMainBar(): MainBar
     {
         $this->gs->collector()->mainmenu()->collectOnce();
-        if (!$this->gs->collector()->mainmenu()->hasVisibleItems()
-            && !$this->gs->collector()->tool()->hasVisibleItems()) {
-            return null;
-        }
-
         $f = $this->ui->factory();
         $main_bar = $f->mainControls()->mainBar();
 
@@ -162,7 +154,7 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getBreadCrumbs(): ?Breadcrumbs
+    public function getBreadCrumbs(): Breadcrumbs
     {
         // TODO this currently gets the items from ilLocatorGUI, should that serve be removed with
         // something like GlobalScreen\Scope\Locator\Item
@@ -183,7 +175,7 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getLogo(): ?Image
+    public function getLogo(): Image
     {
         $std_logo = ilUtil::getImagePath("HeaderIcon.svg");
 
@@ -195,7 +187,7 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getResponsiveLogo(): ?Image
+    public function getResponsiveLogo(): Image
     {
         $responsive_logo = ilUtil::getImagePath("HeaderIconResponsive.svg");
 
@@ -238,7 +230,7 @@ class StandardPagePartProvider implements PagePartProvider
     /**
      * @inheritDoc
      */
-    public function getFooter(): ?Footer
+    public function getFooter(): Footer
     {
         return $this->ui->factory()->mainControls()->footer([]);
     }


### PR DESCRIPTION
**ALTERNATIVE FOR https://github.com/ILIAS-eLearning/ILIAS/pull/5974**

This is a proposal to fix the subsequent problem of https://mantis.ilias.de/view.php?id=37271

Even if this problem should not occur an is always caused by other issues, the basic worklflow of the modifciation process should be unified withing the standard page and the accessing providers.

This PR does that buy stricten the Standard page on its (mostly already implemented) types without the possibility of an nullable return.
The alternative approach, wich targets the accessing provider, can be found [here](https://github.com/ILIAS-eLearning/ILIAS/pull/5974).