### PR TITLE
fix #37833 Ls as precondition for a subsequent object

### DIFF
--- a/Services/Tracking/classes/status/class.ilLPStatusCollection.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusCollection.php
@@ -405,7 +405,7 @@ class ilLPStatusCollection extends ilLPStatus
 
             case 'lso':
                 $participants = ilLearningSequenceParticipants::_getInstanceByObjId($objId);
-                return $participants->isMember($objId);
+                return $participants->isMember($usrId);
         }
 
         return true;


### PR DESCRIPTION
\ilLPStatusCollection::determineStatus checks the lso membership after the status of the grouping is determined. This check failed.