### PR TITLE
ILIAS Trunk: Increase max length of redirect_url for tst redirection to 256

### DIFF
--- a/Modules/Test/classes/Setup/class.ilTest9DBUpdateSteps.php
+++ b/Modules/Test/classes/Setup/class.ilTest9DBUpdateSteps.php
@@ -162,4 +162,16 @@ class ilTest9DBUpdateSteps implements ilDatabaseUpdateSteps
             $this->db->dropTable('tst_seq_qst_postponed');
         }
     }
+
+    public function step_8(): void
+    {
+        if ($this->db->tableExists('tst_tests') && $this->db->tableColumnExists('tst_tests', 'redirection_url')) {
+            $this->db->modifyTableColumn('tst_tests', 'redirection_url', [
+                'type' => 'text',
+                'length' => 256,
+                'notnull' => false,
+                'default' => null
+            ]);
+        }
+    }
 }


### PR DESCRIPTION
Increases the length for the **redirection_url** column for tests.

This is used for the "Redirection" after a test is completed by a user.

because of the nature of ILIAS having a lot of query parameters (and very long ones), it's very easy to reach the current limit of 128 characters when a link like `ilias.php?cmdClass...&baseClass...&cmd...&Id...` is saved.