### PR TITLE
LSO: add error message if "Download Multiple Objects" is used. (#…

### DIFF
--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -85,6 +85,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
     public const CMD_SHOW_TRASH = 'trash';
     public const CMD_UNDELETE = 'undelete';
     public const CMD_REDRAW_HEADER = 'redrawHeaderAction';
+    public const CMD_ENABLE_ADMINISTRATION_PANEL = "enableAdministrationPanel";
 
     public const TAB_VIEW_CONTENT = "view";
     public const TAB_MANAGE = "manage";
@@ -424,6 +425,12 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
 
                     case self::CMD_REDRAW_HEADER:
                         $this->redrawHeaderActionObject();
+                        break;
+                        
+                    // This is a temporary implementation (Mantis Ticket 36631)
+                    case self::CMD_ENABLE_ADMINISTRATION_PANEL:
+                        $tpl->setOnScreenMessage("failure", $this->lng->txt('lso_multidownload_not_available'), false);
+                        $this->manageContent();
                         break;
 
                     default:

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -10448,6 +10448,7 @@ lso#:#lso_members_gallery#:#Mitgliedergalerie
 lso#:#lso_members_print_title#:#Lernsequenzmitglieder
 lso#:#lso_min_one_admin#:#Dieser Lernsequenz muß mindestens ein Administrator zugeordnet bleiben.
 lso#:#lso_msg_member_assigned#:#Benutzer wurde(n) in die Lernsequenz aufgenommen
+lso#:#lso_multidownload_not_available#:#Das Herunterladen verschiedener Objekte ist derzeit nicht für Lernsequenz Objekten verfügbar.
 lso#:#lso_new_status#:#Ihr neuer Status:
 lso#:#lso_notification#:#Benachrichtigung
 lso#:#lso_notification_explanation_admin#:#Sie erhalten diese Mail, da für Sie als Lernsequenzbetreuung die Benachrichtigungen aktiviert sind.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -10448,6 +10448,7 @@ lso#:#lso_members_gallery#:#Learning Sequence Members Gallery
 lso#:#lso_members_print_title#:#Learning sequence members
 lso#:#lso_min_one_admin#:#There has to be at least one administrator assigned to this learning sequence.
 lso#:#lso_msg_member_assigned#:#User(s) assigned as learning sequence member(s)
+lso#:#lso_multidownload_not_available#:#Downloading multiple objects is currently not available for Learning Sequence Objects.
 lso#:#lso_new_status#:#Your new status is:
 lso#:#lso_notification#:#Notification
 lso#:#lso_notification_explanation_admin#:#You receive mail from ILIAS because you are learning sequence administrator with notification enabled.


### PR DESCRIPTION
…36631)

This implementation should be temporary, as the multi-download feature has to be handled differently / should not be a property of the container service. A decision about the handling will be made later.

Mantis Ticket: https://mantis.ilias.de/view.php?id=36631

