### PR TITLE
Remove unused code with potentially high impact on performance (ILIAS 7)

### DIFF
--- a/Services/Membership/classes/class.ilParticipantsTableGUI.php
+++ b/Services/Membership/classes/class.ilParticipantsTableGUI.php
@@ -55,12 +55,6 @@ abstract class ilParticipantTableGUI extends ilTable2GUI
         }
         
         if ($this->isColumnSelected('org_units')) {
-            include_once './Modules/OrgUnit/classes/class.ilObjOrgUnit.php';
-            $root = ilObjOrgUnit::getRootOrgRefId();
-            include_once './Modules/OrgUnit/classes/class.ilObjOrgUnitTree.php';
-            $tree = ilObjOrgUnitTree::_getInstance();
-            $nodes = $tree->getAllChildren($root);
-            
             include_once './Modules/OrgUnit/classes/PathStorage/class.ilOrgUnitPathStorage.php';
             $paths = ilOrgUnitPathStorage::getTextRepresentationOfOrgUnits();
             


### PR DESCRIPTION
The variable `$nodes` is never used in the code. Because the method `ilObjOrgUnitTree::getAllChildren` can potentially lead to performance issues, the unused should be better removed.