### PR TITLE
UI/Init: Add autocomplete="off" for password fields

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -528,7 +528,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         $pi->setRetype(false);
         $pi->setSkipSyntaxCheck(true);
         $pi->setSize(20);
-        $pi->setDisableHtmlAutoComplete(false);
+        $pi->setDisableHtmlAutoComplete(true);
         $pi->setRequired(true);
         $form->addItem($pi);
 

--- a/src/UI/Component/Input/Field/Factory.php
+++ b/src/UI/Component/Input/Field/Factory.php
@@ -320,6 +320,12 @@ interface Factory
      * rules:
      *   usage:
      *     1: Password Input MUST be used for passwords.
+     *   composition:
+     *     1: >
+     *        The input MUST always be rendered with the attribute autocomplete="off".
+     *        This advises browsers to NOT autofill the input field with cached passwords
+     *        and avoids potential exposure of confidential data, especially in
+     *        shared environments.
      *   interaction:
      *     1: >
      *         Password Input SHOULD NOT limit the number of characters.

--- a/src/UI/templates/default/Input/tpl.password.html
+++ b/src/UI/templates/default/Input/tpl.password.html
@@ -1,5 +1,5 @@
 <div class="il-input-password" id="{ID_CONTAINER}">
-	<input id="{ID}" type="password" name="{NAME}"<!-- BEGIN value --> value="{VALUE}"<!-- END value --><!-- BEGIN disabled --> {DISABLED}<!-- END disabled --> class="form-control form-control-sm" />
+	<input id="{ID}" type="password" name="{NAME}"<!-- BEGIN value --> value="{VALUE}"<!-- END value --><!-- BEGIN disabled --> {DISABLED}<!-- END disabled --> class="form-control form-control-sm" autocomplete="off" />
 	<!-- BEGIN revelation -->
 	<span class="revelation-glyph revelation-reveal">
 		{PASSWORD_REVEAL}

--- a/tests/UI/Component/Input/Field/PasswordInputTest.php
+++ b/tests/UI/Component/Input/Field/PasswordInputTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,7 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+declare(strict_types=1);
 
 require_once(__DIR__ . "/../../../../../libs/composer/vendor/autoload.php");
 require_once(__DIR__ . "/../../../Base.php");
@@ -90,12 +89,12 @@ class PasswordInputTest extends ILIAS_UI_TestBase
         $r = $this->getDefaultRenderer();
         $expected = '
             <div class="form-group row">
-                <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">'.$label.'</label>
+                <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div class="il-input-password" id="id_1_container">
-                        <input id="id_1" type="password" name="'.$name.'" class="form-control form-control-sm" />
+                        <input id="id_1" type="password" name="' . $name . '" class="form-control form-control-sm" autocomplete="off" />
                     </div>
-                    <div class="help-block">'.$byline.'</div>
+                    <div class="help-block">' . $byline . '</div>
                 </div>
             </div>';
         $this->assertHTMLEquals($expected, $r->render($pwd));
@@ -116,7 +115,7 @@ class PasswordInputTest extends ILIAS_UI_TestBase
    <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
    <div class="col-sm-8 col-md-9 col-lg-10">
       <div class="help-block alert alert-danger" aria-describedby="id_1" role="alert">an_error</div>
-      <div class="il-input-password" id="id_1_container"><input id="id_1" type="password" name="name_0" class="form-control form-control-sm" /></div>
+      <div class="il-input-password" id="id_1_container"><input id="id_1" type="password" name="name_0" class="form-control form-control-sm" autocomplete="off" /></div>
       <div class="help-block">byline</div>
    </div>
 </div>');
@@ -134,10 +133,10 @@ class PasswordInputTest extends ILIAS_UI_TestBase
         $r = $this->getDefaultRenderer();
         $expected = '
             <div class="form-group row">
-                <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">'.$label.'</label>
+                <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div class="il-input-password" id="id_1_container">
-                        <input id="id_1" type="password" name="'.$name.'" class="form-control form-control-sm" />
+                        <input id="id_1" type="password" name="' . $name . '" class="form-control form-control-sm" autocomplete="off" />
                     </div>
                 </div>
             </div>';
@@ -155,10 +154,10 @@ class PasswordInputTest extends ILIAS_UI_TestBase
         $r = $this->getDefaultRenderer();
         $expected = '
             <div class="form-group row">
-                <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">'.$label.'</label>
+                <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div class="il-input-password" id="id_1_container">
-                        <input id="id_1" type="password" name="'.$name.'" value="'.$value.'" class="form-control form-control-sm" />
+                        <input id="id_1" type="password" name="' . $name . '" value="' . $value . '" class="form-control form-control-sm" autocomplete="off" />
                     </div>
                 </div>
             </div>';
@@ -177,10 +176,10 @@ class PasswordInputTest extends ILIAS_UI_TestBase
 
         $expected = '
         <div class="form-group row">
-            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">'.$label.'<span class="asterisk">*</span></label>
+            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '<span class="asterisk">*</span></label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <div class="il-input-password" id="id_1_container">
-                    <input id="id_1" type="password" name="'.$name.'" class="form-control form-control-sm" />
+                    <input id="id_1" type="password" name="' . $name . '" class="form-control form-control-sm" autocomplete="off" />
                 </div>
             </div>
         </div>';
@@ -199,10 +198,10 @@ class PasswordInputTest extends ILIAS_UI_TestBase
 
         $expected = '
         <div class="form-group row">
-            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">'.$label.'</label>
+            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <div class="il-input-password" id="id_1_container">
-                    <input id="id_1" type="password" name="'.$name.'" disabled="disabled" class="form-control form-control-sm" />
+                    <input id="id_1" type="password" name="' . $name . '" disabled="disabled" class="form-control form-control-sm" autocomplete="off" />
                 </div>
             </div>
         </div>';


### PR DESCRIPTION
As a result of a penetration test for one of our customers, it was critized that the ILIAS password fields are not setting the attribute `autocomplete="off"`. This attribute is meant to tell the browser to not show any (locally stored) autocompletion options when entering data, to avoid the security risk e.g. for computers in a shared environment.

From our research, this attribute is currently **ignored** by a lot of modern browsers, especially when they offer some sort of internal password manager for their users. There is discussion if the use of a password manager rectifies doing this, but it seems to be a common usage today.

Nevertheless, we think it won't hurt to have this attribute in our password input fields, if not only to send a signal to any browser displaying the site. And as an added bonus, we might satisfy at least one point of future penetration tests =)

This PR enables the autocomplete attribute for the main login form and adds it to the UI password input. If you know any other places where this should be added, please let me know and I'll gladly add them to the PR.