### PR TITLE
[Mantis #37524] Ignore JavaScript links in URLs in TestPlayer

### DIFF
--- a/Modules/Test/js/ilTestPlayerQuestionEditControl.js
+++ b/Modules/Test/js/ilTestPlayerQuestionEditControl.js
@@ -393,8 +393,13 @@ il.TestPlayerQuestionEditControl = new function() {
 
         // keep default behavior for links that open in another window
         // (fullscreen view of media objects)
-        if (target && target != '_self' && target != '_parent' && target != '_top')
+        if (target && target !== '_self' && target !== '_parent' && target !== '_top')
         {
+           return true;
+        }
+
+        // ignore JavaScript links
+        if (href.indexOf("javascript:") === 0) {
            return true;
         }
 


### PR DESCRIPTION
Before the patch, the test player would submit JavaScript URLs (`javascript:`) to the server as a redirect target. The browser would follow the redirect and get a 404 from the web server.

e.g. User clicks on volume button linking to
`javascript:void(0)`, the test player would add a form field containing `javascript:void(0)`, the server would send a redirect to `/javascript:void(0);` the browser requests that page, the server sends a 404 Not Found error.

https://mantis.ilias.de/view.php?id=37524