### PR TITLE
Fix 37803: avoid race conditions in getting Mathjax Settings

### DIFF
--- a/Services/MathJax/classes/Setup/class.ilMathJaxConfigCheckedObjective.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxConfigCheckedObjective.php
@@ -53,10 +53,11 @@ class ilMathJaxConfigCheckedObjective implements Setup\Objective
 
     public function achieve(Setup\Environment $environment): Setup\Environment
     {
+        /** @var ilSettingsFactory $factory */
         $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
         $interaction = $environment->getResource(Setup\Environment::RESOURCE_ADMIN_INTERACTION);
 
-        $repo = new ilMathJaxConfigSettingsRepository($factory);
+        $repo = new ilMathJaxConfigSettingsRepository($factory->settingsFor('MathJax'));
         if (!empty($new_config = $this->checkClientScriptUrl($repo->getConfig(), $interaction))) {
             $repo->updateConfig($new_config);
         }

--- a/Services/MathJax/classes/Setup/class.ilMathJaxConfigStoredObjective.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxConfigStoredObjective.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,7 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
 use ILIAS\Setup;
 
 class ilMathJaxConfigStoredObjective implements Setup\Objective

--- a/Services/MathJax/classes/Setup/class.ilMathJaxConfigStoredObjective.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxConfigStoredObjective.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
 use ILIAS\Setup;
 
@@ -50,8 +53,9 @@ class ilMathJaxConfigStoredObjective implements Setup\Objective
 
     public function achieve(Setup\Environment $environment): Setup\Environment
     {
+        /** @var ilSettingsFactory $factory */
         $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
-        $repo = new ilMathJaxConfigSettingsRepository($factory);
+        $repo = new ilMathJaxConfigSettingsRepository($factory->settingsFor('MathJax'));
         $repo->updateConfig($this->config->applyTo($repo->getConfig()));
 
         return $environment;
@@ -59,8 +63,9 @@ class ilMathJaxConfigStoredObjective implements Setup\Objective
 
     public function isApplicable(Setup\Environment $environment): bool
     {
+        /** @var ilSettingsFactory $factory */
         $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
-        $repo = new ilMathJaxConfigSettingsRepository($factory);
+        $repo = new ilMathJaxConfigSettingsRepository($factory->settingsFor('MathJax'));
 
         return $this->config->isApplicableTo($repo->getConfig());
     }

--- a/Services/MathJax/classes/Setup/class.ilMathJaxMetricsCollectedObjective.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxMetricsCollectedObjective.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,7 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
 use ILIAS\Setup;
 use ILIAS\Refinery;
 

--- a/Services/MathJax/classes/Setup/class.ilMathJaxMetricsCollectedObjective.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxMetricsCollectedObjective.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
 use ILIAS\Setup;
 use ILIAS\Refinery;
@@ -29,8 +32,9 @@ class ilMathJaxMetricsCollectedObjective extends Setup\Metrics\CollectedObjectiv
 
     protected function collectFrom(Setup\Environment $environment, Setup\Metrics\Storage $storage): void
     {
+        /** @var ilSettingsFactory $factory */
         $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
-        $repo = new ilMathJaxConfigSettingsRepository($factory);
+        $repo = new ilMathJaxConfigSettingsRepository($factory->settingsFor('MathJax'));
         $config = $repo->getConfig();
 
         $setup_config = new ilMathJaxSetupConfig([]);

--- a/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxSetupAgent.php
@@ -1,20 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
+declare(strict_types=1);
 use ILIAS\Setup;
 use ILIAS\Refinery;
 

--- a/Services/MathJax/classes/Setup/class.ilMathJaxSetupConfig.php
+++ b/Services/MathJax/classes/Setup/class.ilMathJaxSetupConfig.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 

--- a/Services/MathJax/classes/class.ilMathJax.php
+++ b/Services/MathJax/classes/class.ilMathJax.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
 use ILIAS\DI\Container;
 
@@ -116,15 +119,13 @@ class ilMathJax
     }
 
     /**
-     * Singleton: get instance for use in ILIAS
+     * Singleton: get instance for use in ILIAS requests with a config loaded from the settings
      */
     public static function getInstance(): ilMathJax
     {
-        /** @var Container $DIC */
-        global $DIC;
-
         if (!isset(self::$_instance)) {
-            $repo = new ilMathJaxConfigSettingsRepository(new ilSettingsFactory($DIC->database()));
+            // #37803: here we can't use ilSettingsFactory because of race conditions in ilSettingsFactory::settingsFor()
+            $repo = new ilMathJaxConfigSettingsRepository(new ilSetting('MathJax'));
             self::$_instance = new self($repo->getConfig(), new ilMathJaxFactory());
         }
         return self::$_instance;

--- a/Services/MathJax/classes/class.ilMathJax.php
+++ b/Services/MathJax/classes/class.ilMathJax.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,7 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
 use ILIAS\DI\Container;
 
 /**

--- a/Services/MathJax/classes/class.ilMathJaxConfig.php
+++ b/Services/MathJax/classes/class.ilMathJaxConfig.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Global Mathjax configuration

--- a/Services/MathJax/classes/class.ilMathJaxConfigSettingsRepository.php
+++ b/Services/MathJax/classes/class.ilMathJaxConfigSettingsRepository.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Repository for storing and loading the MathJax configuration

--- a/Services/MathJax/classes/class.ilMathJaxConfigSettingsRepository.php
+++ b/Services/MathJax/classes/class.ilMathJaxConfigSettingsRepository.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
 /**
  * Repository for storing and loading the MathJax configuration
@@ -24,10 +27,11 @@ class ilMathJaxConfigSettingsRepository implements ilMathJaxConfigRespository
 
     /**
      * Constructor
+     * @param ilSetting $settings - must be settings with loaded module 'MathJax'
      */
-    public function __construct(ilSettingsFactory $factory)
+    public function __construct(ilSetting $settings)
     {
-        $this->settings = $factory->settingsFor('MathJax');
+        $this->settings = $settings;
     }
 
     /**

--- a/Services/MathJax/classes/class.ilMathJaxException.php
+++ b/Services/MathJax/classes/class.ilMathJaxException.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 class ilMathJaxException extends ilException
 {

--- a/Services/MathJax/classes/class.ilMathJaxFactory.php
+++ b/Services/MathJax/classes/class.ilMathJaxFactory.php
@@ -3,15 +3,18 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
 use ILIAS\DI\Container;
 

--- a/Services/MathJax/classes/class.ilMathJaxImage.php
+++ b/Services/MathJax/classes/class.ilMathJaxImage.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\DI\Container;
 

--- a/Services/MathJax/classes/class.ilMathJaxServer.php
+++ b/Services/MathJax/classes/class.ilMathJaxServer.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class for calling theMathJax server

--- a/Services/MathJax/classes/class.ilMathJaxSettingsGUI.php
+++ b/Services/MathJax/classes/class.ilMathJaxSettingsGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * GUI for MathJax Settings

--- a/Services/MathJax/classes/class.ilMathJaxSettingsGUI.php
+++ b/Services/MathJax/classes/class.ilMathJaxSettingsGUI.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
 /**
  * GUI for MathJax Settings
@@ -52,7 +55,7 @@ class ilMathJaxSettingsGUI
         $this->refinery = $this->dic->refinery();
 
         $factory = new ilSettingsFactory($DIC->database());
-        $this->repository = new ilMathJaxConfigSettingsRepository($factory);
+        $this->repository = new ilMathJaxConfigSettingsRepository($factory->settingsFor('MathJax'));
     }
 
     /**

--- a/Services/MathJax/interfaces/interface.ilMathJaxConfigRespository.php
+++ b/Services/MathJax/interfaces/interface.ilMathJaxConfigRespository.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 interface ilMathJaxConfigRespository
 {

--- a/Services/MathJax/test/bootstrap.php
+++ b/Services/MathJax/test/bootstrap.php
@@ -1,18 +1,21 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 require_once 'libs/composer/vendor/autoload.php';

--- a/Services/MathJax/test/class.ilMathJaxTest.php
+++ b/Services/MathJax/test/class.ilMathJaxTest.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 require_once __DIR__ . '/ilMathJaxBaseTest.php';
 

--- a/Services/MathJax/test/ilMathJaxBaseTest.php
+++ b/Services/MathJax/test/ilMathJaxBaseTest.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 

--- a/Services/MathJax/test/ilServicesMathJaxSuite.php
+++ b/Services/MathJax/test/ilServicesMathJaxSuite.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
This similar, but is slightly different to https://github.com/ILIAS-eLearning/ILIAS/pull/6264

Instead of implementing a fallback in the constructor of ilMathJaxConfigRespository it now get the prepared ilSetting object as parameter. This object is prepaed in different ways for setup and requests.