### PR TITLE
Certificate: Fix FO to XHTML transformation if `font-size` is used

### DIFF
--- a/Services/Certificate/xml/fo2xhtml.xsl
+++ b/Services/Certificate/xml/fo2xhtml.xsl
@@ -116,6 +116,7 @@
 						<xsl:if test="@font-size">
 							<xsl:text>font-size: </xsl:text>
 							<xsl:value-of select="@font-size"/>
+							<xsl:text>; </xsl:text>
 						</xsl:if>
 						<xsl:if test="@padding">
 							<xsl:text>padding: </xsl:text>


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=37681