### PR TITLE
Docu: Added block definition in Mail README

### DIFF
--- a/Services/Mail/README.md
+++ b/Services/Mail/README.md
@@ -683,6 +683,8 @@ $accountMail->setUserPassword($rawPassword);
 
 Internally `\ilAccountMail` makes use of `\ilMimeMail`.
 
+[//]: # (BEGIN Templates)
+
 ## Manual Mail Templates
 
 The concept of ['Manual Mail Templates'](https://www.ilias.de/docu/goto_docu_wiki_wpage_2703_1357.html) is best described
@@ -803,6 +805,8 @@ as callback when an email is actually sent and included
 placeholders should be replaced.
 You also MUST add a key `\ilMailFormCall::CONTEXT_KEY`
 with your context id as value to this array.
+
+[//]: # (END Templates)
 
 ## ilMassMailTaskProcessor
 


### PR DESCRIPTION
I would like to integrate the paragraph about Manual Mail Templates in a LM on docu.ilias.de and therefore added block definition. Would highly appreciate an approval :)