### PR TITLE
trunk style_to_repo: fix check to also include untracked files

### DIFF
--- a/CI/Style-To-Repo/deploy.sh
+++ b/CI/Style-To-Repo/deploy.sh
@@ -65,7 +65,7 @@ function deploy() {
   git -C ${DEPLOY_BASE_FOLDER} update-index --really-refresh >/dev/null 2>&1
   git -C ${DEPLOY_BASE_FOLDER} diff-index --exit-code HEAD
   CHECK1=$?
-  test -z "$(git ls-files --others)"
+  test -z "$(git -C ${DEPLOY_BASE_FOLDER} ls-files --others)"
   CHECK2=$?
 
   if [[ "${CHECK1}" == "0" && "${CHECK2}" == "0" ]]
@@ -73,9 +73,11 @@ function deploy() {
     echo "[${NOW}] No changes detected on style files."
   else
     echo "[${NOW}] Detected changes on style files, which will be committed to ${STYLE_REPO}"
-    git  -C ${DEPLOY_BASE_FOLDER} status
+    git -C ${DEPLOY_BASE_FOLDER} status
+    git -C ${DEPLOY_BASE_FOLDER} ls-files --others
     git -C ${DEPLOY_BASE_FOLDER} add .
-    git  -C ${DEPLOY_BASE_FOLDER} status
+    git -C ${DEPLOY_BASE_FOLDER} ls-files --others
+    git -C ${DEPLOY_BASE_FOLDER} status
     git -C ${DEPLOY_BASE_FOLDER} commit -m "Style changes from '${HASH}'" -m "Original message: '${MSG}'" -m "${URL}"
     git -C ${DEPLOY_BASE_FOLDER} push origin ${BRANCH}
   fi


### PR DESCRIPTION
Since the output in the actions looked strange, here is another fix for the deploy.sh.