### PR TITLE
Trunk: remove limit number of concurrent participants

### DIFF
--- a/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
+++ b/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
@@ -578,10 +578,7 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
             ->withEndTime($section['access_window']['end_time'])
             ->withPasswordEnabled($section['test_password']['password_enabled'])
             ->withPassword($section['test_password']['password_value'])
-            ->withFixedParticipants($section['fixed_participants_enabled'])
-            ->withLimitedUsersEnabled($section['limit_simultaneous_users']['limit_simultaneous_users'])
-            ->withLimitedUsersAmount($section['limit_simultaneous_users']['max_allowed_simultaneous_users'])
-            ->withLimitedUsersTimeGap($section['limit_simultaneous_users']['allowed_simultaneous_users_time_gap']);
+            ->withFixedParticipants($section['fixed_participants_enabled']);
 
         if ($this->test_object->participantDataExist()) {
             return $access_settings;

--- a/Modules/Test/classes/MainSettings/ilObjTestMainSettingsDatabaseRepository.php
+++ b/Modules/Test/classes/MainSettings/ilObjTestMainSettingsDatabaseRepository.php
@@ -60,9 +60,6 @@ class ilObjTestMainSettingsDatabaseRepository implements MainSettingsRepository
             . 'password_enabled,' . PHP_EOL
             . 'password,' . PHP_EOL
             . 'fixed_participants,' . PHP_EOL
-            . 'limit_users_enabled,' . PHP_EOL
-            . 'allowedusers,' . PHP_EOL
-            . 'alloweduserstimegap,' . PHP_EOL
             . 'nr_of_tries,' . PHP_EOL
             . 'block_after_passed,' . PHP_EOL
             . 'pass_waiting,' . PHP_EOL
@@ -138,9 +135,6 @@ class ilObjTestMainSettingsDatabaseRepository implements MainSettingsRepository
                 (bool) $row['password_enabled'],
                 $row['password'],
                 (bool) $row['fixed_participants'],
-                (bool) $row['limit_users_enabled'],
-                $row['allowedusers'],
-                $row['alloweduserstimegap']
             ),
             new ilObjTestSettingsTestBehaviour(
                 $test_id,

--- a/Modules/Test/classes/MainSettings/ilObjTestSettingsAccess.php
+++ b/Modules/Test/classes/MainSettings/ilObjTestSettingsAccess.php
@@ -38,9 +38,6 @@ class ilObjTestSettingsAccess extends TestSettings
         protected bool $password_enabled = false,
         protected ?string $password = null,
         protected bool $fixed_participants = false,
-        protected bool $limited_users_enabled = false,
-        protected ?int $limited_users_amount = null,
-        protected ?int $limited_users_time_gap = null
     ) {
         parent::__construct($test_id);
     }
@@ -62,12 +59,6 @@ class ilObjTestSettingsAccess extends TestSettings
             $inputs['fixed_participants_enabled'] = $inputs['fixed_participants_enabled']
                 ->withDisabled(true);
         }
-
-        $inputs['limit_simultaneous_users'] = $this->getLimitSimultaneousUsersInput(
-            $lng,
-            $f,
-            $refinery
-        );
 
         return $f->section($inputs, $lng->txt('tst_settings_header_execution'));
     }
@@ -184,70 +175,6 @@ class ilObjTestSettingsAccess extends TestSettings
         );
     }
 
-    private function getLimitSimultaneousUsersInput(
-        \ilLanguage $lng,
-        FieldFactory $f,
-        Refinery $refinery
-    ): OptionalGroup {
-        $limit_simultaneous_users = $f->optionalGroup(
-            $this->getSubInputsSimultaneousLogins($lng, $f, $refinery),
-            $lng->txt('tst_allowed_users'),
-            $lng->txt('tst_allowed_users_desc')
-        )->withValue(null)
-            ->withAdditionalTransformation($this->getTrafoSimultaneousLogins($refinery));
-
-        if (!$this->getLimitedUsersEnabled()) {
-            return $limit_simultaneous_users;
-        }
-
-        return $limit_simultaneous_users->withValue(
-            [
-                'max_allowed_simultaneous_users' => $this->getLimitedUsersAmount() ?? 0,
-                'allowed_simultaneous_users_time_gap' => $this->getLimitedUsersTimeGap()
-            ]
-        );
-    }
-
-    private function getSubInputsSimultaneousLogins(
-        \ilLanguage $lng,
-        FieldFactory $f,
-        Refinery $refinery
-    ): array {
-        $sub_inputs_simultaneous['max_allowed_simultaneous_users'] = $f->numeric(
-            $lng->txt('tst_allowed_users_max')
-        )->withRequired(true)
-            ->withAdditionalTransformation($refinery->int()->isGreaterThan(0));
-
-        $sub_inputs_simultaneous['allowed_simultaneous_users_time_gap'] = $f->numeric(
-            $lng->txt('tst_allowed_users_time_gap'),
-            $lng->txt('tst_allowed_users_time_gap_desc')
-        )->withAdditionalTransformation($refinery->int()->isGreaterThanOrEqual(0));
-
-        return $sub_inputs_simultaneous;
-    }
-
-    private function getTrafoSimultaneousLogins(
-        Refinery $refinery
-    ): TransformationInterface {
-        return $refinery->custom()->transformation(
-            static function (?array $vs): array {
-                if ($vs === null) {
-                    return [
-                        'limit_simultaneous_users' => false,
-                        'max_allowed_simultaneous_users' => 0,
-                        'allowed_simultaneous_users_time_gap' => 0
-                    ];
-                }
-
-                return [
-                        'limit_simultaneous_users' => true,
-                        'max_allowed_simultaneous_users' => $vs['max_allowed_simultaneous_users'],
-                        'allowed_simultaneous_users_time_gap' => $vs['allowed_simultaneous_users_time_gap']
-                    ];
-            }
-        );
-    }
-
     public function toStorage(): array
     {
         return [
@@ -257,10 +184,7 @@ class ilObjTestSettingsAccess extends TestSettings
             'ending_time' => ['integer', $this->getEndTime() !== null ? $this->getEndTime()->getTimestamp() : 0],
             'password_enabled' => ['integer', (int) $this->getPasswordEnabled()],
             'password' => ['text', $this->getPassword()],
-            'fixed_participants' => ['integer', (int) $this->getFixedParticipants()],
-            'limit_users_enabled' => ['integer', (int) $this->getLimitedUsersEnabled()],
-            'allowedusers' => ['integer', $this->getLimitedUsersAmount()],
-            'alloweduserstimegap' => ['integer', $this->getLimitedUsersTimeGap()]
+            'fixed_participants' => ['integer', (int) $this->getFixedParticipants()]
         ];
     }
 
@@ -338,39 +262,6 @@ class ilObjTestSettingsAccess extends TestSettings
     {
         $clone = clone $this;
         $clone->fixed_participants = $fixed_participants;
-        return $clone;
-    }
-
-    public function getLimitedUsersEnabled(): bool
-    {
-        return $this->limited_users_enabled;
-    }
-    public function withLimitedUsersEnabled(bool $limited_users_enabled): self
-    {
-        $clone = clone $this;
-        $clone->limited_users_enabled = $limited_users_enabled;
-        return $clone;
-    }
-
-    public function getLimitedUsersAmount(): ?int
-    {
-        return $this->limited_users_amount;
-    }
-    public function withLimitedUsersAmount(?int $limited_users_amount): self
-    {
-        $clone = clone $this;
-        $clone->limited_users_amount = $limited_users_amount;
-        return $clone;
-    }
-
-    public function getLimitedUsersTimeGap(): ?int
-    {
-        return $this->limited_users_time_gap;
-    }
-    public function withLimitedUsersTimeGap(?int $limited_users_time_gap): self
-    {
-        $clone = clone $this;
-        $clone->limited_users_time_gap = $limited_users_time_gap;
         return $clone;
     }
 }

--- a/Modules/Test/classes/Setup/class.ilTest9DBUpdateSteps.php
+++ b/Modules/Test/classes/Setup/class.ilTest9DBUpdateSteps.php
@@ -139,5 +139,9 @@ class ilTest9DBUpdateSteps implements ilDatabaseUpdateSteps
         if ($this->db->tableColumnExists("tst_tests", "alloweduserstimegap")) {
             $this->db->dropTableColumn("tst_tests", "alloweduserstimegap");
         }
+
+        if ($this->db->tableColumnExists("tst_tests", "limit_users_enabled")) {
+            $this->db->dropTableColumn("tst_tests", "limit_users_enabled");
+        }
     }
 }

--- a/Modules/Test/classes/Setup/class.ilTest9DBUpdateSteps.php
+++ b/Modules/Test/classes/Setup/class.ilTest9DBUpdateSteps.php
@@ -129,4 +129,15 @@ class ilTest9DBUpdateSteps implements ilDatabaseUpdateSteps
             );
         }
     }
+
+    public function step_6(): void
+    {
+        if ($this->db->tableColumnExists("tst_tests", "allowedusers")) {
+            $this->db->dropTableColumn("tst_tests", "allowedusers");
+        }
+
+        if ($this->db->tableColumnExists("tst_tests", "alloweduserstimegap")) {
+            $this->db->dropTableColumn("tst_tests", "alloweduserstimegap");
+        }
+    }
 }

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -2700,9 +2700,6 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         if ($this->object->getEnableProcessingTime()) {
             $info->addProperty($this->lng->txt("tst_processing_time"), $this->object->getProcessingTime());
         }
-        if ($this->object->getAllowedUsers() > 0 && ($this->object->getAllowedUsersTimeGap())) {
-            $info->addProperty($this->lng->txt("tst_allowed_users"), $this->object->getAllowedUsers());
-        }
 
         $starting_time = $this->object->getStartingTime();
         if ($this->object->isStartingTimeEnabled() && $starting_time !== 0) {

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -497,11 +497,6 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
      */
     protected function initTestCmd()
     {
-        if ($this->object->checkMaximumAllowedUsers() == false) {
-            $this->showMaximumAllowedUsersReachedMessage();
-            return;
-        }
-
         if ($this->testSession->isAnonymousUser()
             && !$this->testSession->doesAccessCodeInSessionExists()) {
             $accessCode = $this->testSession->createNewAccessCode();
@@ -1531,18 +1526,6 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
     public function outObligationsOnlySummaryCmd()
     {
         $this->outQuestionSummaryCmd(true, true, true, true);
-    }
-
-    public function showMaximumAllowedUsersReachedMessage()
-    {
-        $this->tpl->addBlockFile($this->getContentBlockName(), "adm_content", "tpl.il_as_tst_max_allowed_users_reached.html", "Modules/Test");
-        $this->tpl->setCurrentBlock("adm_content");
-        $this->tpl->setVariable("MAX_ALLOWED_USERS_MESSAGE", sprintf($this->lng->txt("tst_max_allowed_users_message"), $this->object->getAllowedUsersTimeGap()));
-        $this->tpl->setVariable("MAX_ALLOWED_USERS_HEADING", sprintf($this->lng->txt("tst_max_allowed_users_heading"), $this->object->getAllowedUsersTimeGap()));
-        $this->tpl->setVariable("CMD_BACK_TO_INFOSCREEN", ilTestPlayerCommands::BACK_TO_INFO_SCREEN);
-        $this->tpl->setVariable("TXT_BACK_TO_INFOSCREEN", $this->lng->txt("tst_results_back_introduction"));
-        $this->tpl->setVariable("FORMACTION", $this->ctrl->getFormAction($this));
-        $this->tpl->parseCurrentBlock();
     }
 
     public function backFromFinishingCmd()

--- a/Modules/Test/templates/default/tpl.il_as_tst_max_allowed_users_reached.html
+++ b/Modules/Test/templates/default/tpl.il_as_tst_max_allowed_users_reached.html
@@ -1,7 +1,0 @@
-<form name="formAllowedUsersReached" method="POST" action="{FORMACTION}">
-<h1>{MAX_ALLOWED_USERS_HEADING}</h1>
-<p>
-	{MAX_ALLOWED_USERS_MESSAGE}
-</p>
-<input type="submit" class="btn btn-default" name="cmd[{CMD_BACK_TO_INFOSCREEN}]" value="{TXT_BACK_TO_INFOSCREEN}" />
-</form>

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legend
 assessment#:#locked#:#locked
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached
 assessment#:#log_create_new_test#:#Created new test
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s
 assessment#:#log_mark_added#:#Mark added
@@ -1248,11 +1247,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#All user data of this test has been deleted!
-assessment#:#tst_allowed_users#:#Maximum Number of Users Running the Test Simultaneously
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Idle Time for Active Users
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Test has already been finish and submitted.
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonymity
@@ -1494,8 +1488,6 @@ assessment#:#tst_mark_minimum_level#:#Minimum Level (in %)
 assessment#:#tst_mark_official_form#:#Official Form
 assessment#:#tst_mark_passed#:#Passed
 assessment#:#tst_mark_short_form#:#Short Form
-assessment#:#tst_max_allowed_users_heading#:#The maximum number of simultaneous users in this test has been reached
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Maximum Points
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -821,7 +821,6 @@ assessment#:#legend#:#Легенда
 assessment#:#locked#:#заключено
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s###12 11 2006 new variable
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached###25 02 2007 new variable
 assessment#:#log_create_new_test#:#Създаване на нов тест
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s###24 02 2009 new variable
 assessment#:#log_mark_added#:#Оценката добавена
@@ -1245,11 +1244,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Всички потребителски данни за този тест бяха изтрити!
-assessment#:#tst_allowed_users#:#Maximum Number of Users Running the Test Simultaneously###25 02 2007 new variable
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Idle Time for Active Users###25 02 2007 new variable
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Test has already been finish and submitted.###06 09 2006 new variable
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonymity###25 02 2007 new variable
@@ -1491,8 +1485,6 @@ assessment#:#tst_mark_minimum_level#:#Минимално ниво (в %)
 assessment#:#tst_mark_official_form#:#Официална форма
 assessment#:#tst_mark_passed#:#Издържан
 assessment#:#tst_mark_short_form#:#Кратка форма
-assessment#:#tst_max_allowed_users_heading#:#The maximum number of simultaneous users in this test has been reached###25 02 2007 new variable
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.###25 02 2007 new variable
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Максимални точки
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Vysvětlivka
 assessment#:#locked#:#uzamčeno
 assessment#:#log_added_extratime#:#Přidáno dalších %d minut pro id účastníka %d
 assessment#:#log_answer_changed_points#:#Manuální změna bodů testované osoby %s z %d na %d bodů hodnotícím testu %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#Účastník nemůže vstoupit do testu, protože byl dosažen maximální počet simultánních účastníků.
 assessment#:#log_create_new_test#:#Nový test vytvořen
 assessment#:#log_manual_feedback#:#%s přidán manuální ohlas pro testovanou osobu %s a otázku %s: %s
 assessment#:#log_mark_added#:#Známka přidána
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#Způsobilost ve všech testech
 assessment#:#tst_all_user_data_deleted#:#Všechna uživatelská data tohoto testu byly smazány!
-assessment#:#tst_allowed_users#:#Maximální počet uživatelů provádějících test současně
-assessment#:#tst_allowed_users_desc#:#Systém ILIAS bude sledovat počet účastníků, kteří současně skládají test. Pokud se o přístup snaží více uživatelů než maximálně povolený počet, systém ILIAS zabrání spuštění testu.
-assessment#:#tst_allowed_users_max#:#Max. Počet účastníků
-assessment#:#tst_allowed_users_time_gap#:#Čas pasivity pro aktivní uživatele
-assessment#:#tst_allowed_users_time_gap_desc#:#Účastníci, kteří do testu nekliknou za uvedený čas, budou zařazeni do kategorie „neaktivní“ a budou vyřazeni z testu.
 assessment#:#tst_already_submitted#:#Test byl již ukončen a odevzdán.
 assessment#:#tst_analysis#:#Analýza
 assessment#:#tst_anonymity#:#Anonymita
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#Minimální hladina (v %)
 assessment#:#tst_mark_official_form#:#Oficiální tvar
 assessment#:#tst_mark_passed#:#Prošel
 assessment#:#tst_mark_short_form#:#Zkrácený tvar
-assessment#:#tst_max_allowed_users_heading#:#Dosažen maximální počet simultánních účastníků v tomto testu
-assessment#:#tst_max_allowed_users_message#:#Maximální počet simultánních účastníků v tomto testu byl dosažen. Zkuste začít nebo pokračovat znovu později. Pokud bude některý z aktivních účastníků nenaktivní déle než %s s., můžete namísto něj do testu vstoupit. Děkujeme za pochopení.
 assessment#:#tst_max_comp_points#:#Max. Body způsobilosti
 assessment#:#tst_maximum_points#:#Maximum bodů
 assessment#:#tst_mc_label_none_above#:#Žádná z výše uvedených odpovědí

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legend###21 Apr 2005 new variable
 assessment#:#locked#:#låst
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###16 09 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s###12 11 2006 new variable
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached
 assessment#:#log_create_new_test#:#Ny test oprettet
 assessment#:#log_manual_feedback#:#%s tilføjede manuelt feedback til test person %s og spørgsmål %s: %s
 assessment#:#log_mark_added#:#Karakter tildelt
@@ -1248,11 +1247,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Alle brugerdata for denne test er blevet slettet!
-assessment#:#tst_allowed_users#:#Maksimalt antal simultane brugere på denne test.
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Idle time for active users
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Testen er allerede udført og indsendt.
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonymitet
@@ -1494,8 +1488,6 @@ assessment#:#tst_mark_minimum_level#:#Min. niveau (i %)
 assessment#:#tst_mark_official_form#:#Officiel form
 assessment#:#tst_mark_passed#:#Bestået
 assessment#:#tst_mark_short_form#:#Kort form
-assessment#:#tst_max_allowed_users_heading#:#The maximum number of simultaneous users in this test has been reached
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Maksimum point
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -830,7 +830,6 @@ assessment#:#legend#:#Legende
 assessment#:#locked#:#gesperrt
 assessment#:#log_added_extratime#:#Es wurden zusätzliche %d Minuten Bearbeitungsdauer für die Teilnehmer-ID %d hinzugefügt
 assessment#:#log_answer_changed_points#:#Manuelles Setzen der Punkte des Teilnehmers %s von %d auf %d Punkte durch %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#Der Teilnehmer konnte den Test nicht starten, da die maximale Anzahl der gleichzeitiger Teilnehmer für diesen Kurs bereits erreicht ist.
 assessment#:#log_create_new_test#:#Neuer Test erzeugt
 assessment#:#log_manual_feedback#:#%s hat eine manuelle Bewertung für den Teilnehmer %s und die Frage %s erstellt: %s
 assessment#:#log_mark_added#:#Note hinzugefügt
@@ -1260,11 +1259,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Erlaubt formatierten Text f
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#Sie haben den Test bestanden. Der Test kann nicht noch einmal gestartet werden.
 assessment#:#tst_all_test_competences#:#Alle Test-Kompetenzen
 assessment#:#tst_all_user_data_deleted#:#Die Daten aller Testteilnehmer wurden gelöscht!
-assessment#:#tst_allowed_users#:#Anzahl gleichzeitiger Teilnehmer begrenzen
-assessment#:#tst_allowed_users_desc#:#ILIAS prüft die Anzahl der gleichzeitigen Teilnehmer des Tests. Wenn über die maximal erlaubte Anzahl hinaus weitere Benutzer versuchen, den Test zu starten, werden sie am Zugriff gehindert.
-assessment#:#tst_allowed_users_max#:#Maximale Anzahl
-assessment#:#tst_allowed_users_time_gap#:#Inaktivitätszeit der Teilnehmer
-assessment#:#tst_allowed_users_time_gap_desc#:#Teilnehmer die im Ablauf der angegeben Sekunden keinen Klick im Test ausführen, werden als ‚inaktiv‘ eingestuft und aus dem Test entfernt.
 assessment#:#tst_already_submitted#:#Der Test wurde bereits beendet und die Antworten abgeschickt.
 assessment#:#tst_analysis#:#Analyse
 assessment#:#tst_anonymity#:#Datenschutz
@@ -1510,8 +1504,6 @@ assessment#:#tst_mark_minimum_level#:#Mindestprozentsatz
 assessment#:#tst_mark_official_form#:#Offizielle Bezeichnung
 assessment#:#tst_mark_passed#:#Bestanden
 assessment#:#tst_mark_short_form#:#Kurzbezeichnung
-assessment#:#tst_max_allowed_users_heading#:#Die maximale Anzahl von gleichzeitiger Teilnehmern für diesen Test wurde erreicht
-assessment#:#tst_max_allowed_users_message#:#Die maximale Anzahl gleichzeitiger Teilnehmer für diesen Test wurde erreicht. Bitte versuchen Sie etwas später wieder den Test zu starten oder fortzusetzen. Wenn aktive Teilnehmer für mehr als %s Sekunden inaktiv sind, besteht für Sie die Möglichkeit, an diesem Test teilzunehmen. Wir danken Ihnen für Ihr Verständnis.
 assessment#:#tst_max_comp_points#:#Max. Kompetenz-Punkte
 assessment#:#tst_maximum_points#:#Maximale Punktezahl
 assessment#:#tst_mc_label_none_above#:#Keine der obigen Antworten

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -823,7 +823,6 @@ assessment#:#legend#:#Υπόμνημα
 assessment#:#locked#:#κλειδωμένο
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Χειροκίνητη αλλαγή των βαθμών του τέστ του αξιολογούμενου %s απο %d σε %d points κατα %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#Ο χρήστης δεν μπόρεσε να μπει στο διαγώνισμα επειδή ήταν ήδη γεμάτο με το μέγιστο επιτρεπτό αριθμό ταυτόχρονων χρηστών
 assessment#:#log_create_new_test#:#Δημιουργήθηκε νέο τεστ
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s###30 04 2009 new variable
 assessment#:#log_mark_added#:#Προστέθηκε βαθμός
@@ -1249,11 +1248,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Όλα τα στοιχεία χρήστη αυτού του διαγωνίσματος έχουν διαγραφεί!
-assessment#:#tst_allowed_users#:#Μέγιστος αριθμός χρηστών που δίνουν το διαγώνισμα ταυτόχρονα
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Ανενεργός χρόνος για ενεργούς χρήστες
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Το διαγώνισμα έχει ολοκληρωθεί και κατατεθεί
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Ανωνυμία
@@ -1495,8 +1489,6 @@ assessment#:#tst_mark_minimum_level#:#Ελάχιστο επίπεδο (σε %)
 assessment#:#tst_mark_official_form#:#Επίσημη μορφή
 assessment#:#tst_mark_passed#:#Πέρασε
 assessment#:#tst_mark_short_form#:#Σύντομη μορφή
-assessment#:#tst_max_allowed_users_heading#:#Έχετε φθάσει το μέγιστο αριθμό ταυτόχρονων χρηστών γι' αυτό το διαγώνισμα
-assessment#:#tst_max_allowed_users_message#:#Έχετε φθάσει το μέγιστο αριθμό ταυτόχρονων χρηστών γι' αυτό το διαγώνισμα. Παρακαλώ ξαναπροσπαθήστε αργότερα να ξεκινήσετε ή να συνεχίσετε το διαγώνισμα. Αν κάποιος από τους ενεργούς χρήστες μείνει ανενεργός για περισσότερα από %s δευτερόλεπτα, ίσως να έχετε τη δυνατότητα να δώσετε το διαγώνισμα. Σας ευχαριστούμε για την κατανόηση.
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Μέγιστη βαθμολογία
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -830,7 +830,6 @@ assessment#:#legend#:#Legend
 assessment#:#locked#:#locked
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached
 assessment#:#log_create_new_test#:#Created new test
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s
 assessment#:#log_mark_added#:#Mark added
@@ -1260,11 +1259,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.
 assessment#:#tst_all_test_competences#:#All Test Competence
 assessment#:#tst_all_user_data_deleted#:#All user data for this test has been removed!
-assessment#:#tst_allowed_users#:#Limit Number of Concurrent Participants
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If the maximum number of users taking the test at the same time has been reached, ILIAS will prevent additional users from starting the test.
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants
-assessment#:#tst_allowed_users_time_gap#:#Max. Idle Time Permitted for Active Participants
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants who have not clicked on anything in the test for the indicated amount of time, will be categorised as ‘inactive’ and removed from the test.
 assessment#:#tst_already_submitted#:#The test has already been completed and submitted.
 assessment#:#tst_analysis#:#Analysis
 assessment#:#tst_anonymity#:#Privacy
@@ -1510,8 +1504,6 @@ assessment#:#tst_mark_minimum_level#:#Minimum Level (in %)
 assessment#:#tst_mark_official_form#:#Official Form
 assessment#:#tst_mark_passed#:#Passed
 assessment#:#tst_mark_short_form#:#Short Form
-assessment#:#tst_max_allowed_users_heading#:#The maximum number of simultaneous users in this test has been reached
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.
 assessment#:#tst_max_comp_points#:#Max. Competence Points
 assessment#:#tst_maximum_points#:#Maximum Points
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -824,7 +824,6 @@ assessment#:#legend#:#Leyenda
 assessment#:#locked#:#bloqueado
 assessment#:#log_added_extratime#:#Añadidos %d minutos extra para el participante id %d
 assessment#:#log_answer_changed_points#:#Modificación manual de puntuación %s desde %d a %d puntos por %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#El usuario no pudo entrar al test porque se ha alcanzado el máximo número simultáneo de conexiones
 assessment#:#log_create_new_test#:#Nuevo Test creado
 assessment#:#log_manual_feedback#:#%s añadió comentario manual para %s y la pregunta %s: %s
 assessment#:#log_mark_added#:#Nota añadida
@@ -1248,11 +1247,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#Competencias de todos los Tests
 assessment#:#tst_all_user_data_deleted#:#Todos los datos de usuario de este test han sido eliminados!
-assessment#:#tst_allowed_users#:#Máximo número de usuarios permitidos ejecutando el test a la vez
-assessment#:#tst_allowed_users_desc#:#ILIAS controlará el número de participantes que pueden realizar el test al mismo tiempo. Si hay más usuarios intentando acceder del máximo permitido, ILIAS impedirá que comiencen el test.
-assessment#:#tst_allowed_users_max#:#Máx. Número de Participantes
-assessment#:#tst_allowed_users_time_gap#:#Tiempo de inactividad permitido para los usuarios que están ejecutando el test
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.
 assessment#:#tst_already_submitted#:#El Test ya ha sido finalizado y enviado
 assessment#:#tst_analysis#:#Análisis
 assessment#:#tst_anonymity#:#Anonimato
@@ -1494,8 +1488,6 @@ assessment#:#tst_mark_minimum_level#:#Nivel Mínimo (en %)
 assessment#:#tst_mark_official_form#:#Forma oficial
 assessment#:#tst_mark_passed#:#Superado
 assessment#:#tst_mark_short_form#:#Forma abreviada
-assessment#:#tst_max_allowed_users_heading#:#Se ha superado el número máximo de usuarios simultáneos en este test
-assessment#:#tst_max_allowed_users_message#:#El máximo número de usuarios activos simultáneos en el test ha sido alcanzado. Por favor intenta otra vez comenzar o retomar el test. Si uno de los usuarios activos está inactivo más de %s segundos, podrás entrar al test. Esto mejora el rendimiento en la ejecución. Disculpa las molestias
 assessment#:#tst_max_comp_points#:#Máx. puntuación de competencia
 assessment#:#tst_maximum_points#:#Máxima puntuación
 assessment#:#tst_mc_label_none_above#:#Ninguna de las respuestas anteriores

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legend
 assessment#:#locked#:#lukus
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d
 assessment#:#log_answer_changed_points#:#Käsitsi on muudetud osaleja %s punkte:  %d asemel %d punkti (muutja: %s)
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#Kasutaja ei saa testi siseneda, kuna samaaegsete kasutajate maksimumarv on täis.
 assessment#:#log_create_new_test#:#Uus test loodud
 assessment#:#log_manual_feedback#:#%s lisas käsitsi tagasiside osalejale %s ja küsimusele %s: %s
 assessment#:#log_mark_added#:#Hinne on lisatud
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence
 assessment#:#tst_all_user_data_deleted#:#Kõik selle testi kasutajaandmed on kustutatud!
-assessment#:#tst_allowed_users#:#Testi samaaegselt sooritajate maksimaalne arv
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants
-assessment#:#tst_allowed_users_time_gap#:#Aktiivsete kasutajate jõudeaeg
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.
 assessment#:#tst_already_submitted#:#Test on juba lõpetatud ja kinnitatud.
 assessment#:#tst_analysis#:#Analysis
 assessment#:#tst_anonymity#:#Anonüümsus
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#Miinimumtase (protsentides)
 assessment#:#tst_mark_official_form#:#Hinne
 assessment#:#tst_mark_passed#:#Läbitud
 assessment#:#tst_mark_short_form#:#Hinne (sõnaline)
-assessment#:#tst_max_allowed_users_heading#:#Selle testi samaaegsete kasutajate maksimumarv on täis!
-assessment#:#tst_max_allowed_users_message#:#Testi samaaegsete kasutajate maksimumarv on täis. Palun proovi hiljem testi alustada või testi jätkata. Kui üks kasutajatest on mitteaktiivne olnud juba kauem kui %s sekundit, saad testi siseneda. Aitäh arusaava suhtumise eest.
 assessment#:#tst_max_comp_points#:#Max. Competence Points
 assessment#:#tst_maximum_points#:#Maksimumpunktid
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legend
 assessment#:#locked#:#locked
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached
 assessment#:#log_create_new_test#:#تست جدید ساخته شد
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s
 assessment#:#log_mark_added#:#نمره اضافه شد
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#All user data of this test has been deleted!
-assessment#:#tst_allowed_users#:#حداکثر تعداد کاربرانی که می توانند تست را بطور همزمان اجرا کنند
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#زمان بیکاری برای کاربران فعال
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Test has already been finish and submitted.
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#گم نامی
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#کمترین سطح (در %)
 assessment#:#tst_mark_official_form#:#فرم رسمی
 assessment#:#tst_mark_passed#:#موفق
 assessment#:#tst_mark_short_form#:#فرم کوتاه
-assessment#:#tst_max_allowed_users_heading#:#The maximum number of simultaneous users in this test has been reached
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#حداکثر نمره
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Légende
 assessment#:#locked#:#verrouillé
 assessment#:#log_added_extratime#:#Ajouter %d minutes supplémentaires au participant : id %d
 assessment#:#log_answer_changed_points#:#Modification manuelle des points %s de %d à %d points par %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#L'utilisateur ne peut peut pas commenter le test car le nombre maximum d'utilisateurs simultanés de ce test a été atteint
 assessment#:#log_create_new_test#:#Nouveau test créé
 assessment#:#log_manual_feedback#:#%s fichier de commentaire ajouté pour individu testé %s et question %s: %s
 assessment#:#log_mark_added#:#Marque ajoutée
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#Tous les tests de compétence
 assessment#:#tst_all_user_data_deleted#:#Toutes les données utilisateur de ce test ont été détruites
-assessment#:#tst_allowed_users#:#Nombre Maximum d'Utilisateurs Simultanés
-assessment#:#tst_allowed_users_desc#:#ILIAS surveillera le nombre de participants faisant le test en même temps. Si plus d'utilisateurs que le maximum autorisé essayent d'accéder au test, ILIAS les empêchera de commencer le test.
-assessment#:#tst_allowed_users_max#:#Nombre max. de participants
-assessment#:#tst_allowed_users_time_gap#:#Temps Max. d'Inactivité pour les Utilisateurs Actifs
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.
 assessment#:#tst_already_submitted#:#Le test a déjà été passé et enregistré.
 assessment#:#tst_analysis#:#Analyse
 assessment#:#tst_anonymity#:#Anonymat
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#Niveau Minimum (en %)
 assessment#:#tst_mark_official_form#:#Forme Officielle
 assessment#:#tst_mark_passed#:#Valid&eacute;
 assessment#:#tst_mark_short_form#:#Forme Courte
-assessment#:#tst_max_allowed_users_heading#:#Le nombre maximum d'utilisateurs simultanés de ce test a été atteint
-assessment#:#tst_max_allowed_users_message#:#Le nombre maximum d'utilisateurs simultanés de ce test a été atteint. Veuillez effectuer ou reprendre ce test ultérieurement. Si l'un des participants au test est inactif pendant plus de  %s secondes, vous serez autorisé à passer ce test. Merci de votre compréhension.
 assessment#:#tst_max_comp_points#:#Points de compétence max.
 assessment#:#tst_maximum_points#:#Points Max.
 assessment#:#tst_mc_label_none_above#:#Aucune des réponses ci-dessus

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legenda
 assessment#:#locked#:#zaključano
 assessment#:#log_added_extratime#:#Dodano je dodatno %d minuta za id sudionika %d
 assessment#:#log_answer_changed_points#:#Osoba %s je ručno promijenila bodova za ispitanika %s s %d na %d bodova
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#Korisnik ne može pristupiti testu, jer je postignut maksimalni broj istovremenih korisnika
 assessment#:#log_create_new_test#:#Kreiran je novi test
 assessment#:#log_manual_feedback#:#Osoba %s dodala je ručne povratne informacije za ispitanika %s i pitanje%s: %s
 assessment#:#log_mark_added#:#Ocjena dodana
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###04 06 2021 new variable
 assessment#:#tst_all_test_competences#:#Sva kompetencije testa
 assessment#:#tst_all_user_data_deleted#:#Svi korisnički podaci ovog testa su uklonjeni!
-assessment#:#tst_allowed_users#:#Ograničenje broja istovremenih sudionika
-assessment#:#tst_allowed_users_desc#:#ILIAS će pratiti broj sudionika koji istovremeno sudjeluju u testu. Ako više korisnika nego što je maksimalno dopušteno pokuša pristupiti, Ilias će im onemogućiti sudjelovanje u testu.
-assessment#:#tst_allowed_users_max#:#Maks. broj sudionika
-assessment#:#tst_allowed_users_time_gap#:#Vrijeme neaktivnosti sudionika
-assessment#:#tst_allowed_users_time_gap_desc#:#Sudionici koji ne kliknu u testu tijekom određenog vremenskog razdoblja ocijenit će se kao ‘neaktivni’ i ukloniti iz testa.
 assessment#:#tst_already_submitted#:#Test je već završen i odgovori su poslani.
 assessment#:#tst_analysis#:#Analiza
 assessment#:#tst_anonymity#:#Privatnost
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#Minimalna razina (u %)
 assessment#:#tst_mark_official_form#:#Službeni naziv
 assessment#:#tst_mark_passed#:#Položeno
 assessment#:#tst_mark_short_form#:#Skraćeni naziv
-assessment#:#tst_max_allowed_users_heading#:#Dosegnut je maksimalan broj istovremenih korisnika za ovaj test
-assessment#:#tst_max_allowed_users_message#:#Dosegnut je maksimalan broj istovremenih aktivnih korisnika za ovaj test Pokušajte ponovno kasnije započeti ili nastaviti test. Ako je neki aktivan korisnik više od %s sekundi neaktivan, možda ćete biti u mogućnosti sudjelovati u ovom testu. Zahvaljujemo na razumijevanju.
 assessment#:#tst_max_comp_points#:#Maks. bodovi za kompetencije
 assessment#:#tst_maximum_points#:#Maksimalan broj bodova
 assessment#:#tst_mc_label_none_above#:#Nijedan od gore navedenih odgovora

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Jelmagyarázat
 assessment#:#locked#:#Zárolva
 assessment#:#log_added_extratime#:#Extra %d perc adása a(z) %d azonosítójú résztvevőnek
 assessment#:#log_answer_changed_points#:#%s tesztkitöltő pontjainak manuális módosítása %d pontról %d pontra %s által
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#A felhasználó nem tud belépni a tesztbe, mert az egyidejű kitöltők száma elérte a maximumot.
 assessment#:#log_create_new_test#:#Új teszt jött létre
 assessment#:#log_manual_feedback#:#%s manuális visszajelzést adott %s tesztet kitöltőnek a(z) %s kérdéshez
 assessment#:#log_mark_added#:#Érdemjegy hozzáadva.
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#A tesztet sikeresen kitöltötte, több kitöltést nem indíthat el.
 assessment#:#tst_all_test_competences#:#Összes tesztkompetencia
 assessment#:#tst_all_user_data_deleted#:#Ennek a tesztnek minden felhasználói adatát sikeresen eltávolította.
-assessment#:#tst_allowed_users#:#A tesztet egyidejűleg futtató felhasználók számának korlátja
-assessment#:#tst_allowed_users_desc#:#Az ILIAS figyeli a résztvevők egyidejű számát. Ha a maximálisnál többen próbálják elérni a tesztet, az ILIAS megakadályozza számukra a teszt indítását.
-assessment#:#tst_allowed_users_max#:#Résztvevők maximális száma
-assessment#:#tst_allowed_users_time_gap#:#Aktív felhasználók tétlenséggel tölthető ideje
-assessment#:#tst_allowed_users_time_gap_desc#:#A megadott ideig nem kattintó résztvevők inaktívnak minősülnek és az ILIAS eltávolítja őket a tesztből.
 assessment#:#tst_already_submitted#:#A tesztet már befejezte és válaszait elküldte.
 assessment#:#tst_analysis#:#Analízis
 assessment#:#tst_anonymity#:#Adatvédelem
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#Minimumszint (%-ban)
 assessment#:#tst_mark_official_form#:#Hivatalos forma
 assessment#:#tst_mark_passed#:#Sikeres teljesítés-e
 assessment#:#tst_mark_short_form#:#Rövid forma
-assessment#:#tst_max_allowed_users_heading#:#Ebben a tesztben egyidejűleg jelen lévő felhasználók száma elérte a maximális számot
-assessment#:#tst_max_allowed_users_message#:#A tesztben egyidejűleg engedélyezett résztvevőszám elérte a maximumot. Próbálja később elkezdeni, illetve folytatni a tesztet. Ha egy jelenleg aktív felhasználó több mint %s másodpercig tétlen, Ön beléphet a tesztbe. Köszönjük megértését!
 assessment#:#tst_max_comp_points#:#Max. kompetencia-pontszámok
 assessment#:#tst_maximum_points#:#Maximális pontszám
 assessment#:#tst_mc_label_none_above#:#Alábbi válaszok közül egyik sem.

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legenda
 assessment#:#locked#:#Bloccato
 assessment#:#log_added_extratime#:#Aggiunti minuti %d supplementari per l’id dei partecipanti %d
 assessment#:#log_answer_changed_points#:#Impostazione manuale dei punti da %d a %d da parte dell'autore del test
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#L'utente non può fare il test perchè è stato raggiunto il numero massimo di partecipanti
 assessment#:#log_create_new_test#:#Creato nuovo test
 assessment#:#log_manual_feedback#:#aggiunto feedback manuale per studente e domande del test
 assessment#:#log_mark_added#:#Aggiunto marcatore
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#Tutte le competenze di test
 assessment#:#tst_all_user_data_deleted#:#Tutti i dati di questo test sono stati cancellati!
-assessment#:#tst_allowed_users#:#Massimo numero di partecipanti facenti contemporaneamente il test
-assessment#:#tst_allowed_users_desc#:#ILIAS monitorerà il numero di partecipanti che fanno il test allo stesso tempo. Se più utenti di quelli consentiti provano ad accedere, ILIAS impedirà di avviare il test.
-assessment#:#tst_allowed_users_max#:#Numero massimo di partecipanti
-assessment#:#tst_allowed_users_time_gap#:#Tempo di inattività dell'utente
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.
 assessment#:#tst_already_submitted#:#Il test è gia' stato eseguito e inviato.
 assessment#:#tst_analysis#:#Analisi
 assessment#:#tst_anonymity#:#Anonimato
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#Livello minimo (in %)
 assessment#:#tst_mark_official_form#:#Form ufficiale
 assessment#:#tst_mark_passed#:#Superato
 assessment#:#tst_mark_short_form#:#Form ridotto
-assessment#:#tst_max_allowed_users_heading#:#È stato ragguinto il numero massimo di partecipanti a questo test
-assessment#:#tst_max_allowed_users_message#:#È stato ragguinto il numero massimo di partecipanti a questo test. Per favore riprova più tardi. Se dei partecipanti sono inattivi per più di % secondi , avrai la possibilità di partecipare. Ti ringraziamo per la comprensione.
 assessment#:#tst_max_comp_points#:#Punti di massima competenza
 assessment#:#tst_maximum_points#:#Punteggi massimi
 assessment#:#tst_mc_label_none_above#:#Nessuna delle risposte in alto

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -827,7 +827,6 @@ assessment#:#legend#:#凡例
 assessment#:#locked#:#固定
 assessment#:#log_added_extratime#:#受験者ID %dへ%d分時間延長しました
 assessment#:#log_answer_changed_points#:#受験者の点数を %sから%dへ%d 点を手動変更
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#同時最大ユーザ数に達しているため、ユーザ テストを入力できませんでした。
 assessment#:#log_create_new_test#:#新規テストを作成
 assessment#:#log_manual_feedback#:#受験者 %sと問題%s:%sを手動フィードバックで%s追加
 assessment#:#log_mark_added#:#マークを追加
@@ -1253,11 +1252,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#ヒント、フィードバ
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#試験に合格です。試験は再開できません。
 assessment#:#tst_all_test_competences#:#全テスト能力
 assessment#:#tst_all_user_data_deleted#:#このテストの全ユーザデータは削除されました!
-assessment#:#tst_allowed_users#:#同時受験者の制限値
-assessment#:#tst_allowed_users_desc#:#ILIASは同時にテストを受験している受験者数をモニターします。ユーザが最大許容アクセス数を超えようとするとILIASはテスト開始を防止します。
-assessment#:#tst_allowed_users_max#:#最大受験者数
-assessment#:#tst_allowed_users_time_gap#:#アクティブユーザのアイドル時間
-assessment#:#tst_allowed_users_time_gap_desc#:#表示された時間のテスト中にクリックしない受験者は'非アクティブ'としてカテゴリー化されてテストから削除されます。
 assessment#:#tst_already_submitted#:#テストはすでに終了して提出済です。
 assessment#:#tst_analysis#:#分析
 assessment#:#tst_anonymity#:#プライバシー
@@ -1500,8 +1494,6 @@ assessment#:#tst_mark_minimum_level#:#最低レベル (%中)
 assessment#:#tst_mark_official_form#:#正式書式
 assessment#:#tst_mark_passed#:#合格
 assessment#:#tst_mark_short_form#:#略式書式
-assessment#:#tst_max_allowed_users_heading#:#テストの同時最大ユーザ数に達しました
-assessment#:#tst_max_allowed_users_message#:#テストの同時最大ユーザ数に達しました。 後でやり直すかもしくはテストを再開してください。 受験中のユーザのだれかが %s 以上中断すると入力できるようになる場合があります。ご理解ありがとうございます。
 assessment#:#tst_max_comp_points#:#最大能力ポイント
 assessment#:#tst_maximum_points#:#最高点
 assessment#:#tst_mc_label_none_above#:#上記回答なし

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#ლეგენდა/წარწერა
 assessment#:#locked#:#დალუქული
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#სახელმძღვანელო ცვლილება მონაწილის ტესტის ქულებში %s-დან %s-მდე %s-დან %s-ით
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#მომხმრებელმა ვერ გახსნა ტესტი რადგან უკვე მომხმარებელთა მაქსიმალურ რაოდენობას აქვს გახსნილი ტესტი.
 assessment#:#log_create_new_test#:#ახალი ტესტის შექმნა
 assessment#:#log_manual_feedback#:#%s დაემატა სახელმძღვანელო უკუკავშირსტესტის  მომხმარებლის %s-ს და კითხვების %s-ს
 assessment#:#log_mark_added#:#ქულა/შენიშვნა დაემატა
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#ამ ტესტის მომხმარებლების ყველა მონაცემი წაიშალა.
-assessment#:#tst_allowed_users#:#მონაწილეთა მაქსიმალური რაოდენობა ტესტის ერთდროულ წერაზე
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#უმოქმედო დრო აქტიური მომხმარებლებისთვის
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#ტესტი უკვე დასრულდა და ჩაბარდა
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#ანონიმურობა
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#მინიმალური დონ�
 assessment#:#tst_mark_official_form#:#ოფიციალური ფორმა
 assessment#:#tst_mark_passed#:#ჩაბარებული
 assessment#:#tst_mark_short_form#:#მოკლე ფორმა
-assessment#:#tst_max_allowed_users_heading#:#ტესტს ერთდროულად მონაწილეთა მაქსიმალური რაოდენობა წერს
-assessment#:#tst_max_allowed_users_message#:#ტესტს ერთდროულად მონაწილეთა მაქსიმალური რაოდენობა წერს. გთხოვთ მოგვიანებით სცადოთ ან განაახლოთ ტესტი. თუ რომელიმე აქტიურმ მომხმარებელთაგან არააქტიურია %s წამზე მეტი ხანია, თქვენ შეძლებთ ამ ტესტის დაწყებას. Mადლობას გიხდით გაგებისთვის.
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#მაქსიმალური ქულა
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Aprašas
 assessment#:#locked#:#užrakinta
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Testo sudarytojo balų pakeitimas %s iš %d į %d balus %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#Vartotojas negali pradėti testo, kadangi pasiektas maksimalus galimas testą sprendžiančių studentų skaičius
 assessment#:#log_create_new_test#:#Sukurtas naujas testas
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s###24 02 2009 new variable
 assessment#:#log_mark_added#:#Pažymys įvestas
@@ -1248,11 +1247,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Visi šio testo vartotojo duomenys buvo ištrinti!
-assessment#:#tst_allowed_users#:#Maksimalus vienu metu sprendžiančių testą vartotojų skaičius
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Neveiksnumo laikas aktyviems vartotojams
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Testas jau baigtas ir rezultatai nusiųsti.
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonimiškumas
@@ -1494,8 +1488,6 @@ assessment#:#tst_mark_minimum_level#:#Minimalus lygis (%)
 assessment#:#tst_mark_official_form#:#Oficiali forma
 assessment#:#tst_mark_passed#:#Išlaikyta
 assessment#:#tst_mark_short_form#:#Trumpa forma
-assessment#:#tst_max_allowed_users_heading#:#Maksimalus vartotojų skaičius šiame teste pasiektas
-assessment#:#tst_max_allowed_users_message#:#Maksimalus aktyvių vartotojų skaičius šiame teste pasiektas. Norėdami pradėti ar tęsti testą, bandykite vėliaut. Jei vienas iš aktyvių vartotojų tampa neaktyvus daugiau nei %s sekundžių, jūs galėsite spręsti šį testą. Dėkojame už supratimą.
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Maksimalus taškų skaičius
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legende
 assessment#:#locked#:#Gesloten
 assessment#:#log_added_extratime#:#Extra %d minuten zijn toegevoegd aan deelnemer %d
 assessment#:#log_answer_changed_points#:#De handmatige verandering van punten %s van %d to %d door %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#De gebruiker kan de toets niet maken omdat het maximum aantal gebruikers is bereikt.
 assessment#:#log_create_new_test#:#Maak een nieuwe toets
 assessment#:#log_manual_feedback#:#%s toegevoegde handmatige feedback voor toets persoon %s en vraag %s: %s
 assessment#:#log_mark_added#:#Punt toegevoegd
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#Alle toets Competenties
 assessment#:#tst_all_user_data_deleted#:#Alle gebruikersgegevens van deze toets zijn verwijderd!
-assessment#:#tst_allowed_users#:#Maximum aantal gebruikers die deze toets kunnen gebruiken
-assessment#:#tst_allowed_users_desc#:#ILIAS houdt het aantal deelnemers die de toets tegelijkertijd doen in de gaten. Als het toegestane maximum is bereikt, zal ILIAS nieuwe deelnemers niet toelaten dat ze de toets beginnen.
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###06 02 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Inactieve tijd voor actieve gebruikers
-assessment#:#tst_allowed_users_time_gap_desc#:#Deelnemers die niet op tijd klikken in de toets worden beschouwd als inactief en worden verwijderd van de toets.
 assessment#:#tst_already_submitted#:#De toets is al beeindigd en opgestuurd
 assessment#:#tst_analysis#:#Analyse
 assessment#:#tst_anonymity#:#Anonimiteit
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#Minimum niveau (in %
 assessment#:#tst_mark_official_form#:#Officiëel formulier
 assessment#:#tst_mark_passed#:#Geslaagd
 assessment#:#tst_mark_short_form#:#Korte aanduiding
-assessment#:#tst_max_allowed_users_heading#:#Het maximum aantal gebruikers voor de toets is bereikt.
-assessment#:#tst_max_allowed_users_message#:#Het maximum aantal gebruikers voor de toets is bereikt. Probeer laten opnieuw
 assessment#:#tst_max_comp_points#:#Max. competentie-punten
 assessment#:#tst_maximum_points#:#Maximum aantal punten
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legenda
 assessment#:#locked#:#zablokowany
 assessment#:#log_added_extratime#:#Do czasu przetwarzania dla uczestników o nr ID %d zostaną dodane dodatkowe %d minuty
 assessment#:#log_answer_changed_points#:#Ręczna zmiana punktów %s od %d do %d przez %s.
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#Użytkownik nie może przystąpić do rozwiązywania testu ponieważ została przekroczona maksymalna dopuszczalna liczba jednocześnie pracujących użytkowników.
 assessment#:#log_create_new_test#:#Utworzono nowy test
 assessment#:#log_manual_feedback#:#%s utworzono ręczną punktację dla uczestnika %s oraz pytania %s: %s
 assessment#:#log_mark_added#:#Znacznik dodany
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#Wszystkie kompetencje testu
 assessment#:#tst_all_user_data_deleted#:#Wszystkie dane uczestnika testu zostały skasowane!
-assessment#:#tst_allowed_users#:#Maksymalna liczba użytkowników mogąca rozwiązywać test jednocześnie.
-assessment#:#tst_allowed_users_desc#:#ILIAS sprawdza liczbę uczestników, którzy równocześnie brali udział w teście. Wszystkim uczestnikom próbującym rozpocząć test powyżej dopuszczalnego limitu osób dostęp do niego zostanie uniemożliwiony.
-assessment#:#tst_allowed_users_max#:#Maksymalna liczba
-assessment#:#tst_allowed_users_time_gap#:#Czas bezczynności dla aktywnych użytkowników
-assessment#:#tst_allowed_users_time_gap_desc#:#Uczestnicy, którzy w ciągu podanych sekund nie klikną na żadną z opcji, zostaną sklasyfikowany jako 'nieaktywni' i usunięci z testu.
 assessment#:#tst_already_submitted#:#Test został ukończony i przedstawiony do oceny
 assessment#:#tst_analysis#:#Analiza
 assessment#:#tst_anonymity#:#Anonimowość
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#Minimalny poziom (w %)
 assessment#:#tst_mark_official_form#:#Oficjalna forma
 assessment#:#tst_mark_passed#:#Wykonany
 assessment#:#tst_mark_short_form#:#Krótka forma
-assessment#:#tst_max_allowed_users_heading#:#Została przekroczona maksymalna liczba jednocześnie wykonujących test.
-assessment#:#tst_max_allowed_users_message#:#Została przekroczona maksymalna liczba jednocześnie aktywnych użytkowników teście. Spróbuj później rozpocząć lub odzyskać test. Jeśli jeden z aktywnych użytkowników będzie bezczynny więcej niż %s sekund, to będziesz mógł podejść do testu. Dziękujemy za zrozumienie i cierpliwość.
 assessment#:#tst_max_comp_points#:#Maks. liczba punktów kompetencyjnych
 assessment#:#tst_maximum_points#:#Maksimum punktów
 assessment#:#tst_mc_label_none_above#:#Żadna z powyższych odpowiedzi

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legenda
 assessment#:#locked#:#bloqueado
 assessment#:#log_added_extratime#:#Foram adicionados %d minutos extra para o id do participante %d
 assessment#:#log_answer_changed_points#:#Alteração manual dos pontos da pessoa do teste %s de %d para %d pontos por %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#O utilizador não conseguiu introduzir o teste porque foi atingido o número máximo de utilizadores simultâneos
 assessment#:#log_create_new_test#:#Novo teste criado
 assessment#:#log_manual_feedback#:#%s foi adicionado um feedback manual para a pessoa de teste %s e pergunta %s: %s
 assessment#:#log_mark_added#:#Marca adicionada
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#Todas as competências do teste
 assessment#:#tst_all_user_data_deleted#:#Todos os dados de utilizador deste teste foram removidos!
-assessment#:#tst_allowed_users#:#Número limite de participantes simultâneos
-assessment#:#tst_allowed_users_desc#:#ILIAS monitoriza o número de participantes que participam neste teste ao mesmo tempo. Se mais utilizadores do que o máximo permitido tentarem aceder, ILIAS impede-os de iniciarem o teste.
-assessment#:#tst_allowed_users_max#:#Número máx. de participantes
-assessment#:#tst_allowed_users_time_gap#:#Tempo de inatividade para utilizadores ativos
-assessment#:#tst_allowed_users_time_gap_desc#:#Os participantes que não clicam no teste durante o tempo indicado serão categorizados como 'inativos' e serão removidos do teste.
 assessment#:#tst_already_submitted#:#O teste já foi concluído e submetido.
 assessment#:#tst_analysis#:#Análise
 assessment#:#tst_anonymity#:#Privacidade
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#<b>Não é possível um teste com um conju
 assessment#:#tst_mark_official_form#:#Date da última sincronização dos bancos de perguntas selecionados: <b>%s</b>
 assessment#:#tst_mark_passed#:#Os pontos de competência foram guardados.
 assessment#:#tst_mark_short_form#:#A regra foi removida com sucesso.
-assessment#:#tst_max_allowed_users_heading#:#Foi alcançado o número máximo de utilizadores simultâneos no teste
-assessment#:#tst_max_allowed_users_message#:#Foi alcançado o número máximo de utilizadores ativos simultâneos no teste. Tente novamente mais tarde reiniciar ou retomar o teste. Se um dos utilizadores ativos estiver inativo durante mais de %s segundos, pode introduzir este teste. Obrigado pela sua compreensão.
 assessment#:#tst_max_comp_points#:#Pontos máx. de competência
 assessment#:#tst_maximum_points#:#Recebeu esta notificação porque participou neste teste.
 assessment#:#tst_mc_label_none_above#:#Nenhuma das respostas acima

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legenda
 assessment#:#locked#:#blocat
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s###12 11 2006 new variable
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached###10 Jul 2006 new variable
 assessment#:#log_create_new_test#:#Nou test creat
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s###24 02 2009 new variable
 assessment#:#log_mark_added#:#Nota adaugata
@@ -1248,11 +1247,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Toate datele despre utilizator din acest test au foat sterse!
-assessment#:#tst_allowed_users#:#Maximum number of users running the test simultaneously###10 Jul 2006 new variable
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Idle time for active users###10 Jul 2006 new variable
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Testul a fost deja terminat si submis
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonymity###25 10 2006 new variable
@@ -1494,8 +1488,6 @@ assessment#:#tst_mark_minimum_level#:#Nivelul minim (in %)
 assessment#:#tst_mark_official_form#:#Forma oficiala
 assessment#:#tst_mark_passed#:#Trecut
 assessment#:#tst_mark_short_form#:#Forma la limita
-assessment#:#tst_max_allowed_users_heading#:#The maximum number of simultaneous users in this test has been reached###10 Jul 2006 new variable
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.###10 Jul 2006 new variable
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Punctaj maxim
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Легенда
 assessment#:#locked#:#заблокирован
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached
 assessment#:#log_create_new_test#:#Создан новый тест
 assessment#:#log_manual_feedback#:#%s вручную добавил отзыв для участника теста %s и вопроса %s: %s
 assessment#:#log_mark_added#:#Отметка добавлена
@@ -1248,11 +1247,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Все данные пользователей этого теста были удалены!
-assessment#:#tst_allowed_users#:#Максимальное количество пользователей которым можно проходить тест одновременно
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Время простоя для активных пользователей
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Тест уже завершен и результаты отправлены.
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Запись теста
@@ -1494,8 +1488,6 @@ assessment#:#tst_mark_minimum_level#:#Минимальный уровень (в 
 assessment#:#tst_mark_official_form#:#Официальная форма
 assessment#:#tst_mark_passed#:#Сдан
 assessment#:#tst_mark_short_form#:#Короткая форма
-assessment#:#tst_max_allowed_users_heading#:#Максимальное число пользователей, которые могут одновременно проходить этот тест
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Максимальные баллы
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Vysvětlivka
 assessment#:#locked#:#uzamčeno
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manuální změna bodů testované osoby %s z %d na %d bodů hodnotícím testu %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#Účastník nemůže vstoupit do testu, protože byl dosažen maximální počet simultánních účastníků.
 assessment#:#log_create_new_test#:#Vytvořen nový test
 assessment#:#log_manual_feedback#:#%s přidán manuální ohlas pro testovanou osobu %s a otázku %s: %s
 assessment#:#log_mark_added#:#Známka přidána
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Všechna uživatelská data tohoto testu byly smazány!
-assessment#:#tst_allowed_users#:#Maximální počet uživatelů provádějících test současně
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Čas pasivity pro aktivní uživatele
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Test byl již ukončen a odevzdán.
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonymita
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#Minimální hladina (v %)
 assessment#:#tst_mark_official_form#:#Oficiální tvar
 assessment#:#tst_mark_passed#:#Prošel
 assessment#:#tst_mark_short_form#:#Zkrácený tvar
-assessment#:#tst_max_allowed_users_heading#:#Dosažen maximální počet simultánních účastníků v tomto testu
-assessment#:#tst_max_allowed_users_message#:#Maximální počet simultánních účastníků v tomto testu byl dosažen. Zkuste začít nebo pokračovat znovu později. Pokud bude některý z aktivních účastníků nenaktivní déle než %s s., můžete namísto něj do testu vstoupit. Děkujeme za pochopení.
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Maximum bodů
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -827,7 +827,6 @@ assessment#:#legend#:#Legenda
 assessment#:#locked#:#zaklenjeno
 assessment#:#log_added_extratime#:#Udeležencu z ID %d je bilo dodeljenih dodatnih %d minut za obdelavo.
 assessment#:#log_answer_changed_points#:#%s je ročno dodelil točke udeležencu %s od %d na %d točk
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#Udeleženec ni mogel začeti testa, ker je bilo doseženo maksimalno število sočasnih udeležencev za ta test
 assessment#:#log_create_new_test#:#Ustvarjen je bil nov test
 assessment#:#log_manual_feedback#:#%s je ustvaril ročno oceno za udeleženca %s in vprašanje %s %s: %s
 assessment#:#log_mark_added#:#Ocena dodana
@@ -1251,11 +1250,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.
 assessment#:#tst_all_test_competences#:#Vse testne kompetence
 assessment#:#tst_all_user_data_deleted#:#Podatki vseh udeležencev testa so bili izbrisani!
-assessment#:#tst_allowed_users#:#Omejite število hkratnih udeležencev
-assessment#:#tst_allowed_users_desc#:#ILIAS preverja število udeležencev, ki hkrati sodelujejo v testu. Če poskuša dostopati več uporabnikov od največjega dovoljenega števila, jim bo Ilias preprečil dostop do testa.
-assessment#:#tst_allowed_users_max#:#Maksimalno število
-assessment#:#tst_allowed_users_time_gap#:#Čas neaktivnosti udeležencev
-assessment#:#tst_allowed_users_time_gap_desc#:#Udeleženci, ki v določenem časovnem obdobju ne kliknejo na test, bodo ocenjeni kot "neaktivni" in odstranjeni iz testa.
 assessment#:#tst_already_submitted#:#Test je že končan in odgovori so bili poslani.
 assessment#:#tst_analysis#:#Analiza
 assessment#:#tst_anonymity#:#Varstvo podatkov
@@ -1498,8 +1492,6 @@ assessment#:#tst_mark_minimum_level#:#Najnižji odstotek (v %)
 assessment#:#tst_mark_official_form#:#Uradno ime
 assessment#:#tst_mark_passed#:#Opravljeno
 assessment#:#tst_mark_short_form#:#Kratko ime
-assessment#:#tst_max_allowed_users_heading#:#Doseženo je bilo maksimalno število sočasnih uporabnikov za ta test
-assessment#:#tst_max_allowed_users_message#:#Doseženo je bilo maksimalno število sočasnih udeležencev za ta test Poskusite test ponovno odpreti ali nadaljevati nekoliko pozneje. Če so aktivni udeleženci neaktivni več kot %s sekund, imate možnost, da opravljate ta test. Hvala za razumevanje.
 assessment#:#tst_max_comp_points#:#maks. Kompetenčne točke
 assessment#:#tst_maximum_points#:#Maksimalno število točk
 assessment#:#tst_mc_label_none_above#:#Nobeden od zgornjih odgovorov

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legjendë
 assessment#:#locked#:#mbyllur
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s###12 11 2006 new variable
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached###10 Jul 2006 new variable
 assessment#:#log_create_new_test#:#Testi i ri i krijuar
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s###24 02 2009 new variable
 assessment#:#log_mark_added#:#Shënjimi u shtua
@@ -1248,11 +1247,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Të gjitha të dhënat e shfrytëzuesve të këtij testi janë fshirë!
-assessment#:#tst_allowed_users#:#Maximum number of users running the test simultaneously###10 Jul 2006 new variable
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Idle time for active users###10 Jul 2006 new variable
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Test has already been finish and submitted. ### 2006-8-11 --- Add new translation here.
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonymity###25 10 2006 new variable
@@ -1494,8 +1488,6 @@ assessment#:#tst_mark_minimum_level#:#Përqindja minimale
 assessment#:#tst_mark_official_form#:#Formë zyrtare
 assessment#:#tst_mark_passed#:#Kalon
 assessment#:#tst_mark_short_form#:#Formë e shkurtër
-assessment#:#tst_max_allowed_users_heading#:#The maximum number of simultaneous users in this test has been reached###10 Jul 2006 new variable
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.###10 Jul 2006 new variable
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Pikët maksimale
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legenda
 assessment#:#locked#:#zakljucano
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s###12 11 2006 new variable
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached###10 Jul 2006 new variable
 assessment#:#log_create_new_test#:#Kreiran novi test
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s###24 02 2009 new variable
 assessment#:#log_mark_added#:#Dodata ocena
@@ -1248,11 +1247,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Svi podaci o korisniku ovog testa su obrisani!
-assessment#:#tst_allowed_users#:#Maximum number of users running the test simultaneously###10 Jul 2006 new variable
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Idle time for active users###10 Jul 2006 new variable
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Test has already been finish and submitted. ### 2006-8-11 --- Add new translation here.
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonymity###25 10 2006 new variable
@@ -1494,8 +1488,6 @@ assessment#:#tst_mark_minimum_level#:#Najniži nivo (u %)
 assessment#:#tst_mark_official_form#:#Zvanicna forma
 assessment#:#tst_mark_passed#:#Prošao
 assessment#:#tst_mark_short_form#:#Kratka forma
-assessment#:#tst_max_allowed_users_heading#:#The maximum number of simultaneous users in this test has been reached###10 Jul 2006 new variable
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.###10 Jul 2006 new variable
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Maksimalno poena
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Legend
 assessment#:#locked#:#Kilitli
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#Eşzamanlı kullanıcı sayısına ulaşıldığından kullanıcı teste giremedi
 assessment#:#log_create_new_test#:#Yeni test oluşturuldu
 assessment#:#log_manual_feedback#:#%s manuel geri bildirim test kişisi %s ve soru %s: %s için eklendi
 assessment#:#log_mark_added#:#İşaret eklendi
@@ -1246,11 +1245,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Bu testin tüm kullanıcı verileri silindi !
-assessment#:#tst_allowed_users#:#Aynı testi eş zamanlı olarak çalıştaracak kullanıcı sayısı
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Aktif Kullanıcılar için boşa düşme zamanı
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Test zaten bitmiş ve gönderilmiştir.
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonimlik
@@ -1492,8 +1486,6 @@ assessment#:#tst_mark_minimum_level#:#Asgari Seviye (% olarak)
 assessment#:#tst_mark_official_form#:#Resmi Hali
 assessment#:#tst_mark_passed#:#Geçti
 assessment#:#tst_mark_short_form#:#Kısa Hali
-assessment#:#tst_max_allowed_users_heading#:#Bu testte eşzamanlı kullanıcı maksimum sayısına ulaşıldı
-assessment#:#tst_max_allowed_users_message#:#Test eşzamanlı aktif kullanıcı maksimum sayısına ulaşıldı. Testi başlatmak veya sürdürmek için daha sonra tekrar deneyin. Aktif kullanıcı biri% s saniye daha hareketsiz ise, bu test girmek mümkün olabilir. Anlayışınız için teşekkür ederiz.
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Maksimum Puan
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -822,7 +822,6 @@ assessment#:#legend#:#Умовне позначення
 assessment#:#locked#:#заблокований
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s###12 11 2006 new variable
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached###25 02 2007 new variable
 assessment#:#log_create_new_test#:#Створити новий тест
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s###24 02 2009 new variable
 assessment#:#log_mark_added#:#Оцінка додана
@@ -1248,11 +1247,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Усі дані користувача по цьому тесту були видалені!
-assessment#:#tst_allowed_users#:#Maximum Number of Users Running the Test Simultaneously###25 02 2007 new variable
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Idle Time for Active Users###25 02 2007 new variable
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Test has already been finish and submitted.###06 09 2006 new variable
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonymity###25 02 2007 new variable
@@ -1494,8 +1488,6 @@ assessment#:#tst_mark_minimum_level#:#Мінімальний рівень (в %)
 assessment#:#tst_mark_official_form#:#Офіціальна форма
 assessment#:#tst_mark_passed#:#Пройдений
 assessment#:#tst_mark_short_form#:#Коротка форма
-assessment#:#tst_max_allowed_users_heading#:#The maximum number of simultaneous users in this test has been reached###25 02 2007 new variable
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.###25 02 2007 new variable
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Максимум балів
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -824,7 +824,6 @@ assessment#:#legend#:#Chú thích
 assessment#:#locked#:#đã bị khóa
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s###12 11 2006 new variable
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#The user could not enter the test because the maximum number of simultaneous users has been reached###25 02 2007 new variable
 assessment#:#log_create_new_test#:#Tạo một bài kiểm tra mới
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s###24 02 2009 new variable
 assessment#:#log_mark_added#:#Điểm đã được thêm vào
@@ -1250,11 +1249,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#Tất cả thông tin người sử dụng của bài kiểm tra này đã được xóa!
-assessment#:#tst_allowed_users#:#Maximum Number of Users Running the Test Simultaneously###25 02 2007 new variable
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#Idle Time for Active Users###25 02 2007 new variable
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#Bài kiểm tra đã kết thúc và đã được nộp lên.
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#Anonymity###25 02 2007 new variable
@@ -1496,8 +1490,6 @@ assessment#:#tst_mark_minimum_level#:#Mức tối thiểu (dạng %)
 assessment#:#tst_mark_official_form#:#Mẫu chính thức
 assessment#:#tst_mark_passed#:#Đạt
 assessment#:#tst_mark_short_form#:#Mẫu ngắn
-assessment#:#tst_max_allowed_users_heading#:#The maximum number of simultaneous users in this test has been reached###25 02 2007 new variable
-assessment#:#tst_max_allowed_users_message#:#The maximum number of simultaneous active users in the test has been reached. Please try again later to start or resume the test. If one of the active users is inactive for more than %s seconds, you may be able to enter this test. Thank you for your understanding.###25 02 2007 new variable
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#Điểm tối đa
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -821,7 +821,6 @@ assessment#:#legend#:#传说
 assessment#:#locked#:#锁定
 assessment#:#log_added_extratime#:#Added extra %d minutes for participant id %d###24 10 2013 new variable
 assessment#:#log_answer_changed_points#:#Manual change of points of test person %s from %d to %d points by %s
-assessment#:#log_could_not_enter_test_due_to_simultaneous_users#:#此用户不能进入测试，因为已达到最大用户并发数
 assessment#:#log_create_new_test#:#新的测试已创建
 assessment#:#log_manual_feedback#:#%s added manual feedback for test person %s and question %s: %s
 assessment#:#log_mark_added#:#标记已添加
@@ -1245,11 +1244,6 @@ assessment#:#tst_add_quest_cont_edit_mode_RTE_info#:#Allows text formatting of q
 assessment#:#tst_addit_passes_blocked_after_passed_msg#:#You have passed the test. The test cannot be started again.###07 02 2020 new variable
 assessment#:#tst_all_test_competences#:#All Test Competence###26 09 2014 new variable
 assessment#:#tst_all_user_data_deleted#:#此次测试的所有用户数据已全部删除！
-assessment#:#tst_allowed_users#:#正在进行测试的同时已经达到用户数上限
-assessment#:#tst_allowed_users_desc#:#ILIAS will monitor the number of participants taking the test at the same time. If more users than maximally allowed try to access ILIAS will prevent them from starting the test.###07 11 2014 new variable
-assessment#:#tst_allowed_users_max#:#Max. Number of Participants###27 01 2015 new variable
-assessment#:#tst_allowed_users_time_gap#:#活跃用户的空闲时间
-assessment#:#tst_allowed_users_time_gap_desc#:#Participants that do not click in the test fort he indicated amount of time will be categorized as ‚inactive‘ and removed from the test.###07 11 2014 new variable
 assessment#:#tst_already_submitted#:#测试已经完成并已提交
 assessment#:#tst_analysis#:#Analysis###26 09 2014 new variable
 assessment#:#tst_anonymity#:#匿名
@@ -1491,8 +1485,6 @@ assessment#:#tst_mark_minimum_level#:#Minimum level (in %)
 assessment#:#tst_mark_official_form#:#Official form官方形式
 assessment#:#tst_mark_passed#:#已通过
 assessment#:#tst_mark_short_form#:#Short form
-assessment#:#tst_max_allowed_users_heading#:#已经达到此次测试中同时允许的用户人数上限
-assessment#:#tst_max_allowed_users_message#:#已经达到此次测试中同翻搅时允许的活跃用户人数上限。请稍后再尝试启动或恢复测试。如果其中某位活跃用户超过 %s 秒未活动，您将有可能进入此次测试。感谢您的理解。
 assessment#:#tst_max_comp_points#:#Max. Competence Points###26 09 2014 new variable
 assessment#:#tst_maximum_points#:#最大分值
 assessment#:#tst_mc_label_none_above#:#None of the answers above###fau: testNav


### PR DESCRIPTION
Implements [Remove Setting «Limit Number of Concurrent Participants»](https://docu.ilias.de/goto_docu_wiki_wpage_7423_1357.html) (Feature Wiki)