### PR TITLE
TA: patch for #37559

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -65,7 +65,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                         (int) $index,
                         1,
                         "",
-                        $a_value['answer_id'][$index]
+                        (int) $a_value['answer_id'][$index]
                     );
                     if (isset($a_value['imagename'][$index])) {
                         $answer->setImage($a_value['imagename'][$index]);


### PR DESCRIPTION
Hello everyone!

This does not fix the root cause, though. The id should never be a string in the first place, hence we should tackle the form that causes this at some point. Obvious problem would be, that a missing value in the field would do something with something with id=0, because (int)null === 0, sadly.

Best wishes!