### PR TITLE
Slate Description

### DIFF
--- a/src/UI/Component/MainControls/Factory.php
+++ b/src/UI/Component/MainControls/Factory.php
@@ -293,6 +293,7 @@ interface Factory
      *     3: Slates SHOULD NOT use vertical scrollbars.
      *     4: Slates MUST visually relate to their triggering Component.
      *     5: Slates SHOULD NOT be affected by scrolling the page.
+     *     6: Slates MUST present columned content as a vertical sequence. 
      *
      *   accessibility:
      *     1: The Slate MUST be closeable by only using the keyboard


### PR DESCRIPTION
Hi @all,

as a result of the Feature Workshop "Slate content should always be displayed in mobile view" on 15 AUG 2023, the description of the KS component "Slate" shall be extended.

- Link to Feature Workshop: https://docu.ilias.de/goto_docu_sess_13226.html

Many regards,
Enrico