### PR TITLE
0037633: T&A Administration Crash when "Activate Manual Scoring for" all questions are deactivated

### DIFF
--- a/Modules/Test/classes/class.ilObjAssessmentFolderGUI.php
+++ b/Modules/Test/classes/class.ilObjAssessmentFolderGUI.php
@@ -289,7 +289,7 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
 
         $this->getAssessmentFolder()->setSkillTriggeringNumAnswersBarrier((int) $_POST['num_req_answers']);
         $this->getAssessmentFolder()->setExportEssayQuestionsWithHtml((bool) $_POST["export_essay_qst_with_html"]);
-        $this->getAssessmentFolder()->_setManualScoring($_POST["chb_manual_scoring"]);
+        $this->getAssessmentFolder()->_setManualScoring($_POST["chb_manual_scoring"] ?? []);
         $questiontypes = ilObjQuestionPool::_getQuestionTypes(true);
         $forbidden_types = [];
         foreach ($questiontypes as $name => $row) {

--- a/Modules/Test/classes/class.ilObjAssessmentFolderGUI.php
+++ b/Modules/Test/classes/class.ilObjAssessmentFolderGUI.php
@@ -288,27 +288,25 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         }
 
         $this->getAssessmentFolder()->setSkillTriggeringNumAnswersBarrier((int) $_POST['num_req_answers']);
-        $this->getAssessmentFolder()->setExportEssayQuestionsWithHtml((bool) $_POST["export_essay_qst_with_html"]);
+        $this->getAssessmentFolder()->setExportEssayQuestionsWithHtml((bool) ($_POST["export_essay_qst_with_html"] ?? '0'));
         $this->getAssessmentFolder()->_setManualScoring($_POST["chb_manual_scoring"] ?? []);
-        $questiontypes = ilObjQuestionPool::_getQuestionTypes(true);
+        $question_types = ilObjQuestionPool::_getQuestionTypes(true);
         $forbidden_types = [];
-        foreach ($questiontypes as $name => $row) {
-            if (!in_array($row["question_type_id"], $_POST["chb_allowed_questiontypes"])) {
+        foreach ($question_types as $name => $row) {
+            if (!isset($_POST["chb_allowed_questiontypes"]) || !in_array($row["question_type_id"], $_POST["chb_allowed_questiontypes"])) {
                 $forbidden_types[] = (int) $row["question_type_id"];
             }
         }
         $this->getAssessmentFolder()->_setForbiddenQuestionTypes($forbidden_types);
-
-        $this->getAssessmentFolder()->setScoringAdjustmentEnabled((bool) $_POST['chb_scoring_adjust']);
+        $this->getAssessmentFolder()->setScoringAdjustmentEnabled((bool) ($_POST['chb_scoring_adjust'] ?? '0'));
         $scoring_types = [];
-        foreach ($questiontypes as $name => $row) {
-            if (in_array($row["question_type_id"], (array) $_POST["chb_scoring_adjustment"])) {
+        foreach ($question_types as $name => $row) {
+            if (isset($_POST["chb_scoring_adjustment"]) && in_array($row["question_type_id"], $_POST["chb_scoring_adjustment"])) {
                 $scoring_types[] = $row["question_type_id"];
             }
         }
         $this->getAssessmentFolder()->setScoringAdjustableQuestions($scoring_types);
-
-        if (!$_POST['ass_process_lock']) {
+        if (!isset($_POST['ass_process_lock'])) {
             $this->getAssessmentFolder()->setAssessmentProcessLockMode(ilObjAssessmentFolder::ASS_PROC_LOCK_MODE_NONE);
         } elseif (in_array(
             $_POST['ass_process_lock_mode'],


### PR DESCRIPTION
Ticket:
https://mantis.ilias.de/view.php?id=37633

Sympthom:
When setting a lot of inputs empty there have been errors

Problem:
unset post variables

Solution:
Add checks for the post variables and null coalescing
 
Tested:
8

Code compatible with:
ILIAS 8, Trunk