### PR TITLE
T&A 0036734 Partial solution (ILIAS8)

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -1024,7 +1024,7 @@ abstract class assQuestionGUI
 
         // questiontext
         $question = new ilTextAreaInputGUI($this->lng->txt("question"), "question");
-        $question->setValue($this->object->getQuestion());
+        $question->setValue(htmlspecialchars_decode($this->object->getQuestion()));
         $question->setRequired(true);
         $question->setRows(10);
         $question->setCols(80);


### PR DESCRIPTION
Ensures special characters are properly decoded to be shown in Form's Question field when addBasicQuestionFormProperties is used to add the 6 default form entries for questions in ILIAS, It will continue failing for other fields.