### PR TITLE
Fix 37848: Remove return type

### DIFF
--- a/Modules/DataCollection/classes/Fields/Reference/class.ilDclReferenceRecordRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Reference/class.ilDclReferenceRecordRepresentation.php
@@ -100,9 +100,9 @@ class ilDclReferenceRecordRepresentation extends ilDclBaseRecordRepresentation
 
     /**
      * function parses stored value to the variable needed to fill into the form for editing.
-     * @param string|int $value
+     * @param string|array $value
      */
-    public function parseFormInput($value): ?string
+    public function parseFormInput($value)
     {
         if (!$value || $value == []) {
             return null;


### PR DESCRIPTION
According to ilDclBaseRecordFieldModel::getValue which is the only source for this function argument the type is a mixed string|array but the object variable it could also be int|float|array|null (only as type hinting). 

Please check those hints and adjust them if necessary.