### PR TITLE
Implemented HelpId as Attributes

### DIFF
--- a/Services/Help/classes/ScreenId/ClassNameToScreenId.php
+++ b/Services/Help/classes/ScreenId/ClassNameToScreenId.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Services\Help\ScreenId;
+
+trait ClassNameToScreenId
+{
+    private static string $REGEX = '/il(Object|Obj|)(.*)GUI/mi';
+
+    protected function classNameToScreenId(string $classname): ?string
+    {
+        $classname = preg_replace(self::$REGEX, "$2", $classname);
+        $classname = $this->snakeToCamel($classname);
+
+        return $classname;
+    }
+
+    protected function snakeToCamel(string $command): string
+    {
+        return strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $command));
+    }
+}

--- a/Services/Help/classes/ScreenId/HelpScreenId.php
+++ b/Services/Help/classes/ScreenId/HelpScreenId.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Services\Help\ScreenId;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ *
+ *         Short screen name for the class which will be added to the help ID.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class HelpScreenId
+{
+    public function __construct(private string $screen_id)
+    {
+        // $screen id can only constist of lowercase letters and underscores. Otherwise, a InvalidArgumentException is thrown.
+        if (!preg_match('/^[a-z0-9_]+$/', $screen_id)) {
+            throw new \InvalidArgumentException('Screen name must only consist of lowercase letters, numbers and underscores.');
+        }
+    }
+
+    public function getScreenId(): string
+    {
+        return $this->screen_id;
+    }
+}

--- a/Services/Help/classes/ScreenId/HelpScreenIdObserver.php
+++ b/Services/Help/classes/ScreenId/HelpScreenIdObserver.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Services\Help\ScreenId;
+
+class HelpScreenIdObserver implements \ilCtrlObserver
+{
+    use ClassNameToScreenId;
+
+    private const SCREEN_SEPARATOR = '/';
+    private const COMMAND_SEPARATOR = '#';
+    private array $map;
+    protected array $clean_name_stack = [];
+    protected ?string $command = null;
+
+    public function __construct()
+    {
+        $this->map = include __DIR__ . '/../../artifacts/screen_id_map.php';
+    }
+
+    public function getId(): string
+    {
+        return self::class;
+    }
+
+    public function update(\ilCtrlEvent $event, ?string $data): void
+    {
+        match ($event) {
+            \ilCtrlEvent::COMMAND_CLASS_FORWARD => $this->addLatestCommandClass($data),
+            \ilCtrlEvent::COMMAND_DETERMINATION => $this->setLatestCommand($data),
+        };
+    }
+
+    public function getScreenId(): string
+    {
+        return implode(
+            self::SCREEN_SEPARATOR,
+            $this->clean_name_stack
+        ) . ($this->command !== null ? self::COMMAND_SEPARATOR . $this->command : '');
+    }
+
+    protected function addLatestCommandClass(?string $class): void
+    {
+        if (null === $class) {
+            return;
+        }
+
+        $clean_class_name = $this->cleanClassName($class);
+        $last_stack_entry = (($stack_size = count($this->clean_name_stack)) > 0) ?
+            $this->clean_name_stack[($stack_size - 1)] :
+            null;
+
+        if ($last_stack_entry !== $clean_class_name) {
+            $this->clean_name_stack[] = $clean_class_name;
+        }
+    }
+
+    protected function setLatestCommand(?string $command): void
+    {
+        if (null !== $command) {
+            $this->command = $this->cleanCommandName($command);
+        }
+    }
+
+    protected function cleanClassName(string $classname): ?string
+    {
+        // check for attributes in artifact
+        if (isset($this->map[$classname])) {
+            return $this->map[$classname];
+        }
+
+        // This is the fallback for classes which do not have a screen id attribute yet.
+        return $this->classNameToScreenId($classname);
+    }
+
+    protected function cleanCommandName(string $command): string
+    {
+        return $this->snakeToCamel($command);
+    }
+}

--- a/Services/Help/classes/ScreenId/RecurringHelpScreenId.php
+++ b/Services/Help/classes/ScreenId/RecurringHelpScreenId.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Services\Help\ScreenId;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ *
+ *         Used for Classes which are used in different locations
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class RecurringHelpScreenId extends HelpScreenId
+{
+}

--- a/Services/Help/classes/ScreenId/SilentHelpScreenId.php
+++ b/Services/Help/classes/ScreenId/SilentHelpScreenId.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Services\Help\ScreenId;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ *
+ *         Silences the class for the help ID generation
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class SilentHelpScreenId
+{
+}

--- a/Services/Help/classes/Setup/class.ilHelpBuildScreenIdMapObjective.php
+++ b/Services/Help/classes/Setup/class.ilHelpBuildScreenIdMapObjective.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
+use ILIAS\GlobalScreen\Scope\MainMenu\Provider\StaticMainMenuProvider;
+use ILIAS\GlobalScreen\Scope\MetaBar\Provider\StaticMetaBarProvider;
+use ILIAS\GlobalScreen\Scope\Notification\Provider\NotificationProvider;
+use ILIAS\GlobalScreen\Scope\Tool\Provider\DynamicToolProvider;
+use ILIAS\Setup;
+use ILIAS\GlobalScreen\Scope\Toast\Provider\ToastProvider;
+use ILIAS\Services\Help\ScreenId\HelpScreenId;
+use ILIAS\Services\Help\ScreenId\RecurringHelpScreenId;
+use ILIAS\Services\Help\ScreenId\SilentHelpScreenId;
+
+class ilHelpBuildScreenIdMapObjective extends Setup\Artifact\BuildArtifactObjective
+{
+    public const ARTIFACT = "./Services/Help/artifacts/screen_id_map.php";
+
+    public function getArtifactPath(): string
+    {
+        return self::ARTIFACT;
+    }
+
+    public function build(): Setup\Artifact
+    {
+        $finder = new Setup\UsageOfAttributeFinder();
+        $map = [];
+        $get_name = function (string $class_name, string $attribute_name): ?string {
+            $reflection = new \ReflectionClass($class_name);
+            $attributes = $reflection->getAttributes($attribute_name);
+            if (empty($attributes) || !isset($attributes[0])) {
+                return null;
+            }
+            /** @var HelpScreenId $attribute */
+            $attribute = $attributes[0]->newInstance();
+            return $attribute->getScreenId();
+        };
+
+        // Silent
+        foreach ($finder->getMatchingClassNames(SilentHelpScreenId::class) as $matching_class_name) {
+            $map[$matching_class_name] = null;
+        }
+        // Recurring
+        foreach ($finder->getMatchingClassNames(RecurringHelpScreenId::class) as $matching_class_name) {
+            $map[$matching_class_name] = '*' . $get_name($matching_class_name, RecurringHelpScreenId::class);
+        }
+        // Normal
+        foreach ($finder->getMatchingClassNames(HelpScreenId::class) as $matching_class_name) {
+            $map[$matching_class_name] = $get_name($matching_class_name, HelpScreenId::class);
+        }
+
+        // Check for duplicates
+        $check = array_filter(array_diff_assoc($map, array_unique($map)), function ($v): bool {
+            return !is_null($v);
+        });
+        if ($check !== []) {
+            throw new Setup\UnachievableException("Duplicate screen ids found: " . implode(', ', $check));
+        }
+
+        return new Setup\Artifact\ArrayArtifact($map);
+    }
+}

--- a/Services/Help/classes/Setup/class.ilHelpSetupAgent.php
+++ b/Services/Help/classes/Setup/class.ilHelpSetupAgent.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
+
+class ilHelpSetupAgent implements Setup\Agent
+{
+    use Setup\Agent\HasNoNamedObjective;
+
+    protected Refinery $refinery;
+
+    public function __construct(Refinery $refinery)
+    {
+        $this->refinery = $refinery;
+    }
+
+    /**
+     * @inheritdocs
+     */
+    public function hasConfig(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritdocs
+     */
+    public function getArrayToConfigTransformation(): Transformation
+    {
+        throw new LogicException(self::class . " has no Config.");
+    }
+
+    /**
+     * @inheritdocs
+     */
+    public function getInstallObjective(Setup\Config $config = null): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    /**
+     * @inheritdocs
+     */
+    public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    /**
+     * @inheritdocs
+     */
+    public function getBuildArtifactObjective(): Setup\Objective
+    {
+        return new ilHelpBuildScreenIdMapObjective();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMigrations(): array
+    {
+        return [];
+    }
+}

--- a/Services/Help/classes/class.ilHelpGUI.php
+++ b/Services/Help/classes/class.ilHelpGUI.php
@@ -18,6 +18,7 @@
 
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\Item;
 use ILIAS\Help\StandardGUIRequest;
+use ILIAS\Services\Help\ScreenId\HelpScreenIdObserver;
 
 /**
  * Help GUI class.
@@ -58,6 +59,11 @@ class ilHelpGUI implements ilCtrlBaseClassInterface
             $DIC->http(),
             $DIC->refinery()
         );
+        $DIC['help.screen_id_collector'] = function () use ($DIC) {
+            return new HelpScreenIdObserver();
+        };
+
+        $DIC->ctrl()->attachObserver($DIC['help.screen_id_collector']);
     }
 
     protected function symbol(): \ILIAS\Repository\Symbol\SymbolAdapterGUI


### PR DESCRIPTION
This PR brings the functionality of persisting Help-IDs as described in https://docu.ilias.de/goto_docu_wiki_wpage_6926_1357.html

As requested by the JF, the rector is now no longer part of the PR, but you can view it [here](https://github.com/srsolutionsag/ILIAS/commit/897c4f7a2838badba812145ddd7d54b001665415). @alex40724 you may want to use it to automatically switch or remove the old method calls from ilHelp (`ReplaceHelpMethodsRector` does that). please get in touch if i can be of any help.