### PR TITLE
MetaData: introduce lom api to dic

### DIFF
--- a/Services/MetaData/docs/api.md
+++ b/Services/MetaData/docs/api.md
@@ -6,7 +6,8 @@ or contribute a fix via [Pull Request](../../../docs/development/contributing.md
 
 `Services\Metadata` offers an API with which the [Learning Object Metadata
 (LOM)](lom_structure.md) of ILIAS objects can be read out, processed,
-and manipulated. It can be obtained from the `DIC` via the method `lom`.
+and manipulated. It can be obtained from the `DIC` via the method
+`learningObjectMetadata`.
 
 The API offers four different sub-services. In the following, we will
 explain what they offer and how they can be used.

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -474,6 +474,11 @@ class Container extends \Pimple\Container
         return $this['file_delivery'];
     }
 
+    public function learningObjectMetadata(): \ILIAS\MetaData\Services\ServicesInterface
+    {
+        return new \ILIAS\MetaData\Services\Services($this);
+    }
+
     /**
      * Note: Only use isDependencyAvailable if strictly required. The need for this,
      * mostly points to some underlying problem needing to be solved instead of using this.


### PR DESCRIPTION
This PR introduces an API for the reading and editing of Learning Object Metadata of ILIAS Objects into the DIC. For further information, see the [documentation](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/Services/MetaData/docs/api.md).