### PR TITLE
Course & Group: small performance improvements for members view

### DIFF
--- a/Modules/Course/classes/class.ilCourseParticipantsTableGUI.php
+++ b/Modules/Course/classes/class.ilCourseParticipantsTableGUI.php
@@ -182,7 +182,7 @@ class ilCourseParticipantsTableGUI extends ilParticipantTableGUI
             $this->tpl->parseCurrentBlock();
         }
 
-        if (!ilObjUser::_lookupActive($a_set['usr_id'])) {
+        if (!$a_set['active']) {
             $this->tpl->setCurrentBlock('access_warning');
             $this->tpl->setVariable('PARENT_ACCESS', $this->lng->txt('usr_account_inactive'));
             $this->tpl->parseCurrentBlock();

--- a/Modules/Course/classes/class.ilCourseParticipantsTableGUI.php
+++ b/Modules/Course/classes/class.ilCourseParticipantsTableGUI.php
@@ -21,6 +21,7 @@ class ilCourseParticipantsTableGUI extends ilParticipantTableGUI
      * @var ilCertificateUserForObjectPreloader|null
      */
     private $preLoader;
+    protected $cached_user_names = [];
 
     /**
      * Constructor
@@ -438,7 +439,8 @@ class ilCourseParticipantsTableGUI extends ilParticipantTableGUI
         // merge course data
         $course_user_data = $this->getParentObject()->readMemberData(
             $usr_ids,
-            $this->getSelectedColumns()
+            $this->getSelectedColumns(),
+            true
         );
         $a_user_data = array();
         foreach ((array) $usr_data['set'] as $ud) {
@@ -477,7 +479,7 @@ class ilCourseParticipantsTableGUI extends ilParticipantTableGUI
                         if ($pinfo["user_id"] < 0) {
                             $passed_info = $this->lng->txt("crs_passed_status_system");
                         } elseif ($pinfo["user_id"] > 0) {
-                            $name = ilObjUser::_lookupName($pinfo["user_id"]);
+                            $name = $this->lookupUserName((int) $pinfo["user_id"]);
                             $passed_info = $this->lng->txt("crs_passed_status_manual_by") . ": " . $name["login"];
                         }
                     }
@@ -538,7 +540,7 @@ class ilCourseParticipantsTableGUI extends ilParticipantTableGUI
                     $a_user_data[$usr_id]['odf_last_update'] = $edit_info['update_user'];
                     $a_user_data[$usr_id]['odf_last_update'] .= ('_' . $edit_info['editing_time']->get(IL_CAL_UNIX));
                     
-                    $name = ilObjUser::_lookupName($edit_info['update_user']);
+                    $name = $this->lookupUserName((int) $edit_info['update_user']);
                     $a_user_data[$usr_id]['odf_info_txt'] = ($name['firstname'] . ' ' . $name['lastname'] . ', ' . ilDatePresentation::formatDate($edit_info['editing_time']));
                 }
             }
@@ -564,5 +566,16 @@ class ilCourseParticipantsTableGUI extends ilParticipantTableGUI
         );
         
         return $this->setData($a_user_data);
+    }
+
+    /**
+     * @return array{user_id: int, firstname: string, lastname: string, login: string, title: string}
+     */
+    protected function lookupUserName(int $user_id) : array
+    {
+        if (isset($this->cached_user_names[$user_id])) {
+            return $this->cached_user_names[$user_id];
+        }
+        return $this->cached_user_names[$user_id] = ilObjUser::_lookupName($user_id);
     }
 }

--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -1768,7 +1768,7 @@ class ilObjCourseGUI extends ilContainerGUI
         }
     }
     
-    public function readMemberData($ids, $selected_columns = null)
+    public function readMemberData($ids, $selected_columns = null, bool $skip_names = false)
     {
         include_once './Services/Tracking/classes/class.ilObjUserTracking.php';
         $this->show_tracking =
@@ -1808,10 +1808,19 @@ class ilObjCourseGUI extends ilContainerGUI
         }
 
         foreach ((array) $ids as $usr_id) {
-            $name = ilObjUser::_lookupName($usr_id);
-            $tmp_data['firstname'] = $name['firstname'];
-            $tmp_data['lastname'] = $name['lastname'];
-            $tmp_data['login'] = ilObjUser::_lookupLogin($usr_id);
+            /**
+             * When building the members table in a course, user names are
+             * already read out via ilUserQuery::getUserListData (#31394).
+             * Adding skip_name as a parameter here is not super elegant, but
+             * seems like the only practical way avoid unnecessarily reading
+             * out the names again.
+             */
+            if (!$skip_names) {
+                $name = ilObjUser::_lookupName($usr_id);
+                $tmp_data['firstname'] = $name['firstname'];
+                $tmp_data['lastname'] = $name['lastname'];
+                $tmp_data['login'] = $name['login'];
+            }
             $tmp_data['passed'] = $this->object->getMembersObject()->hasPassed($usr_id) ? 1 : 0;
             if ($this->object->getStatusDetermination() == ilObjCourse::STATUS_DETERMINATION_LP) {
                 $tmp_data['passed_info'] = $this->object->getMembersObject()->getPassedInfo($usr_id);

--- a/Modules/Group/classes/class.ilGroupParticipantsTableGUI.php
+++ b/Modules/Group/classes/class.ilGroupParticipantsTableGUI.php
@@ -32,6 +32,8 @@ class ilGroupParticipantsTableGUI extends ilParticipantTableGUI
     
     protected $current_filter = array();
 
+    protected $cached_user_names = [];
+
     /**
      * Constructor
      *
@@ -419,7 +421,7 @@ class ilGroupParticipantsTableGUI extends ilParticipantTableGUI
                     $a_user_data[$usr_id]['odf_last_update'] = $edit_info['edit_user'];
                     $a_user_data[$usr_id]['odf_last_update'] .= ('_' . $edit_info['editing_time']->get(IL_CAL_UNIX));
                     
-                    $name = ilObjUser::_lookupName($edit_info['update_user']);
+                    $name = $this->lookupUserName((int) $edit_info['update_user']);
                     $a_user_data[$usr_id]['odf_info_txt'] = ($name['firstname'] . ' ' . $name['lastname'] . ', ' . ilDatePresentation::formatDate($edit_info['editing_time']));
                 }
             }
@@ -445,5 +447,16 @@ class ilGroupParticipantsTableGUI extends ilParticipantTableGUI
         );
         
         return $this->setData($a_user_data);
+    }
+
+    /**
+     * @return array{user_id: int, firstname: string, lastname: string, login: string, title: string}
+     */
+    protected function lookupUserName(int $user_id) : array
+    {
+        if (isset($this->cached_user_names[$user_id])) {
+            return $this->cached_user_names[$user_id];
+        }
+        return $this->cached_user_names[$user_id] = ilObjUser::_lookupName($user_id);
     }
 }

--- a/Modules/Group/classes/class.ilGroupParticipantsTableGUI.php
+++ b/Modules/Group/classes/class.ilGroupParticipantsTableGUI.php
@@ -144,7 +144,7 @@ class ilGroupParticipantsTableGUI extends ilParticipantTableGUI
             $this->tpl->parseCurrentBlock();
         }
 
-        if (!ilObjUser::_lookupActive($a_set['usr_id'])) {
+        if (!$a_set['active']) {
             $this->tpl->setCurrentBlock('access_warning');
             $this->tpl->setVariable('PARENT_ACCESS', $this->lng->txt('usr_account_inactive'));
             $this->tpl->parseCurrentBlock();

--- a/Modules/Group/classes/class.ilObjGroupGUI.php
+++ b/Modules/Group/classes/class.ilObjGroupGUI.php
@@ -929,7 +929,7 @@ class ilObjGroupGUI extends ilContainerGUI
             (
                 ilObjUserTracking::_enabledLearningProgress() and
             ilObjUserTracking::_enabledUserRelatedData()
-        );
+            );
         if ($this->show_tracking) {
             include_once('./Services/Object/classes/class.ilObjectLP.php');
             $olp = ilObjectLP::getInstance($this->object->getId());
@@ -958,18 +958,17 @@ class ilObjGroupGUI extends ilContainerGUI
                 $this->ctrl->getLinkTarget($this, "members")
             );
         }
-        
+
+        /**
+         * This reads out all fields in usr_data, including usr_id, firstname,
+         * lastname, and login, so should never be necessary here to call
+         * ilObjUser a second time (#31394).
+         */
         $profile_data = ilObjUser::_readUsersProfileData($ids);
         foreach ($ids as $usr_id) {
-            $name = ilObjUser::_lookupName($usr_id);
-            $tmp_data['firstname'] = $name['firstname'];
-            $tmp_data['lastname'] = $name['lastname'];
-            $tmp_data['login'] = ilObjUser::_lookupLogin($usr_id);
             $tmp_data['notification'] = $this->object->members_obj->isNotificationEnabled($usr_id) ? 1 : 0;
             $tmp_data['contact'] = $this->object->members_obj->isContact($usr_id) ? 1 : 0;
-            $tmp_data['usr_id'] = $usr_id;
-            $tmp_data['login'] = ilObjUser::_lookupLogin($usr_id);
-            
+
             foreach ((array) $profile_data[$usr_id] as $field => $value) {
                 $tmp_data[$field] = $value;
             }
@@ -1130,7 +1129,7 @@ class ilObjGroupGUI extends ilContainerGUI
                 $this->ctrl->getLinkTargetByClass(
                     array("ilobjgroupgui", "ilinfoscreengui"),
                     "showSummary"
-                                 ),
+                ),
                 "infoScreen",
                 "",
                 "",
@@ -1394,7 +1393,7 @@ class ilObjGroupGUI extends ilContainerGUI
                     $info->addProperty(
                         $this->lng->txt('mem_free_places'),
                         $reg_info['reg_info_free_places']
-                     );
+                    );
                 }
             }
             
@@ -1821,7 +1820,7 @@ class ilObjGroupGUI extends ilContainerGUI
                 $this->object->getId(),
                 $form,
                 $this->getSubServices()
-                );
+            );
 
 
             $mem = new ilCheckboxInputGUI($this->lng->txt('grp_show_members'), 'show_members');


### PR DESCRIPTION
This PR improves the performance of the members view in Courses and Groups with many members by reducing the number of calls to `ilObjUser::_lookupName`, `ilObjUser::_lookupLogin` and `ilObjUser::_lookupActive`, see [31394](https://mantis.ilias.de/view.php?id=31394). I wouldn't expect any major leaps, but the changes here should at least mitigate problem.

Let me know if you prefer a second PR for R8 and trunk.