### PR TITLE
Enable customized timing of toast inside the GS

### DIFF
--- a/src/GlobalScreen/Scope/Toast/Collector/Renderer/StandardToastRenderer.php
+++ b/src/GlobalScreen/Scope/Toast/Collector/Renderer/StandardToastRenderer.php
@@ -127,13 +127,12 @@ class StandardToastRenderer implements ToastRenderer
             $toast = $toast->withAdditionalLink($link);
         }
 
-        // Times (currently disbaled since these methods are not on the Interface of a Toast
         if ($item->getVanishTime() !== null) {
-            // $toast = $toast->withVanishTime($item->getVanishTime());
+            $toast = $toast->withVanishTime($item->getVanishTime());
         }
 
         if ($item->getDelayTime() !== null) {
-            // $toast = $toast->withDelayTime($item->getDelayTime());
+            $toast = $toast->withDelayTime($item->getDelayTime());
         }
 
         return $toast;


### PR DESCRIPTION
**DEPENDS ON https://github.com/ILIAS-eLearning/ILIAS/pull/6164**

This PR enables the toast integrated timing, which was already established but not activated due to missing interface definitions (See https://github.com/ILIAS-eLearning/ILIAS/commit/5570810c79015b87000e36a5310c5411d5466a7d).