### PR TITLE
LSO: Use centralized online status and replace legacy form for settings

### DIFF
--- a/Modules/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
+++ b/Modules/LearningSequence/classes/Settings/class.ilObjLearningSequenceSettingsGUI.php
@@ -32,9 +32,6 @@ class ilObjLearningSequenceSettingsGUI
     public const CMD_SAVE = "update";
     public const CMD_CANCEL = "cancel";
 
-    public const CMD_OLD_INTRO = "viewlegacyi";
-    public const CMD_OLD_EXTRO = "viewlegacye";
-
     public function __construct(
         protected ilObjLearningSequence $obj,
         protected ilCtrl $ctrl,
@@ -43,7 +40,6 @@ class ilObjLearningSequenceSettingsGUI
         protected ilObjectService $obj_service,
         protected ArrayBasedRequestWrapper $post_wrapper,
         protected ILIAS\Refinery\Factory $refinery,
-        protected ilToolbarGUI $toolbar,
         protected ILIAS\UI\Factory $ui_factory
     ) {
         $this->settings = $obj->getLSSettings();
@@ -65,10 +61,6 @@ class ilObjLearningSequenceSettingsGUI
             case self::CMD_CANCEL:
                 $content = $this->$cmd();
                 break;
-            case self::CMD_OLD_INTRO:
-            case self::CMD_OLD_EXTRO:
-                $content = $this->showLegacyPage($cmd);
-                break;
 
             default:
                 throw new ilException("ilObjLearningSequenceSettingsGUI: Command not supported: $cmd");
@@ -78,9 +70,6 @@ class ilObjLearningSequenceSettingsGUI
 
     protected function settings(): string
     {
-        $this->addLegacypagesToToolbar();
-        $this->tpl->setOnScreenMessage("info", $this->lng->txt("lso_intropages_deprecationhint"));
-
         $form = $this->buildForm();
         $this->fillForm($form);
         $this->addCommonFieldsToForm($form);
@@ -90,47 +79,6 @@ class ilObjLearningSequenceSettingsGUI
     protected function cancel(): void
     {
         $this->ctrl->redirectByClass(ilObjLearningSequenceGUI::class);
-    }
-
-
-    //TODO: remove in release 9
-    public function addLegacypagesToToolbar(): void
-    {
-        $this->toolbar->addComponent(
-            $this->ui_factory->link()->standard(
-                $this->lng->txt("lso_settings_old_extro"),
-                $this->ctrl->getLinkTarget($this, self::CMD_OLD_EXTRO)
-            )
-        );
-    }
-
-    protected function showLegacyPage(string $cmd): string
-    {
-        $this->toolbar->addComponent(
-            $this->ui_factory->link()->standard(
-                $this->lng->txt("back"),
-                $this->ctrl->getLinkTarget($this, self::CMD_EDIT)
-            )
-        );
-
-        $out = [];
-        $settings = $this->settings;
-        if ($cmd === self::CMD_OLD_INTRO) {
-            $out[] = $settings->getAbstract();
-            $img = $settings->getAbstractImage();
-            if ($img) {
-                $out[] = '<img src="' . $img . '"/>';
-            }
-        }
-        if ($cmd === self::CMD_OLD_EXTRO) {
-            $out[] = $settings->getExtro();
-            $img = $settings->getExtroImage();
-            if ($img) {
-                $out[] = '<img src="' . $img . '"/>';
-            }
-        }
-
-        return implode('<hr>', $out);
     }
 
     protected function buildForm(): ilPropertyFormGUI

--- a/Modules/LearningSequence/classes/class.ilDashboardLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilDashboardLearningSequenceGUI.php
@@ -116,11 +116,6 @@ class ilDashboardLearningSequenceGUI
         $link = $this->getLinkedTitle($ref_id, $title);
 
         return $this->factory->item()->standard($link)
-            ->withProperties(
-                [
-                    $this->lng->txt('status') => $this->getOnlineStatus($ref_id)
-                ]
-            )
             ->withLeadIcon($this->getIcon($title))
         ;
     }
@@ -147,17 +142,6 @@ class ilDashboardLearningSequenceGUI
     {
         $link = ilLink::_getLink($ref_id, 'lso');
         return $this->factory->button()->shy($title, $link);
-    }
-
-    protected function getOnlineStatus(int $ref_id): string
-    {
-        $status = ilObjLearningSequenceAccess::isOffline($ref_id);
-
-        if ($status) {
-            return 'Offline';
-        }
-
-        return 'Online';
     }
 
     protected function getIcon(string $title): Icon\Standard

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequence.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequence.php
@@ -215,6 +215,11 @@ class ilObjLearningSequence extends ilContainer
                 ->withActivationEnd($this->getLSActivation()->getActivationEnd());
         }
 
+        $new_status = ($new_obj->getLSActivation()->getEffectiveOnlineStatus())
+            ? $new_obj->getObjectProperties()->getPropertyIsOnline()->withOnline()
+            : $new_obj->getObjectProperties()->getPropertyIsOnline()->withOffline();
+        $new_obj->getObjectProperties()->storePropertyIsOnline($new_status);
+
         $new_obj->getActivationDB()->store(
             $activation
         );

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceAccess.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceAccess.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 class ilObjLearningSequenceAccess extends ilObjectAccess
 {
@@ -68,7 +67,7 @@ class ilObjLearningSequenceAccess extends ilObjectAccess
         $act = $obj->getLSActivation();
         $online = $act->getIsOnline();
 
-        if (!$online
+        if ($online
             && ($act->getActivationStart() !== null ||
                 $act->getActivationEnd() !== null)
         ) {
@@ -98,6 +97,10 @@ class ilObjLearningSequenceAccess extends ilObjectAccess
             $obj->announceLSOOffline();
         }
 
+        $new_status = ($online)
+            ? $obj->getObjectProperties()->getPropertyIsOnline()->withOnline()
+            : $obj->getObjectProperties()->getPropertyIsOnline()->withOffline();
+        $obj->getObjectProperties()->storePropertyIsOnline($new_status);
 
         return !$online;
     }

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -485,7 +485,6 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
             $this->obj_service,
             $this->post_wrapper,
             $this->refinery,
-            $this->toolbar,
             $this->ui_factory
         );
         $this->ctrl->setCmd($cmd);

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -118,6 +118,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
     protected ILIAS\HTTP\Wrapper\RequestWrapper $request_wrapper;
     protected ArrayBasedRequestWrapper $post_wrapper;
     protected ILIAS\Refinery\Factory $refinery;
+    protected Psr\Http\Message\ServerRequestInterface $request;
 
     public static function _goto(string $target): void
     {
@@ -210,6 +211,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
         $this->rbac_review = $DIC['rbacreview'];
         $this->ui_factory = $DIC['ui.factory'];
         $this->ui_renderer = $DIC['ui.renderer'];
+        $this->request = $DIC->http()->request();
 
         $this->log = $DIC["ilLoggerFactory"]->getRootLogger();
         $this->app_event_handler = $DIC['ilAppEventHandler'];
@@ -482,10 +484,10 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
             $this->ctrl,
             $this->lng,
             $this->tpl,
-            $this->obj_service,
-            $this->post_wrapper,
             $this->refinery,
-            $this->ui_factory
+            $this->ui_factory,
+            $this->ui_renderer,
+            $this->request
         );
         $this->ctrl->setCmd($cmd);
         $this->ctrl->forwardCommand($gui);
@@ -863,7 +865,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
     {
         return array_filter(
             array_keys($this->obj_definition->getSubObjects('lso', false)),
-            fn ($type) => $type !== 'rolf'
+            fn($type) => $type !== 'rolf'
         );
     }
 

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceListGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceListGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 class ilObjLearningSequenceListGUI extends ilObjectListGUI
 {
@@ -48,21 +47,6 @@ class ilObjLearningSequenceListGUI extends ilObjectListGUI
         $this->gui_class_name = "ilobjlearningsequencegui";
         $this->type = ilObjLearningSequence::OBJ_TYPE;
         $this->commands = ilObjLearningSequenceAccess::_getCommands();
-    }
-
-    public function getProperties(): array
-    {
-        $props = parent::getProperties();
-
-        if (ilObjLearningSequenceAccess::isOffline($this->ref_id)) {
-            $props[] = [
-                "alert" => true,
-                "property" => $this->lng->txt("status"),
-                "value" => $this->lng->txt("offline")
-            ];
-        }
-
-        return $props;
     }
 
     public function createDefaultCommand(array $command): array

--- a/Modules/LearningSequence/module.xml
+++ b/Modules/LearningSequence/module.xml
@@ -24,6 +24,7 @@
 			workspace="0"
 			repository="1"
 			group="lso"
+			offline_handling="1"
 		>
 			<subobj id="rolf" max="1">rolf</subobj>
 			<subobj id="htlm">htlm</subobj>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -10534,6 +10534,7 @@ lso#:#lso_print_list#:#Liste erstellen
 lso#:#lso_read#:#Lesezugriff auf Learning Sequence
 lso#:#lso_search_users#:#Benutzer suchen
 lso#:#lso_settings_availability#:#Verfügbarkeit
+lso#:#lso_settings_availability_error#:#Das Enddatum darf nicht vor dem Startdatum liegen
 lso#:#lso_settings_extro#:#Abschlussseite bearbeiten
 lso#:#lso_settings_intro#:#Einleitungsseite bearbeiten
 lso#:#lso_settings_old_extro#:#Alte Abschlussseite ansehen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -10532,6 +10532,7 @@ lso#:#lso_print_list#:#Generate list
 lso#:#lso_read#:#User has read access to Learning Sequence
 lso#:#lso_search_users#:#Search Users
 lso#:#lso_settings_availability#:#Availability
+lso#:#lso_settings_availability_error#:#The end date can not be earlier than the start date
 lso#:#lso_settings_extro#:#Edit Exit Page
 lso#:#lso_settings_intro#:#Edit Intro Page
 lso#:#lso_settings_old_extro#:#View Old Exit Page


### PR DESCRIPTION
This is the implementation of https://docu.ilias.de/goto_docu_wiki_wpage_7199_1357.html for the Learning Sequence. It also replaces the legacy form for Settings with a new UI form. An ILIAS update is required for the change in module.xml to activate offline handling.

The LSO's own implementation of ilLearningSequenceActivation is still kept here, as it also includes options for optional start/end dates of the online status. It will be revised with the implementation of https://docu.ilias.de/goto_docu_wiki_wpage_6059_1357.html.

With this PR, the on-/offline status of LSO objects is additionally updated via the object properties of ilObject, as described in https://github.com/ILIAS-eLearning/ILIAS/tree/trunk/Services/Object#Common-Settings. The Dashboard and List GUI have been updated to use the online status of ilObject instead of their own implementations.

With the implementation of the new UI form, the options for editing the legacy pages for intro/outro have been removed, as they were already scheduled for removal with ILIAS 9.

~~(Note: This includes a temporary fix for the issue described in Mantis #37503, which will be fixed later)~~