### PR TITLE
Fix redirect loop when session expires

### DIFF
--- a/Services/Authentication/classes/class.ilSession.php
+++ b/Services/Authentication/classes/class.ilSession.php
@@ -256,9 +256,6 @@ class ilSession
         try {
             // only delete session cookie if it is set in the current request
             if (isset($_COOKIE[session_name()]) && $_COOKIE[session_name()] === $a_session_id) {
-                //$params = session_get_cookie_params();
-               // setcookie(session_name(), '', 0, $params['path'], $params['domain'], $params['secure'], isset($params['httponly']));
-
                 \ilUtil::setCookie(session_name(), '', false,true);
             }
         } catch (\Throwable $e) {

--- a/Services/Authentication/classes/class.ilSession.php
+++ b/Services/Authentication/classes/class.ilSession.php
@@ -253,9 +253,17 @@ class ilSession
 
         $ilDB->manipulate($q);
 
-        $params = session_get_cookie_params();
-        setcookie(session_name(), '', 0, $params['path'], $params['domain'], $params['secure'], isset($params['httponly']));
-        
+        try {
+            // only delete session cookie if it is set in the current request
+            if (isset($_COOKIE[session_name()]) && $_COOKIE[session_name()] == $a_session_id) {
+                $params = session_get_cookie_params();
+                setcookie(session_name(), '', 0, $params['path'], $params['domain'], $params['secure'], isset($params['httponly']));
+            }
+        } catch (\Throwable $e) {
+            // ignore
+            // this is needed for "header already"  sent errors when the random cleanup of expired sessions is triggered
+        }
+
         return true;
     }
 

--- a/Services/Authentication/classes/class.ilSession.php
+++ b/Services/Authentication/classes/class.ilSession.php
@@ -256,7 +256,7 @@ class ilSession
         try {
             // only delete session cookie if it is set in the current request
             if (isset($_COOKIE[session_name()]) && $_COOKIE[session_name()] === $a_session_id) {
-                \ilUtil::setCookie(session_name(), '', false,true);
+                \ilUtil::setCookie(session_name(), '', false, true);
             }
         } catch (\Throwable $e) {
             // ignore

--- a/Services/Authentication/classes/class.ilSession.php
+++ b/Services/Authentication/classes/class.ilSession.php
@@ -255,9 +255,11 @@ class ilSession
 
         try {
             // only delete session cookie if it is set in the current request
-            if (isset($_COOKIE[session_name()]) && $_COOKIE[session_name()] == $a_session_id) {
-                $params = session_get_cookie_params();
-                setcookie(session_name(), '', 0, $params['path'], $params['domain'], $params['secure'], isset($params['httponly']));
+            if (isset($_COOKIE[session_name()]) && $_COOKIE[session_name()] === $a_session_id) {
+                //$params = session_get_cookie_params();
+               // setcookie(session_name(), '', 0, $params['path'], $params['domain'], $params['secure'], isset($params['httponly']));
+
+                \ilUtil::setCookie(session_name(), '', false,true);
             }
         } catch (\Throwable $e) {
             // ignore

--- a/Services/Authentication/classes/class.ilSession.php
+++ b/Services/Authentication/classes/class.ilSession.php
@@ -252,6 +252,9 @@ class ilSession
         ilSessionIStorage::destroySession($a_session_id);
 
         $ilDB->manipulate($q);
+
+        $params = session_get_cookie_params();
+        setcookie(session_name(), '', 0, $params['path'], $params['domain'], $params['secure'], isset($params['httponly']));
         
         return true;
     }

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1406,7 +1406,9 @@ class ilInitialisation
             !$GLOBALS['DIC']['ilAuthSession']->isAuthenticated() or
             $GLOBALS['DIC']['ilAuthSession']->isExpired()
         ) {
-            ilSession::_destroy($_COOKIE[session_name()], ilSession::SESSION_CLOSE_EXPIRE);
+            if ($GLOBALS['DIC']['ilAuthSession']->isExpired()) {
+                ilSession::_destroy($_COOKIE[session_name()], ilSession::SESSION_CLOSE_EXPIRE);
+            }
 
             ilLoggerFactory::getLogger('init')->debug('Current session is invalid: ' . $GLOBALS['DIC']['ilAuthSession']->getId());
             $current_script = substr(strrchr($_SERVER["PHP_SELF"], "/"), 1);

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1406,7 +1406,7 @@ class ilInitialisation
             !$GLOBALS['DIC']['ilAuthSession']->isAuthenticated() or
             $GLOBALS['DIC']['ilAuthSession']->isExpired()
         ) {
-            ilSession::_destroy($_COOKIE[session_name()],ilSession::SESSION_CLOSE_EXPIRE);
+            ilSession::_destroy($_COOKIE[session_name()], ilSession::SESSION_CLOSE_EXPIRE);
 
             ilLoggerFactory::getLogger('init')->debug('Current session is invalid: ' . $GLOBALS['DIC']['ilAuthSession']->getId());
             $current_script = substr(strrchr($_SERVER["PHP_SELF"], "/"), 1);

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -991,22 +991,21 @@ class ilInitialisation
 
     /**
      * go to login
-     *
-     * @param int $a_auth_stat
      */
     protected static function goToLogin()
     {
         ilLoggerFactory::getLogger('init')->debug('Redirecting to login page.');
 
+        $script = "login.php?target=" . $_GET["target"] . "&client_id=" . CLIENT_ID;
+
         if ($GLOBALS['DIC']['ilAuthSession']->isExpired()) {
             ilSession::setClosingContext(ilSession::SESSION_CLOSE_EXPIRE);
+
+            $script .= "&session_expired=1";
         }
         if (!$GLOBALS['DIC']['ilAuthSession']->isAuthenticated()) {
             ilSession::setClosingContext(ilSession::SESSION_CLOSE_LOGIN);
         }
-
-        $script = "login.php?target=" . $_GET["target"] . "&client_id=" . CLIENT_ID .
-            "&auth_stat=" . $a_auth_stat;
 
         self::redirect(
             $script,
@@ -1407,6 +1406,8 @@ class ilInitialisation
             !$GLOBALS['DIC']['ilAuthSession']->isAuthenticated() or
             $GLOBALS['DIC']['ilAuthSession']->isExpired()
         ) {
+            ilSession::_destroy($_COOKIE[session_name()],ilSession::SESSION_CLOSE_EXPIRE);
+
             ilLoggerFactory::getLogger('init')->debug('Current session is invalid: ' . $GLOBALS['DIC']['ilAuthSession']->getId());
             $current_script = substr(strrchr($_SERVER["PHP_SELF"], "/"), 1);
             if (self::blockedAuthentication($current_script)) {

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -265,7 +265,7 @@ class ilStartUpGUI
         $page_editor_html = $this->purgePlaceholders($page_editor_html);
 
         // check expired session and send message
-        if ($GLOBALS['DIC']['ilAuthSession']->isExpired()) {
+        if ($GLOBALS['DIC']['ilAuthSession']->isExpired() || $this->httpRequest->getQueryParams()['session_expired']) {
             ilUtil::sendFailure($GLOBALS['lng']->txt('auth_err_expired'));
         }
 

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -265,7 +265,7 @@ class ilStartUpGUI
         $page_editor_html = $this->purgePlaceholders($page_editor_html);
 
         // check expired session and send message
-        if ($GLOBALS['DIC']['ilAuthSession']->isExpired() || $this->httpRequest->getQueryParams()['session_expired']) {
+        if ($GLOBALS['DIC']['ilAuthSession']->isExpired() || $this->httpRequest->getQueryParams()['session_expired'] ?? false) {
             ilUtil::sendFailure($GLOBALS['lng']->txt('auth_err_expired'));
         }
 


### PR DESCRIPTION
Hello friends of ilias,

i am here again to solve my favorite issue of all the time: https://mantis.ilias.de/view.php?id=31639

The problem is that there is a redirect loop also if the anonymous area is not enabled. An expired session forces the user to clear the cookies or to login again. Most other pages are not reachable if the redirect loop is triggered. 

I had to make some changes to the session handling and destroying expired session to make it work. Also the handling for the "Your session expired" message is changed.


This works for me but there could be some side effects. Someone with deeper initialisation/session knowledge should review this change. 


Greetings Purhur