### PR TITLE
9/UI/dropdown repository add item menu font size and padding

### DIFF
--- a/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
+++ b/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @use "../../../010-settings/" as s;
 @use "../../../010-settings/legacy-settings/legacy-settings_menu" as t-menu;
 @use "../../../030-tools/legacy-bootstrap-mixins/nav-divider" as t-ndiv;
@@ -167,16 +168,6 @@ $cursor-disabled: not-allowed !default;
 	left: 0;
   }
   
-  // Dropdown section headers
-  .dropdown-header {
-	display: block;
-	padding: 3px 20px;
-	font-size: s.$il-font-size-small;
-	line-height: s.$il-line-height-base;
-	color: $dropdown-header-color;
-	white-space: nowrap; // as with > li > a
-  }
-  
   // Backdrop to catch body clicks on mobile, etc.
   .dropdown-backdrop {
 	position: fixed;
@@ -223,7 +214,9 @@ $cursor-disabled: not-allowed !default;
 	margin-bottom: 4px;
 	border-bottom: 1px solid s.$il-main-border-color;
 	> h2 {
-		margin-bottom: 2px;
+		margin-top: math.div(l.$grid-gutter-width, 2);
+		margin-bottom: l.$il-margin-xs-vertical;
+		font-size: s.$il-font-size-large;
 	}
 }
 .dropdown-menu {
@@ -231,6 +224,13 @@ $cursor-disabled: not-allowed !default;
 	font-weight: s.$il-font-weight-base;
 	border: 0 none;
 	@include t-ven.box-shadow(t-menu.$il-dropdown-shadow);
+	// in repo "add object" dropdown
+	.row {
+		margin-bottom: math.div(l.$grid-gutter-width, 2);
+		> ul[class*="col-"] {
+			padding-left: math.div(l.$grid-gutter-width, 2);
+		}
+	}
 	// Links within the dropdown menu
 	li > a,
 	li > .btn-link {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -450,15 +450,6 @@
   left: 0;
 }
 
-.dropdown-header {
-  display: block;
-  padding: 3px 20px;
-  font-size: 0.75rem;
-  line-height: 1.428571429;
-  color: #737373;
-  white-space: nowrap;
-}
-
 .dropdown-backdrop {
   position: fixed;
   top: 0;
@@ -495,7 +486,9 @@
   border-bottom: 1px solid #dddddd;
 }
 .dropdown-header > h2 {
-  margin-bottom: 2px;
+  margin-top: 15px;
+  margin-bottom: 1px;
+  font-size: 1rem;
 }
 
 .dropdown-menu {
@@ -504,6 +497,12 @@
   border: 0 none;
   -webkit-box-shadow: 3px 9px 9px 0 rgba(0, 0, 0, 0.3);
   box-shadow: 3px 9px 9px 0 rgba(0, 0, 0, 0.3);
+}
+.dropdown-menu .row {
+  margin-bottom: 15px;
+}
+.dropdown-menu .row > ul[class*=col-] {
+  padding-left: 15px;
 }
 .dropdown-menu li > a,
 .dropdown-menu li > .btn-link {


### PR DESCRIPTION
# Issue

Font size and padding of the "add item" repo dropdown was off due to the bootstrap grid refactoring.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/12e2a6a4-80d2-4555-bca5-6b0839bbdb85)

# Changes

Tweaked font size and padding.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/a6dd3756-e5b5-444b-8a59-e63fb6133b1e)