### PR TITLE
TA: patch for #37560

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -467,7 +467,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             }
             $this->answers = $newchoices;
         } else {
-            $answer = new ASS_AnswerMultipleResponseImage($answertext, $points, count($this->answers), $answer_id, 0);
+            $answer = new ASS_AnswerMultipleResponseImage($answertext, $points, count($this->answers), (int) $answer_id, 0);
             $answer->setPointsUnchecked($points_unchecked);
             $answer->setImage($answerimage);
             $this->answers[] = $answer;
@@ -812,7 +812,6 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
                             ]
                 );
             }
-
         }
 
         // Delete all entries in qpl_a_mc for question


### PR DESCRIPTION
Hello everyone!

This does not fix the root cause, though. The id should never be a string in the first place, hence we should tackle the form that causes this at some point. Obvious problem would be, that a missing value in the field would do something with something with id=0, because (int)null === 0, sadly.

Best wishes!