### PR TITLE
Delete `Survey` skill data when deleting competences

### DIFF
--- a/Modules/Survey/Skills/Service/class.SkillInternalManagerService.php
+++ b/Modules/Survey/Skills/Service/class.SkillInternalManagerService.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
+namespace ILIAS\Survey\Skills;
+
+/**
+ * @author Thomas Famula <famula@leifos.de>
+ */
+class SkillInternalManagerService
+{
+    public function getSkillDeletionManager(): SurveySkillDeletionManager
+    {
+        return new SurveySkillDeletionManager();
+    }
+}

--- a/Modules/Survey/Skills/Service/class.SkillInternalRepoService.php
+++ b/Modules/Survey/Skills/Service/class.SkillInternalRepoService.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
+namespace ILIAS\Survey\Skills;
+
+/**
+ * @author Thomas Famula <famula@leifos.de>
+ */
+class SkillInternalRepoService
+{
+    public function getSurveySkillRepo(): SurveySkillDBRepository
+    {
+        return new SurveySkillDBRepository();
+    }
+}

--- a/Modules/Survey/Skills/Service/class.SkillInternalService.php
+++ b/Modules/Survey/Skills/Service/class.SkillInternalService.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
+namespace ILIAS\Survey\Skills;
+
+/**
+ * @author Thomas Famula <famula@leifos.de>
+ */
+class SkillInternalService
+{
+    public function __construct()
+    {
+    }
+
+    public function repo(): SkillInternalRepoService
+    {
+        return new SkillInternalRepoService();
+    }
+
+    public function manager(): SkillInternalManagerService
+    {
+        return new SkillInternalManagerService();
+    }
+}

--- a/Modules/Survey/Skills/class.SurveySkillDBRepository.php
+++ b/Modules/Survey/Skills/class.SurveySkillDBRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
+namespace ILIAS\Survey\Skills;
+
+/**
+ * @author Thomas Famula <famula@leifos.de>
+ */
+class SurveySkillDBRepository
+{
+    protected \ilDBInterface $db;
+
+    public function __construct(
+        \ilDBInterface $db = null
+    ) {
+        global $DIC;
+
+        $this->db = ($db) ?: $DIC->database();
+    }
+
+    public function removeForSkill(int $skill_node_id, bool $is_reference): void
+    {
+        if (!$is_reference) {
+            $this->db->manipulate("DELETE FROM svy_quest_skill " .
+                " WHERE base_skill_id = " . $this->db->quote($skill_node_id, "integer"));
+            $this->db->manipulate("DELETE FROM svy_skill_threshold " .
+                " WHERE base_skill_id = " . $this->db->quote($skill_node_id, "integer"));
+        } else {
+            $this->db->manipulate("DELETE FROM svy_quest_skill " .
+                " WHERE tref_id = " . $this->db->quote($skill_node_id, "integer"));
+            $this->db->manipulate("DELETE FROM svy_skill_threshold " .
+                " WHERE tref_id = " . $this->db->quote($skill_node_id, "integer"));
+        }
+    }
+}

--- a/Modules/Survey/Skills/class.SurveySkillDeletionManager.php
+++ b/Modules/Survey/Skills/class.SurveySkillDeletionManager.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
+namespace ILIAS\Survey\Skills;
+
+/**
+ * @author Thomas Famula <famula@leifos.de>
+ */
+class SurveySkillDeletionManager
+{
+    protected SurveySkillDBRepository $survey_skill_repo;
+
+    public function __construct(
+        SurveySkillDBRepository $survey_skill_repo = null
+    ) {
+        global $DIC;
+
+        $this->survey_skill_repo = ($survey_skill_repo)
+            ?: $DIC->skills()->internalSurvey()->repo()->getSurveySkillRepo();
+    }
+
+    public function removeSurveySkillsForSkill(int $skill_node_id, bool $is_reference = false): void
+    {
+        $this->survey_skill_repo->removeForSkill($skill_node_id, $is_reference);
+    }
+}

--- a/Modules/Survey/classes/class.ilSurveyAppEventListener.php
+++ b/Modules/Survey/classes/class.ilSurveyAppEventListener.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
+/**
+ * @author Thomas Famula <famula@leifos.de>
+ */
+class ilSurveyAppEventListener implements ilAppEventListener
+{
+    /**
+     * @inheritDoc
+     */
+    public static function handleEvent(string $a_component, string $a_event, array $a_parameter): void
+    {
+        global $DIC;
+
+        $survey_skill_deletion_manager = $DIC->skills()->internalSurvey()->manager()->getSkillDeletionManager();
+
+        switch ($a_component) {
+            case "Services/Skill":
+                switch ($a_event) {
+                    case "deleteSkill":
+                        $survey_skill_deletion_manager->removeSurveySkillsForSkill(
+                            $a_parameter["node_id"],
+                            $a_parameter["is_reference"]
+                        );
+                        break;
+                }
+                break;
+        }
+    }
+}

--- a/Modules/Survey/module.xml
+++ b/Modules/Survey/module.xml
@@ -29,4 +29,7 @@
 		<context id="svy_rater_inv" class="ilSurveyMailTemplateRaterInvitationContext" />
 	</mailtemplates>
 	<logging />
+	<events>
+		<event type="listen" id="Services/Skill" />
+	</events>
 </module>

--- a/Services/Skill/Service/classes/class.SkillService.php
+++ b/Services/Skill/Service/classes/class.SkillService.php
@@ -117,10 +117,10 @@ class SkillService implements SkillServiceInterface
     /**
      * Internal service for Skill classes in Survey Module
      */
-    /*public function internalSurvey(): Survey\Skills\SkillInternalService
+    public function internalSurvey(): Survey\Skills\SkillInternalService
     {
         return new Survey\Skills\SkillInternalService();
-    }*/
+    }
 
     /**
      * Internal service for Skill classes in Test Module


### PR DESCRIPTION
Related feature: [Improvement of deleting competences](https://docu.ilias.de/goto_docu_wiki_wpage_6588_1357.html)

With the following PR, all `Survey` data, which is related to competences, will be deleted as soon as competences are deleted in the administration. Otherwise, this superfluous data remains unnecessarily in the database, which probably would lead to errors, because old competence assignment would not be found anymore.