### PR TITLE
Fix value presentation and allow combination input types

### DIFF
--- a/Services/Form/classes/class.ilPropertyFormGUI.php
+++ b/Services/Form/classes/class.ilPropertyFormGUI.php
@@ -817,7 +817,7 @@ class ilPropertyFormGUI extends ilFormGUI
             $multi_values = $item->getMultiValues();
             if (is_array($multi_values) && sizeof($multi_values) > 1) {
                 $multi_value = new ilHiddenInputGUI("ilMultiValues~" . $item->getPostVar());
-                $multi_value->setValue(implode("~", $multi_values));
+                $multi_value->setValue(base64_encode(json_encode($multi_values)));
                 $this->addItem($multi_value);
             }
             $cfg["multi_values"] = $multi_values;

--- a/Services/Form/js/ServiceFormMulti.js
+++ b/Services/Form/js/ServiceFormMulti.js
@@ -48,7 +48,7 @@ var ilMultiFormValues = {
 	 */
 	addEvent: function(e) {
 		var id = $(e.delegateTarget).attr('id').split('~');
-		ilMultiFormValues.add(id[1], id[2], '');
+		ilMultiFormValues.add(id[1], id[2], []);
 	},
 
 	/**
@@ -221,13 +221,9 @@ var ilMultiFormValues = {
 		element_id = element_id[1];
 
 		// add element for each additional value
-		var values = $(element).attr('value').split('~');	
-		$(values).each(function(i) {
-			// 1st value can be ignored
-			if(i > 0) {
-				ilMultiFormValues.add(element_id, i-1, this);		
-			}
-		});	
+		JSON.parse(atob($(element).attr('value'))).slice(1).forEach(function(value, i) {
+			ilMultiFormValues.add(element_id, i, (typeof value === 'object') ? value : [value]);
+		});
 	},
 
 	/**
@@ -259,15 +255,21 @@ var ilMultiFormValues = {
 			});
 
 
-		// try to set value 
-		if(preset != '') {
-			$(element).find('select[id*="' + group_id + '"] option[value="' + preset + '"]').attr('selected', true);
-			$(element).find('input:text[id*="' + group_id + '"]').attr('value', preset);
-		}
-		else {
-			$(element).find('select[id*="' + group_id + '"] option:selected').removeAttr('selected');
-			$(element).find('input:text[id*="' + group_id + '"]').val('');
-		}
+		// try to set value
+		$(element).find('select[id*="' + group_id + '"],input:text[id*="' + group_id + '"]').each(function (i) {
+			const value = preset[Object.keys(preset)[i]];
+			$(this).find('option:selected').removeAttr('selected');
+			if(value !== undefined && value != '') {
+				$(this).find('option[value="' + value + '"]').attr('selected', true);
+				if (this.tagName === 'INPUT') {
+					$(this).attr('value', value);
+				}
+			} else {
+				if (this.tagName === 'INPUT') {
+					$(this).val('');
+				}
+			}
+		});
 
 		// non-editable value
 		$(element).find('span[id*="' + group_id + '"]').html(preset);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38015
https://mantis.ilias.de/view.php?id=38017

This resolves both of the bugs above and further allows custom Inputs to use the core based `Multi` flag even for non-single-layered values while simultaneously increase overall robustness.