### PR TITLE
StandardPage Modification: lose modification parameter types

### DIFF
--- a/Modules/LearningModule/Export/class.ilLMHtmlExportViewLayoutProvider.php
+++ b/Modules/LearningModule/Export/class.ilLMHtmlExportViewLayoutProvider.php
@@ -54,7 +54,7 @@ class ilLMHtmlExportViewLayoutProvider extends AbstractModificationProvider impl
                 ->layout()
                 ->factory()
                 ->metabar()
-                ->withModification(function (MetaBar $current = null): ?MetaBar {
+                ->withModification(function (?MetaBar $current): ?MetaBar {
                     return null;
                 })->withHighPriority();
         }
@@ -72,7 +72,7 @@ class ilLMHtmlExportViewLayoutProvider extends AbstractModificationProvider impl
                 ->layout()
                 ->factory()
                 ->mainbar()
-                ->withModification(function (MainBar $current = null): ?MainBar {
+                ->withModification(function (?MainBar $current): ?MainBar {
                     global $DIC;
 
                     $lng = $DIC->language();
@@ -90,13 +90,15 @@ class ilLMHtmlExportViewLayoutProvider extends AbstractModificationProvider impl
                     $lm_tools = new ilLMGSToolProvider($DIC);
                     $ids = $lm_tools->getOfflineToolIds();
 
-                    // copy all offline tools from original main bar to offline main bar
-                    foreach ($current->getToolEntries() as $id => $te) {
-                        if (in_array($id, $ids)) {
-                            $offline_main_bar = $offline_main_bar->withAdditionalToolEntry(
-                                $id,
-                                $te
-                            );
+                    if ($current !== null) {
+                        // copy all offline tools from original main bar to offline main bar
+                        foreach ($current->getToolEntries() as $id => $te) {
+                            if (in_array($id, $ids)) {
+                                $offline_main_bar = $offline_main_bar->withAdditionalToolEntry(
+                                    $id,
+                                    $te
+                                );
+                            }
                         }
                     }
 
@@ -118,7 +120,7 @@ class ilLMHtmlExportViewLayoutProvider extends AbstractModificationProvider impl
                 ->layout()
                 ->factory()
                 ->breadcrumbs()
-                ->withModification(function (Breadcrumbs $current = null): ?Breadcrumbs {
+                ->withModification(function (?Breadcrumbs $current): ?Breadcrumbs {
                     return null;
                 })->withHighPriority();
         } else {

--- a/Modules/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
+++ b/Modules/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
@@ -68,16 +68,18 @@ class ilLSViewLayoutProvider extends AbstractModificationProvider implements Mod
         }
         return $this->globalScreen()->layout()->factory()->mainbar()
             ->withModification(
-                function (MainBar $mainbar): ?MainBar {
-                    $entries = $this->data_collection->get(ilLSPlayer::GS_DATA_LS_MAINBARCONTROLS);
-                    $tools = $mainbar->getToolEntries();
-                    $mainbar = $mainbar->withClearedEntries();
+                function (?MainBar $mainbar): ?MainBar {
+                    if ($mainbar !== null) {
+                        $entries = $this->data_collection->get(ilLSPlayer::GS_DATA_LS_MAINBARCONTROLS);
+                        $tools = $mainbar->getToolEntries();
+                        $mainbar = $mainbar->withClearedEntries();
 
-                    foreach ($entries as $key => $entry) {
-                        $mainbar = $mainbar->withAdditionalEntry($key, $entry);
-                    }
-                    foreach ($tools as $key => $entry) {
-                        $mainbar = $mainbar->withAdditionalToolEntry($key, $entry);
+                        foreach ($entries as $key => $entry) {
+                            $mainbar = $mainbar->withAdditionalEntry($key, $entry);
+                        }
+                        foreach ($tools as $key => $entry) {
+                            $mainbar = $mainbar->withAdditionalToolEntry($key, $entry);
+                        }
                     }
                     return $mainbar;
                 }
@@ -92,7 +94,12 @@ class ilLSViewLayoutProvider extends AbstractModificationProvider implements Mod
         }
         return $this->globalScreen()->layout()->factory()->metabar()
             ->withModification(
-                fn (MetaBar $metabar): ?Metabar => $metabar->withClearedEntries()
+                function (?MetaBar $metabar): ?Metabar {
+                    if ($metabar !== null) {
+                        $metabar = $metabar->withClearedEntries();
+                    }
+                    return $metabar;
+                }
             )
             ->withHighPriority();
     }

--- a/Modules/Test/classes/Screen/class.ilTestPlayerLayoutProvider.php
+++ b/Modules/Test/classes/Screen/class.ilTestPlayerLayoutProvider.php
@@ -56,7 +56,7 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         if ($this->isKioskModeEnabled($called_contexts)) {
             $logo = $this->globalScreen()->layout()->factory()->logo();
 
-            $logo = $logo->withModification(function (Image $current) {
+            $logo = $logo->withModification(function (?Image $current) {
                 return null;
             });
 
@@ -70,7 +70,7 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         if ($this->isKioskModeEnabled($called_contexts)) {
             $logo = $this->globalScreen()->layout()->factory()->logo();
 
-            $logo = $logo->withModification(function (Image $current) {
+            $logo = $logo->withModification(function (?Image $current) {
                 return null;
             });
 
@@ -85,7 +85,7 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         if ($this->isKioskModeEnabled($called_contexts)) {
             $mainBar = $this->globalScreen()->layout()->factory()->mainbar();
 
-            $mainBar = $mainBar->withModification(function (MainBar $current) {
+            $mainBar = $mainBar->withModification(function (?MainBar $current) {
                 return null;
             });
 
@@ -100,7 +100,7 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         if ($this->isKioskModeEnabled($called_contexts)) {
             $metaBar = $this->globalScreen()->layout()->factory()->metabar();
 
-            $metaBar = $metaBar->withModification(function (MetaBar $current) {
+            $metaBar = $metaBar->withModification(function (?MetaBar $current) {
                 return null;
             });
 
@@ -115,7 +115,7 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         if ($this->isKioskModeEnabled($called_contexts)) {
             $footer = $this->globalScreen()->layout()->factory()->footer();
 
-            $footer = $footer->withModification(function (Footer $current) {
+            $footer = $footer->withModification(function (?Footer $current) {
                 return null;
             });
 

--- a/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
+++ b/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
@@ -3,15 +3,20 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
@@ -44,8 +49,11 @@ class DashboardLayoutProvider extends AbstractModificationProvider implements Mo
 
         return $this->globalScreen()->layout()->factory()->mainbar()
             ->withModification(
-                function (MainBar $mainbar): ?MainBar {
-                    return $mainbar->withActive($mainbar::NONE_ACTIVE);
+                function (?MainBar $mainbar): ?MainBar {
+                    if ($mainbar !== null) {
+                        $mainbar = $mainbar->withActive($mainbar::NONE_ACTIVE);
+                    }
+                    return $mainbar;
                 }
             )
             ->withLowPriority();

--- a/Services/Export/HTML/GlobalScreen/classes/class.ilHTMLExportViewLayoutProvider.php
+++ b/Services/Export/HTML/GlobalScreen/classes/class.ilHTMLExportViewLayoutProvider.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
@@ -41,7 +57,7 @@ class ilHTMLExportViewLayoutProvider extends AbstractModificationProvider implem
                         ->layout()
                         ->factory()
                         ->metabar()
-                        ->withModification(function (MetaBar $current = null): ?MetaBar {
+                        ->withModification(function (?MetaBar $current): ?MetaBar {
                             return null;
                         })->withHighPriority();
         }
@@ -60,7 +76,7 @@ class ilHTMLExportViewLayoutProvider extends AbstractModificationProvider implem
                         ->layout()
                         ->factory()
                         ->mainbar()
-                        ->withModification(function (MainBar $current = null): ?MainBar {
+                        ->withModification(function (?MainBar $current): ?MainBar {
                             return null;
                         })->withHighPriority();
         } else {
@@ -80,7 +96,7 @@ class ilHTMLExportViewLayoutProvider extends AbstractModificationProvider implem
                         ->layout()
                         ->factory()
                         ->breadcrumbs()
-                        ->withModification(function (Breadcrumbs $current = null): ?Breadcrumbs {
+                        ->withModification(function (?Breadcrumbs $current): ?Breadcrumbs {
                             return null;
                         })->withHighPriority();
         } else {

--- a/Services/LTI/classes/Screen/LtiViewLayoutProvider.php
+++ b/Services/LTI/classes/Screen/LtiViewLayoutProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\LTI\Screen;
 
@@ -95,16 +95,18 @@ class LtiViewLayoutProvider extends AbstractModificationProvider implements Modi
 
         return $this->globalScreen()->layout()->factory()->mainbar()
                     ->withModification(
-                        function (MainBar $mainbar) use ($is_exit_mode): ?MainBar {
-                            $tools = $mainbar->getToolEntries();
-                            $mainbar = $mainbar->withClearedEntries();
-                            if ($is_exit_mode) {
-                                return $mainbar;
+                        function (?MainBar $mainbar) use ($is_exit_mode): ?MainBar {
+                            if ($mainbar !== null) {
+                                $tools = $mainbar->getToolEntries();
+                                $mainbar = $mainbar->withClearedEntries();
+                                if ($is_exit_mode) {
+                                    return $mainbar;
+                                }
+                                foreach ($tools as $id => $entry) {
+                                    $mainbar = $mainbar->withAdditionalToolEntry($id, $entry);
+                                }
+                                //$mainbar = $mainbar->withAdditionalEntry('lti_home', $lti_home);
                             }
-                            foreach ($tools as $id => $entry) {
-                                $mainbar = $mainbar->withAdditionalToolEntry($id, $entry);
-                            }
-                            //$mainbar = $mainbar->withAdditionalEntry('lti_home', $lti_home);
                             return $mainbar;
                         }
                     )
@@ -120,16 +122,18 @@ class LtiViewLayoutProvider extends AbstractModificationProvider implements Modi
 
         return $this->globalScreen()->layout()->factory()->metabar()
                     ->withModification(
-                        function (MetaBar $metabar) use ($is_exit_mode, $screen_context_stack): ?Metabar {
-                            $metabar = $metabar->withClearedEntries();
-                            if ($is_exit_mode) {
-                                return $metabar;
+                        function (?MetaBar $metabar) use ($is_exit_mode, $screen_context_stack): ?Metabar {
+                            if ($metabar !== null) {
+                                $metabar = $metabar->withClearedEntries();
+                                if ($is_exit_mode) {
+                                    return $metabar;
+                                }
+                                $f = $this->dic->ui()->factory();
+                                $exit_symbol = $f->symbol()->glyph()->close();
+                                $exit_txt = $this->dic['lti']->lng->txt('lti_exit');
+                                $exit = $f->button()->bulky($exit_symbol, $exit_txt, $this->dic["lti"]->getCmdLink('exit'));
+                                $metabar = $metabar->withAdditionalEntry('exit', $exit);
                             }
-                            $f = $this->dic->ui()->factory();
-                            $exit_symbol = $f->symbol()->glyph()->close();
-                            $exit_txt = $this->dic['lti']->lng->txt('lti_exit');
-                            $exit = $f->button()->bulky($exit_symbol, $exit_txt, $this->dic["lti"]->getCmdLink('exit'));
-                            $metabar = $metabar->withAdditionalEntry('exit', $exit);
                             return $metabar;
                         }
                     )


### PR DESCRIPTION
**ALTERNATIVE FOR https://github.com/ILIAS-eLearning/ILIAS/pull/5973**

This is a proposal to fix the subsequent problem of https://mantis.ilias.de/view.php?id=37271

Even if this problem should not occur an is always caused by other issues, the basic worklflow of the modifciation process should be unified withing the standard page and the accessing providers.

This PR does that buy losen the modification closure parameters and handling their dual type withing the modification itsself.
The alternative approach, wich targets the return types of the standard page, can be found [here](https://github.com/ILIAS-eLearning/ILIAS/pull/5973).