### PR TITLE
Membership: Printing list of participants in courses not possible (30617)

### DIFF
--- a/Services/Membership/classes/class.ilAttendanceList.php
+++ b/Services/Membership/classes/class.ilAttendanceList.php
@@ -524,6 +524,12 @@ class ilAttendanceList
 
         $tpl = $DIC->ui()->mainTemplate();
         $tpl->setContent($this->getHTML());
+        $tpl->addOnLoadCode(
+            "var header = document.getElementsByClassName('il_HeaderInner')[0];
+            header.classList.add('hidden-print');
+            il.Util.print();
+            header.classList.remove('hidden-print');"
+        );
         //$tpl->setVariable("CONTENT", $this->getHTML());
         //$tpl->setContent($this->getHTML());
     }
@@ -537,7 +543,7 @@ class ilAttendanceList
     {
         $tpl = new ilTemplate('tpl.attendance_list_print.html', true, true, 'Services/Membership');
 
-        
+
         // title
         
         ilDatePresentation::setUseRelativeDates(false);

--- a/Services/Membership/classes/class.ilAttendanceList.php
+++ b/Services/Membership/classes/class.ilAttendanceList.php
@@ -524,12 +524,7 @@ class ilAttendanceList
 
         $tpl = $DIC->ui()->mainTemplate();
         $tpl->setContent($this->getHTML());
-        $tpl->addOnLoadCode(
-            "var header = document.getElementsByClassName('il_HeaderInner')[0];
-            header.classList.add('hidden-print');
-            il.Util.print();
-            header.classList.remove('hidden-print');"
-        );
+        $tpl->addOnLoadCode("il.Util.print();");
         //$tpl->setVariable("CONTENT", $this->getHTML());
         //$tpl->setContent($this->getHTML());
     }


### PR DESCRIPTION
This PR fixes [30617](https://mantis.ilias.de/view.php?id=30617) / [32662](https://mantis.ilias.de/view.php?id=32662). 

~~I'm hiding the inner header in the print output by fiddling with its css classes via javascript. This is maybe a bit inelegant, but I don't think it's possible otherwise, given how printing of participants is currently implemented.~~