### PR TITLE
UI/Metabar: 33346, do not close metabar slates when there is no 'next focus'

### DIFF
--- a/src/UI/templates/js/MainControls/metabar.js
+++ b/src/UI/templates/js/MainControls/metabar.js
@@ -57,7 +57,8 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 				if(!il.UI.page.isSmallScreen()) {
 					let next_focus_target = event.relatedTarget;
 					let current_slate = event.currentTarget;
-					if (!$.contains(current_slate, next_focus_target)) {
+					if (next_focus_target &&
+						!$.contains(current_slate, next_focus_target)) {
 						onClickDisengageAll();
 					}
 				}


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=33346

please check against https://mantis.ilias.de/view.php?id=31367 (caused the issue), but I think this does not really break it.