### PR TITLE
Init/PasswordAssistance/UsernameAssistance: Use UI framework for password assistance forms

### DIFF
--- a/Services/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/Services/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -193,14 +193,18 @@ class ilPasswordAssistanceGUI
 
         $tpl->setVariable(
             'TXT_ENTER_USERNAME_AND_EMAIL',
-            str_replace(
-                "\\n",
-                '<br />',
-                sprintf(
-                    $this->lng->txt('pwassist_enter_username_and_email'),
-                    '<a href="mailto:' . ilLegacyFormElementsUtil::prepareFormOutput(
-                        $this->settings->get('admin_email')
-                    ) . '">' . ilLegacyFormElementsUtil::prepareFormOutput($this->settings->get('admin_email')) . '</a>'
+            $this->ui_renderer->render(
+                $this->ui_factory->messageBox()->info(
+                    str_replace(
+                        "\\n",
+                        '<br />',
+                        sprintf(
+                            $this->lng->txt('pwassist_enter_username_and_email'),
+                            '<a href="mailto:' . ilLegacyFormElementsUtil::prepareFormOutput(
+                                $this->settings->get('admin_email')
+                            ) . '">' . ilLegacyFormElementsUtil::prepareFormOutput($this->settings->get('admin_email')) . '</a>'
+                        )
+                    )
                 )
             )
         );
@@ -492,7 +496,9 @@ class ilPasswordAssistanceGUI
 
         $tpl->setVariable(
             'TXT_ENTER_USERNAME_AND_NEW_PASSWORD',
-            $this->lng->txt('pwassist_enter_username_and_new_password')
+            $this->ui_renderer->render(
+                $this->ui_factory->messageBox()->info($this->lng->txt('pwassist_enter_username_and_new_password'))
+            )
         );
 
         $tpl->setVariable('FORM', $this->ui_renderer->render($form ?? $this->getAssignPasswordForm($pwassist_id)));
@@ -588,7 +594,11 @@ class ilPasswordAssistanceGUI
             if ($is_successful) {
                 db_pwassist_session_destroy($pwassist_id);
                 $this->showMessageForm(
-                    sprintf($this->lng->txt('pwassist_password_assigned'), $username),
+                    $this->ui_renderer->render(
+                        $this->ui_factory->messageBox()->info(
+                            sprintf($this->lng->txt('pwassist_password_assigned'), $username)
+                        )
+                    ),
                     self::PERMANENT_LINK_TARGET_PW
                 );
             } else {
@@ -634,14 +644,18 @@ class ilPasswordAssistanceGUI
 
         $tpl->setVariable(
             'TXT_ENTER_USERNAME_AND_EMAIL',
-            str_replace(
-                "\\n",
-                '<br />',
-                sprintf(
-                    $this->lng->txt('pwassist_enter_email'),
-                    '<a href="mailto:' . ilLegacyFormElementsUtil::prepareFormOutput(
-                        $this->settings->get('admin_email')
-                    ) . '">' . ilLegacyFormElementsUtil::prepareFormOutput($this->settings->get('admin_email')) . '</a>'
+            $this->ui_renderer->render(
+                $this->ui_factory->messageBox()->info(
+                    str_replace(
+                        "\\n",
+                        '<br />',
+                        sprintf(
+                            $this->lng->txt('pwassist_enter_email'),
+                            '<a href="mailto:' . ilLegacyFormElementsUtil::prepareFormOutput(
+                                $this->settings->get('admin_email')
+                            ) . '">' . ilLegacyFormElementsUtil::prepareFormOutput($this->settings->get('admin_email')) . '</a>'
+                        )
+                    )
                 )
             )
         );

--- a/Services/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/Services/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -25,6 +25,7 @@ class ilPasswordAssistanceGUI
 {
     private const PERMANENT_LINK_TARGET_PW = 'pwassist';
     private const PERMANENT_LINK_TARGET_NAME = 'nameassist';
+
     private const PROP_USERNAME = 'username';
     private const PROP_EMAIL = 'email';
     private const PROP_PASSWORD = 'password';
@@ -55,10 +56,10 @@ class ilPasswordAssistanceGUI
         $this->ilErr = $DIC['ilErr'];
         $this->help = $DIC->help();
         $this->http = $DIC->http();
-        $this->actor = $DIC->user();
         $this->refinery = $DIC->refinery();
         $this->ui_factory = $DIC->ui()->factory();
         $this->ui_renderer = $DIC->ui()->renderer();
+        $this->actor = $DIC->user();
 
         $this->help->setScreenIdComponent('init');
     }
@@ -70,10 +71,12 @@ class ilPasswordAssistanceGUI
 
     public function executeCommand(): void
     {
+        // check correct setup
         if (!$this->settings->get('setup_ok')) {
             $this->ilErr->raiseError('Setup is not completed. Please run setup routine again.', $this->ilErr->FATAL);
         }
 
+        // check hack attempts
         if (!$this->settings->get('password_assistance')) {
             $this->ilErr->raiseError($this->lng->txt('permission_denied'), $this->ilErr->MESSAGE);
         }
@@ -316,10 +319,7 @@ class ilPasswordAssistanceGUI
             $status = $assistance_callback();
         }
 
-        $this->showMessageForm(
-            sprintf($this->lng->txt('pwassist_mail_sent'), $email),
-            self::PERMANENT_LINK_TARGET_PW
-        );
+        $this->showMessageForm(sprintf($this->lng->txt('pwassist_mail_sent'), $email), self::PERMANENT_LINK_TARGET_PW);
     }
 
     /**
@@ -762,6 +762,6 @@ class ilPasswordAssistanceGUI
 
     private function fillPermanentLink(string $context): void
     {
-        $this->tpl->setPermanentLink('usr', 0, $context);
+        $this->tpl->setPermanentLink('usr', null, $context);
     }
 }

--- a/include/inc.pwassist_session_handler.php
+++ b/include/inc.pwassist_session_handler.php
@@ -1,69 +1,32 @@
 <?php
-/**
-* Database Session Handling for the password assistance use case.
-*
-* @module		inc.db_pwassist_session_handler.php
-* @modulegroup	iliascore
-* @version		$Id$
-*/
-
-
-/*
-    +-----------------------------------------------------------------------------+
-    | ILIAS open source                                                           |
-    +-----------------------------------------------------------------------------+
-    | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
-    |                                                                             |
-    | This program is free software; you can redistribute it and/or               |
-    | modify it under the terms of the GNU General Public License                 |
-    | as published by the Free Software Foundation; either version 2              |
-    | of the License, or (at your option) any later version.                      |
-    |                                                                             |
-    | This program is distributed in the hope that it will be useful,             |
-    | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
-    | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
-    | GNU General Public License for more details.                                |
-    |                                                                             |
-    | You should have received a copy of the GNU General Public License           |
-    | along with this program; if not, write to the Free Software                 |
-    | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
-    +-----------------------------------------------------------------------------+
-*/
-
-
-/*
-* open session, normally a db connection would be opened here, but
-* we use the standard ilias db connection, so nothing must be done here
-*
-* @param	string		$save_pathDSN	information about how to access the database, format:
-*										dbtype(dbsyntax)://username:password@protocol+hostspec/database
-*										eg. mysql://phpsessmgr:topsecret@db.example.com/sessiondb
-* @param	string		$name			session name [session_name()]
-*/
-function db_pwassist_session_open($save_path, $name)
-{
-    return true;
-}
 
 /**
-* close session
-*
-* for a db nothing has to be done here
-*/
-function db_pwassist_session_close()
-{
-    return true;
-}
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/*
-* Creates a new secure id.
-*
-* The secure id has the following characteristics:
-* - It is unique
-* - It is a non-uniformly distributed (pseudo) random value
-* - Only a non-substantial number of bits can be predicted from
-*   previously generated id's.
-*/
+declare(strict_types=1);
+
+/**
+ * Creates a new secure id.
+ *
+ * The secure id has the following characteristics:
+ * - It is unique
+ * - It is a non-uniformly distributed (pseudo) random value
+ * - Only a non-substantial number of bits can be predicted from
+ *   previously generated id's.
+ */
 function db_pwassist_create_id(): string
 {
     global $DIC;
@@ -87,111 +50,73 @@ function db_pwassist_create_id(): string
     return $hash;
 }
 
-/*
-* Reads data of the session identified by $pwassist_id and returns it as a
-* associative array. If there is no session with this ID an empty array is
-* returned
-*
-* @param	integer		$pwassist_id	secure id
-*/
-function db_pwassist_session_read($pwassist_id)
+/**
+ * @return null|array{"pwassist_id": string, "expires": int|numeric-string, "user_id": int|numeric-string, "ctime": int|numeric-string}
+ */
+function db_pwassist_session_read(string $pwassist_id): ?array
 {
     global $DIC;
 
     $ilDB = $DIC->database();
 
-    $q = "SELECT * FROM usr_pwassist " .
-        "WHERE pwassist_id = " . $ilDB->quote($pwassist_id, "text");
+    $q = 'SELECT * FROM usr_pwassist WHERE pwassist_id = ' . $ilDB->quote($pwassist_id, ilDBConstants::T_TEXT);
     $r = $ilDB->query($q);
-    $data = $ilDB->fetchAssoc($r);
 
-    return $data;
-}
-
-/*
-* Reads data of the session identified by $user_id.
-* Teturns the data as an associative array.
-* If there is no session for the specified user_id, an
-* empty array is returned
-*
-* @param	integer		$user_id		user id
-**/
-function db_pwassist_session_find($user_id)
-{
-    global $DIC;
-
-    $ilDB = $DIC->database();
-
-    $q = "SELECT * FROM usr_pwassist " .
-        "WHERE user_id = " . $ilDB->quote($user_id, "integer");
-    $r = $ilDB->query($q);
-    $data = $ilDB->fetchAssoc($r);
-
-    return $data;
+    return $ilDB->fetchAssoc($r);
 }
 
 /**
-* Writes serialized session data to the database.
-*
-* @param	integer		$pwassist_id	secure id
-* @param	integer		$maxlifetime	session max lifetime in seconds
-* @param	integer		$user_id		user id
-*/
-function db_pwassist_session_write($pwassist_id, $maxlifetime, $user_id)
+  * @return null|array{"pwassist_id": string, "expires": int|numeric-string, "user_id": int|numeric-string, "ctime": int|numeric-string}
+  */
+function db_pwassist_session_find(int $user_id): ?array
 {
     global $DIC;
 
     $ilDB = $DIC->database();
 
-    $q = "DELETE FROM usr_pwassist " .
-         "WHERE pwassist_id = " . $ilDB->quote($pwassist_id, "text") . " " .
-         "OR user_id = " . $ilDB->quote($user_id, 'integer');
+    $q = 'SELECT * FROM usr_pwassist WHERE user_id = ' . $ilDB->quote($user_id, ilDBConstants::T_INTEGER);
+    $r = $ilDB->query($q);
+
+    return $ilDB->fetchAssoc($r);
+}
+
+function db_pwassist_session_write(string $pwassist_id, int $maxlifetime, int $user_id): void
+{
+    global $DIC;
+
+    $ilDB = $DIC->database();
+
+    $q = 'DELETE FROM usr_pwassist ' .
+        'WHERE pwassist_id = ' . $ilDB->quote($pwassist_id, ilDBConstants::T_TEXT) . ' ' .
+        'OR user_id = ' . $ilDB->quote($user_id, ilDBConstants::T_INTEGER);
     $ilDB->manipulate($q);
 
     $ctime = time();
     $expires = $ctime + $maxlifetime;
     $ilDB->manipulateF(
-        "INSERT INTO usr_pwassist " .
-        "(pwassist_id, expires, user_id,  ctime) " .
-        "VALUES (%s,%s,%s,%s)",
-        array("text", "integer", "integer", "integer"),
-        array($pwassist_id, $expires, $user_id, $ctime)
+        'INSERT INTO usr_pwassist (pwassist_id, expires, user_id,  ctime)  VALUES (%s, %s, %s, %s)',
+        [ilDBConstants::T_TEXT, ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER],
+        [$pwassist_id, $expires, $user_id, $ctime]
     );
-
-    return true;
 }
 
-/**
-* destroy session
-*
-* @param	integer		$pwassist_id			secure id
-*/
-function db_pwassist_session_destroy($pwassist_id)
+function db_pwassist_session_destroy(string $pwassist_id): void
 {
     global $DIC;
 
     $ilDB = $DIC->database();
 
-    $q = "DELETE FROM usr_pwassist " .
-         "WHERE pwassist_id = " . $ilDB->quote($pwassist_id, "text");
+    $q = 'DELETE FROM usr_pwassist WHERE pwassist_id = ' . $ilDB->quote($pwassist_id, ilDBConstants::T_TEXT);
     $ilDB->manipulate($q);
-
-    return true;
 }
 
 
-/**
-* removes all expired sessions
-*/
-function db_pwassist_session_gc()
+function db_pwassist_session_gc(): void
 {
     global $DIC;
 
     $ilDB = $DIC->database();
 
-    $q = "DELETE FROM usr_pwassist " .
-         "WHERE expires < " . $ilDB->quote(time(), "integer");
+    $q = 'DELETE FROM usr_pwassist WHERE expires < ' . $ilDB->quote(time(), ilDBConstants::T_INTEGER);
     $ilDB->manipulate($q);
-
-    return true;
 }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -5807,6 +5807,7 @@ common#:#userfolder_export_file_size#:#Dateigröße
 common#:#userfolder_export_files#:#Dateien
 common#:#userfolder_export_xml#:#XML
 common#:#username#:#Anmeldename###Modified as part of gender mainstreaming activities for ILIAS 8
+common#:#username_assistance#:#Anmeldenamen-Unterstützung
 common#:#users#:#Benutzer
 common#:#users_not_imported#:#Die folgenden Benutzer existieren nicht. Daher können deren Mails nicht importiert werden
 common#:#users_online#:#Aktive Benutzer

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5801,6 +5801,7 @@ common#:#userfolder_export_file_size#:#File size
 common#:#userfolder_export_files#:#Files
 common#:#userfolder_export_xml#:#XML
 common#:#username#:#Username
+common#:#username_assistance#:#Username Assistance
 common#:#users#:#Users
 common#:#users_not_imported#:#The following users do not exist, their messages cannot become imported
 common#:#users_online#:#Active Users


### PR DESCRIPTION
This PR introduces the UI framework forms to the `ilPasswordAssistanceGUI`.

Furthermore I did a little bit of "boy-scouting" and introduced the UI `messageBox` for some texts:

See:
- https://mantis.ilias.de/view.php?id=32727
- https://mantis.ilias.de/view.php?id=32729
- https://mantis.ilias.de/view.php?id=32730
- https://mantis.ilias.de/view.php?id=32742

And it fixes: https://mantis.ilias.de/view.php?id=32290

If approved and merged, #5871 can be closed.