### PR TITLE
9/UI/fix submit button on wrong side

### DIFF
--- a/src/UI/templates/default/Modal/tpl.roundtrip.html
+++ b/src/UI/templates/default/Modal/tpl.roundtrip.html
@@ -17,10 +17,10 @@
 				<!-- BEGIN with_buttons -->
 				{BUTTON}
 				<!-- END with_buttons -->
-				<button class="btn btn-default" data-dismiss="modal">{CANCEL_BUTTON_LABEL}</button>
-				<!-- BEGIN with_submit -->
+                <!-- BEGIN with_submit -->
 				{SUBMIT_BUTTON}
 				<!-- END with_submit -->
+				<button class="btn btn-default" data-dismiss="modal">{CANCEL_BUTTON_LABEL}</button>
 			</div>
 		</div>
 	</div>

--- a/tests/UI/Component/Dropzone/File/StandardTest.php
+++ b/tests/UI/Component/Dropzone/File/StandardTest.php
@@ -47,7 +47,7 @@ class StandardTest extends FileTestBase
 				<div class="modal-body">
 					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">' . $this->input->getCanonicalName() . '</form>
 				</div>
-				<div class="modal-footer"><button class="btn btn-default" data-dismiss="modal">cancel</button><button class="btn btn-default" id="id_3">save</button></div>
+				<div class="modal-footer"><button class="btn btn-default" id="id_3">save</button><button class="btn btn-default" data-dismiss="modal">cancel</button></div>
 			</div>
 		</div>
 	</div>
@@ -116,7 +116,7 @@ class StandardTest extends FileTestBase
 				<div class="modal-body">
 					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">' . $this->input->getCanonicalName() . '</form>
 				</div>
-				<div class="modal-footer"><button class="btn btn-default" data-dismiss="modal">cancel</button><button class="btn btn-default" id="id_3">save</button></div>
+				<div class="modal-footer"><button class="btn btn-default" id="id_3">save</button><button class="btn btn-default" data-dismiss="modal">cancel</button></div>
 			</div>
 		</div>
 	</div>

--- a/tests/UI/Component/Dropzone/File/WrapperTest.php
+++ b/tests/UI/Component/Dropzone/File/WrapperTest.php
@@ -44,7 +44,7 @@ class WrapperTest extends FileTestBase
 				<div class="modal-body">
 					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">File Field Input</form>
 				</div>
-				<div class="modal-footer"><button class="btn btn-default" data-dismiss="modal">cancel</button><button class="btn btn-default" id="id_3">save</button></div>
+				<div class="modal-footer"><button class="btn btn-default" id="id_3">save</button><button class="btn btn-default" data-dismiss="modal">cancel</button></div>
 			</div>
 		</div>
 	</div>

--- a/tests/UI/Component/Launcher/LauncherInlineTest.php
+++ b/tests/UI/Component/Launcher/LauncherInlineTest.php
@@ -236,8 +236,8 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
                         </form>
                     </div>
                     <div class="modal-footer">
-                        <button class="btn btn-default" data-dismiss="modal">some cancel label</button>
                         <button class="btn btn-default" id="id_4">some submit label</button>
+                        <button class="btn btn-default" data-dismiss="modal">some cancel label</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Hi @Amstutz , @klees, and @thibsy 

This is a PR changing the submit button in the Roundtrip Modal from the right to the left of the button to cancel. I think this is in accordance with the Usage Rules.

See: https://mantis.ilias.de/view.php?id=38322

Thanks and best,
@kergomard 