### PR TITLE
9/UI/dropdown fix one line in table header, set inline, menu position 37670

### DIFF
--- a/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
+++ b/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
@@ -55,6 +55,7 @@ $cursor-disabled: not-allowed !default;
   .dropup,
   .dropdown {
 	position: relative;
+	display: inline-block; // so dropdown can be in one line with a button
   }
   
   // Prevent the focus on the dropdown toggle when closing dropdowns

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -376,6 +376,7 @@
 .dropup,
 .dropdown {
   position: relative;
+  display: inline-block;
 }
 
 .dropdown-toggle:focus {
@@ -2195,7 +2196,6 @@ th {
     display: none !important;
   }
 }
-
 .l-bar__container,
 .l-bar__group {
   display: flex;
@@ -2228,6 +2228,9 @@ th {
   margin-right: 0;
 }
 
+/*
+* Elements
+*/
 * {
   box-sizing: border-box;
 }
@@ -10435,73 +10438,6 @@ tbody.collapse.in {
   transition-timing-function: ease;
 }
 
-/*
-// section based on bootstrap 3 - see /templates/default/Guidelines_SCSS-Coding.md
-
-$badge-color:                 s.$il-text-color-invert;
-//** Linked badge text color on hover
-$badge-link-hover-color:      s.$il-text-color-invert;
-$badge-bg:                    s.$il-neutral-color;
-
-//** Badge text color in active nav link
-$badge-active-color:          s.$il-link-color;
-//** Badge background color in active nav link
-$badge-active-bg:             s.$il-main-bg;
-
-$badge-font-weight:           s.$il-border-radius-secondary-large;
-$badge-line-height:           1;
-$badge-border-radius:         10px;
-
-
-// Base class
-.badge {
-    // display: inline-block;
-    // min-width: 10px;
-    padding: 3px 7px;
-    font-size: s.$il-font-size-small;
-    font-weight: $badge-font-weight;
-    line-height: $badge-line-height;
-    color: $badge-color;
-
-    background-color: $badge-bg;
-    border-radius: $badge-border-radius;
-
-    // Empty badges collapse automatically (not available in IE8)
-    &:empty {
-      display: none;
-    }
-
-    // [converter] extracted a& to a.badge
-
-    // Account for badges in navs
-    .list-group-item.active > &,
-    .nav-pills > .active > a > & {
-      color: $badge-active-color;
-      background-color: $badge-active-bg;
-    }
-
-    .list-group-item > & {
-      float: right;
-    }
-
-    .list-group-item > & + & {
-      margin-right: 5px;
-    }
-
-    .nav-pills > li > a > & {
-      margin-left: 3px;
-    }
-  }
-
-  // Hover state, but only for links
-  a.badge {
-    &:hover,
-    &:focus {
-      color: $badge-link-hover-color;
-      text-decoration: none;
-      cursor: pointer;
-    }
-  } */
 .btn-group,
 .btn-group-vertical {
   position: relative;


### PR DESCRIPTION
Fixes: https://mantis.ilias.de/view.php?id=37670

# Issue

## Initial issue
Dropdown menu was misaligned. Dropdown itself should be inline with other buttons.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/7d723704-4b53-48bb-9cd1-0b7244dd55a0)

## Newly discovered issue
Technically, the buttons changing rows and columns and showing/hiding filters are now considered view controls in ILIAS 9. Since the new input viewcontrols are now merged, the row button should be an input viewcontrol pagination. The other ones should be input viewcontrols as well.

# Changes

## Initial issue
Fixed. The buttons are now in one line. The menu opens correctly directly below the dropdown.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/b31c2c54-c1c6-4f31-94d3-6f666af7f5d8)

## Newly discovered issue
My knowledge of php is not good enough to change this. Is it worth fixing the legacy table2? Will they be replaced by UI framework data table soon?