### PR TITLE
UI: remove unused method in `Form`

### DIFF
--- a/src/UI/Implementation/Component/Input/Container/Form/Form.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Form.php
@@ -86,9 +86,6 @@ abstract class Form implements C\Input\Container\Form\Form
      */
     public function withRequest(ServerRequestInterface $request)
     {
-        if (!$this->isSanePostRequest($request)) {
-            throw new LogicException("Server request is not a valid post request.");
-        }
         $post_data = $this->extractPostData($request);
 
         $clone = clone $this;
@@ -143,15 +140,6 @@ abstract class Form implements C\Input\Container\Form\Form
         }
 
         return $content->value();
-    }
-
-    /**
-     * Check the request for sanity.
-     * TODO: implement me!
-     */
-    protected function isSanePostRequest(ServerRequestInterface $request): bool
-    {
-        return true;
     }
 
     /**


### PR DESCRIPTION
Hi @thibsy, hi @Amstutz,

I just stumbled upon this while reviewing something else. I think I included it to make CSRF happen at some point, and we still should, but for now this is only some stub that doesn't do anything besides irritating me... So I think it can go for now.

Kind regards!