### PR TITLE
Test: Remove Month From Waiting Time

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -5639,7 +5639,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             $waiting_between_passes = $this->getMainSettings()->getTestBehaviourSettings()->getPassWaiting();
             if ($last_pass && $waiting_between_passes !== '') {
                 $time_values = explode(":", $waiting_between_passes);
-                $next_pass_allowed = strtotime('+ ' . $time_values[0] . ' Months + ' . $time_values[1] . ' Days + ' . $time_values[2] . ' Hours' . $time_values[3] . ' Minutes', $last_pass);
+                $next_pass_allowed = strtotime('+ ' . $time_values[0] . ' Days + ' . $time_values[1] . ' Hours' . $time_values[2] . ' Minutes', $last_pass);
 
                 if (time() < $next_pass_allowed) {
                     $date = ilDatePresentation::formatDate(new ilDateTime($next_pass_allowed, IL_CAL_UNIX));


### PR DESCRIPTION
This PR removes the month field from the setting for waiting between test passes.

This was approved by the JF on august 7th 2023. See: https://docu.ilias.de/goto_docu_wiki_wpage_7987_1357.html#ilPageTocA2527

Current settings that contain a month value will add 31 days per month to the  count. 