### PR TITLE
[#37876] Add type cast to match argument type

### DIFF
--- a/Services/WebServices/SOAP/classes/class.ilSoapClient.php
+++ b/Services/WebServices/SOAP/classes/class.ilSoapClient.php
@@ -39,7 +39,7 @@ class ilSoapClient
         }
         $this->connect_timeout = $timeout;
         
-        $this->response_timeout = (int) $this->settings->get('soap_response_timeout', self::DEFAULT_RESPONSE_TIMEOUT);
+        $this->response_timeout = (int) $this->settings->get('soap_response_timeout',(string) self::DEFAULT_RESPONSE_TIMEOUT);
     }
 
     public function getServer(): string


### PR DESCRIPTION
Fixes issue [#37876](https://mantis.ilias.de/view.php?id=37876)

```
TypeError thrown with message "Argument 2 passed to ilSetting::get() must be of the type string or null, int given, called in /srv/www/docu.ilias.de/html/ilias/Services/WebServices/SOAP/classes/class.ilSoapClient.php on line 42"

Stacktrace:
#10 TypeError in /srv/www/docu.ilias.de/html/ilias/Services/Administration/classes/class.ilSetting.php:99
#9 ilSetting:get in /srv/www/docu.ilias.de/html/ilias/Services/WebServices/SOAP/classes/class.ilSoapClient.php:42
#8 ilSoapClient:__construct in /srv/www/docu.ilias.de/html/ilias/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php:46
#7 ILIAS\BackgroundTasks\Implementation\TaskManager\AsyncTaskManager:run in /srv/www/docu.ilias.de/html/ilias/Services/Mail/classes/class.ilMail.php:1112
#6 ilMail:enqueue in /srv/www/docu.ilias.de/html/ilias/Services/Mail/classes/class.ilMailFormGUI.php:203
#5 ilMailFormGUI:sendMessage in /srv/www/docu.ilias.de/html/ilias/Services/Mail/classes/class.ilMailFormGUI.php:153
#4 ilMailFormGUI:executeCommand in /srv/www/docu.ilias.de/html/ilias/Services/UICore/classes/class.ilCtrl.php:199
```