### PR TITLE
Object: fix saving offline status

### DIFF
--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -429,7 +429,8 @@ class ilObject
             $property_is_online = $property_is_online->withOffline();
         }
 
-        $this->object_properties = $this->getObjectProperties()->withPropertyIsOnline($property_is_online);
+        $this->getObjectProperties()->withPropertyIsOnline($property_is_online);
+        $this->object_properties = $this->getObjectProperties();
     }
 
     public function getOfflineStatus(): bool


### PR DESCRIPTION
This PR fixes [37844](https://mantis.ilias.de/view.php?id=37844). Feel free to close this if you prefer changing `ilObjectProperties::withPropertyIsOnline` or something like that.