### PR TITLE
Plugins/Repository: Fix PHP type when consuming permanent link target

### DIFF
--- a/Services/Repository/PluginSlot/class.ilObjectPluginGUI.php
+++ b/Services/Repository/PluginSlot/class.ilObjectPluginGUI.php
@@ -457,9 +457,9 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
     }
 
     /**
-     * Goto redirection
+     * @param list<string> $a_target
      */
-    public static function _goto(string $a_target): void
+    public static function _goto(array $a_target): void
     {
         global $DIC;
         $main_tpl = $DIC->ui()->mainTemplate();


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=37481

If approved, this must be cherry-picked to `trunk` as well.