### PR TITLE
[FIX]  0025388: Group  and Course XML parser ignore empty spaces in ContainerSetting element

### DIFF
--- a/Modules/Group/classes/class.ilGroupXMLParser.php
+++ b/Modules/Group/classes/class.ilGroupXMLParser.php
@@ -356,7 +356,7 @@ class ilGroupXMLParser extends ilMDSaxParser implements ilSaxSubsetParser
                     ilContainer::_writeContainerSetting(
                         $this->group_obj->getId(),
                         $this->current_container_setting,
-                        $this->cdata
+                        trim($this->cdata)
                     );
                 }
                 break;


### PR DESCRIPTION
This PR fixes https://mantis.ilias.de/view.php?id=25388