### PR TITLE
Port of #4125(samesite cookies) to ILIAS8.

### DIFF
--- a/Services/Http/classes/class.ilHTTPS.php
+++ b/Services/Http/classes/class.ilHTTPS.php
@@ -87,7 +87,7 @@ class ilHTTPS
      */
     public function isDetected(): bool
     {
-        if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {
+        if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] === "on") {
             return true;
         }
 
@@ -96,7 +96,7 @@ class ilHTTPS
             /* echo $header_name;
              echo $_SERVER[$header_name];*/
             if (isset($_SERVER[$header_name])) {
-                if (strcasecmp($_SERVER[$header_name], $this->header_value) == 0) {
+                if (strcasecmp($_SERVER[$header_name], $this->header_value) === 0) {
                     $_SERVER["HTTPS"] = "on";
                     return true;
                 }
@@ -130,13 +130,14 @@ class ilHTTPS
                 define('IL_COOKIE_SECURE', true);
             }
 
-            session_set_cookie_params(
-                IL_COOKIE_EXPIRE,
-                IL_COOKIE_PATH,
-                IL_COOKIE_DOMAIN,
-                true,
-                IL_COOKIE_HTTPONLY
-            );
+            session_set_cookie_params([
+                'lifetime' => IL_COOKIE_EXPIRE,
+                'path' => IL_COOKIE_PATH,
+                'domain' => IL_COOKIE_DOMAIN,
+                'secure' => IL_COOKIE_SECURE,
+                'httponly' => true,
+                'samesite' => (strtolower(session_get_cookie_params()['samesite'] ?? '')) === 'strict' ? session_get_cookie_params()['samesite'] : 'Lax'
+            ]);
         }
     }
 
@@ -163,13 +164,13 @@ class ilHTTPS
                 return (
                     !in_array(basename($_SERVER['SCRIPT_NAME']), $this->protected_scripts) &&
                     !in_array(strtolower($_GET['cmdClass']), $this->protected_classes)
-                ) && $_SERVER['HTTPS'] == 'on';
+                ) && $_SERVER['HTTPS'] === 'on';
 
             case self::PROTOCOL_HTTPS:
                 return (
                     in_array(basename($_SERVER['SCRIPT_NAME']), $this->protected_scripts) ||
                     in_array(strtolower($_GET['cmdClass']), $this->protected_classes)
-                ) && $_SERVER['HTTPS'] != 'on';
+                ) && $_SERVER['HTTPS'] !== 'on';
         }
 
         return false;

--- a/Services/Http/classes/class.ilHTTPS.php
+++ b/Services/Http/classes/class.ilHTTPS.php
@@ -1,17 +1,20 @@
 <?php
-/******************************************************************************
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
 
 /**
  * Class ilHTTPS
@@ -158,15 +161,15 @@ class ilHTTPS
         switch ($to_protocol) {
             case self::PROTOCOL_HTTP:
                 return (
-                        !in_array(basename($_SERVER['SCRIPT_NAME']), $this->protected_scripts) &&
-                        !in_array(strtolower($_GET['cmdClass']), $this->protected_classes)
-                    ) && $_SERVER['HTTPS'] == 'on';
+                    !in_array(basename($_SERVER['SCRIPT_NAME']), $this->protected_scripts) &&
+                    !in_array(strtolower($_GET['cmdClass']), $this->protected_classes)
+                ) && $_SERVER['HTTPS'] == 'on';
 
             case self::PROTOCOL_HTTPS:
                 return (
-                        in_array(basename($_SERVER['SCRIPT_NAME']), $this->protected_scripts) ||
-                        in_array(strtolower($_GET['cmdClass']), $this->protected_classes)
-                    ) && $_SERVER['HTTPS'] != 'on';
+                    in_array(basename($_SERVER['SCRIPT_NAME']), $this->protected_scripts) ||
+                    in_array(strtolower($_GET['cmdClass']), $this->protected_classes)
+                ) && $_SERVER['HTTPS'] != 'on';
         }
 
         return false;

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -41,6 +41,10 @@ use ILIAS\ResourceStorage\Preloader\DBRepositoryPreloader;
 use ILIAS\Filesystem\Definitions\SuffixDefinitions;
 use ILIAS\FileUpload\Processor\InsecureFilenameSanitizerPreProcessor;
 use ILIAS\FileUpload\Processor\SVGBlacklistPreProcessor;
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use ILIAS\Refinery\Transformation;
 
 require_once("libs/composer/vendor/autoload.php");
 
@@ -436,35 +440,81 @@ class ilInitialisation
         if (!$DIC->isDependencyAvailable('iliasIni')) {
             self::abortAndDie('Fatal Error: ilInitialisation::determineClient called without initialisation of ILIAS ini file object.');
         }
-        $in_unit_tests = defined('IL_PHPUNIT_TEST');
-        $context_supports_persitent_session = ilContext::supportsPersistentSessions();
-        $can_set_cookie = !$in_unit_tests && $context_supports_persitent_session;
-        $has_request_client_id = $DIC->http()->wrapper()->query()->has('client_id');
-        $has_cookie_client_id = $DIC->http()->cookieJar()->has('ilClientId');
+
+        // determine the available clientIds (default, request, cookie)
         $default_client_id = $DIC->iliasIni()->readVariable('clients', 'default');
 
-        // determintaion of client_id:
+        if ($DIC->http()->wrapper()->query()->has('client_id')) {
+            $client_id_from_get = $DIC->http()->wrapper()->query()->retrieve(
+                'client_id',
+                self::getClientIdTransformation()
+            );
+        }
+        if ($DIC->http()->wrapper()->cookie()->has('ilClientId')) {
+            $client_id_from_cookie = $DIC->http()->wrapper()->cookie()->retrieve(
+                'ilClientId',
+                self::getClientIdTransformation()
+            );
+        }
+
+        // set the clientId by availability: 1. request, 2. cookie, fallback to defined default
         $client_id_to_use = '';
-        // first we try to get the client_id from request
-        if ($has_request_client_id) {
-            // @todo refinerey undefined
-            $client_id_from_get = (string) $_GET['client_id'];
+        if (isset($client_id_from_get) && $client_id_from_get !== '') {
+            $client_id_to_use = $client_id_from_get;
         }
-        // we found a client_id in $GET
-        if (isset($client_id_from_get) && strlen($client_id_from_get) > 0) {
-            $client_id_to_use = $_GET['client_id'] = $df->clientId($client_id_from_get)->toString();
-            if ($can_set_cookie) {
-                ilUtil::setCookie('ilClientId', $client_id_to_use);
-            }
-        } else {
-            $client_id_to_use = $default_client_id;
-            if (!isset($_COOKIE['ilClientId'])) {
-                ilUtil::setCookie('ilClientId', $client_id_to_use);
-            }
+
+        if ($client_id_to_use === '' && isset($client_id_from_cookie)) {
+            $client_id_to_use = $client_id_from_cookie;
         }
-        $client_id_to_use = strlen($client_id_to_use) > 0 ? $client_id_to_use : $default_client_id;
+
+        $client_id_to_use = $client_id_to_use ?: $default_client_id;
 
         define('CLIENT_ID', $df->clientId($client_id_to_use)->toString());
+    }
+
+
+    /**
+     * Refinery is not initialized early enough to provide a transformation to be used with the
+     * \ILIAS\HTTP implementation to retrieve the parameters. Instead, this implementation here will be used.
+     *
+     * @return Transformation implementation of a transformation to get the clientId.
+     */
+    private static function getClientIdTransformation(): Transformation
+    {
+        return new class () implements Transformation {
+            /**
+             * @inheritDoc
+             */
+            public function transform($from): string
+            {
+                if (!is_string($from)) {
+                    throw new InvalidArgumentException(__METHOD__ . " the argument is not a string.");
+                }
+                return strip_tags($from);
+            }
+
+            /**
+             * @inheritDoc
+             */
+            public function applyTo(Result $result): Result
+            {
+                return $result->then(function ($value): Result {
+                    try {
+                        return new Ok($this->transform($value));
+                    } catch (Exception $exception) {
+                        return new Error($exception);
+                    }
+                });
+            }
+
+            /**
+             * @inheritDoc
+             */
+            public function __invoke($from): string
+            {
+                return $this->transform($from);
+            }
+        };
     }
 
     /**
@@ -504,8 +554,7 @@ class ilInitialisation
         // invalid client id / client ini
         if ($ilClientIniFile->ERROR != "") {
             $default_client = $ilIliasIniFile->readVariable("clients", "default");
-            ilUtil::setCookie("ilClientId", $default_client);
-            if (CLIENT_ID != "" && CLIENT_ID != $default_client) {
+            if (CLIENT_ID !== "") {
                 $mess = array("en" => "Client does not exist.",
                               "de" => "Mandant ist ungültig."
                 );
@@ -650,6 +699,15 @@ class ilInitialisation
         define('IL_COOKIE_DOMAIN', '');
     }
 
+    private static function setClientIdCookie(): void
+    {
+        if (defined('CLIENT_ID') &&
+            !defined('IL_PHPUNIT_TEST') &&
+            ilContext::supportsPersistentSessions()) {
+            ilUtil::setCookie('ilClientId', CLIENT_ID);
+        }
+    }
+
     /**
      * set session cookie params
      */
@@ -664,13 +722,22 @@ class ilInitialisation
             $cookie_secure = !$ilSetting->get('https', '0') && $DIC['https']->isDetected();
             define('IL_COOKIE_SECURE', $cookie_secure); // Default Value
 
-            session_set_cookie_params(
-                IL_COOKIE_EXPIRE,
-                IL_COOKIE_PATH,
-                IL_COOKIE_DOMAIN,
-                IL_COOKIE_SECURE,
-                IL_COOKIE_HTTPONLY
-            );
+            $cookie_parameters = [
+                'lifetime' => IL_COOKIE_EXPIRE,
+                'path' => IL_COOKIE_PATH,
+                'domain' => IL_COOKIE_DOMAIN,
+                'secure' => IL_COOKIE_SECURE,
+                'httponly' => IL_COOKIE_HTTPONLY,
+            ];
+
+            if (
+                $cookie_secure &&
+                (!isset(session_get_cookie_params()['samesite']) || strtolower(session_get_cookie_params()['samesite']) !== 'strict')
+            ) {
+                $cookie_parameters['samesite'] = 'Lax';
+            }
+
+            session_set_cookie_params($cookie_parameters);
         }
     }
 
@@ -989,15 +1056,7 @@ class ilInitialisation
             $target = "target=" . $target . "&";
         }
 
-        $client_id = $DIC->http()->wrapper()->cookie()->retrieve(
-            'ilClientId',
-            $DIC->refinery()->byTrying([
-                $DIC->refinery()->kindlyTo()->string(),
-                $DIC->refinery()->always('')
-            ])
-        );
-
-        $script = "login.php?" . $target . "client_id=" . $client_id .
+        $script = "login.php?" . $target . "client_id=" . CLIENT_ID .
             "&auth_stat=" . $a_auth_stat;
 
         self::redirect(
@@ -1330,6 +1389,8 @@ class ilInitialisation
         unset($tree);
 
         self::setSessionCookieParams();
+        self::setClientIdCookie();
+
         self::initRefinery($DIC);
 
         (new InitCtrlService())->init($DIC);

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -1465,7 +1466,6 @@ class ilInitialisation
         };
         $c->globalScreen()->tool()->context()->stack()->clear();
         $c->globalScreen()->tool()->context()->claim()->main();
-//        $c->globalScreen()->tool()->context()->current()->addAdditionalData('DEVMODE', (bool) DEVMODE);
     }
 
     /**

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -1398,11 +1398,10 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         }
 
         // reset cookie
-        $client_id = CLIENT_ID;
         ilUtil::setCookie("ilClientId", "");
 
         // redirect and show logout information
-        $this->ctrl->setParameter($this, 'client_id', $client_id);
+        $this->ctrl->setParameter($this, 'client_id', CLIENT_ID);
         $this->ctrl->setParameter($this, 'lang', $user_language);
         $this->ctrl->redirect($this, 'showLogout');
     }

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -19,6 +19,7 @@
 use ILIAS\FileDelivery\Delivery;
 use ILIAS\Filesystem\Stream\Streams;
 use ILIAS\HTTP\Cookies\CookieFactoryImpl;
+use ILIAS\HTTP\Cookies\Cookie;
 
 /**
  * Util class
@@ -1314,6 +1315,12 @@ class ilUtil
                                  ->withHttpOnly(defined('IL_COOKIE_HTTPONLY') ? IL_COOKIE_HTTPONLY : false);
 
 
+        if (
+            defined('IL_COOKIE_SECURE') && IL_COOKIE_SECURE &&
+            (!isset(session_get_cookie_params()['samesite']) || strtolower(session_get_cookie_params()['samesite']) !== 'strict')
+        ) {
+            $cookie = $cookie->withSamesite(Cookie::SAMESITE_LAX);
+        }
         $jar = $cookie_jar->with($cookie);
         $response = $jar->renderIntoResponseHeader($http->response());
         $http->saveResponse($response);

--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -165,7 +166,7 @@ class ilUtil
         // use ilStyleDefinition instead of account to get the current skin
         if (ilStyleDefinition::getCurrentSkin() != "default") {
             $filename = "./Customizing/global/skin/" . ilStyleDefinition::getCurrentSkin(
-                ) . "/" . $a_css_location . $stylesheet_name;
+            ) . "/" . $a_css_location . $stylesheet_name;
         }
         if (strlen($filename) == 0 || !file_exists($filename)) {
             $filename = "./" . $a_css_location . "templates/default/" . $stylesheet_name;
@@ -462,7 +463,7 @@ class ilUtil
             $a_str = strip_tags($a_str);        // strip all other tags
             $a_str = ilUtil::unmaskSecureTags($a_str, $allow_array);
 
-        // a possible solution could be something like:
+            // a possible solution could be something like:
             // $a_str = str_replace("<", "&lt;", $a_str);
             // $a_str = str_replace(">", "&gt;", $a_str);
             // $a_str = ilUtil::unmaskSecureTags($a_str, $allow_array);

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
 		"symfony/yaml": "^5.3",
 		"guzzlehttp/psr7": "1.9.1",
 		"psr/http-message": "^1.0",
-		"dflydev/fig-cookies": "^1.0",
+		"dflydev/fig-cookies": "^3.0",
 		"ralouphie/getallheaders": "^2.0",
 		"league/flysystem": "^1.0",
 		"james-heinrich/getid3": "^1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86b145e5abc753236a7168a100a17394",
+    "content-hash": "b2db538a2735645d3df60933ee4b1ca2",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -56,31 +56,37 @@
         },
         {
             "name": "dflydev/fig-cookies",
-            "version": "v1.0.2",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-fig-cookies.git",
-                "reference": "883233c159d00d39e940bd12cfe42c0d23420c1c"
+                "reference": "ea6934204b1b34ffdf5130dc7e0928d18ced2498"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/883233c159d00d39e940bd12cfe42c0d23420c1c",
-                "reference": "883233c159d00d39e940bd12cfe42c0d23420c1c",
+                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/ea6934204b1b34ffdf5130dc7e0928d18ced2498",
+                "reference": "ea6934204b1b34ffdf5130dc7e0928d18ced2498",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "psr/http-message": "~1.0"
+                "ext-pcre": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/http-message": "^1"
             },
             "require-dev": {
-                "codeclimate/php-test-reporter": "~0.1@dev",
-                "phpunit/phpunit": "~4.5",
-                "squizlabs/php_codesniffer": "~2.3"
+                "doctrine/coding-standard": "^8",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "phpunit/phpunit": "^7.2.6 || ^9",
+                "scrutinizer/ocular": "^1.8",
+                "squizlabs/php_codesniffer": "^3.3",
+                "vimeo/psalm": "^4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-main": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -106,9 +112,9 @@
             ],
             "support": {
                 "issues": "https://github.com/dflydev/dflydev-fig-cookies/issues",
-                "source": "https://github.com/dflydev/dflydev-fig-cookies/tree/master"
+                "source": "https://github.com/dflydev/dflydev-fig-cookies/tree/v3.0.0"
             },
-            "time": "2016-03-28T09:10:18+00:00"
+            "time": "2021-01-22T02:53:56+00:00"
         },
         {
             "name": "enshrined/svg-sanitize",

--- a/src/HTTP/Cookies/Cookie.php
+++ b/src/HTTP/Cookies/Cookie.php
@@ -28,6 +28,10 @@ namespace ILIAS\HTTP\Cookies;
  */
 interface Cookie
 {
+    public const SAMESITE_NONE = 'None';
+    public const SAMESITE_LAX = 'Lax';
+    public const SAMESITE_STRICT = 'Strict';
+
     /**
      * Cookie name.
      */
@@ -76,6 +80,10 @@ interface Cookie
      */
     public function getHttpOnly(): bool;
 
+    /**
+     * Cookie samesite
+     */
+    public function getSamesite(): ?string;
 
     /**
      * Sets the cookie value.
@@ -150,6 +158,13 @@ interface Cookie
      */
     public function withHttpOnly(bool $httpOnly = null): Cookie;
 
+    /**
+     * Sets the samesite attribute.
+     *
+     * @param string $sameSite value of the samesite attribute.  Valid values are
+     *                           @const SAMESITE_LAX, @const SAMESITE_STRICT or @const SAMESITE_NONE
+     */
+    public function withSamesite(string $sameSite): Cookie;
 
     /**
      * Returns the string representation of the object.

--- a/src/HTTP/Cookies/Cookie.php
+++ b/src/HTTP/Cookies/Cookie.php
@@ -1,20 +1,23 @@
 <?php
 
-namespace ILIAS\HTTP\Cookies;
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+namespace ILIAS\HTTP\Cookies;
+
 /**
  * Interface Cookie
  *

--- a/src/HTTP/Cookies/CookieWrapper.php
+++ b/src/HTTP/Cookies/CookieWrapper.php
@@ -3,6 +3,7 @@
 namespace ILIAS\HTTP\Cookies;
 
 use Dflydev\FigCookies\SetCookie;
+use Dflydev\FigCookies\Modifier\SameSite;
 
 /******************************************************************************
  *
@@ -101,6 +102,12 @@ class CookieWrapper implements Cookie
         return $this->cookie->getHttpOnly();
     }
 
+    public function getSamesite(): ?string
+    {
+        $samesite = $this->cookie->getSameSite();
+        return is_null($samesite) ? null : $samesite->asString();
+    }
+
     /**
      * @inheritDoc
      */
@@ -196,6 +203,14 @@ class CookieWrapper implements Cookie
     {
         $clone = clone $this;
         $clone->cookie = $this->cookie->withHttpOnly($httpOnly);
+
+        return $clone;
+    }
+
+    public function withSamesite(string $sameSite): Cookie
+    {
+        $clone = clone $this;
+        $clone->cookie = $this->cookie->withSameSite(SameSite::fromString($sameSite));
 
         return $clone;
     }

--- a/src/HTTP/Cookies/CookieWrapper.php
+++ b/src/HTTP/Cookies/CookieWrapper.php
@@ -1,23 +1,26 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\HTTP\Cookies;
 
 use Dflydev\FigCookies\SetCookie;
 use Dflydev\FigCookies\Modifier\SameSite;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 /**
  * Class CookieWrapper
  * Facade class for the FigCookies SetCookie class.


### PR DESCRIPTION
This PR a port of #4125 to ILIAS8. It contains two changes compared to the PR for ILIAS 7:
- An upgrade of the dfleydev/fig-cookies for allowing the access to the samesite attribute using the Cookie API instead of direct access to $_COOKIE
- An implementation of a transformation to use to HTTP interface provided by ILIAS. The Refinery is not initialized yet and cannot be initialized early enough during init