### PR TITLE
Fix `fixPosition` - don't constantly expand dropdown on click any more

### DIFF
--- a/Services/JavaScript/js/Basic.js
+++ b/Services/JavaScript/js/Basic.js
@@ -230,8 +230,8 @@ il.Util = {
 			return;
 		}
 
-		if (vp.right - 20 < r.right) {
-			il.Util.setX(el, r.x - (r.right - vp.right + 20));
+		if (vp.right - 15 < r.right) {
+			il.Util.setX(el, r.x - (r.right - vp.right + 15));
 		}
 
 		r = il.Util.getRegion(el);


### PR DESCRIPTION
[This default style](https://github.com/ILIAS-eLearning/ILIAS/blob/6c4340641218e131cafbbab0f1a159bd241fbf1a/templates/default/delos.css#L12815) in combination with [this](https://github.com/ILIAS-eLearning/ILIAS/blob/6c4340641218e131cafbbab0f1a159bd241fbf1a/templates/default/delos.css#L2338) places the top right “action” dropDown `15px` from the right side of the screen.

Fix position then checks that the right side is at least 20px from the edge of the screen. Since this is not the case it tries to move the dropdown to the left by decrementing the `left` style property by `5px`. But since the element still has the `right: 0` property this only increases the width of the dropdown, not the right position, leaving the “problem” unresolved.

This causes every click on the “action” button to increase the width of the dropdown

This PR fixes this behaviour by dropping the threshold in `fixPosition` to `15px`, the value that's used in the stylesheets.