### PR TITLE
_9/legacy-UI/form footer cmd padding margin 37636

### DIFF
--- a/templates/default/070-components/legacy/Services/_component_form.scss
+++ b/templates/default/070-components/legacy/Services/_component_form.scss
@@ -572,12 +572,12 @@ input[type="checkbox"] {
 }
 
 .ilFormFooter {
-	padding: $il-padding-small-vertical $il-padding-xlarge-horizontal $il-padding-small-vertical 0;
+	margin: 0; // counteracts grid system negative margin
+	padding: $il-padding-small-vertical 0 $il-padding-small-vertical 0;
 }
 
 .ilFormFooter .ilFormCmds {
 	text-align: right;
-	padding: 0;
 }
 
 /* jQuery ui autocomplete menu */

--- a/templates/default/070-components/legacy/Services/_component_init.scss
+++ b/templates/default/070-components/legacy/Services/_component_init.scss
@@ -49,11 +49,6 @@ div.ilStartupSection form.form-horizontal {
 	border: $il-panel-border;
 	border-radius: $il-panel-border-radius;
 
-
-	.ilFormFooter {
-		margin: 0
-	}
-
 	.ilFormHeader {
 		padding: $il-padding-xlarge-vertical $il-padding-xlarge-horizontal;
 		background-color: $il-main-dark-bg;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -14519,12 +14519,12 @@ fieldset[disabled] .checkbox label {
 }
 
 .ilFormFooter {
-  padding: 3px 15px 3px 0;
+  margin: 0;
+  padding: 3px 0 3px 0;
 }
 
 .ilFormFooter .ilFormCmds {
   text-align: right;
-  padding: 0;
 }
 
 /* jQuery ui autocomplete menu */
@@ -14772,9 +14772,6 @@ div.ilStartupSection form.form-horizontal {
   border-radius: 3px;
   text-align: left;
   width: 40em;
-}
-div.ilStartupSection form.form-horizontal .ilFormFooter {
-  margin: 0;
 }
 div.ilStartupSection form.form-horizontal .ilFormHeader {
   padding: 9px 15px;


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=37636

# Issue

Legacy Form Footer got too close to the border of the form. Margin/padding needs fixing.

<img width="1172" alt="formfooter ilias9" src="https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/55e6c7b8-be53-4a1b-8a3b-9e7a6624e60a">

# Changes

margin: 0 on the form footer counteracts the "negative margin, positive padding"-System of the grid layout. Now all that is left is the gap padding of the column which then works as an padding towards the outer border.

![Screenshot from 2023-08-09 11-27-30](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/ce17886b-d738-4313-9f70-720823e71cf0)