### PR TITLE
Fix/0037784/8/save confirmation with fileupload

### DIFF
--- a/Modules/DataCollection/classes/Helpers/class.ilDclPropertyFormGUI.php
+++ b/Modules/DataCollection/classes/Helpers/class.ilDclPropertyFormGUI.php
@@ -52,7 +52,7 @@ class ilDclPropertyFormGUI extends ilPropertyFormGUI
         $tmp_file_name = implode(
             "~~",
             array(
-                mb_substr(session_id(), 0, 8),
+                session_id(),
                 $a_hash,
                 $a_field,
                 $a_index,

--- a/Services/GlobalCache/classes/Settings/class.ilGlobalCacheSettings.php
+++ b/Services/GlobalCache/classes/Settings/class.ilGlobalCacheSettings.php
@@ -84,7 +84,7 @@ class ilGlobalCacheSettings implements Setup\Config
             )
         );
         $this->setService(
-            $ilIniFile->readVariable(
+            (int)$ilIniFile->readVariable(
                 self::INI_HEADER_CACHE,
                 self::INI_FIELD_GLOBAL_CACHE_SERVICE_TYPE
             )
@@ -232,9 +232,9 @@ class ilGlobalCacheSettings implements Setup\Config
     public function __toString(): string
     {
         $service = 'Service: ' . ($this->getService(
-            ) > 0 ? ilGlobalCache::lookupServiceClassName(
-                $this->getService()
-            ) : 'none');
+        ) > 0 ? ilGlobalCache::lookupServiceClassName(
+            $this->getService()
+        ) : 'none');
         $activated = 'Activated Components: ' . implode(
             ', ',
             $this->getActivatedComponents()


### PR DESCRIPTION
This is a solution for https://mantis.ilias.de/view.php?id=37784. this was the only place where only the first 8 characters of the session id was used for the temp-file.