### PR TITLE
[release_7] Introducing ilDBInterface::primaryExistsByFields  to check if a specific primary key exists in database

### DIFF
--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -2199,4 +2199,19 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
     {
         return $this->manager->getQueryUtils()->cast($a_field_name, $a_dest_type);
     }
+
+	/**
+	 * @inheritdoc
+	 */
+	public function primaryExistsByFields(string $table_name, array $field_names): bool
+	{
+		$constraints  = $this->manager->listTableConstraints($table_name);
+
+		if(in_array('primary', $constraints)) {
+			$definitions = $this->reverse->getTableConstraintDefinition($table_name, 'primary');
+			$primary_fields = array_keys($definitions['fields']);
+			return empty(array_diff($field_names, $primary_fields));
+		}
+		return false;
+	}
 }

--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -2200,18 +2200,21 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
         return $this->manager->getQueryUtils()->cast($a_field_name, $a_dest_type);
     }
 
-	/**
-	 * @inheritdoc
-	 */
-	public function primaryExistsByFields(string $table_name, array $field_names): bool
-	{
-		$constraints  = $this->manager->listTableConstraints($table_name);
+    /**
+     * @inheritdoc
+     */
+    public function primaryExistsByFields(string $table_name, array $fields) : bool
+    {
+        $constraints = $this->manager->listTableConstraints($table_name);
 
-		if(in_array('primary', $constraints)) {
-			$definitions = $this->reverse->getTableConstraintDefinition($table_name, 'primary');
-			$primary_fields = array_keys($definitions['fields']);
-			return empty(array_diff($field_names, $primary_fields));
-		}
-		return false;
-	}
+        if (in_array('primary', $constraints)) {
+            $definitions = $this->reverse->getTableConstraintDefinition($table_name, 'primary');
+            $primary_fields = array_keys($definitions['fields']);
+            sort($primary_fields);
+            sort($fields);
+
+            return $primary_fields === $fields;
+        }
+        return false;
+    }
 }

--- a/Services/Database/interfaces/interface.ilDBInterface.php
+++ b/Services/Database/interfaces/interface.ilDBInterface.php
@@ -687,4 +687,12 @@ interface ilDBInterface
      * @return string;
      */
     public function cast($a_field_name, $a_dest_type);
+
+	/**
+	 * @param string $table_name
+	 * @param array $field_names
+	 * @return bool
+	 */
+	public function primaryExistsByFields(string $table_name, array $field_names): bool;
+
 }

--- a/Services/Database/interfaces/interface.ilDBInterface.php
+++ b/Services/Database/interfaces/interface.ilDBInterface.php
@@ -688,11 +688,11 @@ interface ilDBInterface
      */
     public function cast($a_field_name, $a_dest_type);
 
-	/**
-	 * @param string $table_name
-	 * @param array $field_names
-	 * @return bool
-	 */
-	public function primaryExistsByFields(string $table_name, array $field_names): bool;
+    /**
+     * @param string $table_name
+     * @param array  $fields
+     * @return bool
+     */
+    public function primaryExistsByFields(string $table_name, array $fields) : bool;
 
 }


### PR DESCRIPTION
Dear @chfsx

as discussed in [#37750](https://mantis.ilias.de/view.php?id=37750) an ilDB function to check if a specific primary key exists for a database table. It is later used to check if the tree table has the primary key child set or uses an index instead.

Regards
Fabian Wolf