### PR TITLE
Repository: Überschüssige Panel-Überschrift in Einstellungen des Magazins (24285)

### DIFF
--- a/Modules/RootFolder/classes/class.ilObjRootFolderGUI.php
+++ b/Modules/RootFolder/classes/class.ilObjRootFolderGUI.php
@@ -296,12 +296,7 @@ class ilObjRootFolderGUI extends ilContainerGUI
         include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
         $form = new ilPropertyFormGUI();
         $form->setFormAction($this->ctrl->getFormAction($this));
-        $form->setTitle($this->lng->txt("repository"));
-
-        // presentation
-        $pres = new ilFormSectionHeaderGUI();
-        $pres->setTitle($this->lng->txt('obj_presentation'));
-        $form->addItem($pres);
+        $form->setTitle($this->lng->txt('obj_presentation'));
 
         // list presentation
         $form = $this->initListPresentationForm($form);


### PR DESCRIPTION
This PR fixes [24285](https://mantis.ilias.de/view.php?id=24285) by removing the superfluous section header.