### PR TITLE
Form: FileUpload Should Preserve Files

### DIFF
--- a/Services/Form/classes/class.ilPropertyFormGUI.php
+++ b/Services/Form/classes/class.ilPropertyFormGUI.php
@@ -80,13 +80,13 @@ class ilPropertyFormGUI extends ilFormGUI
         $this->setPreventDoubleSubmission(true);
 
         // do it as early as possible
-        $this->rebuildUploadedFiles();
         if (isset($DIC["http"])) {
             $this->http = $DIC->http();
         }
         if (isset($DIC["refinery"])) {
             $this->refinery = $DIC->refinery();
         }
+        $this->rebuildUploadedFiles();
         if (isset($DIC["tpl"])) {      // some unit tests will fail otherwise
             $this->global_tpl = $DIC['tpl'];
         }
@@ -412,7 +412,7 @@ class ilPropertyFormGUI extends ilFormGUI
 
                 return $ok;
 
-            // Otherwise, we send it using ilUtil, and it will be rendered in the Template
+                // Otherwise, we send it using ilUtil, and it will be rendered in the Template
             default:
 
                 if (!$ok && !$this->getDisableStandardMessage()) {
@@ -504,7 +504,7 @@ class ilPropertyFormGUI extends ilFormGUI
         if ($this->getMode() == "std" &&
             $this->getTitle() == "" &&
             is_object($fi) && $fi->getType() == "section_header"
-            ) {
+        ) {
             $this->setTitle($fi->getTitle());
             unset($this->items[0]);
         }
@@ -925,7 +925,7 @@ class ilPropertyFormGUI extends ilFormGUI
                     "type" => $_FILES[$a_field]["type"][$a_index][$a_sub_index],
                     "error" => $_FILES[$a_field]["error"][$a_index][$a_sub_index],
                     "size" => $_FILES[$a_field]["size"][$a_index][$a_sub_index],
-                    "is_upload" => true
+                    "is_upload" => $_FILES[$a_field]["is_upload"][$a_index][$a_sub_index] ?? true
                 );
             }
         } elseif ($a_sub_index) {
@@ -936,7 +936,7 @@ class ilPropertyFormGUI extends ilFormGUI
                     "type" => $_FILES[$a_field]["type"][$a_index],
                     "error" => $_FILES[$a_field]["error"][$a_index],
                     "size" => $_FILES[$a_field]["size"][$a_index],
-                    "is_upload" => true
+                    "is_upload" => $_FILES[$a_field]["is_upload"][$a_index] ?? true
                 );
             }
         } else {
@@ -947,7 +947,7 @@ class ilPropertyFormGUI extends ilFormGUI
                     "type" => $_FILES[$a_field]["type"],
                     "error" => $_FILES[$a_field]["error"],
                     "size" => $_FILES[$a_field]["size"],
-                    "is_upload" => true
+                    "is_upload" => $_FILES[$a_field]["is_upload"] ?? true
                 );
             }
         }
@@ -1032,6 +1032,7 @@ class ilPropertyFormGUI extends ilFormGUI
                                 $_FILES[$field]["type"][$idx][$idx2] = $type;
                                 $_FILES[$field]["error"][$idx][$idx2] = 0;
                                 $_FILES[$field]["size"][$idx][$idx2] = filesize($full_file);
+                                $_FILES[$field]["is_upload"][$idx][$idx2] = false;
                             }
                         } elseif ($idx != "") {
                             if (!$_FILES[$field]["tmp_name"][$idx]) {
@@ -1040,6 +1041,7 @@ class ilPropertyFormGUI extends ilFormGUI
                                 $_FILES[$field]["type"][$idx] = $type;
                                 $_FILES[$field]["error"][$idx] = 0;
                                 $_FILES[$field]["size"][$idx] = filesize($full_file);
+                                $_FILES[$field]["is_upload"][$idx] = false;
                             }
                         } else {
                             if (!$_FILES[$field]["tmp_name"]) {
@@ -1048,6 +1050,7 @@ class ilPropertyFormGUI extends ilFormGUI
                                 $_FILES[$field]["type"] = $type;
                                 $_FILES[$field]["error"] = 0;
                                 $_FILES[$field]["size"] = filesize($full_file);
+                                $_FILES[$field]["is_upload"] = false;
                             }
                         }
                     }


### PR DESCRIPTION
This fixes the preservation of uploaded files through the form in legacy forms. Needs to be picked to 7 and trunk.
See: https://mantis.ilias.de/view.php?id=37864