### PR TITLE
[FIX] broken file-objects without RID did throw exception

### DIFF
--- a/Modules/File/classes/class.ilObjFileGUI.php
+++ b/Modules/File/classes/class.ilObjFileGUI.php
@@ -758,6 +758,7 @@ class ilObjFileGUI extends ilObject2GUI
         }
 
         $preview = new ilObjFilePreviewRendererGUI($this->object_id);
+        $preview->init();
 
         if (!$this->ctrl->isAsynch()
             && $preview->has()

--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -1112,7 +1112,7 @@ class ilObjectListGUI
             // New Preview Implementation, File-Objects only
             if ($this->type === 'file') {
                 $preview = new ilObjFilePreviewRendererGUI($this->obj_id);
-                if ($preview->has()) {
+                if ($preview->init() && $preview->has()) {
                     $this->tpl->setVariable('PREVIEW_GLYPH', $preview->getRenderedTriggerComponents());
                     $this->tpl->parseCurrentBlock();
                 }


### PR DESCRIPTION
@kergomard On test9 there are a few file-objects that have no RID (and are therefore actually broken anyway). nevertheless I would like to catch the case in the list guis, because otherwise the whole container can no longer be displayed. see small change in ilObjectListGUI