### PR TITLE
Test: Fix availability datetime handling

### DIFF
--- a/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
+++ b/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
@@ -512,8 +512,14 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
         if ($this->test_object->isActivationLimited()) {
             $value = [
                 'time_span' => [
-                    DateTimeImmutable::createFromFormat('U', (string) $this->test_object->getActivationStartingTime()),
-                    DateTimeImmutable::createFromFormat('U', (string) $this->test_object->getActivationEndingTime())
+                    DateTimeImmutable::createFromFormat(
+                        'U',
+                        (string) $this->test_object->getActivationStartingTime()
+                    )->setTimezone(new DateTimeZone($this->activeUser->getTimeZone())),
+                    DateTimeImmutable::createFromFormat(
+                        'U',
+                        (string) $this->test_object->getActivationEndingTime()
+                    )->setTimezone(new DateTimeZone($this->activeUser->getTimeZone())),
                 ],
                 'activation_visibility' => $this->test_object->getActivationVisibility()
             ];


### PR DESCRIPTION
This PR fixes the timezone handling of the test availability when populating the form with the values from the persistence layer.

See comments of https://mantis.ilias.de/view.php?id=37757