### PR TITLE
[FIX] allow finder to find classes in src as well 

### DIFF
--- a/src/Setup/AbstractOfFinder.php
+++ b/src/Setup/AbstractOfFinder.php
@@ -33,7 +33,9 @@ abstract class AbstractOfFinder
      * @var string[]
      */
     protected array $ignore = [
-        '.*/src/',
+        '.*/src/Setup/',
+        '.*/src/GlobalScreen/',
+        '.*/Customizing/.*/src/',
         '.*/libs/',
         '.*/test/',
         '.*/tests/',
@@ -101,7 +103,7 @@ abstract class AbstractOfFinder
             "|",
             array_map(
                 // fix path-separators to respect windows' backspaces.
-                fn ($v): string => "(" . str_replace('/', '(/|\\\\)', $v) . ")",
+                fn($v): string => "(" . str_replace('/', '(/|\\\\)', $v) . ")",
                 $ignore
             )
         );


### PR DESCRIPTION
@klees this changes the rules which directories are excluded from a ImplementationOfInterfaceFinder or UsageOfAttributeFinder which makes it possible to provide e.g. Agents and Objectives in src as well.

src/Setup, src/GlobalScreen and src-directories in Plugins are still excluded.