### PR TITLE
Membership: allow checking whether user may mail to members of course, group or session (22764)

### DIFF
--- a/Services/Membership/classes/class.ilParticipants.php
+++ b/Services/Membership/classes/class.ilParticipants.php
@@ -201,8 +201,12 @@ abstract class ilParticipants
         return false;
     }
 
+    /**
+     * This method was introduced as a band-aid fix for #22764.
+     * Please do not use this anywhere else.
+     */
     public static function canSendMailToMembers(
-        int $obj_id,
+        int $ref_id,
         ?int $usr_id = null,
         ?int $mail_obj_ref_id = null
     ) : bool {
@@ -211,8 +215,6 @@ abstract class ilParticipants
         $access = $DIC->access();
         $rbacsystem = $DIC->rbac()->system();
 
-        $refs = ilObject::_getAllReferences($obj_id);
-        $ref_id = end($refs);
         if (is_null($usr_id)) {
             $usr_id = $DIC->user()->getId();
         }

--- a/Services/Membership/classes/class.ilParticipants.php
+++ b/Services/Membership/classes/class.ilParticipants.php
@@ -201,6 +201,49 @@ abstract class ilParticipants
         return false;
     }
 
+    public static function canSendMailToMembers(
+        int $obj_id,
+        ?int $usr_id = null,
+        ?int $mail_obj_ref_id = null
+    ) : bool {
+        global $DIC;
+
+        $access = $DIC->access();
+        $rbacsystem = $DIC->rbac()->system();
+
+        $refs = ilObject::_getAllReferences($obj_id);
+        $ref_id = end($refs);
+        if (is_null($usr_id)) {
+            $usr_id = $DIC->user()->getId();
+        }
+        if (is_null($mail_obj_ref_id)) {
+            $mail_obj_ref_id = (new ilMail($usr_id))->getMailObjectReferenceId();
+        }
+
+        if (
+            $access->checkAccess('manage_members', '', $ref_id) &&
+            $rbacsystem->checkAccess('internal_mail', $mail_obj_ref_id)
+        ) {
+            return true;
+        }
+
+        $part = self::getInstance($ref_id);
+        if (!$part->isAssigned($usr_id)) {
+            return false;
+        }
+
+        $object = ilObjectFactory::getInstanceByObjId($obj_id);
+        if ($object instanceof ilObjCourse) {
+            return $object->getMailToMembersType() == ilCourseConstants::MAIL_ALLOWED_ALL;
+        } elseif ($object instanceof ilObjGroup) {
+            return $object->getMailToMembersType() == ilObjGroup::MAIL_ALLOWED_ALL;
+        } elseif ($object instanceof ilObjSession) {
+            return $object->getMailToMembersType() == ilObjSession::MAIL_ALLOWED_ALL;
+        }
+
+        return false;
+    }
+
 
     /**
      * Get user membership assignments by type
@@ -226,7 +269,7 @@ abstract class ilParticipants
                         array('obr.ref_id'),
                     ),
                 false
-                );
+            );
         }
 
         $query = "SELECT DISTINCT obd.obj_id,obr.ref_id,ua.usr_id FROM rbac_ua ua " .


### PR DESCRIPTION
This PR makes some changes that allow [22764](https://mantis.ilias.de/view.php?id=22764) to be fixed, see the discussion there.

@mjansenDatabay, this should hopefully work as a minimally invasive solution for R7 and 8, but we could take this as an opportunity to come up with a more clearly defined interface between the Mail Service and Courses/Groups for the trunk. Stefan and I were thinking about something in the vein of a `MailBridge` in the Membership Service. Maybe we could have a quick discussion about this at some point.