### PR TITLE
ilStartUpGUI / TOS: Valid logout URL

### DIFF
--- a/Services/TermsOfService/classes/class.ilTermsOfServiceWithdrawalGUIHelper.php
+++ b/Services/TermsOfService/classes/class.ilTermsOfServiceWithdrawalGUIHelper.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\UI\Component\MainControls\Footer;
 use ILIAS\UI\Factory;
@@ -61,7 +61,7 @@ class ilTermsOfServiceWithdrawalGUIHelper
         $template->setVariable(
             'BTN_TOS_WITHDRAWAL',
             $this->uiRenderer->render(
-                $this->uiFactory->button()->standard($this->lng->txt('withdraw_consent'), 'logout.php?withdraw_consent')
+                $this->uiFactory->button()->standard($this->lng->txt('withdraw_consent'), ilStartUpGUI::logoutUrl(['withdraw_consent' => '']))
             )
         );
 

--- a/Services/User/classes/Provider/UserMetaBarProvider.php
+++ b/Services/User/classes/Provider/UserMetaBarProvider.php
@@ -57,14 +57,8 @@ class UserMetaBarProvider extends AbstractStaticMetaBarProvider
             ->withPosition(2)
             ->withSymbol($f->symbol()->icon()->custom(ilUtil::getImagePath("icon_personal_settings.svg"), $txt("personal_settings")));
 
-        $this->dic->ctrl()->setTargetScript('logout.php');
-        // Actually, we only need the CSRF token, but there is no other way to retrieve this.
-        $logoutUrl = $this->dic->ctrl()->getLinkTargetByClass([ilStartUpGUI::class], 'doLogout');
-        $logoutUrl .= '&lang=' . $this->dic->user()->getCurrentLanguage();
-        $this->dic->ctrl()->setTargetScript('ilias.php');
-
         $children[] = $mb->linkItem($id('logout'))
-            ->withAction($logoutUrl)
+            ->withAction(ilStartUpGUI::logoutUrl())
             ->withPosition(3)
             ->withTitle($txt("logout"))
             ->withSymbol($f->symbol()->glyph()->logout());


### PR DESCRIPTION
Fix Mantis bug: https://mantis.ilias.de/view.php?id=37602

The logout URL works only with a valid CSRF token. To centralize the creation of a valid logout URL this PR adds a new static method `logoutUrl` to the `ilStartUpGUI`.

Additionally this PR replaces direct usages of `logout.php` in `ilStartUpGUI` and `Services/TermsOfService` (fixing the withdrawl process) with a call to `ilStartUpGUI::logoutUrl()`, as the CSRF token is missing from these links and will therefore not work.

The creation of a valid logout URL was taken from `UserMetaBarProvider::getMetaBarItems()` which is also replaced with a call to `ilStartUpGUI::logoutUrl()`.