### PR TITLE
Flush old notifications with incompatible serial objects

### DIFF
--- a/Services/Notifications/classes/Setup/ilNotificationUpdateSteps.php
+++ b/Services/Notifications/classes/Setup/ilNotificationUpdateSteps.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Notifications\ilNotificationSetupHelper;
 
@@ -179,5 +179,7 @@ class ilNotificationUpdateSteps implements ilDatabaseUpdateSteps
                 'default' => ''
             ]);
         }
+
+        $this->db->manipulate('TRUNCATE TABLE notification_osd');
     }
 }


### PR DESCRIPTION
Since OSD Notifications where never cleared within `notification_osd` this table is filled with mostly reduntant data (e.g. chat invitiations from 3 years ago).
Since the refactoring of notifications most of that contained data is not longer unserializable due to lack of its historic multiclasses. 

Although this data should never be accessed anymore its unlikely invocation will therefore cause an error and due to its corrupted state should be removed.