### PR TITLE
MediaCast: 31722 fix ordering issues at copying object

### DIFF
--- a/Modules/MediaCast/classes/class.ilObjMediaCast.php
+++ b/Modules/MediaCast/classes/class.ilObjMediaCast.php
@@ -389,6 +389,9 @@ class ilObjMediaCast extends ilObject
     ): void {
         $items = [];
         foreach ($this->readOrder() as $i) {
+            if(!array_key_exists($i, $mapping)) {
+                continue;
+            }
             $items[] = $mapping[$i];
         }
         $newObj->saveOrder($items);

--- a/Modules/MediaCast/classes/class.ilObjMediaCastGUI.php
+++ b/Modules/MediaCast/classes/class.ilObjMediaCastGUI.php
@@ -943,7 +943,7 @@ class ilObjMediaCastGUI extends ilObjectGUI
             $mc_item = new ilNewsItem($item_id);
             $mc_item->delete();
         }
-
+        $this->object->saveOrder($this->object->readItems());
         $ilCtrl->redirect($this, "listItems");
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=31722

If an item will be deleted there is no reordering of existing items. This causes the mentioned problem in the ticket. There is an old ordering entry for a non existing item. At the copy process the mapping will fail.

I add a reordering after delete of an item and a check the old ordering item id is existing in mapping array.
