### PR TITLE
[FIX] remove funky whitespaces, zero joiner and soft hyphens

### DIFF
--- a/src/FileUpload/Processor/FilenameSanitizerPreProcessor.php
+++ b/src/FileUpload/Processor/FilenameSanitizerPreProcessor.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\FileUpload\Processor;
 
 use ILIAS\Filesystem\Stream\FileStream;
@@ -7,19 +23,6 @@ use ILIAS\FileUpload\DTO\Metadata;
 use ILIAS\FileUpload\DTO\ProcessingStatus;
 use League\Flysystem\Util;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 /**
  * Class FilenameSanitizerPreProcessor
  *
@@ -36,7 +39,12 @@ final class FilenameSanitizerPreProcessor implements PreProcessor
      */
     public function process(FileStream $stream, Metadata $metadata): ProcessingStatus
     {
-        $metadata->setFilename(Util::normalizeRelativePath($metadata->getFilename()));
+        $filename = $metadata->getFilename();
+
+        // remove some special characters
+        $filename = \ILIAS\Filesystem\Util::sanitizeFileName($filename);
+
+        $metadata->setFilename(Util::normalizeRelativePath($filename));
 
         return new ProcessingStatus(ProcessingStatus::OK, 'Filename changed');
     }

--- a/src/Filesystem/Security/Sanitizing/FilenameSanitizerImpl.php
+++ b/src/Filesystem/Security/Sanitizing/FilenameSanitizerImpl.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Filesystem\Security\Sanitizing;
 
 use ilFileUtils;
+use ILIAS\Filesystem\Util;
 
 /**
  * Class FilenameSanitizerImpl
@@ -35,7 +36,6 @@ use ilFileUtils;
  */
 class FilenameSanitizerImpl implements FilenameSanitizer
 {
-    private const FUNKY_WHITESPACES = '#\p{C}+#u';
     /**
      * Contains the whitelisted file suffixes.
      *
@@ -72,7 +72,7 @@ class FilenameSanitizerImpl implements FilenameSanitizer
      */
     public function sanitize(string $filename): string
     {
-        $filename = preg_replace(self::FUNKY_WHITESPACES, '', $filename); // remove funky whitespaces
+        $filename = Util::sanitizeFileName($filename);
 
         if ($this->isClean($filename)) {
             return $filename;

--- a/src/Filesystem/Util.php
+++ b/src/Filesystem/Util.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Filesystem;
+
+use ILIAS\Refinery\String\UTFNormal;
+
+/**
+ * This Util class is a collection of static helper methods to provide file system related functionality.
+ * Currently you can use it to sanitize file names which are compatible with the ILIAS file system.
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class Util
+{
+    private const FUNKY_WHITESPACES = '#\p{C}+#u';
+    private const ZERO_JOINER = '/\\x{00ad}|\\x{0083}|\\x{200c}|\\x{200d}|\\x{2062}|\\x{2063}/iu';
+    private const SOFT_HYPHEN = "/\\x{00a0}/iu";
+    private const CONTROL_CHARACTER = "/\\x{00a0}/iu";
+
+    public static function sanitizeFileName(string $filename): string
+    {
+        // remove control characters
+        $filename = preg_replace('/[\x00-\x1F\x7F]/u', '', $filename);
+        $filename = preg_replace(self::CONTROL_CHARACTER, '', $filename);
+
+        // remove other characters
+        $filename = preg_replace(self::FUNKY_WHITESPACES, '', $filename);
+        $filename = preg_replace(self::SOFT_HYPHEN, ' ', $filename);
+        $filename = preg_replace(self::ZERO_JOINER, '', $filename);
+
+        // UTF normalization form C
+        $form_c = (new UTFNormal())->formC();
+        $filename = $form_c->transform($filename);
+
+        return $filename;
+    }
+}

--- a/tests/Filesystem/Util/FilenameSanitizing.php
+++ b/tests/Filesystem/Util/FilenameSanitizing.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Filesystem\Util;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Filesystem\Util;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class FilenameSanitizing extends TestCase
+{
+    public function provideFilenames(): array
+    {
+        return [
+            ["Control\u{00a0}Character", 'ControlCharacter'],
+            ["Soft\u{00ad}Hyphen", 'SoftHyphen'],
+            ["No\u{0083}Break", 'NoBreak'],
+            ["ZeroWidth\u{200C}NonJoiner", 'ZeroWidthNonJoiner'],
+            ["ZeroWidth\u{200d}Joiner", 'ZeroWidthJoiner'],
+            ["Invisible\u{2062}Times", 'InvisibleTimes'],
+            ["Invisible\u{2063}Comma", 'InvisibleComma'],
+            ["Funky\u{200B}Whitespace", 'FunkyWhitespace'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFilenames
+     */
+    public function testSanitize(string $filename, string $expected): void
+    {
+        $this->assertEquals($expected, Util::sanitizeFilename($filename));
+    }
+}


### PR DESCRIPTION
This PR fixes several problems that occur in ILIAS when uploading files with SoftHyphens or other hidden characters. 

- https://mantis.ilias.de/view.php?id=32339
- https://mantis.ilias.de/view.php?id=35372
- https://mantis.ilias.de/view.php?id=34241
- https://mantis.ilias.de/view.php?id=36879

the problems were partially solved locally, with this PR they should now be solved in general. I will also prepare the same fix for ILIAS 7. @alex40724 this may be interesting for you, as tickets for this topic are also assigned to you in mantis.