### PR TITLE
[FIX] object creation-screen also works for plugins now.

### DIFF
--- a/Services/Repository/PluginSlot/class.ilObjectPluginGUI.php
+++ b/Services/Repository/PluginSlot/class.ilObjectPluginGUI.php
@@ -159,7 +159,7 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
                 $this->ctrl->forwardCommand($gui);
                 break;
             default:
-                if ($cmd === "save" && $this->getCreationMode()) {
+                if ($cmd === "save" || $this->getCreationMode()) {
                     $this->$cmd();
                     return;
                 }


### PR DESCRIPTION
Hi @alex40724

I was updating a RepositoryObject plugin of ours when I stumbled upon an issue with the creation-screens of such plugins, also see https://mantis.ilias.de/view.php?id=37531. 

Clicking on an icon of a custom object-type leads to a request to `ilias.php?baseClass=ilRepositoryGUI&ref_id=1&cmd=create&new_type=PLUGIN_OBJ_TYPE`, which should show the usual ILIAS creation-screen for repository objects. This currently calls the plugins `performCommand()` method with `"create"` as it's argument, which previously got handled by the parent GUI.

I compared the `ilObjectPluginGUI` to an earlier version and found, that `&&` has been used instead of an `||` when in creation mode. Is there a reason why this changed? Anyways, this fixes the creation-screens for plugins.

Kind regards,
@thibsy 