### PR TITLE
Soap response timeout in  setup config

### DIFF
--- a/Services/WebServices/SOAP/classes/class.ilSoapClient.php
+++ b/Services/WebServices/SOAP/classes/class.ilSoapClient.php
@@ -54,7 +54,7 @@ class ilSoapClient
         }
         $this->connect_timeout = $timeout;
         
-        $this->response_timeout = self::DEFAULT_RESPONSE_TIMEOUT;
+        $this->response_timeout = $ilSetting->get('soap_response_timeout', self::DEFAULT_RESPONSE_TIMEOUT);
     }
     
     /**

--- a/Services/WebServices/SOAP/classes/class.ilSoapClient.php
+++ b/Services/WebServices/SOAP/classes/class.ilSoapClient.php
@@ -54,7 +54,7 @@ class ilSoapClient
         }
         $this->connect_timeout = $timeout;
         
-        $this->response_timeout = $ilSetting->get('soap_response_timeout', self::DEFAULT_RESPONSE_TIMEOUT);
+        $this->response_timeout = (int) $ilSetting->get('soap_response_timeout', self::DEFAULT_RESPONSE_TIMEOUT);
     }
     
     /**

--- a/Services/WebServices/classes/Setup/class.ilWebServicesConfigStoredObjective.php
+++ b/Services/WebServices/classes/Setup/class.ilWebServicesConfigStoredObjective.php
@@ -53,6 +53,7 @@ class ilWebServicesConfigStoredObjective implements Setup\Objective
         );
         $settings->set("soap_wsdl_path", $this->config->getSOAPWsdlPath());
         $settings->set("soap_connect_timeout", (int) $this->config->getSOAPConnectTimeout());
+        $settings->set("soap_response_timeout", (int) $this->config->getSoapResponseTimeout());
         $settings->set("rpc_server_host", $this->config->getRPCServerHost());
         $settings->set("rpc_server_port", $this->config->getRPCServerPort());
 

--- a/Services/WebServices/classes/Setup/class.ilWebServicesConfigStoredObjective.php
+++ b/Services/WebServices/classes/Setup/class.ilWebServicesConfigStoredObjective.php
@@ -53,7 +53,7 @@ class ilWebServicesConfigStoredObjective implements Setup\Objective
         );
         $settings->set("soap_wsdl_path", $this->config->getSOAPWsdlPath());
         $settings->set("soap_connect_timeout", (string) $this->config->getSOAPConnectTimeout());
-        $settings->set("soap_response_timeout", (int) $this->config->getSoapResponseTimeout());
+        $settings->set("soap_response_timeout", (string) $this->config->getSoapResponseTimeout());
         $settings->set("rpc_server_host", $this->config->getRPCServerHost());
         $settings->set("rpc_server_port", $this->config->getRPCServerPort());
 

--- a/Services/WebServices/classes/Setup/class.ilWebServicesConfigStoredObjective.php
+++ b/Services/WebServices/classes/Setup/class.ilWebServicesConfigStoredObjective.php
@@ -52,7 +52,7 @@ class ilWebServicesConfigStoredObjective implements Setup\Objective
             $this->bool2string($this->config->isSOAPUserAdministration())
         );
         $settings->set("soap_wsdl_path", $this->config->getSOAPWsdlPath());
-        $settings->set("soap_connect_timeout", (int) $this->config->getSOAPConnectTimeout());
+        $settings->set("soap_connect_timeout", (string) $this->config->getSOAPConnectTimeout());
         $settings->set("soap_response_timeout", (int) $this->config->getSoapResponseTimeout());
         $settings->set("rpc_server_host", $this->config->getRPCServerHost());
         $settings->set("rpc_server_port", $this->config->getRPCServerPort());

--- a/Services/WebServices/classes/Setup/class.ilWebServicesSetupAgent.php
+++ b/Services/WebServices/classes/Setup/class.ilWebServicesSetupAgent.php
@@ -46,8 +46,9 @@ class ilWebServicesSetupAgent implements Setup\Agent
                 (bool) ($data["soap_user_administration"] ?? false),
                 $data["soap_wsdl_path"] ?? "",
                 (int) ($data["soap_connect_timeout"] ?? ilSoapClient::DEFAULT_CONNECT_TIMEOUT),
+                (int) ($data["soap_response_timeout"] ?? ilSoapClient::DEFAULT_RESPONSE_TIMEOUT),
                 $data["rpc_server_host"] ?? "",
-                (int) ($data["rpc_server_port"] ?? 0)
+                (int) ($data["rpc_server_port"] ?? 0),
             );
         });
     }

--- a/Services/WebServices/classes/Setup/class.ilWebServicesSetupConfig.php
+++ b/Services/WebServices/classes/Setup/class.ilWebServicesSetupConfig.php
@@ -77,9 +77,6 @@ class ilWebServicesSetupConfig implements Setup\Config
         return $this->rpc_server_port;
     }
 
-    /**
-     * @return int
-     */
     public function getSoapResponseTimeout(): int
     {
         return $this->soap_response_timeout;

--- a/Services/WebServices/classes/Setup/class.ilWebServicesSetupConfig.php
+++ b/Services/WebServices/classes/Setup/class.ilWebServicesSetupConfig.php
@@ -31,10 +31,16 @@ class ilWebServicesSetupConfig implements Setup\Config
      */
     protected $rpc_server_port;
 
+    /**
+     * @var int
+     */
+    protected $soap_response_timeout;
+
     public function __construct(
         bool $soap_user_administration,
         string $soap_wsdl_path,
         int $soap_connect_timeout,
+        int $soap_response_timeout,
         string $rpc_server_host,
         int $rpc_server_port
     ) {
@@ -43,6 +49,7 @@ class ilWebServicesSetupConfig implements Setup\Config
         $this->soap_connect_timeout = $soap_connect_timeout;
         $this->rpc_server_host = $rpc_server_host;
         $this->rpc_server_port = $rpc_server_port;
+        $this->soap_response_timeout = $soap_response_timeout;
     }
 
     public function isSOAPUserAdministration() : bool
@@ -68,5 +75,13 @@ class ilWebServicesSetupConfig implements Setup\Config
     public function getRPCServerPort() : int
     {
         return $this->rpc_server_port;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSoapResponseTimeout(): int
+    {
+        return $this->soap_response_timeout;
     }
 }


### PR DESCRIPTION
Different components deal with response timeout differently and mostly  use  a default value defined in the soapclient class. For requests which needs  to run a longer time than the default value, this posits an issue. For example, the soap copyObject Method is expected to return reference ids in the response. However,  large objects which usually take longer, send a response to client before the request has finished processing. The IDs sent will be zero since the function returned before they were available. This PR adds the possibility to set this value globally in the setup config. Components are still allowed to set their own values if they don't want to use the default value.