### PR TITLE
User: Fix `Mustache` migration for welcome mail

### DIFF
--- a/Services/User/classes/Setup/Migration/class.ilUpdateNewAccountMailTemplatesForMustache.php
+++ b/Services/User/classes/Setup/Migration/class.ilUpdateNewAccountMailTemplatesForMustache.php
@@ -65,7 +65,7 @@ class ilUpdateNewAccountMailTemplatesForMustache implements Migration
 
     public function getRemainingAmountOfSteps(): int
     {
-        $q = 'SELECT COUNT(lang) AS open FROM mail_template ' . PHP_EOL . $this->getWhere();
+        $q = 'SELECT COUNT(*) AS open FROM mail_template ' . PHP_EOL . $this->getWhere();
         $res = $this->db->query($q);
         $row = $this->db->fetchAssoc($res);
 
@@ -137,12 +137,12 @@ class ilUpdateNewAccountMailTemplatesForMustache implements Migration
             $row = $this->db->fetchAssoc($res);
 
             $subject = preg_replace(
-                '/\[([A-Z_]+?)\]/',
+                '/\[([A-Z_\/]+?)\]/',
                 '{{$1}}',
                 $row['subject'] ?? ''
             );
             $body = preg_replace(
-                '/\[([A-Z_]+?)\]/',
+                '/\[([A-Z_\/]+?)\]/',
                 '{{$1}}',
                 $row['body'] ?? ''
             );


### PR DESCRIPTION
This PR applies some fixes for the `Mustache` syntax migration of welcome mail subjects/bodies.

* `()` were missing in `getWhere`, so the former code was logically wrong.
* `ilDbInterface::setLimit` is used instead of `LIMIT 1` in raw SQL
* The SQL `REGEXP_REPLACE` statements did not work at all. I replaced the code by PHP `preg_replace` calls.