### PR TITLE
Utilities: Fix min pwd length > max pwd length

### DIFF
--- a/Services/Utilities/classes/class.ilUtil.php
+++ b/Services/Utilities/classes/class.ilUtil.php
@@ -3695,7 +3695,7 @@ class ilUtil
                 ? $security->getPasswordMaxLength()
                 : 10;
             if ($min > $max) {
-                $max = $max + 1;
+                $max = $min + 1;
             }
             $random = new \ilRandom();
             $length = $random->int($min, $max);


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=37767

The method is used in `Services/SOAPAuth`, `Services/Init`, `Services/Registration` and `Services/AuthShibboleth`. Since the `Services/Utitlies` folder is not explicitly maintained anymore, I'll assign this correspondingly.

If approved, it has to be picked to `release_8` and `trunk` as well.