### PR TITLE
Taxonomy Settings: Remove Legacy Table, use Panels, Move Activation to Additional Feature Section

### DIFF
--- a/Modules/Category/classes/class.StandardGUIRequest.php
+++ b/Modules/Category/classes/class.StandardGUIRequest.php
@@ -87,4 +87,10 @@ class StandardGUIRequest
     {
         return $this->str("term");
     }
+
+    public function getTaxId(): int
+    {
+        return $this->int("cat_tax_id");
+    }
+
 }

--- a/Modules/Category/classes/class.ilObjCategoryGUI.php
+++ b/Modules/Category/classes/class.ilObjCategoryGUI.php
@@ -29,13 +29,14 @@ use ILIAS\Category\StandardGUIRequest;
  * @ilCtrl_Calls ilObjCategoryGUI: ilPermissionGUI, ilContainerPageGUI, ilObjUserGUI, ilObjUserFolderGUI
  * @ilCtrl_Calls ilObjCategoryGUI: ilInfoScreenGUI, ilObjStyleSheetGUI, ilCommonActionDispatcherGUI, ilObjectTranslationGUI, ilObjectContentStyleSettingsGUI
  * @ilCtrl_Calls ilObjCategoryGUI: ilColumnGUI, ilObjectCopyGUI, ilUserTableGUI, ilDidacticTemplateGUI, ilExportGUI
- * @ilCtrl_Calls ilObjCategoryGUI: ilObjTaxonomyGUI, ilObjectMetaDataGUI, ilContainerNewsSettingsGUI, ilContainerFilterAdminGUI
+ * @ilCtrl_Calls ilObjCategoryGUI: ilTaxonomySettingsGUI, ilObjectMetaDataGUI, ilContainerNewsSettingsGUI, ilContainerFilterAdminGUI
  * @ilCtrl_Calls ilObjCategoryGUI: ilRepositoryTrashGUI
  * @ingroup      ModulesCategory
  */
-class ilObjCategoryGUI extends ilContainerGUI
+class ilObjCategoryGUI extends ilContainerGUI implements \ILIAS\Taxonomy\Settings\ModifierGUIInterface
 {
     public const CONTAINER_SETTING_TAXBLOCK = "tax_sblock_";
+    protected \ILIAS\Taxonomy\Service $taxonomy;
 
     protected ilNavigationHistory $nav_history;
     protected ilHelpGUI $help;
@@ -81,12 +82,14 @@ class ilObjCategoryGUI extends ilContainerGUI
                 ilObjectServiceSettingsGUI::INFO_TAB_VISIBILITY,
                 '1'
             );
+
         }
         $this->cat_request = $DIC
             ->category()
             ->internal()
             ->gui()
             ->standardRequest();
+        $this->taxonomy = $DIC->taxonomy();
     }
 
     public function executeCommand(): void
@@ -243,15 +246,17 @@ class ilObjCategoryGUI extends ilContainerGUI
                 $this->ctrl->forwardCommand($transgui);
                 break;
 
-            case 'ilobjtaxonomygui':
+            case strtolower(ilTaxonomySettingsGUI::class):
                 $this->checkPermissionBool("write");
                 $this->prepareOutput();
-                $this->initTaxSubTabs();
-                $tax = new ilObjTaxonomyGUI();
-                $tax->setAssignedObject($this->object->getId());
-                $tax->setMultiple(true);
-                $tax->setListInfo($this->lng->txt("cntr_tax_list_info"));
-                $this->ctrl->forwardCommand($tax);
+                $this->setEditTabs("taxonomy");
+                $tax_gui = $this->taxonomy->gui()->getSettingsGUI(
+                    $this->object->getId(),
+                    $this->lng->txt("cntr_tax_settings_info"),
+                    true,
+                    $this
+                );
+                $this->ctrl->forwardCommand($tax_gui);
                 break;
 
             case 'ilobjectmetadatagui':
@@ -323,6 +328,7 @@ class ilObjCategoryGUI extends ilContainerGUI
     public function getObjectMetadataGUI(): ilObjectMetaDataGUI
     {
         $md_gui = new ilObjectMetaDataGUI($this->object);
+        /*
         if (ilContainer::_lookupContainerSetting(
             $this->object->getId(),
             ilObjectServiceSettingsGUI::TAXONOMIES,
@@ -389,9 +395,74 @@ class ilObjCategoryGUI extends ilContainerGUI
                     }
                 });
             }
-        }
+        }*/
         return $md_gui;
     }
+
+    protected function showTaxAsSideBlockObject(): void
+    {
+        $prefix = self::CONTAINER_SETTING_TAXBLOCK;
+        $tax_id = $this->cat_request->getTaxId();
+        ilContainer::_writeContainerSetting(
+            $this->object->getId(),
+            $prefix . $tax_id,
+            '1'
+        );
+        $this->ctrl->redirectByClass(ilTaxonomySettingsGUI::class, "");
+    }
+
+    protected function hideTaxAsSideBlockObject(): void
+    {
+        $prefix = self::CONTAINER_SETTING_TAXBLOCK;
+        $tax_id = $this->cat_request->getTaxId();
+        ilContainer::_deleteContainerSettings(
+            $this->object->getId(),
+            $prefix . $tax_id
+        );
+        $this->ctrl->redirectByClass(ilTaxonomySettingsGUI::class, "");
+    }
+
+    public function getProperties(
+        int $tax_id
+    ): array {
+        $active = in_array($tax_id, $this->getActiveBlocks());
+        $value = $active
+            ? $this->lng->txt("yes")
+            : $this->lng->txt("no");
+
+        return [
+            $this->lng->txt("cntr_taxonomy_show_sideblock") => $value
+        ];
+    }
+
+    public function getActions(
+        int $tax_id
+    ): array {
+        $actions = [];
+        $this->ctrl->setParameterByClass(self::class, "cat_tax_id", $tax_id);
+        $active = in_array($tax_id, $this->getActiveBlocks());
+        if (!$active) {
+            $actions[] = $this->ui->factory()->button()->shy(
+                $this->lng->txt("cat_show_tax_in_side_block"),
+                $this->ctrl->getLinkTargetByClass(
+                    self::class,
+                    "showTaxAsSideBlock"
+                )
+            );
+        } else {
+            $actions[] = $this->ui->factory()->button()->shy(
+                $this->lng->txt("cat_hide_tax_in_side_block"),
+                $this->ctrl->getLinkTargetByClass(
+                    self::class,
+                    "hideTaxAsSideBlock"
+                )
+            );
+        }
+        $this->ctrl->setParameterByClass(self::class, "cat_tax_id", null);
+
+        return $actions;
+    }
+
 
     protected function getTabs(): void
     {
@@ -447,13 +518,13 @@ class ilObjCategoryGUI extends ilContainerGUI
 
             // metadata / taxonomies
             $mdgui = new ilObjectMetaDataGUI($this->object);
-            if (ilContainer::_lookupContainerSetting(
+            /*if (ilContainer::_lookupContainerSetting(
                 $this->object->getId(),
                 ilObjectServiceSettingsGUI::TAXONOMIES,
                 '0'
             )) {
                 $mdgui->enableTaxonomyDefinition(true);
-            }
+            }*/
             $mdtab = $mdgui->getTab();
             if ($mdtab) {
                 $this->tabs_gui->addTab(
@@ -697,6 +768,10 @@ class ilObjCategoryGUI extends ilContainerGUI
             $this->lng->txt("cont_filter"),
             $this->ctrl->getLinkTargetByClass("ilcontainerfilteradmingui", "")
         );
+
+        if ($obj = $this->getObject()) {
+            $this->taxonomy->gui()->addSettingsSubTab($obj->getId());
+        }
 
         $this->tabs_gui->activateTab("settings");
         $this->tabs_gui->activateSubTab($active_tab);

--- a/Modules/Glossary/Presentation/class.ilGlossaryPresentationGUI.php
+++ b/Modules/Glossary/Presentation/class.ilGlossaryPresentationGUI.php
@@ -26,6 +26,9 @@ use ILIAS\Glossary\Presentation;
 class ilGlossaryPresentationGUI implements ilCtrlBaseClassInterface
 {
     protected \ILIAS\COPage\Xsl\XslManager $xsl;
+    protected \ILIAS\GlobalScreen\Services $global_screen;
+    protected \ILIAS\Glossary\InternalGUIService $gui;
+    protected \ILIAS\Glossary\InternalDomainService $domain;
     protected array $mobs;
     protected bool $fill_on_load_code;
     protected string $offline_dir;
@@ -67,28 +70,36 @@ class ilGlossaryPresentationGUI implements ilCtrlBaseClassInterface
     ) {
         global $DIC;
 
+        $service = $DIC->glossary()->internal();
+
+        $this->domain = $domain = $service->domain();
+        $this->gui = $gui = $service->gui();
+
+        $this->access = $DIC->access();
+        $this->user = $domain->user();
+        $this->lng = $DIC->language();
+
+        $this->toolbar = $gui->toolbar();
+        $this->help = $gui->help();
+        $this->nav_history = $DIC["ilNavigationHistory"];
+        $this->tpl = $gui->ui()->mainTemplate();
+        $this->ctrl = $gui->ctrl();
+        $this->tabs_gui = $gui->tabs();
+        $this->global_screen = $gui->globalScreen();
+
         $this->export_format = $export_format;
         $this->setOfflineDirectory($export_dir);
         $this->offline = ($export_format != "");
-        $this->access = $DIC->access();
-        $this->nav_history = $DIC["ilNavigationHistory"];
-        $this->toolbar = $DIC->toolbar();
-        $this->user = $DIC->user();
-        $this->help = $DIC["ilHelp"];
-        $this->lng = $DIC->language();
-        $this->tpl = $DIC->ui()->mainTemplate();
-        $this->ctrl = $DIC->ctrl();
-        $this->tabs_gui = $DIC->tabs();
         $this->ui_fac = $DIC->ui()->factory();
         $this->ui_ren = $DIC->ui()->renderer();
+        $this->offline = ($export_format !== "");
 
         $this->ctrl->saveParameter($this, array("ref_id", "letter", "tax_node"));
-        $this->service = $DIC->glossary()
-                       ->internal();
         $this->content_style_service =
             $DIC->contentStyle();
         $this->initByRequest();
         $this->xsl = $DIC->copage()->internal()->domain()->xsl();
+        $this->tax_manager = $domain->taxonomy($this->glossary);
     }
 
     /**
@@ -100,15 +111,13 @@ class ilGlossaryPresentationGUI implements ilCtrlBaseClassInterface
      */
     public function initByRequest(?array $query_params = null): void
     {
-        $service = $this->service;
-        $request = $service
-            ->gui()
+        $request = $this->gui
             ->presentation()
             ->request($query_params);
 
         $this->requested_ref_id = $request->getRefId();
         $this->term_id = $request->getTermId();
-        $this->glossary_gui = $service->gui()->presentation()->ObjGlossaryGUI($this->requested_ref_id);
+        $this->glossary_gui = $this->gui->presentation()->ObjGlossaryGUI($this->requested_ref_id);
         $this->glossary = $this->glossary_gui->getGlossary();
         $this->requested_def_page_id = $request->getDefinitionPageId();
         $this->requested_search_str = $request->getSearchString();
@@ -1179,52 +1188,36 @@ class ilGlossaryPresentationGUI implements ilCtrlBaseClassInterface
 
     public function showTaxonomy(): void
     {
-        global $DIC;
         $ctrl = $this->ctrl;
-        if (!$this->offlineMode() && $this->glossary->getShowTaxonomy()) {
-            $tax_ids = ilObjTaxonomy::getUsageOfObject($this->glossary->getId());
-            if (count($tax_ids) > 0) {
-                $tax_id = $tax_ids[0];
-                $DIC->globalScreen()->tool()->context()->current()
-                    ->addAdditionalData(
-                        ilTaxonomyGSToolProvider::SHOW_TAX_TREE,
-                        true
-                    );
-                $DIC->globalScreen()->tool()->context()->current()
-                    ->addAdditionalData(
-                        ilTaxonomyGSToolProvider::TAX_TREE_GUI_PATH,
-                        [self::class]
-                    );
-                $DIC->globalScreen()->tool()->context()->current()
-                    ->addAdditionalData(
-                        ilTaxonomyGSToolProvider::TAX_ID,
-                        $tax_id
-                    );
-                $DIC->globalScreen()->tool()->context()->current()
-                    ->addAdditionalData(
-                        ilTaxonomyGSToolProvider::TAX_TREE_CMD,
-                        "listTerms"
-                    );
-                $DIC->globalScreen()->tool()->context()->current()
-                    ->addAdditionalData(
-                        ilTaxonomyGSToolProvider::TAX_TREE_PARENT_CMD,
-                        "showTaxonomy"
-                    );
 
-                $tax_exp = new ilTaxonomyExplorerGUI(
-                    get_class($this),
-                    "showTaxonomy",
-                    $tax_id,
-                    "ilglossarypresentationgui",
-                    "listTerms"
-                );
-                /*
-                if (!$tax_exp->handleCommand()) {
-                    //$tpl->setLeftNavContent($tax_exp->getHTML());
-                    //$tpl->setLeftContent($tax_exp->getHTML()."&nbsp;");
-                }*/
-            }
+        if ($this->offlineMode() || !$this->tax_manager->showInPresentation()) {
+            return;
         }
+
+        $tax_id = $this->tax_manager->getTaxonomyId();
+
+        $tool_context = $this->global_screen->tool()->context()->current();
+
+        $tool_context->addAdditionalData(
+            ilTaxonomyGSToolProvider::SHOW_TAX_TREE,
+            true
+        );
+        $tool_context->addAdditionalData(
+            ilTaxonomyGSToolProvider::TAX_TREE_GUI_PATH,
+            [self::class]
+        );
+        $tool_context->addAdditionalData(
+            ilTaxonomyGSToolProvider::TAX_ID,
+            $tax_id
+        );
+        $tool_context->addAdditionalData(
+            ilTaxonomyGSToolProvider::TAX_TREE_CMD,
+            "listTerms"
+        );
+        $tool_context->addAdditionalData(
+            ilTaxonomyGSToolProvider::TAX_TREE_PARENT_CMD,
+            "showTaxonomy"
+        );
     }
 
     public function showFlashcards(): void

--- a/Modules/Glossary/Service/class.InternalDomainService.php
+++ b/Modules/Glossary/Service/class.InternalDomainService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\Glossary;
 
 use ILIAS\DI\Container;
@@ -26,6 +26,7 @@ use ILIAS\Glossary\Flashcard\FlashcardManager;
 use ILIAS\Repository\GlobalDICDomainServices;
 use ILIAS\Glossary\Flashcard\FlashcardShuffleManager;
 use ILIAS\Glossary\Presentation\PresentationManager;
+use ILIAS\Glossary\Taxonomy\TaxonomyManager;
 
 /**
  * @author Alexander Killing <killing@leifos.de>
@@ -47,16 +48,10 @@ class InternalDomainService
         $this->initDomainServices($DIC);
     }
 
-    /*
-    public function access(int $ref_id, int $user_id) : Access\AccessManager
+    public function log(): \ilLogger
     {
-        return new Access\AccessManager(
-            $this,
-            $this->access,
-            $ref_id,
-            $user_id
-        );
-    }*/
+        return $this->logger()->glo();
+    }
 
     public function term(\ilObjGlossary $glossary, int $user_id = 0): TermManager
     {
@@ -99,6 +94,14 @@ class InternalDomainService
             $this->repo_service->presentationSession(),
             $glossary,
             $user_id
+        );
+    }
+
+    public function taxonomy(\ilObjGlossary $glossary): TaxonomyManager
+    {
+        return new TaxonomyManager(
+            $this->DIC->taxonomy()->domain(),
+            $glossary
         );
     }
 }

--- a/Modules/Glossary/Taxonomy/TaxonomyManager.php
+++ b/Modules/Glossary/Taxonomy/TaxonomyManager.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Glossary\Taxonomy;
+
+use ILIAS\Taxonomy\DomainService;
+
+class TaxonomyManager
+{
+    protected \ilObjGlossary $glossary;
+
+    public function __construct(
+        DomainService $tax_domain,
+        \ilObjGlossary $glossary
+    ) {
+        $this->glossary = $glossary;
+        $this->tax_domain = $tax_domain;
+    }
+
+    public function showInEditing(): bool
+    {
+        if (!$this->tax_domain->isActivated($this->glossary->getId())) {
+            return false;
+        }
+        $usage = $this->tax_domain->getUsageOfObject($this->glossary->getId());
+        return count($usage) === 1;
+    }
+    public function showInPresentation(): bool
+    {
+        return $this->showInEditing() && $this->glossary->getShowTaxonomy();
+    }
+
+    public function getTaxonomyId(): int
+    {
+        $usage = $this->tax_domain->getUsageOfObject($this->glossary->getId());
+        if (count($usage) === 1) {
+            return (int) current($usage);
+        }
+        return 0;
+    }
+}

--- a/Modules/Glossary/classes/class.ilObjGlossaryGUI.php
+++ b/Modules/Glossary/classes/class.ilObjGlossaryGUI.php
@@ -21,12 +21,17 @@
  * @author Alexander Killing <killing@leifos.de>
  * @ilCtrl_Calls ilObjGlossaryGUI: ilGlossaryTermGUI, ilMDEditorGUI, ilPermissionGUI
  * @ilCtrl_Calls ilObjGlossaryGUI: ilInfoScreenGUI, ilCommonActionDispatcherGUI, ilObjectContentStyleSettingsGUI
- * @ilCtrl_Calls ilObjGlossaryGUI: ilObjTaxonomyGUI, ilExportGUI, ilObjectCopyGUI
+ * @ilCtrl_Calls ilObjGlossaryGUI: ilTaxonomySettingsGUI, ilExportGUI, ilObjectCopyGUI
  * @ilCtrl_Calls ilObjGlossaryGUI: ilObjectMetaDataGUI, ilGlossaryForeignTermCollectorGUI
  * @ilCtrl_Calls ilObjGlossaryGUI: ilTermDefinitionBulkCreationGUI
  */
-class ilObjGlossaryGUI extends ilObjectGUI
+class ilObjGlossaryGUI extends ilObjectGUI implements \ILIAS\Taxonomy\Settings\ModifierGUIInterface
 {
+    protected ?\ILIAS\Glossary\Taxonomy\TaxonomyManager $tax_manager = null;
+    protected \ILIAS\Glossary\InternalDomainService $domain;
+    protected \ILIAS\Glossary\InternalGUIService $gui;
+    protected \ILIAS\DI\UIServices $ui;
+    protected \ILIAS\Taxonomy\Service $taxonomy;
     protected ilRbacSystem $rbacsystem;
     protected ilPropertyFormGUI $form;
     protected int $tax_node = 0;
@@ -58,30 +63,28 @@ class ilObjGlossaryGUI extends ilObjectGUI
     ) {
         global $DIC;
 
-        $this->ctrl = $DIC->ctrl();
-        $this->lng = $DIC->language();
-        $this->user = $DIC->user();
-        $this->toolbar = $DIC->toolbar();
-        $this->tabs = $DIC->tabs();
-        $this->setting = $DIC["ilSetting"];
-        $this->access = $DIC->access();
-        $this->rbacsystem = $DIC->rbac()->system();
-        $this->help = $DIC["ilHelp"];
-        $this->ui_fac = $DIC->ui()->factory();
-        $this->ui_ren = $DIC->ui()->renderer();
+        $service = $DIC->glossary()->internal();
+        $this->gui = $gui = $service->gui();
+        $this->domain = $domain = $service->domain();
 
-        $this->gui_presentation_service = $DIC->glossary()
-            ->internal()
-            ->gui()
-            ->presentation();
-        $this->edit_request = $DIC->glossary()
-            ->internal()
-            ->gui()
-            ->editing()
-            ->request();
+        $this->lng = $domain->lng();
+        $this->user = $domain->user();
+        $this->setting = $domain->settings();
+        $this->access = $domain->access();
+        $this->rbacsystem = $domain->rbac()->system();
+        $this->log = $domain->log();
 
-        $this->log = ilLoggerFactory::getLogger('glo');
+        $this->ctrl = $gui->ctrl();
+        $this->toolbar = $gui->toolbar();
+        $this->tabs = $gui->tabs();
+        $this->help = $gui->help();
+        $this->ui = $gui->ui();
+        $this->ui_fac = $gui->ui()->factory();
+        $this->ui_ren = $gui->ui()->renderer();
+        $this->global_screen = $gui->globalScreen();
+        $this->gui_presentation_service = $gui->presentation();
 
+        $this->edit_request = $gui->editing()->request();
         $this->term_perm = ilGlossaryTermPermission::getInstance();
 
         $this->ctrl->saveParameter($this, array("ref_id"));
@@ -112,13 +115,13 @@ class ilObjGlossaryGUI extends ilObjectGUI
         }
 
         if ($this->getGlossary()) {
-            $this->term_manager = $DIC->glossary()
-                  ->internal()
-                  ->domain()
-                  ->term(
-                      $this->getGlossary(),
-                      $this->user->getId()
-                  );
+            $this->term_manager = $domain->term(
+                $this->getGlossary(),
+                $this->user->getId()
+            );
+            $this->tax_manager = $domain->taxonomy(
+                $this->getGlossary()
+            );
         }
 
         $this->term_def_bulk_gui = $this->gui_presentation_service
@@ -130,6 +133,7 @@ class ilObjGlossaryGUI extends ilObjectGUI
         $this->content_style_gui = $cs->gui();
         if (is_object($this->object)) {
             $this->content_style_domain = $cs->domain()->styleForRefId($this->object->getRefId());
+            $this->taxonomy = $DIC->taxonomy();
         }
     }
 
@@ -206,7 +210,7 @@ class ilObjGlossaryGUI extends ilObjectGUI
                 $this->ctrl->forwardCommand($gui);
                 break;
 
-            case "ilobjtaxonomygui":
+            case strtolower(ilTaxonomySettingsGUI::class):
                 $this->getTemplate();
                 $this->setTabs();
                 $this->setLocator();
@@ -215,10 +219,12 @@ class ilObjGlossaryGUI extends ilObjectGUI
                 $this->setSettingsSubTabs("taxonomy");
 
                 $this->ctrl->setReturn($this, "properties");
-                $tax_gui = new ilObjTaxonomyGUI();
-                $tax_gui->setMultiple(false);
-
-                $tax_gui->setAssignedObject($this->object->getId());
+                $tax_gui = $this->taxonomy->gui()->getSettingsGUI(
+                    $this->object->getId(),
+                    $this->lng->txt("glo_tax_info"),
+                    false,
+                    $this
+                );
                 $ret = $this->ctrl->forwardCommand($tax_gui);
                 break;
 
@@ -606,9 +612,6 @@ class ilObjGlossaryGUI extends ilObjectGUI
             $glo_mode->setValue($mode1);
             $pres_mode->setValue($this->object->getPresentationMode());
             $snl->setValue($this->object->getSnippetLength());
-            if (count($tax_ids) > 0) {
-                $show_tax->setChecked($this->object->getShowTaxonomy());
-            }
 
             $down->setChecked($this->object->isActiveDownloads());
             $flash_active->setChecked($this->object->isActiveFlashcards());
@@ -623,7 +626,8 @@ class ilObjGlossaryGUI extends ilObjectGUI
                 $this->object->getId(),
                 $this->form,
                 array(
-                        ilObjectServiceSettingsGUI::CUSTOM_METADATA
+                        ilObjectServiceSettingsGUI::CUSTOM_METADATA,
+                        ilObjectServiceSettingsGUI::TAXONOMIES
                     )
             );
         }
@@ -660,7 +664,6 @@ class ilObjGlossaryGUI extends ilObjectGUI
             $this->object->setActiveDownloads(ilUtil::yn2tf($this->form->getInput("glo_act_downloads")));
             $this->object->setPresentationMode($this->form->getInput("pres_mode"));
             $this->object->setSnippetLength($this->form->getInput("snippet_length"));
-            $this->object->setShowTaxonomy($this->form->getInput("show_tax"));
             $this->object->setActiveFlashcards(ilUtil::yn2tf($this->form->getInput("flash_active")));
             $this->object->setFlashcardsMode($this->form->getInput("flash_mode"));
             $this->object->update();
@@ -682,7 +685,8 @@ class ilObjGlossaryGUI extends ilObjectGUI
                 $this->object->getId(),
                 $this->form,
                 array(
-                    ilObjectServiceSettingsGUI::CUSTOM_METADATA
+                    ilObjectServiceSettingsGUI::CUSTOM_METADATA,
+                    ilObjectServiceSettingsGUI::TAXONOMIES
                 )
             );
 
@@ -695,6 +699,61 @@ class ilObjGlossaryGUI extends ilObjectGUI
         }
         $this->form->setValuesByPost();
         $this->tpl->setContent($this->form->getHTML());
+    }
+
+    public function getProperties(
+        int $tax_id
+    ): array {
+        $active = $this->object->getShowTaxonomy();
+        $value = $active
+            ? $this->lng->txt("yes")
+            : $this->lng->txt("no");
+
+        return [
+            $this->lng->txt("glo_show_in_presentation") => $value
+        ];
+    }
+
+    public function getActions(
+        int $tax_id
+    ): array {
+        $actions = [];
+        $this->ctrl->setParameterByClass(self::class, "glo_tax_id", $tax_id);
+        $active = $this->object->getShowTaxonomy();
+        if (!$active) {
+            $actions[] = $this->ui->factory()->button()->shy(
+                $this->lng->txt("glo_show_in_presentation_on"),
+                $this->ctrl->getLinkTargetByClass(
+                    self::class,
+                    "showTaxInPresentation"
+                )
+            );
+        } else {
+            $actions[] = $this->ui->factory()->button()->shy(
+                $this->lng->txt("glo_show_in_presentation_off"),
+                $this->ctrl->getLinkTargetByClass(
+                    self::class,
+                    "hideTaxInPresentation"
+                )
+            );
+        }
+        $this->ctrl->setParameterByClass(self::class, "glo_tax_id", null);
+
+        return $actions;
+    }
+
+    protected function showTaxInPresentation(): void
+    {
+        $this->object->setShowTaxonomy(true);
+        $this->object->update();
+        $this->ctrl->redirectByClass(ilTaxonomySettingsGUI::class);
+    }
+
+    protected function hideTaxInPresentation(): void
+    {
+        $this->object->setShowTaxonomy(false);
+        $this->object->update();
+        $this->ctrl->redirectByClass(ilTaxonomySettingsGUI::class);
     }
 
     public function listTerms(): void
@@ -1183,13 +1242,7 @@ class ilObjGlossaryGUI extends ilObjectGUI
                 $this->ctrl->getLinkTargetByClass("ilobjectcontentstylesettingsgui", '')
             );
 
-            // taxonomy
-            ilObjTaxonomy::loadLanguageModule();
-            $this->tabs->addSubTab(
-                "taxonomy",
-                $this->lng->txt("tax_taxonomy"),
-                $this->ctrl->getLinkTargetByClass("ilobjtaxonomygui", '')
-            );
+            $this->taxonomy->gui()->addSettingsSubTab($this->getObject()->getId());
 
             // style properties
             $this->tabs->addSubTab(
@@ -1281,52 +1334,36 @@ class ilObjGlossaryGUI extends ilObjectGUI
      */
     public function showTaxonomy(): void
     {
-        global $DIC;
+        $ctrl = $this->ctrl;
 
-        $ctrl = $DIC->ctrl();
-
-        $tax_ids = ilObjTaxonomy::getUsageOfObject($this->object->getId());
-        if (count($tax_ids) > 0) {
-            $tax_id = $tax_ids[0];
-            $DIC->globalScreen()->tool()->context()->current()
-                ->addAdditionalData(
-                    ilTaxonomyGSToolProvider::SHOW_TAX_TREE,
-                    true
-                );
-            $DIC->globalScreen()->tool()->context()->current()
-                ->addAdditionalData(
-                    ilTaxonomyGSToolProvider::TAX_TREE_GUI_PATH,
-                    $ctrl->getCurrentClassPath()
-                );
-            $DIC->globalScreen()->tool()->context()->current()
-                ->addAdditionalData(
-                    ilTaxonomyGSToolProvider::TAX_ID,
-                    $tax_id
-                );
-            $DIC->globalScreen()->tool()->context()->current()
-                ->addAdditionalData(
-                    ilTaxonomyGSToolProvider::TAX_TREE_CMD,
-                    "listTerms"
-                );
-            $DIC->globalScreen()->tool()->context()->current()
-                ->addAdditionalData(
-                    ilTaxonomyGSToolProvider::TAX_TREE_PARENT_CMD,
-                    "showTaxonomy"
-                );
-
-
-            $tax_exp = new ilTaxonomyExplorerGUI(
-                get_class($this),
-                "showTaxonomy",
-                $tax_ids[0],
-                "ilobjglossarygui",
-                "listTerms"
-            );
-            if (!$tax_exp->handleCommand()) {
-                //$this->tpl->setLeftNavContent($tax_exp->getHTML());
-                //$this->tpl->setLeftNavContent($tax_exp->getHTML() . "&nbsp;");
-            }
+        if (is_null($this->tax_manager) || !$this->tax_manager->showInEditing()) {
+            return;
         }
+
+        $tool_context = $this->global_screen->tool()->context()->current();
+
+        $tax_id = $this->tax_manager->getTaxonomyId();
+
+        $tool_context->addAdditionalData(
+            ilTaxonomyGSToolProvider::SHOW_TAX_TREE,
+            true
+        );
+        $tool_context->addAdditionalData(
+            ilTaxonomyGSToolProvider::TAX_TREE_GUI_PATH,
+            $ctrl->getCurrentClassPath()
+        );
+        $tool_context->addAdditionalData(
+            ilTaxonomyGSToolProvider::TAX_ID,
+            $tax_id
+        );
+        $tool_context->addAdditionalData(
+            ilTaxonomyGSToolProvider::TAX_TREE_CMD,
+            "listTerms"
+        );
+        $tool_context->addAdditionalData(
+            ilTaxonomyGSToolProvider::TAX_TREE_PARENT_CMD,
+            "showTaxonomy"
+        );
     }
 
     //

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -34,7 +34,7 @@ use ILIAS\DI\RBACServices;
  * @ilCtrl_Calls ilObjQuestionPoolGUI: assOrderingQuestionGUI, assImagemapQuestionGUI
  * @ilCtrl_Calls ilObjQuestionPoolGUI: assNumericGUI, assTextSubsetGUI, assSingleChoiceGUI, ilPropertyFormGUI
  * @ilCtrl_Calls ilObjQuestionPoolGUI: assTextQuestionGUI, ilObjectMetaDataGUI, ilPermissionGUI, ilObjectCopyGUI
- * @ilCtrl_Calls ilObjQuestionPoolGUI: ilQuestionPoolExportGUI, ilInfoScreenGUI, ilObjTaxonomyGUI, ilCommonActionDispatcherGUI
+ * @ilCtrl_Calls ilObjQuestionPoolGUI: ilQuestionPoolExportGUI, ilInfoScreenGUI, ilTaxonomySettingsGUI, ilCommonActionDispatcherGUI
  * @ilCtrl_Calls ilObjQuestionPoolGUI: ilAssQuestionHintsGUI, ilAssQuestionFeedbackEditingGUI, ilLocalUnitConfigurationGUI
  * @ilCtrl_Calls ilObjQuestionPoolGUI: ilObjQuestionPoolSettingsGeneralGUI, assFormulaQuestionGUI
  * @ilCtrl_Calls ilObjQuestionPoolGUI: ilAssQuestionPreviewGUI
@@ -48,6 +48,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 {
     protected \ILIAS\DI\UIServices $ui;
     private \ILIAS\TestQuestionPool\QuestionInfoService $questioninfo;
+    protected \ILIAS\Taxonomy\Service $taxonomy;
     public ?ilObject $object;
     protected ILIAS\TestQuestionPool\InternalRequestService $qplrequest;
     protected ilDBInterface $db;
@@ -84,6 +85,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->ctrl->saveParameterByClass('ilAssQuestionPageGUI', 'consumer_context');
         $this->ctrl->saveParameterByClass('ilobjquestionpoolgui', 'calling_consumer');
         $this->ctrl->saveParameterByClass('ilobjquestionpoolgui', 'consumer_context');
+        $this->taxonomy = $DIC->taxonomy();
 
         $this->lng->loadLanguageModule('assessment');
     }
@@ -373,7 +375,9 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 $this->ctrl->forwardCommand($gui);
                 break;
 
-            case 'ilobjtaxonomygui':
+            case strtolower(ilTaxonomySettingsGUI::class):
+
+                /** @var ilObjQuestionPool $obj */
                 $obj = $this->object;
                 $forwarder = new ilObjQuestionPoolTaxonomyEditingCommandForwarder(
                     $obj,
@@ -381,7 +385,8 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                     $component_repository,
                     $ilCtrl,
                     $ilTabs,
-                    $lng
+                    $lng,
+                    $this->taxonomy
                 );
 
                 $forwarder->forward();
@@ -1425,7 +1430,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             case 'ilquestionpoolskilladministrationgui':
                 break;
 
-            case 'ilobjtaxonomygui':
+            case strtolower(ilTaxonomySettingsGUI::class):
             case 'ilobjquestionpoolsettingsgeneralgui':
 
                 if ($currentUserHasWriteAccess) {
@@ -1579,12 +1584,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             'ilObjQuestionPoolSettingsGeneralGUI'
         );
 
-        $tabs->addSubTabTarget(
-            'qpl_settings_subtab_taxonomies',
-            $this->ctrl->getLinkTargetByClass('ilObjTaxonomyGUI', 'editAOTaxonomySettings'),
-            '',
-            'ilObjTaxonomyGUI'
-        );
+        $this->taxonomy->gui()->addSettingsSubTab($this->getObject()->getId());
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -75,6 +75,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->ui = $DIC->ui();
         $this->questioninfo = $DIC->testQuestionPool()->questionInfo();
         $this->qplrequest = $DIC->testQuestionPool()->internal()->request();
+        $this->taxonomy = $DIC->taxonomy();
         parent::__construct('', $this->qplrequest->raw('ref_id'), true, false);
 
         $this->ctrl->saveParameter($this, [
@@ -85,7 +86,6 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->ctrl->saveParameterByClass('ilAssQuestionPageGUI', 'consumer_context');
         $this->ctrl->saveParameterByClass('ilobjquestionpoolgui', 'calling_consumer');
         $this->ctrl->saveParameterByClass('ilobjquestionpoolgui', 'consumer_context');
-        $this->taxonomy = $DIC->taxonomy();
 
         $this->lng->loadLanguageModule('assessment');
     }

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -1585,7 +1585,14 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             'ilObjQuestionPoolSettingsGeneralGUI'
         );
 
-        $this->taxonomy->gui()->addSettingsSubTab($this->getObject()->getId());
+        if ($this->object->getShowTaxonomies()) {
+            $tabs->addSubTabTarget(
+                'qpl_settings_subtab_taxonomies',
+                $this->ctrl->getLinkTargetByClass('ilTaxonomySettingsGUI', ''),
+                '',
+                'ilTaxonomySettingsGUI'
+            );
+        }
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -20,6 +20,7 @@ require_once './Modules/Test/classes/inc.AssessmentConstants.php';
 
 use ILIAS\Refinery\Random\Group as RandomGroup;
 use ILIAS\DI\RBACServices;
+use ILIAS\Taxonomy\Service;
 
 /**
  * Class ilObjQuestionPoolGUI
@@ -48,7 +49,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 {
     protected \ILIAS\DI\UIServices $ui;
     private \ILIAS\TestQuestionPool\QuestionInfoService $questioninfo;
-    protected \ILIAS\Taxonomy\Service $taxonomy;
+    protected Service $taxonomy;
     public ?ilObject $object;
     protected ILIAS\TestQuestionPool\InternalRequestService $qplrequest;
     protected ilDBInterface $db;

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
@@ -202,6 +202,14 @@ class ilObjQuestionPoolSettingsGeneralGUI
             $this->poolOBJ->setSkillServiceEnabled($skillService->getChecked());
         }
 
+        ilObjectServiceSettingsGUI::updateServiceSettingsForm(
+            $this->poolOBJ->getId(),
+            $form,
+            array(
+                ilObjectServiceSettingsGUI::TAXONOMIES
+            )
+        );
+
         $this->poolOBJ->saveToDb();
     }
 
@@ -266,6 +274,19 @@ class ilObjQuestionPoolSettingsGeneralGUI
             $skillService->setChecked($this->poolOBJ->isSkillServiceEnabled());
             $form->addItem($skillService);
         }
+
+        // additional features
+        $feat = new ilFormSectionHeaderGUI();
+        $feat->setTitle($this->lng->txt('obj_features'));
+        $form->addItem($feat);
+
+        ilObjectServiceSettingsGUI::initServiceSettingsForm(
+            $this->poolOBJ->getId(),
+            $form,
+            array(
+                ilObjectServiceSettingsGUI::TAXONOMIES
+            )
+        );
 
         return $form;
     }

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
@@ -192,20 +192,15 @@ class ilObjQuestionPoolSettingsGeneralGUI
         $online = $form->getItemByPostVar('online');
         $this->poolOBJ->setOnline($online->getChecked());
 
+        $showTax = $form->getItemByPostVar('show_taxonomies');
+        $this->poolOBJ->setShowTaxonomies($showTax->getChecked());
+
         $DIC->object()->commonSettings()->legacyForm($form, $this->poolOBJ)->saveTileImage();
 
         if ($this->formPropertyExists($form, 'skill_service')) {
             $skillService = $form->getItemByPostVar('skill_service');
             $this->poolOBJ->setSkillServiceEnabled($skillService->getChecked());
         }
-
-        ilObjectServiceSettingsGUI::updateServiceSettingsForm(
-            $this->poolOBJ->getId(),
-            $form,
-            [
-                ilObjectServiceSettingsGUI::TAXONOMIES
-            ]
-        );
 
         $this->poolOBJ->saveToDb();
     }
@@ -270,13 +265,10 @@ class ilObjQuestionPoolSettingsGeneralGUI
         $feat->setTitle($this->lng->txt('obj_features'));
         $form->addItem($feat);
 
-        ilObjectServiceSettingsGUI::initServiceSettingsForm(
-            $this->poolOBJ->getId(),
-            $form,
-            [
-                ilObjectServiceSettingsGUI::TAXONOMIES
-            ]
-        );
+        $showTax = new ilCheckboxInputGUI($this->lng->txt('qpl_settings_general_form_property_show_taxonomies'), 'show_taxonomies');
+        $showTax->setInfo($this->lng->txt('qpl_settings_general_form_prop_show_tax_desc'));
+        $showTax->setChecked($this->poolOBJ->getShowTaxonomies());
+        $form->addItem($showTax);
 
         return $form;
     }

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
@@ -192,9 +192,6 @@ class ilObjQuestionPoolSettingsGeneralGUI
         $online = $form->getItemByPostVar('online');
         $this->poolOBJ->setOnline($online->getChecked());
 
-        $showTax = $form->getItemByPostVar('show_taxonomies');
-        $this->poolOBJ->setShowTaxonomies($showTax->getChecked());
-
         $DIC->object()->commonSettings()->legacyForm($form, $this->poolOBJ)->saveTileImage();
 
         if ($this->formPropertyExists($form, 'skill_service')) {
@@ -249,13 +246,6 @@ class ilObjQuestionPoolSettingsGeneralGUI
         $online->setInfo($this->lng->txt('qpl_settings_general_form_property_online_description'));
         $online->setChecked($this->poolOBJ->getOnline());
         $form->addItem($online);
-
-        // show taxonomies
-
-        $showTax = new ilCheckboxInputGUI($this->lng->txt('qpl_settings_general_form_property_show_taxonomies'), 'show_taxonomies');
-        $showTax->setInfo($this->lng->txt('qpl_settings_general_form_prop_show_tax_desc'));
-        $showTax->setChecked($this->poolOBJ->getShowTaxonomies());
-        $form->addItem($showTax);
 
         $section = new ilFormSectionHeaderGUI();
         $section->setTitle($this->lng->txt('tst_presentation_settings_section'));

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
@@ -205,9 +205,9 @@ class ilObjQuestionPoolSettingsGeneralGUI
         ilObjectServiceSettingsGUI::updateServiceSettingsForm(
             $this->poolOBJ->getId(),
             $form,
-            array(
+            [
                 ilObjectServiceSettingsGUI::TAXONOMIES
-            )
+            ]
         );
 
         $this->poolOBJ->saveToDb();
@@ -283,9 +283,9 @@ class ilObjQuestionPoolSettingsGeneralGUI
         ilObjectServiceSettingsGUI::initServiceSettingsForm(
             $this->poolOBJ->getId(),
             $form,
-            array(
+            [
                 ilObjectServiceSettingsGUI::TAXONOMIES
-            )
+            ]
         );
 
         return $form;

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolTaxonomyEditingCommandForwarder.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolTaxonomyEditingCommandForwarder.php
@@ -23,6 +23,7 @@
  */
 class ilObjQuestionPoolTaxonomyEditingCommandForwarder
 {
+    protected \ILIAS\Taxonomy\Service $taxonomy;
     protected ilObjQuestionPool $poolOBJ;
     protected ilDBInterface $db;
     protected ilComponentRepository $component_repository;
@@ -36,7 +37,8 @@ class ilObjQuestionPoolTaxonomyEditingCommandForwarder
         ilComponentRepository $component_repository,
         ilCtrl $ctrl,
         ilTabsGUI $tabs,
-        ilLanguage $lng
+        ilLanguage $lng,
+        \ILIAS\Taxonomy\Service $taxonomy
     ) {
         $this->poolOBJ = $poolOBJ;
         $this->db = $db;
@@ -44,6 +46,7 @@ class ilObjQuestionPoolTaxonomyEditingCommandForwarder
         $this->ctrl = $ctrl;
         $this->tabs = $tabs;
         $this->lng = $lng;
+        $this->taxonomy = $taxonomy;
     }
 
     public function forward(): void
@@ -57,13 +60,17 @@ class ilObjQuestionPoolTaxonomyEditingCommandForwarder
 
         $questionList->load();
 
-        $taxGUI = new ilObjTaxonomyGUI();
+        $tax_gui = $this->taxonomy->gui()->getSettingsGUI(
+            $this->poolOBJ->getId(),
+            "",
+            true
+        )->withAssignedItemSorting(
+            $questionList,
+            'qpl',
+            $this->poolOBJ->getId(),
+            'quest'
+        );
 
-        $taxGUI->setAssignedObject($this->poolOBJ->getId());
-        $taxGUI->setMultiple(true);
-
-        $taxGUI->activateAssignedItemSorting($questionList, 'qpl', $this->poolOBJ->getId(), 'quest');
-
-        $this->ctrl->forwardCommand($taxGUI);
+        $this->ctrl->forwardCommand($tax_gui);
     }
 }

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolTaxonomyEditingCommandForwarder.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolTaxonomyEditingCommandForwarder.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Taxonomy\Service;
+
 /**
  * class can be used as forwarder for taxonomy editing context
  * @author		Björn Heyser <bheyser@databay.de>
@@ -23,7 +25,7 @@
  */
 class ilObjQuestionPoolTaxonomyEditingCommandForwarder
 {
-    protected \ILIAS\Taxonomy\Service $taxonomy;
+    protected Service $taxonomy;
     protected ilObjQuestionPool $poolOBJ;
     protected ilDBInterface $db;
     protected ilComponentRepository $component_repository;
@@ -38,7 +40,7 @@ class ilObjQuestionPoolTaxonomyEditingCommandForwarder
         ilCtrl $ctrl,
         ilTabsGUI $tabs,
         ilLanguage $lng,
-        \ILIAS\Taxonomy\Service $taxonomy
+        Service $taxonomy
     ) {
         $this->poolOBJ = $poolOBJ;
         $this->db = $db;

--- a/Services/Taxonomy/Service/class.DomainService.php
+++ b/Services/Taxonomy/Service/class.DomainService.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\Taxonomy;
+
+/**
+ * Domain facade
+ */
+class DomainService
+{
+    protected InternalDomainService $domain;
+
+    public function __construct(
+        InternalDomainService $domain
+    ) {
+        $this->domain = $domain;
+    }
+
+    /**
+     * Returns the taxonomies (ids or array with id/title) used by a repository object
+     */
+    public function getUsageOfObject(int $obj_id, bool $include_titles = false): array
+    {
+        return $this->domain->usage()->getUsageOfObject($obj_id, $include_titles);
+    }
+
+    public function isActivated(int $obj_id): bool
+    {
+        return $this->domain->settings($obj_id)->isActivated();
+    }
+}

--- a/Services/Taxonomy/Service/class.GUIService.php
+++ b/Services/Taxonomy/Service/class.GUIService.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy;
+
+class GUIService
+{
+    protected InternalGUIService $internal_gui_service;
+
+    public function __construct(InternalGUIService $internal_gui_service)
+    {
+        $this->internal_gui_service = $internal_gui_service;
+    }
+
+    public function addSettingsSubTab(int $rep_obj_id): void
+    {
+        $this->internal_gui_service->settings()->addSubTab($rep_obj_id);
+    }
+
+    public function getSettingsGUI(
+        int $rep_obj_id,
+        string $list_info = "",
+        bool $multiple = true,
+        \ILIAS\Taxonomy\Settings\ModifierGUIInterface $modifier = null
+    ): \ilTaxonomySettingsGUI {
+        return $this->internal_gui_service->settings()->getSettingsGUI(
+            $rep_obj_id,
+            $list_info,
+            $multiple,
+            $modifier
+        );
+    }
+
+}

--- a/Services/Taxonomy/Service/class.InternalDataService.php
+++ b/Services/Taxonomy/Service/class.InternalDataService.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy;
+
+class InternalDataService
+{
+    public function __construct()
+    {
+        //$this->..._factory = new ...\DataFactory();
+    }
+
+}

--- a/Services/Taxonomy/Service/class.InternalDomainService.php
+++ b/Services/Taxonomy/Service/class.InternalDomainService.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy;
+
+use ILIAS\DI\Container;
+use ILIAS\Repository\GlobalDICDomainServices;
+use ILIAS\Taxonomy\Settings\SettingsManager;
+use ILIAS\Taxonomy\Usage\UsageManager;
+
+class InternalDomainService
+{
+    use GlobalDICDomainServices;
+
+    protected InternalRepoService $repo_service;
+    protected InternalDataService $data_service;
+
+    public function __construct(
+        Container $DIC,
+        InternalRepoService $repo_service,
+        InternalDataService $data_service
+    ) {
+        $this->repo_service = $repo_service;
+        $this->data_service = $data_service;
+        $this->initDomainServices($DIC);
+    }
+
+    public function settings(int $rep_obj_id): SettingsManager
+    {
+        return new SettingsManager($rep_obj_id);
+    }
+
+    public function usage(): UsageManager
+    {
+        return new UsageManager(
+            $this->repo_service->usage()
+        );
+    }
+}

--- a/Services/Taxonomy/Service/class.InternalGUIService.php
+++ b/Services/Taxonomy/Service/class.InternalGUIService.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy;
+
+use ILIAS\DI\Container;
+use ILIAS\Repository\GlobalDICGUIServices;
+
+class InternalGUIService
+{
+    use GlobalDICGUIServices;
+
+    protected InternalDataService $data_service;
+    protected InternalDomainService $domain_service;
+
+    public function __construct(
+        Container $DIC,
+        InternalDataService $data_service,
+        InternalDomainService $domain_service
+    ) {
+        $this->data_service = $data_service;
+        $this->domain_service = $domain_service;
+        $this->initGUIServices($DIC);
+    }
+
+    public function settings(): \ILIAS\Taxonomy\Settings\GUIService
+    {
+        return new \ILIAS\Taxonomy\Settings\GUIService(
+            $this->domain_service,
+            $this
+        );
+    }
+
+    public function getObjTaxonomyGUI(int $rep_obj_id): \ilObjTaxonomyGUI
+    {
+        $tax_gui = new \ilObjTaxonomyGUI();
+        $tax_gui->setAssignedObject($rep_obj_id);
+        return $tax_gui;
+    }
+
+
+}

--- a/Services/Taxonomy/Service/class.InternalRepoService.php
+++ b/Services/Taxonomy/Service/class.InternalRepoService.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy;
+
+use ILIAS\Taxonomy\Usage\UsageDBRepository;
+use ILIAS\Taxonomy\Usage\UsageManager;
+
+class InternalRepoService
+{
+    protected InternalDataService $data;
+    protected \ilDBInterface $db;
+
+    public function __construct(InternalDataService $data, \ilDBInterface $db)
+    {
+        $this->data = $data;
+        $this->db = $db;
+    }
+
+    public function usage(): UsageDBRepository
+    {
+        return new UsageDBRepository($this->db);
+    }
+}

--- a/Services/Taxonomy/Service/class.InternalService.php
+++ b/Services/Taxonomy/Service/class.InternalService.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy;
+
+use ILIAS\DI\Container;
+
+class InternalService
+{
+    protected Container $DIC;
+    protected static ?InternalDataService $data = null;
+    protected static ?InternalRepoService $repo = null;
+    protected static ?InternalDomainService $domain = null;
+    protected static ?InternalGUIService $gui = null;
+
+    public function __construct(Container $DIC)
+    {
+        $this->DIC = $DIC;
+    }
+
+    public function data(): InternalDataService
+    {
+        if (is_null(self::$data)) {
+            self::$data = new InternalDataService();
+        }
+        return self::$data;
+    }
+
+    public function repo(): InternalRepoService
+    {
+        if (is_null(self::$repo)) {
+            self::$repo = new InternalRepoService(
+                $this->data(),
+                $this->DIC->database()
+            );
+        }
+        return self::$repo;
+    }
+
+    public function domain(): InternalDomainService
+    {
+        if (is_null(self::$domain)) {
+            self::$domain = new InternalDomainService(
+                $this->DIC,
+                $this->repo(),
+                $this->data()
+            );
+        }
+        return self::$domain;
+    }
+
+    public function gui(): InternalGUIService
+    {
+        if (is_null(self::$gui)) {
+            self::$gui = new InternalGUIService(
+                $this->DIC,
+                $this->data(),
+                $this->domain()
+            );
+        }
+        return self::$gui;
+    }
+}

--- a/Services/Taxonomy/Service/class.Service.php
+++ b/Services/Taxonomy/Service/class.Service.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy;
+
+use ILIAS\DI\Container;
+
+class Service
+{
+    protected Container $DIC;
+
+    public function __construct(Container $DIC)
+    {
+        $this->DIC = $DIC;
+    }
+
+    /**
+     * Internal service, do not use in other components
+     */
+    public function internal(): InternalService
+    {
+        return new InternalService($this->DIC);
+    }
+
+    /**
+     * External GUI service
+     */
+    public function gui(): GUIService
+    {
+        return new GUIService(
+            $this->internal()->gui()
+        );
+    }
+
+    /**
+     * External domain service
+     */
+    public function domain(): DomainService
+    {
+        return new DomainService(
+            $this->internal()->domain()
+        );
+    }
+}

--- a/Services/Taxonomy/Settings/ModifierGUIInterface.php
+++ b/Services/Taxonomy/Settings/ModifierGUIInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy\Settings;
+
+interface ModifierGUIInterface
+{
+    public function getProperties(
+        int $tax_id
+    ): array;
+
+    public function getActions(
+        int $tax_id
+    ): array;
+
+}

--- a/Services/Taxonomy/Settings/Service/class.GUIService.php
+++ b/Services/Taxonomy/Settings/Service/class.GUIService.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy\Settings;
+
+use ILIAS\Taxonomy\InternalDomainService;
+use ILIAS\Taxonomy\InternalGUIService;
+
+class GUIService
+{
+    protected InternalGUIService $gui;
+    protected InternalDomainService $domain;
+
+    public function __construct(
+        InternalDomainService $domain,
+        InternalGUIService $gui
+    ) {
+        $this->domain = $domain;
+        $this->gui = $gui;
+    }
+
+    public function getSettingsGUI(
+        int $rep_obj_id,
+        string $list_info = "",
+        bool $multiple = true,
+        \ILIAS\Taxonomy\Settings\ModifierGUIInterface $modifier = null
+    ): \ilTaxonomySettingsGUI {
+        return new \ilTaxonomySettingsGUI(
+            $this->domain,
+            $this->gui,
+            $rep_obj_id,
+            $list_info,
+            $multiple,
+            $modifier
+        );
+    }
+
+    public function addSubTab(int $rep_obj_id): void
+    {
+        $tabs = $this->gui->tabs();
+        $ctrl = $this->gui->ctrl();
+        $lng = $this->domain->lng();
+        if ($this->domain->settings($rep_obj_id)->isActivated()) {
+            $lng->loadLanguageModule("tax");
+            $tabs->addSubTab(
+                "tax_settings",
+                $lng->txt("tax_taxonomy"),
+                $ctrl->getLinkTargetByClass(\ilTaxonomySettingsGUI::class, "")
+            );
+        }
+    }
+}

--- a/Services/Taxonomy/Settings/SettingsManager.php
+++ b/Services/Taxonomy/Settings/SettingsManager.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy\Settings;
+
+class SettingsManager
+{
+    protected $rep_obj_id;
+
+    public function __construct($rep_obj_id)
+    {
+        $this->rep_obj_id = $rep_obj_id;
+    }
+
+    public function isActivated(): bool
+    {
+        return (bool) \ilContainer::_lookupContainerSetting(
+            $this->rep_obj_id,
+            \ilObjectServiceSettingsGUI::TAXONOMIES,
+            '0'
+        );
+    }
+}

--- a/Services/Taxonomy/Settings/class.ilTaxonomySettingsGUI.php
+++ b/Services/Taxonomy/Settings/class.ilTaxonomySettingsGUI.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @ilCtrl_Calls ilTaxonomySettingsGUI: ilObjTaxonomyGUI
+ */
+class ilTaxonomySettingsGUI
+{
+    protected ilTabsGUI $tabs;
+    protected ilGlobalTemplateInterface $tpl;
+    protected ilCtrl $ctrl;
+    protected ilLanguage $lng;
+    protected ilToolbarGUI $toolboar;
+    protected ?\ILIAS\Taxonomy\Settings\ModifierGUIInterface $modifier;
+    protected string $list_info;
+    protected bool $multiple;
+    protected \ILIAS\Taxonomy\InternalGUIService $gui;
+    protected \ILIAS\Taxonomy\InternalDomainService $domain;
+    protected int $rep_obj_id;
+    protected bool $assigned_item_sorting = false;
+    protected ilTaxAssignedItemInfo $assigned_item_info_obj;
+    protected string $assigned_item_comp_id = "";
+    protected int $assigned_item_obj_id = 0;
+    protected string $assigned_item_type = "";
+
+
+    public function __construct(
+        \ILIAS\Taxonomy\InternalDomainService $domain,
+        \ILIAS\Taxonomy\InternalGUIService $gui,
+        int $rep_obj_id,
+        string $list_info = "",
+        bool $multiple = true,
+        \ILIAS\Taxonomy\Settings\ModifierGUIInterface $modifier = null
+    ) {
+        $this->domain = $domain;
+        $this->gui = $gui;
+
+        $this->toolboar = $gui->toolbar();
+        $this->ctrl = $gui->ctrl();
+        $this->tpl = $gui->ui()->mainTemplate();
+        $this->tabs = $gui->tabs();
+
+        $this->lng = $domain->lng();
+
+        $this->rep_obj_id = $rep_obj_id;
+        $this->multiple = $multiple;
+        $this->list_info = $list_info;
+        $this->modifier = $modifier;
+
+    }
+
+    public function withAssignedItemSorting(
+        ilTaxAssignedItemInfo $a_item_info_obj,
+        string $a_component_id,
+        int $a_obj_id,
+        string $a_item_type
+    ): self {
+        $new = clone $this;
+        $new->assigned_item_sorting = true;
+        $new->assigned_item_info_obj = $a_item_info_obj;
+        $new->assigned_item_comp_id = $a_component_id;
+        $new->assigned_item_obj_id = $a_obj_id;
+        $new->assigned_item_type = $a_item_type;
+        return $new;
+    }
+
+    public function executeCommand(): void
+    {
+        $ctrl = $this->gui->ctrl();
+
+        $next_class = $ctrl->getNextClass($this);
+        $cmd = $ctrl->getCmd("listTaxonomies");
+
+        $this->tabs->activateSubTab("tax_settings");
+
+        switch ($next_class) {
+
+            case strtolower(ilObjTaxonomyGUI::class):
+                $ctrl->setReturn($this, "");
+                $tax_gui = $this->gui->getObjTaxonomyGUI($this->rep_obj_id);
+                if ($this->assigned_item_sorting) {
+                    $tax_gui->activateAssignedItemSorting(
+                        $this->assigned_item_info_obj,
+                        $this->assigned_item_comp_id,
+                        $this->assigned_item_obj_id,
+                        $this->assigned_item_type
+                    );
+                }
+                $this->ctrl->forwardCommand($tax_gui);
+                break;
+
+            default:
+                if (in_array($cmd, ["listTaxonomies"])) {
+                    $this->$cmd();
+                }
+        }
+    }
+
+    protected function listTaxonomies(): void
+    {
+        $f = $this->gui->ui()->factory();
+        $r = $this->gui->ui()->renderer();
+        $um = $this->domain->usage();
+        $tax_ids = $um->getUsageOfObject($this->rep_obj_id, true);
+        if ($this->multiple || count($tax_ids) === 0) {
+            $this->toolboar->addButton(
+                $this->lng->txt("tax_add_taxonomy"),
+                $this->ctrl->getLinkTargetByClass(ilObjTaxonomyGUI::class, "createAssignedTaxonomy")
+            );
+        } else {
+            $this->tpl->setOnScreenMessage('info', $this->lng->txt("tax_max_one_tax"));
+        }
+        $items = [];
+        foreach($tax_ids as $t) {
+            $this->ctrl->setParameterByClass(ilObjTaxonomyGUI::class, "tax_id", $t["tax_id"]);
+            $action = [];
+            $action[] = $f->button()->shy(
+                $this->lng->txt("edit"),
+                $this->ctrl->getLinkTargetByClass(ilObjTaxonomyGUI::class, "listNodes")
+            );
+            $action[] = $f->button()->shy(
+                $this->lng->txt("delete"),
+                $this->ctrl->getLinkTargetByClass(ilObjTaxonomyGUI::class, "confirmDeleteTaxonomy")
+            );
+            $properties = [];
+            if ($this->modifier) {
+                $properties = $this->modifier->getProperties((int) $t["tax_id"]);
+                foreach ($this->modifier->getActions((int) $t["tax_id"]) as $act) {
+                    $action[] = $act;
+                }
+            }
+            $dd = $f->dropdown()->standard($action);
+            $item = $f->item()->standard($t["title"])->withActions($dd);
+            if (count($properties) > 0) {
+                $item = $item->withProperties($properties);
+            }
+            $items[] = $item;
+        }
+        $title = ($this->multiple)
+            ? $this->lng->txt("obj_taxf")
+            : $this->lng->txt("obj_tax");
+        $panel = $f->panel()->listing()->standard(
+            $title,
+            [$f->item()->group("", $items) ]
+        );
+        $components = [];
+        if ($this->list_info !== "") {
+            $this->tpl->setOnScreenMessage("info", $this->list_info);
+        }
+        $components[] = $panel;
+        $this->tpl->setContent($r->render($components));
+    }
+
+}

--- a/Services/Taxonomy/Usage/UsageDBRepository.php
+++ b/Services/Taxonomy/Usage/UsageDBRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy\Usage;
+
+class UsageDBRepository
+{
+    protected \ilDBInterface $db;
+
+    public function __construct(
+        \ilDBInterface $db
+    ) {
+        $this->db = $db;
+    }
+
+    public function getUsageOfObject(int $obj_id, bool $include_titles = false): array
+    {
+        $set = $this->db->query(
+            "SELECT tax_id FROM tax_usage " .
+            " WHERE obj_id = " . $this->db->quote($obj_id, "integer")
+        );
+        $tax = array();
+        while ($rec = $this->db->fetchAssoc($set)) {
+            if (!$include_titles) {
+                $tax[] = (int) $rec["tax_id"];
+            } else {
+                $tax[] = array("tax_id" => (int) $rec["tax_id"],
+                               "title" => \ilObject::_lookupTitle((int) $rec["tax_id"])
+                );
+            }
+        }
+        return $tax;
+    }
+
+}

--- a/Services/Taxonomy/Usage/UsageManager.php
+++ b/Services/Taxonomy/Usage/UsageManager.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Taxonomy\Usage;
+
+class UsageManager
+{
+    public function __construct(
+        UsageDBRepository $db_repo
+    ) {
+        $this->db_repo = $db_repo;
+    }
+
+    public function getUsageOfObject(int $obj_id, bool $include_titles = false): array
+    {
+        return $this->db_repo->getUsageOfObject($obj_id, $include_titles);
+    }
+}

--- a/Services/Taxonomy/classes/class.ilObjTaxonomy.php
+++ b/Services/Taxonomy/classes/class.ilObjTaxonomy.php
@@ -230,28 +230,12 @@ class ilObjTaxonomy extends ilObject2
      * @param int  $a_obj_id         object id
      * @param bool $a_include_titles include titles in array
      * @return array array of tax IDs or array of arrays with keys tax_id, title
+     * @deprecated Use $DIC->taxonomy()->domain()->usage()->getUsageOfObject() instead
      */
     public static function getUsageOfObject(int $a_obj_id, bool $a_include_titles = false): array
     {
         global $DIC;
-
-        $ilDB = $DIC->database();
-
-        $set = $ilDB->query(
-            "SELECT tax_id FROM tax_usage " .
-            " WHERE obj_id = " . $ilDB->quote($a_obj_id, "integer")
-        );
-        $tax = array();
-        while ($rec = $ilDB->fetchAssoc($set)) {
-            if (!$a_include_titles) {
-                $tax[] = (int) $rec["tax_id"];
-            } else {
-                $tax[] = array("tax_id" => (int) $rec["tax_id"],
-                               "title" => ilObject::_lookupTitle((int) $rec["tax_id"])
-                );
-            }
-        }
-        return $tax;
+        return $DIC->taxonomy()->internal()->domain()->usage()->getUsageOfObject($a_obj_id, $a_include_titles);
     }
 
     // Delete all usages of a taxonomy

--- a/Services/Taxonomy/classes/class.ilObjTaxonomyGUI.php
+++ b/Services/Taxonomy/classes/class.ilObjTaxonomyGUI.php
@@ -23,6 +23,10 @@
  */
 class ilObjTaxonomyGUI extends ilObject2GUI
 {
+    protected ?\ILIAS\Taxonomy\TaxonomyModifierGUI $modifier = null;
+    protected \ILIAS\DI\UIServices $ui;
+    protected \ILIAS\Taxonomy\InternalGUIService $gui;
+    protected \ILIAS\Taxonomy\InternalDomainService $domain;
     protected ilTabsGUI $tabs;
     protected ilHelpGUI $help;
     protected bool $multiple = false;
@@ -40,30 +44,36 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     /**
      * @inheritDoc
      */
-    public function __construct($a_id = 0)
+    public function __construct()
     {
         global $DIC;
 
-        $this->ctrl = $DIC->ctrl();
-        $this->lng = $DIC->language();
-        $this->user = $DIC->user();
-        $this->tabs = $DIC->tabs();
-        $this->toolbar = $DIC->toolbar();
-        $this->tpl = $DIC["tpl"];
-        $this->help = $DIC[ilHelp::class];
-        $ilCtrl = $DIC->ctrl();
-        $lng = $DIC->language();
+        $service = $DIC->taxonomy()->internal();
+        $this->gui = $gui = $service->gui();
+        $this->domain = $domain = $service->domain();
 
-        parent::__construct($a_id, ilObject2GUI::OBJECT_ID);
+        $this->ctrl = $gui->ctrl();
+        $this->tabs = $gui->tabs();
+        $this->toolbar = $gui->toolbar();
+        $this->tpl = $gui->ui()->mainTemplate();
+        $this->help = $gui->help();
+        // @todo introduce request wrapper
+        $this->request = $gui->http()->request();
 
-        $ilCtrl->saveParameter($this, "tax_node");
-        $ilCtrl->saveParameter($this, "tax_id");
+        $this->lng = $domain->lng();
+        $this->user = $domain->user();
+        $this->ui = $gui->ui();
 
-        $lng->loadLanguageModule("tax");
+
+        parent::__construct(0, ilObject2GUI::OBJECT_ID);
+
+        $this->ctrl->saveParameter($this, "tax_node");
+        $this->ctrl->saveParameter($this, "tax_id");
+
+        $this->lng->loadLanguageModule("tax");
 
         // @todo introduce request wrapper
-        $this->request = $DIC->http()->request();
-        $params = $DIC->http()->request()->getQueryParams();
+        $params = $this->request->getQueryParams();
         $this->current_tax_node = (int) ($params["tax_node"] ?? null);
         $this->requested_tax_id = (int) ($params["tax_id"] ?? null);
         $this->requested_move_ids = (string) ($params["move_ids"] ?? "");
@@ -101,6 +111,11 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         return $this->multiple;
     }
 
+    public function setModifier(?\ILIAS\Taxonomy\TaxonomyModifierGUI $modifier): void
+    {
+        $this->modifier = $modifier;
+    }
+
     public function setListInfo(string $a_val): void
     {
         $this->list_info = trim($a_val);
@@ -133,6 +148,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     public function executeCommand(): void
     {
         $ilCtrl = $this->ctrl;
+        $this->tabs->activateSubTab("tax_settings");
 
         $cmd = $ilCtrl->getCmd("listTaxonomies");
         $this->$cmd();
@@ -250,7 +266,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
     {
         $ilCtrl = $this->ctrl;
         if ($this->getAssignedObject() > 0) {
-            $ilCtrl->redirect($this, "listTaxonomies");
+            $ilCtrl->redirectToURL($this->getSettingsBackUrl());
         }
         parent::cancel();
     }
@@ -660,7 +676,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $cgui = new ilConfirmationGUI();
         $cgui->setFormAction($ilCtrl->getFormAction($this));
         $cgui->setHeaderText($lng->txt("tax_confirm_deletion"));
-        $cgui->setCancel($lng->txt("cancel"), "listTaxonomies");
+        $cgui->setCancel($lng->txt("cancel"), "returnToSettingsParent");
         $cgui->setConfirm($lng->txt("delete"), "deleteTaxonomy");
 
         $cgui->addItem("id[]", 0, $tax->getTitle());
@@ -680,7 +696,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $tax->delete();
 
         $this->tpl->setOnScreenMessage('success', $lng->txt("tax_tax_deleted"), true);
-        $ilCtrl->redirect($this, "listTaxonomies");
+        $this->returnToSettingsParent();
     }
 
     /**
@@ -713,6 +729,16 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $tpl->setContent($tab->getHTML());
     }
 
+    protected function getSettingsBackUrl(): string
+    {
+        return $this->ctrl->getParentReturn($this);
+    }
+
+    protected function returnToSettingsParent(): void
+    {
+        $this->ctrl->redirectToURL($this->getSettingsBackUrl());
+    }
+
     /**
      * @inheritDoc
      */
@@ -734,7 +760,7 @@ class ilObjTaxonomyGUI extends ilObject2GUI
 
         $ilTabs->setBackTarget(
             $lng->txt("back"),
-            $ilCtrl->getLinkTarget($this, "listTaxonomies")
+            $this->getSettingsBackUrl()
         );
 
         $ilTabs->addTab(

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2618,8 +2618,10 @@ buddysystem#:#buddy_use_osd_info#:#Zeigt ein Popup an, wenn ein Benutzer mit mir
 buddysystem#:#buddy_view_gallery#:#Galerie
 buddysystem#:#buddy_view_table#:#Liste
 cat#:#cat_copy#:#Kategorie kopieren
+cat#:#cat_hide_tax_in_side_block#:#Nicht im Seitenblock darstellen
 cat#:#cat_import#:#Kategorie importieren
 cat#:#cat_more_translations#:#Weitere Übersetzungen
+cat#:#cat_show_tax_in_side_block#:#Im Seitenblock darstellen
 cert#:#cert_currently_no_certs#:#Aktuell besitzen Sie noch keine Zertifikate.
 cert#:#cert_description_label#:#Beschreibung
 cert#:#cert_download_label#:#Herunterladen
@@ -3302,6 +3304,7 @@ cntr#:#cntr_switch_to_new_editor_message#:#Dies ist der Standard-Seiteneditor. W
 cntr#:#cntr_switched_editor#:#Auf neue Darstellung umgestellt
 cntr#:#cntr_tax_list_info#:#Nachfolgend sind alle Taxonomien gelistet, die für dieses Objekt definiert wurden.
 cntr#:#cntr_tax_none_available#:#Es gibt keine verfügbaren Taxonomien.
+cntr#:#cntr_tax_settings_info#:#Taxonomien in Kategorien klassifizieren und filtern die in der Kategorie enthaltenen Objekte. Nach dem Hinzufügen von Taxonomien können über die Reiter „Metadaten“ und die Unterreiter „Taxonomiezuordnung“ der jeweiligen Objekte Klassifizierungen vorgenommen werden. Taxonomien können zusätzlich im Seitenblock des Reiters „Inhalt“ der Kategorie angezeigt werden, um ein direktes Filtern der zugeordneten Objekte zu ermöglichen.
 cntr#:#cntr_taxonomy_definitions#:#Taxonomie-Definition
 cntr#:#cntr_taxonomy_show_sideblock#:#Taxonomie im Seitenblock darstellen
 cntr#:#cntr_taxonomy_sideblock_settings#:#Präsentationseinstellungen
@@ -9897,7 +9900,11 @@ glo#:#glo_selected_glossaries_info#:#Die Begriffe stammen aus den folgenden Glos
 glo#:#glo_selected_glossary_is_current_info#:#Das ausgewählte Glossar entspricht dem aktuellen Glossar. Bitte wählen Sie ein anderes Glossar.
 glo#:#glo_selected_terms_have_been_copied#:#Die ausgewählten Begriffe wurden in die Zwischenablage kopiert. Bitte öffnen Sie das Zielglossar und klicken dann auf "Einfügen".
 glo#:#glo_show_definition#:#Definition zeigen
+glo#:#glo_show_in_presentation#:#Anzeige in Präsentationsansicht
+glo#:#glo_show_in_presentation_off#:#Nicht in Präsentationsansicht anzeigen
+glo#:#glo_show_in_presentation_on#:#In Präsentationsansicht anzeigen
 glo#:#glo_show_term#:#Begriff zeigen
+glo#:#glo_tax_info#:#Eine Taxonomie im Glossar klassifiziert und filtert die Begriffe. In der Bearbeitungsansicht steht sie immer zur Verfügung. Für die Präsentationsansicht muss die Darstellung der Taxonomie zunächst aktiviert werden. In einem Glossar kann genau eine einzige Taxonomie genutzt werden.
 glo#:#glo_term#:#Glossarbegriff
 glo#:#glo_term_definition_pairs#:#Begriffs/Definitions-Paare
 glo#:#glo_term_definition_pairs_info#:#Bitte geben Sie pro Zeile ein Begriffs/Definitions-Paar ein. Begriff und Definition müssen getrennt sein durch ein Semikolon oder ein TAB-Zeichen (werden überlicherweise durch Zwischenablage-Aktionen von Tabellenkalkulationsprogramm unterstützt).

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2618,8 +2618,10 @@ buddysystem#:#buddy_use_osd_info#:#Display a popup to indicate a user wants to a
 buddysystem#:#buddy_view_gallery#:#Gallery
 buddysystem#:#buddy_view_table#:#List
 cat#:#cat_copy#:#Copy Category
+cat#:#cat_hide_tax_in_side_block#:#Don't Present in Side Panel
 cat#:#cat_import#:#Import Category
 cat#:#cat_more_translations#:#More Translations
+cat#:#cat_show_tax_in_side_block#:#Present in Side Panel
 cert#:#cert_currently_no_certs#:#Currently you did not achieve any certificate, yet.
 cert#:#cert_description_label#:#Description
 cert#:#cert_download_label#:#Download
@@ -3302,8 +3304,9 @@ cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor
 cntr#:#cntr_switched_editor#:#Switched to new content.
 cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.
+cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition
-cntr#:#cntr_taxonomy_show_sideblock#:#Show taxonomy in side block
+cntr#:#cntr_taxonomy_show_sideblock#:#Present in Side Panel
 cntr#:#cntr_taxonomy_sideblock_settings#:#Presentation Settings
 cntr#:#cntr_text_media_editor#:#Customize Page
 cntr#:#cntr_view_by_type#:#Grouped-by-Type View
@@ -9889,7 +9892,11 @@ glo#:#glo_selected_glossaries_info#:#Terms are collected from the following glos
 glo#:#glo_selected_glossary_is_current_info#:#The selected glossary corresponds to the current glossary. Please select another glossary.
 glo#:#glo_selected_terms_have_been_copied#:#The selected terms have been copied to the clipboard. Please open the target glossary and click "Paste".
 glo#:#glo_show_definition#:#Show Definition
+glo#:#glo_show_in_presentation#:#Shown in Presentation View
+glo#:#glo_show_in_presentation_off#:#Hide in Presentation View
+glo#:#glo_show_in_presentation_on#:#Show in Presentation View
 glo#:#glo_show_term#:#Show Term
+glo#:#glo_tax_info#:#A taxonomy in a Glossary classifies and filters the terms. It always is available in the editing view. For the presentation view, the taxonomy must first be activated. In glossaries, only one taxonomy can be used.
 glo#:#glo_term#:#Glossary Term
 glo#:#glo_term_definition_pairs#:#Term/Definition Pairs
 glo#:#glo_term_definition_pairs_info#:#Please enter a term and a definition pair in each line. Term and definition must be separated by a semicolon or a TAB character (usually provided by clipboard actions from spreadsheet applications).

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -408,6 +408,11 @@ class Container extends \Pimple\Container
         return new \ILIAS\PersonalWorkspace\Service();
     }
 
+    public function taxonomy(): \ILIAS\Taxonomy\Service
+    {
+        return new \ILIAS\Taxonomy\Service($this);
+    }
+
     public function fileServiceSettings(): \ilFileServicesSettings
     {
         if ($this->file_service_settings === null) {


### PR DESCRIPTION
Feature Wiki
https://docu.ilias.de/goto_docu_wiki_wpage_7694_1357.html
and
https://docu.ilias.de/goto_docu_wiki_wpage_7696_1357.html

This moves the taxonomy listing from a legacy table to a listing panel. Activation is generally under the "Additional Features" section, see FW above.

@maxbecker
The second commit contains the quesstion pool changes: https://github.com/ILIAS-eLearning/ILIAS/pull/6392/commits/89ec33380e1db8e6462ae8892f4ff2ab4913dd44

This integrates the general activation settings according to https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/Services/Taxonomy/README-technical.md#taxonomy-settings-in-repository-objects-ilias-9 under "Additional Features".

This also removes the direct instantiation of ilObjTaxonomyGUI and uses the service available through DIC. I did not touch the "Show/Taxonomy Filter as Navigation Tree" setting. Not sure if this is to be abandoned.