### PR TITLE
Certificate/StudyProgramme: Relocate code for `Certificate` issuing

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeAppEventListener.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeAppEventListener.php
@@ -36,6 +36,8 @@ class ilStudyProgrammeAppEventListener
      */
     public static function handleEvent(string $component, string $event, array $parameter): void
     {
+        global $DIC;
+
         switch ($component) {
             case "Services/User":
                 switch ($event) {
@@ -137,6 +139,17 @@ class ilStudyProgrammeAppEventListener
                         self::removeMemberFromProgrammes(
                             ilStudyProgrammeAutoMembershipSource::TYPE_ORGU,
                             $parameter
+                        );
+                        break;
+                }
+                break;
+
+            case 'Modules/StudyProgramme':
+                switch ($event) {
+                    case 'userSuccessful':
+                        $DIC->certificate()->userCertificates()->certificateCriteriaMet(
+                            (int) $parameter['usr_id'],
+                            (int) $parameter['prg_id']
                         );
                         break;
                 }

--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeAppEventListener.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeAppEventListener.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Event listener for study programs. Has the following tasks:

--- a/Modules/StudyProgramme/module.xml
+++ b/Modules/StudyProgramme/module.xml
@@ -32,6 +32,7 @@
 		<event type="listen" id="Services/Object" />
 		<event type="listen" id="Services/ContainerReference" />
 		<event type="listen" id="Services/AccessControl" />
+		<event type="listen" id="Modules/StudyProgramme" />
 		<event type="listen" id="Modules/Course" />
 		<event type="listen" id="Modules/Group" />
 		<event type="listen" id="Modules/OrgUnit" />

--- a/Services/Certificate/classes/API/UserCertificateAPI.php
+++ b/Services/Certificate/classes/API/UserCertificateAPI.php
@@ -118,21 +118,8 @@ class UserCertificateAPI
         }
 
         $template = $this->template_repository->fetchCurrentlyActiveCertificate($obj_id);
-        if (!$template->isCurrentlyActive()) {
-            $this->logger->debug(sprintf(
-                'Did not trigger certificate achievement for inactive template: usr_id: %s/obj_id: %s/type: %s/template_id: %s',
-                $usr_id,
-                $template->getObjId(),
-                $template->getObjType(),
-                $template->getId()
-            ));
-            return;
-        }
 
-        $this->processEntry(
-            $usr_id,
-            $template
-        );
+        $this->certificateCriteriaMetForGivenTemplate($usr_id, $template);
     }
 
     private function processEntry(

--- a/Services/Certificate/classes/API/UserCertificateAPI.php
+++ b/Services/Certificate/classes/API/UserCertificateAPI.php
@@ -23,25 +23,53 @@ namespace ILIAS\Certificate\API;
 use ILIAS\Certificate\API\Data\UserCertificateDto;
 use ILIAS\Certificate\API\Filter\UserDataFilter;
 use ILIAS\Certificate\API\Repository\UserDataRepository;
+use ilCertificateQueueEntry;
+use ilCertificateCron;
+use ilCertificateTypeClassMap;
+use ilCertificateTemplateRepository;
+use ilLogger;
+use ilCertificateTemplateDatabaseRepository;
+use ilCertificateQueueRepository;
+use ilCronConstants;
+use ilSetting;
+use ilObjectDataCache;
+use ilCertificateTemplate;
+use ilCertificateConsumerNotSupported;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class UserCertificateAPI
 {
-    private readonly UserDataRepository $userCertificateRepository;
+    private readonly UserDataRepository $user_data_repository;
+    private readonly ilCertificateTemplateRepository $template_repository;
+    private readonly ilCertificateTypeClassMap $type_class_map;
+    private readonly ilCertificateQueueRepository $queue_repository;
+    private readonly ilLogger $logger;
+    private readonly ilObjectDataCache $object_data_cache;
 
-    public function __construct(?UserDataRepository $userCertificateRepository = null)
-    {
-        if (null === $userCertificateRepository) {
-            global $DIC;
+    public function __construct(
+        ?UserDataRepository $user_data_repository = null,
+        ?ilCertificateTemplateRepository $template_repository = null,
+        ?ilCertificateQueueRepository $queue_repository = null,
+        ?ilCertificateTypeClassMap $type_class_map = null,
+        ?ilLogger $logger = null,
+        ?ilObjectDataCache $object_data_cache = null,
+    ) {
+        global $DIC;
 
-            $userCertificateRepository = new UserDataRepository(
-                $DIC->database(),
-                $DIC->ctrl()
-            );
-        }
-        $this->userCertificateRepository = $userCertificateRepository;
+        $this->logger = $logger ?? $DIC->logger()->cert();
+        $this->object_data_cache = $object_data_cache ?? $DIC['ilObjDataCache'];
+        $this->user_data_repository = $user_data_repository ?? new UserDataRepository(
+            $DIC->database(),
+            $DIC->ctrl()
+        );
+        $this->template_repository = $template_repository ?? new ilCertificateTemplateDatabaseRepository(
+            $DIC->database(),
+            $this->logger
+        );
+        $this->type_class_map = $type_class_map ?? new ilCertificateTypeClassMap();
+        $this->queue_repository = $queue_repository ?? new ilCertificateQueueRepository(
+            $DIC->database(),
+            $this->logger
+        );
     }
 
     /**
@@ -52,11 +80,93 @@ class UserCertificateAPI
      */
     public function getUserCertificateData(UserDataFilter $filter, array $ilCtrlStack = []): array
     {
-        return $this->userCertificateRepository->getUserData($filter, $ilCtrlStack);
+        return $this->user_data_repository->getUserData($filter, $ilCtrlStack);
     }
 
     public function getUserCertificateDataMaxCount(UserDataFilter $filter): int
     {
-        return $this->userCertificateRepository->getUserCertificateDataMaxCount($filter);
+        return $this->user_data_repository->getUserCertificateDataMaxCount($filter);
+    }
+
+    public function certificateCriteriaMetForGivenTemplate(int $usr_id, ilCertificateTemplate $template): void
+    {
+        if (!$template->isCurrentlyActive()) {
+            $this->logger->debug(sprintf(
+                'Did not trigger certificate achievement for inactive template: usr_id: %s/obj_id: %s/type: %s/template_id: %s',
+                $usr_id,
+                $template->getObjId(),
+                $template->getObjType(),
+                $template->getId()
+            ));
+            return;
+        }
+
+        $this->processEntry(
+            $usr_id,
+            $template
+        );
+    }
+
+    public function certificateCriteriaMet(int $usr_id, int $obj_id): void
+    {
+        $type = $this->object_data_cache->lookupType($obj_id);
+        if (!$this->type_class_map->typeExistsInMap($type)) {
+            throw new ilCertificateConsumerNotSupported(sprintf(
+                "Oject type '%s' is not supported by the certificate component!",
+                $type
+            ));
+        }
+
+        $template = $this->template_repository->fetchCurrentlyActiveCertificate($obj_id);
+        if (!$template->isCurrentlyActive()) {
+            $this->logger->debug(sprintf(
+                'Did not trigger certificate achievement for inactive template: usr_id: %s/obj_id: %s/type: %s/template_id: %s',
+                $usr_id,
+                $template->getObjId(),
+                $template->getObjType(),
+                $template->getId()
+            ));
+            return;
+        }
+
+        $this->processEntry(
+            $usr_id,
+            $template
+        );
+    }
+
+    private function processEntry(
+        int $userId,
+        ilCertificateTemplate $template
+    ): void {
+        $this->logger->debug(sprintf(
+            'Trigger persisting certificate achievement for: usr_id: %s/obj_id: %s/type: %s/template_id: %s',
+            $userId,
+            $template->getObjId(),
+            $template->getObjType(),
+            $template->getId()
+        ));
+
+        $entry = new ilCertificateQueueEntry(
+            $template->getObjId(),
+            $userId,
+            $this->type_class_map->getPlaceHolderClassNameByType($template->getObjType()),
+            ilCronConstants::IN_PROGRESS,
+            $template->getId(),
+            time()
+        );
+
+        $mode = (new ilSetting('certificate'))->get(
+            'persistent_certificate_mode',
+            'persistent_certificate_mode_cron'
+        );
+        if ($mode === 'persistent_certificate_mode_instant') {
+            $cronjob = new ilCertificateCron();
+            $cronjob->init();
+            $cronjob->processEntry(0, $entry, []);
+            return;
+        }
+
+        $this->queue_repository->addToQueue($entry);
     }
 }

--- a/Services/Certificate/classes/Cron/class.ilCertificateConsumerNotSupported.php
+++ b/Services/Certificate/classes/Cron/class.ilCertificateConsumerNotSupported.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilCertificateConsumerNotSupported extends ilException
+{
+}

--- a/Services/Certificate/classes/Placeholder/Values/class.ilStudyProgrammePlaceholderValues.php
+++ b/Services/Certificate/classes/Placeholder/Values/class.ilStudyProgrammePlaceholderValues.php
@@ -119,7 +119,7 @@ class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValue
     {
         $successful = array_filter(
             $assignments,
-            fn ($ass) => $ass->getProgressTree()->isSuccessful()
+            fn($ass) => $ass->getProgressTree()->isSuccessful()
         );
         if (count($successful) === 0) {
             return null;
@@ -128,13 +128,13 @@ class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValue
         //is there an unlimited validity? if so, take latest.
         $unlimited = array_filter(
             $successful,
-            fn ($ass) => is_null($ass->getProgressTree()->getValidityOfQualification())
+            fn($ass) => is_null($ass->getProgressTree()->getValidityOfQualification())
         );
         if (count($unlimited) > 0) {
             $successful = $unlimited;
             usort($successful, static function (ilPRGAssignment $a, ilPRGAssignment $b): int {
-                $a_dat =$a->getProgressTree()->getCompletionDate();
-                $b_dat =$b->getProgressTree()->getCompletionDate();
+                $a_dat = $a->getProgressTree()->getCompletionDate();
+                $b_dat = $b->getProgressTree()->getCompletionDate();
                 if ($a_dat > $b_dat) {
                     return -1;
                 } elseif ($a_dat < $b_dat) {
@@ -147,12 +147,12 @@ class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValue
             //there are (only) limited validities: take the one that lasts the longest.
             $limited = array_filter(
                 $successful,
-                fn ($ass) => !is_null($ass->getProgressTree()->getValidityOfQualification())
+                fn($ass) => !is_null($ass->getProgressTree()->getValidityOfQualification())
             );
             $successful = $limited;
             usort($successful, static function (ilPRGAssignment $a, ilPRGAssignment $b): int {
-                $a_dat =$a->getProgressTree()->getValidityOfQualification();
-                $b_dat =$b->getProgressTree()->getValidityOfQualification();
+                $a_dat = $a->getProgressTree()->getValidityOfQualification();
+                $b_dat = $b->getProgressTree()->getValidityOfQualification();
                 if ($a_dat > $b_dat) {
                     return -1;
                 } elseif ($a_dat < $b_dat) {

--- a/Services/Certificate/classes/Service/CertificateService.php
+++ b/Services/Certificate/classes/Service/CertificateService.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Certificate\Service;
+
+use ILIAS\DI\Container;
+use ILIAS\Certificate\API\UserCertificateAPI;
+
+class CertificateService
+{
+    public const USER_API = 'certificate.user.api';
+
+    public function __construct(private Container $dic)
+    {
+        if (!isset($this->dic[self::USER_API])) {
+            $this->dic[self::USER_API] = static function (Container $c): UserCertificateAPI {
+                return new UserCertificateAPI();
+            };
+        }
+    }
+
+    public function userCertificates(): UserCertificateAPI
+    {
+        return $this->dic[self::USER_API];
+    }
+}

--- a/Services/Certificate/classes/Template/class.ilCertificateTemplateDatabaseRepository.php
+++ b/Services/Certificate/classes/Template/class.ilCertificateTemplateDatabaseRepository.php
@@ -88,9 +88,6 @@ class ilCertificateTemplateDatabaseRepository implements ilCertificateTemplateRe
         return $this->database->manipulate($sql);
     }
 
-    /**
-     * @throws ilException
-     */
     public function fetchTemplate(int $templateId): ilCertificateTemplate
     {
         $this->logger->debug(sprintf('START - Fetch certificate template with id: "%s"', $templateId));
@@ -107,7 +104,7 @@ ORDER BY version ASC';
             return $this->createCertificateTemplate($row);
         }
 
-        throw new ilException(sprintf('No template with id "%s" found', $templateId));
+        throw new ilCouldNotFindCertificateTemplate(sprintf('No template with id "%s" found', $templateId));
     }
 
     /**
@@ -180,7 +177,7 @@ ORDER BY id DESC
     }
 
     /**
-     * @throws ilException
+     * @throws ilCouldNotFindCertificateTemplate
      */
     public function fetchCurrentlyActiveCertificate(int $objId): ilCertificateTemplate
     {
@@ -201,7 +198,7 @@ AND currently_active = 1
             return $this->createCertificateTemplate($row);
         }
 
-        throw new ilException((sprintf('NO active certificate template found for: "%s"', $objId)));
+        throw new ilCouldNotFindCertificateTemplate((sprintf('NO active certificate template found for: "%s"', $objId)));
     }
 
     public function fetchPreviousCertificate(int $objId): ilCertificateTemplate
@@ -345,7 +342,7 @@ WHERE id = ' . $this->database->quote($previousCertificate->getId(), 'integer');
     }
 
     /**
-     * @throws ilException
+     * @throws ilCouldNotFindCertificateTemplate
      */
     public function fetchFirstCreatedTemplate(int $objId): ilCertificateTemplate
     {
@@ -365,7 +362,7 @@ ORDER BY id ASC ';
             return $this->createCertificateTemplate($row);
         }
 
-        throw new ilException('No matching template found. MAY missing DBUpdate. Please check if the correct version is installed.');
+        throw new ilCouldNotFindCertificateTemplate('No matching template found. MAY missing DBUpdate. Please check if the correct version is installed.');
     }
 
     private function deactivatePreviousTemplates(int $objId): void

--- a/Services/Certificate/classes/Template/class.ilCouldNotFindCertificateTemplate.php
+++ b/Services/Certificate/classes/Template/class.ilCouldNotFindCertificateTemplate.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilCouldNotFindCertificateTemplate extends ilException
+{
+}

--- a/Services/Certificate/classes/Template/interface.ilCertificateTemplateRepository.php
+++ b/Services/Certificate/classes/Template/interface.ilCertificateTemplateRepository.php
@@ -25,7 +25,7 @@ interface ilCertificateTemplateRepository
     public function updateActivity(ilCertificateTemplate $certificateTemplate, bool $currentlyActive): int;
 
     /**
-     * @throws ilException
+     * @throws ilCouldNotFindCertificateTemplate
      */
     public function fetchTemplate(int $templateId): ilCertificateTemplate;
 
@@ -37,7 +37,7 @@ interface ilCertificateTemplateRepository
     public function fetchCurrentlyUsedCertificate(int $objId): ilCertificateTemplate;
 
     /**
-     * @throws ilException
+     * @throws ilCouldNotFindCertificateTemplate
      */
     public function fetchCurrentlyActiveCertificate(int $objId): ilCertificateTemplate;
 
@@ -56,7 +56,7 @@ interface ilCertificateTemplateRepository
     ): array;
 
     /**
-     * @throws ilException
+     * @throws ilCouldNotFindCertificateTemplate
      */
     public function fetchFirstCreatedTemplate(int $objId): ilCertificateTemplate;
 }

--- a/Services/Certificate/classes/class.ilCertificateAppEventListener.php
+++ b/Services/Certificate/classes/class.ilCertificateAppEventListener.php
@@ -144,7 +144,7 @@ class ilCertificateAppEventListener implements ilAppEventListener
                     $usr_id,
                     $object_id
                 );
-            } catch (ilCouldNotFindCertificateTemplate|ilCertificateConsumerNotSupported) {
+            } catch (ilCouldNotFindCertificateTemplate | ilCertificateConsumerNotSupported) {
                 $this->logger->debug(sprintf(
                     'Did not find an active certificate template for case: usr_id: %s/obj_id: %s/type: %s',
                     $usr_id,

--- a/Services/Certificate/classes/class.ilCertificateAppEventListener.php
+++ b/Services/Certificate/classes/class.ilCertificateAppEventListener.php
@@ -19,30 +19,26 @@
 declare(strict_types=1);
 
 use ILIAS\Filesystem\Exception\IOException;
+use ILIAS\Certificate\API\UserCertificateAPI;
 
-/**
- * Class ilCertificateAppEventListener
- * @author  Niels Theen <ntheen@databay.de>
- * @version $Id:$
- * @package Services/Certificate
- */
 class ilCertificateAppEventListener implements ilAppEventListener
 {
     protected string $component = '';
     protected string $event = '';
+    /** @var array<string, mixed> */
     protected array $parameters = [];
+
     private readonly ilCertificateQueueRepository $certificateQueueRepository;
-    private readonly ilCertificateTypeClassMap $certificateClassMap;
     private readonly ilCertificateTemplateRepository $templateRepository;
     private readonly ilUserCertificateRepository $userCertificateRepository;
 
     public function __construct(
+        private UserCertificateAPI $user_certificate_api,
         protected ilDBInterface $db,
         private readonly ilObjectDataCache $objectDataCache,
         private readonly ilLogger $logger
     ) {
         $this->certificateQueueRepository = new ilCertificateQueueRepository($this->db, $this->logger);
-        $this->certificateClassMap = new ilCertificateTypeClassMap();
         $this->templateRepository = new ilCertificateTemplateDatabaseRepository($this->db, $this->logger);
         $this->userCertificateRepository = new ilUserCertificateRepository($this->db, $this->logger);
     }
@@ -65,6 +61,9 @@ class ilCertificateAppEventListener implements ilAppEventListener
         return $clone;
     }
 
+    /**
+     * @param array<string, mixed> $parameters
+     */
     public function withParameters(array $parameters): self
     {
         $clone = clone $this;
@@ -77,24 +76,16 @@ class ilCertificateAppEventListener implements ilAppEventListener
     protected function isLearningAchievementEvent(): bool
     {
         return (
-            'Services/Tracking' === $this->component &&
-            'updateStatus' === $this->event
+            $this->component === 'Services/Tracking' &&
+            $this->event === 'updateStatus'
         );
     }
 
     protected function isUserDeletedEvent(): bool
     {
         return (
-            'Services/User' === $this->component &&
-            'deleteUser' === $this->event
-        );
-    }
-
-    protected function isCompletedStudyProgramme(): bool
-    {
-        return (
-            'Modules/StudyProgramme' === $this->component &&
-            'userSuccessful' === $this->event
+            $this->component === 'Services/User' &&
+            $this->event === 'deleteUser'
         );
     }
 
@@ -108,22 +99,18 @@ class ilCertificateAppEventListener implements ilAppEventListener
                 $this->handleLPUpdate();
             } elseif ($this->isUserDeletedEvent()) {
                 $this->handleDeletedUser();
-            } elseif ($this->isCompletedStudyProgramme()) {
-                $this->handleCompletedStudyProgramme();
             }
         } catch (ilException $e) {
             $this->logger->error($e->getMessage());
         }
     }
 
-    /**
-     * @throws IOException
-     */
     public static function handleEvent(string $a_component, string $a_event, array $a_parameter): void
     {
         global $DIC;
 
         $listener = new self(
+            $DIC->certificate()->userCertificates(),
             $DIC->database(),
             $DIC['ilObjDataCache'],
             $DIC->logger()->cert()
@@ -140,55 +127,32 @@ class ilCertificateAppEventListener implements ilAppEventListener
     {
         $status = (int) ($this->parameters['status'] ?? ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM);
 
-        $settings = new ilSetting('certificate');
-
         if ($status === ilLPStatus::LP_STATUS_COMPLETED_NUM) {
-            $objectId = (int) ($this->parameters['obj_id'] ?? 0);
-            $userId = (int) ($this->parameters['usr_id'] ?? 0);
-
-            $type = $this->objectDataCache->lookupType($objectId);
+            $object_id = (int) ($this->parameters['obj_id'] ?? 0);
+            $usr_id = (int) ($this->parameters['usr_id'] ?? 0);
+            $type = $this->objectDataCache->lookupType($object_id);
 
             $this->logger->debug(sprintf(
                 "Certificate evaluation triggered, received 'completed' learning progress for: usr_id: %s/obj_id: %s/type: %s",
-                $userId,
-                $objectId,
+                $usr_id,
+                $object_id,
                 $type
             ));
 
-            if ($this->certificateClassMap->typeExistsInMap($type)) {
-                try {
-                    $template = $this->templateRepository->fetchCurrentlyActiveCertificate($objectId);
-
-                    if ($template->isCurrentlyActive()) {
-                        $this->logger->debug(sprintf(
-                            "Trigger persisting certificate achievement for: usr_id: %s/obj_id: %s/type: %s/template_id: %s",
-                            $userId,
-                            $objectId,
-                            $type,
-                            $template->getId()
-                        ));
-                        $this->processEntry($type, $objectId, $userId, $template, $settings);
-                    } else {
-                        $this->logger->debug(sprintf(
-                            "Did not trigger certificate achievement for inactive template: usr_id: %s/obj_id: %s/type: %s/template_id: %s",
-                            $userId,
-                            $objectId,
-                            $type,
-                            $template->getId()
-                        ));
-                    }
-                } catch (ilException) {
-                    $this->logger->debug(sprintf(
-                        "Did not find an active certificate template for case: usr_id: %s/obj_id: %s/type: %s",
-                        $userId,
-                        $objectId,
-                        $type
-                    ));
-                }
-            } else {
-                $this->logger->debug(
-                    "Object type ($type) is not of interest, skipping certificate evaluation for this object"
+            try {
+                $this->user_certificate_api->certificateCriteriaMet(
+                    $usr_id,
+                    $object_id
                 );
+            } catch (ilCouldNotFindCertificateTemplate|ilCertificateConsumerNotSupported) {
+                $this->logger->debug(sprintf(
+                    'Did not find an active certificate template for case: usr_id: %s/obj_id: %s/type: %s',
+                    $usr_id,
+                    $object_id,
+                    $type
+                ));
+            } catch (ilException $e) {
+                $this->logger->warning($e->getMessage());
             }
 
             if ($type === 'crs') {
@@ -208,13 +172,13 @@ class ilCertificateAppEventListener implements ilAppEventListener
                     $this->templateRepository
                 )
             );
-            foreach (ilObject::_getAllReferences($objectId) as $refId) {
-                $templatesOfCompletedCourses = $progressEvaluation->evaluate($refId, $userId);
+            foreach (ilObject::_getAllReferences($object_id) as $refId) {
+                $templatesOfCompletedCourses = $progressEvaluation->evaluate($refId, $usr_id);
                 if ([] === $templatesOfCompletedCourses) {
                     $this->logger->debug(sprintf(
-                        "No dependent course certificate template configuration found for child object: usr_id: %s/obj_id: %s/ref_id: %s/type: %s",
-                        $userId,
-                        $objectId,
+                        'No dependent course certificate template configuration found for child object: usr_id: %s/obj_id: %s/ref_id: %s/type: %s',
+                        $usr_id,
+                        $object_id,
                         $refId,
                         $type
                     ));
@@ -224,30 +188,12 @@ class ilCertificateAppEventListener implements ilAppEventListener
                 foreach ($templatesOfCompletedCourses as $courseTemplate) {
                     // We do not check if we support the type anymore, because the type 'crs' is always supported
                     try {
-                        $courseObjectId = $courseTemplate->getObjId();
-
-                        if ($courseTemplate->isCurrentlyActive()) {
-                            $type = $this->objectDataCache->lookupType($courseObjectId);
-
-                            $this->logger->debug(sprintf(
-                                "Trigger persisting certificate achievement for: usr_id: %s/obj_id: %s/type: %s/template_id: %s",
-                                $userId,
-                                $courseObjectId,
-                                'crs',
-                                $courseTemplate->getId()
-                            ));
-                            $this->processEntry($type, $courseObjectId, $userId, $courseTemplate, $settings);
-                        } else {
-                            $this->logger->debug(sprintf(
-                                "Did not trigger certificate achievement for inactive template: usr_id: %s/obj_id: %s/type: %s/template_id: %s",
-                                $userId,
-                                $objectId,
-                                $type,
-                                $courseTemplate->getId()
-                            ));
-                        }
-                    } catch (ilException $exception) {
-                        $this->logger->warning($exception->getMessage());
+                        $this->user_certificate_api->certificateCriteriaMetForGivenTemplate(
+                            $usr_id,
+                            $courseTemplate
+                        );
+                    } catch (ilException $e) {
+                        $this->logger->warning($e->getMessage());
                         continue;
                     }
                 }
@@ -259,9 +205,6 @@ class ilCertificateAppEventListener implements ilAppEventListener
         }
     }
 
-    /**
-     * @throws IOException
-     */
     private function handleDeletedUser(): void
     {
         $portfolioFileService = new ilPortfolioCertificateFileService();
@@ -285,64 +228,5 @@ class ilCertificateAppEventListener implements ilAppEventListener
             'All relevant data sources for the user certificates for user (usr_id: "%s" deleted)',
             $userId
         ));
-    }
-
-    private function processEntry(
-        string $type,
-        int $objectId,
-        int $userId,
-        ilCertificateTemplate $template,
-        ilSetting $settings
-    ): void {
-        $className = $this->certificateClassMap->getPlaceHolderClassNameByType($type);
-
-        $entry = new ilCertificateQueueEntry(
-            $objectId,
-            $userId,
-            $className,
-            ilCronConstants::IN_PROGRESS,
-            $template->getId(),
-            time()
-        );
-
-        $mode = $settings->get('persistent_certificate_mode', 'persistent_certificate_mode_cron');
-        if ($mode === 'persistent_certificate_mode_instant') {
-            $cronjob = new ilCertificateCron();
-            $cronjob->init();
-            $cronjob->processEntry(0, $entry, []);
-            return;
-        }
-
-        $this->certificateQueueRepository->addToQueue($entry);
-    }
-
-    private function handleCompletedStudyProgramme(): void
-    {
-        $settings = new ilSetting('certificate');
-        $objectId = $this->parameters['prg_id'] ?? 0;
-        $userId = $this->parameters['usr_id'] ?? 0;
-        try {
-            $template = $this->templateRepository->fetchCurrentlyActiveCertificate($objectId);
-            if ($template->isCurrentlyActive()) {
-                $entry = new ilCertificateQueueEntry(
-                    $objectId,
-                    $userId,
-                    ilStudyProgrammePlaceholderValues::class,
-                    ilCronConstants::IN_PROGRESS,
-                    $template->getId(),
-                    time()
-                );
-                $mode = $settings->get('persistent_certificate_mode', '');
-                if ($mode === 'persistent_certificate_mode_instant') {
-                    $cronjob = new ilCertificateCron();
-                    $cronjob->init();
-                    $cronjob->processEntry(0, $entry, []);
-                    return;
-                }
-                $this->certificateQueueRepository->addToQueue($entry);
-            }
-        } catch (ilException $exception) {
-            $this->logger->warning($exception->getMessage());
-        }
     }
 }

--- a/Services/Certificate/service.xml
+++ b/Services/Certificate/service.xml
@@ -12,7 +12,6 @@
 		<event type="listen" id="Services/Tracking" />
 		<event type="listen" id="Services/Certificate" />
 		<event type="listen" id="Services/User" />
-		<event type="listen" id="Modules/StudyProgramme" />
 		<event type="raise" id="certificateIssued" />
 	</events>
 	<crons>

--- a/Services/Certificate/test/UserCertificateAPITest.php
+++ b/Services/Certificate/test/UserCertificateAPITest.php
@@ -30,6 +30,8 @@ class UserCertificateAPITest extends ilCertificateBaseTestCase
         $repository = $this->getMockBuilder(UserDataRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $logger = new \ILIAS\Services\Logging\NullLogger();
+        $database = $this->createMock(ilDBInterface::class);
 
         $userData = new \ILIAS\Certificate\API\Data\UserCertificateDto(
             5,
@@ -48,7 +50,17 @@ class UserCertificateAPITest extends ilCertificateBaseTestCase
         $repository->method('getUserData')
                    ->willReturn([5 => $userData]);
 
-        $api = new \ILIAS\Certificate\API\UserCertificateAPI($repository);
+        $api = new \ILIAS\Certificate\API\UserCertificateAPI(
+            $repository,
+            $this->createMock(ilCertificateTemplateRepository::class),
+            new ilCertificateQueueRepository(
+                $database,
+                $logger
+            ),
+            new ilCertificateTypeClassMap(),
+            $logger,
+            $this->getMockBuilder(ilObjectDataCache::class)->disableOriginalConstructor()->getMock()
+        );
 
         $result = $api->getUserCertificateData(new \ILIAS\Certificate\API\Filter\UserDataFilter(), []);
 

--- a/Services/EventHandling/interfaces/interface.ilAppEventListener.php
+++ b/Services/EventHandling/interfaces/interface.ilAppEventListener.php
@@ -30,7 +30,7 @@ interface ilAppEventListener
     * Handle an event in a listener.
     * @param	string $a_component component, e.g. "Modules/Forum" or "Services/User"
     * @param	string $a_event     event e.g. "createUser", "updateUser", "deleteUser", ...
-    * @param	array  $a_parameter parameter array (assoc), array("name" => ..., "phone_office" => ...)
+    * @param	array<string, mixed> $a_parameter parameter array (assoc), array("name" => ..., "phone_office" => ...)
     */
     public static function handleEvent(string $a_component, string $a_event, array $a_parameter): void;
 }

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -452,6 +452,11 @@ class Container extends \Pimple\Container
         return new \ILIAS\Mail\Service\MailService($this);
     }
 
+    public function certificate(): \ILIAS\Certificate\Service\CertificateService
+    {
+        return new \ILIAS\Certificate\Service\CertificateService($this);
+    }
+
     /**
      * Note: Only use isDependencyAvailable if strictly required. The need for this,
      * mostly points to some underlying problem needing to be solved instead of using this.


### PR DESCRIPTION
Hi @klees ,

with this PR I relocated the code for the issuing of the `StudyProgramme` certificates. IMO this should NOT be located in the `ilCertificateAppEventListener` (I know, there are other wrong "arrows" in the certificate component as well, and if we revised all these, we could also re-think the issuing mechanism).

There are other components (like the `Course` in https://mantis.ilias.de/view.php?id=26314) which want to issue user certificates regardless of the generic learning progress (handled by the certificate component) as well, so they could adopt the approach of the `StudyProgramme`.

I had to introduce the `$DIC` to your event listener (https://github.com/ILIAS-eLearning/ILIAS/pull/6063/files#diff-c88441e27125ff17c627060d51be537885398424df54257a296a9390faec9b7d), but this is already a static method and other cases consume many static methods and local `DIC`s as well.

Best regards,
@mjansenDatabay 