### PR TITLE
AccessControl: Make items with preconditions clickable in Tree View (#28292)

### DIFF
--- a/Services/Repository/classes/class.ilRepositoryExplorerGUI.php
+++ b/Services/Repository/classes/class.ilRepositoryExplorerGUI.php
@@ -446,7 +446,10 @@ class ilRepositoryExplorerGUI extends ilTreeExplorerGUI
         $ilDB = $this->db;
 
         $obj_id = ilObject::_lookupObjId($a_node["child"]);
-        if (!ilConditionHandler::_checkAllConditionsOfTarget($a_node["child"], $obj_id)) {
+        if (
+            !ilConditionHandler::_checkAllConditionsOfTarget($a_node["child"], $obj_id)
+            && !$rbacsystem->checkAccess('write', $a_node["child"])
+        ) {
             return false;
         }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=28292

Makes items with preconditions clickable in Tree View for people with write access.