### PR TITLE
UI: buttons are labeled, not named or captioned

### DIFF
--- a/Modules/File/classes/class.ilObjFileGUI.php
+++ b/Modules/File/classes/class.ilObjFileGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -377,7 +378,7 @@ class ilObjFileGUI extends ilObject2GUI
         return $this->ui->factory()->input()->container()->form()->standard(
             $this->ctrl->getFormActionByClass(self::class, self::CMD_UPLOAD_FILES),
             $inputs
-        )->withSubmitCaption($this->lng->txt('upload_files'));
+        )->withSubmitLabel($this->lng->txt('upload_files'));
     }
 
     /**

--- a/Modules/File/classes/class.ilObjFileUploadDropzone.php
+++ b/Modules/File/classes/class.ilObjFileUploadDropzone.php
@@ -117,7 +117,7 @@ class ilObjFileUploadDropzone
                 (int) ilFileUtils::getUploadSizeLimitBytes()
             ),
             $additional_input
-        )->withSubmitCaption(
+        )->withSubmitLabel(
             $this->language->txt('upload_files')
         );
 

--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
@@ -160,7 +160,7 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
 
         $this->setToolbar();
         $form = $this->buildForm($this->getFormActionForCommand(self::CMD_SAVE_AMEND), true, true);
-        $form->withSubmitCaption($this->lng->txt("save_amend"));
+        $form->withSubmitLabel($this->lng->txt("save_amend"));
         $this->tpl->setContent($this->renderer->render($form));
     }
 
@@ -374,7 +374,7 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
 
     public function getInfoForExistingFiles(array $file_ids): array
     {
-        $file_ids = array_filter($file_ids, fn ($id) => $id !== "");
+        $file_ids = array_filter($file_ids, fn($id) => $id !== "");
         $path = $this->getUserFileStorage()->getAbsolutePath();
         return array_map(function ($id) use ($path) {
             return new BasicFileInfoResult(

--- a/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/Services/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -438,7 +438,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI
               "soap_pw" => $soap_pw,
               "new_user" => $new_user
             ]
-        )->withSubmitCaption("Send");
+        )->withSubmitLabel("Send");
         return $form;
     }
 

--- a/Services/Repository/Service/Form/class.FormAdapterGUI.php
+++ b/Services/Repository/Service/Form/class.FormAdapterGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\Repository\Form;
 
@@ -364,7 +364,7 @@ class FormAdapterGUI
         );
 
         if (count($mime_types) > 0) {
-            $description.= $this->lng->txt("rep_allowed_types") . ": " .
+            $description .= $this->lng->txt("rep_allowed_types") . ": " .
                 implode(", ", $mime_types);
         }
 
@@ -478,15 +478,15 @@ class FormAdapterGUI
                 $inputs
             );
             if ($this->submit_caption !== "") {
-                $this->form = $this->form->withSubmitCaption($this->submit_caption);
+                $this->form = $this->form->withSubmitLabel($this->submit_caption);
             }
         }
         return $this->form;
     }
 
-    public function getSubmitCaption(): string
+    public function getSubmitLabel(): string
     {
-        return $this->getForm()->getSubmitCaption() ?? $this->lng->txt("save");
+        return $this->getForm()->getSubmitLabel() ?? $this->lng->txt("save");
     }
 
     protected function _getData(): void

--- a/Services/Repository/Service/Modal/class.ModalAdapterGUI.php
+++ b/Services/Repository/Service/Modal/class.ModalAdapterGUI.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
+ *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\Repository\Modal;
 
@@ -108,7 +111,7 @@ class ModalAdapterGUI
         if ($this->ctrl->isAsynch()) {
             $this->form = $form->asyncModal();
             $button = $this->ui->factory()->button()->standard(
-                $this->form->getSubmitCaption(),
+                $this->form->getSubmitLabel(),
                 "#"
             )->withOnLoadCode(function ($id) {
                 return

--- a/Services/Style/System/classes/Less/class.ilSystemStyleLessGUI.php
+++ b/Services/Style/System/classes/Less/class.ilSystemStyleLessGUI.php
@@ -251,7 +251,7 @@ class ilSystemStyleLessGUI
         return $f->container()->form()->standard(
             $this->ctrl->getFormAction($this, 'update'),
             [$form_section]
-        )->withSubmitCaption($this->lng->txt('update_variables'));
+        )->withSubmitLabel($this->lng->txt('update_variables'));
     }
 
     public function update(): Form

--- a/src/UI/Component/Input/Container/Form/Factory.php
+++ b/src/UI/Component/Input/Container/Form/Factory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Input\Container\Form;
 
@@ -56,7 +56,7 @@ interface Factory
      *     4: >
      *        On top and bottom of a standard form there SHOULD be the “Save” button for the form.
      *     5: >
-     *        In some rare exceptions the Buttons MAY be named differently: if “Save” is
+     *        In some rare exceptions the Buttons MAY be labeled differently: if “Save” is
      *        clearly a misleading since the action is more than storing
      *        the data into the database. “Send Mail” would be an example of this.
      * ---

--- a/src/UI/Component/Input/Container/Form/Standard.php
+++ b/src/UI/Component/Input/Container/Form/Standard.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Component\Input\Container\Form;
 
 /**
@@ -26,12 +26,12 @@ namespace ILIAS\UI\Component\Input\Container\Form;
 interface Standard extends FormWithPostURL
 {
     /**
-     * Sets the caption of the submit button of the form
+     * Sets the label of the submit button of the form
      */
-    public function withSubmitCaption(string $caption): Standard;
+    public function withSubmitLabel(string $label): Standard;
 
     /**
-     * Gets submit caption of the form
+     * Gets the submit label of the form.
      */
-    public function getSubmitCaption(): ?string;
+    public function getSubmitLabel(): ?string;
 }

--- a/src/UI/Implementation/Component/Dropzone/File/File.php
+++ b/src/UI/Implementation/Component/Dropzone/File/File.php
@@ -199,16 +199,16 @@ abstract class File implements FileDropzone
         return $this->modal->getPostURL();
     }
 
-    public function withSubmitCaption(string $caption): self
+    public function withSubmitLabel(string $caption): self
     {
         $clone = clone $this;
-        $clone->modal = $clone->modal->withSubmitCaption($caption);
+        $clone->modal = $clone->modal->withSubmitLabel($caption);
         return $clone;
     }
 
-    public function getSubmitCaption(): ?string
+    public function getSubmitLabel(): ?string
     {
-        return $this->modal->getSubmitCaption();
+        return $this->modal->getSubmitLabel();
     }
 
     public function getInputs(): array

--- a/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Container\Form;
 
@@ -59,7 +59,8 @@ class Renderer extends AbstractComponentRenderer
         $this->maybeAddError($component, $tpl);
 
         $submit_button = $this->getUIFactory()->button()->standard(
-            $component->getSubmitCaption() ?? $this->txt("save"), ""
+            $component->getSubmitLabel() ?? $this->txt("save"),
+            ""
         );
 
         $tpl->setVariable("BUTTONS_TOP", $default_renderer->render($submit_button));

--- a/src/UI/Implementation/Component/Input/Container/Form/Standard.php
+++ b/src/UI/Implementation/Component/Input/Container/Form/Standard.php
@@ -47,7 +47,7 @@ class Standard extends Form implements C\Input\Container\Form\Standard
     /**
      * @inheritDoc
      */
-    public function withSubmitCaption(string $caption): C\Input\Container\Form\Standard
+    public function withSubmitLabel(string $caption): C\Input\Container\Form\Standard
     {
         $clone = clone $this;
         $clone->submit_caption = $caption;
@@ -57,7 +57,7 @@ class Standard extends Form implements C\Input\Container\Form\Standard
     /**
      * @inheritDoc
      */
-    public function getSubmitCaption(): ?string
+    public function getSubmitLabel(): ?string
     {
         return $this->submit_caption;
     }

--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -172,7 +172,7 @@ class Renderer extends AbstractComponentRenderer
     ): string {
         $items_of_class = array_filter(
             $items,
-            fn ($i) => $i instanceof $class_name
+            fn($i) => $i instanceof $class_name
         );
         $rendered_items = '';
         foreach ($items_of_class as $item) {
@@ -211,7 +211,7 @@ class Renderer extends AbstractComponentRenderer
 
             // render submit in modal footer.
             $submit = $this->getUIFactory()->button()->standard(
-                $modal->getSubmitCaption() ?? $this->txt('save'),
+                $modal->getSubmitLabel() ?? $this->txt('save'),
                 ''
             )->withOnClick($modal->getForm()->getSubmitSignal());
             $tpl->setCurrentBlock('with_submit');

--- a/src/UI/Implementation/Component/Modal/RoundTrip.php
+++ b/src/UI/Implementation/Component/Modal/RoundTrip.php
@@ -222,7 +222,7 @@ class RoundTrip extends Modal implements M\RoundTrip
     /**
      * @inheritDoc
      */
-    public function withSubmitCaption(string $caption): self
+    public function withSubmitLabel(string $caption): self
     {
         $clone = clone $this;
         $clone->submit_button_label = $caption;
@@ -232,7 +232,7 @@ class RoundTrip extends Modal implements M\RoundTrip
     /**
      * @inheritDoc
      */
-    public function getSubmitCaption(): ?string
+    public function getSubmitLabel(): ?string
     {
         return $this->submit_button_label;
     }

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -150,12 +151,12 @@ class StandardFormTest extends ILIAS_UI_TestBase
             $if->text("label", "byline"),
         ]);
 
-        $this->assertNull($form->getSubmitCaption());
+        $this->assertNull($form->getSubmitLabel());
 
         $caption = 'Caption';
-        $form = $form->withSubmitCaption($caption);
+        $form = $form->withSubmitLabel($caption);
 
-        $this->assertEquals($caption, $form->getSubmitCaption());
+        $this->assertEquals($caption, $form->getSubmitLabel());
     }
 
     public function test_submit_caption_render(): void
@@ -166,7 +167,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $url = "MY_URL";
         $form = $f->standard($url, [
             $if->text("label", "byline"),
-        ])->withSubmitCaption('create');
+        ])->withSubmitLabel('create');
 
         $r = $this->getDefaultRenderer();
         $html = $this->brutallyTrimHTML($r->render($form));


### PR DESCRIPTION
Hi everybody,

this tries to rectify some wording issue. On the one hand, this is a rather concrete change. On the other hand this is exemplary. So I try to explain a little why we should do this AFAIC.

So, there are three words that are involved here:

* **[caption](https://dictionary.cambridge.org/dictionary/english/caption)**: "a short piece of text under a picture in a book or article that describes the picture or explains what the people in it are doing or saying"
* **[label](https://dictionary.cambridge.org/dictionary/english/label)**: "a piece of paper or other material that gives you information about the object it is attached to"
* **[name](https://dictionary.cambridge.org/dictionary/english/name)**: "the word or words that a person, thing, or place is known by"

The thing we want to set here is not a "caption", because it does not describe or explain what we see in another piece of media. It is no "name", because the button will still be known by its name "submit button". (Also, it is no [title](https://dictionary.cambridge.org/dictionary/english/title)). It is a label, because it gives information (*What will happen exactly?*) about the submit button. Also, I think, this is how the general programming and internet community would call this thingy =)

Lets try to get this right an be consistent in the future when it comes to "labels", "names", "caption" and "titles".

Thanks =)

