### PR TITLE
fix mantis bug #37702: Placeholders get lost along with HTML tags in langvars

### DIFF
--- a/Services/Language/README.md
+++ b/Services/Language/README.md
@@ -1,0 +1,6 @@
+# Language Service
+
+document in progress
+
+## HTML Tags
+All secure tags plus br and span are allowed inside of language variable values.

--- a/Services/Language/classes/class.ilObjLanguageExtGUI.php
+++ b/Services/Language/classes/class.ilObjLanguageExtGUI.php
@@ -394,7 +394,7 @@ class ilObjLanguageExtGUI extends ilObjectGUI
                 // avoid line breaks
                 $value = preg_replace("/(\015\012)|(\015)|(\012)/", "<br />", $value);
                 $value = str_replace("<<", "«",$value);
-                $value = ilUtil::stripSlashes($value);
+                $value = ilUtil::stripSlashes($value, true, "<strong><em><u><strike><ol><li><ul><p><div><i><b><code><sup><pre><gap><a><img><bdo><br><span>");
                 $save_array[$key] = $value;
 
                 // the comment has the key of the language with the suffix


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=37702

in ilUtil::secureString the allow_array and secure_tags differ, therefore all secure tags and additionally span and br are transmitted 