### PR TITLE
`Refinery`: Transformation for escaping html/css/js

### DIFF
--- a/components/ILIAS/Refinery/src/Encode/Group.php
+++ b/components/ILIAS/Refinery/src/Encode/Group.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery\Encode;
+
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\Encode\Transformation\HTMLAttributeValue;
+use ILIAS\Refinery\Encode\Transformation\HTMLSpecialCharsAsEntities;
+use ILIAS\Refinery\Encode\Transformation\Json;
+use ILIAS\Refinery\Encode\Transformation\URL;
+
+class Group
+{
+    public function htmlAttributeValue(): Transformation
+    {
+        return new HTMLAttributeValue();
+    }
+
+    public function htmlSpecialCharsAsEntities(): Transformation
+    {
+        return new HTMLSpecialCharsAsEntities();
+    }
+
+    public function json(): Transformation
+    {
+        return new Json();
+    }
+
+    public function url(): Transformation
+    {
+        return new URL();
+    }
+}

--- a/components/ILIAS/Refinery/src/Encode/Transformation/HTMLAttributeValue.php
+++ b/components/ILIAS/Refinery/src/Encode/Transformation/HTMLAttributeValue.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery\Encode\Transformation;
+
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ValueError;
+
+/**
+ * Inspired by: Laminas escaper: https://github.com/laminas/laminas-escaper.
+ * This class expects a valid UTF-8 string. Conversion between encodings is not the responsibility of this class.
+ *
+ * This class encodes a given string so it can be used as a value inside a HTML attribute tag (e.g. <div class="ENCODED_VALUE"></div>).
+ * The given string is encoded so it can be used in any HTML Tag regardless if the value is enclosed in double quotes ("), single quotes (') or no quotes at all (e.g. <div class=ENCODED_VALUE></div>).
+ * Please see for more information of the syntax of HTML attributes: https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+ * Please see https://html.spec.whatwg.org/multipage/dom.html#phrasing-content for a list of all allowed characters and escape sequences.
+ */
+class HTMLAttributeValue implements Transformation
+{
+    use DeriveInvokeFromTransform;
+    use DeriveApplyToFromTransform;
+
+    public function transform($from)
+    {
+        return $this->encode($from);
+    }
+
+    private function encode(string $from): string
+    {
+        return preg_replace_callback(
+            '/[^a-z0-9,._-]/iSu',
+            fn(array $m): string => $this->replace($m[0]),
+            $from
+        ) ?? throw new ValueError('Invalid UTF-8 string given.');
+    }
+
+    private function replace(string $utf8_char): string
+    {
+        $codepoint = $this->utf8CharacterToCodepoint($utf8_char);
+
+        // All unicode control characters besides white space codepoints as well as noncharacters are not allowed in HTML attributes.
+        if ($this->isNonPrintableControl($utf8_char, $codepoint) || $this->isNonCharacter($codepoint)) {
+            return '&#xFFFD;'; // Unicode "replacement character", indicating a non printable character.
+        }
+
+        return match ($codepoint) {
+            34 => '&quot;',
+            38 => '&amp;',
+            60 => '&lt;',
+            62 => '&gt;',
+            default => sprintf($codepoint > 255 ? '&#x%04X;' : '&#x%02X;', $codepoint),
+        };
+    }
+
+    /**
+     * Decodes a given UTF-8 character (which may be multibyte) to a Unicode codepoint.
+     * E.g. The multibyte character "€", encoded in UTF-8 as the byte sequence 0xE2 0x82 0xAC,
+     * will return the integer 0x20AC, which is the corresponding unicode codepoint.
+     */
+    private function utf8CharacterToCodepoint(string $utf8_char): int
+    {
+        // UTF-32 encodes Unicode codepoints as itself. BE stands for Big Endian.
+        return hexdec(bin2hex(strlen($utf8_char) > 1 ? (mb_convert_encoding($utf8_char, 'UTF-32BE', 'UTF-8')) : $utf8_char));
+    }
+
+    /**
+     * The unicode range for control codepoints is from U+0000 NULL to U+001F (inclusive) and from U+007F to U+009F (inclusive).
+     * The range U+0000 NULL to U+001F and the codepoint U+007F are all one byte long and are covered by the PHP function ctype_cntrl.
+     *
+     * See https://infra.spec.whatwg.org/#control for more information.
+     */
+    private function isNonPrintableControl(string $utf8_char, int $codepoint): bool
+    {
+        return strlen($utf8_char) === 1 ?
+            ctype_cntrl($utf8_char) && !ctype_space($utf8_char) :
+            $codepoint <= 0x9F;
+    }
+
+    /**
+     * Unicode specifies a fixed list of 66 codepoints to be "noncharacters".
+     * Please see https://infra.spec.whatwg.org/#noncharacter for the complete list.
+     */
+    private function isNonCharacter(int $codepoint): bool
+    {
+        return 0xFDD0 <= $codepoint && $codepoint <= 0xFDEF ||
+               in_array($codepoint, [0xFFFE, 0xFFFF, 0x1FFFE, 0x1FFFF, 0x2FFFE, 0x2FFFF, 0x3FFFE, 0x3FFFF, 0x4FFFE, 0x4FFFF, 0x5FFFE, 0x5FFFF, 0x6FFFE, 0x6FFFF, 0x7FFFE, 0x7FFFF, 0x8FFFE, 0x8FFFF, 0x9FFFE, 0x9FFFF, 0xAFFFE, 0xAFFFF, 0xBFFFE, 0xBFFFF, 0xCFFFE, 0xCFFFF, 0xDFFFE, 0xDFFFF, 0xEFFFE, 0xEFFFF, 0xFFFFE, 0xFFFFF, 0x10FFFE,  0x10FFFF], true);
+    }
+}

--- a/components/ILIAS/Refinery/src/Encode/Transformation/HTMLSpecialCharsAsEntities.php
+++ b/components/ILIAS/Refinery/src/Encode/Transformation/HTMLSpecialCharsAsEntities.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery\Encode\Transformation;
+
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ValueError;
+
+/**
+ * Inspired by: Laminas escaper: https://github.com/laminas/laminas-escaper.
+ * This class expects a valid UTF-8 string. Conversion between encodings is not the responsibility of this class.
+ *
+ * This class escapes all HTML characters that have special meaning in HTML in order to preserve their meaning.
+ * Please see https://www.php.net/manual/en/function.htmlspecialchars.php for more information.
+ * Given a valid UTF-8 string this class will return a valid HTML string.
+ * This class is a wrapper around `htmlspecialchars` but ensures that the correct flags are set.
+ */
+class HTMLSpecialCharsAsEntities implements Transformation
+{
+    use DeriveInvokeFromTransform;
+    use DeriveApplyToFromTransform;
+
+    public function transform($from)
+    {
+        if (false === preg_match('//u', $from)) {
+            throw new ValueError('Invalid UTF-8 string given.');
+        }
+        return htmlspecialchars($from, ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8');
+    }
+}

--- a/components/ILIAS/Refinery/src/Encode/Transformation/Json.php
+++ b/components/ILIAS/Refinery/src/Encode/Transformation/Json.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery\Encode\Transformation;
+
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ValueError;
+
+/**
+ * This class expects a valid UTF-8 string. Conversion between encodings is not the responsibility of this class.
+ *
+ * This class is a wrapper around `json_encode` but ensures that the correct flags are set.
+ * These flags ensure that the encoded JSON string can be included in (X)HTML embedded JS too.
+ * Please see https://www.php.net/manual/en/function.json-encode.php for more information.
+ */
+class Json implements Transformation
+{
+    use DeriveInvokeFromTransform;
+    use DeriveApplyToFromTransform;
+
+    public function transform($from)
+    {
+        return json_encode($from, JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_THROW_ON_ERROR);
+    }
+}

--- a/components/ILIAS/Refinery/src/Encode/Transformation/URL.php
+++ b/components/ILIAS/Refinery/src/Encode/Transformation/URL.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery\Encode\Transformation;
+
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ValueError;
+
+/**
+ * Inspired by: Laminas escaper: https://github.com/laminas/laminas-escaper.
+ * This class expects a valid UTF-8 string. Conversion between encodings is not the responsibility of this class.
+ *
+ * This class encodes a given string as as an URL according to RFC 3986 (http://www.faqs.org/rfcs/rfc3986.html).
+ * Please see https://www.php.net/manual/en/function.rawurlencode.php for further information.
+ */
+class URL implements Transformation
+{
+    use DeriveInvokeFromTransform;
+    use DeriveApplyToFromTransform;
+
+    public function transform($from)
+    {
+        if (false === preg_match('//u', $from)) {
+            throw new ValueError('Invalid UTF-8 string given.');
+        }
+        return rawurlencode($from);
+    }
+}

--- a/components/ILIAS/Refinery/src/Factory.php
+++ b/components/ILIAS/Refinery/src/Factory.php
@@ -152,6 +152,11 @@ class Factory
         return new URI\Group();
     }
 
+    public function encode(): Encode\Group
+    {
+        return new Encode\Group();
+    }
+
     /**
      * Accepts Transformations and uses first successful one.
      * @param Transformation[] $transformations

--- a/components/ILIAS/Refinery/tests/Encode/GroupTest.php
+++ b/components/ILIAS/Refinery/tests/Encode/GroupTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Refinery\Encode;
+
+use ILIAS\Refinery\Encode\Group;
+use PHPUnit\Framework\TestCase;
+use ILIAS\Refinery\Encode\Transformation\HTMLAttributeValue;
+use ILIAS\Refinery\Encode\Transformation\HTMLSpecialCharsAsEntities;
+use ILIAS\Refinery\Encode\Transformation\Json;
+use ILIAS\Refinery\Encode\Transformation\URL;
+
+class GroupTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(Group::class, new Group());
+    }
+
+    public function testHtmlAttributeValue(): void
+    {
+        $group = new Group();
+        $this->assertInstanceOf(HTMLAttributeValue::class, $group->htmlAttributeValue());
+    }
+
+    public function testHtmlSpecialCharsAsEntities(): void
+    {
+        $group = new Group();
+        $this->assertInstanceOf(HTMLSpecialCharsAsEntities::class, $group->htmlSpecialCharsAsEntities());
+    }
+
+    public function testJson(): void
+    {
+        $group = new Group();
+        $this->assertInstanceOf(Json::class, $group->json());
+    }
+
+    public function testUrl(): void
+    {
+        $group = new Group();
+        $this->assertInstanceOf(URL::class, $group->url());
+    }
+}

--- a/components/ILIAS/Refinery/tests/Encode/Transformation/HTMLAttributeValueTest.php
+++ b/components/ILIAS/Refinery/tests/Encode/Transformation/HTMLAttributeValueTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Refinery\Encode\Transformation;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Refinery\Encode\Transformation\HTMLAttributeValue;
+use ValueError;
+use TypeError;
+
+require_once __DIR__ . '/ProvideUTF8CodepointRange.php';
+
+class HTMLAttributeValueTest extends TestCase
+{
+    use ProvideUTF8CodepointRange;
+
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(HTMLAttributeValue::class, new HTMLAttributeValue());
+    }
+
+    /**
+     * @dataProvider provideTransformData
+     */
+    public function testTransform(string $exptected, string $in, string $method): void
+    {
+        $this->$method($exptected, (new HTMLAttributeValue())->transform($in));
+    }
+
+    public function testInvalidEncoding(): void
+    {
+        $this->expectException(ValueError::class);
+        (new HTMLAttributeValue())->transform(chr(128));
+    }
+
+    public function testInvalidType(): void
+    {
+        $this->expectException(TypeError::class);
+        (new HTMLAttributeValue())->transform(8);
+    }
+
+    public function provideTransformData(): array
+    {
+        return [
+            'Empty string' => ['', '', 'assertSame'],
+            'Single quote' => ['&#x27;', '\'', 'assertSame'],
+            'Different quotes' => ['&quot;Hey,&#x20;y&#x27;all&quot;', '"Hey, y' . "'" . 'all"', 'assertSame'],
+            'UTF-8' => ['&#xAE40;&#xCE58;', '김치', 'assertSame'],
+            'Characters beyond ASCII value 255' => ['&#x0100;', 'Ā', 'assertSame'],
+            'Characters beyond Unicode BMP' => ['&#x10000;', "\xF0\x90\x80\x80", 'assertSame'],
+            'Printable control characters' => ['&#x0D;&#x0A;&#x09;', "\r\n\t", 'assertSame'],
+            'Unprintable control characters' => ['&#xFFFD;&#xFFFD;&#xFFFD;&#xFFFD;', "\0\1\x1F\x7F", 'assertSame'],
+            'Named entities' => ['&lt;&gt;&amp;&quot;', '<>&"', 'assertSame'],
+            'Single space' => ['&#x20;', ' ', 'assertSame'],
+            'Encode entities' => ['&amp;quot&#x3B;hello&amp;quot&#x3B;', '&quot;hello&quot;', 'assertSame'],
+            'Braces' => ['&#x7B;&#x5B;&#x28;&#x29;&#x5D;&#x7D;', '{[()]}', 'assertSame'],
+            ...$this->oneByteRangeExcept([',', '.', '-', '_']),
+        ];
+    }
+}

--- a/components/ILIAS/Refinery/tests/Encode/Transformation/HTMLSpecialCharsAsEntitiesTest.php
+++ b/components/ILIAS/Refinery/tests/Encode/Transformation/HTMLSpecialCharsAsEntitiesTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Refinery\Encode\Transformation;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Refinery\Encode\Transformation\HTMLSpecialCharsAsEntities;
+use ValueError;
+use TypeError;
+
+class HTMLSpecialCharsAsEntitiesTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(HTMLSpecialCharsAsEntities::class, new HTMLSpecialCharsAsEntities());
+    }
+
+    /**
+     * @dataProvider provideTransformData
+     */
+    public function testTransform(string $exptected, string $in): void
+    {
+        $this->assertSame($exptected, (new HTMLSpecialCharsAsEntities())->transform($in));
+    }
+
+    public function testInvalidType(): void
+    {
+        $this->expectException(TypeError::class);
+        (new HTMLSpecialCharsAsEntities())->transform(9);
+    }
+
+    public function testInvalidEncoding(): void
+    {
+        $this->expectException(ValueError::class);
+        (new HTMLSpecialCharsAsEntities())->transform(chr(128));
+    }
+
+    public function provideTransformData(): array
+    {
+        $alpha = implode('', range(ord('A'), ord('z')));
+        $numbers = implode('', range(ord('0'), ord('9')));
+
+        return array_map(fn($s) => [htmlspecialchars($s, ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8'), $s], [
+            'Empty string' => '',
+            'Single quotes' => '\'',
+            'Different quotes' => '"Hey, y' . "'" . 'all"',
+            'Characters beyond ASCII value 255' => 'Ā',
+            'Characters beyond Unicode BMP' => "\xF0\x90\x80\x80",
+            'UTF-8' => '커피',
+            'Immune chars' => ',.-_',
+            'Alpha' => $alpha,
+            'Numbers' => $numbers,
+            'Basic control characters and null' => "\r\n\t\0",
+            'Named entities' => '<>&"',
+            'Single space' => ' ',
+            'Encode entities' => '&quot;hello&quot;',
+            'Braces' => '{[()]}',
+        ]);
+    }
+
+    public function htmlSpecialCharsProvider(): array
+    {
+        return [
+            '\'' => ['\'', '&#039;'],
+            '"' => ['"', '&quot;'],
+            '<' => ['<', '&lt;'],
+            '>' => ['>', '&gt;'],
+            '&' => ['&', '&amp;'],
+        ];
+    }
+}

--- a/components/ILIAS/Refinery/tests/Encode/Transformation/JsonTest.php
+++ b/components/ILIAS/Refinery/tests/Encode/Transformation/JsonTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Refinery\Encode\Transformation;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Refinery\Encode\Transformation\Json;
+use JsonException;
+
+require_once __DIR__ . '/ProvideUTF8CodepointRange.php';
+
+class JsonTest extends TestCase
+{
+    use ProvideUTF8CodepointRange;
+
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(Json::class, new Json());
+    }
+
+    /**
+     * @dataProvider provideTransformData
+     */
+    public function testTransform(string $exptected, string $in, string $method): void
+    {
+        $this->$method($exptected, (new Json())->transform($in));
+    }
+
+    public function testInvalidEncoding(): void
+    {
+        $this->expectException(JsonException::class);
+        (new Json())->transform(chr(128));
+    }
+
+    public function provideTransformData(): array
+    {
+        return [
+            'Empty string' => ['""', '', 'assertSame'],
+            'UTF-8' => ['"\uc548\ub155\ud558\uc11c\u3163\uc694"', '안녕하서ㅣ요', 'assertSame'],
+            'HTML special chars' => ['"\\u003C\\u003E\\u0027\\u0022\\u0026"', '<>\'"&', 'assertSame'],
+            'Characters beyond ASCII value 255' => ['"\\u0100"', 'Ā', 'assertSame'],
+            'Characters beyond Unicode BMP' => ['"\\ud800\\udc00"', "\xF0\x90\x80\x80", 'assertSame'],
+            'Basic control characters and null' => ['"\\r\\n\\t\\u0000"', "\r\n\t\0", 'assertSame'],
+            'Single space' => ['" "', ' ', 'assertSame'],
+            'Slash' => ['"\\/"', '/', 'assertSame'],
+        ];
+    }
+}

--- a/components/ILIAS/Refinery/tests/Encode/Transformation/ProvideUTF8CodepointRange.php
+++ b/components/ILIAS/Refinery/tests/Encode/Transformation/ProvideUTF8CodepointRange.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Refinery\Encode\Transformation;
+
+/**
+ * Helper trait which provides a data provider for codepoint ranges where it is common wether or not a codepoint needs to be changed in order to preserve it's meaning when encdoding from one language to another.
+ */
+trait ProvideUTF8CodepointRange
+{
+    /**
+     * Returns an array in a format that can be used for a data provider.
+     * The purpose of this method is to provide a basic data provider to check the first byte range (255 entries) for common characters which are never encoded or which are always encoded among many languages.
+     *
+     * The returned data provider is designed to be fed to a test method of 3 parameters of types: string $exptected, string $input and string $assertionMethod.
+     * For all alphanumeric characters in the range this method expects that the `input` and `expected` strings are the same additionally to all characters that should be ignored.
+     * For all other characters it expects that the input character is not the same as the output character.
+     *
+     * @param string[] $ignore
+     * @return array<string, {0: string, 1: string, 2: string}>
+     */
+    private function oneByteRangeExcept(array $ignore = []): array
+    {
+        $byte_range = range(0, 0xFE);
+        $set_names = array_map(fn(int $codepoint) => 'Codepoint: ' . $codepoint, $byte_range);
+
+        return array_combine(
+            $set_names,
+            array_map(
+                fn(string $chr, int $codepoint) => (
+                    ctype_alnum($chr) || in_array($chr, $ignore, true) ?
+                        $this->asDataProviderArgs($chr, 'assertSame') :
+                        $this->asDataProviderArgs($this->isAscii($codepoint) ? $chr : $this->twoByteChar($codepoint), 'assertNotSame')
+                ),
+                array_map(chr(...), $byte_range),
+                $byte_range
+            )
+        );
+    }
+
+    private function isAscii(int $codepoint): bool
+    {
+        return $codepoint <= 127;
+    }
+
+    /**
+     * Convert a Unicode codepoint between 0x80 and 0x7FF to a valid UTF-8 character.
+     * This is the range where unicode codepoints are encoded in UTF-8 with two bytes.
+     */
+    private function twoByteChar(int $codepoint): string
+    {
+        return chr($codepoint >> 6 & 0x3f | 0xc0) . chr($codepoint & 0x3f | 0x80);
+    }
+
+    /**
+     * Returns an entry for a dataset of a data provider for a test case with a signature of the form: string $exptected, string $input and string $assertionMethod.
+     * @return {0: string, 1: string, 2: string}
+     */
+    private function asDataProviderArgs(string $chr, string $method): array
+    {
+        return [$chr, $chr, $method];
+    }
+}

--- a/components/ILIAS/Refinery/tests/Encode/Transformation/URLTest.php
+++ b/components/ILIAS/Refinery/tests/Encode/Transformation/URLTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Refinery\Encode\Transformation;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Refinery\Encode\Transformation\URL;
+use ValueError;
+use TypeError;
+
+class URLTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(URL::class, new URL());
+    }
+
+    /**
+     * @dataProvider provideTransformData
+     */
+    public function testTransform(string $exptected, string $in): void
+    {
+        $this->assertSame($exptected, (new URL())->transform($in));
+    }
+
+    public function testInvalidEncoding(): void
+    {
+        $this->expectException(ValueError::class);
+        (new URL())->transform(chr(128));
+    }
+
+    public function testInvalidType(): void
+    {
+        $this->expectException(TypeError::class);
+        (new URL())->transform(9);
+    }
+
+    public function provideTransformData(): array
+    {
+        $alpha = implode('', range(ord('A'), ord('z')));
+        $numbers = implode('', range(ord('0'), ord('9')));
+
+        $data = array_map(fn($s) => [rawurlencode($s), $s], [
+            'Empty string' => '',
+            'Alpha' => $alpha,
+            'Numbers' => $numbers,
+            'Quotes' => "'" . '"',
+            'Different quotes' => '"Hey, y' . "'" . 'all"',
+            'UTF-8' => '두유',
+            'Encode entities' => '&quot;hello&quot;',
+            'Braces' => '{<>}',
+            'HTML special chars' => '<>\'"&',
+            'Characters beyond ASCII value 255' => 'Ā',
+            'Punctuation and unreserved check' => ',._-:;',
+            'Basic control characters and null' => "\r\n\t\0",
+        ]);
+
+        return [
+            ...$data,
+            'PHP quirks from the past' => ['%20~%2B', ' ~+'],
+        ];
+    }
+}

--- a/components/ILIAS/Refinery/tests/FactoryTest.php
+++ b/components/ILIAS/Refinery/tests/FactoryTest.php
@@ -35,6 +35,7 @@ use ILIAS\Refinery\Password\Group as PasswordGroup;
 use ILIAS\Refinery\String\Group as StringGroup;
 use ILIAS\Refinery\To\Group as ToGroup;
 use ILIAS\Refinery\URI\Group as URIGroup;
+use ILIAS\Refinery\Encode\Group as EncodeGroup;
 use ILIAS\Language\Language;
 use PHPUnit\Framework\TestCase;
 
@@ -120,10 +121,15 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(DateTimeGroup::class, $group);
     }
 
-    public function testCreateUriGrouo(): void
+    public function testCreateUriGroup(): void
     {
         $group = $this->basicFactory->uri();
         $this->assertInstanceOf(URIGroup::class, $group);
+    }
+
+    public function testCreateEncodeGroup(): void
+    {
+        $this->assertInstanceOf(EncodeGroup::class, $this->basicFactory->encode());
     }
 
     public function testByTryingInGroup(): void


### PR DESCRIPTION
This PR introduces 5 new transformations to escape: Javascript, HTML, HTML attributes, CSS and URL's.
The implementation is based upon this repository: https://github.com/laminas/laminas-escaper/