### PR TITLE
Object: Fix Error Propagation

### DIFF
--- a/Modules/Folder/classes/class.ilObjFolderGUI.php
+++ b/Modules/Folder/classes/class.ilObjFolderGUI.php
@@ -135,7 +135,7 @@ class ilObjFolderGUI extends ilContainerGUI
                 $this->tabs_gui->setTabActive('learning_progress');
                 break;
 
-            // container page editing
+                // container page editing
             case "ilcontainerpagegui":
                 $this->prepareOutput(false);
                 $ret = $this->forwardToPageObject();
@@ -229,11 +229,11 @@ class ilObjFolderGUI extends ilContainerGUI
         $this->folder_tree = $a_tree;
     }
 
-    protected function importFileObject(?int $parent_id = null, bool $catch_errors = true): void
+    protected function importFileObject(?int $parent_id = null): void
     {
         $lng = $this->lng;
 
-        parent::importFileObject($parent_id, $catch_errors);
+        parent::importFileObject($parent_id);
 
         $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
         $this->ctrl->returnToParent($this);

--- a/Modules/HTMLLearningModule/classes/class.ilObjFileBasedLMGUI.php
+++ b/Modules/HTMLLearningModule/classes/class.ilObjFileBasedLMGUI.php
@@ -641,7 +641,7 @@ class ilObjFileBasedLMGUI extends ilObjectGUI
         }
     }
 
-    protected function importFileObject(int $parent_id = null, bool $catch_errors = true): void
+    protected function importFileObject(int $parent_id = null): void
     {
         try {
             parent::importFileObject();

--- a/Modules/LearningModule/classes/class.ilObjContentObjectGUI.php
+++ b/Modules/LearningModule/classes/class.ilObjContentObjectGUI.php
@@ -308,7 +308,7 @@ class ilObjContentObjectGUI extends ilObjectGUI
                 $this->ctrl->forwardCommand($perm_gui);
                 break;
 
-            // infoscreen
+                // infoscreen
             case 'ilinfoscreengui':
                 $this->addHeaderAction();
                 $this->addLocations(true);
@@ -925,7 +925,7 @@ class ilObjContentObjectGUI extends ilObjectGUI
         return $form;
     }
 
-    protected function importFileObject(int $parent_id = null, bool $catch_errors = true): void
+    protected function importFileObject(int $parent_id = null): void
     {
         $tpl = $this->tpl;
 
@@ -933,7 +933,7 @@ class ilObjContentObjectGUI extends ilObjectGUI
 
         try {
             // the new import
-            parent::importFileObject(null, false);
+            parent::importFileObject(null);
             return;
         } catch (ilManifestFileNotFoundImportException $e) {
             // we just run through in this case.

--- a/Modules/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPoolGUI.php
+++ b/Modules/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPoolGUI.php
@@ -621,7 +621,7 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
         return $forms;
     }
 
-    protected function importFileObject(int $parent_id = null, bool $catch_errors = true): void
+    protected function importFileObject(int $parent_id = null): void
     {
         $tpl = $this->tpl;
 
@@ -749,7 +749,7 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
             case "cancel":
                 break;
             default:
-            $ilLocator->addItem($this->object->getTitle(), $this->ctrl->getLinkTarget($this, ""), "", $this->edit_request->getRefId());
+                $ilLocator->addItem($this->object->getTitle(), $this->ctrl->getLinkTarget($this, ""), "", $this->edit_request->getRefId());
                 break;
         }
         if ($this->edit_request->getQuestionId() > 0) {

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1056,7 +1056,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
     /**
     * form for new test object import
     */
-    protected function importFileObject(int $parent_id = null, bool $catch_errors = true): void
+    protected function importFileObject(int $parent_id = null): void
     {
         if (!$this->checkPermissionBool("create", "", $_REQUEST["new_type"])) {
             $this->error->raiseError($this->lng->txt("no_create_permission"));

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -783,8 +783,8 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         }
 
         if (is_string(ilSession::get("qpl_import_dir")) && is_string(ilSession::get("qpl_import_subdir")) && is_file(
-                ilSession::get("qpl_import_dir") . '/' . ilSession::get("qpl_import_subdir") . "/manifest.xml"
-            )) {
+            ilSession::get("qpl_import_dir") . '/' . ilSession::get("qpl_import_subdir") . "/manifest.xml"
+        )) {
             ilSession::set("qpl_import_idents", $this->qplrequest->raw("ident"));
 
             $fileName = ilSession::get("qpl_import_subdir") . '.zip';
@@ -1413,7 +1413,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     /**
     * form for new questionpool object import
     */
-    protected function importFileObject(int $parent_id = null, bool $catch_errors = true): void
+    protected function importFileObject(int $parent_id = null): void
     {
         if ($_REQUEST['new_type'] === null) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('import_file_not_valid'), true);

--- a/Services/Object/classes/class.ilObjectGUI.php
+++ b/Services/Object/classes/class.ilObjectGUI.php
@@ -291,10 +291,10 @@ class ilObjectGUI
                 $class_path = $this->ctrl->lookupClassPath($class);
                 $class_name = $this->ctrl->getClassForClasspath($class_path);
 
-//                $parent_gui_obj = new $class_name($this->requested_ref_id, true, false); // TODO: this fails in many cases since the parameters of the constructor are not known
+                //                $parent_gui_obj = new $class_name($this->requested_ref_id, true, false); // TODO: this fails in many cases since the parameters of the constructor are not known
                 // the next line prevents the header action menu being shown
-//                $parent_gui_obj->setCreationMode(true);
-//                $parent_gui_obj->setTitleAndDescription();
+                //                $parent_gui_obj->setCreationMode(true);
+                //                $parent_gui_obj->setTitleAndDescription();
             }
         } else {
             $this->setTitleAndDescription();
@@ -1102,7 +1102,7 @@ class ilObjectGUI
         return $form;
     }
 
-    protected function importFileObject(int $parent_id = null, bool $catch_errors = true): void
+    protected function importFileObject(int $parent_id = null): void
     {
         if (!$parent_id) {
             $parent_id = $this->requested_ref_id;
@@ -1154,13 +1154,8 @@ class ilObjectGUI
                     );
                 }
             } catch (ilException $e) {
-                if (DEVMODE) {
-                    throw $e;
-                }
                 $this->tmp_import_dir = $imp->getTemporaryImportDir();
-                if (!$catch_errors) {
-                    throw $e;
-                }
+
                 // display message and form again
                 $this->tpl->setOnScreenMessage(
                     "failure",


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=36397

I would actually like to remove all the special casing here.

@alex40724 : [This line here](https://github.com/ILIAS-eLearning/ILIAS/compare/release_8...kergomard:8/object/fix_36397?expand=1#diff-703859b4bb21d7febf34b768a316dfad9476f95fa72dc30d60b72b032ce2cce3L936) is the only place where a real change is needed. Outside of `ilObject`.