### PR TITLE
T&A 0037632: T&A Administration Crash when all "Available Question Types" are deactivated

### DIFF
--- a/Modules/Test/classes/class.ilObjAssessmentFolderGUI.php
+++ b/Modules/Test/classes/class.ilObjAssessmentFolderGUI.php
@@ -292,8 +292,10 @@ class ilObjAssessmentFolderGUI extends ilObjectGUI
         $this->getAssessmentFolder()->_setManualScoring($_POST["chb_manual_scoring"]);
         $questiontypes = ilObjQuestionPool::_getQuestionTypes(true);
         $forbidden_types = [];
+
+
         foreach ($questiontypes as $name => $row) {
-            if (!in_array($row["question_type_id"], $_POST["chb_allowed_questiontypes"])) {
+            if (is_null($_POST["chb_allowed_questiontypes"]) || !in_array($row["question_type_id"], $_POST["chb_allowed_questiontypes"])) {
                 $forbidden_types[] = (int) $row["question_type_id"];
             }
         }


### PR DESCRIPTION
Ticket:
https://mantis.ilias.de/view.php?id=37632

Symptom:
Deactivation of all question types leads to a null error.

Solution:
add null check

broken on
7, 8, Trunk

Tested:
7, 8 

Code compatible with:
ILIAS 7, 8, Trunk