### PR TITLE
Improvement/9/new filedelivery service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ phpstan-baseline.neon
 override.php
 Services/ResourceStorage/artifacts/flavour_data.php
 Services/FileHandlingDemo
+src/FileDelivery/artifacts

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -32,6 +32,7 @@ use ILIAS\HTTP\Wrapper\SuperGlobalDropInReplacement;
 use ILIAS\Filesystem\Definitions\SuffixDefinitions;
 use ILIAS\FileUpload\Processor\InsecureFilenameSanitizerPreProcessor;
 use ILIAS\FileUpload\Processor\SVGBlacklistPreProcessor;
+use ILIAS\FileDelivery\Init;
 
 require_once("libs/composer/vendor/autoload.php");
 
@@ -1126,6 +1127,7 @@ class ilInitialisation
         if (ilContext::initClient()) {
             self::initClient();
             self::initFileUploadService($GLOBALS["DIC"]);
+            Init::init($GLOBALS["DIC"]);
             self::initSession();
 
             if (ilContext::hasUser()) {

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -464,6 +464,11 @@ class Container extends \Pimple\Container
         return new \ILIAS\Certificate\Service\CertificateService($this);
     }
 
+    public function fileDelivery(): \ILIAS\FileDelivery\Services
+    {
+        return $this['file_delivery'];
+    }
+
     /**
      * Note: Only use isDependencyAvailable if strictly required. The need for this,
      * mostly points to some underlying problem needing to be solved instead of using this.

--- a/src/FileDelivery/Delivery/BaseDelivery.php
+++ b/src/FileDelivery/Delivery/BaseDelivery.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Delivery;
+
+use ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder;
+use ILIAS\HTTP\Response\ResponseHeader;
+use Psr\Http\Message\ResponseInterface;
+use ILIAS\FileDelivery\Token\Data\Stream;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+abstract class BaseDelivery
+{
+    public function __construct(
+        protected \ILIAS\HTTP\Services $http,
+        protected ResponseBuilder $response_builder
+    ) {
+    }
+
+    protected function saveAndClose(
+        ResponseInterface $r,
+        string $path_to_delete = null
+    ): never {
+        $sender = function () use ($r) {
+            $this->http->saveResponse($r);
+            $this->http->sendResponse();
+            $this->http->close();
+        };
+
+        if ($path_to_delete !== null && file_exists($path_to_delete)) {
+            ignore_user_abort(true);
+            set_time_limit(0);
+            ob_start();
+
+            $sender();
+
+            ob_flush();
+            ob_end_flush();
+            flush();
+
+            unlink($path_to_delete);
+        } else {
+            $sender();
+        }
+    }
+
+    protected function setGeneralHeaders(
+        ResponseInterface $r,
+        string $uri,
+        string $mime_type,
+        string $file_name,
+        Disposition $disposition = Disposition::INLINE
+    ): ResponseInterface {
+        $r = $r->withHeader('X-ILIAS-FileDelivery-Method', $this->response_builder->getName());
+        $r = $r->withHeader(ResponseHeader::CONTENT_TYPE, $mime_type);
+
+        $r = $r->withHeader(
+            ResponseHeader::CONTENT_DISPOSITION,
+            $disposition->value . '; filename="' . $file_name . '"'
+        );
+        $r = $r->withHeader(ResponseHeader::CACHE_CONTROL, 'max-age=31536000, immutable, private');
+        $r = $r->withHeader(
+            ResponseHeader::EXPIRES,
+            date("D, j M Y H:i:s", strtotime('+5 days')) . " GMT"
+        );
+        $r = $r->withHeader(ResponseHeader::ETAG, md5($uri));
+        $r = $r->withHeader(
+            ResponseHeader::LAST_MODIFIED,
+            date("D, j M Y H:i:s", filemtime($uri) ?: time()) . " GMT"
+        );
+        return $r;
+    }
+}

--- a/src/FileDelivery/Delivery/Disposition.php
+++ b/src/FileDelivery/Delivery/Disposition.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Delivery;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+enum Disposition: string
+{
+    case ATTACHMENT = 'attachment';
+    case INLINE = 'inline';
+}

--- a/src/FileDelivery/Delivery/LegacyDelivery.php
+++ b/src/FileDelivery/Delivery/LegacyDelivery.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Delivery;
+
+use ILIAS\FileDelivery\Token\Data\Stream;
+use ILIAS\Filesystem\Stream\Streams;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class LegacyDelivery extends BaseDelivery
+{
+    public function attached(
+        string $path_to_file,
+        ?string $download_file_name = null,
+        ?string $mime_type = null,
+        ?bool $delete_file = false
+    ): never {
+        $this->deliver(
+            $path_to_file,
+            Disposition::ATTACHMENT,
+            $download_file_name,
+            $mime_type,
+            $delete_file
+        );
+    }
+
+    public function inline(
+        string $path_to_file,
+        ?string $download_file_name = null,
+        ?string $mime_type = null,
+        ?bool $delete_file = false
+    ): never {
+        $this->deliver(
+            $path_to_file,
+            Disposition::INLINE,
+            $download_file_name,
+            $mime_type,
+            $delete_file
+        );
+    }
+
+    protected function deliver(
+        string $path_to_file,
+        Disposition $disposition,
+        ?string $download_file_name = null,
+        ?string $mime_type = null,
+        ?bool $delete_file = false
+    ): never {
+        $r = $this->setGeneralHeaders(
+            $this->http->response(),
+            $path_to_file,
+            $mime_type ?? mime_content_type($path_to_file),
+            $download_file_name ?? basename($path_to_file),
+            $disposition
+        );
+        $r = $this->response_builder->buildForStream(
+            $r,
+            Streams::ofResource(fopen($path_to_file, 'rb'))
+        );
+        $this - $this->saveAndClose($r, $delete_file ? $path_to_file : null);
+    }
+}

--- a/src/FileDelivery/Delivery/ResponseBuilder/PHPResponseBuilder.php
+++ b/src/FileDelivery/Delivery/ResponseBuilder/PHPResponseBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Delivery\ResponseBuilder;
+
+use Psr\Http\Message\ResponseInterface;
+use ILIAS\FileDelivery\Token\Data\Stream;
+use ILIAS\Filesystem\Stream\FileStream;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class PHPResponseBuilder implements ResponseBuilder
+{
+    public function getName(): string
+    {
+        return 'php';
+    }
+
+    public function buildForStream(
+        ResponseInterface $response,
+        FileStream $stream,
+    ): ResponseInterface {
+        return $response->withBody($stream);
+    }
+
+    public function supportStreaming(): bool
+    {
+        return false;
+    }
+
+    public function supportFileDeletion(): bool
+    {
+        return true;
+    }
+
+    public function supportsInlineDelivery(): bool
+    {
+        return true;
+    }
+
+    public function supportsAttachmentDelivery(): bool
+    {
+        return true;
+    }
+}

--- a/src/FileDelivery/Delivery/ResponseBuilder/ResponseBuilder.php
+++ b/src/FileDelivery/Delivery/ResponseBuilder/ResponseBuilder.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Delivery\ResponseBuilder;
+
+use Psr\Http\Message\ResponseInterface;
+use ILIAS\FileDelivery\Token\Data\Stream;
+use ILIAS\Filesystem\Stream\FileStream;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+interface ResponseBuilder
+{
+    public function getName(): string;
+
+    public function buildForStream(
+        ResponseInterface $response,
+        FileStream $stream,
+    ): ResponseInterface;
+
+    public function supportStreaming(): bool;
+
+    public function supportFileDeletion(): bool;
+
+    public function supportsInlineDelivery(): bool;
+
+    public function supportsAttachmentDelivery(): bool;
+}

--- a/src/FileDelivery/Delivery/ResponseBuilder/XAccelResponseBuilder.php
+++ b/src/FileDelivery/Delivery/ResponseBuilder/XAccelResponseBuilder.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Delivery\ResponseBuilder;
+
+use Psr\Http\Message\ResponseInterface;
+use ILIAS\FileDelivery\Token\Data\Stream;
+use ILIAS\Filesystem\Stream\FileStream;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class XAccelResponseBuilder implements ResponseBuilder
+{
+    private const DATA = 'data';
+    private const SECURED_DATA = 'secured-data';
+    private const X_ACCEL_REDIRECT_HEADER = 'X-Accel-Redirect';
+
+    public function getName(): string
+    {
+        return 'x-accel';
+    }
+
+    public function buildForStream(
+        ResponseInterface $response,
+        FileStream $stream,
+    ): ResponseInterface {
+        $path_to_file = $stream->getStream()->getMetadata('uri');
+        if (str_starts_with($path_to_file, './' . self::DATA . '/')) {
+            $path_to_file = str_replace(
+                './' . self::DATA . '/',
+                '/' . self::SECURED_DATA
+                . '/',
+                $path_to_file
+            );
+        }
+
+        return $response->withHeader(
+            self::X_ACCEL_REDIRECT_HEADER,
+            $path_to_file
+        );
+    }
+
+    public function supportStreaming(): bool
+    {
+        return true;
+    }
+
+    public function supportFileDeletion(): bool
+    {
+        return false;
+    }
+
+    public function supportsInlineDelivery(): bool
+    {
+        return true;
+    }
+
+    public function supportsAttachmentDelivery(): bool
+    {
+        return true;
+    }
+}

--- a/src/FileDelivery/Delivery/ResponseBuilder/XSendFileResponseBuilder.php
+++ b/src/FileDelivery/Delivery/ResponseBuilder/XSendFileResponseBuilder.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Delivery\ResponseBuilder;
+
+use Psr\Http\Message\ResponseInterface;
+use ILIAS\FileDelivery\Token\Data\Stream;
+use ILIAS\Filesystem\Stream\FileStream;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class XSendFileResponseBuilder implements ResponseBuilder
+{
+    private const X_SENDFILE_HEADER = 'X-Sendfile';
+
+    public function getName(): string
+    {
+        return 'xsendfile';
+    }
+
+    public function buildForStream(
+        ResponseInterface $response,
+        FileStream $stream,
+    ): ResponseInterface {
+        return $response->withHeader(
+            self::X_SENDFILE_HEADER,
+            $stream->getStream()->getMetadata('uri')
+        );
+    }
+
+    public function supportStreaming(): bool
+    {
+        return true;
+    }
+
+    public function supportFileDeletion(): bool
+    {
+        return false;
+    }
+
+    public function supportsInlineDelivery(): bool
+    {
+        return true;
+    }
+
+    public function supportsAttachmentDelivery(): bool
+    {
+        return true;
+    }
+}

--- a/src/FileDelivery/Delivery/StreamDelivery.php
+++ b/src/FileDelivery/Delivery/StreamDelivery.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Delivery;
+
+use ILIAS\FileDelivery\Token\DataSigner;
+use ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder;
+use ILIAS\FileDelivery\Token\Data\Stream;
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\FileDelivery\Token\Signer\Payload\FilePayload;
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\FileDelivery\Delivery\ResponseBuilder\PHPResponseBuilder;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class StreamDelivery extends BaseDelivery
+{
+    public function __construct(
+        private DataSigner $data_signer,
+        \ILIAS\HTTP\Services $http,
+        ResponseBuilder $response_builder
+    ) {
+        parent::__construct($http, $response_builder);
+    }
+
+    /**
+     * @param \Psr\Http\Message\ResponseInterface $r
+     * @return void
+     * @throws \ILIAS\HTTP\Response\Sender\ResponseSendingException
+     */
+    protected function notFound(\Psr\Http\Message\ResponseInterface $r): void
+    {
+        $this->http->saveResponse($r->withStatus(404));
+        $this->http->sendResponse();
+        $this->http->close();
+    }
+
+    public function attached(
+        FileStream $stream,
+        string $download_file_name,
+        ?string $mime_type = null
+    ): never {
+        $this->deliver(
+            $stream,
+            $download_file_name,
+            $mime_type,
+            Disposition::ATTACHMENT
+        );
+    }
+
+    public function inline(
+        FileStream $stream,
+        string $download_file_name,
+        ?string $mime_type = null
+    ): never {
+        $this->deliver(
+            $stream,
+            $download_file_name,
+            $mime_type,
+            Disposition::ATTACHMENT
+        );
+    }
+
+    public function deliver(
+        FileStream $stream,
+        string $download_file_name,
+        ?string $mime_type = null,
+        Disposition $disposition = Disposition::INLINE
+    ): never {
+        $r = $this->http->response();
+        $uri = $stream->getMetadata()['uri'];
+
+        $r = $this->setGeneralHeaders(
+            $r,
+            $uri,
+            $mime_type ?? mime_content_type($uri),
+            $download_file_name,
+            $disposition
+        );
+        $r = $this->response_builder->buildForStream(
+            $r,
+            $stream
+        );
+        $this->saveAndClose($r);
+    }
+
+    public function deliverFromToken(string $token): never
+    {
+        // check if $token has a sub-request, such as .../index.html
+        $parts = explode('/', $token);
+        $sub_request = null;
+        if (count($parts) > 1) {
+            $token = $parts[0];
+            $sub_request = implode('/', array_slice($parts, 1));
+        }
+
+        $r = $this->http->response();
+        $payload = $this->data_signer->verifyStreamToken($token);
+        if (!$payload instanceof FilePayload) {
+            $this->notFound($r);
+        }
+        // handle direct access to file
+        if ($sub_request === null) {
+            $r = $this->setGeneralHeaders(
+                $r,
+                $payload->getUri(),
+                $payload->getMimeType(),
+                $payload->getFilename(),
+                Disposition::from($payload->getDisposition())
+            );
+
+            $this->http->saveResponse(
+                $this->response_builder->buildForStream(
+                    $r,
+                    Streams::ofResource(fopen($payload->getUri(), 'rb'))
+                )
+            );
+        } else { // handle subrequest, aka file in a ZIP
+            $requested_zip = $payload->getUri();
+            $file_inside_zip_uri = "zip://$requested_zip#$sub_request";
+            $file_inside_zip_stream = fopen($file_inside_zip_uri, 'rb');
+
+            if ($file_inside_zip_stream === false) {
+                $this->notFound($r);
+            }
+
+            $r = $this->setGeneralHeaders(
+                $r,
+                $file_inside_zip_uri,
+                $this->determineMimeType($file_inside_zip_uri),
+                basename($sub_request),
+                Disposition::INLINE
+            );
+
+            // we must use PHPResponseBuilder here, because the streams inside zips cant be delivered using XSendFile or others
+            $response_builder = new PHPResponseBuilder();
+
+            $this->http->saveResponse(
+                $response_builder->buildForStream(
+                    $r,
+                    Streams::ofResource($file_inside_zip_stream, true)
+                )
+            );
+        }
+        $this->http->sendResponse();
+        $this->http->close();
+    }
+
+    private function determineMimeType(string $file_inside_zip_uri): string
+    {
+        $mime_type = mime_content_type($file_inside_zip_uri);
+        if ($mime_type === 'application/octet-stream') {
+            $mime_type = mime_content_type(substr($file_inside_zip_uri, 6));
+        }
+        return $mime_type ?: 'application/octet-stream';
+    }
+}

--- a/src/FileDelivery/Init.php
+++ b/src/FileDelivery/Init.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery;
+
+use ILIAS\DI\Container;
+use ILIAS\FileDelivery\Setup\KeyRotationObjective;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
+use ILIAS\FileDelivery\Token\DataSigner;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKeyRotation;
+use ILIAS\FileDelivery\Delivery\ResponseBuilder\XSendFileResponseBuilder;
+use ILIAS\FileDelivery\Delivery\ResponseBuilder\PHPResponseBuilder;
+use ILIAS\FileDelivery\Delivery\ResponseBuilder\ResponseBuilder;
+use ILIAS\FileDelivery\Setup\DeliveryMethodObjective;
+use ILIAS\FileDelivery\Delivery\LegacyDelivery;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class Init
+{
+    public static function init(Container $c): void
+    {
+        $c['file_delivery.response_builder'] = static function (): ResponseBuilder {
+            $settings = (require DeliveryMethodObjective::ARTIFACT) ?? [];
+
+            switch ($settings[DeliveryMethodObjective::SETTINGS] ?? null) {
+                case DeliveryMethodObjective::XSENDFILE:
+                    return new XSendFileResponseBuilder();
+                case DeliveryMethodObjective::PHP:
+                default:
+                    return new PHPResponseBuilder();
+            }
+        };
+
+        $c['file_delivery.data_signer'] = static function (): DataSigner {
+            $keys = array_map(static function (string $key): SecretKey {
+                return new SecretKey($key);
+            }, (require KeyRotationObjective::KEY_ROTATION) ?? []);
+
+            $current_key = array_shift($keys);
+
+            return new DataSigner(
+                new SecretKeyRotation(
+                    $current_key,
+                    ...$keys
+                )
+            );
+        };
+
+        $c['file_delivery.delivery'] = static function () use ($c): \ILIAS\FileDelivery\Delivery\StreamDelivery {
+            // if http is not initialized, we need to do it here
+            if (!$c->offsetExists('http')) {
+                $init_http = new \InitHttpServices();
+                $init_http->init($c);
+            }
+
+            return new \ILIAS\FileDelivery\Delivery\StreamDelivery(
+                $c['file_delivery.data_signer'],
+                $c['http'],
+                $c['file_delivery.response_builder']
+            );
+        };
+
+        $c['file_delivery.legacy_delivery'] = static function () use ($c): LegacyDelivery {
+            // if http is not initialized, we need to do it here
+            if (!$c->offsetExists('http')) {
+                $init_http = new \InitHttpServices();
+                $init_http->init($c);
+            }
+
+            return new LegacyDelivery(
+                $c['http'],
+                $c['file_delivery.response_builder']
+            );
+        };
+
+        $c['file_delivery'] = static function () use ($c): Services {
+            return new Services(
+                $c['file_delivery.delivery'],
+                $c['file_delivery.legacy_delivery'],
+                $c['file_delivery.data_signer']
+            );
+        };
+    }
+}

--- a/src/FileDelivery/README.md
+++ b/src/FileDelivery/README.md
@@ -1,0 +1,232 @@
+# Delivering Files to Browser
+
+This service is the central place to deliver files to the browser. The new server in /src will completely replace the
+old implementations in the future, currently they are used in parallel or as wrappers.
+
+## Usage
+
+The service is accessible via the DIC as follows:
+
+```php
+global $DIC;
+/** @var \ILIAS\FileDelivery\Services $file_delivery  */
+$file_delivery = $DIC['file_delivery'];
+```
+
+you get an instance of `\ILIAS\FileDelivery\Services` which contains other functions besides the actual delivery of
+files, see below.
+
+The service then is used as follows to deliver FileStreams:
+
+```php
+global $DIC;
+/** @var \ILIAS\FileDelivery\Services $file_delivery  */
+$file_delivery = $DIC['file_delivery'];
+$file_stream = ILIAS\Filesystem\Stream\Streams::ofResource(
+    fopen('/path/to/file', 'rb')
+);
+
+// downloads the file
+$file_delivery->delivery()->attached(
+    $file_stream,
+    'filename.txt',
+);
+
+// delivers the file inline
+$file_delivery->delivery()->inline(
+    $file_stream,
+    'filename.png',
+);
+
+```
+
+### Legacy usage
+
+In many cases, files (in the sense of paths) are still delivered. With the increasing use of IRSS, however, these cases
+will become fewer and should eventually disappear altogether.
+The delivery of a file happens as follows:
+
+```php
+global $DIC;
+/** @var \ILIAS\FileDelivery\Services $file_delivery  */
+$file_delivery = $DIC['file_delivery'];
+$file_path = '/path/to/file';
+
+// downloads the file
+$file_delivery->legacyDelivery()->attached(
+    $file_path,
+    'filename.txt',
+);
+
+// delivers the file inline
+$file_delivery->legacyDelivery()->inline(
+    $file_path,
+    'filename.png',
+);
+
+```
+
+# Signed Delivery
+
+The IRSS uses exclusively streamss for files and flavours, from ILIAS 9 also for structured data (e.g. later for HTML
+learning modules or SCORM learning modules). Up to ILIAS 9 these dtaeias are also delivered via a special mechanism
+through the WebAccessChecker. Now streams can be delivered very easily via a token-based way to protect the files. This
+will be the general way to deliver the files in the future and will replace the WebAccessChecker completely in the
+medium term.
+
+## How does the Signing work in general?
+
+The project ["It's Dangerous"](https://itsdangerous.palletsprojects.com/en/2.1.x/) was used as inspiration for the
+implementation. The machnism can be summarized simply:
+
+A token is created for a payload of simple data. In a first step, the payload is serialized for further processing. This
+string is optionally supplemented with a validity timestamp. This data is then signed with a Machnism. For the
+signature, a secret key as well as a salt is used depending on the use case.
+The serialized payload is merged with the signature, compressed, and formatted for embedding in URLs.
+Once a token is then to be verified, the following happens: URl preparation is reversed, and the data is decompressed.
+The result consists of the serialized payload and the signature. A new signature is now made for the payload and
+compared with the one supplied. If these are identical, it is certain that the dtaen are valid and have not been
+manipulated.
+The mechanism uses a key rotation, currently always 5 keys are kept. with a composer install / dump-autoload a new key
+is generated in each case.
+
+### Example:
+
+```php
+use ILIAS\FileDelivery\Token\Serializer\JSONSerializer;
+use ILIAS\FileDelivery\Token\Signer\KeyRotatingSigner;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKeyRotation;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
+use ILIAS\FileDelivery\Token\Signer\HMACSigner;
+use ILIAS\FileDelivery\Token\Signer\Algorithm\SHA1;
+use ILIAS\FileDelivery\Token\Signer\Key\Signing\HMACSigningKeyGenerator;
+use ILIAS\FileDelivery\Token\Signer\Salt\Salt;
+use ILIAS\FileDelivery\Token\Compression\DeflateCompression;
+use ILIAS\FileDelivery\Token\Transport\URLSafeTransport;
+
+// This is the payload we want to sign. It should use a "personal" component, e.g. the user ID, and a "global" component, e.g. the path to the file.
+ 
+$payload = [
+    'user_id' => 123,
+    'uri' => '/path/to/file',
+];
+
+// Using a `Serializer` we can serialize the payload to a string. The `JSONSerializer` is used here, but you can also use the `PHPSerializer` or implement your own.
+$serializer = new JSONSerializer();
+$serialized_payload = $serializer->serializePayload($payload);
+// $serialized_payload = '{"user_id":123,"uri":"/path/to/file"}'
+
+// Since we want the token to expire after a certain time, we add a timestamp to the payload. The timestamp is the current time plus the desired lifetime of the token in seconds.
+$signable_payload = $serialized_payload.'|'.(time() + 3600);
+// $signable_payload = '{"user_id":123,"uri":"/path/to/file"}|1631631631'
+
+// new we can sign the payload. The `KeyRotatingSigner` is used here. It uses a Key Rotation to sign the payload. The `KeyRotation` is used to store the keys. The `SecretKey` is used to store the actual keys. The `HMACSigner` is used to sign the payload. The `HMACSigningKeyGenerator` is used to generate the keys to sign. Using SHA1 as the algorithm, the `HMACSigner` will use the SHA1 algorithm to sign the payload. The `HMACSigningKeyGenerator` will use the SHA1 algorithm to generate the keys.
+
+$signer = new KeyRotatingSigner(
+    new SecretKeyRotation(
+        new SecretKey('key_one'),
+        new SecretKey('key_two')
+        new SecretKey('key_three')
+    ),
+    new HMACSigner(new SHA1())
+    new HMACSigningKeyGenerator(new SHA1())
+);
+
+$signature = $signer->sign($signable_payload, new Salt('salt'));
+// $signature = '...';
+
+// we can now merge the payload and the signature. 
+$signed_payload = $signable_payload.'|'.$signature;
+// $signed_payload = '{"user_id":123,"uri":"/path/to/file"}|1631631631|...';
+
+// now we can compress the payload. The `DeflateCompression` is used here, but you can also implement your own.
+$compression = new DeflateCompression();
+$compressed_payload = $compression->compress($signed_payload);
+
+// now we can encode the payload. The `URLSafeTransport` is used here since we use the tokens in URLs.
+$transport = new URLSafeTransport();
+$token = $transport->encode($compressed_payload);
+
+```
+
+Now, when a token is to be verified, the following happens:
+
+```php
+use ILIAS\FileDelivery\Token\Transport\URLSafeTransport;
+use ILIAS\FileDelivery\Token\Compression\DeflateCompression;
+use ILIAS\FileDelivery\Token\Signer\KeyRotatingSigner;
+use ILIAS\FileDelivery\Token\Signer\Salt\Salt;
+use ILIAS\FileDelivery\Token\Serializer\JSONSerializer;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKeyRotation;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
+use ILIAS\FileDelivery\Token\Signer\HMACSigner;
+use ILIAS\FileDelivery\Token\Signer\Key\Signing\HMACSigningKeyGenerator;
+use ILIAS\FileDelivery\Token\Signer\Algorithm\SHA1;
+
+// this is the token
+$token = '...';
+
+// first we decode the token
+$transport = new URLSafeTransport();
+$decoded_token = $transport->readFromTransport($token);
+
+// after that, we decompress the token
+$compression = new DeflateCompression();
+$decompressed_token = $compression->decompress($decoded_token);
+
+$parts = explode('|', $decompressed_token);
+$serialized_payload = $split_data[0] ?? '';
+$validity = $split_data[1] ?? '';
+$signature = $split_data[2] ?? '';
+$payload_with_validity = $serialized_payload . self::SEPARATOR . $validity;
+
+// now we can verify the token by signing the payload and comparing the signature
+$signer = new KeyRotatingSigner(
+    new SecretKeyRotation(
+        new SecretKey('key_one'),
+        new SecretKey('key_two')
+        new SecretKey('key_three')
+    ),
+    new HMACSigner(new SHA1())
+    new HMACSigningKeyGenerator(new SHA1())
+);
+
+// `verify` loops all keys from the keyrotation and signs the payload. if the signature matches, the payload is valid.
+$is_valid = $signer->verify($payload_with_validity, $signature, new Salt('salt'));
+
+if($is_valid) {
+    $serializer = new JSONSerializer();
+    $payload = $serializer->unserializePayload($serialized_payload);
+    // $payload = ['user_id' => 123, 'uri' => '/path/to/file']
+}else {
+    // the token is invalid
+    $payload = null;
+}
+```
+
+Since this process is quite complex, this is simply offered to generate appropriate tokens for FileStreams. You get a
+ready URL, which can then deliver the file, if the token is valid:
+
+```php
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\FileDelivery\Delivery\Disposition;
+
+global $DIC;
+$stream = Streams::ofResource(fopen('/path/to/file', 'r'));
+$uri = $DIC->fileDelivery()->buildTokenURL(
+    $stream,
+    'Download-Filename.png',
+    Disposition::INLINE
+    123 // user_id
+    6 // valid for at least 6 hours
+)
+
+// $uri = 'http://trunk.ilias.localhost/src/FileDelivery/deliver.php/LY3NasMwEITy[...]RFiKcUmOmJx8Ac'
+```
+
+This mechanism is then simply used, for example, to deliver structured resources (container resources). A URL on HTML
+learning module can then look like this:
+
+```
+http://trunk.ilias.localhost/src/FileDelivery/deliver.php/LY3NasMwEITy[...]RFiKcUmOmJx8Ac/index.html
+```

--- a/src/FileDelivery/Services.php
+++ b/src/FileDelivery/Services.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery;
+
+use ILIAS\FileDelivery\Token\DataSigner;
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\FileDelivery\Delivery\Disposition;
+use ILIAS\FileDelivery\Delivery\LegacyDelivery;
+use ILIAS\Data\URI;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class Services
+{
+    public const DELIVERY_ENDPOINT = '/src/FileDelivery/deliver.php/';
+
+    public function __construct(
+        private \ILIAS\FileDelivery\Delivery\StreamDelivery $delivery,
+        private LegacyDelivery $legacy_delivery,
+        private DataSigner $data_signer
+    ) {
+    }
+
+    public function delivery(): \ILIAS\FileDelivery\Delivery\StreamDelivery
+    {
+        return $this->delivery;
+    }
+
+    public function legacyDelivery(): LegacyDelivery
+    {
+        return $this->legacy_delivery;
+    }
+
+    public function buildTokenURL(
+        FileStream $stream,
+        string $filename,
+        Disposition $disposition,
+        int $user_id,
+        int $valid_for_at_least_hours
+    ): URI {
+        // a new DateTimeImmutable which is set to the end of now + $valid_for_at_least_hours hours
+        $until = new \DateTimeImmutable(
+            (new \DateTimeImmutable("now +$valid_for_at_least_hours hours"))->format('Y-m-d H:00')
+        );
+
+        $token = $this->data_signer->getSignedStreamToken(
+            $stream,
+            $filename,
+            $disposition,
+            $user_id,
+            $until
+        );
+        return new URI(
+            rtrim(ILIAS_HTTP_PATH, '/') . self::DELIVERY_ENDPOINT . $token
+        );
+    }
+}

--- a/src/FileDelivery/Setup/Agent.php
+++ b/src/FileDelivery/Setup/Agent.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Setup;
+
+use ILIAS\Setup;
+use ILIAS\Setup\Objective;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Setup\Metrics;
+use ILIAS\Setup\Config;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class Agent implements Setup\Agent
+{
+    public function getBuildArtifactObjective(): Objective
+    {
+        return new Setup\ObjectiveCollection(
+            'File StreamDelivery Artifacts',
+            true,
+            new KeyRotationObjective(),
+            new DeliveryMethodObjective()
+        );
+    }
+
+    public function getNamedObjectives(?Config $config = null): array
+    {
+        return [];
+    }
+
+    public function hasConfig(): bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation(): Transformation
+    {
+        throw new LogicException("No Config");
+    }
+
+    public function getInstallObjective(Config $config = null): Objective
+    {
+        return new DeliveryMethodObjective();
+    }
+
+    public function getUpdateObjective(Config $config = null): Objective
+    {
+        return new DeliveryMethodObjective();
+    }
+
+    public function getStatusObjective(Metrics\Storage $storage): Objective
+    {
+        return new Objective\NullObjective();
+    }
+
+    public function getMigrations(): array
+    {
+        return [];
+    }
+}

--- a/src/FileDelivery/Setup/DeliveryMethodObjective.php
+++ b/src/FileDelivery/Setup/DeliveryMethodObjective.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Setup;
+
+use ILIAS\Setup\Artifact\BuildArtifactObjective;
+use ILIAS\Setup;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class DeliveryMethodObjective extends BuildArtifactObjective
+{
+    public const ARTIFACT = './src/FileDelivery/artifacts/delivery_method.php';
+    public const SETTINGS = 'delivery_method';
+    public const XSENDFILE = 'xsendfile';
+    public const PHP = 'php';
+
+    public function getArtifactPath(): string
+    {
+        return self::ARTIFACT;
+    }
+
+    public function build(): Setup\Artifact
+    {
+        // check if mod_xsendfile is loaded
+        if ($this->isModXSendFileLoaded()) {
+            return new Setup\Artifact\ArrayArtifact([
+                self::SETTINGS => self::XSENDFILE
+            ]);
+        }
+
+        return new Setup\Artifact\ArrayArtifact([
+            self::SETTINGS => self::PHP
+        ]);
+    }
+
+    private function isModXSendFileLoaded(): bool
+    {
+        if (function_exists('apache_get_modules') && in_array('mod_xsendfile', apache_get_modules(), true)) {
+            return true;
+        }
+
+        try {
+            $loaded_modules = array_map(static function ($module) {
+                return explode(" ", trim($module))[0] ?? "";
+            }, explode("\n", shell_exec("apache2ctl -M")));
+        } catch (\Throwable $e) {
+            $loaded_modules = [];
+        }
+        if (in_array('xsendfile_module', $loaded_modules, true)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/FileDelivery/Setup/KeyRotationObjective.php
+++ b/src/FileDelivery/Setup/KeyRotationObjective.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Setup;
+
+use ILIAS\Setup\Artifact\BuildArtifactObjective;
+use ILIAS\Setup;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class KeyRotationObjective extends BuildArtifactObjective
+{
+    public const KEY_ROTATION = './src/FileDelivery/artifacts/key_rotation.php';
+    public const KEY_LENGTH = 32;
+    private const NUMBER_OF_KEYS = 5;
+
+    public function getArtifactPath(): string
+    {
+        return self::KEY_ROTATION;
+    }
+
+    public function build(): Setup\Artifact
+    {
+        if (is_readable(self::KEY_ROTATION)) {
+            /** @var array $current_keys */
+            $current_keys = require self::KEY_ROTATION;
+        }
+
+        $new_keys = [];
+
+        if (is_array($current_keys)) {
+            // drop the first key
+            $current_keys = array_slice($current_keys, 1);
+            $new_keys = $current_keys;
+        }
+        // $push a new key to the array at first position
+        while (count($new_keys) < self::NUMBER_OF_KEYS) {
+            $new_keys[] = $this->generateRandomString(self::KEY_LENGTH);
+        }
+        // keep only the first 5 keys
+        $new_keys = array_slice($new_keys, 0, self::NUMBER_OF_KEYS);
+
+        return new Setup\Artifact\ArrayArtifact($new_keys);
+    }
+
+    private function generateRandomString(int $length): string
+    {
+        $return = '';
+        for ($i = 0; $i < $length; $i++) {
+            $return .= chr(random_int(33, 125));
+        }
+        return $return;
+    }
+}

--- a/src/FileDelivery/Token/Compression/Compression.php
+++ b/src/FileDelivery/Token/Compression/Compression.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Compression;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+interface Compression
+{
+    /**
+     * @throws CompressionFailure
+     */
+    public function compress(string $data): string;
+
+    /**
+     * @throws CompressionFailure
+     */
+    public function decompress(string $data): string;
+}

--- a/src/FileDelivery/Token/Compression/CompressionFailure.php
+++ b/src/FileDelivery/Token/Compression/CompressionFailure.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Compression;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class CompressionFailure extends \RuntimeException
+{
+}

--- a/src/FileDelivery/Token/Compression/DeflateCompression.php
+++ b/src/FileDelivery/Token/Compression/DeflateCompression.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Compression;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class DeflateCompression implements Compression
+{
+    private const LEVEL = 9;
+
+    /**
+     * @throws CompressionFailure
+     */
+    public function compress(string $data): string
+    {
+        $compressed = \gzdeflate($data, self::LEVEL);
+        if ($compressed === false) {
+            throw new CompressionFailure();
+        }
+        return $compressed;
+    }
+
+    /**
+     * @throws CompressionFailure
+     */
+    public function decompress(string $data): string
+    {
+        $decompressed = \gzinflate($data);
+        if ($decompressed === false) {
+            throw new CompressionFailure();
+        }
+
+        return $decompressed;
+    }
+}

--- a/src/FileDelivery/Token/Compression/NullCompression.php
+++ b/src/FileDelivery/Token/Compression/NullCompression.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Compression;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class NullCompression implements Compression
+{
+    /**
+     * @throws CompressionFailure
+     */
+    public function compress(string $data): string
+    {
+        return $data;
+    }
+
+    /**
+     * @throws CompressionFailure
+     */
+    public function decompress(string $data): string
+    {
+        return $data;
+    }
+}

--- a/src/FileDelivery/Token/DataSigner.php
+++ b/src/FileDelivery/Token/DataSigner.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token;
+
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKeyRotation;
+use ILIAS\FileDelivery\Token\Signer\Signer;
+use ILIAS\FileDelivery\Token\Serializer\Serializer;
+use ILIAS\FileDelivery\Token\Signer\Payload\Payload;
+use ILIAS\FileDelivery\Token\Signer\HMACSigner;
+use ILIAS\FileDelivery\Token\Serializer\JSONSerializer;
+use ILIAS\FileDelivery\Token\Signer\Key\DigestMethod\Concat as NoneDigest;
+use ILIAS\FileDelivery\Token\Signer\Key\Signing\HMACSigningKeyGenerator;
+use ILIAS\FileDelivery\Token\Signer\Algorithm\SHA1;
+use ILIAS\FileDelivery\Token\Compression\GZipCompression;
+use ILIAS\FileDelivery\Token\Transport\URLSafeTransport;
+use ILIAS\FileDelivery\Token\Compression\DeflateCompression;
+use ILIAS\FileDelivery\Token\Signer\KeyRotatingSigner;
+use ILIAS\FileDelivery\Token\Signer\Salt\Factory;
+use ILIAS\FileDelivery\Token\Signer\Payload\StructuredPayload;
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\FileDelivery\Token\Data\Stream;
+use ILIAS\FileDelivery\Token\Compression\Compression;
+use ILIAS\FileDelivery\Token\Transport\Transport;
+use ILIAS\FileDelivery\Token\Signer\Payload\Builder;
+use ILIAS\FileDelivery\Delivery\Disposition;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class DataSigner
+{
+    private Signer $signer;
+    private Serializer $serializer;
+    private SigningSerializer $signing_serializer;
+    private Factory $salt_factory;
+    private Compression $compression;
+    private Transport $transport;
+    private Builder $payload_builder;
+
+    public function __construct(
+        SecretKeyRotation $key_rotation
+    ) {
+        $this->salt_factory = new Factory();
+        $this->compression = new DeflateCompression();
+        $this->transport = new URLSafeTransport();
+        $this->signing_serializer = new SigningSerializer(
+            new KeyRotatingSigner(
+                $key_rotation,
+                new HMACSigner(
+                    new SHA1()
+                ),
+                new HMACSigningKeyGenerator(
+                    new SHA1()
+                )
+            ),
+            new JSONSerializer(),
+            $this->compression,
+            $this->transport
+        );
+
+        $this->payload_builder = new Builder();
+    }
+
+    public function getSignedStreamToken(
+        FileStream $stream,
+        string $filename,
+        Disposition $disposition,
+        int $user_id,
+        \DateTimeImmutable $until = null
+    ): string {
+        $payload = $this->payload_builder->file(
+            $stream,
+            $filename,
+            $disposition,
+            $user_id,
+            $until
+        );
+
+        return $this->sign($payload->get(), 'stream', $until);
+    }
+
+    public function verifyStreamToken(string $token): ?Payload
+    {
+        $data = $this->verify($token, 'stream');
+        if ($data === null) {
+            return null;
+        }
+        return $this->payload_builder->fileFromRaw($data);
+    }
+
+    public function sign(
+        array $data,
+        string $salt,
+        \DateTimeImmutable $until = null
+    ): string {
+        return $this->signing_serializer->sign(
+            new StructuredPayload($data, $until?->getTimestamp()),
+            $this->salt_factory->create($salt)
+        );
+    }
+
+    public function verify(
+        string $token,
+        string $salt
+    ): ?array {
+        return $this->signing_serializer->verify(
+            $token,
+            $this->salt_factory->create($salt)
+        )?->get();
+    }
+}

--- a/src/FileDelivery/Token/Request.php
+++ b/src/FileDelivery/Token/Request.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token;
+
+use ILIAS\FileDelivery\Token\Compression\GZipCompression;
+use ILIAS\FileDelivery\Delivery\Disposition;
+use ILIAS\Filesystem\Stream\FileStream;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class Request
+{
+    public function __construct(
+        private FileStream $stream,
+        private Disposition $disposition,
+        private string $file_name,
+        private int $valid_for_at_least_hours,
+    ) {
+    }
+
+    public static function fromStreamAttached(
+        FileStream $stream,
+        string $file_name,
+        int $valid_for_at_least_hours,
+    ): self {
+        return new self(
+            $stream,
+            Disposition::ATTACHMENT,
+            $file_name,
+            $valid_for_at_least_hours
+        );
+    }
+
+    public static function fromStreamInline(
+        FileStream $stream,
+        string $file_name,
+        int $valid_for_at_least_hours,
+    ): self {
+        return new self(
+            $stream,
+            Disposition::INLINE,
+            $file_name,
+            $valid_for_at_least_hours
+        );
+    }
+}

--- a/src/FileDelivery/Token/Serializer/JSONSerializer.php
+++ b/src/FileDelivery/Token/Serializer/JSONSerializer.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Serializer;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class JSONSerializer implements Serializer
+{
+    public function __construct()
+    {
+    }
+
+    public function serializePayload(array $payload_data): string
+    {
+        return json_encode($payload_data, JSON_THROW_ON_ERROR);
+    }
+
+    public function unserializePayload(string $payload_string): array
+    {
+        return json_decode($payload_string, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    public function serializeValidity(?int $valid_until_timestamp): string
+    {
+        return (string) ($valid_until_timestamp ?? '');
+    }
+
+    public function unserializeValidity(string $valid_until_string): ?int
+    {
+        return $valid_until_string === '' ? null : (int) $valid_until_string;
+    }
+}

--- a/src/FileDelivery/Token/Serializer/PHPSerializer.php
+++ b/src/FileDelivery/Token/Serializer/PHPSerializer.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Serializer;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class PHPSerializer implements Serializer
+{
+    public function __construct()
+    {
+    }
+
+    public function serializePayload(array $payload_data): string
+    {
+        return serialize($payload_data);
+    }
+
+    public function unserializePayload(string $payload_string): array
+    {
+        return unserialize($payload_string, ['allowed_classes' => false]);
+    }
+
+    public function serializeValidity(?int $valid_until_timestamp): string
+    {
+        return (string) ($valid_until_timestamp ?? '');
+    }
+
+    public function unserializeValidity(string $valid_until_string): ?int
+    {
+        return $valid_until_string === '' ? null : (int) $valid_until_string;
+    }
+}

--- a/src/FileDelivery/Token/Serializer/Serializer.php
+++ b/src/FileDelivery/Token/Serializer/Serializer.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Serializer;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+interface Serializer
+{
+    public function __construct();
+
+    public function serializePayload(array $payload_data): string;
+
+    public function unserializePayload(string $payload_string): array;
+
+    public function serializeValidity(?int $valid_until_timestamp): string;
+
+    public function unserializeValidity(string $valid_until_string): ?int;
+}

--- a/src/FileDelivery/Token/Signer/Algorithm/Algorithm.php
+++ b/src/FileDelivery/Token/Signer/Algorithm/Algorithm.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Algorithm;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+interface Algorithm
+{
+    public function getName(): string;
+}

--- a/src/FileDelivery/Token/Signer/Algorithm/MD5.php
+++ b/src/FileDelivery/Token/Signer/Algorithm/MD5.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Algorithm;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class MD5 implements Algorithm
+{
+    public function getName(): string
+    {
+        return 'md5';
+    }
+}

--- a/src/FileDelivery/Token/Signer/Algorithm/None.php
+++ b/src/FileDelivery/Token/Signer/Algorithm/None.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Algorithm;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class None implements Algorithm
+{
+    public function getName(): string
+    {
+        return '';
+    }
+}

--- a/src/FileDelivery/Token/Signer/Algorithm/SHA1.php
+++ b/src/FileDelivery/Token/Signer/Algorithm/SHA1.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Algorithm;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class SHA1 implements Algorithm
+{
+    public function getName(): string
+    {
+        return 'sha1';
+    }
+}

--- a/src/FileDelivery/Token/Signer/Algorithm/SHA256.php
+++ b/src/FileDelivery/Token/Signer/Algorithm/SHA256.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Algorithm;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class SHA256 implements Algorithm
+{
+    public function getName(): string
+    {
+        return 'sha256';
+    }
+}

--- a/src/FileDelivery/Token/Signer/HMACSigner.php
+++ b/src/FileDelivery/Token/Signer/HMACSigner.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer;
+
+use ILIAS\FileDelivery\Token\Signer\Key\DigestMethod\DigestMethod;
+use ILIAS\FileDelivery\Token\Signer\Algorithm\Algorithm;
+use ILIAS\FileDelivery\Token\Signer\Key\Signing\SigningKey;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class HMACSigner implements Signer
+{
+    public function __construct(
+        private Algorithm $algorithm
+    ) {
+    }
+
+    protected function getAlgorithm(): string
+    {
+        return $this->algorithm->getName();
+    }
+
+    public function sign(
+        string $signable_payload,
+        SigningKey $signing_key
+    ): string {
+        // sign the payload using hmac_hash
+        return hash_hmac(
+            $this->getAlgorithm(),
+            $signable_payload,
+            $signing_key->get(),
+            false
+        );
+    }
+
+    public function verify(
+        string $data,
+        string $signature,
+        int $validity,
+        SigningKey $signing_key
+    ): bool {
+        $signature_check = $this->sign($data, $signing_key);
+        if ($signature_check !== $signature) {
+            return false;
+        }
+        if ($validity > 0 && $validity < time()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/FileDelivery/Token/Signer/Key/Secret/SecretKey.php
+++ b/src/FileDelivery/Token/Signer/Key/Secret/SecretKey.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Key\Secret;
+
+/**
+ * Signatures are secured by the secret_key. Typically one secret key is used with all signers, and the salt is used to
+ * distinguish different contexts. Changing the secret key will invalidate existing tokens.
+ *
+ * It should be a long random string of bytes. This value must be kept secret and should not be saved in source code or
+ * committed to version control. If an attacker learns the secret key, they can change and resign data to look valid.
+ * If you suspect this happened, change the secret key to invalidate existing tokens.
+ *
+ * One way to keep the secret key separate is to read it from an environment variable. When deploying for the first time,
+ * generate a key and set the environment variable when running the application.
+ * All process managers (like systemd) and hosting services have a way to specify environment variables.
+ *
+ * @see    https://itsdangerous.palletsprojects.com/en/2.1.x/concepts/#the-secret-key
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class SecretKey
+{
+    public function __construct(
+        private string $secret_key
+    ) {
+    }
+
+    public function get(): string
+    {
+        return $this->secret_key;
+    }
+}

--- a/src/FileDelivery/Token/Signer/Key/Secret/SecretKeyRotation.php
+++ b/src/FileDelivery/Token/Signer/Key/Secret/SecretKeyRotation.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Key\Secret;
+
+/**
+ * Key rotation can provide an extra layer of mitigation against an attacker discovering a secret key. A rotation system
+ * will keep a list of valid keys, generating a new key and removing the oldest key periodically. If it takes four weeks
+ * for an attacker to crack a key, but the key is rotated out after three weeks, they will not be able to use any keys
+ * they crack. However, if a user doesn’t refresh their token within three weeks it will be invalid too.
+ *
+ * The system that generates and maintains this list is outside the scope of ItsDangerous, but ItsDangerous does support
+ * validating against a list of keys.
+ *
+ * Instead of passing a single key, you can pass a list of keys, oldest to newest. When signing the last (newest) key
+ * will be used, and when validating each key will be tried from newest to oldest before raising a validation error.
+ *
+ * @see    https://itsdangerous.palletsprojects.com/en/2.1.x/concepts/#key-rotation
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ *
+ * @internal
+ */
+final class SecretKeyRotation
+{
+    /**
+     * @var SecretKey[]
+     */
+    private array $older_keys;
+
+    public function __construct(
+        private SecretKey $current_key,
+        SecretKey ...$older_keys
+    ) {
+        $this->older_keys = $older_keys;
+    }
+
+    public function getAllKeys(): array
+    {
+        return array_merge([$this->current_key], $this->older_keys);
+    }
+
+    public function getOlderKeys(): array
+    {
+        return $this->older_keys;
+    }
+
+    public function getCurrentKey(): SecretKey
+    {
+        return $this->current_key;
+    }
+}

--- a/src/FileDelivery/Token/Signer/Key/Signing/ConcatSigningKeyGenerator.php
+++ b/src/FileDelivery/Token/Signer/Key/Signing/ConcatSigningKeyGenerator.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Key\Signing;
+
+use ILIAS\FileDelivery\Token\Signer\Salt\Salt;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ *
+ * @internal
+ */
+class ConcatSigningKeyGenerator implements SigningKeyGenerator
+{
+    public function generate(SecretKey $secret_key, Salt $salt): SigningKey
+    {
+        return new SigningKey($secret_key->get() . $salt->get());
+    }
+}

--- a/src/FileDelivery/Token/Signer/Key/Signing/HMACSigningKeyGenerator.php
+++ b/src/FileDelivery/Token/Signer/Key/Signing/HMACSigningKeyGenerator.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Key\Signing;
+
+use ILIAS\FileDelivery\Token\Signer\Salt\Salt;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
+use ILIAS\FileDelivery\Token\Signer\Algorithm\Algorithm;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ *
+ * @internal
+ */
+class HMACSigningKeyGenerator implements SigningKeyGenerator
+{
+    public function __construct(
+        private Algorithm $algorithm
+    ) {
+    }
+
+    public function generate(SecretKey $secret_key, Salt $salt): SigningKey
+    {
+        return new SigningKey(hash_hmac($this->algorithm->getName(), $salt->get(), $secret_key->get(), false));
+    }
+}

--- a/src/FileDelivery/Token/Signer/Key/Signing/SigningKey.php
+++ b/src/FileDelivery/Token/Signer/Key/Signing/SigningKey.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Key\Signing;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ *
+ * @internal
+ */
+final class SigningKey
+{
+    public function __construct(
+        private string $signing_key
+    ) {
+    }
+
+    public function get(): string
+    {
+        return $this->signing_key;
+    }
+}

--- a/src/FileDelivery/Token/Signer/Key/Signing/SigningKeyGenerator.php
+++ b/src/FileDelivery/Token/Signer/Key/Signing/SigningKeyGenerator.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Key\Signing;
+
+use ILIAS\FileDelivery\Token\Signer\Salt\Salt;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ *
+ * @internal
+ */
+interface SigningKeyGenerator
+{
+    public function generate(SecretKey $secret_key, Salt $salt): SigningKey;
+}

--- a/src/FileDelivery/Token/Signer/KeyRotatingSigner.php
+++ b/src/FileDelivery/Token/Signer/KeyRotatingSigner.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer;
+
+use ILIAS\FileDelivery\Token\Signer\Key\Signing\SigningKeyGenerator;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKeyRotation;
+use ILIAS\FileDelivery\Token\Signer\Salt\Salt;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class KeyRotatingSigner
+{
+    private SecretKey $current_secret_key;
+
+    public function __construct(
+        private SecretKeyRotation $key_rotation,
+        private Signer $signer,
+        private SigningKeyGenerator $signing_key_generator,
+    ) {
+        $this->current_secret_key = $key_rotation->getCurrentKey();
+    }
+
+    public function sign(string $signable_payload, Salt $salt): string
+    {
+        return $this->signer->sign(
+            $signable_payload,
+            $this->signing_key_generator->generate(
+                $this->current_secret_key,
+                $salt
+            )
+        );
+    }
+
+    public function verify(
+        string $data,
+        string $signature,
+        int $validity,
+        Salt $salt
+    ): bool {
+        foreach ($this->key_rotation->getAllKeys() as $secret_key) {
+            $signing_key = $this->signing_key_generator->generate($secret_key, $salt);
+            if ($this->signer->verify(
+                $data,
+                $signature,
+                $validity,
+                $signing_key
+            )) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/FileDelivery/Token/Signer/NullSigner.php
+++ b/src/FileDelivery/Token/Signer/NullSigner.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer;
+
+use ILIAS\FileDelivery\Token\Signer\Key\Signing\SigningKey;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ * @internal
+ */
+class NullSigner implements Signer
+{
+    public function sign(
+        string $signable_payload,
+        SigningKey $signing_key,
+    ): string {
+        return $signing_key->get();
+    }
+
+    public function verify(
+        string $data,
+        string $signature,
+        int $validity,
+        SigningKey $signing_key
+    ): bool {
+        return $signature === $signing_key->get();
+    }
+}

--- a/src/FileDelivery/Token/Signer/Payload/BadPayload.php
+++ b/src/FileDelivery/Token/Signer/Payload/BadPayload.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Payload;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class BadPayload implements Payload
+{
+    public function get(): array
+    {
+        return [];
+    }
+
+    public function set(array $data): void
+    {
+    }
+
+    public function until(): ?int
+    {
+        return 0;
+    }
+}

--- a/src/FileDelivery/Token/Signer/Payload/Builder.php
+++ b/src/FileDelivery/Token/Signer/Payload/Builder.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Payload;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\FileDelivery\Delivery\Disposition;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class Builder
+{
+    public function file(
+        FileStream $stream,
+        string $filename,
+        Disposition $disposition,
+        int $valid_for_at_least_hours
+    ): FilePayload {
+        $uri = $stream->getMetadata()['uri'];
+
+        return new FilePayload(
+            $uri,
+            mime_content_type($uri),
+            $filename,
+            $disposition->value,
+            $valid_for_at_least_hours
+        );
+    }
+
+    public function fileFromRaw(
+        array $raw
+    ): FilePayload {
+        return FilePayload::fromArray($raw);
+    }
+}

--- a/src/FileDelivery/Token/Signer/Payload/FilePayload.php
+++ b/src/FileDelivery/Token/Signer/Payload/FilePayload.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Payload;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class FilePayload extends StructuredPayload
+{
+    public function __construct(
+        private string $uri,
+        private string $mime_type,
+        private string $file_name,
+        private string $disposition,
+        private int $user_id,
+        ?int $valid_until = null
+    ) {
+        parent::__construct([
+            'p' => $uri,
+            'm' => $mime_type,
+            'n' => $file_name,
+            'd' => $disposition,
+            'u' => $user_id,
+        ], $valid_until);
+    }
+
+    public static function fromArray(array $raw_payload): self
+    {
+        return new self(
+            $raw_payload['p'],
+            $raw_payload['m'],
+            $raw_payload['n'],
+            $raw_payload['d'],
+            $raw_payload['u'],
+            $raw_payload['v'] ?? null
+        );
+    }
+
+    public function getUri(): string
+    {
+        return $this->uri;
+    }
+
+    public function getMimeType(): string
+    {
+        return $this->mime_type;
+    }
+
+    public function getFileName(): string
+    {
+        return $this->file_name;
+    }
+
+    public function getDisposition(): string
+    {
+        return $this->disposition;
+    }
+
+    public function getUserId(): int
+    {
+        return $this->user_id;
+    }
+}

--- a/src/FileDelivery/Token/Signer/Payload/Payload.php
+++ b/src/FileDelivery/Token/Signer/Payload/Payload.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Payload;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+interface Payload
+{
+    public function get(): array;
+
+    public function set(array $data): void;
+
+    public function until(): ?int;
+}

--- a/src/FileDelivery/Token/Signer/Payload/StructuredPayload.php
+++ b/src/FileDelivery/Token/Signer/Payload/StructuredPayload.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Payload;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class StructuredPayload implements Payload
+{
+    public function __construct(
+        protected array $data,
+        protected ?int $valid_until = null
+    ) {
+    }
+
+    public function get(): array
+    {
+        return $this->data;
+    }
+
+    public function set(array $data): void
+    {
+        $this->data = $data;
+    }
+
+    public function until(): ?int
+    {
+        return $this->valid_until;
+    }
+}

--- a/src/FileDelivery/Token/Signer/Salt/Factory.php
+++ b/src/FileDelivery/Token/Signer/Salt/Factory.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Salt;
+
+/**
+ * The salt is combined with the secret key to derive a unique key for distinguishing different contexts. Unlike the
+ * secret key, the salt doesn’t have to be random, and can be saved in code. It only has to be unique between
+ * contexts, not private.
+ *
+ * For example, you want to email activation links to activate user accounts, and upgrade links to upgrade users to a
+ * paid accounts. If all you sign is the user id, and you don’t use different salts, a user could reuse the token from
+ * the activation link to upgrade the account. If you use different salts, the signatures will be different and will
+ * not be valid in the other context.
+ *
+ * @see    https://itsdangerous.palletsprojects.com/en/2.1.x/concepts/#serializer-vs-signer
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class Factory
+{
+    private array $known_salts;
+
+    public function __construct()
+    {
+        $this->known_salts = []; // TODO: load known salts from artifact
+    }
+
+    public function create(string $salt): Salt
+    {
+        if (!in_array($salt, $this->known_salts, true)) {
+            // throw new \InvalidArgumentException('Unknown salt'); // currently disabled because of missing artifact
+        }
+
+        return new Salt($salt);
+    }
+}

--- a/src/FileDelivery/Token/Signer/Salt/Salt.php
+++ b/src/FileDelivery/Token/Signer/Salt/Salt.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer\Salt;
+
+/**
+ * The salt is combined with the secret key to derive a unique key for distinguishing different contexts. Unlike the
+ * secret key, the salt doesn’t have to be random, and can be saved in code. It only has to be unique between
+ * contexts, not private.
+ *
+ * For example, you want to email activation links to activate user accounts, and upgrade links to upgrade users to a
+ * paid accounts. If all you sign is the user id, and you don’t use different salts, a user could reuse the token from
+ * the activation link to upgrade the account. If you use different salts, the signatures will be different and will
+ * not be valid in the other context.
+ *
+ * @see    https://itsdangerous.palletsprojects.com/en/2.1.x/concepts/#serializer-vs-signer
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class Salt
+{
+    public function __construct(
+        private string $salt
+    ) {
+    }
+
+    public function get(): string
+    {
+        return $this->salt;
+    }
+}

--- a/src/FileDelivery/Token/Signer/Signer.php
+++ b/src/FileDelivery/Token/Signer/Signer.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token\Signer;
+
+use ILIAS\FileDelivery\Token\Signer\Key\Signing\SigningKey;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+interface Signer
+{
+    public const SEPARATOR = '.';
+
+    public function sign(
+        string $signable_payload,
+        SigningKey $signing_key,
+    ): string;
+
+    public function verify(
+        string $data,
+        string $signature,
+        int $validity,
+        SigningKey $signing_key
+    ): bool;
+}

--- a/src/FileDelivery/Token/SigningSerializer.php
+++ b/src/FileDelivery/Token/SigningSerializer.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\FileDelivery\Token;
+
+use ILIAS\FileDelivery\Token\Serializer\Serializer;
+use ILIAS\FileDelivery\Token\Signer\Payload\Payload;
+use ILIAS\FileDelivery\Token\Signer\Payload\StructuredPayload;
+use ILIAS\FileDelivery\Token\Compression\GZipCompression;
+use ILIAS\FileDelivery\Token\Compression\Compression;
+use ILIAS\FileDelivery\Token\Transport\Transport;
+use ILIAS\FileDelivery\Token\Signer\KeyRotatingSigner;
+use ILIAS\FileDelivery\Token\Signer\Salt\Salt;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ *
+ * @internal
+ */
+final class SigningSerializer
+{
+    private const SEPARATOR = '<<>>';
+
+    public function __construct(
+        private KeyRotatingSigner $signer,
+        private Serializer $serializer,
+        private Compression $compression,
+        private Transport $transport
+    ) {
+    }
+
+    public function sign(Payload $payload, Salt $salt): string
+    {
+        // serialize payload
+        $serialized_payload = $this->serializer->serializePayload($payload->get());
+        $serialized_validity = $this->serializer->serializeValidity($payload->until());
+        $signable_payload = $serialized_payload . self::SEPARATOR . $serialized_validity;
+
+        // sign payload
+        $signature = $this->signer->sign($signable_payload, $salt);
+
+        $signed_payload = $signable_payload . self::SEPARATOR . $signature;
+
+        $compressed_payload = $this->compression->compress($signed_payload);
+
+        $prepare_for_transport = $this->transport->prepareForTransport($compressed_payload);
+
+        return $prepare_for_transport;
+    }
+
+    public function verify(string $data, Salt $salt): ?Payload
+    {
+        // decompress payload
+        $decompressed_payload = $this->compression->decompress(
+            $this->transport->readFromTransport($data)
+        );
+
+        $split_data = explode(self::SEPARATOR, $decompressed_payload);
+        $serialized_payload = $split_data[0] ?? '';
+        $validity = $split_data[1] ?? '';
+        $signature = $split_data[2] ?? '';
+
+        $payload_with_validity = $serialized_payload . self::SEPARATOR . $validity;
+
+        if ($this->signer->verify($payload_with_validity, $signature, (int) $validity, $salt) === false) {
+            return null;
+        }
+
+        return new StructuredPayload($this->serializer->unserializePayload($serialized_payload));
+    }
+}

--- a/src/FileDelivery/Token/Transport/NullTransport.php
+++ b/src/FileDelivery/Token/Transport/NullTransport.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\FileDelivery\Token\Transport;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class NullTransport implements Transport
+{
+    public function prepareForTransport(string $compressed_token): string
+    {
+        return ($compressed_token);
+    }
+
+    public function readFromTransport(string $compressed_token): string
+    {
+        return ($compressed_token);
+    }
+}

--- a/src/FileDelivery/Token/Transport/Transport.php
+++ b/src/FileDelivery/Token/Transport/Transport.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\FileDelivery\Token\Transport;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+interface Transport
+{
+    public function prepareForTransport(string $compressed_token): string;
+
+    public function readFromTransport(string $compressed_token): string;
+}

--- a/src/FileDelivery/Token/Transport/URLSafeTransport.php
+++ b/src/FileDelivery/Token/Transport/URLSafeTransport.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\FileDelivery\Token\Transport;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class URLSafeTransport implements Transport
+{
+    public function prepareForTransport(string $compressed_token): string
+    {
+        return rtrim(str_replace(['+', '/'], ['-', '_'], base64_encode($compressed_token)), '=');
+    }
+
+    public function readFromTransport(string $compressed_token): string
+    {
+        return base64_decode(str_replace(['-', '_'], ['+', '/'], $compressed_token . '=='));
+    }
+}

--- a/src/FileDelivery/deliver.php
+++ b/src/FileDelivery/deliver.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once __DIR__ . '/../../libs/composer/vendor/autoload.php';
+
+use ILIAS\DI\Container;
+use ILIAS\FileDelivery\Init;
+use ILIAS\FileDelivery\Services;
+
+chdir(__DIR__ . '/../../');
+
+$c = new Container();
+Init::init($c);
+/** @var Services $file_delivery */
+/** @var ILIAS\HTTP\Services $http */
+$file_delivery = $c['file_delivery'];
+$http = $c['http'];
+
+$requested_url = (string) $http->request()->getUri();
+
+// get everything after StreamDelivery::DELIVERY_ENDPOINT in the requested url
+$access_token = substr(
+    $requested_url,
+    strpos($requested_url, Services::DELIVERY_ENDPOINT) + strlen(Services::DELIVERY_ENDPOINT)
+);
+
+$file_delivery->delivery()->deliverFromToken($access_token);

--- a/src/Filesystem/Stream/Streams.php
+++ b/src/Filesystem/Stream/Streams.php
@@ -61,7 +61,7 @@ final class Streams
      *
      * @see fopen()
      */
-    public static function ofResource($resource): \ILIAS\Filesystem\Stream\Stream
+    public static function ofResource($resource, bool $inside_zip = false): \ILIAS\Filesystem\Stream\Stream
     {
         if (!is_resource($resource)) {
             throw new \InvalidArgumentException(
@@ -69,6 +69,9 @@ final class Streams
             );
         }
 
+        if ($inside_zip) {
+            return new ZIPStream($resource);
+        }
         return new Stream($resource);
     }
 

--- a/src/Filesystem/Stream/ZIPStream.php
+++ b/src/Filesystem/Stream/ZIPStream.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Filesystem\Stream;
+
+use ILIAS\Filesystem\Util\PHPStreamFunctions;
+
+/**
+ * @author                 Fabian Schmid <fabian@sr.solutions>
+ */
+class ZIPStream extends Stream
+{
+    public function seek($offset, $whence = SEEK_SET): void
+    {
+        // zip streams are not seekable
+    }
+}

--- a/src/Setup/AbstractOfFinder.php
+++ b/src/Setup/AbstractOfFinder.php
@@ -33,7 +33,9 @@ abstract class AbstractOfFinder
      * @var string[]
      */
     protected array $ignore = [
-        '.*/src/',
+        '.*/src/Setup/',
+        '.*/src/GlobalScreen/',
+        '.*/Customizing/.*/src/',
         '.*/libs/',
         '.*/test/',
         '.*/tests/',
@@ -101,7 +103,7 @@ abstract class AbstractOfFinder
             "|",
             array_map(
                 // fix path-separators to respect windows' backspaces.
-                fn ($v): string => "(" . str_replace('/', '(/|\\\\)', $v) . ")",
+                fn($v): string => "(" . str_replace('/', '(/|\\\\)', $v) . ")",
                 $ignore
             )
         );

--- a/tests/FileDelivery/AbstractBaseTest.php
+++ b/tests/FileDelivery/AbstractBaseTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\FileDelivery;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions.ch>
+ */
+abstract class AbstractBaseTest extends TestCase
+{
+}

--- a/tests/FileDelivery/Token/TokenTest.php
+++ b/tests/FileDelivery/Token/TokenTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Tests\FileDelivery\Token;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\FileDelivery\Token\DataSigner;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKeyRotation;
+use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
+use ILIAS\FileDelivery\Token\Signer\Salt\Salt;
+use ILIAS\FileDelivery\Token\Signer\KeyRotatingSigner;
+use ILIAS\FileDelivery\Token\Signer\NullSigner;
+use ILIAS\FileDelivery\Token\Signer\Key\Signing\ConcatSigningKeyGenerator;
+use ILIAS\FileDelivery\Token\Compression\GZipCompression;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions.ch>
+ */
+class TokenTest extends TestCase
+{
+    public function testSomething(): void
+    {
+        $data_signer = new DataSigner(
+            new SecretKeyRotation(
+                new SecretKey('test_key_one')
+            )
+        );
+
+        $payload_data = [
+            't' => 1,
+            'p' => 'fsv2/63a/6a5/5a2/1cf42b2ad0bc1ee729a5965/1/data',
+            'u' => 6
+        ];
+
+        $singed_data = $data_signer->sign($payload_data, 'test_salt', new \DateTimeImmutable('2099-01-01 00:00:00'));
+
+        $this->assertIsString($singed_data);
+        $this->assertSame(
+            'Fck5CsMwEEDRu0xt0GySJWF8EjWjrTbESRNy98jNh8f_wg2ZNrggw3x9uLggtmK-OG-L1KZyZetYG42xczKfwrpUXLfbYIM35PA7jvNU3DFhjIiPRpjapabGlTj2JsJch8rQmJ5lUVUo0B8',
+            $singed_data
+        );
+        $this->assertEquals(143, strlen($singed_data));
+
+        $retrieve = $data_signer->verify($singed_data, 'test_salt');
+        $this->assertSame($payload_data, $retrieve);
+    }
+
+    public function providePayloads(): array
+    {
+        $random = static function (int $chars): string {
+            for ($i = 0, $str = ''; $i < $chars; $i++) {
+                $str .= chr(random_int(33, 125));
+            }
+            return $str;
+        };
+
+        return [
+            ['lorem ipsum'],
+            ['o@3z||w^h\F(G[Z,*qjo/n8$Q_yO({,%9h4]UK&s*E$H=/8L6:#2VDFb5<Is%;=3p=2\'xb{skeOKw^Pt]wwya$6JV_e{7qbZUmcl{V3JRl<w{N=M_512x4DV=>i]=2$X+od8+#KVG+mN"9yHWW+RGb>eDZ\+RW>\%ks2yj%m)29=)cpLT8w4{rBl]Yvx%njk3?)Mrc-|`Dd4I)F?y;f2%-W/ObD?v"TWk(:pHN4?FXTeT7f@{[)N/2XQW@c<ddk6\'b&;R;bcB8@W)[l(7RCvUU1EE4>[CN1w1.U1`+LVUKZaN_v<?CUAjTXe=B-@4c\'$.kB;HjI)\03<ll29`o_0$U@KF8JQH8=pQ^j>i:+R&m\jOOuys3"Ow|out8=[vM\^an:|^NZE-za668{I\'YPwXpIONsa"+fwjn)nj%{b$2{gZoljdq4:MA?I&dz9d;K-9t%A%8,@9rLwF1tuMxx@f{NoH+J[;PVRByLz&Z9,)wNXS"wO|eD%e$0wDW\Ie*fQsSHSuU(S8W9O8RNc+VQVbJAKC+0#gYHBBFtNPDKn#XvyhsOTEi/+lAO5\HA=PvG<g{d$lP;^|A1a^BvaJH:k|U88KH<34ub`S*J92Sw>(tTt{#/*\'%dAcdm$JJ<6MP+J4.ifdi-D_<`)D1Xf(O6rxB>$HCw9IVR/lJ]7eK1q&:.z7mUi4C@W+/d-35\:GdeL4Yu9jEvbL)yd9{49FXx<iV4]_HoF(CLySJm^l3eX|||_"RV*+[\'M\+8O]xlzfTalIE3;<)cS9">?RbuKY^N4Y[o^lr5\'8O55skRBGli:&Kq75WPT(w#Zpj]_UMluSs:"e_(SRX?%4<m,8H:`fH@hR(i9sIz6spfcp8igK5IXp`Vx1=Lv?Ast"m2nvGs4O^/VoN-Aqn`SflY+QSB+XIcJ1@2rA5[GNnN3{zkb*<MXz/\'\'X\'n=e&F>4nVQ`Fb0"WNvi)ZYbY]/%aDN>wMlT)M\=XGk^[2H?pgf8#BrC"A:bj2=Qfm^#2ZegzFBYV.E,b,xC_;<{P.ps*Vm&ErnTp|)qMOV:GBXH\l?6x?S]hUV.$CESk/ns/Zg5NGrC/$\'f>\'tVY{"Oa(DB@UN#yVh@n6JZ$F*(q)Ty]^.OTmAXSX^f\'j_1q80sB]2q^?<f2<(7=0[_l^i;HrU.$NgqgIy/N?hN-6IgL=:Z(tX\+A\B*{QJTT\'LY{tD:5S)t^Vcn=PC$;5*<^2@/3Ahgw&,`JQ0+a-JnB\+H/Kc|pF<\'(q6d\uz?_?<yyICy6+|jpK{LJ`UT>f*\'BLsv*AvoH|ET07EiO"xFh/{[+>=xT9DnLh0F>j#L(B&iBxaq6mW%TO"[]W]pIM{:Y]tQK4@TO[O>qg{eSr4W:Vkp6#ECM+&O>5uH3##]#?d4mV(?wJt;Jb|TXCD?t<BNV"%p#KB)H=i0y\'z%Rf)0Dp{JE*0zGY<KG)gMDylE;_1PukRAe)qxfSd{uA`8\vqpzfcaM6_gYDwy_w-JQf=z;-UnxvF";Sf;OnCIGm3-/0S$1jPuFb:n_9=pu\'jE3A6Ne)FxN@3An5x/EwiOTYQ-6w;rYA>4_zldc\'"0g=hYUVIQ=U7B@>+`@hN#HNV\'Z6ul2UL-/eld6xGeDV)s@.)B9t2LS+rmM?ZREmV.coe-SUkLV)Wp-sO/SWeeF..zi\Yj3pNqx(j6"#B@St]M@>:k-sb#h(5RRP2%jeVP5KM\a\Q.n#T"Z0qpcsD6/WQ|GbuhK84<C[GCjN+@>VE7WZFM)O1@]bhl;{@q4aQ?\Vv%hv3;CG]J%+N\'J9]_=N8iI?Y:l4I%?0W?,iI5V,Fqq(Zz&4vH1c"|&82YMVhx0?Wk:dFf\mZv%BkX6K9?{+6w:ikAUq7cw1oYin\'{"ayy/sZ`oF[aFa=_mO/EG-Is\'6Ks{Dg#Q\'@XCw&YSUHE1UP9ITeJL`R%]=-;qY%*#]-rcq;+iOPT\V/(iO(6GhjW/dA2fD&dxwVS*I(gQx4V6\'K;I0e\'P5cY<P]=u>Ck9dS"I]iOnX)<?P7\DB;9MkJ|5zld9=hxQAJ5XVfp*F0e.SDl|""'],
+            [$random(1024)],
+            [$random(2048)],
+            [$random(4094)],
+            [$random(8192)],
+            [$random(16384)],
+            [$random(32768)],
+        ];
+    }
+
+    /**
+     * @dataProvider providePayloads
+     */
+    public function testLargeAmountOfData($data): void
+    {
+        $datasigner = new DataSigner(
+            new SecretKeyRotation(
+                new SecretKey('test_key_one'),
+            )
+        );
+
+        $singed_data = $datasigner->sign([$data], 'salt');
+        $verified_data = $datasigner->verify($singed_data, 'salt');
+
+        if ($verified_data === null) {
+            $this->fail('Could not verify data');
+        }
+
+        $this->assertNotNull($verified_data);
+        $this->assertEquals([$data], $verified_data);
+        $this->assertEquals($singed_data, urlencode($singed_data));
+        $signed_data_without_suffix = rtrim($singed_data, '=');
+        $this->assertEquals($signed_data_without_suffix, urlencode($signed_data_without_suffix));
+    }
+
+    public function testExpiredTokens(): void
+    {
+        $datasigner = new DataSigner(
+            new SecretKeyRotation(
+                new SecretKey('test_key_one'),
+            )
+        );
+
+        $singed_data = $datasigner->sign(['a', 'b', 'c'], 'salt', new \DateTimeImmutable('-1 day'));
+        $verified_data = $datasigner->verify($singed_data, 'salt');
+
+        $this->assertNull($verified_data);
+
+        $singed_data = $datasigner->sign(['a', 'b', 'c'], 'salt', new \DateTimeImmutable('-1 second'));
+        $verified_data = $datasigner->verify($singed_data, 'salt');
+
+        $this->assertNull($verified_data);
+
+        $singed_data = $datasigner->sign(['a', 'b', 'c'], 'salt', new \DateTimeImmutable('+1 second'));
+        $verified_data = $datasigner->verify($singed_data, 'salt');
+
+        $this->assertNotNull($verified_data);
+    }
+
+    public function testKeyRotation(): void
+    {
+        $salt = new Salt('test_salt');
+
+        $key_rotation = new SecretKeyRotation(
+            new SecretKey('test_key_one'),
+        );
+        $rotating_signer = new KeyRotatingSigner(
+            $key_rotation,
+            new NullSigner(),
+            new ConcatSigningKeyGenerator(),
+            $salt
+        );
+
+        $payload = 'singed_data_one';
+        $signature = $rotating_signer->sign($payload, $salt);
+        $this->assertTrue($rotating_signer->verify($payload, $signature, 0, $salt));
+
+        $key_rotation = new SecretKeyRotation(
+            new SecretKey('test_key_two'),
+            new SecretKey('test_key_one'),
+        );
+        $rotating_signer = new KeyRotatingSigner(
+            $key_rotation,
+            new NullSigner(),
+            new ConcatSigningKeyGenerator(),
+            $salt
+        );
+        $this->assertTrue($rotating_signer->verify($payload, $signature, 0, $salt));
+
+        $key_rotation = new SecretKeyRotation(
+            new SecretKey('test_key_three'),
+            new SecretKey('test_key_two'),
+        );
+        $rotating_signer = new KeyRotatingSigner(
+            $key_rotation,
+            new NullSigner(),
+            new ConcatSigningKeyGenerator(),
+            $salt
+        );
+        $this->assertFalse($rotating_signer->verify($payload, $signature, 0, $salt));
+    }
+}


### PR DESCRIPTION
I would like to present the new implementation of the FileDeliver service, which will replace the old implementations in ilFileDelivery (ancient) and Delivery in Services in the medium term. Unfortunately I will probably not be able to attend the JF on monday, but I would like to briefly point to this PR for information and describe how to proceed.

The new service distinguishes itself from the old implementations as follows:
- Optimized caching headers according to latest recommendations 
- Accessible via the Dependecy Injection Container
- No dependency on an initialized ILIAS (see reason below) from HTTP service
- Code up to date

First to the new service:

This service is the central place to deliver files to the browser. The new server in /src will completely replace the
old implementations in the future, currently they are used in parallel or as wrappers.

## Usage

The service is accessible via the DIC as follows:

```php
global $DIC;
/** @var \ILIAS\FileDelivery\Services $file_delivery  */
$file_delivery = $DIC['file_delivery'];
```

you get an instance of `\ILIAS\FileDelivery\Services` which contains other functions besides the actual delivery of
files, see below.

The service then is used as follows to deliver FileStreams:

```php
global $DIC;
/** @var \ILIAS\FileDelivery\Services $file_delivery  */
$file_delivery = $DIC['file_delivery'];
$file_stream = ILIAS\Filesystem\Stream\Streams::ofResource(
    fopen('/path/to/file', 'rb')
);

// downloads the file
$file_delivery->delivery()->attached(
    $file_stream,
    'filename.txt',
);

// delivers the file inline
$file_delivery->delivery()->inline(
    $file_stream,
    'filename.png',
);

```

### Legacy usage

In many cases, files (in the sense of paths) are still delivered. With the increasing use of IRSS, however, these cases
will become fewer and should eventually disappear altogether.
The delivery of a file happens as follows:

```php
global $DIC;
/** @var \ILIAS\FileDelivery\Services $file_delivery  */
$file_delivery = $DIC['file_delivery'];
$file_path = '/path/to/file';

// downloads the file
$file_delivery->legacyDelivery()->attached(
    $file_path,
    'filename.txt',
);

// delivers the file inline
$file_delivery->legacyDelivery()->inline(
    $file_path,
    'filename.png',
);

```

The most important innovation is certainly the following:

# Signed Delivery

The IRSS uses exclusively streamss for files and flavours, from ILIAS 9 also for structured data (e.g. later for HTML
learning modules or SCORM learning modules). Up to ILIAS 9 these dtaeias are also delivered via a special mechanism
through the WebAccessChecker. Now streams can be delivered very easily via a token-based way to protect the files. This
will be the general way to deliver the files in the future and will replace the WebAccessChecker completely in the
medium term.

## How does the Signing work in general?

The project ["It's Dangerous"](https://itsdangerous.palletsprojects.com/en/2.1.x/) was used as inspiration for the
implementation. The machnism can be summarized simply:

A token is created for a payload of simple data. In a first step, the payload is serialized for further processing. This
string is optionally supplemented with a validity timestamp. This data is then signed with a Machnism. For the
signature, a secret key as well as a salt is used depending on the use case.
The serialized payload is merged with the signature, compressed, and formatted for embedding in URLs.
Once a token is then to be verified, the following happens: URl preparation is reversed, and the data is decompressed.
The result consists of the serialized payload and the signature. A new signature is now made for the payload and
compared with the one supplied. If these are identical, it is certain that the dtaen are valid and have not been
manipulated.
The mechanism uses a key rotation, currently always 5 keys are kept. with a composer install / dump-autoload a new key
is generated in each case.

### Example:

```php
use ILIAS\FileDelivery\Token\Serializer\JSONSerializer;
use ILIAS\FileDelivery\Token\Signer\KeyRotatingSigner;
use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKeyRotation;
use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
use ILIAS\FileDelivery\Token\Signer\HMACSigner;
use ILIAS\FileDelivery\Token\Signer\Algorithm\SHA1;
use ILIAS\FileDelivery\Token\Signer\Key\Signing\HMACSigningKeyGenerator;
use ILIAS\FileDelivery\Token\Signer\Salt\Salt;
use ILIAS\FileDelivery\Token\Compression\DeflateCompression;
use ILIAS\FileDelivery\Token\Transport\URLSafeTransport;

// This is the payload we want to sign. It should use a "personal" component, e.g. the user ID, and a "global" component, e.g. the path to the file.
 
$payload = [
    'user_id' => 123,
    'uri' => '/path/to/file',
];

// Using a `Serializer` we can serialize the payload to a string. The `JSONSerializer` is used here, but you can also use the `PHPSerializer` or implement your own.
$serializer = new JSONSerializer();
$serialized_payload = $serializer->serializePayload($payload);
// $serialized_payload = '{"user_id":123,"uri":"/path/to/file"}'

// Since we want the token to expire after a certain time, we add a timestamp to the payload. The timestamp is the current time plus the desired lifetime of the token in seconds.
$signable_payload = $serialized_payload.'|'.(time() + 3600);
// $signable_payload = '{"user_id":123,"uri":"/path/to/file"}|1631631631'

// new we can sign the payload. The `KeyRotatingSigner` is used here. It uses a Key Rotation to sign the payload. The `KeyRotation` is used to store the keys. The `SecretKey` is used to store the actual keys. The `HMACSigner` is used to sign the payload. The `HMACSigningKeyGenerator` is used to generate the keys to sign. Using SHA1 as the algorithm, the `HMACSigner` will use the SHA1 algorithm to sign the payload. The `HMACSigningKeyGenerator` will use the SHA1 algorithm to generate the keys.

$signer = new KeyRotatingSigner(
    new SecretKeyRotation(
        new SecretKey('key_one'),
        new SecretKey('key_two')
        new SecretKey('key_three')
    ),
    new HMACSigner(new SHA1())
    new HMACSigningKeyGenerator(new SHA1())
);

$signature = $signer->sign($signable_payload, new Salt('salt'));
// $signature = '...';

// we can now merge the payload and the signature. 
$signed_payload = $signable_payload.'|'.$signature;
// $signed_payload = '{"user_id":123,"uri":"/path/to/file"}|1631631631|...';

// now we can compress the payload. The `DeflateCompression` is used here, but you can also implement your own.
$compression = new DeflateCompression();
$compressed_payload = $compression->compress($signed_payload);

// now we can encode the payload. The `URLSafeTransport` is used here since we use the tokens in URLs.
$transport = new URLSafeTransport();
$token = $transport->encode($compressed_payload);

```

Now, when a token is to be verified, the following happens:

```php
use ILIAS\FileDelivery\Token\Transport\URLSafeTransport;
use ILIAS\FileDelivery\Token\Compression\DeflateCompression;
use ILIAS\FileDelivery\Token\Signer\KeyRotatingSigner;
use ILIAS\FileDelivery\Token\Signer\Salt\Salt;
use ILIAS\FileDelivery\Token\Serializer\JSONSerializer;
use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKeyRotation;
use ILIAS\FileDelivery\Token\Signer\Key\Secret\SecretKey;
use ILIAS\FileDelivery\Token\Signer\HMACSigner;
use ILIAS\FileDelivery\Token\Signer\Key\Signing\HMACSigningKeyGenerator;
use ILIAS\FileDelivery\Token\Signer\Algorithm\SHA1;

// this is the token
$token = '...';

// first we decode the token
$transport = new URLSafeTransport();
$decoded_token = $transport->readFromTransport($token);

// after that, we decompress the token
$compression = new DeflateCompression();
$decompressed_token = $compression->decompress($decoded_token);

$parts = explode('|', $decompressed_token);
$serialized_payload = $split_data[0] ?? '';
$validity = $split_data[1] ?? '';
$signature = $split_data[2] ?? '';
$payload_with_validity = $serialized_payload . self::SEPARATOR . $validity;

// now we can verify the token by signing the payload and comparing the signature
$signer = new KeyRotatingSigner(
    new SecretKeyRotation(
        new SecretKey('key_one'),
        new SecretKey('key_two')
        new SecretKey('key_three')
    ),
    new HMACSigner(new SHA1())
    new HMACSigningKeyGenerator(new SHA1())
);

// `verify` loops all keys from the keyrotation and signs the payload. if the signature matches, the payload is valid.
$is_valid = $signer->verify($payload_with_validity, $signature, new Salt('salt'));

if($is_valid) {
    $serializer = new JSONSerializer();
    $payload = $serializer->unserializePayload($serialized_payload);
    // $payload = ['user_id' => 123, 'uri' => '/path/to/file']
}else {
    // the token is invalid
    $payload = null;
}
```

Since this process is quite complex, this is simply offered to generate appropriate tokens for FileStreams. You get a
ready URL, which can then deliver the file, if the token is valid:

```php
use ILIAS\Filesystem\Stream\Streams;
use ILIAS\FileDelivery\Delivery\Disposition;

global $DIC;
$stream = Streams::ofResource(fopen('/path/to/file', 'r'));
$uri = $DIC->fileDelivery()->buildTokenURL(
    $stream,
    'Download-Filename.png',
    Disposition::INLINE
    123 // user_id
    6 // valid for at least 6 hours
)

// $uri = 'http://trunk.ilias.localhost/src/FileDelivery/deliver.php/LY3NasMwEITy[...]RFiKcUmOmJx8Ac'
```

This mechanism is then simply used, for example, to deliver structured resources (container resources). A URL on HTML
learning module can then look like this:

```
http://trunk.ilias.localhost/src/FileDelivery/deliver.php/LY3NasMwEITy[...]RFiKcUmOmJx8Ac/index.html
```
 
# Summary and further procedure
- The service is ready for new container resources, which will support e.g. HTML learning modules and SCORM modules enormously in storage and delivery.
- In the medium term, we can replace the WebAccessChecker with the new Signed Delivery, but this will be handled separately and will probably only be an issue with ILIAS 11 or 12.
- The old implementation will be replaced internally by the new service, but will remain for a moment. 
- the commit https://github.com/ILIAS-eLearning/ILIAS/commit/7fcb88d097cb1d597d2e814465b4513273665b84 is only necessary so that the artifacts of the new service are built correctly. but there is a separate pull request for this: #6323 
