### PR TITLE
Fix headings for panel (Mantis 37445)

### DIFF
--- a/src/UI/Component/Card/Card.php
+++ b/src/UI/Component/Card/Card.php
@@ -98,4 +98,14 @@ interface Card extends Component, JavaScriptBindable, Clickable
      * Returns whether the Card is highlighted
      */
     public function isHighlighted(): bool;
+
+    /**
+     * Sets the component in the context as further information within another component
+     */
+    public function withFurtherInformationContext(bool $context): Card;
+
+    /**
+     * Is the component standalone or serves as further information within another component?
+     */
+    public function getFurtherInformationContext(): bool;
 }

--- a/src/UI/Component/Panel/Secondary/Secondary.php
+++ b/src/UI/Component/Panel/Secondary/Secondary.php
@@ -49,4 +49,14 @@ interface Secondary extends Component\Component, HasViewControls
      * Gets the action dropdown to be displayed on the right of the title
      */
     public function getActions(): ?Dropdown\Standard;
+
+    /**
+     * Sets the component in the context as further information within another component
+     */
+    public function withFurtherInformationContext(bool $context): Secondary;
+
+    /**
+     * Is the component standalone or serves as further information within another component?
+     */
+    public function getFurtherInformationContext(): bool;
 }

--- a/src/UI/Implementation/Component/Card/Card.php
+++ b/src/UI/Implementation/Component/Card/Card.php
@@ -58,6 +58,7 @@ class Card implements C\Card
      * @var Component[]
      */
     protected array $hidden_sections = [];
+    protected bool $further_information_context = false;
 
     /**
      * @param string|Shy$title
@@ -197,6 +198,24 @@ class Card implements C\Card
     public function isHighlighted(): bool
     {
         return $this->highlight;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withFurtherInformationContext(bool $context): Card
+    {
+        $clone = clone $this;
+        $clone->further_information_context = $context;
+        return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFurtherInformationContext(): bool
+    {
+        return $this->further_information_context;
     }
 
     /**

--- a/src/UI/Implementation/Component/Panel/Renderer.php
+++ b/src/UI/Implementation/Component/Panel/Renderer.php
@@ -112,7 +112,9 @@ class Renderer extends AbstractComponentRenderer
         if ($component->getFurtherInformation()) {
             $tpl->setCurrentBlock("with_further_information");
             $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
-            $tpl->setVariable("INFO", $default_renderer->render($component->getFurtherInformation()));
+            $tpl->setVariable("INFO", $default_renderer->render(
+                $component->getFurtherInformation()->withFurtherInformationContext(true)
+            ));
             $tpl->parseCurrentBlock();
         } else {
             $tpl->setCurrentBlock("no_further_information");

--- a/src/UI/Implementation/Component/Panel/Secondary/Renderer.php
+++ b/src/UI/Implementation/Component/Panel/Secondary/Renderer.php
@@ -87,7 +87,15 @@ class Renderer extends AbstractComponentRenderer
         $view_controls = $component->getViewControls();
 
         if ($title != "" || $actions || $view_controls) {
-            $tpl->setVariable("TITLE", $title);
+            if ($component->getFurtherInformationContext()) {
+                $tpl->setCurrentBlock("title_h4");
+                $tpl->setVariable("TITLE_H4", $title);
+                $tpl->parseCurrentBlock();
+            } else {
+                $tpl->setCurrentBlock("title_h2");
+                $tpl->setVariable("TITLE_H2", $title);
+                $tpl->parseCurrentBlock();
+            }
             if ($actions) {
                 $tpl->setVariable("ACTIONS", $default_renderer->render($actions));
             }

--- a/src/UI/Implementation/Component/Panel/Secondary/Secondary.php
+++ b/src/UI/Implementation/Component/Panel/Secondary/Secondary.php
@@ -36,6 +36,7 @@ abstract class Secondary implements C\Panel\Secondary\Secondary
     protected string $title;
     protected ?C\Dropdown\Standard $actions = null;
     protected ?C\Button\Shy $footer_component = null;
+    protected bool $further_information_context = false;
 
     /**
      * Gets the secondary panel title
@@ -79,5 +80,23 @@ abstract class Secondary implements C\Panel\Secondary\Secondary
     public function getFooter(): ?C\Button\Shy
     {
         return $this->footer_component;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withFurtherInformationContext(bool $context): C\Panel\Secondary\Secondary
+    {
+        $clone = clone $this;
+        $clone->further_information_context = $context;
+        return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFurtherInformationContext(): bool
+    {
+        return $this->further_information_context;
     }
 }

--- a/src/UI/templates/default/Panel/tpl.secondary.html
+++ b/src/UI/templates/default/Panel/tpl.secondary.html
@@ -1,7 +1,12 @@
 <div class="panel panel-secondary panel-flex">
 	<!-- BEGIN heading -->
 	<div class="panel-heading ilHeader">
-		<h2>{TITLE}</h2>
+		<!-- BEGIN title_h2 -->
+		<h2>{TITLE_H2}</h2>
+		<!-- END title_h2 -->
+		<!-- BEGIN title_h4 -->
+		<h4>{TITLE_H4}</h4>
+		<!-- END title_h4 -->
 		{ACTIONS}
 		<!-- BEGIN view_controls -->
 			{VIEW_CONTROL}

--- a/templates/default/070-components/UI-framework/Panel/_ui-component_panel.scss
+++ b/templates/default/070-components/UI-framework/Panel/_ui-component_panel.scss
@@ -45,7 +45,7 @@
 		h4, h4.ilBlockHeader {
 			margin: 0;
 			color: ls.$il-panel-heading-color;
-			font-size: $il-font-size-base;
+			font-size: $il-font-size-xlarge;
 		}
 	}
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -12382,7 +12382,7 @@ div.alert ul > li:before {
 .panel .panel-heading.ilBlockHeader h4.ilBlockHeader {
   margin: 0;
   color: #161616;
-  font-size: 0.875rem;
+  font-size: 1.115rem;
 }
 .panel .panel-body {
   padding: 15px 15px;


### PR DESCRIPTION
Hi @Amstutz and @klees,
I found out that the HTML heading of the Secondary Panel is not correct, if it appears within a "normal" panel. Currently, it is h2, but it should be h4 IMO.
I am not sure if my PR is the right way to solve this problem. I tried to keep the changes minimal for this little distinction. But I fear that I maybe have overlooked something in other places, which will cause new problems. However, if I raise awareness for this, it's already a good start.

If the PR should be accepted, I can also write a new unit test for the different behaviour.

https://mantis.ilias.de/view.php?id=37445