### PR TITLE
ILIAS 7: Increase max length of redirect_url for tst redirection to 256

### DIFF
--- a/setup/sql/7_hotfixes.php
+++ b/setup/sql/7_hotfixes.php
@@ -1791,4 +1791,14 @@ if ($ilDB->tableExists('adv_md_values_text') &&
 <?php
     $ilDB->manipulate("DELETE FROM rbac_operations WHERE operation='create_dbk'");
 ?>
-
+<#106>
+<?php
+if ($ilDB->tableExists('tst_tests') && $ilDB->tableColumnExists('tst_tests', 'redirection_url')) {
+    $ilDB->modifyTableColumn('tst_tests', 'redirection_url', [
+        'type' => 'text',
+        'length' => 256,
+        'notnull' => false,
+        'default' => null
+    ]);
+}
+?>


### PR DESCRIPTION
Increases the length for the **redirection_url** column for tests.

This is used for the "Redirection" after a test is completed by a user.

because of the nature of ILIAS having a lot of query parameters (and very long ones), it's very easy to reach the current limit of 128 characters when a link like `ilias.php?cmdClass...&baseClass...&cmd...&Id...` is saved.