### PR TITLE
PHP8 compatibility: fix search result when searching by org unit (#38092)

### DIFF
--- a/Services/Search/classes/Like/class.ilLikeUserOrgUnitSearch.php
+++ b/Services/Search/classes/Like/class.ilLikeUserOrgUnitSearch.php
@@ -38,7 +38,7 @@ class ilLikeUserOrgUnitSearch extends ilAbstractSearch
 
         $res = $this->db->query($query);
         while ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
-            $this->search_result->addEntry($row->user_id, 'user', $this->__prepareFound($row));
+            $this->search_result->addEntry((int) $row->user_id, 'user', $this->__prepareFound($row));
         }
         return $this->search_result;
     }


### PR DESCRIPTION
Fixes an error that occurs, when searching for new course members via "search for user" with orgunit dropwdown filter item.

I did not create a mantis ticket for this yet. Please let me know if the combination of ticket + pr is preferred. 