### PR TITLE
Proposal for new Footer-Interface

### DIFF
--- a/src/UI/Component/MainControls/Factory.php
+++ b/src/UI/Component/MainControls/Factory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Component\MainControls;
 
@@ -315,8 +315,9 @@ interface Factory
      *     such as links to the pages's imprint or a privacy policy document.
      *
      *   composition: >
-     *     The Footer is composed of a list of Links or Shy Buttons triggering
-     *     Round Trip Modals and an optional text-part.
+     *     The Footer is redered empty or composed with a list of Links or Shy Buttons triggering
+     *     Round Trip Modals and optional text-parts. The composition is divided into three areas: Sharing-Links,
+     *     Utility-Link-Groups and Meta-Information. An empty Footer will not be rendered.
      *
      * context:
      *   - The Footer is used with the Standard Page.
@@ -330,12 +331,14 @@ interface Factory
      *     3: >
      *        Although the footer is constructed only with its "static" parts,
      *        it SHOULD have attached a permanent URL for the current page/object.
+     *     4: >
+     *        The Footer SHOULD NOT contain Meta-Infos which are other than plaintext and/or
+     *        longer than 1000 characters.
+     *
      * ----
-     * @param  \ILIAS\UI\Component\Link\Standard[] $links
-     * @param  string $text
      * @return  \ILIAS\UI\Component\MainControls\Footer
      */
-    public function footer(array $links, string $text = ''): Footer;
+    public function footer(): Footer;
 
 
     /**

--- a/src/UI/Component/MainControls/Footer.php
+++ b/src/UI/Component/MainControls/Footer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Component\MainControls;
 
 use ILIAS\Data\URI;
@@ -32,20 +32,35 @@ use ILIAS\UI\Component\Modal;
 interface Footer extends Component
 {
     /**
-     * @return Link\Standard[]
+     * @description Sharing links are used, for example, to share the current page in ILIAS. In ILIAS itself,
+     * for example, the permanent link is used as a sharing link. Accepted are `\ILIAS\UI\Component\Link\Standard`
+     * and `\ILIAS\UI\Component\Button\Shy`. Please note that modals which should be triggered e.g. via buttons must
+     * be passed via the @see withModalsToRender method. The bundling of button and modal is up to the consumer.
      */
-    public function getLinks(): array;
-
-    public function getText(): string;
+    public function withAdditionalSharingLink(Link\Standard|Button\Shy $link): static;
 
     /**
-     * @return array<Modal\RoundTrip, Button\Shy>[]
+     * @description Utility link groups are thematically bundled collections of links. Title $title is expected to be
+     * translated. The links can be supplied as `\ILIAS\UI\Component\Link\Standard` or `\ILIAS\UI\Component\Button\Shy`.
+     * The groups are rendered in the order they are added to the Footer.
+     * Please note that modals which should be triggered e.g. via buttons must be passed via the @see withModalsToRender
+     * method. The bundling of button and modal is up to the consumer.
      */
-    public function getModals(): array;
+    public function withAdditionalUtilityLinkGroup(string $title, Link\Standard|Button\Shy ...$links): static;
 
-    public function withAdditionalModalAndTrigger(Modal\RoundTrip $roundTripModal, Button\Shy $shyButton): Footer;
+    /**
+     * @description Meta-infos are short, simple, often technical information about the current page or the entire
+     * installation. Due to the lack of a defined component, strings are currently accepted here. However, the strings
+     * may only consist of sanitized plain text. The footer will require a stricter declaration here in the future,
+     * as soon as it is available.
+     */
+    public function withMetaInfo(string ...$meta_info): static;
 
-    public function getPermanentURL(): ?URI;
+    /**
+     * @description So that modals triggered by `\ILIAS\UI\Component\Button\Shy` buttons in
+     * @see withAdditionalSharingLink or @see withAdditionalUtilityLinkGroup are rendered on the page,
+     * they can be passed here. The bundling of button and modal is up to the consumer.
+     */
+    public function withModalsToRender(Modal\Modal ...$modal): static;
 
-    public function withPermanentURL(URI $url): Footer;
 }


### PR DESCRIPTION
This is the interface change as a suggestion for the rebuilding of the footer according to [Revamping Footer with Link-Groups](https://docu.ilias.de/goto_docu_wiki_wpage_7883_1357.html).

The new footer is divided into three areas: Sharing-Links, Utility-Link-Groups and Meta-Infos:

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/6661332/45c357fd-bdce-455b-bb4a-563fd0a7fe22)

Rendered, the new footer looks like this: 

Desktop:
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/6661332/98a1d09a-2e4c-49e6-ad79-06abda200751)


Mobile:
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/6661332/72010381-bb58-449d-80c9-be4a54519833)


The interface loses all getter methods, as these do not have to be part of the interface. these are for internal use in the renderer and are only done on the implementation.
