### PR TITLE
 UI/Launcher: Modal button label customization

### DIFF
--- a/src/UI/Component/Launcher/Launcher.php
+++ b/src/UI/Component/Launcher/Launcher.php
@@ -23,7 +23,6 @@ namespace ILIAS\UI\Component\Launcher;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Chart\ProgressMeter\ProgressMeter;
 use ILIAS\UI\Component\Symbol\Icon\Icon;
-use ILIAS\UI\Component\Input\Container\Form\Form;
 use ILIAS\UI\Component\Input\Field\Group;
 use ILIAS\UI\Component\MessageBox;
 use Psr\Http\Message\ServerRequestInterface;
@@ -63,4 +62,8 @@ interface Launcher extends Component
     public function withButtonLabel(string $label, bool $launchable = true): self;
 
     public function withRequest(ServerRequestInterface $request): self;
+
+    public function withModalSubmitLabel(?string $label): self;
+
+    public function withModalCancelLabel(?string $label): self;
 }

--- a/src/UI/Implementation/Component/Launcher/Inline.php
+++ b/src/UI/Implementation/Component/Launcher/Inline.php
@@ -47,6 +47,8 @@ class Inline implements C\Launcher\Inline
     protected ?MessageBox\MessageBox $instruction = null;
     protected ?MessageBox\MessageBox $status_message = null;
     protected ?ServerRequestInterface $request = null;
+    protected ?string $submit_button_label = null;
+    protected ?string $cancel_button_label = null;
 
     public function __construct(
         Modal\Factory $modal_factory,
@@ -154,5 +156,29 @@ class Inline implements C\Launcher\Inline
     public function getEvaluation(): \Closure
     {
         return $this->evaluation;
+    }
+
+    public function withSubmitLabel(string $caption): self
+    {
+        $clone = clone $this;
+        $clone->submit_button_label = $caption;
+        return $clone;
+    }
+
+    public function getSubmitLabel(): ?string
+    {
+        return $this->submit_button_label;
+    }
+
+    public function withCancelButtonLabel(string $label): self
+    {
+        $clone = clone $this;
+        $clone->cancel_button_label = $label;
+        return $clone;
+    }
+
+    public function getCancelButtonLabel(): ?string
+    {
+        return $this->cancel_button_label;
     }
 }

--- a/src/UI/Implementation/Component/Launcher/Inline.php
+++ b/src/UI/Implementation/Component/Launcher/Inline.php
@@ -47,8 +47,8 @@ class Inline implements C\Launcher\Inline
     protected ?MessageBox\MessageBox $instruction = null;
     protected ?MessageBox\MessageBox $status_message = null;
     protected ?ServerRequestInterface $request = null;
-    protected ?string $submit_button_label = null;
-    protected ?string $cancel_button_label = null;
+    protected ?string $modal_submit_label = null;
+    protected ?string $modal_cancel_label = null;
 
     public function __construct(
         Modal\Factory $modal_factory,
@@ -158,27 +158,27 @@ class Inline implements C\Launcher\Inline
         return $this->evaluation;
     }
 
-    public function withSubmitLabel(string $caption): self
+    public function withModalSubmitLabel(?string $label): self
     {
         $clone = clone $this;
-        $clone->submit_button_label = $caption;
+        $clone->modal_submit_label = $label;
         return $clone;
     }
 
-    public function getSubmitLabel(): ?string
+    public function getModalSubmitLabel(): ?string
     {
-        return $this->submit_button_label;
+        return $this->modal_submit_label;
     }
 
-    public function withCancelButtonLabel(string $label): self
+    public function withModalCancelLabel(?string $label): self
     {
         $clone = clone $this;
-        $clone->cancel_button_label = $label;
+        $clone->modal_cancel_label = $label;
         return $clone;
     }
 
-    public function getCancelButtonLabel(): ?string
+    public function getModalCancelLabel(): ?string
     {
-        return $this->cancel_button_label;
+        return $this->modal_cancel_label;
     }
 }

--- a/src/UI/Implementation/Component/Launcher/Renderer.php
+++ b/src/UI/Implementation/Component/Launcher/Renderer.php
@@ -53,6 +53,14 @@ class Renderer extends AbstractComponentRenderer
         $start_button = $ui_factory->button()->bulky($launch_glyph, $label, (string) $target);
 
         if ($modal = $component->getModal()) {
+            if ($submit_lable = $component->getSubmitLabel()) {
+                $modal = $modal->withSubmitLabel($submit_lable);
+            }
+
+            if ($cancel_label = $component->getCancelButtonLabel()) {
+                $modal = $modal->withCancelButtonLabel($cancel_label);
+            }
+
             $tpl->setVariable("FORM", $default_renderer->render($modal));
             $start_button = $start_button->withOnClick($modal->getShowSignal());
         }

--- a/src/UI/Implementation/Component/Launcher/Renderer.php
+++ b/src/UI/Implementation/Component/Launcher/Renderer.php
@@ -53,12 +53,12 @@ class Renderer extends AbstractComponentRenderer
         $start_button = $ui_factory->button()->bulky($launch_glyph, $label, (string) $target);
 
         if ($modal = $component->getModal()) {
-            if ($submit_lable = $component->getSubmitLabel()) {
-                $modal = $modal->withSubmitLabel($submit_lable);
+            if ($modal_submit_lable = $component->getModalSubmitLabel()) {
+                $modal = $modal->withSubmitLabel($modal_submit_lable);
             }
 
-            if ($cancel_label = $component->getCancelButtonLabel()) {
-                $modal = $modal->withCancelButtonLabel($cancel_label);
+            if ($modal_cancel_label = $component->getModalCancelLabel()) {
+                $modal = $modal->withCancelButtonLabel($modal_cancel_label);
             }
 
             $tpl->setVariable("FORM", $default_renderer->render($modal));

--- a/src/UI/examples/Launcher/Inline/with_fields.php
+++ b/src/UI/examples/Launcher/Inline/with_fields.php
@@ -90,8 +90,8 @@ function with_fields()
         ->withInputs($group, $evaluation, $instruction)
         ->withStatusIcon($icon)
         ->withStatusMessageBox($status_message)
-        ->withSubmitLabel('Begin Exam')
-        ->withCancelButtonLabel('Cancel')
+        ->withModalSubmitLabel('Begin Exam')
+        ->withModalCancelLabel('Cancel')
     ;
 
     if (array_key_exists('launcher_id', $request->getQueryParams()) && $request->getQueryParams()['launcher_id'] === 'l3') {

--- a/src/UI/examples/Launcher/Inline/with_fields.php
+++ b/src/UI/examples/Launcher/Inline/with_fields.php
@@ -89,7 +89,10 @@ function with_fields()
         ->withDescription('')
         ->withInputs($group, $evaluation, $instruction)
         ->withStatusIcon($icon)
-        ->withStatusMessageBox($status_message);
+        ->withStatusMessageBox($status_message)
+        ->withSubmitLabel('Begin Exam')
+        ->withCancelButtonLabel('Cancel')
+    ;
 
     if (array_key_exists('launcher_id', $request->getQueryParams()) && $request->getQueryParams()['launcher_id'] === 'l3') {
         $launcher3 = $launcher3->withRequest($request);

--- a/src/UI/templates/default/Launcher/tpl.launcher_inline.html
+++ b/src/UI/templates/default/Launcher/tpl.launcher_inline.html
@@ -9,7 +9,7 @@
         <!-- END status_icon -->
     </div>
     <!-- END status -->
-    
+
     <div class="c-launcher__description">
         {DESCRIPTION}
     </div>

--- a/src/UI/templates/default/Launcher/tpl.launcher_inline.html
+++ b/src/UI/templates/default/Launcher/tpl.launcher_inline.html
@@ -9,7 +9,7 @@
         <!-- END status_icon -->
     </div>
     <!-- END status -->
-
+    
     <div class="c-launcher__description">
         {DESCRIPTION}
     </div>

--- a/tests/UI/Component/Launcher/LauncherInlineTest.php
+++ b/tests/UI/Component/Launcher/LauncherInlineTest.php
@@ -124,17 +124,23 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
         $this->assertNull($l->getStatusIcon());
         $this->assertNull($l->getStatusMessageBox());
         $this->assertNull($l->getModal());
+        $this->assertNull($l->getModalSubmitLabel());
+        $this->assertNull($l->getModalCancelLabel());
     }
 
     public function testLauncherInlineBasicModifier(): void
     {
         $msg = $this->getMessageBox();
         $icon = $this->getIconFactory()->standard('course', 'some icon');
+        $some_submit_label = 'some submit label';
+        $some_cancel_label = 'some cancel label';
         $l = $this->getLauncher()
             ->withDescription('some description')
             ->withButtonLabel('different label', false)
             ->withStatusMessageBox($msg)
             ->withStatusIcon($icon)
+            ->withModalSubmitLabel($some_submit_label)
+            ->withModalCancelLabel($some_cancel_label)
         ;
 
         $this->assertEquals($this->df->link('LaunchSomething', $this->getURI()), $l->getTarget());
@@ -143,6 +149,8 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
         $this->assertEquals($msg, $l->getStatusMessageBox());
         $this->assertEquals($icon, $l->getStatusIcon());
         $this->assertNull($l->getModal());
+        $this->assertEquals($l->getModalSubmitLabel(), $some_submit_label);
+        $this->assertEquals($l->getModalCancelLabel(), $some_cancel_label);
     }
 
     public function testLauncherInlineWithFields(): void
@@ -188,7 +196,10 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
             ->withButtonLabel('different label', false)
             ->withStatusMessageBox($msg)
             ->withStatusIcon($icon)
-            ->withInputs($group, $evaluation, $msg);
+            ->withInputs($group, $evaluation, $msg)
+            ->withModalSubmitLabel('some submit label')
+            ->withModalCancelLabel('some cancel label')
+        ;
 
         $expected = <<<EXP
 <div class="c-launcher c-launcher--inline" id="">
@@ -225,8 +236,8 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
                         </form>
                     </div>
                     <div class="modal-footer">
-                        <button class="btn btn-default" data-dismiss="modal">cancel</button>
-                        <button class="btn btn-default" id="id_4">save</button>
+                        <button class="btn btn-default" data-dismiss="modal">some cancel label</button>
+                        <button class="btn btn-default" id="id_4">some submit label</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
As of right now, you are unable to set the labels for the buttons inside the `Launcher` modal. The default labels **Cancel** & **Save** are not always suitable for every purpose. Therefore I propose this change to make the labels adjustable if needed. If no label is provided, the default value **Cancel** or **Save** will be applied accordingly.