### PR TITLE
TA: Corrected syntax typo  class=0"form-control text-right"

### DIFF
--- a/Modules/TestQuestionPool/templates/default/tpl.prop_singlechoicewizardinput.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.prop_singlechoicewizardinput.html
@@ -51,7 +51,7 @@
 				</td>
 <!-- BEGIN points -->
 				<td class="ilValignTop">
-					<input type="text" class=0"form-control text-right" size="5" id="{POINTS_ID}" name="{POINTS_POST_VAR}[points][{POINTS_ROW_NUMBER}]" <!-- BEGIN prop_points_propval -->value="{PROPERTY_VALUE}" <!-- END prop_points_propval -->{DISABLED_POINTS}/>
+					<input type="text" class="form-control text-right" size="5" id="{POINTS_ID}" name="{POINTS_POST_VAR}[points][{POINTS_ROW_NUMBER}]" <!-- BEGIN prop_points_propval -->value="{PROPERTY_VALUE}" <!-- END prop_points_propval -->{DISABLED_POINTS}/>
 				</td>
 <!-- END points -->
 <!-- BEGIN answer id field -->


### PR DESCRIPTION
Came upon this typo while updated to v7.23