### PR TITLE
T&A 0016123 Fix Multiple issues related to linking answers and feedback

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php
+++ b/Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php
@@ -1,8 +1,8 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once "./Modules/TestQuestionPool/classes/class.assAnswerMultipleResponse.php";
-include_once "./Modules/Test/classes/inc.AssessmentConstants.php";
+include_once './Modules/TestQuestionPool/classes/class.assAnswerMultipleResponse.php';
+include_once './Modules/Test/classes/inc.AssessmentConstants.php';
 
 /**
 * ASS_AnswerBinaryStateImage is a class for answers with a binary state
@@ -37,16 +37,17 @@ class ASS_AnswerMultipleResponseImage extends ASS_AnswerMultipleResponse
     * @param integer $order A nonnegative value representing a possible display or sort order
     * @param double $points_unchecked The points when the answer is not checked
     * @param string $a_image The image filename
+    * @param integer $id The database id of the answer
     * @access public
     */
     public function __construct(
-        $answertext = "",
+        $answertext = '',
         $points_checked = 0.0,
         $order = 0,
         $points_unchecked = 0,
-        $a_image = "",
+        $a_image = '',
         $id = -1
-  ) {
+    ) {
         parent::__construct($answertext, $points_checked, $order, $points_unchecked, $id);
         $this->image = $a_image;
     }

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -756,6 +756,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             foreach ($this->answers as $answer){
                 // Only the first appearance of an id is used
                 if ($answer->getId() !== null && !in_array($answer->getId(), array_keys($post_answer_order_for_id))) {
+                    // -1 is happening while import and also if a new multi line answer is generated
                     if ($answer->getId() == -1) {
                         continue;
                     }

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -749,7 +749,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         // Check if feedback exists
         if (sizeof($feedback) >= 1
             && $this->getAdditionalContentEditingMode() == 'default'
-            && !$ctrl->getCmd() == 'importVerifiedFile'){
+            && !($ctrl->getCmd() == 'importVerifiedFile')){
             // Get all existing answer data for question
             $result = $ilDB->queryF(
                 "SELECT answer_id, aorder  FROM qpl_a_mc WHERE question_fi = %s",

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -741,6 +741,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             [$this->getId()]
         );
         $db_feedback = $ilDB->fetchAll($result);
+
         // Check if feedback exists and the regular editor is used and not the page editor
         if (sizeof($db_feedback) >= 1 && $this->getAdditionalContentEditingMode() == 'default'){
             // Get all existing answer data for question
@@ -784,6 +785,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
 
                 // Delete all feedback in the database
                 $this->feedbackOBJ->deleteSpecificAnswerFeedbacks($this->getId(), false);
+                // Recreate feedback
                 foreach ($db_feedback as $feedback_option) {
                     // skip feedback which answer is deleted
                     if (in_array(intval($feedback_option['answer']), $unused_answer_ids)) {
@@ -793,6 +795,12 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
                     // Reorder feedback
                     $feedback_order_db = intval($feedback_option['answer']);
                     $db_answer_id = $db_answer_id_for_order[$feedback_order_db];
+                    // This cuts feedback that currently would have no corresponding answer
+                    // This case can happen while copying "broken" questions
+                    // Or when saving a question with less answers than feedback
+                    if (is_null($db_answer_id) || $db_answer_id < 0) {
+                        continue;
+                    }
                     $feedback_order_post = $post_answer_order_for_id[$db_answer_id];
                     $feedback_option['answer'] = $feedback_order_post;
 

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -736,7 +736,6 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         /** @var $ilDB ilDBInterface */
         global $DIC;
         $ilDB = $DIC['ilDB'];
-        $ctrl = $DIC->ctrl();
 
         // Get all feedback entrys
         $result = $ilDB->queryF(
@@ -745,11 +744,8 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             array( $this->getId() )
         );
         $feedback = $ilDB->fetchAll($result);
-
         // Check if feedback exists
-        if (sizeof($feedback) >= 1
-            && $this->getAdditionalContentEditingMode() == 'default'
-            && !($ctrl->getCmd() == 'importVerifiedFile')){
+        if (sizeof($feedback) >= 1 && $this->getAdditionalContentEditingMode() == 'default'){
             // Get all existing answer data for question
             $result = $ilDB->queryF(
                 "SELECT answer_id, aorder  FROM qpl_a_mc WHERE question_fi = %s",
@@ -759,52 +755,54 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             $db_answers = $ilDB->fetchAll($result);
 
             // Collect old and new order entries by ids and order to calculate a diff/intersection and remove/update feedback
-            $db_ids = [];
             $post_ids = [];
-            $db_idsr = [];
             foreach ($this->answers as $answer){
                 // Only the first appearance of an id is used
                 if ($answer->getId() !== null && !in_array($answer->getId(), array_keys($post_ids))) {
+                    if ($answer->getId() == -1) {
+                        continue;
+                    }
                     $post_ids[$answer->getId()] = $answer->getOrder();
                 }
             }
-            foreach ($db_answers as $old_answer){
-                $db_ids[$old_answer["answer_id"]] = intval($old_answer["aorder"]);
-                $db_idsr[intval($old_answer["aorder"])] = $old_answer["answer_id"];
-            }
+            if (sizeof($post_ids) >= 1) {
+                $db_ids = [];
+                $db_idsr = [];
+                foreach ($db_answers as $old_answer){
+                    $db_ids[$old_answer["answer_id"]] = intval($old_answer["aorder"]);
+                    $db_idsr[intval($old_answer["aorder"])] = $old_answer["answer_id"];
+                }
+                // Handle feedback
+                $id_diff = array_diff(array_keys($db_ids), array_keys($post_ids)); // should be deleted
+                // delete corresponding feedback from array
+                foreach (array_keys($id_diff) as $key){
+                    unset($feedback[$key]);
+                }
+                // Reorder feedback in array
+                foreach ($feedback as $feedback_option){
+                    $feedback[array_search($feedback_option, $feedback)]["answer"] = $post_ids[$db_idsr[$feedback_option["answer"]]];
+                }
 
-            // Handle feedback
-            $id_diff = array_diff(array_keys($db_ids), array_keys($post_ids)); // should be deleted
-            // delete corresponding feedback from array
-            foreach (array_keys($id_diff) as $key){
-                unset($feedback[$key]);
-            }
-
-            // Reorder feedback in array
-            foreach ($feedback as $feedback_option){
-                $feedback[array_search($feedback_option, $feedback)]["answer"] = $post_ids[$db_idsr[$feedback_option["answer"]]];
-            }
-
-            // Delete all feedback in database
-            $this->feedbackOBJ->deleteSpecificAnswerFeedbacks($this->getId(), false);
-            // Recreate remaining feedback in database
-            foreach ($feedback as $feedback_option) {
-                $next_id = $ilDB->nextId('qpl_fb_specific');
-                $ilDB->manipulateF(
-                    "INSERT INTO qpl_fb_specific (feedback_id, question_fi, answer, tstamp, feedback, question) 
+                // Delete all feedback in database
+                $this->feedbackOBJ->deleteSpecificAnswerFeedbacks($this->getId(), false);
+                // Recreate remaining feedback in database
+                foreach ($feedback as $feedback_option) {
+                    $next_id = $ilDB->nextId('qpl_fb_specific');
+                    $ilDB->manipulateF(
+                        "INSERT INTO qpl_fb_specific (feedback_id, question_fi, answer, tstamp, feedback, question) 
                             VALUES (%s, %s, %s, %s, %s, %s)",
-                            ['integer', 'integer', 'integer', 'integer', 'text', 'integer'],
-                            [
-                                $next_id,
-                                $feedback_option["question_fi"],
-                                $feedback_option["answer"],
-                                time(),
-                                $feedback_option["feedback"],
-                                $feedback_option["question"]
-                            ]
-                );
+                        ['integer', 'integer', 'integer', 'integer', 'text', 'integer'],
+                        [
+                            $next_id,
+                            $feedback_option["question_fi"],
+                            $feedback_option["answer"],
+                            time(),
+                            $feedback_option["feedback"],
+                            $feedback_option["question"]
+                        ]
+                    );
+                }
             }
-
         }
 
         // Delete all entries in qpl_a_mc for question

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -736,6 +736,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         /** @var $ilDB ilDBInterface */
         global $DIC;
         $ilDB = $DIC['ilDB'];
+        $ctrl = $DIC->ctrl();
 
         // Get all feedback entrys
         $result = $ilDB->queryF(
@@ -746,7 +747,9 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         $feedback = $ilDB->fetchAll($result);
 
         // Check if feedback exists
-        if (sizeof($feedback) >= 1 && $this->getAdditionalContentEditingMode() == 'default'){
+        if (sizeof($feedback) >= 1
+            && $this->getAdditionalContentEditingMode() == 'default'
+            && !$ctrl->getCmd() == 'importVerifiedFile'){
             // Get all existing answer data for question
             $result = $ilDB->queryF(
                 "SELECT answer_id, aorder  FROM qpl_a_mc WHERE question_fi = %s",

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -740,6 +740,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
                     $_POST['choice']['points'][$index],
                     $_POST['choice']['points_unchecked'][$index],
                     $index,
+                    "",
                     $_POST['choice']['answer_id'][$index]
                 );
             }

--- a/Modules/TestQuestionPool/classes/class.assSingleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoice.php
@@ -719,7 +719,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         // Check if feedback exists
         if (sizeof($feedback) >= 1
             && $this->getAdditionalContentEditingMode() == 'default'
-            && !$ctrl->getCmd() == 'importVerifiedFile'){
+            && !($ctrl->getCmd() == 'importVerifiedFile')){
             // Get all existing answer data for question
             $result = $ilDB->queryF(
                 "SELECT answer_id, aorder  FROM qpl_a_sc WHERE question_fi = %s",

--- a/Modules/TestQuestionPool/classes/class.assSingleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoice.php
@@ -703,6 +703,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         /** @var $ilDB ilDBInterface */
         global $DIC;
         $ilDB = $DIC['ilDB'];
+        $ctrl = $DIC->ctrl();
 
         if (!$this->isSingleline) {
             ilUtil::delDir($this->getImagePath());
@@ -716,7 +717,9 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         $feedback = $ilDB->fetchAll($result);
 
         // Check if feedback exists
-        if (sizeof($feedback) >= 1 && $this->getAdditionalContentEditingMode() == 'default'){
+        if (sizeof($feedback) >= 1
+            && $this->getAdditionalContentEditingMode() == 'default'
+            && !$ctrl->getCmd() == 'importVerifiedFile'){
             // Get all existing answer data for question
             $result = $ilDB->queryF(
                 "SELECT answer_id, aorder  FROM qpl_a_sc WHERE question_fi = %s",

--- a/Modules/TestQuestionPool/classes/class.assSingleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoice.php
@@ -707,21 +707,21 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         if (!$this->isSingleline) {
             ilUtil::delDir($this->getImagePath());
         }
-        // Get all feedback entrys
+        // Get all feedback entries
         $result = $ilDB->queryF(
             "SELECT * FROM qpl_fb_specific WHERE question_fi = %s",
-            array( 'integer' ),
-            array( $this->getId() )
+            ['integer'],
+            [$this->getId()]
         );
         $feedback = $ilDB->fetchAll($result);
 
-        // Check if feedback exists
+        // Check if feedback exists and the regular editor is used and not the page editor
         if (sizeof($feedback) >= 1 && $this->getAdditionalContentEditingMode() == 'default'){
             // Get all existing answer data for question
             $result = $ilDB->queryF(
                 "SELECT answer_id, aorder  FROM qpl_a_sc WHERE question_fi = %s",
-                array( 'integer' ),
-                array( $this->getId() )
+                ['integer'],
+                [$this->getId()]
             );
             $db_answers = $ilDB->fetchAll($result);
 
@@ -737,41 +737,45 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
                 }
             }
 
-            if (sizeof($post_ids) >= 1)  {
-                $db_ids = [];
-                $db_idsr = [];
+            // If there is no usable ids from post, it's better to not touch the feedback
+            // This is useful since the import is also using this function or the first creation of a new question in general
+            if (sizeof($post_ids) >= 1) {
+                $db_order_ids = [];
+                $db_order_ids_swapped = [];
                 foreach ($db_answers as $old_answer){
-                    $db_ids[$old_answer["answer_id"]] = intval($old_answer["aorder"]);
-                    $db_idsr[intval($old_answer["aorder"])] = $old_answer["answer_id"];
-                }
-                // Handle feedback
-                $id_diff = array_diff(array_keys($db_ids), array_keys($post_ids)); // should be deleted
-                // delete corresponding feedback from array
-                foreach (array_keys($id_diff) as $key) {
-                    unset($feedback[$key]);
-                }
-                // Reorder feedback in array
-                foreach ($feedback as $feedback_option) {
-                    $feedback[array_search($feedback_option, $feedback)]["answer"] = $post_ids[$db_idsr[$feedback_option["answer"]]];
+                    $db_order_ids[$old_answer['answer_id']] = intval($old_answer['aorder']);
+                    $db_order_ids_swapped[intval($old_answer['aorder'])] = $old_answer['answer_id'];
                 }
 
-                // Delete all feedback in database
+                // Handle feedback the diff between the already existing feedback order and the order received via post
+                // should be deleted or in our case not recreated.
+                $del_answer_order = array_keys(array_diff(array_keys($db_order_ids), array_keys($post_ids)));
+
+                // Delete all feedback in the database
                 $this->feedbackOBJ->deleteSpecificAnswerFeedbacks($this->getId(), false);
-                // Recreate remaining feedback in database
-                foreach ($feedback as $feedback_option){
+                foreach ($feedback as $feedback_option) {
+                    // skip feedback which answer is deleted
+                    if (in_array($feedback_option['answer'], $del_answer_order)) {
+                        continue;
+                    }
+                    // Reorder feedback in array
+                    $feedback_option['answer'] = $post_ids[$db_order_ids_swapped[$feedback_option['answer']]];
+
+                    // Recreate remaining feedback in database
                     $next_id = $ilDB->nextId('qpl_fb_specific');
                     $ilDB->manipulateF(
                         "INSERT INTO qpl_fb_specific (feedback_id, question_fi, answer, tstamp, feedback, question) 
                             VALUES (%s, %s, %s, %s, %s, %s)",
-                        [ 'integer', 'integer', 'integer', 'integer', 'text', 'integer'],
+                        ['integer', 'integer', 'integer', 'integer', 'text', 'integer'],
                         [
                             $next_id,
-                            $feedback_option["question_fi"],
-                            $feedback_option["answer"],
+                            $feedback_option['question_fi'],
+                            $feedback_option['answer'],
                             time(),
-                            $feedback_option["feedback"],
-                            $feedback_option["question"]
-                        ]);
+                            $feedback_option['feedback'],
+                            $feedback_option['question']
+                        ]
+                    );
                 }
             }
         }
@@ -779,8 +783,8 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         // Delete all entries in qpl_a_sc for question
         $ilDB->manipulateF(
             "DELETE FROM qpl_a_sc WHERE question_fi = %s",
-            array( 'integer' ),
-            array( $this->getId() )
+            ['integer'],
+            [$this->getId()]
         );
 
         // Recreate answers one by one
@@ -790,16 +794,16 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
             $next_id = $ilDB->nextId('qpl_a_sc');
             $ilDB->manipulateF(
                 "INSERT INTO qpl_a_sc (answer_id, question_fi, answertext, points, aorder, imagefile, tstamp) VALUES (%s, %s, %s, %s, %s, %s, %s)",
-                array( 'integer', 'integer', 'text', 'float', 'integer', 'text', 'integer' ),
-                array(
-                        $next_id,
-                        $this->getId(),
-                        ilRTE::_replaceMediaObjectImageSrc($answer_obj->getAnswertext(), 0),
-                        $answer_obj->getPoints(),
-                        $answer_obj->getOrder(),
-                        $answer_obj->getImage(),
-                        time()
-                )
+                ['integer', 'integer', 'text', 'float', 'integer', 'text', 'integer'],
+                [
+                    $next_id,
+                    $this->getId(),
+                    ilRTE::_replaceMediaObjectImageSrc($answer_obj->getAnswertext(), 0),
+                    $answer_obj->getPoints(),
+                    $answer_obj->getOrder(),
+                    $answer_obj->getImage(),
+                    time()
+                ]
             );
         }
         $this->rebuildThumbnails();

--- a/Modules/TestQuestionPool/classes/class.assSingleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoice.php
@@ -714,6 +714,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
             [$this->getId()]
         );
         $db_feedback = $ilDB->fetchAll($result);
+
         // Check if feedback exists and the regular editor is used and not the page editor
         if (sizeof($db_feedback) >= 1 && $this->getAdditionalContentEditingMode() == 'default'){
             // Get all existing answer data for question
@@ -757,6 +758,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
 
                 // Delete all feedback in the database
                 $this->feedbackOBJ->deleteSpecificAnswerFeedbacks($this->getId(), false);
+                // Recreate feedback
                 foreach ($db_feedback as $feedback_option) {
                     // skip feedback which answer is deleted
                     if (in_array(intval($feedback_option['answer']), $unused_answer_ids)) {
@@ -766,6 +768,12 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
                     // Reorder feedback
                     $feedback_order_db = intval($feedback_option['answer']);
                     $db_answer_id = $db_answer_id_for_order[$feedback_order_db];
+                    // This cuts feedback that currently would have no corresponding answer
+                    // This case can happen while copying "broken" questions
+                    // Or when saving a question with less answers than feedback
+                    if (is_null($db_answer_id) || $db_answer_id < 0) {
+                        continue;
+                    }
                     $feedback_order_post = $post_answer_order_for_id[$db_answer_id];
                     $feedback_option['answer'] = $feedback_order_post;
 

--- a/Modules/TestQuestionPool/classes/class.assSingleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoice.php
@@ -713,10 +713,9 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
             ['integer'],
             [$this->getId()]
         );
-        $feedback = $ilDB->fetchAll($result);
-
+        $db_feedback = $ilDB->fetchAll($result);
         // Check if feedback exists and the regular editor is used and not the page editor
-        if (sizeof($feedback) >= 1 && $this->getAdditionalContentEditingMode() == 'default'){
+        if (sizeof($db_feedback) >= 1 && $this->getAdditionalContentEditingMode() == 'default'){
             // Get all existing answer data for question
             $result = $ilDB->queryF(
                 "SELECT answer_id, aorder  FROM qpl_a_sc WHERE question_fi = %s",
@@ -726,40 +725,48 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
             $db_answers = $ilDB->fetchAll($result);
 
             // Collect old and new order entries by ids and order to calculate a diff/intersection and remove/update feedback
-            $post_ids = [];
+            $post_answer_order_for_id = [];
             foreach ($this->answers as $answer){
                 // Only the first appearance of an id is used
-                if ($answer->getId() !== null && !in_array($answer->getId(), array_keys($post_ids))) {
+                if ($answer->getId() !== null && !in_array($answer->getId(), array_keys($post_answer_order_for_id))) {
                     if ($answer->getId() == -1) {
                         continue;
                     }
-                    $post_ids[$answer->getId()] = $answer->getOrder();
+                    $post_answer_order_for_id[$answer->getId()] = $answer->getOrder();
                 }
             }
 
             // If there is no usable ids from post, it's better to not touch the feedback
             // This is useful since the import is also using this function or the first creation of a new question in general
-            if (sizeof($post_ids) >= 1) {
-                $db_order_ids = [];
-                $db_order_ids_swapped = [];
-                foreach ($db_answers as $old_answer){
-                    $db_order_ids[$old_answer['answer_id']] = intval($old_answer['aorder']);
-                    $db_order_ids_swapped[intval($old_answer['aorder'])] = $old_answer['answer_id'];
+            if (sizeof($post_answer_order_for_id) >= 1) {
+                $db_answer_order_for_id = [];
+                $db_answer_id_for_order = [];
+                foreach ($db_answers as $db_answer){
+                    $db_answer_order_for_id[intval($db_answer['answer_id'])] = intval($db_answer['aorder']);
+                    $db_answer_id_for_order[intval($db_answer['aorder'])] = intval($db_answer['answer_id']);
                 }
 
-                // Handle feedback the diff between the already existing feedback order and the order received via post
-                // should be deleted or in our case not recreated.
-                $del_answer_order = array_keys(array_diff(array_keys($db_order_ids), array_keys($post_ids)));
+                // Handle feedback
+                // the diff between the already existing answer ids from the Database and the answer ids from post
+                // feedback related to the answer ids should be deleted or in our case not recreated.
+                $db_answer_ids = array_keys($db_answer_order_for_id);
+                $post_answer_ids = array_keys($post_answer_order_for_id);
+                $diff_db_post_answer_ids = array_diff($db_answer_ids, $post_answer_ids);
+                $unused_answer_ids = array_keys($diff_db_post_answer_ids);
 
                 // Delete all feedback in the database
                 $this->feedbackOBJ->deleteSpecificAnswerFeedbacks($this->getId(), false);
-                foreach ($feedback as $feedback_option) {
+                foreach ($db_feedback as $feedback_option) {
                     // skip feedback which answer is deleted
-                    if (in_array($feedback_option['answer'], $del_answer_order)) {
+                    if (in_array(intval($feedback_option['answer']), $unused_answer_ids)) {
                         continue;
                     }
-                    // Reorder feedback in array
-                    $feedback_option['answer'] = $post_ids[$db_order_ids_swapped[$feedback_option['answer']]];
+
+                    // Reorder feedback
+                    $feedback_order_db = intval($feedback_option['answer']);
+                    $db_answer_id = $db_answer_id_for_order[$feedback_order_db];
+                    $feedback_order_post = $post_answer_order_for_id[$db_answer_id];
+                    $feedback_option['answer'] = $feedback_order_post;
 
                     // Recreate remaining feedback in database
                     $next_id = $ilDB->nextId('qpl_fb_specific');

--- a/Modules/TestQuestionPool/classes/class.assSingleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoice.php
@@ -729,6 +729,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
             foreach ($this->answers as $answer){
                 // Only the first appearance of an id is used
                 if ($answer->getId() !== null && !in_array($answer->getId(), array_keys($post_answer_order_for_id))) {
+                    // -1 is happening while import and also if a new multi line answer is generated
                     if ($answer->getId() == -1) {
                         continue;
                     }

--- a/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -653,7 +653,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         } else {
             foreach ($_POST['choice']['answer'] as $index => $answer) {
                 $answertext = $answer;
-                $this->object->addAnswer($answertext, $_POST['choice']['points'][$index], $index, $_POST['choice']['answer_id'][$index]);
+                $this->object->addAnswer($answertext, $_POST['choice']['points'][$index], $index,"", $_POST['choice']['answer_id'][$index]);
             }
         }
     }

--- a/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -23,8 +23,8 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         if (is_array($a_value)) {
             if (is_array($a_value['answer'])) {
                 foreach ($a_value['answer'] as $index => $value) {
-                    include_once "./Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php";
-                    $answer = new ASS_AnswerMultipleResponseImage($value, $a_value['points'][$index], $index, $a_value['points_unchecked'][$index], $a_value['imagename'][$index]);
+                    include_once './Modules/TestQuestionPool/classes/class.assAnswerMultipleResponseImage.php';
+                    $answer = new ASS_AnswerMultipleResponseImage($value, $a_value['points'][$index], $index, $a_value['points_unchecked'][$index], $a_value['imagename'][$index], $a_value['answer_id'][$index]);
                     array_push($this->values, $answer);
                 }
             }

--- a/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -256,6 +256,9 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                     $tpl->setCurrentBlock("prop_points_unchecked_propval");
                     $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getPointsUnchecked()));
                     $tpl->parseCurrentBlock();
+                    $tpl->setCurrentBlock("prop_answer_id_propval");
+                    $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getId()));
+                    $tpl->parseCurrentBlock();
                 }
                 $tpl->setCurrentBlock('multiline');
                 $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getAnswertext()));

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -396,6 +396,9 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                         $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getPoints()));
                         $tpl->parseCurrentBlock();
                     }
+                    $tpl->setCurrentBlock("prop_answer_id_propval");
+                    $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getId()));
+                    $tpl->parseCurrentBlock();
                 }
                 $tpl->setCurrentBlock('multiline');
                 $tpl->setVariable("PROPERTY_VALUE", ilUtil::prepareFormOutput($value->getAnswertext()));

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -48,7 +48,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         if (is_array($a_value)) {
             if (is_array($a_value['answer'])) {
                 foreach ($a_value['answer'] as $index => $value) {
-                    include_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php';
+                    include_once "./Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php";
                     $answer = new ASS_AnswerBinaryStateImage($value, $a_value['points'][$index], $index, 1, $a_value['imagename'][$index], $a_value['answer_id'][$index]);
                     array_push($this->values, $answer);
                 }

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -13,7 +13,7 @@ require_once 'Services/UIComponent/Glyph/classes/class.ilGlyphGUI.php';
 class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
 {
     /** @var string */
-    protected const ALLOWED_PAGE_HTML_TAGS = "<em>, <strong>";
+    protected const ALLOWED_PAGE_HTML_TAGS = '<em>, <strong>';
 
     protected $values = [];
     protected $allowMove = false;
@@ -29,12 +29,12 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     * @param	string	$a_title	Title
     * @param	string	$a_postvar	Post Variable
     */
-    public function __construct($a_title = "", $a_postvar = "")
+    public function __construct($a_title = '', $a_postvar = '')
     {
         parent::__construct($a_title, $a_postvar);
-        $this->setSuffixes(["jpg", "jpeg", "png", "gif"]);
+        $this->setSuffixes(['jpg', 'jpeg', 'png', 'gif']);
         $this->setSize('25');
-        $this->validationRegexp = "";
+        $this->validationRegexp = '';
     }
 
     /**
@@ -48,7 +48,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         if (is_array($a_value)) {
             if (is_array($a_value['answer'])) {
                 foreach ($a_value['answer'] as $index => $value) {
-                    include_once "./Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php";
+                    include_once './Modules/TestQuestionPool/classes/class.assAnswerBinaryStateImage.php';
                     $answer = new ASS_AnswerBinaryStateImage($value, $a_value['points'][$index], $index, 1, $a_value['imagename'][$index], $a_value['answer_id'][$index]);
                     array_push($this->values, $answer);
                 }


### PR DESCRIPTION
Ticket:
https://mantis.ilias.de/view.php?id=16123 Continuation, I'm sorry

Symptom:
Import has no feedback
SQL error
Error on invalid saves

Problem:
Import: The importer has a code path running through the code I have changed and I was unaware this circumstance.
SQL: Mapping error
Invalid saves: on an save with missing points ids have been lost

Solution:
Import: the code reorganizing the feedback is no longer used on imports.
SQL: Fix mapping
Invalid saves: added missing id handover

Checked solution on:
ILIAS 7


As always, let me know where this solution needs further improvement.