### PR TITLE
Docu: Fixed link in use-language-object.md

### DIFF
--- a/Services/Language/use-language-object.md
+++ b/Services/Language/use-language-object.md
@@ -1,6 +1,6 @@
 # Language Handling in ILIAS
 
-ILIAS offers multi-language support. Guidelines and additional information about the syntax and how to create language entries and the language handling in ILIAS are described in the file [language.md](docs/development/language.md)
+ILIAS offers multi-language support. Guidelines and additional information about the syntax and how to create language entries and the language handling in ILIAS are described in the file [language.md](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/docs/development/language.md)
 
 ## $lng Language Object
 


### PR DESCRIPTION
Hi @matthiaskunkel, I fixed the link to 'language.md'. Please merge if it looks good for you. Thanks!