### PR TITLE
[release_8] Introducing ilDBInterface::primaryExistsByFields  to check if a specific primary key exists in database

### DIFF
--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -1500,4 +1500,19 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
     {
         return $this->manager->getQueryUtils()->cast($a_field_name, $a_dest_type);
     }
+
+    public function primaryExistsByFields(string $table_name, array $fields): bool
+    {
+        $constraints = $this->manager->listTableConstraints($table_name);
+
+        if (in_array('primary', $constraints)) {
+            $definitions = $this->reverse->getTableConstraintDefinition($table_name, 'primary');
+            $primary_fields = array_keys($definitions['fields']);
+            sort($primary_fields);
+            sort($fields);
+
+            return $primary_fields === $fields;
+        }
+        return false;
+    }
 }

--- a/Services/Database/interfaces/interface.ilDBInterface.php
+++ b/Services/Database/interfaces/interface.ilDBInterface.php
@@ -293,4 +293,6 @@ interface ilDBInterface
     public function groupConcat(string $a_field_name, string $a_seperator = ",", ?string $a_order = null): string;
 
     public function cast(string $a_field_name, string $a_dest_type): string;
+
+    public function primaryExistsByFields(string $table_name, array $fields) : bool;
 }


### PR DESCRIPTION
Dear @chfsx

as discussed in [#37750](https://mantis.ilias.de/view.php?id=37750) an ilDB function to check if a specific primary key exists for a database table. It is later used to check if the tree table has the primary key child set or uses an index instead.

Regards
Fabian Wolf