### PR TITLE
LearningModule: Unneeded Setting of Offline-Status

### DIFF
--- a/Modules/LearningModule/classes/class.ilObjContentObject.php
+++ b/Modules/LearningModule/classes/class.ilObjContentObject.php
@@ -103,7 +103,6 @@ class ilObjContentObject extends ilObject
     public function create(
         bool $a_no_meta_data = false
     ): int {
-        $this->setOfflineStatus(true);
         $id = parent::create();
 
         // meta data will be created by


### PR DESCRIPTION
Hi @alex40724 

See: https://mantis.ilias.de/view.php?id=37820

This call is unnecessary. In cases it absolutely needs to be set to ONLINE, this should be done after creation of the object.

Best,
@kergomard 