### PR TITLE
Fix unable to save Dashboard Settings

### DIFF
--- a/Services/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php
+++ b/Services/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php
@@ -187,8 +187,8 @@ class ilObjDashboardSettingsGUI extends ilObjectGUI
         $form = $this->initForm();
         $form = $form->withRequest($request);
         $form_data = $form->getData();
-        $this->viewSettings->enableSelectedItems((int) ($form_data['main_panel']['enable_favourites'] != ""));
-        $this->viewSettings->enableMemberships((int) ($form_data['main_panel']['enable_memberships'] != ""));
+        $this->viewSettings->enableSelectedItems($form_data['main_panel']['enable_favourites'] != "");
+        $this->viewSettings->enableMemberships($form_data['main_panel']['enable_memberships'] != "");
 
         foreach ($side_panel->getValidModules() as $mod) {
             $side_panel->enable($mod, (bool) $form_data['side_panel']['enable_' . $mod]);


### PR DESCRIPTION
Hello,

I hope this message finds you well. Yesterday, I set up a fresh ILIAS environment based on the release_8 branch. During the configuration process inside the administration ui, I encountered an issue when attempting to modify the dashboard behavior.

Here is the error log:

```log
TypeError thrown with message "ilPDSelectedItemsBlockViewSettings::enableSelectedItems(): Argument #1 ($status) must be of type bool, int given, called in /app/ilias/Services/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php on line 190"

Stacktrace:
#7 TypeError in /app/ilias/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockViewSettings.php:281
#6 ilPDSelectedItemsBlockViewSettings:enableSelectedItems in /app/ilias/Services/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php:190
#5 ilObjDashboardSettingsGUI:saveSettings in /app/ilias/Services/Dashboard/Administration/classes/class.ilObjDashboardSettingsGUI.php:91
#4 ilObjDashboardSettingsGUI:executeCommand in /app/ilias/Services/UICore/classes/class.ilCtrl.php:199
#3 ilCtrl:forwardCommand in /app/ilias/Services/Administration/classes/class.ilAdministrationGUI.php:237
#2 ilAdministrationGUI:executeCommand in /app/ilias/Services/UICore/classes/class.ilCtrl.php:199
#1 ilCtrl:forwardCommand in /app/ilias/Services/UICore/classes/class.ilCtrl.php:174
#0 ilCtrl:callBaseClass in /app/ilias/ilias.php:24
```

I have also attached a screenshot highlighting the specific location where the error occurs.

![Bildschirmfoto vom 2023-07-14 10-24-32](https://github.com/ILIAS-eLearning/ILIAS/assets/21999844/925a6918-2584-42f3-b386-6f38de6367c9)
![Bildschirmfoto vom 2023-07-14 10-26-56](https://github.com/ILIAS-eLearning/ILIAS/assets/21999844/62616417-f574-41a1-887c-01bd8c063293)

This pull request addresses the issue and resolves the problem with the incorrect type cast.

Thank you for considering my contribution.

Best regards,
Thomas