### PR TITLE
Draft: UI: Resource Selector Prototype

### DIFF
--- a/src/UI/examples/Input/Field/resource_selector_prototype.php
+++ b/src/UI/examples/Input/Field/resource_selector_prototype.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field;
+
+use ILIAS\UI\Implementation\Render\ilTemplateWrapper;
+use ILIAS\Data\URI;
+use ILIAS\UI\Factory;
+use ILIAS\UI\Component\Menu\Drilldown;
+use ILIAS\UI\Implementation\Render\Template;
+use ILIAS\UI\Component\Symbol\Symbol;
+use ILIAS\UI\Renderer;
+
+function resource_selector_prototype(): string
+{
+    global $DIC;
+
+    $main_template = $DIC->ui()->mainTemplate();
+    $renderer = $DIC->ui()->renderer();
+    $factory = $DIC->ui()->factory();
+
+    $prototype = getInputTemplate($main_template, 'tpl.resource_selector_prototype.html');
+
+    $c_icon = $factory->symbol()->icon()->standard('', '')->withAbbreviation('C');
+    $g_icon = $factory->symbol()->icon()->standard('', '')->withAbbreviation('G');
+
+    $structure = [
+        new PseudoEntry('1 Category', $c_icon, [
+            new PseudoEntry('1.1 Sub Category', $c_icon, [
+                new PseudoEntry('1.1.1 Course', $c_icon),
+                new PseudoEntry('1.1.2 Group', $g_icon),
+            ]),
+            new PseudoEntry('1.2 Course', $c_icon),
+            new PseudoEntry('1.3 Group', $g_icon),
+        ]),
+        new PseudoEntry('2 Category', $c_icon, [
+            new PseudoEntry('2.1 Course', $c_icon),
+            new PseudoEntry('2.2 Group', $g_icon),
+        ]),
+        new PseudoEntry(
+            '3 Course with an extremely long title which should be handled by the component somehow in an unfrastrating manner, which IMO is not yet the case, right?' .
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae nisl eget nunc aliquam aliquet.' .
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae nisl eget nunc aliquam aliquet.' .
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae nisl eget nunc aliquam aliquet.',
+            $c_icon
+        ),
+        new PseudoEntry('4 Group', $g_icon),
+        new PseudoEntry('Test breadcrumb nesting', $c_icon, [
+            new PseudoEntry('Level 1', $c_icon, [
+                new PseudoEntry('Level 2', $c_icon, [
+                    new PseudoEntry('Level 3', $c_icon, [
+                        new PseudoEntry('Level 4', $c_icon, [
+                            new PseudoEntry('Level 5', $c_icon, [
+                                new PseudoEntry('Level 6', $c_icon, [
+                                    new PseudoEntry('Level 7', $c_icon, [
+                                        new PseudoEntry('Level 8', $c_icon, [
+                                            new PseudoEntry('Level 9', $c_icon, [
+                                                new PseudoEntry('Level 10', $c_icon, [
+                                                    new PseudoEntry('You have reached the target, yay!', $c_icon),
+                                                ]),
+                                            ]),
+                                        ]),
+                                    ]),
+                                ]),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ]),
+        ...generateManyEntries($c_icon),
+    ];
+
+    $html = '';
+    foreach ($structure as $pseudo_entry) {
+        $html .= renderPseudoEntry($main_template, $renderer, $pseudo_entry);
+    }
+
+    $prototype->setVariable('ENTRIES', $html);
+
+    $prototype->setVariable('DROPDOWN', $renderer->render($factory->dropdown()->standard([
+        $factory->button()->shy('Entry 1', '#'),
+        $factory->button()->shy('Entry 1', '#'),
+        $factory->button()->shy('Entry 1', '#'),
+    ])));
+
+    return $prototype->get();
+}
+
+function getNewContainerEntry(
+    \ilGlobalTemplateInterface $main_template,
+    Renderer $renderer,
+    PseudoEntry $pseudo_entry,
+    int $level = 0
+): string {
+    $entry = getInputTemplate($main_template, 'tpl.resource_selector_container_item.html');
+    $entry->setVariable('ITEM_ICON', $renderer->render($pseudo_entry->icon));
+    $entry->setVariable('ITEM_NAME', $pseudo_entry->title);
+    $entry->setVariable('SELECT_ACTION', getSelectActionHtml($main_template));
+    $entry->setVariable('MENU_LEVEL', $level);
+
+    $sub_entries = $pseudo_entry->entries ?? [];
+    foreach ($sub_entries as $sub_entry) {
+        if (null === $sub_entry->entries) {
+            $sub_entry_html = getNewStandardEntry($main_template, $renderer, $sub_entry);
+        } else {
+            $sub_entry_html = getNewContainerEntry($main_template, $renderer, $sub_entry, $level + 1);
+        }
+
+        $entry->setCurrentBlock('block_sub_entry');
+        $entry->setVariable('SUB_ENTRY', $sub_entry_html);
+        $entry->parseCurrentBlock();
+    }
+
+    return $entry->get();
+}
+
+function getNewStandardEntry(
+    \ilGlobalTemplateInterface $main_template,
+    Renderer $renderer,
+    PseudoEntry $pseudo_entry,
+): string {
+    $entry = getInputTemplate($main_template, 'tpl.resource_selector_standard_item.html');
+    $entry->setVariable('ITEM_ICON', $renderer->render($pseudo_entry->icon));
+    $entry->setVariable('ITEM_NAME', $pseudo_entry->title);
+    $entry->setVariable('SELECT_ACTION', getSelectActionHtml($main_template));
+    return $entry->get();
+}
+
+function getSelectActionHtml(\ilGlobalTemplateInterface $main_template): string
+{
+    $action = getInputTemplate($main_template, 'tpl.resource_selector_select_action.html');
+    return $action->get();
+}
+
+function renderPseudoEntry(
+    \ilGlobalTemplateInterface $main_template,
+    Renderer $renderer,
+    PseudoEntry $pseudo_entry,
+): string {
+    if (null !== $pseudo_entry->entries) {
+        return getNewContainerEntry($main_template, $renderer, $pseudo_entry);
+    }
+
+    return getNewStandardEntry($main_template, $renderer, $pseudo_entry);
+}
+
+function getInputTemplate(\ilGlobalTemplateInterface $main_template, string $relative_path): Template
+{
+    return new ilTemplateWrapper(
+        $main_template,
+        new \ilTemplate(
+            __DIR__ . "/../../../templates/default/Input/$relative_path",
+            true,
+            false
+        )
+    );
+}
+
+function generateManyEntries(Symbol $pseudo_icon): array
+{
+    $array = [];
+    foreach (range(0, 100) as $i) {
+        $array[] = new PseudoEntry("Entry $i", $pseudo_icon);
+    }
+
+    return $array;
+}
+
+class PseudoEntry
+{
+    public function __construct(
+        public string $title,
+        public Symbol $icon,
+        public ?array $entries = null,
+    ) {
+    }
+}

--- a/src/UI/examples/Input/Field/with_dedicated_name.php
+++ b/src/UI/examples/Input/Field/with_dedicated_name.php
@@ -28,5 +28,7 @@ function with_dedicated_name()
          ->withDedicatedName('valid');
 
     $form = $ui->input()->container()->form()->standard("", [$text_input, $password_input, $duration_input]);
-    return $renderer->render($form);
+    return $renderer->render([$form, $ui->dropdown()->standard([
+        $ui->button()->shy('lbl', '#'),
+    ])]);
 }

--- a/src/UI/templates/default/Input/tpl.resource_selector_container_item.html
+++ b/src/UI/templates/default/Input/tpl.resource_selector_container_item.html
@@ -1,0 +1,17 @@
+<li>
+    <button class="menulevel" aria-expanded="false">
+        <div>
+            {ITEM_ICON}<span data-item-name>{ITEM_NAME}</span>
+        </div>
+        <div>
+            <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
+        </div>
+    </button>
+    {SELECT_ACTION}
+
+    <ul data-ddindex="{MENU_LEVEL}">
+        <!-- BEGIN block_sub_entry -->
+        {SUB_ENTRY}
+        <!-- END block_sub_entry -->
+    </ul>
+</li>

--- a/src/UI/templates/default/Input/tpl.resource_selector_prototype.html
+++ b/src/UI/templates/default/Input/tpl.resource_selector_prototype.html
@@ -1,0 +1,307 @@
+<div class="c-input-resource_selector modal fade il-modal-roundtrip in" tabindex="-1" role="dialog" id="modal">
+    <div class="modal-dialog" role="document" data-replace-marker="component">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                        aria-hidden="true">×</span></button>
+                <span class="modal-title">Select Resource</span>
+            </div>
+
+            <div class="modal-body">
+                <div class="il-drilldown" id="drilldown">
+                    <!-- this should probably be inside <header> but I could not manage to fix the css so the appearance is nice. -->
+                    <!-- also, this should probably be "sticky", but I could not manage this too. -->
+                    <nav aria-label="Breadcrumbs" class="breadcrumb_wrapper">
+                        <div id="breadcrumb-list" class="breadcrumb">
+                            <!-- <span id="root-breadcrumb" class="crumb"><a href="#">Repository</a></span> -->
+                        </div>
+                    </nav>
+                    <header class="show-title">
+                        <h2>Repository Root</h2>
+                        <div class="backnav">
+                            <button class="btn btn-bulky" id="drilldown_back" aria-label="back">
+                                    <span class="glyph" role="img"><span class="glyphicon glyphicon-triangle-left"
+                                                                         aria-hidden="true"></span></span><span
+                                    class="bulky-label"></span>
+                            </button>
+                        </div>
+                    </header>
+                    <ul>
+                        <li>
+                            <button class="menulevel engaged" aria-expanded="false">
+                                <span data-item-name>Repository</span>
+                                <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
+                            </button>
+                            <ul data-ddindex="0">
+                                {ENTRIES}
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <div id="selection">
+                    {DROPDOWN}
+                </div>
+                <button class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <button class="btn btn-primary" disabled="disabled">Choose</button>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- standard form to wrap prototype -->
+<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="#" method="post"
+      novalidate="novalidate">
+    <div class="il-standard-form-header clearfix">
+        <div class="il-standard-form-cmd">
+            <button class="btn btn-default" data-action="">Save</button>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label for="some_other_input" class="control-label col-sm-4 col-md-3 col-lg-2">Some other input</label>
+        <div class="col-sm-8 col-md-9 col-lg-10">
+            <input id="some_other_input" type="text" name="some_other_input"
+                   class="form-control form-control-sm">
+        </div>
+    </div>
+
+    <!-- form group containing the prototype -->
+    <div class="form-group row">
+        <label for="modal_triggerer" class="control-label col-sm-4 col-md-3 col-lg-2">Resource</label>
+        <div class="col-sm-8 col-md-9 col-lg-10">
+            <!-- prototype triggerer -->
+            <button type="button" class="btn btn-link dz-clickable" data-action="#" id="modal_triggerer">Select
+                Resources
+            </button>
+        </div>
+    </div>
+
+    <div class="il-standard-form-footer clearfix">
+        <div class="il-standard-form-cmd">
+            <button class="btn btn-default" data-action="">Save</button>
+        </div>
+    </div>
+</form>
+
+<!-- loaded implicitly by because of main menu -->
+<!--<script type="application/javascript" src="./src/UI/templates/js/Drilldown/dist/drilldown.js?version=9_0"></script>-->
+<script type="application/javascript" src="./node_modules/jquery/dist/jquery.js?version=9_0"></script>
+<script type="application/javascript" src="./node_modules/bootstrap/dist/js/bootstrap.min.js?version=9_0"></script>
+<script type="application/javascript" src="./src/UI/templates/js/Modal/modal.js?version=9_0"></script>
+<script type="application/ecmascript">
+  (function () {
+    // initialize drilldown menu manually, register back-button signal
+    $().ready(function() {
+      const drilldownBackSignal = 'drilldown-back-signal-id';
+      const openModalSignal = 'modal-open-signal-id';
+
+      $('#drilldown_back').on('click', function () {
+        $(this).trigger(drilldownBackSignal,
+          {
+            id: drilldownBackSignal,
+            event: 'click',
+            triggerer: $(this),
+            options: {},
+          }
+        );
+        // since I could not figure out how to listen to the back signal, remove the last crumb here.
+        popBreadCrumbs();
+        return false;
+      });
+
+      $('#modal_triggerer').on('click', function (e) {
+        il.UI.modal.showModal('modal', {}, {
+          id: 'modal',
+          event: 'click',
+          triggerer: $(this),
+          options: {},
+        });
+        e.stopPropagation();
+        return false;
+      });
+
+      il.UI.menu.drilldown.init('drilldown', drilldownBackSignal, null);
+
+      il.UI.menu.drilldown.instances['drilldown'].onEngage((level, parent) => {
+        if (parent.label && parent.id) {
+          addBreadCrumbForDrilldown(parent.label, parent.id);
+        }
+      });
+
+      // open modal immediately because I am lazy.
+      // $('#modal_triggerer').click();
+    });
+
+    const selector = document.querySelector('.c-input-resource_selector .il-drilldown');
+    let bulkyButtons = Array.from(selector.querySelectorAll('.btn-bulky'));
+    const chooseButton = selector.closest('.modal-content').querySelector('.btn-primary');
+    const breadCrumbs = document.getElementById('breadcrumb-list');
+    const currentSelection = new Map();
+
+    chooseButton.addEventListener('click', () => {
+
+    });
+
+    // const rootBreadcrumb = document.getElementById('root-breadcrumb');
+
+    function addBreadCrumbForDrilldown(label, level) {
+      const crumb = document.createElement('div');
+      crumb.innerHTML = '<span class="crumb" data-drilldown-level="' + level + '"><a href="#">' + label + '</a></span>';
+
+      crumb.firstElementChild.addEventListener('click', (event) => {
+        // engage the appropriate drilldown level.
+        const drilldown = il.UI.menu.drilldown.instances['drilldown'];
+        drilldown.engage(level);
+
+        // remove all crumbs after the clicked one.
+        const existingCrumbs = breadCrumbs.querySelectorAll('.crumb');
+        const clickedIndex = Array.prototype.indexOf.call(existingCrumbs, event.currentTarget);
+        popBreadCrumbs(existingCrumbs.length - clickedIndex);
+      });
+
+      breadCrumbs.append(crumb.firstElementChild);
+    }
+
+    function popBreadCrumbs(amount = 1) {
+      const crumbs = Array.from(breadCrumbs.querySelectorAll('.crumb')).reverse();
+      for (let i = 0; i < amount; i++) {
+        const crumb = crumbs[i];
+        if (crumb) {
+          crumb.remove();
+        }
+      }
+    }
+
+    // rootBreadcrumb.addEventListener('click', () => {
+    //   const drilldown = il.UI.menu.drilldown.instances['drilldown'];
+    //   drilldown.engage(0); // get more sophisticated way of getting menu-level, 0 is just a guess.
+    //   breadCrumbs.querySelectorAll('.crumb').forEach((crumb) => {
+    //     if (crumb.id !== rootBreadcrumb.id) {
+    //       crumb.remove();
+    //     }
+    //   });
+    // });
+
+    const selectButtons = bulkyButtons.filter((button) => {
+      return !button.parentElement.classList.contains('backnav');
+    });
+
+    selectButtons.forEach((button) => {
+      button.addEventListener('click', selectButtonHandler);
+    });
+
+    function selectButtonHandler(event) {
+      const button = event.target;
+      button.querySelectorAll('span').forEach((span) => {
+        span.classList.toggle('hidden');
+      });
+
+      const entry = button.closest('li');
+      const item = entry.querySelector('[data-item-name]').textContent;
+
+      if (currentSelection.has(item)) {
+        currentSelection.delete(item);
+      } else {
+        currentSelection.set(item, item);
+      }
+
+      entry.classList.toggle('selected');
+
+      chooseButton.disabled = currentSelection.size <= 0;
+
+      // for single choice selection, toggles all buttons except the clicked one.
+      // const currentValue = button.parentElement.querySelector('[data-item-name]').textContent;
+      // selectButtons.forEach((otherButton) => {
+      //   const otherValue = otherButton.parentElement.querySelector('[data-item-name]').textContent;
+      //   if (currentValue !== otherValue) {
+      //     otherButton.disabled = !otherButton.disabled;
+      //   }
+      // });
+    }
+  })();
+</script>
+
+<style>
+    .c-input-resource_selector .il-drilldown .engaged ~ ul > li {
+        display: flex;
+        flex-direction: row;
+    }
+
+    .c-input-resource_selector .il-drilldown .il-link {
+        cursor: auto;
+    }
+
+    /** using vh feels bad, is there a better way? */
+    .c-input-resource_selector .modal-body {
+        max-height: 75vh;
+        overflow-y: scroll;
+    }
+
+    /* NOTE these styles will apply to all children. for production, we may need to introduce a class
+     * which can be directly assigned to all elements which should be darkened.
+     */
+    /* only needed for single choice to "grey-out" action button too */
+    /*.c-input-resource_selector .il-drilldown .selected .btn-bulky .glyphicon,*/
+    .c-input-resource_selector .il-drilldown .selected .menulevel .icon,
+    .c-input-resource_selector .il-drilldown .selected .il-link .icon,
+    .c-input-resource_selector .il-drilldown .selected [data-item-name] {
+        filter: invert(50%);
+    }
+
+    .c-input-resource_selector .il-drilldown .btn-bulky .glyphicon,
+    .c-input-resource_selector .il-drilldown .menulevel .icon,
+    .c-input-resource_selector .il-drilldown .il-link .icon {
+        color: #4c6586;
+        filter: none;
+    }
+
+    .c-input-resource_selector .il-drilldown .link-bulky {
+        text-align: left;
+    }
+
+    .c-input-resource_selector .il-drilldown .il-link:hover {
+        background-color: white;
+        border-color: transparent;
+    }
+
+    .c-input-resource_selector .il-drilldown .engaged ~ ul > li > .btn-bulky {
+        max-width: 50px;
+        display: flex;
+        justify-content: center !important;
+    }
+
+    .c-input-resource_selector .il-drilldown .engaged ~ ul > li > .link-bulky {
+        display: flex;
+        justify-content: space-between;
+    }
+
+    /* aligns all modal content nicely to the left. */
+    .c-input-resource_selector .breadcrumb,
+    .c-input-resource_selector .il-drilldown .menulevel,
+    .c-input-resource_selector .il-drilldown .show-title:not(.show-backnav) {
+        padding-left: 12px;
+    }
+
+    .c-input-resource_selector .breadcrumb {
+        /*padding-left: 0;*/
+    }
+
+    /* someone with css skills might be able to make this element stick to the
+     * top of the modal-body, so they don't disappear on scroll.
+     */
+    .c-input-resource_selector .breadcrumb_wrapper {
+        /*height: 34px;*/
+        /*margin-top: 4px;*/
+    }
+
+    .c-input-resource_selector .il-drilldown .btn-bulky:focus-visible {
+        outline: 3px solid #0078D7;
+        box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 6px #FFFFFF;
+    }
+
+    #selection {
+        float: left;
+    }
+
+</style>

--- a/src/UI/templates/default/Input/tpl.resource_selector_select_action.html
+++ b/src/UI/templates/default/Input/tpl.resource_selector_select_action.html
@@ -1,0 +1,4 @@
+<button class="btn btn-bulky" aria-expanded="false">
+    <span data-action="select" class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+    <span data-action="unselect" class="glyphicon glyphicon-ok hidden" aria-hidden="true"></span>
+</button>

--- a/src/UI/templates/default/Input/tpl.resource_selector_standard_item.html
+++ b/src/UI/templates/default/Input/tpl.resource_selector_standard_item.html
@@ -1,0 +1,8 @@
+<li>
+    <a class="il-link link-bulky">
+        <div>
+            {ITEM_ICON}<span data-item-name>{ITEM_NAME}</span>
+        </div>
+    </a>
+    {SELECT_ACTION}
+</li>

--- a/src/UI/templates/js/Menu/dist/drilldown.js
+++ b/src/UI/templates/js/Menu/dist/drilldown.js
@@ -41,7 +41,7 @@
 			engageLevel(level);
 		},
 		engageLevel = function(id) {
-			model.actions.engageLevel(id);
+			model.actions.engageLevel(id, handler);
 			apply();
 		},
 		upLevel = function() {
@@ -55,10 +55,15 @@
 			mapping.setHeaderTitle(current.label);
 			mapping.setHeaderBacknav(current.parent != null);
 		},
+		addEngageListener = function (_handler) {
+			handler = _handler;
+		},
+		handler = null,
 
 		public_interface = {
 			init: init,
-			engage: engageLevel
+			engage: engageLevel,
+			onEngage: addEngageListener,
 	    };
 	    return public_interface;
 	};
@@ -97,11 +102,15 @@
 	        /**
 	         * @param  {String} id
 	         */
-	        engageLevel : function(id) {
+	        engageLevel : function(id, handler = null) {
 	            for(var idx in data) {
 	                data[idx].engaged = false;
 	                if(data[idx].id === id) {
 	                    data[idx].engaged = true;
+											if (handler) {
+												// pass by value, since arrays are objects. otherwise handler may tamper with it.
+												handler(structuredClone(data[idx]), structuredClone(data[data[idx].parent] ?? {}));
+											}
 	                }
 	            }
 	        },
@@ -127,7 +136,7 @@
 	};
 
 	var ddmapping = function() {
-	    var 
+	  var
 	    classes = {
 	        MENU: 'il-drilldown',
 	        BUTTON: 'button.menulevel',
@@ -160,19 +169,23 @@
 	                list.setAttribute(classes.ID_ATTRIBUTE, id);
 	            },
 	            getLabelForList = function(list) {
-	                var btn = list.parentElement.querySelector(classes.BUTTON); 
-	                return btn.childNodes[0].nodeValue;     
+	              var btn = list.parentElement.querySelector(classes.BUTTON);
+	              var lbl = btn.querySelector('[data-item-name]');
+	              if (lbl === null) {
+	                return btn.childNodes[0].nodeValue;
+	              }
+	              return lbl.textContent;
 	            },
 	            getParentIdOfList = function(list) {
 	                var parent = list.parentElement.parentElement;
 	                return parent.getAttribute(classes.ID_ATTRIBUTE);
 	            },
 	            registerHandler = function(list, handler, id) {
-	                var btn = list.parentElement.querySelector(classes.BUTTON); 
+	              var btn = list.parentElement.querySelector(classes.BUTTON);
 	                btn.addEventListener('click', function(){handler(id);});
 	            },
-	            
-	            sublists = list.querySelectorAll(classes.LIST_TAG);
+
+	              sublists = list.querySelectorAll(classes.LIST_TAG);
 
 	            for(var idx = 0; idx < sublists.length; idx = idx + 1) {
 	                var sublist = sublists[idx],
@@ -271,4 +284,4 @@
 		dd
 	);
 
-}());
+})();

--- a/src/UI/templates/js/Menu/src/drilldown.mapping.js
+++ b/src/UI/templates/js/Menu/src/drilldown.mapping.js
@@ -1,5 +1,5 @@
 var ddmapping = function() {
-    var 
+  var
     classes = {
         MENU: 'il-drilldown',
         BUTTON: 'button.menulevel',
@@ -32,19 +32,23 @@ var ddmapping = function() {
                 list.setAttribute(classes.ID_ATTRIBUTE, id);
             },
             getLabelForList = function(list) {
-                var btn = list.parentElement.querySelector(classes.BUTTON); 
-                return btn.childNodes[0].nodeValue;     
+              var btn = list.parentElement.querySelector(classes.BUTTON);
+              var lbl = btn.querySelector('[data-item-name]');
+              if (lbl === null) {
+                return btn.childNodes[0].nodeValue;
+              }
+              return lbl.textContent;
             },
             getParentIdOfList = function(list) {
                 var parent = list.parentElement.parentElement;
                 return parent.getAttribute(classes.ID_ATTRIBUTE);
             },
             registerHandler = function(list, handler, id) {
-                var btn = list.parentElement.querySelector(classes.BUTTON); 
+              var btn = list.parentElement.querySelector(classes.BUTTON);
                 btn.addEventListener('click', function(){handler(id);});
             },
-            
-            sublists = list.querySelectorAll(classes.LIST_TAG);
+
+              sublists = list.querySelectorAll(classes.LIST_TAG);
 
             for(var idx = 0; idx < sublists.length; idx = idx + 1) {
                 var sublist = sublists[idx],


### PR DESCRIPTION
Hi @Amstutz,

As promised (although a little late), here is a working example of the resource selector prototype. I will briefly recap for you and the general public as well.

We have discussed several ideas of resource selectors (formerly known as tree picker) in two UI Clinic meetings, where we have decided to pursue a drilldown approach for browsing possible items. This leaves the option to implement a sort of multi-column drilldown for larger devices, like we know it from the MacOS finder. Now to test the user experience of this approach, as well as the accessibility, we have been tasked to implement a clickable prototype. 

This prototype therefore merely implements some minimal functionality for selecting items visually. I could reuse most of the drilldown components logic and only needed to tweak the CSS a little bit. The JavaScript code was almost entirely compatible except for minor changes when fetching the entry label.

I have implemented this as a working UI example, which you can find in the documentation under `UI Component > Input > Field`.

Kind regards,
@thibsy 