### PR TITLE
9/UI/image responsive max width fix 37743

### DIFF
--- a/templates/default/050-layout/_layout_responsive-img.scss
+++ b/templates/default/050-layout/_layout_responsive-img.scss
@@ -3,3 +3,7 @@
     max-width: 100%; // Part 1: Set a maximum relative to the parent
     height: auto; // Part 2: Scale the height according to the width, otherwise you get stretching
 }
+
+.img-responsive {
+    @include img-responsive();
+}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1,4 +1,7 @@
 @charset "UTF-8";
+/*
+* Dependencies
+*/
 /*!
  * Datetimepicker for Bootstrap 3
  * version : 4.17.37
@@ -681,8 +684,9 @@ table.mceToolbar tbody, table.mceToolbar tr, table.mceToolbar td {
 }
 
 /*
-* Dependencies
-*/ /* print less */
+* Normalize
+*/
+/* print less */
 @media print {
   * {
     /* see bug 0022342 */
@@ -890,9 +894,6 @@ th {
   padding: 0;
 }
 
-/*
-* Normalize
-*/
 .row {
   --bs-gutter-x: 30px;
   --bs-gutter-y: 0;
@@ -2227,6 +2228,9 @@ th {
   margin-right: 0;
 }
 
+/*
+* Elements
+*/
 * {
   box-sizing: border-box;
 }
@@ -2601,8 +2605,9 @@ code {
   }
 }
 /*
-* Elements
+* Components
 */
+/* UI Framework */
 .c-tooltip__container {
   position: relative;
   display: inline-block;
@@ -9806,6 +9811,7 @@ td.c-table-data__cell--highlighted {
   width: 5rem;
 }
 
+/* Component parts from old delos.scss */
 div#agreement {
   width: 100%;
   height: 375px;
@@ -10526,6 +10532,7 @@ div.il_info {
   text-align: left;
 }
 
+/* Adapted from Bootstrap 3 */
 .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
@@ -10758,6 +10765,12 @@ tbody.collapse.in {
   position: absolute;
   clip: rect(0, 0, 0, 0);
   pointer-events: none;
+}
+
+.img-responsive {
+  display: block;
+  max-width: 100%;
+  height: auto;
 }
 
 .carousel {
@@ -11151,6 +11164,7 @@ tbody.collapse.in {
   clip: auto;
 }
 
+/* Legacy Modules & Services */
 /* Modules/Bibliographic */
 span.bibl_text_inline_Emph {
   font-style: italic;
@@ -18764,13 +18778,6 @@ img.ilUserXXSmall {
   padding: 5px;
 }
 
-/*
-* Components
-*/
-/* UI Framework */
-/* Component parts from old delos.scss */
-/* Adapted from Bootstrap 3 */
-/* Legacy Modules & Services */
 /*
 	These classes are used to limit the number of rows when displaying larger chunks of text.
 	The mixin receives $height-in-rows as an integer. The classes il-multi-line-cap-2,3,5,10


### PR DESCRIPTION
Fixes
https://mantis.ilias.de/view.php?id=37743
and in extension
https://mantis.ilias.de/view.php?id=38123
https://mantis.ilias.de/view.php?id=38122

# Issue

Responsive images can overflow their container. This is very noticeable on the UI Component Items:
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/b964cd73-cf1b-4520-99f4-be5c0182466b)

# Changes

The existing img-responsive mixin now also generates a utility css class that is already in use by the image UI component.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/f758ee62-c8b4-4b79-afa6-5417ce021f28)

We might want to discuss...

- if we even need an img-responsive class. Shouldn't all images always be responsive? When do we ever want the image to not fit inside its container?
- how/where to generate CSS utility classes in one clearly defined location as CSS utility classe are only allowed as an exception to the rules stated in the SCSS Guidelines: https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/templates/Guidelines_SCSS-Coding.md

