### PR TITLE
UI, Modal/DataTable: relay signal options to Modal

### DIFF
--- a/src/UI/examples/Modal/RoundTrip/show_form_in_modal.php
+++ b/src/UI/examples/Modal/RoundTrip/show_form_in_modal.php
@@ -11,6 +11,7 @@ function show_form_in_modal()
     $renderer = $DIC->ui()->renderer();
     $request = $DIC->http()->request();
     $factory = $DIC->ui()->factory();
+    $request_wrapper = $DIC->http()->wrapper()->query();
 
     // declare roundtrip with inputs and form action.
     $modal = $factory->modal()->roundtrip(
@@ -20,7 +21,7 @@ function show_form_in_modal()
             $factory->input()->field()->text('some text'),
             $factory->input()->field()->numeric('some numbere'),
         ],
-        '#'
+        $request->getUri()->__toString() . '&rtwithform=1'
     );
 
     // declare something that triggers the modal.
@@ -28,7 +29,9 @@ function show_form_in_modal()
 
     // please use ilCtrl to generate an appropriate link target
     // and check it's command instead of this.
-    if ('POST' === $request->getMethod()) {
+    if ($request->getMethod() === 'POST' &&
+        $request_wrapper->has('rtwithform')
+    ) {
         $modal = $modal->withRequest($request);
         $data = $modal->getData();
     } else {

--- a/src/UI/templates/js/Modal/modal.js
+++ b/src/UI/templates/js/Modal/modal.js
@@ -22,22 +22,34 @@ il.UI = il.UI || {};
             }
             triggeredSignalsStorage[signalData.id] = true;
             options = $.extend(defaultShowOptions, options);
+
             if (options.ajaxRenderUrl) {
-                var $container = $('#' + id);
-                $container.load(options.ajaxRenderUrl, function() {
-                    var $modal = $(this).find('.modal');
-                    if ($modal.length) {
-                        $modal.modal(options);
+                let $container = $('#' + id);
+                let opts = {};
+                Object.keys(signalData.options).forEach(
+                  (v) => {opts[v] = JSON.stringify(signalData.options[v]);}
+                );
+
+                $.ajax({
+                    type: 'POST',
+                    url: options.ajaxRenderUrl,
+                    data: opts,
+                    success: function(response){
+                        $container.html(response);
+                        let modal = $container.find('.modal');
+                        if (modal.length) {
+                            modal.modal(options);
+                        }
+                        triggeredSignalsStorage[signalData.id] = false;
                     }
-                    triggeredSignalsStorage[signalData.id] = false;
                 });
             } else {
                 var $modal = $('#' + id);
                 $modal.modal(options);
                 triggeredSignalsStorage[signalData.id] = false;
             }
-			initializedModalboxes[signalData.id] = id;
-		};
+            initializedModalboxes[signalData.id] = id;
+        };
 
         var closeModal = function (id) {
             $('#' + id).modal('close');

--- a/src/UI/templates/js/Table/dist/datatable.js
+++ b/src/UI/templates/js/Table/dist/datatable.js
@@ -189,7 +189,7 @@ class DataTable {
       const opts = {};
       opts[this.#actionsConstants.opt.id] = target.id;
       opts[this.#actionsConstants.opt.mainkey] = target.options;
-      this.#jquery(`#${this.#component.getAttr('id')}`).trigger(target.id, opts);
+      this.#jquery(`#${this.#component.id}`).trigger(target.id, opts);
     }
   }
 

--- a/src/UI/templates/js/Table/src/datatable.class.js
+++ b/src/UI/templates/js/Table/src/datatable.class.js
@@ -189,7 +189,7 @@ export default class DataTable {
       const opts = {};
       opts[this.#actionsConstants.opt.id] = target.id;
       opts[this.#actionsConstants.opt.mainkey] = target.options;
-      this.#jquery(`#${this.#component.getAttr('id')}`).trigger(target.id, opts);
+      this.#jquery(`#${this.#component.id}`).trigger(target.id, opts);
     }
   }
 


### PR DESCRIPTION
I was working on the removal of legacy ConfirmationGUI and did not find a good way to relay items to the Interruptive Modal via JS. This seems to be a common situation, though, when there are several items being picked in the GUI and the modal should react to this selection.
With this change, the signal options are sent along as POST to the ajaxRenderUrl.
