### PR TITLE
Component: define integration mechanisms

### DIFF
--- a/docs/development/components-and-directories.md
+++ b/docs/development/components-and-directories.md
@@ -133,6 +133,7 @@ A components folder also contains this substructure:
 * `/docs` for component specific documentation
 * `/src` for the code to be used for production
 * `/tests` for code that performs automated tests
+* `/resources` for auxiliary files like icons, endpoints
 * a `$COMPONENT.php` (e.g. AccessControl.php) that defines the binding of the
   component to the rest of the system
 * a `component.json` that contains component metadata, such as contact of
@@ -178,10 +179,556 @@ The xml-based definition was droppped for various reasons:
 
 ## Types of Dependencies and Integration Strategies
 
-*To save results and decide for (or against) their implementation, I decided to
-not present my ideas regarding integration here yet. Proprosals for integration
-strategies will be optional in the sense that we will totally have made progress
-if we'd only implemented the proposed changes in directories.*
+This chapter describes how different components of the system may depend on each
+other and how these dependencies are implemented. Components may implement different
+patterns in their relation to other components. A component might [define one service](#define-service)
+and [provide code](#provide-code) to ease the implementation of that service, but
+also [pull code](#pull-code) from yet another component. The component `ILIAS\AccessControl`,
+for example, defines how an `ilAccessHandler` (yet to be namespaced...) needs to
+look and also provides a base class `ilAccess` (yet to be namespaced...) to ease
+the implementation of the handler. It also pulls code from `ILIAS\Refinery` to
+implement some checks.
+
+Each of the types of dependencies described here might in general be implemented
+by various means from the perspective of PHP. We still strive to limit ourselves
+to certain patterns for the different types. Some patterns lead to better overall
+properties of the system then others, a limited number of patterns make the system
+comprehensible.
+
+The types of dependencies and the patterns have a different strength of coupling.
+In general, we try to strive to use weaker forms of dependencies if possible,
+to reduce coupling between components of the system.
+
+
+### Basics
+
+Location and namespacing of components is discussed in the [according section](#components-folder-and-namespacing).
+What's left is a description how components actually integrate into the rest of
+the system and how the according code looks like.
+This section describes the code that needs to be put into the component to actually
+define the integration.
+
+#### How
+
+The integrations are defined by implementing the interface `\ILIAS\Core\Component`
+for the class that has the same qualified name as the component it ought to describe.
+The component `Vendor\SomeComponent` should have file `SomeComponent.php` in its
+folder, containing a class `Vendor\SomeComponent`. The interface `\ILIAS\Core\Component`
+defines one method `init`, that describes the integration with other components:
+
+```php
+namespace Vendor;
+
+class SomeComponent implements Component
+{
+
+    public function init(
+        array | \ArrayAccess &$define,
+        array | \ArrayAccess &$implement,
+        array | \ArrayAccess &$use,
+        array | \ArrayAccess &$seek,
+        array | \ArrayAccess &$contribute,
+        array | \ArrayAccess &$provide,
+        array | \ArrayAccess &$pull,
+        array | \ArrayAccess &$internal,
+    ) : void {
+        // ...
+    }
+}
+```
+
+The integration uses a dependency injection container, as established in `Services\Init`
+over the last years. Instead of one container we use eight containers for the various
+types of integrations described below and for internal use.
+
+The fields in the containers need to be filled with closures to allow for defered
+instantion of the objects we define. All containers that allow to access objects
+can be used during instantiation. The easiest way to fill the containers hence is
+to use anonymouns short closures which can access variables from the complete
+scope.
+
+```php
+        $internal["my_internal_thingy"] = fn() => new InternalThingy($use[SomeOtherService::class]);
+
+```
+
+The different containers represents different directions of dependencies, hence
+some of them can be only written, some of them can only be read:
+
+* `$define`, `$implement`, `$contribute` and `$provide` define facilities that the
+   component at hand offers to the rest of the system. They can only be written.
+* `$use`, `$seek`, `$pull` define requirements that the   component demands from
+  the rest of the system. They can only be read.
+
+The `$internal` is meant to construct interal wiring of the components, hence it can
+be read and written. It can be used for facilities that are internal to the component,
+but it can also be used to wire up external dependencies. A component might for
+example provide some facility that contributes to various other components.
+`$internal` can then be used to contribute that facility to both other components:
+
+```php
+        $internal["my_internal_thingy"] = fn() => new InternalThingy();
+        $contribute[Vendor\Component\SomeContribution::class] = fn () => $internal["my_internal_thingy"];
+        $contribute[Vendor\OtherComponent\OtherContribution::class] = fn () => $internal["my_internal_thingy"];
+```
+
+#### Why
+
+The technique to define dependency graphs via array-access syntax and anonymous
+functions is well established by the pimple dependency injection container. There
+are tons of other dependency injection containers out there, many of them using
+other techniques to define the dependency graph. For our use case we consider
+the pimple technique to be appropriate:
+
+* There is no need to learn a domain specific language for the dependency graph, as
+  e.g. the [dependency injection component of symfony](https://symfony.com/doc/current/components/dependency_injection.html)
+  uses.
+* There is no need to learn a new PHP interface to define the dependency graph, as
+  e.g. the [dependency injection component of symfony](https://symfony.com/doc/current/components/dependency_injection.html)
+  uses.
+* The environment is easy to set up, because all we need for a first approximation
+  are arrays. Hence the technique is good for automated testing and general tinkering.
+  No need to parse any file or mock some interface.
+
+We propose to increase the amount of containers that are used to define the graph
+to eight since we are looking to get a good grasp of the dependencies in the system.
+There are fundamentally different types of dependencies, as outlined below, that
+we need to model and want to understand. One array-like object would not be enough
+to capture these types. We are then faced with the decision to make one container
+more complex (see above) or just use more containers (as proposed).
+
+
+### Define Service
+
+A component may define the interface to a service it provides. To be a service
+definition it is crucial that the interface...
+
+* ...is defined from the perspective of an intended usage, not an intended or actual
+  implementation
+* ...is minimal, i.e. only contains what is necessary for the intended usage
+* ...is an abstraction, i.e. hides complexity, instead of being a generalisation
+  which spans complexity
+* ...is the frontend to some subsystem, not just a way to hide some implementation
+  details
+
+A mostly good example for the service definition is the [`Logger`-interface of PSR-3](https://www.php-fig.org/psr/psr-3/).
+It is clearly defined from a usage-perspective and it hides various potentially
+very different or complex systems or implementations behind a fairly abstract
+interface. An anti-example from the same domain is the `ilLog`-class that publishes
+various implementation details of a concrete implementation of a certain logging
+mechanism.
+
+A service definition and the interface to the service do not necessarily need to be
+made from one PHP interface or class only. Dependending on the subsystem and intended
+usage that is abstracted by the service definition, various interfaces or even classes
+for data transfer might be required.
+
+Still, if a service definition sticks to the qualities defined above, it should
+be simple to reimplement it, outsource it to some other system, provide an alternative
+implementation, or, in general, just replace it by another implementation. Which
+is a sign for decoupled components and hence a flexible system.
+
+This is the weakest form of coupling, as the component only provides some definition
+to the world without knowing other components.
+
+#### How?
+
+To define a service, the component needs to specify the service via some interface:
+
+```php
+namespace Vendor\Component;
+
+interface Service
+{
+    /* ... */
+}
+```
+
+To announce that the service exists the component puts the interface in the container
+named `$define`:
+
+```php
+namespace Vendor;
+
+use Vendor\Component\Service;
+
+class Component implements \ILIAS\Core\Component
+{
+    public function init(
+        array | \ArrayAccess &$define,
+        // ...
+    ) {
+        $define[Vendor\Component\Service::class] = null;
+    }
+```
+
+This just announces the existence of the service to the system. The component might
+also provide a [Null-object](https://en.wikipedia.org/wiki/Null_object_pattern) or
+a minimal implementation for the service:
+
+```php
+namespace Vendor;
+
+use Vendor\Component\Service;
+
+class Component implements \ILIAS\Core\Component
+{
+    public function init(
+        array | \ArrayAccess &$define,
+        // ...
+    ) {
+        $define[Vendor\Component\Service::class] = fn () => new NullService();
+    }
+```
+
+The Null-object or minimal implementation may not depend on anything else and need
+to have an empty parameter list in its constructor.
+
+#### Why?
+
+Before this proposal there is no unified way to speak about or announce services or
+service interfaces in ILIAS. This proposal will allow to discover all services that
+are available in a given ILIAS codebase with a simple grep statement. More complex
+search or analysis can be build accordingly.
+
+The possibility to define a null object or minimal implementation will provide leafs
+in the dependency tree that we will need for initialisation. The future initialisation
+will use a heuristic with some possibility for configuration to define how dependencies
+are resolved. Minimal or null objects will provide options for that heuristic.
+
+
+### Use Service
+
+A component may use a service that is [defined by another component](#define-service).
+When using a service it is crucial that the component only relies on the defined
+interface and not on some concrete implementation of that service. A good service
+definition will make this easy and the using component will be able to use all
+implementations of the service equally. Other than with [Pull Code](#pull-code), which is
+described later on, we are not really interested in any details regarding the service,
+such as state, configuration etc. We just want any implementation that matches
+services interface.
+
+This coupling is littler stronger then a mere [service definition](#define-service)
+because the component depends on some component providing the service. It does not
+need to know any implementor of the service and these can be exchanged, so there is
+no strong dependency on a certain implementation.
+
+#### How?
+
+To use a service implemented by some other component, access the `$use` container
+with the name of the service. The used services will mostly be passed to some
+other object as a dependency, for example some internal factory. Keep in mind
+that we cannot expect a certain implementation for a given service, only some
+implementation for the required interface. 
+
+```php
+namespace Vendor;
+
+use Vendor\Component\Service;
+
+class Component implements \ILIAS\Core\Component
+{
+    public function init(
+        // ...
+        array | \ArrayAccess &$use,
+        // ...
+        array | \ArrayAccess &$internal,
+    ) {
+        $internal["internal_thingy"] = fn () => new InternalThingy($use[Vendor\Component\SomeService::class]);
+    }
+```
+
+
+
+### Implement Service
+
+Components might implement services that are defined by other components or
+themselves. The component provides some concrete implementation that fulfils
+requirements defined by some interface. To be a good implementation, it should
+accurately follow the specification of the service definition, i.e. neither
+do more nor less than required. For example, an implementation...:
+
+* ...should accept all arguments from the outside that fit the service definition
+  and not fail on any of these arguments
+* ...should not throw exceptions to open up side channels to the defined interface
+* ...should implement all required parts of the interface and not fail on certain
+  calls.
+
+It is absolutely fine, though, if various interfaces and service definitions are
+implemented by the same class.
+
+The coupling here is even stronger than it is the case when we [use a service](#use-service).
+In both cases the component depends on the component defining the service. But
+while we might ignore certain parts of an interface when just using the service,
+we can not do so when we implement a service. Some users might rely the complete
+interface.
+
+#### How?
+
+To declare that a component implements some service (be it defined by itself, be it
+defined by some other component) the implementation is inserted to the `$implement`
+container:
+
+
+```php
+namespace Vendor;
+
+use Vendor\Component\Service;
+
+class Component implements \ILIAS\Core\Component
+{
+    public function init(
+        // ...
+        array | \ArrayAccess &$implement,
+        // ...
+    ) {
+        $implement[OtherVendor\SomeComponent\SomeService::class] = fn () => new MyImplementation(/*...*/);
+    }
+```
+
+The implementation could `$use`, `$seek` or `$pull` from other components and
+also user `$internal` facilities.
+
+
+
+### Seek Contributions to Service or Functionality
+
+Some components need contributions from other services to provide their services to
+the system. In this type of dependency the component [`implements a service`](#implement-service),
+or functionality, but cannot do all the work on its own. Instead, it needs support
+from other components and hence requires contributions from them.
+
+The event system `Services\EventHandling` provides the service to raise and handle
+events, in definition and implementation. Still, on its own, it won't be able to do
+anything useful, as it hasn't handlers that do the actual handling of events. So
+`Services\EventHandling` seeks contributions of event handlers from other services.
+
+This superficially might look like the [definition of a service](#define-service),
+as the seeking component will most certainly provide some interface that needs
+to be implemented by the contributing component. Still, the dependency is reversed:
+it is the seeker that needs to contributing component to do its work.
+
+This coupling is stronger than the [usage of a service](#use-service), because the
+seeker needs contributions with an actually useful implementation to do any work.
+It won't break from a code perspective, if there are no contributions, but it will
+most certainly feel broken to its user if nothing interesting happens.
+
+#### How?
+
+To seek for contributions to a service, the `$seek` container is used. It may be
+queried for a certain interface and returns a list of all contributions that are
+made via this interface:
+
+```php
+namespace Vendor;
+
+use Vendor\Component\Service;
+
+class Component implements \ILIAS\Core\Component
+{
+    public function init(
+        // ...
+        array | \ArrayAccess &$seek,
+        // ...
+        array | \ArrayAccess &$internal,
+    ) {
+        $internal["internal_thingy"] = fn () => new InternalThingy($seek[Vendor\Component\TypeOfContribution::class]);
+    }
+```
+
+While the fields in other readable containers only return singular objects, the
+`$seek` container returns lists of objects implementing the seeked interface. These
+lists might be empty if no contribution to the interface was made.
+
+#### Why?
+
+Other than for services, possible contributions need not be defined abstractly before
+actual contributions are seeked. An abstract definition won't be very useful anyway.
+On the one hand, a component might be able to contribute to some service that the
+system at hand does not even implement. On the other hand `$seek` can always return
+an empty array if no contributions exist.
+
+
+
+### Contribute to Service or Functionality
+
+Sometimes components are in a position to contribute to the service or function that
+another component provides. That other component [seeks contributions](#seek-contributions-to-service-or-functionality)
+from other components by defining requirements in form of an interface. The contributing
+component can implement the requirements and hence participate in the service or
+functionality.
+
+Many components, for example, contribute entries to the main bar or the meta bar.
+Both bars would be useless if there were no contributions. But the individual
+contributors would be just fine without main bar items.
+
+This might superficially look like a combination of a [service usage](#use-service)
+and a [service implementation](#implement-service), but the requirements are flipped:
+The component that contributes to the service does not require the seeking component to
+function, but the seeking component needs the contributor instead.
+
+#### How?
+
+To contribute to a service, the `$contribute` container is used:
+
+```php
+namespace Vendor;
+
+use Vendor\Component\Service;
+
+class Component implements \ILIAS\Core\Component
+{
+    public function init(
+        // ...
+        array | \ArrayAccess &$contribute,
+        // ...
+    ) {
+        $contribute[Vendor/Component/SomeContribution::class] = fn () => new MyContribution();
+    }
+```
+
+Components can add various contributions for the same interface. These should just
+be added one after another:
+
+```php
+        $contribute[Vendor/Component/SomeContribution::class] = fn () => new FirstContribution();
+        $contribute[Vendor/Component/SomeContribution::class] = fn () => new SecondContribution();
+```
+
+
+
+### Provide Code
+
+Some components are, at least partly, providers of code to other components. Although
+this might look similar to components [defining](#define-service) and [implementing](#implement service)
+services, providing code is another beast:
+
+* Although there might be interfaces guarding internals and implementation details
+  from the outside world (as e.g. [the UI Framework](src/UI) does), these interfaces
+  are designed from the perspective of the code that is offered.
+* So there is little abstraction going on in these components, instead they might
+  more try to generalize use cases. While abstraction tries to hide complexity behind
+  simpler concepts, generalisation tries to tame complexity by spanning and unifying
+  various concepts.
+* Users will become dependent on any behaviour of our code. It won't matter if the
+  behaviour is indeed intended or just emerged accidentially. A bugfix for the one
+  might be a breaking change for the other.
+* The code will need to work. Now. In every combination. As intended by the user.
+
+So, if possible, components should try to provide their functionality by a combination
+of a service definition as thin as possible, together with an according implementation.
+Still, the system needs functionality that can only be understood as a code repository.
+Also, many components will want to provide smallish snippets to other components, e.g.
+abstract base classes, traits or utility classes to be used for other integration
+patterns.
+
+Examples for components that can be seen as repositories of code are the
+[`Refinery`](src/Refinery) and the [`UI-Framework`](src/UI). The setup mostly acts
+as a [seeker of contributions](#seek-contributions-to-service-or-functionality)
+to its functionality, but also provides some snippets of code to its contributors.
+
+It might look as if the components that use the code are more dependent on the
+provider as the other way round. This is not the case: While the components using
+the code only depend on the parts they use, the providing component depends on
+all the usages in the sense that these usages force requirements on the implementation
+(explicitly and implicitly). This restricts possible implementations in the provider
+and changes thereof. This also implies, that the highlander principle applies to
+code providers: there can only be one.
+
+#### How?
+
+The preferred mechanism to provide code looks just like the according mechanism for
+services. Other than for services, an implementation must be provided and it may
+use other dependencies from the system.
+
+```php
+namespace Vendor;
+
+use Vendor\Component\Service;
+
+class Component implements \ILIAS\Core\Component
+{
+    public function init(
+        // ...
+        array | \ArrayAccess &$provide,
+        // ...
+    ) {
+        $provide[Vendor\Component\SomeCode::class] = fn () => new Vendor\Component\SomeCode(/*...*/);
+    }
+```
+
+Still, there are important differences:
+
+* While some specific service could be implemented by various components, code with
+  a certain name can only be provided by one component.
+* While for services we always use interfaces to name and describe them, we might
+  use classes to do so for code.
+* The component providing the code also owns the interface or class that is used to
+  name the code. In some circumstances, there will be only one class, providing the
+  name and the code. On the other hand, components can implement services that are
+  defined by another component.
+
+Code provided via this mechanism could for example be a factory or a library of
+functions. It can and often should be accompanied by interfaces that define how
+the code is used and classes for, e.g., DTOs or other even other purposes. The
+definition of the code provided via the `$provide` container should allow its users
+to discover the connected classes and interfaces. Explanations, howtos, tutorials
+and such can be given in the components `doc`-folder.
+
+Another way to provide code to other components is to offer `trait`s to users. These
+can be useful to help users to implement certain, maybe common, parts of interfaces
+or encapsulate algorithms for easier use.
+
+In general, we should try to provide code in the most abstract way that is available.
+Can you provide a factory instead of making users use `new` with a certain name?
+Great, do it. Can we use composition (e.g. traits) instead of inheritance (abstract
+base class)? Awesome. Just because we are providing code (instead of services) we
+should not forget to strive for a loose coupling between components.
+
+Thus, we should not use bare `functions` or static methods to provide code to
+some other component. We can always replace these to techniques with an injected
+class carrying the functions. This will to replace the calls, e.g. for unit tests.
+
+
+### Pull Code
+
+The ways to pull code should come at no surprise given [the previous chapter](#provide-code).
+Developers often have a rather strange relationship to other peoples code. On the one
+hand we love to pull some dependency from somewhere into our project so we do not need
+to write it (whatever it is) on our own. This makes us productive. On the other hand,
+we often tend to rewrite stuff that has been done a hundred times before. This makes
+us slow. To keep a system like ILIAS coherent and workable we should fall on neiher
+side:
+
+* Only pull code into your component if you are positive that it is indeed meant to
+  be used by other components in the intended way. Documentation and the $provide-array
+  should already help a lot. When in doubt: ask.
+* If there is code designed to solve your problem, use it. When it does not fit exactly
+  or it lacks ease of use, just improve it instead of implementing your own solution.
+  Sharing common code is at the core of every open source community.
+
+#### How?
+
+This is the preferred mechanism to pull code from another component:
+
+```php
+namespace Vendor;
+
+use Vendor\Component\Service;
+
+class Component implements \ILIAS\Core\Component
+{
+    public function init(
+        // ...
+        array | \ArrayAccess &$pull,
+        // ...
+    ) {
+        $internal["internal_thingy"] = fn () => new InternalThingy($pull[Vendor\Component\TypeOfContribution::class]);
+    }
+```
+
+There is a variety of other methods that can be used to pull code. Look into the
+documentation of the component you want to use.
 
 
 ## Roadmap and Migration
@@ -194,13 +741,29 @@ if we'd only implemented the proposed changes in directories.*
     if directories are moved inside the codebase. The classmap created by composer
     will simply point to other locations.
   * Most important endpoints and js-includes will be moved with the PR.
-* If we could not agree on integration strategy and `$COMPONENT.php` by then:
-  * We can continue to use service.xml/module.xml with minimal changes.
-  * We can continue using Plugins as is with minimal changes.
-  * CaT will provide further PRs that moves missing endpoints and client-side
-    includes to `\public`.
-* If we could agree on integration strategies and `$COMPONENT.php` by then:
-  * ... we will have discussed how to move existing integrations via xmls to new
-    logic:
+* Plugins can continue to use the existing slots for at least ILIAS 10. The implementation
+  status for this proposal should be assessed during the development of ILIAS 10
+  (about a year from now...) to reconsider when to abandon existing plugin slots.
+* After the PR to introduce namespaces is merged, CaT will propose a second PR, that:
+  * introduces a `$COMPONENT.php` for every component
+  * moves integrations for these components to the new system:
+    * COPage
+    * Logging
+    * Mail
+    * Setup
+    * Badge
+    * WebAccessChecker
+    * Object
+    * EventHandling
+    * Cron
+    * SystemCheck
+  * moves current initialisation into a `ILIAS\Legacy` component:
+    * move `Dependencies` from `Services\Init` to the respective components
+    * initialize DIC in Component::init
+    * potentially: improve structure of initialisation
+  * takes care about endpoints, so they will exist in the `public` folder afterwards
+* DIC can be used for at least ILIAS 10. The implementation status for this proposal
+  should be assessed during the development of ILIAS 10 (about a year from now...) to
+  reconsider when to abandon DIC.
 * CaT will provide migrations and howtos to move existing installations to new
   structure.


### PR DESCRIPTION
Hello everyone,

this the followup to #5971, my proposals to implement [the goals from the Component Revision 2022](https://docu.ilias.de/goto_docu_wiki_wpage_7295_1357.html). This proposal clarifies how components can actually be integrated with each other.

As for the last PR, I expect that there will be concerns and question. I would kindly ask you to add them to this PR. I will try to answer them here and adjust the paper accordingly. If it feels to much or if someone explicitly asks, I will invite to a workshop to discuss this proposal.

The changes seem to be a lot, but this is mostly because I moved `src/Setup` to the new structure to showcase the general proposal. So you might want to start with the [actual written proposal in docs/development/components-and-directories.md](https://github.com/ILIAS-eLearning/ILIAS/pull/6123/files#diff-c644c12a057658345bd16fdaf75c50db8b18cc25f8c33a0dd92bb82175db03d9R182). [components/ILIAS/Setup/Setup.php](https://github.com/ILIAS-eLearning/ILIAS/pull/6123/files#diff-38c5807538c0937482540e0f93cf8d82a4468edf7364d26a98794fe126b779b3R35) then shows how this could look for the Setup. This is basically initialisation that currently lives in [setup/cli.php](https://github.com/ILIAS-eLearning/ILIAS/blob/release_8/setup/cli.php#L51). So this is a nice possibility to see how things will actually change if we implement this proposal. New endpoints or scripts will mostly look like [this](https://github.com/ILIAS-eLearning/ILIAS/pull/6123/files#diff-c680ef30e6885d4a352539ab49cc06706d2dfba3e7de32ae8ebbde25d0fee2b2).

**If this is accepted I will only merge the changes in docs/development/components-and-directories.md.**

Best wishes! 