### PR TITLE
Fix  0036953: SOAP method copyObjects returns no ref_ids for long requests

### DIFF
--- a/Services/Container/classes/class.ilContainer.php
+++ b/Services/Container/classes/class.ilContainer.php
@@ -675,7 +675,7 @@ class ilContainer extends ilObject
         include_once 'Services/WebServices/SOAP/classes/class.ilSoapClient.php';
 
         $soap_client = new ilSoapClient();
-        $soap_client->setResponseTimeout(5);
+        $soap_client->setResponseTimeout($soap_client->getResponseTimeout());
         $soap_client->enableWSDL(true);
 
         $ilLog->write(__METHOD__ . ': Trying to call Soap client...');


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=36953
This PR allows  the methods to use the response timeout defined in  settings instead of the hardcoded default one.