### PR TITLE
Init/ErrorHandling: Hide sensitive information

### DIFF
--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -30,6 +30,17 @@ use Whoops\Exception\Inspector;
 
 class ilErrorHandling extends PEAR
 {
+    private const SENSTIVE_PARAMETER_NAMES = [
+        'password',
+        'passwd',
+        'passwd_retype',
+        'current_password',
+        'usr_password',
+        'usr_password_retype',
+        'new_password',
+        'new_password_retype',
+    ];
+
     /**
     * Toggle debugging on/off
     * @var		boolean
@@ -357,6 +368,7 @@ class ilErrorHandling extends PEAR
             $logger = ilLoggingErrorSettings::getInstance();
             if (!empty($logger->folder())) {
                 $lwriter = new ilLoggingErrorFileStorage($inspector, $logger->folder(), $file_name);
+                $lwriter = $lwriter->withExclusionList(self::SENSTIVE_PARAMETER_NAMES);
                 $lwriter->write();
             }
 
@@ -391,9 +403,9 @@ class ilErrorHandling extends PEAR
         
         switch (ERROR_HANDLER) {
             case "TESTING":
-                return new ilTestingHandler();
+                return (new ilTestingHandler())->withExclusionList(self::SENSTIVE_PARAMETER_NAMES);
             case "PLAIN_TEXT":
-                return new ilPlainTextHandler();
+                return (new ilPlainTextHandler())->withExclusionList(self::SENSTIVE_PARAMETER_NAMES);
             case "PRETTY_PAGE":
                 // fallthrough
             default:
@@ -407,6 +419,10 @@ class ilErrorHandling extends PEAR
                 $prettyPageHandler = new PrettyPageHandler();
 
                 $this->addEditorSupport($prettyPageHandler);
+
+                foreach (self::SENSTIVE_PARAMETER_NAMES as $param) {
+                    $prettyPageHandler->blacklist('_POST', $param);
+                }
 
                 return $prettyPageHandler;
         }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=37522

If approved, this MUST be chery-picked to `release_8` and `trunk`. Please introduce `Typed Properties` for these branches.

In my opinion this should be the **last** fix of this kind, at least for the user interface part. Sensitive data in log files should still be obscured in future.

Why?

1. Adding parameter names considered `sensitive information` to a list always fixes a local problem.
2. Using an exclusion list in general is not recommended
3. We have no mechanism to enforce a particular name for sensitive parameters (like `passwd`, `token`, etc.).
4. Using exclusion lists will be even harder if the `UI Input` forms are used more and more.
5. `PrettyPageHandler` supports an exclusion list natively (but only for values on the first level of a super global array), `ilPlaintextHandler` and `ilLoggingErrorFileStorage` have nothing in common (base class, interface), so the exclusion list must be injected from a central location by calling methods being not a part of any contract.
6. (All the arguments of the) Official statement of the vendor: https://github.com/filp/whoops/issues/571
7. With PHP 8.2 sensitive data could be handled on language level, see: https://stitcher.io/blog/new-in-php-82#redact-parameters-in-back-traces-rfc / https://wiki.php.net/rfc/redact_parameters_in_back_traces , allthough I doubt that the super global arrays could be tackled with this.