### PR TITLE
Init/Auth/OpenIDConnect: Don't set `SameSite` param for `PHPSESSID`

### DIFF
--- a/Services/Http/classes/class.ilHTTPS.php
+++ b/Services/Http/classes/class.ilHTTPS.php
@@ -212,7 +212,6 @@ class ilHTTPS
                 'domain' => IL_COOKIE_DOMAIN,
                 'secure' => true,
                 'httponly' => IL_COOKIE_HTTPONLY,
-                'samesite' => (strtolower(session_get_cookie_params()['samesite'] ?? '')) === 'strict' ? session_get_cookie_params()['samesite'] : 'Lax'
             ]);
         }
 


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=37628