### PR TITLE
Course: activate dormant participantHasPassedCourse event

### DIFF
--- a/Modules/Course/module.xml
+++ b/Modules/Course/module.xml
@@ -39,6 +39,7 @@
 		<event type="raise" id="deleteParticipant" />
 		<event type="raise" id="addToWaitingList" />
 		<event type="raise" id="addSubscriber" />
+		<event type="raise" id="participantHasPassedCourse" />
 	</events>
 	<crons>
 		<cron id="crs_timings_reminder" class="ilTimingsCronReminder" />


### PR DESCRIPTION
This PR activates the already existing event 'participantHasPassedCourse'. It was implemented 2016 and never activated, but it seems to work fine, and should be sufficient for fixing [26314](https://mantis.ilias.de/view.php?id=26314).
Note that the event triggers when a course participant's 'passed' status is granted, but not when 'passed' is taken away.