### PR TITLE
T&A-0019197-Competence-text-customization-for-essay-question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -377,12 +377,17 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         $tpl = new ilTemplate($tplFile, true, true, 'Modules/TestQuestionPool');
 
         foreach ($answers as $answer) {
-            $keywordString = $answer->getAnswertext();
-
+            $keywordString = '';
             if (in_array($this->object->getKeywordRelation(), assTextQuestion::getScoringModesWithPointsByKeyword())) {
+                $keywordString .= $answer->getPoints() . ' ';
+                if ($answer->getPoints() == '1' || $answer->getPoints() == '-1'){
+                    $keywordString .= $this->lng->txt('point');
+                } else {
+                    $keywordString .= $this->lng->txt('points');
+                }
                 $keywordString .= ' ' . $this->lng->txt('for') . ' ';
-                $keywordString .= $answer->getPoints() . ' ' . $this->lng->txt('points');
             }
+            $keywordString .=  $answer->getAnswertext();
 
             $tpl->setCurrentBlock('keyword');
             $tpl->setVariable('KEYWORD', $keywordString);


### PR DESCRIPTION
Ticket:
https://mantis.ilias.de/view.php?id=19197

Changerequest:
Change sentence structure from:
"$answertext for $x points" to "$x points for $answertext"


Code compatible with:
ILIAS 7, 8 

As always, let me know where this solution needs further improvement.