### PR TITLE
Added Language How-Tos

### DIFF
--- a/Services/Language/use-language-logging.md
+++ b/Services/Language/use-language-logging.md
@@ -1,0 +1,46 @@
+# Language Logging
+
+___
+*This feature is available for ILIAS 5.2.x+.*
+___
+
+After years and years of ILIAS development by a big amount of developers and language maintainers, it's necessary to tidy up the language files. To get an overview of which language variable is needed or isn't needed anymore, there is a language logging in ILIAS.
+
+## Requirements
+
+- MySQL Database
+- Developer Mode turned on or client.ini entry `LANGUAGE_LOG = "1"` in section `[system]`
+
+## Evaluation
+
+If both requirements are fulfilled, every used language variable will be stored in the database as "module" and "Identifier" in table `lng_log`. After **extensive** usage of ILIAS, these data could be used to decide if a language variable could be deleted or kept according to its appearance in this dataset.
+
+There is no function provided by ILIAS itself to gain this data. You have to access the database of ILIAS with a script and obtain it by a SQL-statement.
+
+```php
+<?php
+//Init ILIAS for a database connection
+require_once("Services/Init/classes/class.ilInitialisation.php");
+ilInitialisation::initILIAS();
+global $ilDB;
+header("Content-Type:text/plain");
+ 
+//Collects all language variables which were not used since logging
+$lang_log_query = $ilDB->query(
+	"SELECT ldat.module module, ldat.identifier identifier " .
+	"FROM lng_data ldat LEFT JOIN lng_log llog " .
+	"ON (ldat.module = llog.module AND ldat.identifier = llog.identifier) " .
+	"WHERE ldat.lang_key = 'en' AND llog.module IS NULL AND llog.identifier IS NULL"
+);
+ 
+while($row = $lang_log_query->fetchRow(ilDBConstants::FETCHMODE_OBJECT))
+{
+	echo($row->module . "#:#" . $row->identifier . "\n");
+}
+```
+
+After execution it's recommended to delete all data in lng_log to build a new 'clean' dataset. This should be done via SQL by executing:
+
+```
+DELETE FROM lng_log;
+```

--- a/Services/Language/use-language-object.md
+++ b/Services/Language/use-language-object.md
@@ -1,0 +1,31 @@
+# $lng language object
+
+ILIAS offers multi-language support. All text strings are stored in **language files** in the subdirectory `lang`. The lines of these files have the format:
+ 
+`module#:#variable_name#:#text content`
+ 
+It is best practice that as module a short ID for your component is used, e.g. frm for forums. This should also be used as a prefix for the variable names in this language module, e.g.:
+ 
+`frm#:#frm_new_posting#:#New Posting`
+ 
+The file contains one module block called the **common module**. Entries of this block start with "common#:#". This block is always read from the database into memory for each request. Other modules need to be loaded on demand. **Try to minimize the use of new common variables**.
+ 
+The **english language** file is the **master language file**. This means you must always add new variables to this file, since we synchronize the variables of all files from time to time. If a variable exists in a file of another language then English, but not in the English one, it will be removed from the file.
+ 
+Adding new entries into these files will not make them available automatically in the user interface. You need to refresh the languages by executing Administration > Languages > **Refresh Languages** in your ILIAS installation.
+ 
+The global language object `$lng`, an instance of class ilLanguage, provides methods to access these strings in the language of the user currently logged in. This is done by using the functions `loadLanguageModule()` and `txt()`.
+
+```php
+$lng->loadLanguageModule("frm");
+$tpl->setVariable("TEXT", $lng->txt("frm_new_posting"));
+```
+
+## Maintaining Languages
+
+The different languages supported by ILIAS are maintained by volunteers. We are offering language maintenance installations for every version. They are clients of the regular testing installation.
+
+- [http://lang54.ilias.de](http://lang54.ilias.de) is the language maintenance installation for 5.4
+- [http://lang6.ilias.de](http://lang6.ilias.de) is the language maintenance installation for 6 a.s.o.
+
+You find more information about language maintenance in the document ['Language Instructions'](https://docu.ilias.de/goto_docu_pg_130_37.html).


### PR DESCRIPTION
As announced at the DevConf and in the [Jour Fixe of 12.06.2023](https://docu.ilias.de/goto_docu_wiki_wpage_7950_1357.html), all DevGuide pages that are how-tos and no training materials are changed to .md-files, stored in GitHub and embedded in the current DevGuide LM using the related page component plugin. This way we can ensure improved accessibility and maintenance.