### PR TITLE
Tracking: Learning Progress - Summary (missing explanation / legend) (19414) for R7

### DIFF
--- a/Services/Tracking/classes/repository_statistics/class.ilLPListOfObjectsGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilLPListOfObjectsGUI.php
@@ -316,7 +316,9 @@ class ilLPListOfObjectsGUI extends ilLearningProgressBaseGUI
         $lp_table = new ilTrSummaryTableGUI($this, "", ROOT_FOLDER_ID);
         
         $this->tpl->setVariable("LP_OBJECTS", $lp_table->getHTML());
-        $this->tpl->setVariable('LEGEND', $this->__getLegendHTML(ilLPStatusIcons::ICON_VARIANT_SHORT));
+        if ($lp_table->isStatusShown()) {
+            $this->tpl->setVariable('LEGEND', $this->__getLegendHTML(ilLPStatusIcons::ICON_VARIANT_SHORT));
+        }
     }
 
     public function __initDetails($a_details_id)
@@ -364,7 +366,11 @@ class ilLPListOfObjectsGUI extends ilLearningProgressBaseGUI
         include_once("./Services/Tracking/classes/repository_statistics/class.ilTrSummaryTableGUI.php");
         $table = new ilTrSummaryTableGUI($this, "showObjectSummary", $this->getRefId(), $print_view);
         if (!$print_view) {
-            $tpl->setContent($table->getHTML());
+            $content = $table->getHTML();
+            if ($table->isStatusShown()) {
+                $content .= $this->__getLegendHTML(ilLPStatusIcons::ICON_VARIANT_SHORT);
+            }
+            $tpl->setContent($content);
         } else {
             $tpl->setVariable("ADM_CONTENT", $table->getHTML());
             echo $tpl->getSpecial("DEFAULT", false, false, false, false, false, false);

--- a/Services/Tracking/classes/repository_statistics/class.ilTrSummaryTableGUI.php
+++ b/Services/Tracking/classes/repository_statistics/class.ilTrSummaryTableGUI.php
@@ -763,6 +763,11 @@ class ilTrSummaryTableGUI extends ilLPTableBaseGUI
         return false;
     }
 
+    public function isStatusShown() : bool
+    {
+        return in_array('status', $this->getSelectedColumns());
+    }
+
     protected function fillHeaderExcel(ilExcel $a_excel, &$a_row)
     {
         $a_excel->setCell($a_row, 0, $this->lng->txt("title"));


### PR DESCRIPTION
This PR fixes [19414](https://mantis.ilias.de/view.php?id=19414) by showing the learning progress icons legend for the summary tables (both in the learning progress tab of objects and in the Tracking administration), but only if the column 'Status' is selected.

Please don't pick this to R8 or trunk, I'll provide a separate PR for that.