### PR TITLE
Bugfix: 0037009: Threads-Tab wird nicht als aktiv angezeigt, wenn man…

### DIFF
--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -1342,6 +1342,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
         $active = [
             '',
             'showThreads',
+            'sortThreads',
             'view',
             'markAllRead',
             'enableForumNotification',


### PR DESCRIPTION
Bugfix: 0037009: "Threads"-Tab wird nicht als aktiv angezeigt, wenn man im Subtab "Sticky Threads Sorting" ist.

https://mantis.ilias.de/view.php?id=37009


