### PR TITLE
ContainerReference: fix empty title on creation (32383)

### DIFF
--- a/Services/ContainerReference/ROADMAP.md
+++ b/Services/ContainerReference/ROADMAP.md
@@ -1,0 +1,20 @@
+# Roadmap
+
+## Short Term
+
+...
+
+## Mid Term
+
+### Listen for changes of target object's title
+
+ContainerReference objects that reuse the title of their target should update their title
+when the target does, e.g. via event handling. Currently, different components
+handle the rendering of the title of references differently, some looking up
+the title of the target and some just using the title of the reference directly from
+object_data, leading to inconsistent results when the title of the target is
+changed.
+
+## Long Term
+
+...

--- a/Services/ContainerReference/classes/class.ilContainerReferenceGUI.php
+++ b/Services/ContainerReference/classes/class.ilContainerReferenceGUI.php
@@ -239,6 +239,8 @@ class ilContainerReferenceGUI extends ilObjectGUI
         $a_new_object->setTitleType($this->form->getInput('title_type'));
         if ($this->form->getInput('title_type') == ilContainerReference::TITLE_TYPE_CUSTOM) {
             $a_new_object->setTitle($this->form->getInput('title'));
+        } elseif ($this->form->getInput('title_type') == ilContainerReference::TITLE_TYPE_REUSE) {
+            $a_new_object->setTitle(ilObject::_lookupTitle($a_new_object->getTargetId()));
         }
 
         $a_new_object->update();
@@ -349,7 +351,7 @@ class ilContainerReferenceGUI extends ilObjectGUI
             array_merge(
                 array($this->getTargetType()),
                 array("root", "cat", "grp", "fold", "crs")
-        )
+            )
         );
         $repo->setInfo($this->lng->txt($this->getReferenceType() . '_edit_info'));
 


### PR DESCRIPTION
This PR is a quick fix for part of [32383](https://mantis.ilias.de/view.php?id=32383). It makes it so ContainerReferences set their title to the title of their target on creation (if they are set to reuse the target's title).
There is also a pre-exisiting issue of references not updating their title when their target does. I took the liberty to add a potential fix for that to the roadmap.