### PR TITLE
Docu: Added User Data How-To

### DIFF
--- a/Services/User/handle-user-data.md
+++ b/Services/User/handle-user-data.md
@@ -1,0 +1,32 @@
+# User Data
+## Access Data of the User Currently Logged in
+
+An instance of class `ilObjUser` for the user currently logged in ILIAS is available in the global variable `$ilUser`. You can use the public methods of this class to access the data of the current user (see `Services/User/classes/class.ilObjUser.php`):
+
+```php
+function foo()
+{
+	global $ilUser;
+	[...]
+	$user_id = $ilUser->getId();
+	$user_firstname = $ilUser->getFirstname();
+	$user_lastname = $ilUser->getLastname();
+	[...]
+}
+```
+
+## Standard User Name Presentation
+
+The class `ilUserUtil` provides a static method called `getNamePresentation(...)` that should be used to display user first and last name whenever possible.
+
+- The login is always displayed as [login]
+- First and last name are only displayed if there is a public profile (this can be overridden by parameter `$a_force_first_lastname`)
+- Optionally the user image can be included
+- Optionally a link to the public profile of the user can be included
+
+```php
+// embed user name in GUI
+include_once("./Services/User/classes/class.ilUserUtil.php");
+$this->tpl->setVariable("TXT_USER",
+	ilUserUtil::getNamePresentation($user_id, true, true, $back_link));
+```


### PR DESCRIPTION
As announced at the DevConf and in the [Jour Fixe of 12.06.2023](https://docu.ilias.de/goto_docu_wiki_wpage_7950_1357.html), all DevGuide pages that are how-tos and no training materials are changed to .md-files, stored in GitHub and embedded in the current DevGuide LM using the related page component plugin. This way we can ensure improved accessibility and maintenance. Any update or improvement of the content by the responsible maintainer is highly appreciated.