### PR TITLE
9/legacy-UI/form Textarea height 37674

### DIFF
--- a/templates/default/070-components/legacy/Services/_component_form.scss
+++ b/templates/default/070-components/legacy/Services/_component_form.scss
@@ -176,6 +176,10 @@ input[type="checkbox"]:focus {
 	}
 }
 
+textarea.form-control {
+    height: auto;
+}
+
 
 // Search inputs in iOS
 //

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -14220,6 +14220,10 @@ textarea .form-control {
   height: auto;
 }
 
+textarea.form-control {
+  height: auto;
+}
+
 input[type=search] {
   -webkit-appearance: none;
 }


### PR DESCRIPTION
Mantis https://mantis.ilias.de/view.php?id=37674

# Issue

Textarea for messages is currently single line. Users don't know immediately that they can write a longer message. Used to by a multi line field in ILIAS 8.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/93690a54-8fa7-420a-ae0c-6df6d795b87c)

# Change

Setting textarea heigth back to browser default

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/3d05ba1d-5413-4f73-98ba-eb2fd91b680e)