### PR TITLE
Fix/7/layout modification

### DIFF
--- a/Modules/LearningModule/Export/class.ilLMHtmlExportViewLayoutProvider.php
+++ b/Modules/LearningModule/Export/class.ilLMHtmlExportViewLayoutProvider.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Factory\MetaBarModification;

--- a/Modules/LearningModule/Export/class.ilLMHtmlExportViewLayoutProvider.php
+++ b/Modules/LearningModule/Export/class.ilLMHtmlExportViewLayoutProvider.php
@@ -74,7 +74,10 @@ class ilLMHtmlExportViewLayoutProvider extends AbstractModificationProvider impl
                 ->layout()
                 ->factory()
                 ->mainbar()
-                ->withModification(function (MainBar $current = null) : ?MainBar {
+                ->withModification(function (?MainBar $current = null) : ?MainBar {
+                    if ($current === null) {
+                        return null;
+                    }
                     global $DIC;
 
                     $lng = $DIC->language();
@@ -120,7 +123,7 @@ class ilLMHtmlExportViewLayoutProvider extends AbstractModificationProvider impl
                 ->layout()
                 ->factory()
                 ->breadcrumbs()
-                ->withModification(function (Breadcrumbs $current = null) : ?Breadcrumbs {
+                ->withModification(function (?Breadcrumbs $current = null) : ?Breadcrumbs {
                     return null;
                 })->withHighPriority();
         } else {

--- a/Modules/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
+++ b/Modules/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
@@ -69,7 +69,10 @@ class ilLSViewLayoutProvider extends AbstractModificationProvider implements Mod
         }
         return $this->globalScreen()->layout()->factory()->mainbar()
             ->withModification(
-                function (MainBar $mainbar) : ?MainBar {
+                function (?MainBar $mainbar) : ?MainBar {
+                    if ($mainbar === null) {
+                        return null;
+                    }
                     $entries = $this->data_collection->get(\ilLSPlayer::GS_DATA_LS_MAINBARCONTROLS);
                     $tools = $mainbar->getToolEntries();
                     $mainbar = $mainbar->withClearedEntries();
@@ -93,7 +96,10 @@ class ilLSViewLayoutProvider extends AbstractModificationProvider implements Mod
         }
         return $this->globalScreen()->layout()->factory()->metabar()
             ->withModification(
-                function (MetaBar $metabar) : ?Metabar {
+                function (?MetaBar $metabar) : ?Metabar {
+                    if ($metabar === null) {
+                        return null;
+                    }
                     $metabar = $metabar->withClearedEntries();
                     foreach ($this->data_collection->get(\ilLSPlayer::GS_DATA_LS_METABARCONTROLS) as $key => $entry) {
                         $metabar = $metabar->withAdditionalEntry($key, $entry);

--- a/Modules/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
+++ b/Modules/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;

--- a/Modules/Test/classes/Screen/class.ilTestPlayerLayoutProvider.php
+++ b/Modules/Test/classes/Screen/class.ilTestPlayerLayoutProvider.php
@@ -1,6 +1,20 @@
 <?php
 
-/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 use ILIAS\GlobalScreen\Scope\Layout\Factory\FooterModification;
 use ILIAS\GlobalScreen\Scope\Layout\Factory\LogoModification;

--- a/Modules/Test/classes/Screen/class.ilTestPlayerLayoutProvider.php
+++ b/Modules/Test/classes/Screen/class.ilTestPlayerLayoutProvider.php
@@ -57,7 +57,7 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         if ($this->isKioskModeEnabled($called_contexts)) {
             $logo = $this->globalScreen()->layout()->factory()->logo();
 
-            $logo = $logo->withModification(function (Image $current) {
+            $logo = $logo->withModification(function (?Image $current) : ?Image {
                 return null;
             });
 
@@ -71,7 +71,7 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         if ($this->isKioskModeEnabled($called_contexts)) {
             $logo = $this->globalScreen()->layout()->factory()->logo();
 
-            $logo = $logo->withModification(function (Image $current) {
+            $logo = $logo->withModification(function (?Image $current) : ?Image {
                 return null;
             });
 
@@ -87,7 +87,7 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         if ($this->isKioskModeEnabled($called_contexts)) {
             $mainBar = $this->globalScreen()->layout()->factory()->mainbar();
 
-            $mainBar = $mainBar->withModification(function (MainBar $current) {
+            $mainBar = $mainBar->withModification(function (?MainBar $current) : ?MainBar {
                 return null;
             });
 
@@ -103,7 +103,7 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         if ($this->isKioskModeEnabled($called_contexts)) {
             $metaBar = $this->globalScreen()->layout()->factory()->metabar();
 
-            $metaBar = $metaBar->withModification(function (MetaBar $current) {
+            $metaBar = $metaBar->withModification(function (?MetaBar $current) : ?MetaBar {
                 return null;
             });
 
@@ -119,7 +119,7 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
         if ($this->isKioskModeEnabled($called_contexts)) {
             $footer = $this->globalScreen()->layout()->factory()->footer();
 
-            $footer = $footer->withModification(function (Footer $current) {
+            $footer = $footer->withModification(function (?Footer $current) : ?Footer {
                 return null;
             });
 
@@ -148,12 +148,12 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
     {
         if ($this->isKioskModeEnabled($called_contexts)) {
             $title = $called_contexts->current()->getAdditionalData()->get(self::TEST_PLAYER_SHORT_TITLE);
-            if($title == null) {
+            if ($title === null) {
                 $title = '';
             }
             return $this->globalScreen()->layout()->factory()->short_title()
             ->withModification(
-                function (string $content) use ($title) : string {
+                function (?string $content) use ($title) : ?string {
                     return $title;
                 }
             )
@@ -166,12 +166,12 @@ class ilTestPlayerLayoutProvider extends AbstractModificationProvider implements
     {
         if ($this->isKioskModeEnabled($called_contexts)) {
             $title = $called_contexts->current()->getAdditionalData()->get(self::TEST_PLAYER_TITLE);
-            if($title == null) {
+            if ($title === null) {
                 $title = '';
             }
             return $this->globalScreen()->layout()->factory()->view_title()
             ->withModification(
-                function (string $content) use ($title) : string {
+                function (?string $content) use ($title) : ?string {
                     return $title;
                 }
             )

--- a/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
+++ b/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
@@ -51,8 +51,8 @@ class DashboardLayoutProvider extends AbstractModificationProvider implements Mo
 
         return $this->globalScreen()->layout()->factory()->mainbar()
             ->withModification(
-                function (MainBar $mainbar) : ?MainBar {
-                    return $mainbar->withActive($mainbar::NONE_ACTIVE);
+                function (?MainBar $mainbar = null) : ?MainBar {
+                    return $mainbar !== null ? $mainbar->withActive($mainbar::NONE_ACTIVE) : null;
                 }
             )
             ->withLowPriority();

--- a/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
+++ b/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;

--- a/Services/Export/HTML/GlobalScreen/classes/class.ilHTMLExportViewLayoutProvider.php
+++ b/Services/Export/HTML/GlobalScreen/classes/class.ilHTMLExportViewLayoutProvider.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Factory\MetaBarModification;

--- a/Services/Export/HTML/GlobalScreen/classes/class.ilHTMLExportViewLayoutProvider.php
+++ b/Services/Export/HTML/GlobalScreen/classes/class.ilHTMLExportViewLayoutProvider.php
@@ -55,7 +55,7 @@ class ilHTMLExportViewLayoutProvider extends AbstractModificationProvider implem
                 ->layout()
                 ->factory()
                 ->metabar()
-                ->withModification(function (MetaBar $current = null) : ?MetaBar {
+                ->withModification(function (?MetaBar $current = null) : ?MetaBar {
                     return null;
                 })->withHighPriority();
         }
@@ -73,7 +73,7 @@ class ilHTMLExportViewLayoutProvider extends AbstractModificationProvider implem
                 ->layout()
                 ->factory()
                 ->mainbar()
-                ->withModification(function (MainBar $current = null) : ?MainBar {
+                ->withModification(function (?MainBar $current = null) : ?MainBar {
                     return null;
                 })->withHighPriority();
         } else {
@@ -92,7 +92,7 @@ class ilHTMLExportViewLayoutProvider extends AbstractModificationProvider implem
                 ->layout()
                 ->factory()
                 ->breadcrumbs()
-                ->withModification(function (Breadcrumbs $current = null) : ?Breadcrumbs {
+                ->withModification(function (?Breadcrumbs $current = null) : ?Breadcrumbs {
                     return null;
                 })->withHighPriority();
         } else {

--- a/Services/LTI/classes/Screen/LtiViewLayoutProvider.php
+++ b/Services/LTI/classes/Screen/LtiViewLayoutProvider.php
@@ -1,4 +1,20 @@
-<?php namespace ILIAS\LTI\Screen;
+<?php /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\LTI\Screen;
 
 use ILIAS\GlobalScreen\Scope\Layout\Provider\PagePart\PagePartProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;

--- a/Services/LTI/classes/Screen/LtiViewLayoutProvider.php
+++ b/Services/LTI/classes/Screen/LtiViewLayoutProvider.php
@@ -96,7 +96,10 @@ class LtiViewLayoutProvider extends AbstractModificationProvider implements Modi
 
         return $this->globalScreen()->layout()->factory()->mainbar()
             ->withModification(
-                function (MainBar $mainbar) use ($is_exit_mode) : ?MainBar {
+                function (?MainBar $mainbar) use ($is_exit_mode) : ?MainBar {
+                    if ($mainbar === null) {
+                        return null;
+                    }
                     $tools = $mainbar->getToolEntries();
                     $mainbar = $mainbar->withClearedEntries();
                     if ($is_exit_mode) {
@@ -121,7 +124,10 @@ class LtiViewLayoutProvider extends AbstractModificationProvider implements Modi
 
         return $this->globalScreen()->layout()->factory()->metabar()
             ->withModification(
-                function (MetaBar $metabar) use ($is_exit_mode, $screen_context_stack): ?Metabar {
+                function (?MetaBar $metabar) use ($is_exit_mode, $screen_context_stack) : ?Metabar {
+                    if ($metabar === null) {
+                        return null;
+                    }
                     $metabar = $metabar->withClearedEntries();
                     if ($is_exit_mode) {
                         return $metabar;
@@ -146,7 +152,7 @@ class LtiViewLayoutProvider extends AbstractModificationProvider implements Modi
 
         return $this->globalScreen()->layout()->factory()->title()
             ->withModification(
-                function (string $content) use ($is_exit_mode) : string {
+                function (?string $content) use ($is_exit_mode) : ?string {
                     if ($is_exit_mode) {
                         return $this->dic["lti"]->getTitleForExitPage();
                     }

--- a/Services/UICore/classes/Screen/PageContentProvider.php
+++ b/Services/UICore/classes/Screen/PageContentProvider.php
@@ -116,7 +116,10 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
      */
     public function getContentModification(CalledContexts $screen_context_stack) : ?ContentModification
     {
-        return $this->globalScreen()->layout()->factory()->content()->withModification(function (Legacy $content) : Legacy {
+        return $this->globalScreen()->layout()->factory()->content()->withModification(function (?Legacy $content) : ?Legacy {
+            if ($content === null) {
+                return null;
+            }
             $ui = $this->dic->ui();
             return $ui->factory()->legacy(
                 $ui->renderer()->render($content) . self::$content
@@ -128,7 +131,7 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
     public function getTitleModification(CalledContexts $screen_context_stack) : ?TitleModification
     {
         return $this->globalScreen()->layout()->factory()->title()->withModification(
-            function (string $content) : string {
+            function (?string $content) : string {
                 return self::$title;
             }
         )->withLowPriority();
@@ -137,7 +140,7 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
     public function getShortTitleModification(CalledContexts $screen_context_stack) : ?ShortTitleModification
     {
         return $this->globalScreen()->layout()->factory()->short_title()->withModification(
-            function (string $content) : string {
+            function (?string $content) : string {
                 return self::$short_title;
             }
         )->withLowPriority();
@@ -146,7 +149,7 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
     public function getViewTitleModification(CalledContexts $screen_context_stack) : ?ViewTitleModification
     {
         return $this->globalScreen()->layout()->factory()->view_title()->withModification(
-            function (string $content) : string {
+            function (?string $content) : string {
                 return self::$view_title;
             }
         )->withLowPriority();
@@ -157,7 +160,7 @@ class PageContentProvider extends AbstractModificationProvider implements Modifi
      */
     public function getFooterModification(CalledContexts $screen_context_stack) : ?FooterModification
     {
-        return $this->globalScreen()->layout()->factory()->footer()->withModification(function () : Footer {
+        return $this->globalScreen()->layout()->factory()->footer()->withModification(function (?Footer $footer = null) : ?Footer {
             $f = $this->dic->ui()->factory();
 
             $links = [];

--- a/Services/UICore/classes/Screen/PageContentProvider.php
+++ b/Services/UICore/classes/Screen/PageContentProvider.php
@@ -1,4 +1,20 @@
-<?php namespace ILIAS\UICore;
+<?php /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UICore;
 
 use ILIAS\Data\URI;
 use ILIAS\GlobalScreen\Scope\Layout\Factory\ContentModification;

--- a/src/GlobalScreen/Scope/Layout/Factory/InvalidModification.php
+++ b/src/GlobalScreen/Scope/Layout/Factory/InvalidModification.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\GlobalScreen\Scope\Layout\Factory;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class InvalidModification extends \InvalidArgumentException
+{
+    public function __construct(LayoutModification $modification, $message = "")
+    {
+        // Context
+        $modification_class = get_class($modification);
+        $closure_file = 'Unknown';
+        $closure_line = 0;
+        try {
+            $closure = $modification->getModification();
+            $reflection = new \ReflectionFunction($closure);
+            $closure_file = $reflection->getClosureScopeClass()->getName();
+            $closure_line = $reflection->getStartLine();
+        } catch (\Throwable $e) {
+            // ignore
+        }
+        $message = sprintf(
+            "Invalid modification %s in %s (Line %s). %s",
+            $modification_class,
+            $closure_file,
+            $closure_line,
+            $message
+        );
+
+        parent::__construct($message, 0);
+    }
+}

--- a/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
+++ b/src/GlobalScreen/Scope/Layout/Provider/PagePart/StandardPagePartProvider.php
@@ -112,7 +112,11 @@ class StandardPagePartProvider implements PagePartProvider
      */
     public function getMainBar() : ?MainBar
     {
+        // Collect all items which could be displayed in the main bar
         $this->gs->collector()->mainmenu()->collectOnce();
+        $this->gs->collector()->tool()->collectOnce();
+
+        // If there are no items to display, return null. By definition, no MainBar is added to the Page in this case.
         if (!$this->gs->collector()->mainmenu()->hasVisibleItems()
             && !$this->gs->collector()->tool()->hasVisibleItems()) {
             return null;
@@ -135,7 +139,6 @@ class StandardPagePartProvider implements PagePartProvider
 
         // Tools
         $grid_icon = $f->symbol()->icon()->custom(ilUtil::getImagePath("outlined/icon_tool.svg"), $this->lang->txt('more'));
-        $this->gs->collector()->tool()->collectOnce();
         if ($this->gs->collector()->tool()->hasItems()) {
             $tools_button = $f->button()->bulky($grid_icon, $this->lang->txt('tools'), "#")->withEngagedState(true);
             $main_bar = $main_bar->withToolsButton($tools_button);


### PR DESCRIPTION
Thank you @PurHur and @iszmais for your PRs:
- #5972
- #5973
- #5974

This PR here replaces them and implements the following changes:

- The missing collect of tools as in #5972 (but the collectOnce at the bottom removed instead).
- LayoutModifications are provided as Closures, there already existed "definitions" how these have to look like, but these were not checked correctly. I have therefore adapted checkClosure to check the definitions. Violations are now thrown as InvalidModification exceptions, these are also output if DEVMODE is activated, otherwise the LayoutModifications are regarded as invalif.
- I have adapted the existing modifications (as in PR #5974).

What we cannot adapt are the changes in #5973: The UI\Page allows certain parts to be `null`, the GlobalScreen must take this into account and allow this as well.

I will therefore close the other three PRs and adopt the changes from here to and including trunk.

This solves the following issues:
- https://mantis.ilias.de/view.php?id=37418
- https://mantis.ilias.de/view.php?id=37271