### PR TITLE
`Refinery`: Add more transformations (to improve `Refinery` usage in `ILIAS\Setup\Agent::getArrayToConfigTransformation`)

### DIFF
--- a/components/ILIAS/Refinery/README.md
+++ b/components/ILIAS/Refinery/README.md
@@ -187,6 +187,11 @@ transformation to create structures like `list`, `dictonary`,
                  parameters on the objects.
 * `data()`     - Returns a data factory to create a certain data type
 
+###### Other
+
+* `inArray()` - Returns an object that validates that a value is a member of the given array.
+                 E.g.: `$t = $refinery->to()->memberOf(['red', 'green', 'blue']); $t->transform('blue'); /* => 'blue' */ $t->transform('yellow'); /* => Exception */`
+
 ##### in
 
 The `in` group is a group with a dict of `Transformations`
@@ -352,7 +357,7 @@ Just the `applyTo` method needs to be created in the new transformation class.
 
 ##### Error Handling
 
-Exceptions thrown inside the `applyTo` method will be
+Exceptions thrown inside the `applyTo` method will
 **not be** caught.
 On return of an [error result object (`Result\Error`)](/src/Data/README.md#result)
 the `transform` method will throw an exception.
@@ -361,6 +366,15 @@ the `transform` method will throw an exception.
   thrown.
 * If the content of the error object is an string this string will be added
   to a an `Exception` which will be thrown.
+
+#### DeriveTransformWithProblem
+
+This trait is used to simplify the creation of new constraints and reduce duplicated code.
+For a constraint only the methods `accepts($value): bool` and `getError()` must be implemented.
+
+#### Other Transformations
+
+* `$refinery->executable()` Returns an object that validates that a given path designates an executable OS path.
 
 ## Libraries
 

--- a/components/ILIAS/Refinery/src/DeriveTransformWithProblem.php
+++ b/components/ILIAS/Refinery/src/DeriveTransformWithProblem.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery;
+
+use UnexpectedValueException;
+
+/**
+ * This trait is a convenience trait which uses `DeriveApplyToFromTransform`, `DeriveInvokeFromTransform` and `ProblemBuilder`
+ * and implements some methods that are always implemented the same.
+ * The main purpose of this trait is to reduce duplicated code and make it easier to implement new constraints.
+ */
+trait DeriveTransformWithProblem
+{
+    use DeriveApplyToFromTransform;
+    use DeriveInvokeFromTransform;
+    use ProblemBuilder;
+
+    public function transform($from)
+    {
+        $this->check($from);
+        return $from;
+    }
+
+    public function check($value)
+    {
+        if (!$this->accepts($value)) {
+            throw new UnexpectedValueException($this->getErrorMessage($value));
+        }
+    }
+
+    public function problemWith($value): ?string
+    {
+        if (!$this->accepts($value)) {
+            return $this->getErrorMessage($value);
+        }
+
+        return null;
+    }
+}

--- a/components/ILIAS/Refinery/src/Factory.php
+++ b/components/ILIAS/Refinery/src/Factory.php
@@ -44,7 +44,7 @@ class Factory
      */
     public function to(): To\Group
     {
-        return new To\Group($this->dataFactory);
+        return new To\Group($this->dataFactory, $this->language);
     }
 
     /**
@@ -77,7 +77,7 @@ class Factory
      */
     public function int(): Integer\Group
     {
-        return new Integer\Group($this->dataFactory, $this->language);
+        return new Integer\Group($this->dataFactory, $this->language, $this->in());
     }
 
     /**
@@ -174,5 +174,10 @@ class Factory
     public function always($value): Transformation
     {
         return new ConstantTransformation($value);
+    }
+
+    public function executable(): Transformation
+    {
+        return new IsExecutableTransformation($this->language);
     }
 }

--- a/components/ILIAS/Refinery/src/Integer/Group.php
+++ b/components/ILIAS/Refinery/src/Integer/Group.php
@@ -22,17 +22,16 @@ namespace ILIAS\Refinery\Integer;
 
 use ILIAS\Data\Factory;
 use ILIAS\Refinery\Constraint;
+use ILIAS\Refinery\In\Group as In;
 use ILIAS\Language\Language;
 
 class Group
 {
-    private Factory $dataFactory;
-    private \ILIAS\Language\Language $language;
-
-    public function __construct(Factory $dataFactory, \ILIAS\Language\Language $language)
-    {
-        $this->dataFactory = $dataFactory;
-        $this->language = $language;
+    public function __construct(
+        private readonly Factory $dataFactory,
+        private readonly Language $language,
+        private readonly In $in
+    ) {
     }
 
     /**
@@ -69,5 +68,17 @@ class Group
     public function isLessThanOrEqual(int $maximum): Constraint
     {
         return new LessThanOrEqual($maximum, $this->dataFactory, $this->language);
+    }
+
+    /**
+     * Creates a constraint that can be used to check if an integer value is between the given lower and upper bounds.
+     * The ranges are inclusive [$lower_bound, $upper_bound].
+     */
+    public function isBetween(int $lower_bound, int $upper_bound): Constraint
+    {
+        return $this->in->series([
+            $this->isGreaterThanOrEqual($lower_bound),
+            $this->isLessThanOrEqual($upper_bound),
+        ]);
     }
 }

--- a/components/ILIAS/Refinery/src/IsExecutableTransformation.php
+++ b/components/ILIAS/Refinery/src/IsExecutableTransformation.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery;
+
+use ILIAS\Language\Language;
+
+/**
+ * Validates that the given string is a valid and executable file path.
+ */
+class IsExecutableTransformation implements Constraint
+{
+    use DeriveTransformWithProblem;
+
+    /** @var string|callable */
+    private $error = 'The value MUST specify an executable path.';
+
+    public function __construct(private readonly Language $lng)
+    {
+    }
+
+    public function accepts($value): bool
+    {
+        return is_string($value) && is_executable($value);
+    }
+
+    public function getError()
+    {
+        return $this->error;
+    }
+}

--- a/components/ILIAS/Refinery/src/To/Group.php
+++ b/components/ILIAS/Refinery/src/To/Group.php
@@ -31,17 +31,18 @@ use ILIAS\Refinery\To\Transformation\RecordTransformation;
 use ILIAS\Refinery\To\Transformation\StringTransformation;
 use ILIAS\Refinery\To\Transformation\TupleTransformation;
 use ILIAS\Refinery\To\Transformation\DateTimeTransformation;
+use ILIAS\Refinery\To\DefaultToNull\Group as DefaultToNull;
 use ILIAS\Refinery\Transformation;
 use ILIAS\Data\Factory;
 use InvalidArgumentException;
+use ILIAS\Language\Language;
 
 class Group
 {
-    private Factory $dataFactory;
-
-    public function __construct(Factory $dataFactory)
-    {
-        $this->dataFactory = $dataFactory;
+    public function __construct(
+        private readonly Factory $dataFactory,
+        private readonly Language $language
+    ) {
     }
 
     /**
@@ -178,5 +179,17 @@ class Group
     public function dateTime(): Transformation
     {
         return new DateTimeTransformation();
+    }
+
+    /**
+     * Validates that the value to be transformed is in the set given to this transformation.
+     * There is no constraint on the type of the elements in the set.
+     *
+     * @template list<A>
+     * @return Transformation<A, A>
+     */
+    public function inArray(array $valid_members): Transformation
+    {
+        return new InArrayTransformation($valid_members, $this->language);
     }
 }

--- a/components/ILIAS/Refinery/src/To/Transformation/InArrayTransformation.php
+++ b/components/ILIAS/Refinery/src/To/Transformation/InArrayTransformation.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Refinery\To\Transformation;
+
+use ILIAS\Refinery\Constraint;
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+use ILIAS\Refinery\DeriveTransformWithProblem;
+use ILIAS\Refinery\ProblemBuilder;
+use UnexpectedValueException;
+use ILIAS\Language\Language;
+
+/**
+ * Validates that the value to be transformed is in the set given to this transformation.
+ * There is no constraint on the type of the elements in the set.
+ *
+ * @template A
+ * @implements Constraint<A, A>
+ */
+class InArrayTransformation implements Constraint
+{
+    use DeriveTransformWithProblem;
+
+    /** @var string|callable */
+    private $error;
+
+    /**
+     *
+     * @param list<A> $valid_members
+     */
+    public function __construct(private readonly array $valid_members, private readonly Language $lng)
+    {
+        if (!array_is_list($this->valid_members)) {
+            throw new ConstraintViolationException('The valid members MUST be a list.', 'array_not_a_list');
+        }
+        $this->error = sprintf(
+            'The value MUST be one of: %s.',
+            join(', ', array_map(json_encode(...), $this->valid_members))
+        );
+    }
+
+    public function accepts($value): bool
+    {
+        return in_array($value, $this->valid_members, true);
+    }
+
+    public function getError()
+    {
+        return $this->error;
+    }
+}

--- a/components/ILIAS/Refinery/tests/Custom/Constraint/CustomTest.php
+++ b/components/ILIAS/Refinery/tests/Custom/Constraint/CustomTest.php
@@ -84,7 +84,7 @@ class CustomTest extends TestCase
     {
         $lng_closure = $this->constraint->_getLngClosure();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ArgumentCountError::class);
 
         $lng_closure();
     }

--- a/components/ILIAS/Refinery/tests/FactoryTest.php
+++ b/components/ILIAS/Refinery/tests/FactoryTest.php
@@ -27,6 +27,7 @@ use ILIAS\Refinery\DateTime\Group as DateTimeGroup;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\IdentityTransformation;
+use ILIAS\Refinery\IsExecutableTransformation;
 use ILIAS\Refinery\In\Group as InGroup;
 use ILIAS\Refinery\Integer\Group as IntegerGroup;
 use ILIAS\Refinery\Logical\Group as LogicalGroup;
@@ -139,5 +140,11 @@ class FactoryTest extends TestCase
     {
         $instance = $this->basicFactory->identity();
         $this->assertInstanceOf(IdentityTransformation::class, $instance);
+    }
+
+    public function testExecutable(): void
+    {
+        $instance = $this->basicFactory->executable();
+        $this->assertInstanceOf(IsExecutableTransformation::class, $instance);
     }
 }

--- a/components/ILIAS/Refinery/tests/IsExecutableTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/IsExecutableTransformationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Refinery;
+
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use ILIAS\Refinery\IsExecutableTransformation;
+use PHPUnit\Framework\TestCase;
+use ILIAS\Language\Language;
+
+class IsExecutableTransformationTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $language = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();
+        $this->assertInstanceOf(IsExecutableTransformation::class, new IsExecutableTransformation($language));
+    }
+
+    public function testFailingAccept(): void
+    {
+        $language = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();
+        $transformation = new IsExecutableTransformation($language);
+
+        $this->assertFalse($transformation->accepts('I hope this string is no valid path...'));
+    }
+
+    public function testSuccessfulAccept(): void
+    {
+        if (!is_file('/bin/sh')) {
+            $this->markTestSkipped('Shell /bin/sh is not available.');
+            return;
+        }
+        $language = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();
+        $transformation = new IsExecutableTransformation($language);
+
+        $this->assertTrue($transformation->accepts('/bin/sh'));
+    }
+}

--- a/components/ILIAS/Refinery/tests/To/GroupTest.php
+++ b/components/ILIAS/Refinery/tests/To/GroupTest.php
@@ -35,6 +35,7 @@ use ILIAS\Refinery\To\Transformation\StringTransformation;
 use ILIAS\Refinery\To\Transformation\TupleTransformation;
 use PHPUnit\Framework\TestCase;
 use InvalidArgumentException;
+use ILIAS\Language\Language;
 
 class GroupTest extends TestCase
 {
@@ -42,7 +43,8 @@ class GroupTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->basicGroup = new ToGroup(new DataFactory());
+        $language = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();
+        $this->basicGroup = new ToGroup(new DataFactory(), $language);
     }
 
     public function testIsIntegerTransformationInstance(): void

--- a/components/ILIAS/Refinery/tests/To/Transformation/InArrayTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/To/Transformation/InArrayTransformationTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\Refinery\To\Transformation;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Refinery\To\Transformation\InArrayTransformation;
+use PHPUnit\Framework\TestCase;
+use ILIAS\Language\Language;
+use UnexpectedValueException;
+
+class InArrayTransformationTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $language = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();
+        $this->assertInstanceOf(InArrayTransformation::class, new InArrayTransformation([], $language));
+    }
+
+    /**
+     * @dataProvider memberProvider
+     */
+    public function testAccept(string $value, bool $successful): void
+    {
+        $language = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();
+        $transformation = new InArrayTransformation(['foo', 'bar'], $language);
+
+        $this->assertSame($successful, $transformation->accepts($value));
+    }
+
+    /**
+     * @dataProvider memberProvider
+     */
+    public function testTransform(string $value, bool $successful): void
+    {
+        if (!$successful) {
+            $this->expectException(UnexpectedValueException::class);
+        }
+
+        $language = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();
+        $transformation = new InArrayTransformation(['foo', 'bar'], $language);
+
+        $this->assertSame($value, $transformation->transform($value));
+    }
+
+    /**
+     * @dataProvider memberProvider
+     */
+    public function testApplyTo(string $value, bool $successful): void
+    {
+        $language = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();
+        $transformation = new InArrayTransformation(['foo', 'bar'], $language);
+
+        $result = $transformation->applyTo(new Ok($value));
+        $this->assertSame($successful, $result->isOk());
+        if ($successful) {
+            $this->assertSame($value, $result->value());
+        } else {
+            $this->assertInstanceOf(UnexpectedValueException::class, $result->error());
+        }
+    }
+
+    public function memberProvider(): array
+    {
+        return [
+            'Invalid member.' => ['hej', false],
+            'Valid member.' => ['foo', true],
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces new transformations for the refinery, mostly designed to be usable for the ILIAS Setup:

## `$refinery->to()->memberOf()`
Enum validation: Checks if a value is in a specified set.

Example use case in the config would be: `chatroom.log_level` which must be one of `emerg`, `alert`, `crit`, `error`, `warning`, `notice`, `info`, `debug` or `silly`

## `$refinery->executable()`
Checks if the given string specifies an executable path.

I could not find a suitable place for this transformation so I placed it on the top level of the refinery.

An example use case would be for config paths like: `mediaobject.path_to_ffmpeg`, `style.path_to_scss`, `virusscanner.path_to_scan` etc.

## `$refinery->int()->isBetween()`
This is just a convenience transformation but IMO very nice to have.
There is no actual class for this constraint as it can be composed from other transformations and constraints.

Example use case would be in the config would be: `chatroom.deletion_interval.deletion_value` which have both min and max values.

## Other changes

### `DeriveTransformWithProblem`
This trait is implemented to prevent boilerplate when implementing new transformations, as some methods are always implemented the same.

### `ProblemBuilder`
No behavior is changed, just some simplifications (with one exception (pun intended): the `InvalidArgumentExcpetion` is now a `ArgumentCountError`)

-----------------

Just FYI: Another PR will follow which will introduce deeper changes to the refinery and the relation between Transformations and Constraints but that PR will be independent of the changes made in this PR.