### PR TITLE
Update security.md

### DIFF
--- a/docs/development/security.md
+++ b/docs/development/security.md
@@ -31,5 +31,3 @@ Please subscribe to our admin mailing list (ilias-admins@lists.ilias.de) to get 
 * Tim Bongers, CaT Concepts and Training GmbH, Cologne, Germany
 * Rob Falkenstein, University of Freiburg - IT Services, Germany
 * Manuel G. Müller, Qualitus GmbH, Cologne, Germany
-* Fabian Sesterhenn, TH Köln, Cologne, Germany
-* Nadimo Staszak, University of Cologne, Cologne, Germany


### PR DESCRIPTION
This PR removes inactive members of the security group from the corresponding README file. If approved, this needs to be cherry-picked to `trunk` as well.