### PR TITLE
Remove unused code with potentially high impact on performance (ILIAS 9)

### DIFF
--- a/Services/Membership/classes/class.ilParticipantTableGUI.php
+++ b/Services/Membership/classes/class.ilParticipantTableGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\UI\Implementation\Factory as UIImplementationFactory;
 use ILIAS\UI\Renderer as UIRenderer;

--- a/Services/Membership/classes/class.ilParticipantTableGUI.php
+++ b/Services/Membership/classes/class.ilParticipantTableGUI.php
@@ -82,10 +82,6 @@ abstract class ilParticipantTableGUI extends ilTable2GUI
         }
 
         if ($this->isColumnSelected('org_units')) {
-            $root = ilObjOrgUnit::getRootOrgRefId();
-            $tree = ilObjOrgUnitTree::_getInstance();
-            $nodes = $tree->getAllChildren($root);
-
             $paths = ilOrgUnitPathStorage::getTextRepresentationOfOrgUnits();
 
             $options[0] = $this->lng->txt('select_one');


### PR DESCRIPTION
The variable `$nodes` is never used in the code. Because the method `ilObjOrgUnitTree::getAllChildren` can potentially lead to performance issues, the unused should be better removed.