### PR TITLE
Exclude 1 and 0 from quotation

### DIFF
--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -251,7 +251,7 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
      */
     public function quoteIdentifier($identifier, $check_option = false)
     {
-        return '`' . $identifier . '`';
+        return ($identifier === '1' || $identifier === '0') ? $identifier : '`' . $identifier . '`';
     }
 
 


### PR DESCRIPTION
Temporary solution for https://mantis.ilias.de/view.php?id=38013

The best practice here where to remove the requirement from the WHERE clause, since its trivial in said occurences.
However since this might be a bit time critical to fix an exception for the redunant `WHERE 1=1` or `WHERE 0 = 0` calls might be sufficent for the moment.