### PR TITLE
Course: expand export/import (24733)

### DIFF
--- a/Modules/Course/classes/class.ilCourseXMLParser.php
+++ b/Modules/Course/classes/class.ilCourseXMLParser.php
@@ -298,12 +298,21 @@ class ilCourseXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
             case 'WaitingListAutoFill':
             case 'CancellationEnd':
             case 'MinMembers':
+            case 'StatusDetermination':
+            case 'MailToMembersType':
                 break;
 
             case 'WelcomeMail':
                 if (array_key_exists('status', $a_attribs)) {
                     $this->course_obj->setAutoNotification((bool) $a_attribs['status']);
                 }
+                break;
+
+            case 'CourseMap':
+                $this->course_obj->setEnableCourseMap((bool) $a_attribs['enabled'] ?? false);
+                $this->course_obj->setLatitude((string) $a_attribs['latitude'] ?? '');
+                $this->course_obj->setLongitude((string) $a_attribs['longitude'] ?? '');
+                $this->course_obj->setLocationZoom((int) $a_attribs['location_zoom'] ?? 0);
                 break;
 
             case 'SessionLimit':
@@ -515,6 +524,11 @@ class ilCourseXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
             case 'Course':
 
                 $this->log->write('CourseXMLParser: import_id = ' . $this->course_obj->getImportId());
+                /*
+                 * This needs to be before MDUpdateListener, since otherwise container settings are
+                 * overwritten by ilContainer::update in MDUpdateListener, see #24733.
+                 */
+                $this->course_obj->readContainerSettings();
                 $this->course_obj->MDUpdateListener('General');
                 $this->course_obj->update();
                 $this->adv_md_handler->save();
@@ -562,8 +576,7 @@ class ilCourseXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
                     if ((int) $this->cdata) {
                         if ($this->in_period_with_time) {
                             $this->period_end = new \ilDateTime((int) $this->cdata, IL_CAL_UNIX);
-                        }
-                        else {
+                        } else {
                             $this->period_end = new \ilDate((int) $this->cdata, IL_CAL_UNIX);
                         }
                     }
@@ -656,6 +669,14 @@ class ilCourseXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
 
             case 'TimingMode':
                 $this->course_obj->setTimingMode((int) $this->cdata);
+                break;
+
+            case 'StatusDetermination':
+                $this->course_obj->setStatusDetermination((int) $this->cdata);
+                break;
+
+            case 'MailToMembersType':
+                $this->course_obj->setMailToMembersType((int) $this->cdata);
                 break;
         }
         $this->cdata = '';

--- a/Modules/Course/classes/class.ilCourseXMLWriter.php
+++ b/Modules/Course/classes/class.ilCourseXMLWriter.php
@@ -404,6 +404,15 @@ class ilCourseXMLWriter extends ilXmlWriter
             ]
         );
 
+        $this->xmlElement('StatusDetermination', null, (int) $this->course_obj->getStatusDetermination());
+        $this->xmlElement('MailToMembersType', null, (int) $this->course_obj->getMailToMembersType());
+        $this->xmlElement('CourseMap', [
+            'enabled' => (int) $this->course_obj->getEnableCourseMap(),
+            'latitude' => $this->course_obj->getLatitude(),
+            'longitude' => $this->course_obj->getLongitude(),
+            'location_zoom' => $this->course_obj->getLocationZoom()
+        ]);
+
 
         $this->xmlEndTag('Settings');
 

--- a/xml/ilias_crs_7.dtd
+++ b/xml/ilias_crs_7.dtd
@@ -69,7 +69,7 @@
 	action (Attach|Detach) #IMPLIED
 >
 <!-- Description of course settings -->
-<!ELEMENT Settings (Availability?,Syllabus?,ImportantInformation?,TargetGroup?,Contact?,Registration?, Period?, ViewMode?, SessionLimit?, WelcomeMail?)>
+<!ELEMENT Settings (Availability?,Syllabus?,ImportantInformation?,TargetGroup?,Contact?,Registration?, Period?, ViewMode?, SessionLimit?, WelcomeMail?, StatusDetermination?, MailToMembersType?, CourseMap?)>
 
 <!-- Availability -->
 <!ELEMENT Availability (NotAvailable | Unlimited | TemporarilyAvailable)>
@@ -163,3 +163,13 @@
 		status (0,1) #REQUIRED
 >
 
+<!ELEMENT StatusDetermination (#PCDATA)>
+<!ELEMENT MailToMembersType (#PCDATA)>
+
+<!ELEMENT CourseMap EMPTY>
+<!ATTLIST
+		enabled (0,1) #REQUIRED
+		latitude #REQUIRED
+		longitude #REQUIRED
+		location_zoom #REQUIRED
+>


### PR DESCRIPTION
This PR fixes [24733](https://mantis.ilias.de/view.php?id=24733) by solving a problem with importing the Course setting 'News', and implementing import/export for the settings 'Determination of Status 'Passed'' and 'Mail to Members' as well as for the Course Map.

The setting 'Add to Favourites' and the 'Files for Download' from Course Information were intentionally left out: the former because of the low relevance of the setting, and the latter because of the larger footprint of the necessary changes.