### PR TITLE
Fix 37803: Frequent errors in ILIAS log »Duplicate entry 'MathJax-dummy' for key 'PRIMARY«

### DIFF
--- a/Services/MathJax/classes/class.ilMathJax.php
+++ b/Services/MathJax/classes/class.ilMathJax.php
@@ -124,7 +124,7 @@ class ilMathJax
         global $DIC;
 
         if (!isset(self::$_instance)) {
-            $repo = new ilMathJaxConfigSettingsRepository(new ilSettingsFactory($DIC->database()));
+            $repo = new ilMathJaxConfigSettingsRepository();
             self::$_instance = new self($repo->getConfig(), new ilMathJaxFactory());
         }
         return self::$_instance;

--- a/Services/MathJax/classes/class.ilMathJaxConfigSettingsRepository.php
+++ b/Services/MathJax/classes/class.ilMathJaxConfigSettingsRepository.php
@@ -25,9 +25,13 @@ class ilMathJaxConfigSettingsRepository implements ilMathJaxConfigRespository
     /**
      * Constructor
      */
-    public function __construct(ilSettingsFactory $factory)
+    public function __construct(?ilSettingsFactory $factory = null)
     {
-        $this->settings = $factory->settingsFor('MathJax');
+        if($factory === null) {
+            $this->settings = new ilSetting('MathJax', true);
+        } else {
+            $this->settings = $factory->settingsFor('MathJax');
+        }
     }
 
     /**

--- a/Services/MathJax/classes/class.ilMathJaxSettingsGUI.php
+++ b/Services/MathJax/classes/class.ilMathJaxSettingsGUI.php
@@ -51,8 +51,7 @@ class ilMathJaxSettingsGUI
         $this->request = $this->dic->http()->request();
         $this->refinery = $this->dic->refinery();
 
-        $factory = new ilSettingsFactory($DIC->database());
-        $this->repository = new ilMathJaxConfigSettingsRepository($factory);
+        $this->repository = new ilMathJaxConfigSettingsRepository();
     }
 
     /**


### PR DESCRIPTION
Remove the usage of ilSettingsFactory::settingsFor outside of a setup environment because it tends to trigger database integrity constraint violations if called simultaneously on crowded installations