### PR TITLE
IASS: Add centralized online status

### DIFF
--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentSettingsGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentSettingsGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 use ILIAS\UI\Component\Input\Container\Form;
 use ILIAS\UI\Component\Input;
@@ -148,14 +147,25 @@ class ilIndividualAssessmentSettingsGUI
             $this->lng,
             $this->refinery
         );
-        return $this->input_factory->container()->form()->standard(
-            $this->ctrl->getFormAction($this, "update"),
-            [$field]
-        )
-        ->withAdditionalTransformation(
+
+        // Use centralized on/offline
+        $online = $this->object->getObjectProperties()->getPropertyIsOnline()->toForm(
+            $this->lng,
+            $this->input_factory->field(),
+            $this->refinery
+        )->withByline($this->lng->txt('iass_settings_availability_info'));
+        $availability = $this->input_factory->field()->section(
+            [$online],
+            $this->lng->txt('iass_settings_availability')
+        )->withAdditionalTransformation(
             $this->refinery->custom()->transformation(function ($v) {
                 return array_shift($v);
             })
+        );
+
+        return $this->input_factory->container()->form()->standard(
+            $this->ctrl->getFormAction($this, "update"),
+            [$field, $availability]
         );
     }
 
@@ -174,8 +184,11 @@ class ilIndividualAssessmentSettingsGUI
         $settings = $form->getData();
 
         if (!is_null($settings)) {
-            $this->object->setSettings($settings);
+            $this->object->setSettings($settings[0]);
             $this->object->update();
+
+            $this->object->getObjectProperties()->storePropertyIsOnline($settings[1]);
+
             $this->tpl->setOnScreenMessage("success", $this->lng->txt("settings_saved"), true);
             $this->ctrl->redirect($this, "edit");
         } else {

--- a/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentListGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentListGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 class ilObjIndividualAssessmentListGUI extends ilObjectListGUI
 {
@@ -68,18 +67,5 @@ class ilObjIndividualAssessmentListGUI extends ilObjectListGUI
         }
 
         return $return;
-    }
-
-    /**
-    * Get item properties
-    *
-    * @return	array		array of property arrays:
-    *						"alert" (boolean) => display as an alert property (usually in red)
-    *						"property" (string) => property name
-    *						"value" (string) => property value
-    */
-    public function getProperties(): array
-    {
-        return [];
     }
 }

--- a/Modules/IndividualAssessment/module.xml
+++ b/Modules/IndividualAssessment/module.xml
@@ -23,6 +23,7 @@
 			export="1"
 			orgunit_permissions="1"
 			amet="1"
+			offline_handling="1"
 		>
 			<parent id="cat">cat</parent>
 			<parent id="crs">crs</parent>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -10132,6 +10132,8 @@ iass#:#iass_record_template_explanation#:#Hier eingegebener Text dient als Vorla
 iass#:#iass_remove_user_qst#:#Soll der Teilnehmer wirklich entfernt werden?
 iass#:#iass_responsibility#:#Zuständigkeit
 iass#:#iass_save_amend#:#Geänderte Prüfungsdaten speichern
+iass#:#iass_settings_availability#:#Verfügbarkeit
+iass#:#iass_settings_availability_info#:#Nur wenn die Individuelle Bewertung online geschaltet ist, können Benutzer beitreten und Mitglieder darauf zugreifen. Wenn nicht, ist die Individuelle Bewertung nur für Administratoren und Tutoren verfügbar.
 iass#:#iass_settings_saved#:#Einstellungen gespeichert.
 iass#:#iass_sort_changetime_asc#:#Letzte Änderung → aufsteigend
 iass#:#iass_sort_changetime_desc#:#Letzte Änderung → absteigend

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -10130,6 +10130,8 @@ iass#:#iass_record_template_explanation#:#Template for participant grading recor
 iass#:#iass_remove_user_qst#:#Should the participant really be removed?
 iass#:#iass_responsibility#:#Responsibility
 iass#:#iass_save_amend#:#Save Amended Record
+iass#:#iass_settings_availability#:#Availability
+iass#:#iass_settings_availability_info#:#Set the Individual Assessment online to make it visible and available for members. If not, only administrators and tutors will have access to it.
 iass#:#iass_settings_saved#:#Settings saved.
 iass#:#iass_sort_changetime_asc#:#Last Change ascending
 iass#:#iass_sort_changetime_desc#:#Last Change descending


### PR DESCRIPTION
This is the implementation of https://docu.ilias.de/goto_docu_wiki_wpage_7199_1357.html for the **Individual Assessment.** An ILIAS update is required for the change in module.xml to activate offline handling.

With this PR, an on-/offline status for IASS objects is added to the settings and updated via the object properties of ilObject, as described in https://github.com/ILIAS-eLearning/ILIAS/tree/trunk/Services/Object#Common-Settings. The List GUI has been updated to display the online status from ilObject.