### PR TITLE
[FEATURE] UI: add chunked-upload for file-inputs.

### DIFF
--- a/Services/Init/classes/Dependencies/InitUIFramework.php
+++ b/Services/Init/classes/Dependencies/InitUIFramework.php
@@ -267,7 +267,8 @@ class InitUIFramework
                             $c["refinery"],
                             $c["ui.pathresolver"],
                             $c["ui.data_factory"],
-                            $c["help.text_retriever"]
+                            $c["help.text_retriever"],
+                            $c["ui.upload_limit_resolver"]
                         ),
                         new ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphRendererFactory(
                             $c["ui.factory"],
@@ -277,7 +278,8 @@ class InitUIFramework
                             $c["refinery"],
                             $c["ui.pathresolver"],
                             $c["ui.data_factory"],
-                            $c["help.text_retriever"]
+                            $c["help.text_retriever"],
+                            $c["ui.upload_limit_resolver"]
                         ),
                         new ILIAS\UI\Implementation\Component\Symbol\Icon\IconRendererFactory(
                             $c["ui.factory"],
@@ -287,7 +289,8 @@ class InitUIFramework
                             $c["refinery"],
                             $c["ui.pathresolver"],
                             $c["ui.data_factory"],
-                            $c["help.text_retriever"]
+                            $c["help.text_retriever"],
+                            $c["ui.upload_limit_resolver"]
                         ),
                         new ILIAS\UI\Implementation\Component\Input\Field\FieldRendererFactory(
                             $c["ui.factory"],
@@ -297,7 +300,8 @@ class InitUIFramework
                             $c["refinery"],
                             $c["ui.pathresolver"],
                             $c["ui.data_factory"],
-                            $c["help.text_retriever"]
+                            $c["help.text_retriever"],
+                            $c["ui.upload_limit_resolver"]
                         )
                     )
                 )

--- a/src/UI/Component/Input/Field/FileUpload.php
+++ b/src/UI/Component/Input/Field/FileUpload.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Component\Input\Field;
 
 /**
@@ -27,6 +27,13 @@ interface FileUpload
 {
     public function getUploadHandler(): UploadHandler;
 
+    /**
+     * Get an instance like this with a local upload-size limitation. This value will take
+     * precedence over other implicit upload-limits which may apply.
+     *
+     * Please note that upload-limits greater than the PHP limit can only be applied if the
+     * corresponding @see UploadHandler supports chunked uploads.
+     */
     public function withMaxFileSize(int $size_in_bytes): FileUpload;
 
     public function getMaxFileSize(): int;

--- a/src/UI/Implementation/Component/Input/Field/FieldRendererFactory.php
+++ b/src/UI/Implementation/Component/Input/Field/FieldRendererFactory.php
@@ -36,7 +36,8 @@ class FieldRendererFactory extends Render\DefaultRendererFactory
                 $this->refinery,
                 $this->image_path_resolver,
                 $this->data_factory,
-                $this->help_text_retriever
+                $this->help_text_retriever,
+                $this->upload_limit_resolver
             );
         }
         return new Renderer(
@@ -47,7 +48,8 @@ class FieldRendererFactory extends Render\DefaultRendererFactory
             $this->refinery,
             $this->image_path_resolver,
             $this->data_factory,
-            $this->help_text_retriever
+            $this->help_text_retriever,
+            $this->upload_limit_resolver
         );
     }
 }

--- a/src/UI/Implementation/Component/Input/Field/File.php
+++ b/src/UI/Implementation/Component/Input/Field/File.php
@@ -47,7 +47,7 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
     protected array $accepted_mime_types = [];
     protected bool $has_metadata_inputs = false;
     protected int $max_file_amount = 1;
-    protected ?int $max_file_size = null;
+    protected int $max_file_size_in_bytes;
 
     public function __construct(
         ilLanguage $language,
@@ -60,6 +60,7 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
         ?string $byline
     ) {
         $this->upload_limit_resolver = $upload_limit_resolver;
+        $this->max_file_size_in_bytes = $upload_limit_resolver->getBestPossibleUploadLimitInBytes($handler);
         $this->language = $language;
         $this->data_factory = $data_factory;
         $this->refinery = $refinery;
@@ -83,17 +84,18 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
 
     public function withMaxFileSize(int $size_in_bytes): FileUpload
     {
-        $size_in_bytes = $this->upload_limit_resolver->min($size_in_bytes);
-
         $clone = clone $this;
-        $clone->max_file_size = $size_in_bytes;
+        $clone->max_file_size_in_bytes = $clone->upload_limit_resolver->getBestPossibleUploadLimitInBytes(
+            $clone->upload_handler,
+            $size_in_bytes
+        );
 
         return $clone;
     }
 
     public function getMaxFileSize(): int
     {
-        return $this->max_file_size ?? $this->upload_limit_resolver->getUploadLimit();
+        return $this->max_file_size_in_bytes;
     }
 
     public function withMaxFiles(int $max_file_amount): FileUpload

--- a/src/UI/Implementation/Component/Input/UploadLimitResolver.php
+++ b/src/UI/Implementation/Component/Input/UploadLimitResolver.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,39 +15,68 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  */
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Input;
 
+use ILIAS\UI\Component\Input\Field\UploadHandler;
+
 /**
+ * This class will bee used by @see FileUpload to resolve upload-limits.
+ *
+ * The UI framework knows three kinds of values which might affect an upload-limit:
+ *      - PHP: The upload-limit is defined by the php.ini options 'post_max_size' and 'upload_max_filesize'
+ *      - Global: The upload-limit is defined by a higher order system like ILIAS, which is determined by various factors.
+ *      - Local: The upload-limit is defined by the @see FileUpload itself for specific use-cases.
+ *
+ * Note:
+ *      - local limits will always take precedence over other limits, because they are
+ *        tailored for specific use-cases.
+ *      - global or local limits exceeding the php-limit can only be applied if the
+ *        corresponding @see UploadHandler supports chunked uploads.
+ *
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
 class UploadLimitResolver
 {
-    protected int $default_upload_size_limit;
-
-    public function __construct(int $default_upload_size_limit)
-    {
-        $this->default_upload_size_limit = $default_upload_size_limit;
+    /**
+     * @param int      $php_upload_limit_in_bytes           smaller php-ini option of 'post_max_size' and 'upload_max_filesize'
+     * @param int|null $custom_global_upload_limit_in_bytes custom upload limit (may exceed $php_upload_limit_in_bytes)
+     */
+    public function __construct(
+        protected int $php_upload_limit_in_bytes,
+        protected ?int $custom_global_upload_limit_in_bytes = null
+    ) {
     }
 
-    public function min(int $size_in_bytes): int
-    {
-        return min($this->default_upload_size_limit, $size_in_bytes);
-    }
-
-    public function max(int $size_in_bytes): int
-    {
-        return max($this->default_upload_size_limit, $size_in_bytes);
-    }
-
-    public function checkUploadLimit(int $size_in_bytes): void
-    {
-        if ($size_in_bytes > $this->default_upload_size_limit) {
-            throw new \InvalidArgumentException("File size exceeds $this->default_upload_size_limit bytest.");
+    public function getBestPossibleUploadLimitInBytes(
+        UploadHandler $upload_handler,
+        int $local_limit_in_bytes = null
+    ): int {
+        if (null !== $local_limit_in_bytes && $this->canUploadLimitBeUsed($upload_handler, $local_limit_in_bytes)) {
+            return $local_limit_in_bytes;
         }
+
+        if (null !== $this->custom_global_upload_limit_in_bytes &&
+            $this->canUploadLimitBeUsed($upload_handler, $this->custom_global_upload_limit_in_bytes)
+        ) {
+            return $this->custom_global_upload_limit_in_bytes;
+        }
+
+        return $this->php_upload_limit_in_bytes;
     }
 
-    public function getUploadLimit(): int
+    public function getPhpUploadLimitInBytes(): int
     {
-        return $this->default_upload_size_limit;
+        return $this->php_upload_limit_in_bytes;
+    }
+
+    protected function canUploadLimitBeUsed(UploadHandler $upload_handler, ?int $limit_in_bytes): bool
+    {
+        if ($upload_handler->supportsChunkedUploads()) {
+            return true;
+        }
+
+        return $limit_in_bytes <= $this->php_upload_limit_in_bytes;
     }
 }

--- a/src/UI/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
@@ -42,7 +42,8 @@ class GlyphRendererFactory extends Render\DefaultRendererFactory
                 $this->refinery,
                 $this->image_path_resolver,
                 $this->data_factory,
-                $this->help_text_retriever
+                $this->help_text_retriever,
+                $this->upload_limit_resolver
             );
         }
         return new Renderer(
@@ -53,7 +54,8 @@ class GlyphRendererFactory extends Render\DefaultRendererFactory
             $this->refinery,
             $this->image_path_resolver,
             $this->data_factory,
-            $this->help_text_retriever
+            $this->help_text_retriever,
+            $this->upload_limit_resolver
         );
     }
 }

--- a/src/UI/Implementation/Component/Symbol/Icon/IconRendererFactory.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/IconRendererFactory.php
@@ -42,7 +42,8 @@ class IconRendererFactory extends Render\DefaultRendererFactory
                 $this->refinery,
                 $this->image_path_resolver,
                 $this->data_factory,
-                $this->help_text_retriever
+                $this->help_text_retriever,
+                $this->upload_limit_resolver
             );
         }
         return new Renderer(
@@ -53,7 +54,8 @@ class IconRendererFactory extends Render\DefaultRendererFactory
             $this->refinery,
             $this->image_path_resolver,
             $this->data_factory,
-            $this->help_text_retriever
+            $this->help_text_retriever,
+            $this->upload_limit_resolver
         );
     }
 }

--- a/src/UI/Implementation/Render/AbstractComponentRenderer.php
+++ b/src/UI/Implementation/Render/AbstractComponentRenderer.php
@@ -30,6 +30,7 @@ use ILIAS\UI\Help;
 use ilLanguage;
 use InvalidArgumentException;
 use LogicException;
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
  * Base class for all component renderers.
@@ -50,7 +51,8 @@ abstract class AbstractComponentRenderer implements ComponentRenderer, HelpTextR
         private \ILIAS\Refinery\Factory $refinery,
         private ImagePathResolver $image_path_resolver,
         private DataFactory $data_factory,
-        private HelpTextRetriever $help_text_retriever
+        private HelpTextRetriever $help_text_retriever,
+        private UploadLimitResolver $upload_limit_resolver,
     ) {
     }
 
@@ -80,6 +82,11 @@ abstract class AbstractComponentRenderer implements ComponentRenderer, HelpTextR
     final protected function getRefinery(): \ILIAS\Refinery\Factory
     {
         return $this->refinery;
+    }
+
+    final protected function getUploadLimitResolver(): UploadLimitResolver
+    {
+        return $this->upload_limit_resolver;
     }
 
     /**

--- a/src/UI/Implementation/Render/DefaultRendererFactory.php
+++ b/src/UI/Implementation/Render/DefaultRendererFactory.php
@@ -26,6 +26,7 @@ use ILIAS\UI\Component\Component;
 use ILIAS\UI\Factory as RootFactory;
 use ILIAS\UI\HelpTextRetriever;
 use ilLanguage;
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 class DefaultRendererFactory implements RendererFactory
 {
@@ -37,7 +38,8 @@ class DefaultRendererFactory implements RendererFactory
         protected Refinery $refinery,
         protected ImagePathResolver $image_path_resolver,
         protected DataFactory $data_factory,
-        protected HelpTextRetriever $help_text_retriever
+        protected HelpTextRetriever $help_text_retriever,
+        protected UploadLimitResolver $upload_limit_resolver,
     ) {
     }
 
@@ -55,7 +57,8 @@ class DefaultRendererFactory implements RendererFactory
             $this->refinery,
             $this->image_path_resolver,
             $this->data_factory,
-            $this->help_text_retriever
+            $this->help_text_retriever,
+            $this->upload_limit_resolver,
         );
     }
 

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -205,6 +205,20 @@ template and asynch-mechanisms, but rather inject the HTML/JS in its own templat
 (see tpl.datatable.html, datatable.clas.js::asyncAction).
 The DataTable should fully use UI\Component\Modal.
 
+### Revise UploadHandlers (beginner, ~1d)
+
+There is a method `supportsChunckedUpload()` which should be removed and made mandatory
+for all implementations, meaning every implementation should be able to handle chunked
+uploads. This has been avoided due to touching many implementations, of which also many
+are not yet using the IRSS and most likely need special care. However, the concept is rather
+trivial and can be implemented in a generic way, so implementations can reuse it. As long
+as this task is unfinished, there is no guarantee that larger files than the PHP-limit can
+be uploaded, which makes some features like upload-policies unusable.
+
+In addition, the `UploadHandler` interface contains methods which are not required anymore
+and can be safely removed (along with their implementations): `getExistingFileInfoURL()`,
+`getInfoForExistingFiles()`, and `getInfoResult()`.
+
 ## Long Term
 
 ### Make Constraint in Tag Input Field work again

--- a/src/UI/templates/js/Input/Field/file.js
+++ b/src/UI/templates/js/Input/Field/file.js
@@ -1,4 +1,17 @@
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
  * this script wraps dropzone.js library for inputs of
  * ILIAS\UI\Component\Input\Field\File.
  *
@@ -96,7 +109,7 @@ il.UI.Input = il.UI.Input || {};
 		 * @param {string} file_identifier
 		 * @param {int} current_file_count
 		 * @param {int} max_file_amount
-		 * @param {int} max_file_size
+		 * @param {int} max_file_size_in_bytes
 		 * @param {string} mime_types
 		 * @param {boolean} is_disabled
 		 * @param {string[]} translations
@@ -108,12 +121,12 @@ il.UI.Input = il.UI.Input || {};
 			file_identifier,
 			current_file_count,
 			max_file_amount,
-			max_file_size,
+			max_file_size_in_bytes,
 			mime_types,
 			is_disabled,
 			translations,
-			chunked_upload,
-			chunk_size
+			should_upload_be_chunked,
+			chunk_size_in_bytes
 		) {
 			if (typeof dropzones[input_id] !== 'undefined') {
 				console.error(`Error: tried to register input '${input_id}' as file input twice.`);
@@ -138,10 +151,10 @@ il.UI.Input = il.UI.Input || {};
 				`#${input_id} ${SELECTOR.dropzone}`,
 				{
 					url: encodeURI(upload_url),
-					uploadMultiple: (1 < max_file_amount),
+					uploadMultiple: (!should_upload_be_chunked && 1 < max_file_amount),
 					acceptedFiles: (0 < mime_types.length) ? mime_types : null,
 					maxFiles: max_file_amount,
-					maxFilesize: max_file_size,
+					maxFilesize: bytesToMiB(max_file_size_in_bytes), // official dropzone.js docu is wrong, MiB is expected.
 					previewsContainer: file_list,
 					clickable: action_button,
 					autoProcessQueue: false,
@@ -150,9 +163,9 @@ il.UI.Input = il.UI.Input || {};
 					file_identifier: file_identifier,
 					removal_url: removal_url,
 					input_id: input_id,
-					chunking: chunked_upload,
-					chunkSize: chunk_size,
-					forceChunking: chunked_upload,
+					chunking: should_upload_be_chunked,
+					forceChunking: should_upload_be_chunked,
+					chunkSize: chunk_size_in_bytes,
 
 					// override default rendering function.
 					addedfile: file => {
@@ -355,7 +368,7 @@ il.UI.Input = il.UI.Input || {};
 			}
 
 			// abort if the given file size exceeds the max limit.
-			if (dropzones[input_id].options.maxFilesize < file.size) {
+			if ((dropzones[input_id].options.maxFilesize * 1024 * 1024) < file.size) {
 				let allowed_file_size = dropzones[input_id].filesize(dropzones[input_id].options.maxFilesize);
 				displayErrorMessage(
 					I18N.invalid_size.replace('%s', allowed_file_size),
@@ -699,6 +712,14 @@ il.UI.Input = il.UI.Input || {};
 		 */
 		let removeErrorMessage = function (container) {
 			container.find(SELECTOR.error_message).text('');
+		}
+
+		/**
+		 * @param {number} bytes
+		 * @returns {number}
+		 */
+		let bytesToMiB = function (bytes) {
+			return bytes / 1024 / 1024;
 		}
 
 		// ==========================================

--- a/tests/UI/Base.php
+++ b/tests/UI/Base.php
@@ -43,6 +43,7 @@ use ILIAS\UI\Component\Component;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\UI\HelpTextRetriever;
 use ILIAS\UI\Help;
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 class ilIndependentTemplateFactory implements TemplateFactory
 {
@@ -368,6 +369,11 @@ abstract class ILIAS_UI_TestBase extends TestCase
         return new Help\TextRetriever\Echoing();
     }
 
+    public function getUploadLimitResolver(): UploadLimitResolver
+    {
+        return $this->createMock(UploadLimitResolver::class);
+    }
+
     public function getDefaultRenderer(
         JavaScriptBinding $js_binding = null,
         array $with_stub_renderings = []
@@ -397,7 +403,8 @@ abstract class ILIAS_UI_TestBase extends TestCase
                         $refinery,
                         $image_path_resolver,
                         $data_factory,
-                        $help_text_retriever
+                        $help_text_retriever,
+                        $this->getUploadLimitResolver()
                     ),
                     new GlyphRendererFactory(
                         $ui_factory,
@@ -407,7 +414,8 @@ abstract class ILIAS_UI_TestBase extends TestCase
                         $refinery,
                         $image_path_resolver,
                         $data_factory,
-                        $help_text_retriever
+                        $help_text_retriever,
+                        $this->getUploadLimitResolver()
                     ),
                     new IconRendererFactory(
                         $ui_factory,
@@ -417,7 +425,8 @@ abstract class ILIAS_UI_TestBase extends TestCase
                         $refinery,
                         $image_path_resolver,
                         $data_factory,
-                        $help_text_retriever
+                        $help_text_retriever,
+                        $this->getUploadLimitResolver()
                     ),
                     new FieldRendererFactory(
                         $ui_factory,
@@ -427,7 +436,8 @@ abstract class ILIAS_UI_TestBase extends TestCase
                         $refinery,
                         $image_path_resolver,
                         $data_factory,
-                        $help_text_retriever
+                        $help_text_retriever,
+                        $this->getUploadLimitResolver()
                     )
                 )
             )

--- a/tests/UI/Component/Input/UploadLimitResolverTest.php
+++ b/tests/UI/Component/Input/UploadLimitResolverTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Tests\UI\Component\Input;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\UI\Component\Input\Field\UploadHandler;
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class UploadLimitResolverTest extends TestCase
+{
+    protected UploadHandler $upload_handler_with_chunks;
+    protected UploadHandler $upload_handler_without_chunks;
+
+    protected function setUp(): void
+    {
+        $pseudo_upload_handler = $this->createMock(UploadHandler::class);
+        $pseudo_upload_handler->method('getFileIdentifierParameterName')->willReturn('');
+
+        $this->upload_handler_with_chunks = clone $pseudo_upload_handler;
+        $this->upload_handler_with_chunks->method('supportsChunkedUploads')->willReturn(true);
+
+        $this->upload_handler_without_chunks = clone $pseudo_upload_handler;
+        $this->upload_handler_without_chunks->method('supportsChunkedUploads')->willReturn(false);
+    }
+
+    public static function provideUploadLimitResolutionDataSet(): array
+    {
+        return [
+            [
+                'ini_value' => 10,
+                'custom_global_value' => null,
+                'local_value' => null,
+                'upload_handler_supports_chunks' => true,
+                'result' => 10
+            ],
+            [
+                'ini_value' => 10,
+                'custom_global_value' => null,
+                'local_value' => 20,
+                'upload_handler_supports_chunks' => true,
+                'result' => 20
+            ],
+            [
+                'ini_value' => 10,
+                'custom_global_value' => null,
+                'local_value' => 20,
+                'upload_handler_supports_chunks' => true,
+                'result' => 20
+            ],
+            [
+                'ini_value' => 10,
+                'custom_global_value' => 15,
+                'local_value' => 20,
+                'upload_handler_supports_chunks' => true,
+                'result' => 20
+            ],
+            [
+                'ini_value' => 10,
+                'custom_global_value' => 20,
+                'local_value' => 15,
+                'upload_handler_supports_chunks' => true,
+                'result' => 15
+            ],
+            [
+                'ini_value' => 10,
+                'custom_global_value' => null,
+                'local_value' => 20,
+                'upload_handler_supports_chunks' => false,
+                'result' => 10
+            ],
+            [
+                'ini_value' => 10,
+                'custom_global_value' => 20,
+                'local_value' => null,
+                'upload_handler_supports_chunks' => false,
+                'result' => 10
+            ],
+            [
+                'ini_value' => 10,
+                'custom_global_value' => 20,
+                'local_value' => 5,
+                'upload_handler_supports_chunks' => false,
+                'result' => 5
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideUploadLimitResolutionDataSet
+     */
+    public function testUploadLimitResolution(
+        int $php_ini_value,
+        ?int $custom_global_value,
+        ?int $local_value,
+        bool $upload_handler_supports_chunks,
+        int $expected_result,
+    ): void {
+        $resolver = new UploadLimitResolver($php_ini_value, $custom_global_value);
+
+        if ($upload_handler_supports_chunks) {
+            $upload_handler = $this->upload_handler_with_chunks;
+        } else {
+            $upload_handler = $this->upload_handler_without_chunks;
+        }
+
+        $actual_value = $resolver->getBestPossibleUploadLimitInBytes($upload_handler, $local_value);
+
+        $this->assertEquals($expected_result, $actual_value);
+    }
+}

--- a/tests/UI/Component/Input/ViewControl/ViewControlPaginationTest.php
+++ b/tests/UI/Component/Input/ViewControl/ViewControlPaginationTest.php
@@ -161,7 +161,8 @@ class ViewControlPaginationTest extends ViewControlBaseTest
             $this->getRefinery(),
             $this->getImagePathResolver(),
             $this->getDataFactory(),
-            $this->getHelpTextRetriever()
+            $this->getHelpTextRetriever(),
+            $this->getUploadLimitResolver()
         );
     }
 

--- a/tests/UI/Component/Symbol/Glyph/GlyphTest.php
+++ b/tests/UI/Component/Symbol/Glyph/GlyphTest.php
@@ -444,7 +444,8 @@ class GlyphTest extends ILIAS_UI_TestBase
             $this->getRefinery(),
             new ilImagePathResolver(),
             $this->createMock(DataFactory::class),
-            $this->createMock(HelpTextRetriever::class)
+            $this->createMock(HelpTextRetriever::class),
+            $this->getUploadLimitResolver()
         );
         $f = $this->getCounterFactory();
 

--- a/tests/UI/Component/Table/DataRendererTest.php
+++ b/tests/UI/Component/Table/DataRendererTest.php
@@ -82,7 +82,8 @@ class DataRendererTest extends ILIAS_UI_TestBase
             $this->getRefinery(),
             new ilImagePathResolver(),
             new \ILIAS\Data\Factory(),
-            new \ILIAS\UI\Help\TextRetriever\Echoing()
+            new \ILIAS\UI\Help\TextRetriever\Echoing(),
+            $this->getUploadLimitResolver()
         );
     }
 

--- a/tests/UI/Renderer/AbstractRendererTest.php
+++ b/tests/UI/Renderer/AbstractRendererTest.php
@@ -208,7 +208,8 @@ namespace {
                 $this->getRefinery(),
                 $this->image_path_resolver,
                 $this->getDataFactory(),
-                $this->help_text_retriever
+                $this->help_text_retriever,
+                $this->getUploadLimitResolver()
             );
             $r->_getTemplate("tpl.glyph.html", true, false);
 
@@ -229,7 +230,8 @@ namespace {
                 $this->getRefinery(),
                 $this->image_path_resolver,
                 $this->getDataFactory(),
-                $this->help_text_retriever
+                $this->help_text_retriever,
+                $this->getUploadLimitResolver()
             );
 
             $this->expectException(TypeError::class);
@@ -251,7 +253,8 @@ namespace {
                 $this->getRefinery(),
                 $this->image_path_resolver,
                 $this->getDataFactory(),
-                $this->help_text_retriever
+                $this->help_text_retriever,
+                $this->getUploadLimitResolver()
             );
 
             $g = new Glyph(C\Symbol\Glyph\Glyph::SETTINGS, "aria_label");
@@ -278,7 +281,8 @@ namespace {
                 $this->getRefinery(),
                 $this->image_path_resolver,
                 $this->getDataFactory(),
-                $this->help_text_retriever
+                $this->help_text_retriever,
+                $this->getUploadLimitResolver()
             );
 
             $g = new Glyph(C\Symbol\Glyph\Glyph::SETTINGS, "aria_label");

--- a/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
+++ b/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
@@ -52,6 +52,7 @@ class ComponentRendererFSLoaderTest extends TestCase
                 ->getMock();
         $data_factory = $this->getMockBuilder(ILIAS\Data\Factory::class)->getMock();
         $help_text_retriever = $this->createMock(ILIAS\UI\HelpTextRetriever::class);
+        $upload_limit_resolver = $this->createMock(ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class);
 
         $default_renderer_factory = new I\Render\DefaultRendererFactory(
             $ui_factory,
@@ -61,7 +62,8 @@ class ComponentRendererFSLoaderTest extends TestCase
             $refinery_mock,
             $image_path_resolver,
             $data_factory,
-            $help_text_retriever
+            $help_text_retriever,
+            $upload_limit_resolver,
         );
         $this->glyph_renderer = $this->createMock(I\Render\RendererFactory::class);
         $this->icon_renderer = $this->createMock(I\Render\RendererFactory::class);


### PR DESCRIPTION
Hi folks,

I am currently working on a FR for ILIAS 9 (see https://docu.ilias.de/goto_docu_wiki_wpage_6387_1357.html), which introduces a customisable upload-limit that should be applied to all `Field\File` inputs implicitly.

The current implementation of `Field\File` inputs is either limited to a "local" upload-limit, explicitly set by `withMaxFileSize()`, or implicitly, to the PHP-limit (the smaller of both ini-options `post_max_size` and `upload_max_filesize`). Local limits exceeding the PHP-limit will fallback to the PHP-limit silently, making it impossible to upload larger files than this.

In order to upload files exceeding this limit, we need to implement a mechanism called chunked-upload, where files are sent to the server in smaller pieces where they are assembled back together again, so to avoid this limitation.

The new feature will take advantage of this mechanism, but for full support all `Field\UploadHandler` implementations need to be able to provide such a mechanism. However, because of timeline issues, I have decided to implement this feature following the same principle as `Field\File::withMaxFileSize()`, where invalid upload-limits silently fallback to the next-best value. I have added a roadmap-entry so we can tackle this in a later iteration. The new priority is: `local limit > custom global limit > PHP limit`, whereas the local and custom limit will only apply, if they are smaller than the PHP limit or the corresponding upload-handler supports chunked-uploads.

The custom global limit can be injected in the initialisation of the UI framework when creating the `Input\UploadLimitResolver`, leaving the task of determining this limit up to ILIAS.

Kind regards,
@thibsy