### PR TITLE
Feature/9/irss upload question

### DIFF
--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -531,7 +531,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
      */
     public function exportFileUploadsForAllParticipants()
     {
-        $question_object = assQuestion::instantiateQuestion($this->testrequest->raw("qid"));
+        $question_object = assQuestion::instantiateQuestion((int) $this->testrequest->raw("qid"));
         if ($question_object instanceof ilObjFileHandlingQuestionType) {
             $question_object->deliverFileUploadZIPFile(
                 $this->ref_id,

--- a/Modules/Test/classes/class.ilTestParticipantAccessFilter.php
+++ b/Modules/Test/classes/class.ilTestParticipantAccessFilter.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 class ilTestParticipantAccessFilterFactory
 {
     public function __construct(
-        private ilAccess $access
+        private ilAccessHandler $access
     ) {
     }
 

--- a/Modules/TestQuestionPool/classes/Setup/Migration/class.ilTestQuestionPoolFileUploadQuestionMigration.php
+++ b/Modules/TestQuestionPool/classes/Setup/Migration/class.ilTestQuestionPoolFileUploadQuestionMigration.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup\Migration;
+use ILIAS\Setup\Environment;
+
+class ilTestQuestionPoolFileUploadQuestionMigration implements Migration
+{
+    private ?ilResourceStorageMigrationHelper $helper = null;
+
+    public function getLabel(): string
+    {
+        return 'File Upload Question Migration';
+    }
+
+    public function getDefaultAmountOfStepsPerRun(): int
+    {
+        return 1000;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return ilResourceStorageMigrationHelper::getPreconditions();
+    }
+
+    public function prepare(Environment $environment): void
+    {
+        $this->helper = new \ilResourceStorageMigrationHelper(
+            new \assFileUploadStakeholder(),
+            $environment
+        );
+    }
+
+    public function step(Environment $environment): void
+    {
+        $db = $this->helper->getDatabase();
+        $res = $db->query(
+            "SELECT
+                        tst_solutions.solution_id AS solution_id,
+                        tst_active.user_fi AS user_id,
+                        tst_solutions.question_fi AS question_id,
+                        tst_solutions.active_fi AS active_id,
+                        tst_active.test_fi AS test_id,
+                        tst_solutions.value1 AS filename,
+                        tst_solutions.value2 AS revision_name
+                    FROM tst_solutions
+                             INNER JOIN qpl_qst_fileupload ON qpl_qst_fileupload.question_fi = tst_solutions.question_fi
+                             INNER JOIN tst_active ON tst_active.active_id =  tst_solutions.active_fi
+                    WHERE tst_solutions.value2 != 'rid';"
+        );
+
+        $res = $db->fetchAssoc($res);
+
+        // read common data for all files of this question id
+        $user_id = (int) $res['user_id'];
+        $active_id = (int) $res['active_id'];
+        $test_id = (int) $res['test_id'];
+        $question_id = (int) $res['question_id'];
+        $filename = $res['filename'];
+        $revision_name = $res['revision_name'];
+        $solution_id = (int) $res['solution_id'];
+
+        // build path to file
+        $path = $this->buildAbsolutPath(
+            $test_id,
+            $active_id,
+            $question_id,
+            $filename
+        );
+
+        $rid = $this->helper->movePathToStorage(
+            $path,
+            $user_id,
+            null,
+            static function () use ($revision_name): string {
+                return $revision_name;
+            }
+        );
+        if ($rid === null) {
+            return; // no files found
+        }
+
+        // store the rid in as value1 and 'rid' as value2
+        $db->update(
+            'tst_solutions',
+            [
+                'value1' => ['string', $rid->serialize()],
+                'value2' => ['string', 'rid']
+            ],
+            [
+                'solution_id' => ['integer', $solution_id]
+            ]
+        );
+    }
+
+    public function getRemainingAmountOfSteps(): int
+    {
+        $database = $this->helper->getDatabase();
+        $res = $database->query(
+            "SELECT COUNT(*) as count
+FROM tst_solutions
+         INNER JOIN qpl_qst_fileupload ON qpl_qst_fileupload.question_fi = tst_solutions.question_fi
+         INNER JOIN tst_active ON tst_active.active_id =  tst_solutions.active_fi
+WHERE tst_solutions.value2 != 'rid';"
+        );
+
+        return (int) $database->fetchAssoc($res)['count'];
+    }
+
+    protected function buildAbsolutPath(
+        int $test_id,
+        int $active_id,
+        int $question_id,
+        string $filename
+    ): string {
+        return CLIENT_WEB_DIR
+            . '/assessment'
+            . '/tst_' . $test_id
+            . '/' . $active_id
+            . '/' . $question_id
+            . '/files/'
+            . $filename;
+    }
+
+}

--- a/Modules/TestQuestionPool/classes/Setup/class.ilTestQuestionPoolSetupAgent.php
+++ b/Modules/TestQuestionPool/classes/Setup/class.ilTestQuestionPoolSetupAgent.php
@@ -52,4 +52,12 @@ class ilTestQuestionPoolSetupAgent extends NullAgent
             )
         );
     }
+
+    public function getMigrations(): array
+    {
+        return [
+            new ilTestQuestionPoolFileUploadQuestionMigration()
+        ];
+    }
+
 }

--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -837,6 +837,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
         $test_id = $this->testParticipantInfo->lookupTestIdByActiveId($active_id);
         if ($test_id !== -1) {
+            // TODO: This can be removed with ILIAS 10
             $this->deleteUnusedFiles([], $test_id, $active_id, $pass);
         }
     }

--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -786,19 +786,17 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     protected function resolveRIDStoDelete(): array
     {
         $rids_to_delete = [];
-        if ($this->isFileDeletionAction()) {
-            if ($this->isFileDeletionSubmitAvailable()) {
-                $res = $this->db->query(
-                    "SELECT value1 FROM tst_solutions WHERE value2 = 'rid' AND " . $this->db->in(
-                        'solution_id',
-                        $_POST[self::DELETE_FILES_TBL_POSTVAR],
-                        false,
-                        'integer'
-                    )
-                );
-                while ($d = $this->db->fetchAssoc($res)) {
-                    $rids_to_delete[] = $d['value1'];
-                }
+        if ($this->isFileDeletionAction() && $this->isFileDeletionSubmitAvailable()) {
+            $res = $this->db->query(
+                "SELECT value1 FROM tst_solutions WHERE value2 = 'rid' AND " . $this->db->in(
+                    'solution_id',
+                    $_POST[self::DELETE_FILES_TBL_POSTVAR],
+                    false,
+                    'integer'
+                )
+            );
+            while ($d = $this->db->fetchAssoc($res)) {
+                $rids_to_delete[] = $d['value1'];
             }
         }
         return $rids_to_delete;

--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -1090,22 +1090,17 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
         $ilDB = $DIC['ilDB'];
         $lng = $DIC['lng'];
 
-        $exporter = new ilAssFileUploadUploadsExporter($ilDB, $lng);
+        $exporter = new ilAssFileUploadUploadsExporter(
+            $ilDB,
+            $lng,
+            $ref_id,
+            $test_id
+        );
 
-        $exporter->setRefId($ref_id);
-        $exporter->setTestId($test_id);
         $exporter->setTestTitle($test_title);
         $exporter->setQuestion($this);
 
-        $exporter->build();
-
-        ilFileDelivery::deliverFileLegacy(
-            $exporter->getFinalZipFilePath(),
-            $exporter->getDispoZipFileName(),
-            $exporter->getZipFileMimeType(),
-            false,
-            true
-        );
+        $exporter->buildAndDownload();
     }
 
     public function isCompletionBySubmissionEnabled(): bool

--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\FileDelivery\Delivery\Disposition;
+
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
 
 /**
@@ -37,6 +39,9 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     // hey.
 
     protected const HAS_SPECIFIC_FEEDBACK = false;
+    private \ILIAS\ResourceStorage\Services $irss;
+    private \ILIAS\FileDelivery\Services $file_delivery;
+    private \ILIAS\FileUpload\FileUpload $file_upload;
 
     protected ?int $maxsize = null;
 
@@ -66,6 +71,10 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
         $question = ''
     ) {
         parent::__construct($title, $comment, $author, $owner, $question);
+        global $DIC;
+        $this->irss = $DIC->resourceStorage();
+        $this->file_delivery = $DIC->fileDelivery();
+        $this->file_upload = $DIC->upload();
     }
 
     /**
@@ -349,78 +358,37 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     public function checkUpload(): bool
     {
         $this->lng->loadLanguageModule('form');
-        // remove trailing '/'
-        $_FILES['upload']['name'] = rtrim($_FILES['upload']['name'], '/');
 
-        $filename = $_FILES['upload']['name'];
-        $filename_arr = pathinfo($_FILES['upload']['name']);
-        $suffix = $filename_arr['extension'];
-        $mimetype = $_FILES['upload']['type'];
-        $size_bytes = $_FILES['upload']['size'];
-        $temp_name = $_FILES['upload']['tmp_name'];
-        $error = $_FILES['upload']['error'];
-
-        if ($size_bytes > $this->getMaxFilesizeInBytes()) {
-            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_size_exceeds'), true);
-            return false;
-        }
-
-        // error handling
-        if ($error > 0) {
-            switch ($error) {
-                case UPLOAD_ERR_FORM_SIZE:
-                case UPLOAD_ERR_INI_SIZE:
-                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_size_exceeds'), true);
-                    return false;
-                    break;
-
-                case UPLOAD_ERR_PARTIAL:
-                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_partially_uploaded'), true);
-                    return false;
-                    break;
-
-                case UPLOAD_ERR_NO_FILE:
-                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_no_upload'), true);
-                    return false;
-                    break;
-
-                case UPLOAD_ERR_NO_TMP_DIR:
-                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_missing_tmp_dir'), true);
-                    return false;
-                    break;
-
-                case UPLOAD_ERR_CANT_WRITE:
-                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_cannot_write_to_disk'), true);
-                    return false;
-                    break;
-
-                case UPLOAD_ERR_EXTENSION:
-                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_upload_stopped_ext'), true);
-                    return false;
-                    break;
-            }
-        }
-
-        // check suffixes
-        if (count($this->getAllowedExtensionsArray())) {
-            if (!strlen($suffix)) {
-                $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_missing_file_ext'), true);
+        foreach (
+            $this->file_upload->getResults() as $upload_result
+        ) { // only one supported at the moment, but we check all
+            if (!$upload_result->isOK()) {
                 return false;
             }
 
-            if (!in_array(strtolower($suffix), $this->getAllowedExtensionsArray())) {
-                $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_wrong_file_type'), true);
+            // check file size
+            $size_bytes = $upload_result->getSize();
+            if ($size_bytes > $this->getMaxFilesizeInBytes()) {
+                $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_size_exceeds'), true);
                 return false;
             }
-        }
 
-        // virus handling
-        if (strlen($temp_name)) {
-            $vir = ilVirusScanner::virusHandling($temp_name, $filename);
-            if ($vir[0] == false) {
-                $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_virus_found') . '<br />' . $vir[1], true);
-                return false;
+            // check suffixes
+            if (count($this->getAllowedExtensionsArray())) {
+                $filename_arr = pathinfo($upload_result->getName());
+                $suffix = $filename_arr['extension'];
+                $mimetype = $upload_result->getMimeType();
+                if ($suffix === '') {
+                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_missing_file_ext'), true);
+                    return false;
+                }
+
+                if (!in_array(strtolower($suffix), $this->getAllowedExtensionsArray(), true)) {
+                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_msg_file_wrong_file_type'), true);
+                    return false;
+                }
             }
+            // virus handling already done in upload-service
         }
         return true;
     }
@@ -524,21 +492,42 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     */
     public function getUploadedFilesForWeb($active_id, $pass): array
     {
-        global $DIC;
-        $ilDB = $DIC['ilDB'];
-
         $found = $this->getUploadedFiles($active_id, $pass);
-        $result = $ilDB->queryF(
+        $result = $this->db->queryF(
             'SELECT test_fi FROM tst_active WHERE active_id = %s',
             ['integer'],
             [$active_id]
         );
         if ($result->numRows() == 1) {
-            $row = $ilDB->fetchAssoc($result);
+            $row = $this->db->fetchAssoc($result);
             $test_id = $row['test_fi'];
             $path = $this->getFileUploadPathWeb($test_id, $active_id);
             foreach ($found as $idx => $data) {
-                $found[$idx]['webpath'] = $path;
+                // depending on whether the files are already stored in the IRSS or not, the files are compiled differently here.
+                // this can be removed with ILIAs 10 and switched exclusively to the IRSS variant.
+                // We recommend then to revise the whole handling of files
+
+                if ($data['value2'] === 'rid') {
+                    $rid = $this->irss->manage()->find($data['value1']);
+                    if($rid === null) {
+                        continue;
+                    }
+                    $revision = $this->irss->manage()->getCurrentRevision($rid);
+                    $stream = $this->irss->consume()->stream($rid)->getStream();
+                    $url = $this->file_delivery->buildTokenURL(
+                        $stream,
+                        $revision->getTitle(),
+                        Disposition::ATTACHMENT,
+                        $this->current_user->getId(),
+                        1
+                    );
+
+                    $path = (string) $url;
+                    $found[$idx]['webpath'] = $path;
+                    $found[$idx]['value2'] = $revision->getTitle();
+                } else {
+                    $found[$idx]['webpath'] = $path;
+                }
             }
         }
         return $found;
@@ -696,85 +685,87 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
         $test_id = $this->testParticipantInfo->lookupTestIdByActiveId($active_id);
 
         $upload_handling_required = $this->isFileUploadAvailable() && $this->checkUpload();
-        $upload_file_data = [];
+        $rid = null;
 
         if ($upload_handling_required) {
-            if (!@file_exists($this->getFileUploadPath($test_id, $active_id))) {
-                ilFileUtils::makeDirParents($this->getFileUploadPath($test_id, $active_id));
-            }
-
-            $upload_file_data ['solution_file_versioning_upload_ts'] = time();
-            $filename_arr = pathinfo($_FILES['upload']['name']);
-            $extension = $filename_arr['extension'];
-            $new_file_name = 'file_' . $active_id . '_' . $pass . '_'
-                . $upload_file_data ['solution_file_versioning_upload_ts'] . '.' . $extension;
-            $upload_file_data['new_file_name'] = ilFileUtils::getValidFilename($new_file_name);
-
-            ilFileUtils::moveUploadedFile(
-                $_FILES['upload']['tmp_name'],
-                $_FILES['upload']['name'],
-                $this->getFileUploadPath($test_id, $active_id) . $upload_file_data['new_file_name']
+            // upload new file to storage
+            $upload_results = $this->file_upload->getResults();
+            $upload_result = end($upload_results); // only one supported at the moment
+            $rid = $this->irss->manage()->upload(
+                $upload_result,
+                new assFileUploadStakeholder()
             );
         }
 
         $entered_values = false;
 
-        $this->getProcessLocker()->executeUserSolutionUpdateLockOperation(function () use (&$entered_values, $upload_handling_required, $upload_file_data, $test_id, $active_id, $pass, $authorized) {
-            if ($authorized == false) {
-                $this->forceExistingIntermediateSolution($active_id, $pass, true);
-            }
+        $this->getProcessLocker()->executeUserSolutionUpdateLockOperation(
+            function () use (
+                &$entered_values,
+                $upload_handling_required,
+                $test_id,
+                $active_id,
+                $pass,
+                $authorized,
+                $rid
+            ) {
+                if ($authorized === false) {
+                    $this->forceExistingIntermediateSolution($active_id, $pass, true);
+                }
 
-            if ($this->isFileDeletionAction()) {
-                if ($this->isFileDeletionSubmitAvailable()) {
-                    foreach ($_POST[self::DELETE_FILES_TBL_POSTVAR] as $solution_id) {
-                        $this->removeSolutionRecordById($solution_id);
+                if ($this->isFileDeletionAction()) {
+                    if ($this->isFileDeletionSubmitAvailable()) {
+                        foreach ($_POST[self::DELETE_FILES_TBL_POSTVAR] as $solution_id) {
+                            $this->removeSolutionRecordById($solution_id);
+                        }
+                    } else {
+                        $this->tpl->setOnScreenMessage('info', $this->lng->txt('no_checkbox'), true);
                     }
                 } else {
-                    $this->tpl->setOnScreenMessage('info', $this->lng->txt('no_checkbox'), true);
-                }
-            } else {
-                if ($this->isFileReuseHandlingRequired()) {
-                    foreach ($_POST[self::REUSE_FILES_TBL_POSTVAR] as $solutionId) {
-                        $solution = $this->getSolutionRecordById($solutionId);
+                    if ($this->isFileReuseHandlingRequired()) {
+                        foreach ($_POST[self::REUSE_FILES_TBL_POSTVAR] as $solutionId) { // FSX TODO test
+                            $solution = $this->getSolutionRecordById($solutionId);
+
+                            $this->saveCurrentSolution(
+                                $active_id,
+                                $pass,
+                                $solution['value1'],
+                                $solution['value2'],
+                                false,
+                                $solution['tstamp']
+                            );
+                        }
+                    }
+
+                    if ($upload_handling_required && $rid !== null) {
+
+                        $revision = $this->irss->manage()->getCurrentRevision($rid);
 
                         $this->saveCurrentSolution(
                             $active_id,
                             $pass,
-                            $solution['value1'],
-                            $solution['value2'],
+                            $rid->serialize(),
+                            'rid',
                             false,
-                            $solution['tstamp']
+                            time()
                         );
+
+                        $entered_values = true;
                     }
                 }
 
-                if ($upload_handling_required) {
-                    $dispoFilename = ilFileUtils::getValidFilename($_FILES['upload']['name']);
+                if ($authorized === true && $this->intermediateSolutionExists($active_id, $pass)) {
+                    // remove the dummy record of the intermediate solution
+                    $this->deleteDummySolutionRecord($active_id, $pass);
 
-                    $this->saveCurrentSolution(
-                        $active_id,
-                        $pass,
-                        $upload_file_data['new_file_name'],
-                        $dispoFilename,
-                        false,
-                        $upload_file_data ['solution_file_versioning_upload_ts']
-                    );
-
-                    $entered_values = true;
+                    // delete the authorized solution and make the intermediate solution authorized (keeping timestamps)
+                    $this->removeCurrentSolution($active_id, $pass, true);
+                    $this->updateCurrentSolutionsAuthorization($active_id, $pass, true, true);
                 }
+
+                $this->deleteUnusedFiles($test_id, $active_id, $pass); // FSX TODO: test
             }
-
-            if ($authorized == true && $this->intermediateSolutionExists($active_id, $pass)) {
-                // remove the dummy record of the intermediate solution
-                $this->deleteDummySolutionRecord($active_id, $pass);
-
-                // delete the authorized solution and make the intermediate solution authorized (keeping timestamps)
-                $this->removeCurrentSolution($active_id, $pass, true);
-                $this->updateCurrentSolutionsAuthorization($active_id, $pass, true, true);
-            }
-
-            $this->deleteUnusedFiles($test_id, $active_id, $pass);
-        });
+        );
 
         if ($entered_values) {
             if (ilObjAssessmentFolder::_enabledAssessmentLogging()) {
@@ -795,6 +786,29 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
         }
 
         return true;
+    }
+
+    protected function removeSolutionRecordById(int $solution_id): int
+    {
+        // Unfortunately, at the moment it is not possible to delete the files from the IRSS, because the process takes
+        // place within the ProcessLocker and the IRSS tables cannot be used.
+
+        // find corresponsing ResourceIdentification if available
+        /*
+        $result = $this->db->queryF(
+            "SELECT value1 FROM tst_solutions WHERE solution_id = %s AND value2 = %s",
+            ['integer', 'text'],
+            [$solution_id, 'rid']
+        );
+        if ($result->numRows() > 0) {
+            $rid = $this->irss->manage()->find($this->db->fetchAssoc($result)['value1']);
+            if ($rid !== null) {
+                $this->irss->manage()->remove($rid, new assFileUploadStakeholder());
+            }
+        }
+        */
+
+        return parent::removeSolutionRecordById($solution_id);
     }
 
     /**
@@ -1158,14 +1172,9 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
     protected function isFileUploadAvailable(): bool
     {
-        if (!isset($_FILES['upload'])) {
-            return false;
+        if (!$this->file_upload->hasBeenProcessed()) {
+            $this->file_upload->process();
         }
-
-        if (!isset($_FILES['upload']['tmp_name'])) {
-            return false;
-        }
-
-        return strlen($_FILES['upload']['tmp_name']) > 0;
+        return $this->file_upload->hasUploads();
     }
 }

--- a/Modules/TestQuestionPool/classes/class.assFileUploadStakeholder.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUploadStakeholder.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class assFileUploadStakeholder extends AbstractResourceStakeholder
+{
+    private int $current_user;
+
+    public function __construct()
+    {
+        global $DIC;
+        $anonymous = defined(
+            'ANONYMOUS_USER_ID'
+        ) ? ANONYMOUS_USER_ID : 13;
+        $this->current_user = (int) ($DIC->isDependencyAvailable('user') ? $DIC->user()->getId() : $anonymous);
+    }
+
+    public function getId(): string
+    {
+        return 'qpl_file_upload';
+    }
+
+    public function getOwnerOfNewResources(): int
+    {
+        return $this->current_user;
+    }
+
+}

--- a/Modules/TestQuestionPool/classes/tables/class.assFileUploadFileTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.assFileUploadFileTableGUI.php
@@ -24,10 +24,10 @@
 *
 * @ingroup ModulesGroup
 */
-
 class assFileUploadFileTableGUI extends ilTable2GUI
 {
     // hey: prevPassSolutions - support file reuse with table
+    private \ILIAS\ResourceStorage\Services $irss;
     protected $postVar = '';
     // hey.
 
@@ -39,6 +39,7 @@ class assFileUploadFileTableGUI extends ilTable2GUI
 
         $this->lng = $lng;
         $this->ctrl = $ilCtrl;
+        $this->irss = $DIC->resourceStorage();
 
         parent::__construct($a_parent_obj, $a_parent_cmd);
 
@@ -136,12 +137,21 @@ class assFileUploadFileTableGUI extends ilTable2GUI
      */
     protected function buildFileItemContent($a_set): string
     {
+        $value = $a_set['value2'];
+        if($value === 'rid') {
+            $rid = $this->irss->manage()->find($a_set['value1']);
+            if($rid === null) {
+                return ilLegacyFormElementsUtil::prepareFormOutput($value);
+            }
+            $value = $this->irss->manage()->getCurrentRevision($rid)->getTitle();
+        }
+
         if (!isset($a_set['webpath']) || !strlen($a_set['webpath'])) {
-            return ilLegacyFormElementsUtil::prepareFormOutput($a_set['value2']);
+            return ilLegacyFormElementsUtil::prepareFormOutput($value);
         }
 
         $link = "<a href='{$a_set['webpath']}{$a_set['value1']}' download target='_blank'>";
-        $link .= ilLegacyFormElementsUtil::prepareFormOutput($a_set['value2']) . '</a>';
+        $link .= ilLegacyFormElementsUtil::prepareFormOutput($value) . '</a>';
 
         return $link;
     }

--- a/Modules/TestQuestionPool/test/assBaseTestCase.php
+++ b/Modules/TestQuestionPool/test/assBaseTestCase.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\Factory as RefineryFactory;
 use ILIAS\Refinery\Random\Group as RandomGroup;
 use ILIAS\DI\Container;
+use ILIAS\ResourceStorage\Services;
 
 /**
  * Class assBaseTestCase
@@ -117,6 +118,14 @@ abstract class assBaseTestCase extends TestCase
     protected function getDatabaseMock()
     {
         return $this->getMockBuilder(\ilDBInterface::class)->disableOriginalConstructor()->getMock();
+    }
+    protected function getIRSSMock()
+    {
+        return $this->getMockBuilder(Services::class)->disableOriginalConstructor()->getMock();
+    }
+    protected function getFileDeliveryMock()
+    {
+        return $this->getMockBuilder(\ILIAS\FileDelivery\Services::class)->disableOriginalConstructor()->getMock();
     }
 
     protected function getIliasMock()

--- a/Modules/TestQuestionPool/test/assFileUploadGUITest.php
+++ b/Modules/TestQuestionPool/test/assFileUploadGUITest.php
@@ -50,6 +50,8 @@ class assFileUploadGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilias', $this->getIliasMock());
         $this->setGlobalVariable('tpl', $this->getGlobalTemplateMock());
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
+        $this->setGlobalVariable('resource_storage', $this->getIRSSMock());
+        $this->setGlobalVariable('file_delivery', $this->getFileDeliveryMock());
     }
 
     public function test_instantiateObject_shouldReturnInstance(): void

--- a/Modules/TestQuestionPool/test/assFileUploadTest.php
+++ b/Modules/TestQuestionPool/test/assFileUploadTest.php
@@ -48,6 +48,8 @@ class assFileUploadTest extends assBaseTestCase
         $this->setGlobalVariable('ilias', $this->getIliasMock());
         $this->setGlobalVariable('tpl', $this->getGlobalTemplateMock());
         $this->setGlobalVariable('ilDB', $this->getDatabaseMock());
+        $this->setGlobalVariable('resource_storage', $this->getIRSSMock());
+        $this->setGlobalVariable('file_delivery', $this->getFileDeliveryMock());
     }
 
     public function test_instantiateObject_shouldReturnInstance(): void


### PR DESCRIPTION
Hi @kergomard !

This PR introduces a migration for files in test questions of type "File Upload".

The PR is divided into the following commits:

- [Add new Stakeholder](https://github.com/ILIAS-eLearning/ILIAS/commit/984171fecca232cc92e98ce94d9f2275176fa05e)
- [Add migration](https://github.com/ILIAS-eLearning/ILIAS/commit/5918de38bfda5890ad9a123ff6830de4ee8fd342): The actual migration of the existing files. This is done using the table `tst_solutions`. Up to now the file name was stored in `value1` and the display name in `value2`. Now the `ResourceIdentification` is stored in `value1` and in `value2` the string `'rid'` to identify which datasets already use an IRSS storage.
- [Implemented Storage and Consumption of Files](https://github.com/ILIAS-eLearning/ILIAS/commit/6d67c868a86772b98f2fd38709018781c6a96c7a): This covers uploading new files and accessing existing files (old location and new in IRSS).
- [Download all submissions](https://github.com/ILIAS-eLearning/ILIAS/commit/f7f4a466df5d445d03a3979f028658f30f92e6d4): Here are still adjustments in downloading all submissions of a question.

[An open issue](https://github.com/ILIAS-eLearning/ILIAS/compare/trunk...srsolutionsag:ILIAS:feature/9/irss-upload-question?expand=1#diff-f8e6a091f181fe83c9f2a451b1f88787b3966704ebee2c9220cb3910939d5d2aR793) is currently known: Since the storage of the test submission takes place in an AtomQuery (ProcessLocker), no changes can be made to the IRSS, i.e. the files could not be effectively deleted. We can discuss the further procedure together.
