### PR TITLE
Group: fix import/export of News, Map, admission link

### DIFF
--- a/Modules/Group/classes/class.ilGroupXMLParser.php
+++ b/Modules/Group/classes/class.ilGroupXMLParser.php
@@ -279,6 +279,17 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
                 }
                 break;
 
+            case 'GroupMap':
+                $this->group_data['map_enabled'] = (bool) $a_attribs['enabled'] ?? false;
+                $this->group_data['map_latitude'] = (string) $a_attribs['latitude'] ?? '';
+                $this->group_data['map_longitude'] = (string) $a_attribs['longitude'] ?? '';
+                $this->group_data['map_location_zoom'] = (int) $a_attribs['location_zoom'] ?? 0;
+                break;
+
+            case 'RegistrationAccessCode':
+                $this->group_data['registration_code_enabled'] = (bool) $a_attribs['enabled'] ?? false;
+                $this->group_data['registration_code'] = (string) $a_attribs['code'] ?? '';
+                break;
             
             case 'WaitingListAutoFill':
             case 'CancellationEnd':
@@ -532,7 +543,6 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
             $this->group_obj->enableUnlimitedRegistration(false);
             $this->group_obj->setRegistrationStart($registration_start);
             $this->group_obj->setRegistrationEnd($registration_end);
-
         } else {
             $this->group_obj->enableUnlimitedRegistration(true);
         }
@@ -547,6 +557,10 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
         $this->group_obj->setShowMembers($this->group_data['show_members'] ? $this->group_data['show_members'] : 0);
         $this->group_obj->setAutoNotification($this->group_data['auto_notification'] ? true : false);
         $this->group_obj->setMailToMembersType((int) $this->group_data['mail_members_type']);
+
+        $this->group_obj->enableRegistrationAccessCode((bool) $this->group_data['registration_code_enabled'] ?? false);
+        $this->group_obj->setRegistrationAccessCode((string) $this->group_data['registration_code'] ?? '');
+
         if (isset($this->group_data['view_mode'])) {
             $this->group_obj->setViewMode((int) $this->group_data['view_mode']);
         }
@@ -559,6 +573,17 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
         if (isset($this->group_data['session_next'])) {
             $this->group_obj->setNumberOfNextSessions((int) $this->group_data['session_next']);
         }
+
+        $this->group_obj->setEnableGroupMap((bool) $this->group_data['map_enabled'] ?? false);
+        $this->group_obj->setLatitude((string) $this->group_data['map_latitude'] ?? '');
+        $this->group_obj->setLongitude((string) $this->group_data['map_longitude'] ?? '');
+        $this->group_obj->setLocationZoom((int) $this->group_data['map_location_zoom'] ?? 0);
+
+        /*
+         * readContainerSettings needs to be called before update, otherwise container
+         * settings are overwritten by the default, see #24742.
+         */
+        $this->group_obj->readContainerSettings();
         $this->group_obj->update();
 
         // ASSIGN ADMINS/MEMBERS

--- a/Modules/Group/classes/class.ilGroupXMLWriter.php
+++ b/Modules/Group/classes/class.ilGroupXMLWriter.php
@@ -282,8 +282,16 @@ class ilGroupXMLWriter extends ilXmlWriter
         $this->xmlElement('minMembers', null, (int) $this->group_obj->getMinMembers());
         $this->xmlElement('WaitingListAutoFill', null, (int) $this->group_obj->hasWaitingListAutoFill());
         $this->xmlElement('CancellationEnd', null, ($this->group_obj->getCancellationEnd() && !$this->group_obj->getCancellationEnd()->isNull()) ? $this->group_obj->getCancellationEnd()->get(IL_CAL_UNIX) : null);
-        
+
         $this->xmlElement('mailMembersType', null, (string) $this->group_obj->getMailToMembersType());
+
+        $this->xmlElement(
+            'RegistrationAccessCode',
+            [
+                'enabled' => (int) $this->group_obj->isRegistrationAccessCodeEnabled(),
+                'code' => $this->group_obj->getRegistrationAccessCode()
+            ]
+        );
 
         $this->xmlEndTag('registration');
     }
@@ -305,6 +313,13 @@ class ilGroupXMLWriter extends ilXmlWriter
                 'next' => $this->group_obj->getNumberOfNextSessions()
             ]
         );
+
+        $this->xmlElement('GroupMap', [
+            'enabled' => (int) $this->group_obj->getEnableGroupMap(),
+            'latitude' => $this->group_obj->getLatitude(),
+            'longitude' => $this->group_obj->getLongitude(),
+            'location_zoom' => $this->group_obj->getLocationZoom()
+        ]);
     }
 
     public function __buildAdmin()

--- a/xml/ilias_grp_7.dtd
+++ b/xml/ilias_grp_7.dtd
@@ -4,7 +4,7 @@
 
 <!-- GROUP -->
 <!-- Added registration as optional due to BC to ILIAS 2 export -->
-<!ELEMENT group (title,description,owner?,information?,registration?,admissionNotification?,period?, admin*,member*,file*,folder*,Sort?, ViewMode?, SessionLimit?, ContainerSetting*)>
+<!ELEMENT group (title,description,owner?,information?,registration?,admissionNotification?,period?, admin*,member*,file*,folder*,Sort?, ViewMode?, SessionLimit?, ContainerSetting*, GroupMap?)>
 <!-- type is 'open' or 'closed' -->
 <!ATTLIST group
     exportVersion CDATA #REQUIRED
@@ -49,7 +49,7 @@
 
 
 		<!-- Registration settings -->
-<!ELEMENT registration (password?,(temporarilyAvailable | expiration)?,maxMembers?, minMembers?, mailMembersType?)>
+<!ELEMENT registration (password?,(temporarilyAvailable | expiration)?,maxMembers?, minMembers?, mailMembersType?, RegistrationAccessCode?)>
 
 <!--
 
@@ -99,6 +99,12 @@
 
 <!ELEMENT mailMembersType (#PCDATA)>
 
+<!ELEMENT RegistrationAccessCode EMPTY>
+<!ATTLIST
+	enabled (0,1) #REQUIRED
+	code #REQUIRED
+>
+
 <!-- FILE stored in objects directory with filename "id" -->
 <!ELEMENT file EMPTY>
 <!ATTLIST file
@@ -134,3 +140,11 @@
 <!ELEMENT ContainerSetting (#PCDATA)>
 <!ATTLIST ContainerSetting
 		id CDATA #REQUIRED>
+
+<!ELEMENT GroupMap EMPTY>
+<!ATTLIST
+	enabled (0,1) #REQUIRED
+	latitude #REQUIRED
+	longitude #REQUIRED
+	location_zoom #REQUIRED
+>


### PR DESCRIPTION
This PR fixes [24742](https://mantis.ilias.de/view.php?id=24742) by repairing the import of the News setting in groups, and implementing import/export of the Map and the setting 'Admission per Link', similar to #6228.