### PR TITLE
Public Interface for Draft Revisions

### DIFF
--- a/src/ResourceStorage/Manager/Manager.php
+++ b/src/ResourceStorage/Manager/Manager.php
@@ -32,6 +32,7 @@ use ILIAS\ResourceStorage\Resource\StorableResource;
 use ILIAS\ResourceStorage\Revision\Revision;
 use ILIAS\ResourceStorage\Stakeholder\ResourceStakeholder;
 use ILIAS\ResourceStorage\Resource\ResourceType;
+use ILIAS\ResourceStorage\Revision\RevisionStatus;
 
 /**
  * Class StorageManager
@@ -67,6 +68,27 @@ class Manager
         }
     }
 
+    /**
+     * @description Publish a resource. A resource can contain a maximum of one revision in DRAFT on top status.
+     * This method can be used to publish this revision. If the latest revision is already published, nothing changes.
+     */
+    public function publish(ResourceIdentification $rid): void
+    {
+        $this->resource_builder->publish($this->resource_builder->get($rid));
+    }
+
+    /**
+     * @description Unpublish a resource. The newest revision of a resource is set to the DRAFT status.
+     * If the latest revision is already in DRAFT, nothing changes.
+     */
+    public function unpublish(ResourceIdentification $rid): void
+    {
+        $this->resource_builder->unpublish($this->resource_builder->get($rid));
+    }
+
+    /**
+     * @description Creates a new resource from an upload, the status in this case is always PUBLISHED.
+     */
     public function upload(
         UploadResult $result,
         ResourceStakeholder $stakeholder,
@@ -174,11 +196,18 @@ class Manager
 
     // Revision
 
+    /**
+     * @description  Append a new revision from an UploadResult. By passing $draft = true, the revision will be created as a
+     *               DRAFT on top of the current revision. Consumers will always use the latest published revision.
+     *               Appending new Revisions is not possible if the latest revision is already a DRAFT. In this case,
+     *               the DRAFT will be updated.
+     */
     public function appendNewRevision(
         ResourceIdentification $identification,
         UploadResult $result,
         ResourceStakeholder $stakeholder,
-        string $revision_title = null
+        string $revision_title = null,
+        bool $draft = false
     ): Revision {
         if ($result->isOK()) {
             if (!$this->resource_builder->has($identification)) {
@@ -193,7 +222,7 @@ class Manager
 
             $info_resolver = new UploadInfoResolver(
                 $result,
-                $resource->getMaxRevision() + 1,
+                $resource->getMaxRevision(true) + 1,
                 $stakeholder->getOwnerOfNewResources(),
                 $revision_title ?? $result->getName()
             );
@@ -201,17 +230,24 @@ class Manager
             $this->resource_builder->append(
                 $resource,
                 $result,
-                $info_resolver
+                $info_resolver,
+                $draft ? RevisionStatus::DRAFT : RevisionStatus::PUBLISHED
             );
             $resource->addStakeholder($stakeholder);
 
             $this->resource_builder->store($resource);
 
-            return $resource->getCurrentRevision();
+            return $resource->getCurrentRevisionIncludingDraft();
         }
         throw new \LogicException("Can't handle UploadResult: " . $result->getStatus()->getMessage());
     }
 
+    /**
+     * @throws \ILIAS\ResourceStorage\Policy\FileNamePolicyException if the filename is not allowed
+     * @throws \LogicException if the resource is not found
+     * @throws \LogicException if the resource is a container and the stream is not a ZIP
+     * @throws \LogicException if the latest revision is a DRAFT
+     */
     public function replaceWithUpload(
         ResourceIdentification $identification,
         UploadResult $result,
@@ -228,9 +264,12 @@ class Manager
             if ($resource->getType() === ResourceType::CONTAINER) {
                 $this->checkZIP($result->getMimeType());
             }
+            if ($resource->getCurrentRevisionIncludingDraft()->getStatus() === RevisionStatus::DRAFT) {
+                throw new \LogicException("Can't replace DRAFT revision, use appendNewRevision instead to update the DRAFT");
+            }
             $info_resolver = new UploadInfoResolver(
                 $result,
-                $resource->getMaxRevision() + 1,
+                $resource->getMaxRevision(true) + 1,
                 $stakeholder->getOwnerOfNewResources(),
                 $revision_title ?? $result->getName()
             );
@@ -243,16 +282,23 @@ class Manager
 
             $this->resource_builder->store($resource);
 
-            return $resource->getCurrentRevision();
+            return $resource->getCurrentRevisionIncludingDraft();
         }
         throw new \LogicException("Can't handle UploadResult: " . $result->getStatus()->getMessage());
     }
 
+    /**
+     * @description Append a new revision from a stream. By passing $draft = true, the revision will be created as a
+     *              DRAFT on top of the current revision. Consumers will always use the latest published revision.
+     *              Appending new Revisions is not possible if the latest revision is already a DRAFT. In this case,
+     *              the DRAFT will be updated.
+     */
     public function appendNewRevisionFromStream(
         ResourceIdentification $identification,
         FileStream $stream,
         ResourceStakeholder $stakeholder,
-        string $revision_title = null
+        string $revision_title = null,
+        bool $draft = false
     ): Revision {
         if (!$this->resource_builder->has($identification)) {
             throw new \LogicException(
@@ -266,7 +312,7 @@ class Manager
         }
         $info_resolver = new StreamInfoResolver(
             $stream,
-            $resource->getMaxRevision() + 1,
+            $resource->getMaxRevision(true) + 1,
             $stakeholder->getOwnerOfNewResources(),
             $revision_title ?? $stream->getMetadata()['uri']
         );
@@ -281,9 +327,15 @@ class Manager
 
         $this->resource_builder->store($resource);
 
-        return $resource->getCurrentRevision();
+        return $resource->getCurrentRevisionIncludingDraft();
     }
 
+    /**
+     * @throws \ILIAS\ResourceStorage\Policy\FileNamePolicyException if the filename is not allowed
+     * @throws \LogicException if the resource is not found
+     * @throws \LogicException if the resource is a container and the stream is not a ZIP
+     * @throws \LogicException if the latest revision is a DRAFT
+     */
     public function replaceWithStream(
         ResourceIdentification $identification,
         FileStream $stream,
@@ -297,12 +349,15 @@ class Manager
         }
 
         $resource = $this->resource_builder->get($identification);
+        if ($resource->getCurrentRevisionIncludingDraft()->getStatus() === RevisionStatus::DRAFT) {
+            throw new \LogicException("Can't replace DRAFT revision, use appendNewRevisionFromStream instead to update the DRAFT");
+        }
         if ($resource->getType() === ResourceType::CONTAINER) {
             $this->checkZIP(mime_content_type($stream->getMetadata()['uri']));
         }
         $info_resolver = new StreamInfoResolver(
             $stream,
-            $resource->getMaxRevision() + 1,
+            $resource->getMaxRevision(true) + 1,
             $stakeholder->getOwnerOfNewResources(),
             $revision_title ?? $stream->getMetadata()['uri']
         );
@@ -317,12 +372,18 @@ class Manager
 
         $this->resource_builder->store($resource);
 
-        return $resource->getCurrentRevision();
+        return $resource->getCurrentRevisionIncludingDraft();
     }
 
-    public function getCurrentRevision(ResourceIdentification $identification): Revision
-    {
+    public function getCurrentRevision(
+        ResourceIdentification $identification
+    ): Revision {
         return $this->resource_builder->get($identification)->getCurrentRevision();
+    }
+    public function getCurrentRevisionIncludingDraft(
+        ResourceIdentification $identification
+    ): Revision {
+        return $this->resource_builder->get($identification)->getCurrentRevisionIncludingDraft();
     }
 
     public function updateRevision(Revision $revision): bool

--- a/src/ResourceStorage/README.md
+++ b/src/ResourceStorage/README.md
@@ -192,6 +192,41 @@ if (null !== $identification) {
 }
 ```
 
+# Drafts
+Revisions are published by default. However, a maximum of one revision can be added to a resource in the status DRAFT on top. Cosumers continue to receive the latest revision that has been published. As long as a DRAFT revision exists, no new revisions can be created, but the current DRAFT revision will be updated until the one published via `Manager::publish`.
+
+## Example
+
+```php
+// Create new Resource from Upload
+use ILIAS\ResourceStorage\Services;
+global $DIC;
+/** @var Services $irss */
+$irss = $DIC['resource_storage'];
+$upload_result = $DIC['upload']->getResults()['my_uploaded_file'];
+$stakeholder = new ilMyComponentResourceStakeholder();
+
+$rid = $irss->manage()->upload($upload_result, $stakeholder);
+
+// later, add a draft:
+$new_upload_result = $DIC['upload']->getResults()['my_uploaded_file'];
+$revision = $irss->manage()->appendNewRevision($rid, $upload_result, $stakeholder, null, true);
+
+// $revision->getStatus() is RevisionStatus::DRAFT
+
+$latest_published_revision = $irss->manage()->getCurrentRevision($rid); // First upload
+$latest_draft_revision = $irss->manage()->getCurrentRevisionIncludingDraft($rid); // Second Upload
+
+$irss->manage()->publish($rid); // Publish the latest draft revision
+$latest_published_revision = $irss->manage()->getCurrentRevision($rid); // Second File
+$latest_published_revision = $irss->manage()->getCurrentRevisionIncludingDraft($rid); // Second File
+
+// im some cases you want to unpublish the latest revision again
+$irss->manage()->unpublish($rid);
+$latest_published_revision = $irss->manage()->getCurrentRevision($rid); // First upload
+$latest_draft_revision = $irss->manage()->getCurrentRevisionIncludingDraft($rid); // Second Upload
+```
+
 # Collections
 
 In many cases a component does not only need a single resource to be stored, but wants to be able to use a collection of


### PR DESCRIPTION
This is the Public Interface for the Feature "IRSS: Draft-Revisions" for your information: https://docu.ilias.de/goto_docu_wiki_wpage_7856_1357.html

# Drafts
Revisions are published by default. However, a maximum of one revision can be added to a resource in the status DRAFT on top. Cosumers continue to receive the latest revision that has been published. As long as a DRAFT revision exists, no new revisions can be created, but the current DRAFT revision will be updated until the one published via `Manager::publish`.

## Example

```php
// Create new Resource from Upload
use ILIAS\ResourceStorage\Services;
global $DIC;
/** @var Services $irss */
$irss = $DIC['resource_storage'];
$upload_result = $DIC['upload']->getResults()['my_uploaded_file'];
$stakeholder = new ilMyComponentResourceStakeholder();

$rid = $irss->manage()->upload($upload_result, $stakeholder);

// later, add a draft:
$new_upload_result = $DIC['upload']->getResults()['my_uploaded_file'];
$revision = $irss->manage()->appendNewRevision($rid, $upload_result, $stakeholder, null, true);

// $revision->getStatus() is RevisionStatus::DRAFT

$latest_published_revision = $irss->manage()->getCurrentRevision($rid); // First upload
$latest_draft_revision = $irss->manage()->getCurrentRevisionIncludingDraft($rid); // Second Upload

$irss->manage()->publish($rid); // Publish the latest draft revision
$latest_published_revision = $irss->manage()->getCurrentRevision($rid); // Second File
$latest_published_revision = $irss->manage()->getCurrentRevisionIncludingDraft($rid); // Second File

// im some cases you want to unpublish the latest revision again
$irss->manage()->unpublish($rid);
$latest_published_revision = $irss->manage()->getCurrentRevision($rid); // First upload
$latest_draft_revision = $irss->manage()->getCurrentRevisionIncludingDraft($rid); // Second Upload
```
