### PR TITLE
T&A Bugfix #0037462: non-numerical mark scheme percentage

### DIFF
--- a/Modules/Test/classes/class.ilMarkSchemaGUI.php
+++ b/Modules/Test/classes/class.ilMarkSchemaGUI.php
@@ -97,12 +97,18 @@ class ilMarkSchemaGUI
                 //replace , with . for float values
                 $value = str_replace(',', '.', $value);
 
-                $this->object->getMarkSchema()->addMarkStep(
-                    ilUtil::stripSlashes($postdata["mark_short_$matches[1]"]),
-                    ilUtil::stripSlashes($postdata["mark_official_$matches[1]"]),
-                    str_replace(',', '.', ilUtil::stripSlashes($postdata["mark_percentage_$matches[1]"])),
-                    ilUtil::stripSlashes($passed)
-                );
+                $percentage = str_replace(',', '.', ilUtil::stripSlashes($postdata["mark_percentage_$matches[1]"]));
+                if (!is_numeric($percentage)) {
+                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt('mark_schema_invalid'), true);
+                    $this->showMarkSchema();
+                } else {
+                    $this->object->getMarkSchema()->addMarkStep(
+                        ilUtil::stripSlashes($postdata["mark_short_$matches[1]"]),
+                        ilUtil::stripSlashes($postdata["mark_official_$matches[1]"]),
+                        (float) $percentage,
+                        (int) ilUtil::stripSlashes($passed)
+                    );
+                }
             }
         }
     }

--- a/Modules/Test/classes/class.ilMarkSchemaGUI.php
+++ b/Modules/Test/classes/class.ilMarkSchemaGUI.php
@@ -175,7 +175,9 @@ class ilMarkSchemaGUI
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('saved_successfully'), true);
         }
 
-        $this->ctrl->redirect($this);
+        $this->object->getMarkSchema()->flush();
+        $this->object->getMarkSchema()->loadFromDb($this->object->getTestId());
+        $this->showMarkSchema();
     }
 
     private function objectSupportsEctsGrades(): bool

--- a/Modules/Test/classes/class.ilMarkSchemaGUI.php
+++ b/Modules/Test/classes/class.ilMarkSchemaGUI.php
@@ -99,16 +99,15 @@ class ilMarkSchemaGUI
 
                 $percentage = str_replace(',', '.', ilUtil::stripSlashes($postdata["mark_percentage_$matches[1]"]));
                 if (!is_numeric($percentage)) {
-                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt('mark_schema_invalid'), true);
-                    $this->showMarkSchema();
-                } else {
-                    $this->object->getMarkSchema()->addMarkStep(
-                        ilUtil::stripSlashes($postdata["mark_short_$matches[1]"]),
-                        ilUtil::stripSlashes($postdata["mark_official_$matches[1]"]),
-                        (float) $percentage,
-                        (int) ilUtil::stripSlashes($passed)
-                    );
+                    throw new ilException('mark_percentage_invalid');
                 }
+
+                $this->object->getMarkSchema()->addMarkStep(
+                    ilUtil::stripSlashes($postdata["mark_short_$matches[1]"]),
+                    ilUtil::stripSlashes($postdata["mark_official_$matches[1]"]),
+                    (float) $percentage,
+                    (int) ilUtil::stripSlashes($passed)
+                );
             }
         }
     }
@@ -165,7 +164,7 @@ class ilMarkSchemaGUI
             $this->saveMarkSchemaFormData();
             $result = $this->object->checkMarks();
         } catch (Exception $e) {
-            $result = $this->lng->txt('mark_schema_invalid');
+            $result = 'mark_schema_invalid';
         }
 
         if (is_string($result)) {

--- a/Modules/Test/classes/tables/class.ilMarkSchemaTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilMarkSchemaTableGUI.php
@@ -24,8 +24,6 @@
 class ilMarkSchemaTableGUI extends ilTable2GUI
 {
     private ?ilMarkSchemaAware $object;
-    private ILIAS\HTTP\Wrapper\ArrayBasedRequestWrapper $post_wrapper;
-    private ILIAS\Refinery\Factory $refinery;
 
     protected bool $is_editable = true;
 
@@ -39,9 +37,6 @@ class ilMarkSchemaTableGUI extends ilTable2GUI
 
         $this->object = $object;
         $this->ctrl = $ilCtrl;
-        $this->post_wrapper = $DIC->http()->wrapper()->post();
-        $this->refinery = $DIC->refinery();
-
         $this->is_editable = $this->object->canEditMarks();
 
         $this->setId('mark_schema_gui_' . $this->object->getMarkSchemaForeignId());
@@ -82,29 +77,17 @@ class ilMarkSchemaTableGUI extends ilTable2GUI
     {
         $this->object->getMarkSchema()->sort();
 
-        $data = array();
+        $data = [];
 
         $marks = $this->object->getMarkSchema()->getMarkSteps();
         foreach ($marks as $key => $value) {
-            $precentage = $this->post_wrapper->has('mark_percentage_' . $key) ?
-                $this->post_wrapper->retrieve('mark_percentage_' . $key, $this->refinery->kindlyTo()->string()) :
-                $value->getMinimumLevel();
-            if (!is_numeric($precentage)) {
-                $precentage = 0;
-            }
-            $data[] = array(
+            $data[] = [
                 'mark_id' => $key,
-                'mark_short' => $this->post_wrapper->has('mark_short_' . $key) ?
-                    $this->post_wrapper->retrieve('mark_short_' . $key, $this->refinery->kindlyTo()->string()) :
-                    $value->getShortName(),
-                'mark_official' => $this->post_wrapper->has('mark_official_' . $key) ?
-                    $this->post_wrapper->retrieve('mark_official_' . $key, $this->refinery->kindlyTo()->string()) :
-                    $value->getOfficialName(),
-                'mark_percentage' => $precentage,
-                'mark_passed' => $this->post_wrapper->has('passed_' . $key) ?
-                    $this->post_wrapper->retrieve('passed_' . $key, $this->refinery->kindlyTo()->int()) :
-                    $value->getPassed()
-            );
+                'mark_short' => $value->getShortName(),
+                'mark_official' => $value->getOfficialName(),
+                'mark_percentage' => $value->getMinimumLevel(),
+                'mark_passed' => $value->getPassed()
+            ];
         }
 
         $this->setData($data);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=37462

Used lng variable "mark_schema_invalid" => "One of your grade categories needs to start at the ‘Minimum Score Required (in %)’ level of 0% Your grading system hasn’t been saved." will be displayed when percentage is non numerical 

Change of behaviour to 7 where percentage is set to 0 instead