### PR TITLE
Added Development How-Tos

### DIFF
--- a/docs/development/use-developer-mode.md
+++ b/docs/development/use-developer-mode.md
@@ -1,0 +1,36 @@
+# Developer Mode
+
+Sometimes features that are not implemented completely need to be committed to CVS because several programmers work on the same source code or new features or objects should be tested on dependencies to other parts of ILIAS. For these cases we have created the possibility to set parts of the system or whole object types into **developer mode**.
+
+Object types or functions in developer mode are not shown in ILIAS by default. So users are not affected with features that are not working properly yet.
+
+## Activating Objects
+
+To display functions in developer mode please add the following line in your `client.ini` in the `[system]` section:
+
+```php
+DEVMODE = "1"
+```
+
+Now you will see everything as usual.
+
+If you delete the line or set the value to 0 you will disable developer mode again.
+
+## How to Use DEVMODE for Programming
+
+To hide entire object types by setting them to DEVMODE just add a new attribute to the desired object in `objects.xml`, e.g.:
+
+```xml
+<object name="grp" class_name="Group" checkbox="1" inherit="1" translate="0" devmode="1">
+```
+
+In this case group objects will now not longer appear in the system.
+
+To hide particular code parts or functions use the new constant DEVMODE:
+
+```php
+if (DEVMODE) 
+    {
+        // do something only if devmode is activated
+    }
+```

--- a/docs/development/use-exceptions.md
+++ b/docs/development/use-exceptions.md
@@ -1,0 +1,104 @@
+# Using Exceptions
+
+If code identifies any problems that prevent the normal processing from being executed, e.g. a directory is not writable even if it should be, exceptions should be thrown. This usually happens within the application layer. Upper contexts that have called the application classes (e.g. GUI or SOAP) can act appropriate. E.g. the user interface layour can present the error using `ilUtil::sendFailure`.
+
+## Defining new Exceptions
+
+- New exceptions should be implemented as classes derived from `ilException` (found in component Services/Exceptions).
+- These class file should be put into a subdirectory `exceptions` within the component directory, e.g. `Services/AdvancedEditing/exceptions`.
+- If a component uses exceptions a top exception named after the component should be used. Other exceptions classes should be derived from this class, e.g. `Services/AdvancedEditing/exceptions/class.ilAdvancedEditingException.php`.
+
+
+```php
+<?php
+/* Copyright (c) 1998-2011 ILIAS open source, Extended GPL, see docs/LICENSE */
+ 
+require_once 'Services/Exceptions/classes/class.ilException.php'; 
+ 
+/** 
+ * Class for advanced editing exception handling in ILIAS. 
+ * 
+ * @author Michael Jansen <mjansen@databay.de>
+ * @version $Id$ 
+ * 
+ */
+class ilAdvancedEditingException extends ilException
+{
+    /** 
+     * Constructor
+     * 
+     * A message is not optional as in build in class Exception
+     * 
+     * @param   string $a_message message
+     */
+    public function __construct($a_message)
+    {
+        parent::__construct($a_message);
+    }
+}
+?>
+```
+
+
+## Throwing and Catching Exceptions
+Throwing an exception:
+
+```php
+function update()
+{
+    if (!$this->getId())
+    {
+        throw new ilObjectException('No id given');
+    }
+}
+```
+
+Catching an exception (in this case in the GUI layer):
+
+```php
+try
+{
+    $this->object->setTitle($title);
+    $this->object->update();
+    ilUtil::sendSuccess($this->lng->txt('saved_settings'));
+    return true;
+}
+catch (ilObjectException $e)
+{
+    ilUtil::sendFailure($e->getMessage());
+    return false;
+}
+```
+
+
+## Exception Wrapping
+Advantages of exception wrapping are:
+
+- Exception wrapping avoids the breaking of layer abstractions
+- Exception wrapping gives layers the possibility to add context informations to the exception
+
+```php
+Exception Wrapping I (application class):
+...
+    try 
+    {
+        $parser = new ilSaxParser($this->xml);
+        $parser->parse();
+        ...
+    {
+    catch (ilSaxParserException $e)
+    {
+        throw new ilObjectException(?Cannot parse object XML: ?.e->getMessage());
+    }
+...
+ 
+Exception Wrapping II (here: GUI class):
+ 
+...
+    try 
+    {
+        $this->object->import();
+        lUtil::sendSuccess($this->$lng('obj_created'));
+    }
+    catch(ilObjectException $e)
+```

--- a/docs/development/write-unit-tests.md
+++ b/docs/development/write-unit-tests.md
@@ -1,0 +1,125 @@
+# Writing Unit Tests
+
+ILIAS supports unit testing with the PHPUnit testing framework. We highly recommend their [excellent documentation](https://phpunit.de/) that explains the basic ideas of unit testing, how PHPUnit works and how it is installed.
+
+## Configuration
+After installing PHPUnit on your machine you need to configure ILIAS to work with it. The test cases are performed with an authenticated user in your ILIAS installation. The configuration determines which user is used to perform the test cases. You will find a configuration file template at:
+
+`Services/PHPUnit/config/cfg.phpunit.template.php`
+
+Make a copy at:
+
+`Services/PHPUnit/config/cfg.phpunit.php`
+
+Now change the file and provide a valid client ID, account ID, and username.
+
+>*Please activate the [developer mode](https://docu.ilias.de/goto_docu_pg_1082_42.html) in your `client.ini.php` when running PHPUnit tests.*
+
+## Test Cases
+Test classes should be located in a subdirectory test of your module or service directory.
+
+`[Services/Modules]/[ComponentName]/test`
+
+E.g. the test classes for the Administration service are located at `Services/Administration/test`. The names for test class files should usually be derived from the application class they are written for.
+
+`[ApplicationClassName]Test.php`
+
+E.g. if you write test cases for a class ilSetting the test class file should be named `ilSettingTest.php`.
+
+The class should contain a method starting with "test" for each test case.
+
+```php
+<?php
+/*
+    +-----------------------------------------------------------------------------+
+    | ILIAS open source                                                           |
+    +-----------------------------------------------------------------------------+
+    | Copyright (c) 1998-2006 ILIAS open source, University of Cologne            |
+[...]
+    +-----------------------------------------------------------------------------+
+*/
+ 
+class ilSettingTest extends PHPUnit_Framework_TestCase
+{
+    protected $backupGlobals = FALSE;
+ 
+    protected function setUp()
+    {
+        include_once("./Services/PHPUnit/classes/class.ilUnitUtil.php");
+        ilUnitUtil::performInitialisation();
+    }
+ 
+    public function testSetGetSettings()
+    {
+        $set = new ilSetting("test_module");
+        $set->set("foo", "bar");
+        $value = $set->get("foo");
+ 
+        $this->assertEquals("bar", $value);
+    }
+[...]
+}
+?>
+```
+
+- Your test class must be **derived from class PHPUnit_Framework_TestCase**.
+- Your test must be executable with **PHPUnit 5.7**.
+- If your test needs an ILIAS Installation, it must be annotated with **@group needsInstalledILIAS**, and...
+  - you must set **$backupGlobals to false**, otherwise, your test cases will not work.
+  - the setUp() method should contain the **ilUnitUtil::performInitialisation();** call. ilUnitUtil can be found in Services/PHPUnit/classes.
+- If your test does not need an ILIAS Installation, it must not be annotated with @group needsInstalledILIAS and also should not use ilUnitUtil::performInitialisation().
+
+To run your test class you simply call phpunit in your ILIAS root directory with the local path of your test class (omit the .php suffix):
+
+`> phpunit Services/Administration/test/ilSettingTest`
+
+
+>1. *Please write your test cases in a way that the* ***requirements to run them are minimal***. *The test cases should run on a usual system. They should not require that certain conditions are given on the test system, e.g. an empty repository.*
+>2. ***Clean up the data*** *that is written during the test case. If possible, a test run should not leave any data created during the test in the system.*
+
+## Test Suites
+Test suites allow to perform aggregated tests. They should be provided on the component level, one test suite for each service and module. The file name must follow the format:
+`il[Services/Modules][ComponentName]Suite.php`
+
+E.g. the test suite class for the Administration service is located at:
+`Services/Administration/test/ilServicesAdministrationSuite.php`
+
+The class is named:
+`ilServicesAdministrationSuite`
+
+```php
+<?php
+/*
+    +-----------------------------------------------------------------------------+
+    | ILIAS open source                                                           |
+    +-----------------------------------------------------------------------------+
+    | Copyright (c) 1998-2009 ILIAS open source, University of Cologne            |
+[...]
+    +-----------------------------------------------------------------------------+
+*/
+ 
+class ilServicesAdministrationSuite extends PHPUnit_Framework_TestSuite
+{
+    public static function suite()
+    {
+        $suite = new ilServicesAdministrationSuite();
+ 
+        // add each test class of the component     
+        include_once("./Services/Administration/test/ilSettingTest.php");
+        $suite->addTestSuite("ilSettingTest");
+        [...]
+ 
+        return $suite;
+    }
+}
+?>
+```
+
+The example outlines the basic structure of a test suite class. To run the test suite, simply pass the class name to phpunit in the ILIAS main directory:
+`> phpunit Services/Administration/test/ilServicesAdministrationSuite`
+
+## The Global Test Suite
+The global test suite scans all Services and Modules directory automatically for component level test suites and aggregates them to one big test suite. The suite is located in the PHPUnit Service. You can run the suite by typing:
+`> phpunit Services/PHPUnit/test/ilGlobalSuite`
+
+The global suite will first list all component suites that are included in execution. If your suite is not listed, you should check whether your suite file and class is following the naming conventions as written in the previous section.


### PR DESCRIPTION
As announced at the DevConf and in the [Jour Fixe of 12.06.2023](https://docu.ilias.de/goto_docu_wiki_wpage_7950_1357.html), all DevGuide pages that are how-tos and no training materials are changed to .md-files, stored in GitHub and embedded in the current DevGuide LM using the related page component plugin. This way we can ensure improved accessibility and maintenance. Any update or improvement of the content by the responsible maintainer is highly appreciated.