### PR TITLE
Form: fix start and end labels of duration input (36124)

### DIFF
--- a/Services/Form/classes/class.ilDateDurationInputGUI.php
+++ b/Services/Form/classes/class.ilDateDurationInputGUI.php
@@ -29,8 +29,8 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
 
     protected ?ilDateTime $start = null;
     protected ?int $startyear = null;
-    protected string $start_text = "";
-    protected string $end_text = "";
+    protected ?string $start_text = null;
+    protected ?string $end_text = null;
     protected int $minute_step_size = 5;
     protected ?ilDateTime $end = null;
     protected bool $showtime = false;
@@ -87,7 +87,7 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
         $this->start_text = $a_txt;
     }
 
-    public function getStartText(): string
+    public function getStartText(): ?string
     {
         return $this->start_text;
     }
@@ -97,7 +97,7 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
         $this->end_text = $a_txt;
     }
 
-    public function getEndText(): string
+    public function getEndText(): ?string
     {
         return $this->end_text;
     }


### PR DESCRIPTION
This PR fixes [36124](https://mantis.ilias.de/view.php?id=36124). The duration input only falls back to the default start- and end-labels if their respective properties are `null`, not if they're empty strings. Empty strings are used when the labels should be skipped.