### PR TITLE
T&A Bugfix: SCWizardInputGUI checkInput broken

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -228,7 +228,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
             // check answers
             if (is_array($foundvalues['answer'])) {
                 foreach ($foundvalues['answer'] as $aidx => $answervalue) {
-                    if (((strlen($answervalue)) == 0) && (isset($foundvalues['imagename'])) && (!isset($foundvalues['imagename'][$aidx]) || strlen($foundvalues['imagename'][$aidx]) == 0)) {
+                    if (((strlen($answervalue)) == 0) && (!isset($foundvalues['imagename'][$aidx]) || strlen($foundvalues['imagename'][$aidx]) == 0)) {
                         $this->setAlert($lng->txt("msg_input_is_required"));
                         return false;
                     }


### PR DESCRIPTION
Fixes changes from (empty answer text passes checkInput check)
https://github.com/ILIAS-eLearning/ILIAS/commit/946673ffc3b52fd02afddea4e964240d4b73dccc
https://github.com/ILIAS-eLearning/ILIAS/commit/d1498dad31371102e259b29eb71a37437fdacce2

Bug appeared in https://mantis.ilias.de/view.php?id=37363#c93970
