### PR TITLE
[FIX] 0031534: Identical Page Titles

### DIFF
--- a/Services/UICore/classes/Screen/PageContentProvider.php
+++ b/Services/UICore/classes/Screen/PageContentProvider.php
@@ -111,11 +111,40 @@ class PageContentProvider extends AbstractModificationProvider
     {
         /** @var $modification ViewTitleModification */
         $modification = $this->globalScreen()->layout()->factory()->view_title()->withModification(
-            fn (?string $content): ?string => self::$view_title
+            fn (?string $content): ?string => $this->buildTabTitle() . self::$view_title
         )->withLowPriority();
 
         return $modification;
     }
+
+    /**
+     * @description This method was introduced due to A11y problems, see https://mantis.ilias.de/view.php?id=31534.
+     * This is definitely only a workaround, but since this is currently the only way to implement it, it is just introduced...
+     */
+    private function buildTabTitle(): string
+    {
+        $tabs = $this->dic->tabs()->target; // this only works because target is currently public...
+        $tab_title = '';
+        $active_tab = $this->dic->tabs()->getActiveTab();
+        if ($active_tab === '' && isset($tabs[0])) {
+            $active_tab = $tabs[0]['id']; // if no tab is active, use the first one
+        }
+
+        foreach ($tabs as $tab) {
+            if ($tab['id'] === $active_tab) {
+                if (($tab['dir_text'] ?? false) === false) {
+                    $tab_title = $this->dic->language()->txt($tab['text']);
+                } else {
+                    $tab_title = $tab['text'] ?? '';
+                }
+                $tab_title .= ': ';
+                break;
+            }
+        }
+
+        return $tab_title === '' ? '' : $tab_title . ': ';
+    }
+
 
     public function getFooterModification(CalledContexts $screen_context_stack): ?FooterModification
     {

--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -12,7 +12,7 @@
 	<base href="{BASE}" />
 	<!-- END for_ui_examples_only -->
 
-	<title>{SHORT_TITLE}: {VIEW_TITLE}</title>
+	<title>{VIEW_TITLE}: {SHORT_TITLE}</title>
 	<link rel="icon" href="{FAVICON_PATH}" type="image/x-icon">
 
 	<style>

--- a/tests/UI/Component/Layout/Page/StandardPageTest.php
+++ b/tests/UI/Component/Layout/Page/StandardPageTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 require_once("libs/composer/vendor/autoload.php");
 require_once(__DIR__ . "/../../../Base.php");
@@ -255,7 +255,7 @@ class StandardPageTest extends ILIAS_UI_TestBase
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Short Title: View Title</title>
+    <title>View Title: Short Title</title>
     <link rel="icon" href="favicon.ico" type="image/x-icon">
     <style></style>
 </head>


### PR DESCRIPTION
this PR solves the described A11y problem from https://mantis.ilias.de/view.php?id=31534. in my opinion, this is a workaround and will certainly be revised in the context of general refactoring, how a page is put together. for the moment, however, we can probably live with it...

Some examples:
- Settings: My funny Course Title: ILIAS
- Dashboard: ILIAS