### PR TITLE
Fix 37898: Use ilPropertyFromGUI to access post values

### DIFF
--- a/Modules/Category/classes/class.ilObjCategoryGUI.php
+++ b/Modules/Category/classes/class.ilObjCategoryGUI.php
@@ -930,7 +930,7 @@ class ilObjCategoryGUI extends ilContainerGUI implements \ILIAS\Taxonomy\Setting
                 }
                 // Update ecs export settings
                 $ecs = new ilECSCategorySettings($this->object);
-                if ($ecs->handleSettingsUpdate()) {
+                if ($ecs->handleSettingsUpdate($form)) {
                     $this->afterUpdate();
                     return;
                 }

--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -907,7 +907,7 @@ class ilObjCourseGUI extends ilContainerGUI
 
         // Update ecs export settings
         $ecs = new ilECSCourseSettings($this->object);
-        if (!$ecs->handleSettingsUpdate()) {
+        if (!$ecs->handleSettingsUpdate($form)) {
             $form->setValuesByPost();
             $this->tpl->setOnScreenMessage('failure', $GLOBALS['DIC']->language()->txt('err_check_input'));
             $this->editObject($form);

--- a/Modules/Glossary/classes/class.ilObjGlossaryGUI.php
+++ b/Modules/Glossary/classes/class.ilObjGlossaryGUI.php
@@ -693,7 +693,7 @@ class ilObjGlossaryGUI extends ilObjectGUI implements \ILIAS\Taxonomy\Settings\M
 
             // Update ecs export settings
             $ecs = new ilECSGlossarySettings($this->object);
-            if ($ecs->handleSettingsUpdate()) {
+            if ($ecs->handleSettingsUpdate($this->form)) {
                 $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_obj_modified"), true);
                 $this->ctrl->redirect($this, "properties");
             }

--- a/Modules/Group/classes/class.ilObjGroupGUI.php
+++ b/Modules/Group/classes/class.ilObjGroupGUI.php
@@ -695,7 +695,7 @@ class ilObjGroupGUI extends ilContainerGUI
             // END PATCH ChangeEvents: Record update Object.
             // Update ecs export settings
             $ecs = new ilECSGroupSettings($this->object);
-            $ecs->handleSettingsUpdate();
+            $ecs->handleSettingsUpdate($form);
         } else {
             $this->tpl->setOnScreenMessage('failure', $GLOBALS['DIC']->language()->txt('err_check_input')); // #16975
 

--- a/Modules/LearningModule/classes/class.ilObjContentObjectGUI.php
+++ b/Modules/LearningModule/classes/class.ilObjContentObjectGUI.php
@@ -753,7 +753,7 @@ class ilObjContentObjectGUI extends ilObjectGUI
 
             // Update ecs export settings
             $ecs = new ilECSLearningModuleSettings($this->lm);
-            if ($ecs->handleSettingsUpdate()) {
+            if ($ecs->handleSettingsUpdate($form)) {
                 $valid = true;
             }
         }

--- a/Modules/Wiki/classes/class.ilObjWikiGUI.php
+++ b/Modules/Wiki/classes/class.ilObjWikiGUI.php
@@ -981,7 +981,7 @@ class ilObjWikiGUI extends ilObjectGUI
 
                 // Update ecs export settings
                 $ecs = new ilECSWikiSettings($this->object);
-                if ($ecs->handleSettingsUpdate()) {
+                if ($ecs->handleSettingsUpdate($this->form)) {
                     $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_obj_modified"), true);
                     $ilCtrl->redirect($this, "editSettings");
                 }

--- a/Services/WebServices/ECS/classes/class.ilECSObjectSettings.php
+++ b/Services/WebServices/ECS/classes/class.ilECSObjectSettings.php
@@ -331,18 +331,17 @@ abstract class ilECSObjectSettings
      *
      * Processes post data from addSettingstoForm()
      * to be used in ilObject->update() AFTER object data has been updated
-     *
-     * @return bool
      */
-    public function handleSettingsUpdate(): bool
+    public function handleSettingsUpdate(ilPropertyFormGUI $form): bool
     {
-        $ecs_export = (bool) $_POST['ecs_export'];
-        $selected_receivers = (array) $_POST['ecs_sid'];
-        return $this->handleSettings($ecs_export, $selected_receivers);
+        return $this->handleSettings(
+            (bool) $form->getInput("ecs_export"),
+            (array) $form->getInput("ecs_sid")
+        );
     }
 
 
-    protected function handleSettings(
+    private function handleSettings(
         bool $ecs_export,
         array $selected_receivers
     ): bool {


### PR DESCRIPTION
Fixes using the $_POST variables directly inside a deeply layered service.

https://mantis.ilias.de/view.php?id=37898