### PR TITLE
Fixed type hint of assignment type

### DIFF
--- a/Modules/Exercise/Assignment/class.ilExAssignment.php
+++ b/Modules/Exercise/Assignment/class.ilExAssignment.php
@@ -1067,7 +1067,7 @@ class ilExAssignment
         return self::lookup($a_id, "title");
     }
 
-    public static function lookupType(int $a_id): string
+    public static function lookupType(int $a_id): int
     {
         return self::lookup($a_id, "type");
     }


### PR DESCRIPTION
_There is no Mantis ticket since this issue doesnt cause anything rn.
But i will do when a strict type is enforced on the file._

The Type of assignments is, in contrast to object types like `crs` or `grp`, no string but a number specified in constants and is required as such by other components.