### PR TITLE
UI: Fix withValue with DateTimeImmutable

### DIFF
--- a/Modules/IndividualAssessment/classes/ilIndividualAssessmentUserGrading.php
+++ b/Modules/IndividualAssessment/classes/ilIndividualAssessmentUserGrading.php
@@ -194,7 +194,7 @@ class ilIndividualAssessmentUserGrading
 
         if (!is_null($this->getEventTime())) {
             $event_time = $event_time->withValue(
-                $this->getEventTime()->format($date_format->toString() . ' HH:mm')
+                $this->getEventTime()
             );
         }
 

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -49,6 +49,9 @@ class Renderer extends AbstractComponentRenderer
     public const TYPE_DATE = 'date';
     public const TYPE_DATETIME = 'datetime-local';
     public const TYPE_TIME = 'time';
+    public const HTML5_NATIVE_DATETIME_FORMAT = 'Y-m-d H:i';
+    public const HTML5_NATIVE_DATE_FORMAT = 'Y-m-d';
+    public const HTML5_NATIVE_TIME_FORMAT = 'H:i';
 
     public const DATEPICKER_FORMAT_MAPPING = [
         'd' => 'DD',
@@ -671,7 +674,17 @@ class Renderer extends AbstractComponentRenderer
 
         $tpl->setVariable("PLACEHOLDER", $format);
 
-        $this->applyValue($component, $tpl, $this->escapeSpecialChars());
+        $this->applyValue($component, $tpl, function (?string $value) use ($dt_type) {
+            if ($value !== null) {
+                $value = new \DateTimeImmutable($value);
+                return $value->format(match ($dt_type) {
+                    self::TYPE_DATETIME => self::HTML5_NATIVE_DATETIME_FORMAT,
+                    self::TYPE_DATE => self::HTML5_NATIVE_DATE_FORMAT,
+                    self::TYPE_TIME => self::HTML5_NATIVE_TIME_FORMAT,
+                });
+            }
+            return null;
+        });
         $this->maybeDisable($component, $tpl);
         $id = $this->bindJSandApplyId($component, $tpl);
         return $this->wrapInFormContext($component, $tpl->get(), $id);

--- a/tests/UI/Component/Input/Field/DateTimeInputTest.php
+++ b/tests/UI/Component/Input/Field/DateTimeInputTest.php
@@ -150,7 +150,7 @@ class DateTimeInputTest extends ILIAS_UI_TestBase
 
     public function testWithValueThatIsDateTimeImmutable(): void
     {
-        $string_value = "1985-05-04";
+        $string_value = "1985-05-04 00:00";
         $value = new \DateTimeImmutable($string_value);
         $datetime = $this->factory->datetime('label', 'byline')
             ->withValue($value);
@@ -158,5 +158,12 @@ class DateTimeInputTest extends ILIAS_UI_TestBase
             $string_value,
             $datetime->getValue()
         );
+    }
+
+    public function testWithInvalidValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $datetime = $this->factory->datetime('label', 'byline')
+            ->withValue("this is no datetime...");
     }
 }


### PR DESCRIPTION
Apparently the html5 datetime-local input expects the given value to be in the format 'Y-m-d H:i'.

See: https://mantis.ilias.de/view.php?id=38265