### PR TITLE
DateTime and Duration Inputs for Filter

### DIFF
--- a/src/UI/Component/Input/Field/DateTime.php
+++ b/src/UI/Component/Input/Field/DateTime.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Input\Field;
 
-use ILIAS\UI\Component\Input\Container\Form\FormInput;
+use ILIAS\UI\Component\Input\Container\Filter\FilterInput;
 use ILIAS\Data\DateFormat\DateFormat;
 use ILIAS\UI\Component\Component;
 use DateTimeImmutable;
@@ -28,7 +28,7 @@ use DateTimeImmutable;
 /**
  * This describes the datetime-field.
  */
-interface DateTime extends FormInput
+interface DateTime extends FilterInput
 {
     /**
      * Get an input like this using the given format.

--- a/src/UI/Component/Input/Field/Duration.php
+++ b/src/UI/Component/Input/Field/Duration.php
@@ -20,14 +20,14 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Input\Field;
 
-use ILIAS\UI\Component\Input\Container\Form\FormInput;
+use ILIAS\UI\Component\Input\Container\Filter\FilterInput;
 use ILIAS\Data\DateFormat\DateFormat;
 use DateTimeImmutable;
 
 /**
  * This describes the duration input.
  */
-interface Duration extends Group
+interface Duration extends Group, FilterInput
 {
     /**
      * Get an input like this using the given format.

--- a/src/UI/Implementation/Component/Input/Field/DateTime.php
+++ b/src/UI/Implementation/Component/Input/Field/DateTime.php
@@ -33,7 +33,7 @@ use Closure;
 /**
  * This implements the date input.
  */
-class DateTime extends FormInput implements C\Input\Field\DateTime
+class DateTime extends FilterInput implements C\Input\Field\DateTime
 {
     use ComponentHelper;
     use JavaScriptBindable;
@@ -211,9 +211,17 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
 
     public function getUpdateOnLoadCode(): Closure
     {
-        return fn($id) => "$('#$id').on('input dp.change', function(event) {
+        return fn($id) => "$('#$id').on('input', function(event) {
 				il.UI.input.onFieldUpdate(event, '$id', $('#$id').find('input').val());
 			});
 			il.UI.input.onFieldUpdate(event, '$id', $('#$id').find('input').val());";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isComplex(): bool
+    {
+        return false;
     }
 }

--- a/src/UI/Implementation/Component/Input/Field/Duration.php
+++ b/src/UI/Implementation/Component/Input/Field/Duration.php
@@ -89,7 +89,7 @@ class Duration extends Group implements C\Input\Field\Duration
     protected function addValidation(): void
     {
         $txt_id = 'duration_end_must_not_be_earlier_than_start';
-        $error = fn (callable $txt, $value) => $txt($txt_id, $value);
+        $error = fn(callable $txt, $value) => $txt($txt_id, $value);
         $is_ok = function ($v) {
             if (is_null($v)) {
                 return true;
@@ -126,7 +126,7 @@ class Duration extends Group implements C\Input\Field\Duration
     protected function applyFormat(): void
     {
         $this->inputs = array_map(
-            fn ($input) => $input->withFormat($this->getFormat()),
+            fn($input) => $input->withFormat($this->getFormat()),
             $this->inputs
         );
     }
@@ -148,7 +148,7 @@ class Duration extends Group implements C\Input\Field\Duration
     protected function applyMinValue(): void
     {
         $this->inputs = array_map(
-            fn ($input) => $input->withMinValue($this->getMinValue()),
+            fn($input) => $input->withMinValue($this->getMinValue()),
             $this->inputs
         );
     }
@@ -178,7 +178,7 @@ class Duration extends Group implements C\Input\Field\Duration
     protected function applyMaxValue(): void
     {
         $this->inputs = array_map(
-            fn ($inpt) => $inpt->withMaxValue($this->getMaxValue()),
+            fn($inpt) => $inpt->withMaxValue($this->getMaxValue()),
             $this->inputs
         );
     }
@@ -208,7 +208,7 @@ class Duration extends Group implements C\Input\Field\Duration
     protected function applyWithTimeOnly(): void
     {
         $this->inputs = array_map(
-            fn ($input) => $input->withTimeOnly($this->getTimeOnly()),
+            fn($input) => $input->withTimeOnly($this->getTimeOnly()),
             $this->inputs
         );
     }
@@ -246,7 +246,7 @@ class Duration extends Group implements C\Input\Field\Duration
     protected function applyWithUseTime(): void
     {
         $this->inputs = array_map(
-            fn ($input) => $input->withUseTime($this->getUseTime()),
+            fn($input) => $input->withUseTime($this->getUseTime()),
             $this->inputs
         );
     }
@@ -259,7 +259,7 @@ class Duration extends Group implements C\Input\Field\Duration
         $clone = clone $this;
         $clone->timezone = $tz;
         $clone->inputs = array_map(
-            fn ($input) => $input->withTimezone($tz),
+            fn($input) => $input->withTimezone($tz),
             $clone->inputs
         );
         return $clone;
@@ -298,14 +298,14 @@ class Duration extends Group implements C\Input\Field\Duration
      */
     public function getUpdateOnLoadCode(): Closure
     {
-        return fn ($id) => "var combinedDuration = function() {
+        return fn($id) => "var combinedDuration = function() {
 				var options = [];
 				$('#$id').find('input').each(function() {
 					options.push($(this).val());
 				});
 				return options.join(' - ');
 			}
-			$('#$id').on('input dp.change', function(event) {
+			$('#$id').on('input', function(event) {
 				il.UI.input.onFieldUpdate(event, '$id', combinedDuration());
 			});
 			il.UI.input.onFieldUpdate(event, '$id', combinedDuration());";
@@ -319,5 +319,13 @@ class Duration extends Group implements C\Input\Field\Duration
             $clone->inputs[1]->withLabel($end_label)
         ];
         return $clone;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isComplex(): bool
+    {
+        return true;
     }
 }

--- a/src/UI/Implementation/Component/Input/Field/FilterInput.php
+++ b/src/UI/Implementation/Component/Input/Field/FilterInput.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Input\Field;
+
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use ILIAS\UI\Implementation\Component\Triggerer;
+
+abstract class FilterInput extends FormInput implements \ILIAS\UI\Component\Input\Container\Filter\FilterInput
+{
+    use JavaScriptBindable;
+    use Triggerer;
+
+    protected bool $in_popover = false;
+
+    public function __construct(
+        DataFactory $data_factory,
+        Refinery $refinery,
+        protected string $label,
+        protected ?string $byline = null,
+    ) {
+        parent::__construct($data_factory, $refinery, $this->label, $this->byline);
+    }
+
+    /**
+     * Is this input a sub-component of a complex input and rendered within a Popover?
+     */
+    public function isInPopoverView(): bool
+    {
+        return $this->in_popover;
+    }
+
+    /**
+     * Get an input like this, but set it to a state rendered in a Popover.
+     *
+     * @return static
+     */
+    public function withPopoverView(bool $in_popover): self
+    {
+        $clone = clone $this;
+        $clone->in_popover = $in_popover;
+        return $clone;
+    }
+}

--- a/src/UI/Implementation/Component/Input/Field/MultiSelect.php
+++ b/src/UI/Implementation/Component/Input/Field/MultiSelect.php
@@ -28,13 +28,12 @@ use Closure;
 /**
  * This implements the multi-select input.
  */
-class MultiSelect extends FormInput implements C\Input\Field\MultiSelect
+class MultiSelect extends FilterInput implements C\Input\Field\MultiSelect
 {
     /**
      * @var array <string,string> {$value => $label}
      */
     protected array $options = [];
-    private bool $complex = true;
 
     /**
      * @param array<string, string> $options
@@ -118,6 +117,6 @@ class MultiSelect extends FormInput implements C\Input\Field\MultiSelect
      */
     public function isComplex(): bool
     {
-        return $this->complex;
+        return true;
     }
 }

--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -30,10 +30,8 @@ use ILIAS\Refinery\ConstraintViolationException;
 /**
  * This implements the numeric input.
  */
-class Numeric extends FormInput implements C\Input\Field\Numeric
+class Numeric extends FilterInput implements C\Input\Field\Numeric
 {
-    private bool $complex = false;
-
     public function __construct(
         DataFactory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
@@ -90,6 +88,6 @@ class Numeric extends FormInput implements C\Input\Field\Numeric
      */
     public function isComplex(): bool
     {
-        return $this->complex;
+        return false;
     }
 }

--- a/src/UI/Implementation/Component/Input/Field/Select.php
+++ b/src/UI/Implementation/Component/Input/Field/Select.php
@@ -28,7 +28,7 @@ use Closure;
 /**
  * This implements the select.
  */
-class Select extends FormInput implements C\Input\Field\Select
+class Select extends FilterInput implements C\Input\Field\Select
 {
     protected array $options;
     protected string $label;
@@ -37,7 +37,6 @@ class Select extends FormInput implements C\Input\Field\Select
      * @var mixed
      */
     protected $value;
-    private bool $complex = false;
 
     public function __construct(
         DataFactory $data_factory,
@@ -97,6 +96,6 @@ class Select extends FormInput implements C\Input\Field\Select
      */
     public function isComplex(): bool
     {
-        return $this->complex;
+        return false;
     }
 }

--- a/src/UI/Implementation/Component/Input/Field/Text.php
+++ b/src/UI/Implementation/Component/Input/Field/Text.php
@@ -28,10 +28,9 @@ use Closure;
 /**
  * This implements the text input.
  */
-class Text extends FormInput implements C\Input\Field\Text
+class Text extends FilterInput implements C\Input\Field\Text
 {
     private ?int $max_length = null;
-    private bool $complex = false;
 
     /**
      * @inheritdoc
@@ -112,6 +111,6 @@ class Text extends FormInput implements C\Input\Field\Text
      */
     public function isComplex(): bool
     {
-        return $this->complex;
+        return false;
     }
 }

--- a/src/UI/examples/Input/Container/Filter/Standard/base.php
+++ b/src/UI/examples/Input/Container/Filter/Standard/base.php
@@ -24,6 +24,8 @@ function base()
         "Multi Selection",
         ["one" => "Num One", "two" => "Num Two", "three" => "Num Three", "four" => "Num Four", "five" => "Num Five"]
     );
+    $date = $ui->input()->field()->dateTime("Date/Time")->withUseTime(true);
+    $duration = $ui->input()->field()->duration("Duration")->withUseTime(true);
 
     //Step 2: Define the filter and attach the inputs.
     $action = $DIC->ctrl()->getLinkTargetByClass("ilsystemstyledocumentationgui", "entries", "", true);
@@ -36,9 +38,11 @@ function base()
             "with_def" => $with_def,
             "init_hide" => $init_hide,
             "number" => $number,
-            "multi_select" => $multi_select
+            "multi_select" => $multi_select,
+            "date" => $date,
+            "duration" => $duration
         ],
-        [true, true, true, false, true, true],
+        [true, true, true, false, true, true, true, true],
         true,
         true
     );

--- a/src/UI/templates/default/Input/tpl.context_filter_popover.html
+++ b/src/UI/templates/default/Input/tpl.context_filter_popover.html
@@ -1,0 +1,6 @@
+<div class="form-group row">
+    <label <!-- BEGIN for -->for="{ID}" <!-- END for -->class="control-label col-sm-4 col-md-3 col-lg-2">{LABEL}</label>
+    <div class="col-sm-8 col-md-9 col-lg-10">
+        {FILTER_INPUT}
+    </div>
+</div>


### PR DESCRIPTION
Hello everybody!

This PR adds the [recently revised](https://github.com/ILIAS-eLearning/ILIAS/pull/6276) `DateTime` and `Duration` Inputs for the Filter. 

Although the general implementation seems to be fine, there are some issues I could not solve at the moment:

- Layout in Popover content: The Duration Input is rendered as a "complex" Filter Input in a Popover (see screenshot). This does not look that bad, but it could still use some polish. Maybe some UI experts could help here with the HTML/CSS. (Side note: Please ignore the wrong placement of the Popover. This is a general problem of the Popovers within the Filter – and maybe some other UI components – in the current trunk and should be tackled separately.)
- Method getUpdateOnLoadCode: This method is primarily used for "complex" Filter Inputs to synchronize the changes within the Popover with the Filter Field, which triggers the Popover. Unfortunately, it turned out to be difficult to make this method work for the new Inputs, especially for the Duration Input, which technically consists of two DateTime Inputs, what makes it more difficult. I've run out of ideas and probably will need some help here. But it's important to mention here, that this will not obstruct the functionality of the Inputs within the Filter. The problem is limited to usability and could theoretically be tackled as a separate issue.

@tfamula 


![Bildschirmfoto vom 2023-10-20 11-58-02](https://github.com/ILIAS-eLearning/ILIAS/assets/35489053/37a79932-3162-412c-b86f-f4c2284f56d3)