### PR TITLE
#0037994 fix error when copying large container objects

### DIFF
--- a/Services/Container/Sorting/class.ilContainerSorting.php
+++ b/Services/Container/Sorting/class.ilContainerSorting.php
@@ -139,8 +139,8 @@ class ilContainerSorting
                 if (in_array($row->parent_type, ["sess", "itgr"])) {
                     $par_refs = ilObject::_getAllReferences($row->parent_id);
                     $par_ref_id = current($par_refs);			// should be only one
-                    $ilLog->debug("Got ref id: " . $par_ref_id . " for obj_id " . $row->parent_id . " map ref id: " . $mappings[$par_ref_id] . ".");
-                    if (isset($mappings[$par_ref_id])) {
+                    if (!empty($mappings[$par_ref_id])) {
+                        $ilLog->debug("Got ref id: " . $par_ref_id . " for obj_id " . $row->parent_id . " map ref id: " . $mappings[$par_ref_id] . ".");
                         $new_parent_ref_id = $mappings[$par_ref_id];
                         $new_parent_id = ilObject::_lookupObjectId($new_parent_ref_id);
                     }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=37994

Writing the log entry can occasionally cause an error. To fix that, the log entry could be shoved into the if-clause. 
Switching from 'isset' to '!empty' may bring an additional safeguard against undefined array key exceptions.