### PR TITLE
Course: issue certificates based on passed status, if lp is deactivated globally (26314)

### DIFF
--- a/Modules/Course/README.md
+++ b/Modules/Course/README.md
@@ -1,0 +1,14 @@
+# Course
+
+This documentation is a work in progress, and will be updated with
+more information.
+
+### Certificates
+
+If the Learning Progress is globally activated, then Course Certificates
+will only be issued to users via their Learning Progress status: when
+a user achieves the status 'Completed', they will recieve a Certificate.
+This is handled automatically by `Services/Certificate`.
+
+If the Learning Progress is globally deactivated, Courses will instead issue
+Certificates to users when their status in the Course is set to 'Passed'.

--- a/Modules/Course/classes/class.ilCourseAppEventListener.php
+++ b/Modules/Course/classes/class.ilCourseAppEventListener.php
@@ -122,6 +122,16 @@ class ilCourseAppEventListener
         return true;
     }
 
+    protected static function awardCertificate(int $a_obj_id, int $a_usr_id): void
+    {
+        global $DIC;
+
+        $DIC->certificate()->userCertificates()->certificateCriteriaMet(
+            $a_usr_id,
+            $a_obj_id
+        );
+    }
+
     public static function handleEvent(string $a_component, string $a_event, array $a_parameter): void
     {
         if ($a_component == 'Services/AccessControl') {
@@ -138,6 +148,9 @@ class ilCourseAppEventListener
                 if ($a_event == 'deleteParticipant') {
                     self::destroyTimings($a_parameter['obj_id'], $a_parameter['usr_id']);
                     return;
+                }
+                if ($a_event === 'participantHasPassedCourse' && !ilObjUserTracking::_enabledLearningProgress()) {
+                    self::awardCertificate($a_parameter['obj_id'], $a_parameter['usr_id']);
                 }
                 break;
         }


### PR DESCRIPTION
With this PR, Courses issue Certificates to users that achieve the status 'Passed', but only if the Learning Progress is globally deactivated. For further information, see [26314](https://mantis.ilias.de/view.php?id=26314). 