### PR TITLE
[FIX] #34328: pass along `$move_operation` to plugins.

### DIFF
--- a/Services/COPage/classes/class.ilPageObject.php
+++ b/Services/COPage/classes/class.ilPageObject.php
@@ -3096,7 +3096,7 @@ s     */
                 if (is_object($curr_node)) {
                     $parent_node = $curr_node->parent_node();
                     if ($parent_node->node_name() != "TableRow") {
-                        $this->handleDeleteContent($curr_node);
+                        $this->handleDeleteContent($curr_node, $move_operation);
                         $curr_node->unlink_node($curr_node);
                     }
                 }


### PR DESCRIPTION
Hi @alex40724 

I was updating a PageComponent plugin of ours when I stumbled upon https://mantis.ilias.de/view.php?id=34328 again, as also discussed in #3990 once.

This PR fixes the issue by passing along the `$move_operation` variable to the `onDelete()` hook.
This probably needs to be picked for trunk as well.

Kind regards,
@thibsy 