### PR TITLE
UI Components: Refactor/Extend Toast Interfaces

### DIFF
--- a/src/UI/Component/Toast/Container.php
+++ b/src/UI/Component/Toast/Container.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,14 +16,12 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Component\Toast;
 
 use ILIAS\UI\Component\Component;
 
-/**
- * Interface Container
- * @package ILIAS\UI\Component\Toast
- */
 interface Container extends Component
 {
     /**

--- a/src/UI/Component/Toast/Factory.php
+++ b/src/UI/Component/Toast/Factory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,13 +16,12 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Component\Toast;
 
 use ILIAS\UI\Component\Symbol\Icon\Icon;
 
-/**
- * This is how a factory for Toast looks like.
- */
 interface Factory
 {
     /**

--- a/src/UI/Component/Toast/Toast.php
+++ b/src/UI/Component/Toast/Toast.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Component\Toast;
 
 use ILIAS\UI\Component\Button\Shy;
@@ -28,10 +28,6 @@ use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Component\Symbol\Icon\Icon;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 
-/**
- * Interface Toast
- * @package ILIAS\UI\Component\Toast
- */
 interface Toast extends Component, JavaScriptBindable
 {
     /**
@@ -43,6 +39,10 @@ interface Toast extends Component, JavaScriptBindable
 
     public function getDescription(): string;
 
+    /**
+     * Create a copy of this toast with a link, which is shown in the toasts content.
+     * A toast can have multiple links.
+     */
     public function withAdditionalLink(Link $link): Toast;
 
     public function withoutLinks(): Toast;
@@ -70,4 +70,20 @@ interface Toast extends Component, JavaScriptBindable
      * Get the signal to show this toast in the frontend
      */
     public function getShowSignal(): Signal;
+
+    /**
+     * Create a copy of this toast with a vanish time in seconds.
+     * The vanish time defines the time after which the toast vanishes.
+     */
+    public function withVanishTime(int $vanishTime): Toast;
+
+    public function getVanishTime(): int;
+
+    /**
+     * Create a copy of this toast with a delay time in miliseconds.
+     * The delay time defines the time when the toast is shown after a page refresh or an asyncronous update.
+     */
+    public function withDelayTime(int $delayTime): Toast;
+
+    public function getDelayTime(): int;
 }


### PR DESCRIPTION
This PR involves a proposal to extend the toast UI Component by 2 functionalities:
- vanish Timing
- delay Timing

This where already implemented within the dynamic implemetation process of the toast feature request which included the origin toast UI component (https://github.com/ILIAS-eLearning/ILIAS/pull/3411), but where never added to the interface itsself and are therefore not used within the actual presentation through the GS (https://github.com/ILIAS-eLearning/ILIAS/commit/5570810c79015b87000e36a5310c5411d5466a7d).

To keep a clean workflow this PR should preceed the establishment of any usage of the future within the GS.