### PR TITLE
BOOK: adjust deletion of booking objects. (#21705)

### DIFF
--- a/Modules/BookingManager/Objects/class.ilBookingObject.php
+++ b/Modules/BookingManager/Objects/class.ilBookingObject.php
@@ -410,6 +410,19 @@ class ilBookingObject
         return 0;
     }
 
+    public function deleteReservationAndCalEntry(int $object_id): void
+    {
+        $reservation_db = new ilBookingReservationDBRepository($this->db);
+        $reservation_ids = $reservation_db->getReservationIdByBookingObjectId($object_id);
+        
+        foreach ($reservation_ids as $reservation_id) {
+            $reservation = new ilBookingReservation($reservation_id);
+            $entry = new ilCalendarEntry($reservation->getCalendarEntry());
+            $reservation_db->delete($reservation_id);
+            $entry->delete();
+        }
+    }
+
     /**
      * Get nr of available items for a set of object ids
      * @param int[] $a_obj_ids

--- a/Modules/BookingManager/Objects/class.ilBookingObjectGUI.php
+++ b/Modules/BookingManager/Objects/class.ilBookingObjectGUI.php
@@ -536,6 +536,7 @@ class ilBookingObjectGUI
         $lng = $this->lng;
 
         $obj = new ilBookingObject($this->object_id);
+        $obj->deleteReservationAndCalEntry($this->object_id);
         $obj->delete();
 
         $this->tpl->setOnScreenMessage('success', $lng->txt('book_object_deleted'), true);

--- a/Modules/BookingManager/Reservations/class.ilBookingReservationDBRepository.php
+++ b/Modules/BookingManager/Reservations/class.ilBookingReservationDBRepository.php
@@ -328,4 +328,17 @@ class ilBookingReservationDBRepository
             return ($row["context_obj_id"] == $context_obj_id);
         });
     }
+
+    public function getReservationIdByBookingObjectId(int $booking_object_id): array
+    {
+        $query = "SELECT booking_reservation_id FROM booking_reservation " . PHP_EOL
+            . " WHERE object_id = " . $this->db->quote($booking_object_id, "integer");
+        $res = $this->db->query($query);
+        $ret = [];
+        while ($row = $this->db->fetchAssoc($res)) {
+            $ret[] = (int) $row['booking_reservation_id'];
+        }
+
+        return $ret;
+    }
 }


### PR DESCRIPTION
If a booking object is deleted all reservations and calendar entries related to the booking object will be deleted too. Those steps were missing before, therefore the entry was still visible in the calendar.

Mantis Ticket: https://mantis.ilias.de/view.php?id=21705