### PR TITLE
Trunk: T&A - Fix int value used as parameter in ilRadioOption obj creation

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1648,15 +1648,15 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         // use pool
         $usage = new ilRadioGroupInputGUI($this->lng->txt("assessment_pool_selection"), "usage");
         $usage->setRequired(true);
-        $no_pool = new ilRadioOption($this->lng->txt("assessment_no_pool"), 1);
+        $no_pool = new ilRadioOption($this->lng->txt("assessment_no_pool"), "1");
         $usage->addOption($no_pool);
-        $existing_pool = new ilRadioOption($this->lng->txt("assessment_existing_pool"), 3);
+        $existing_pool = new ilRadioOption($this->lng->txt("assessment_existing_pool"), "3");
         $usage->addOption($existing_pool);
-        $new_pool = new ilRadioOption($this->lng->txt("assessment_new_pool"), 2);
+        $new_pool = new ilRadioOption($this->lng->txt("assessment_new_pool"), "2");
         $usage->addOption($new_pool);
         $form->addItem($usage);
 
-        $usage->setValue(1);
+        $usage->setValue("1");
 
         $questionpools = ilObjQuestionPool::_getAvailableQuestionpools(false, false, true, false, false, "write");
         $pools_data = array();
@@ -1999,15 +1999,15 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         // use pool
         $usage = new ilRadioGroupInputGUI($this->lng->txt("assessment_pool_selection"), "usage");
         $usage->setRequired(true);
-        $no_pool = new ilRadioOption($this->lng->txt("assessment_no_pool"), 1);
+        $no_pool = new ilRadioOption($this->lng->txt("assessment_no_pool"), "1");
         $usage->addOption($no_pool);
-        $existing_pool = new ilRadioOption($this->lng->txt("assessment_existing_pool"), 3);
+        $existing_pool = new ilRadioOption($this->lng->txt("assessment_existing_pool"), "3");
         $usage->addOption($existing_pool);
-        $new_pool = new ilRadioOption($this->lng->txt("assessment_new_pool"), 2);
+        $new_pool = new ilRadioOption($this->lng->txt("assessment_new_pool"), "2");
         $usage->addOption($new_pool);
         $form->addItem($usage);
 
-        $usage->setValue(1);
+        $usage->setValue("1");
 
         $questionpools = ilObjQuestionPool::_getAvailableQuestionpools(false, false, true, false, false, "write");
         $pools_data = array();

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1648,15 +1648,15 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         // use pool
         $usage = new ilRadioGroupInputGUI($this->lng->txt("assessment_pool_selection"), "usage");
         $usage->setRequired(true);
-        $no_pool = new ilRadioOption($this->lng->txt("assessment_no_pool"), "1");
+        $no_pool = new ilRadioOption($this->lng->txt("assessment_no_pool"), '1');
         $usage->addOption($no_pool);
-        $existing_pool = new ilRadioOption($this->lng->txt("assessment_existing_pool"), "3");
+        $existing_pool = new ilRadioOption($this->lng->txt("assessment_existing_pool"), '3');
         $usage->addOption($existing_pool);
-        $new_pool = new ilRadioOption($this->lng->txt("assessment_new_pool"), "2");
+        $new_pool = new ilRadioOption($this->lng->txt("assessment_new_pool"), '2');
         $usage->addOption($new_pool);
         $form->addItem($usage);
 
-        $usage->setValue("1");
+        $usage->setValue('1');
 
         $questionpools = ilObjQuestionPool::_getAvailableQuestionpools(false, false, true, false, false, "write");
         $pools_data = array();
@@ -1999,15 +1999,15 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         // use pool
         $usage = new ilRadioGroupInputGUI($this->lng->txt("assessment_pool_selection"), "usage");
         $usage->setRequired(true);
-        $no_pool = new ilRadioOption($this->lng->txt("assessment_no_pool"), "1");
+        $no_pool = new ilRadioOption($this->lng->txt("assessment_no_pool"), '1');
         $usage->addOption($no_pool);
-        $existing_pool = new ilRadioOption($this->lng->txt("assessment_existing_pool"), "3");
+        $existing_pool = new ilRadioOption($this->lng->txt("assessment_existing_pool"), '3');
         $usage->addOption($existing_pool);
-        $new_pool = new ilRadioOption($this->lng->txt("assessment_new_pool"), "2");
+        $new_pool = new ilRadioOption($this->lng->txt("assessment_new_pool"), '2');
         $usage->addOption($new_pool);
         $form->addItem($usage);
 
-        $usage->setValue("1");
+        $usage->setValue('1');
 
         $questionpools = ilObjQuestionPool::_getAvailableQuestionpools(false, false, true, false, false, "write");
         $pools_data = array();


### PR DESCRIPTION
Fixes problem causing a crash when trying to access the **Create question** view in a Test


- ilRadioOption only takes a string **value** parameter. `declare(strict_types=1)` added to this class in the past (31.03.2023) makes this fail then.

There are a lot of those wrong value parameters for ilRadioOption in ILIAS,  
most/all of which are in classes that don't yet have `declare(strict_types=1)` enabled.

If desired I can fix those too.

I stumbled over this error specifically while working on implementing:

https://docu.ilias.de/goto_docu_wiki_wpage_7423_1357.html