### PR TITLE
`Services/User`: `ilSetting` wrong argument type (trunk)

### DIFF
--- a/Services/User/Profile/classes/class.ilPersonalProfileGUI.php
+++ b/Services/User/Profile/classes/class.ilPersonalProfileGUI.php
@@ -352,7 +352,7 @@ class ilPersonalProfileGUI
             ($this->user->getAuthMode() === 'default' && $defaultAuth == ilAuthUtils::AUTH_LDAP)
         ) {
             $withdrawalType = 2;
-        } elseif ($this->setting->get('tos_withdrawal_usr_deletion', false)) {
+        } elseif ($this->setting->get('tos_withdrawal_usr_deletion', '0') !== '0') {
             $withdrawalType = 1;
         }
 


### PR DESCRIPTION
Fix Mantis bug: https://mantis.ilias.de/view.php?id=37602

Fix wrong argument type for `ilSetting::get` for the Terms of Service withdrawl process.