### PR TITLE
`Services/User`: `ilSetting` wrong argument type (ILIAS8)

### DIFF
--- a/Services/User/Profile/classes/class.ilPersonalProfileGUI.php
+++ b/Services/User/Profile/classes/class.ilPersonalProfileGUI.php
@@ -346,7 +346,7 @@ class ilPersonalProfileGUI
             ($this->user->getAuthMode() === 'default' && $defaultAuth == ilAuthUtils::AUTH_LDAP)
         ) {
             $withdrawalType = 2;
-        } elseif ($this->setting->get('tos_withdrawal_usr_deletion', false)) {
+        } elseif ($this->setting->get('tos_withdrawal_usr_deletion', '0') !== '0') {
             $withdrawalType = 1;
         }
 


### PR DESCRIPTION
Sister PR to #6103.
As the `ilPersonalProfileGUI` does not contain `declare(strict_types=1);` in ILIAS8, this does not throw an error but it is still wrong.