### PR TITLE
trunk style_to_repo: add another check to also include untracked files; made deploy.sh more verbose

### DIFF
--- a/CI/Style-To-Repo/deploy.sh
+++ b/CI/Style-To-Repo/deploy.sh
@@ -63,16 +63,20 @@ function deploy() {
   fi
 
   git -C ${DEPLOY_BASE_FOLDER} update-index --really-refresh >/dev/null 2>&1
-  git -C ${DEPLOY_BASE_FOLDER} diff-index --quiet HEAD
+  git -C ${DEPLOY_BASE_FOLDER} diff-index --exit-code HEAD
+  CHECK1=$?
+  test -z "$(git ls-files --others)"
+  CHECK2=$?
 
-  CHECK=$?
-  if [[ "${CHECK}" == "0" ]]
+  if [[ "${CHECK1}" == "0" && "${CHECK2}" == "0" ]]
   then
     echo "[${NOW}] No changes detected on style files."
   else
     echo "[${NOW}] Detected changes on style files, which will be committed to ${STYLE_REPO}"
-    git -C ${DEPLOY_BASE_FOLDER} add . >/dev/null 2>&1
-    git -C ${DEPLOY_BASE_FOLDER} commit -m "Style changes from '${HASH}'" -m "Original message: '${MSG}'" -m "${URL}" >/dev/null 2>&1
-    git -C ${DEPLOY_BASE_FOLDER} push origin ${BRANCH} >/dev/null 2>&1
+    git  -C ${DEPLOY_BASE_FOLDER} status
+    git -C ${DEPLOY_BASE_FOLDER} add .
+    git  -C ${DEPLOY_BASE_FOLDER} status
+    git -C ${DEPLOY_BASE_FOLDER} commit -m "Style changes from '${HASH}'" -m "Original message: '${MSG}'" -m "${URL}"
+    git -C ${DEPLOY_BASE_FOLDER} push origin ${BRANCH}
   fi
 }


### PR DESCRIPTION
Locally we could not recreate the lack of new files in the style repo. The only thing that struck is that the check currently ignores untracked files. This has been changed and also the deploy.sh output has been made more verbose in hopes that bugs will be found that way.