### PR TITLE
UI: datetime_required LangVar in Wrong Module

### DIFF
--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -16256,7 +16256,6 @@ trac#:#user_total#:#User Total
 trac#:#view_mode#:#اسلوب المعاينة
 tstv#:#tstv_create#:#Create Test Verification
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16413,6 +16412,7 @@ user#:#usr_public_profile_logged_in#:#تسجيل دخول المستخدمين
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -16253,7 +16253,6 @@ trac#:#user_total#:#User Total###06 08 2010 new variable
 trac#:#view_mode#:#View mode###25 02 2007 new variable
 tstv#:#tstv_create#:#Create Test Verification###12 06 2011 new variable
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it###12 06 2011 new variable
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16410,6 +16409,7 @@ user#:#usr_public_profile_logged_in#:#Logged in Users###24 07 2009 new variable
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#Celkem uživatelů
 trac#:#view_mode#:#Mód zobrazení
 tstv#:#tstv_create#:#Vytvořit verifikaci testu
 tstv#:#tstv_create_info#:#Vyberte úplný test pro generování jeho certifikátu
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#Viditelné pro přihlášené uživatele.
 usr#:#user_action#:#Akce uživatele
 usr#:#user_actions#:#Akce uživatele
 usr#:#user_actions_activation_info#:#Akce budou pouze vedeny v seznamech pouze pro uživatele, pokud budou aktivovány odpovídající služby a pokud jsou dány všechny předpoklady (např. požadavky na oprávnění).
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Hodnota typu '%s' není nula.
 validation#:#not_a_string#:#Hodnota typu '%s' není řada.

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -16256,7 +16256,6 @@ trac#:#user_total#:#User Total###06 08 2010 new variable
 trac#:#view_mode#:#View mode
 tstv#:#tstv_create#:#Create Test Verification###12 06 2011 new variable
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it###12 06 2011 new variable
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16413,6 +16412,7 @@ user#:#usr_public_profile_logged_in#:#Brugere der er logget ind
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -17010,7 +17010,6 @@ ui#:#datatable_multiactionmodal_buttonlabel#:#Ausführen
 ui#:#datatable_multiactionmodal_listentry#:#Für alle ausführen
 ui#:#datatable_multiactionmodal_msg#:#<b>Achtung!</b> mehrere Objekte betroffen
 ui#:#datatable_multiactionmodal_title#:#Aktion für mehrere Objekte
-ui#:#datetime_required#:#Zeit/Datum erforderlich
 ui#:#duration_default_label_end#:#Ende
 ui#:#duration_default_label_start#:#Beginn
 ui#:#duration_end_must_not_be_earlier_than_start#:#Der Beginn muss zeitlich vor dem Ende liegen.
@@ -17181,6 +17180,7 @@ user#:#usr_public_profile_logged_in#:#Für angemeldete Benutzer sichtbar
 usr#:#user_action#:#Benutzeraktion
 usr#:#user_actions#:#Benutzeraktionen
 usr#:#user_actions_activation_info#:#Die Aktionen werden nur angeboten, wenn die entsprechenden Dienste aktiviert sind und für die Benutzer die notwendigen Voraussetzungen (z.B. Berechtigungen) gegeben sind.
+validation#:#datetime_required#:#Zeit/Datum erforderlich
 validation#:#no_array#:#Wert ist kein Feld
 validation#:#not_a_null#:#Wert vom Typ '%s' ist keine Null.
 validation#:#not_a_string#:#Wert vom Typ '%s' ist kein String.

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -16257,7 +16257,6 @@ trac#:#user_total#:#User Total###06 08 2010 new variable
 trac#:#view_mode#:#Κατάσταση προβολής
 tstv#:#tstv_create#:#Create Test Verification###12 06 2011 new variable
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it###12 06 2011 new variable
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16414,6 +16413,7 @@ user#:#usr_public_profile_logged_in#:#Logged in Users###24 07 2009 new variable
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -17003,7 +17003,6 @@ ui#:#datatable_multiactionmodal_buttonlabel#:#Execute
 ui#:#datatable_multiactionmodal_listentry#:#apply to all objects
 ui#:#datatable_multiactionmodal_msg#:#<b>Caution!</b> multiple objects affected.
 ui#:#datatable_multiactionmodal_title#:#Operation on multiple objects
-ui#:#datetime_required#:#Time/Date required
 ui#:#duration_default_label_end#:#end
 ui#:#duration_default_label_start#:#start
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.
@@ -17174,6 +17173,7 @@ user#:#usr_public_profile_logged_in#:#Visible for logged in Users
 usr#:#user_action#:#User Action
 usr#:#user_actions#:#User Actions
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).
+validation#:#datetime_required#:#Time/Date required
 validation#:#no_array#:#Given value is not an array
 validation#:#not_a_null#:#Value of type '%s' is not a null.
 validation#:#not_a_string#:#Value of type '%s' is not a string.

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -16256,7 +16256,6 @@ trac#:#user_total#:#Total del usuario
 trac#:#view_mode#:#Modo de vista
 tstv#:#tstv_create#:#Crear informe de test completado
 tstv#:#tstv_create_info#:#Seleccione un test completado para generar un informe
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16413,6 +16412,7 @@ user#:#usr_public_profile_logged_in#:#Conectado como Usuario.
 usr#:#user_action#:#Acción de usuario
 usr#:#user_actions#:#Acciones de usuario
 usr#:#user_actions_activation_info#:#Las acciones solo se enumerarán para los usuarios si los servicios correspondientes están activados y se cumplen todas las condiciones previas (por ejemplo, requisitos de permisos).
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.
 validation#:#not_a_string#:#Value of type '%s' is not a string.

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#Kasutajaid kokku
 trac#:#view_mode#:#Vaata olekut
 tstv#:#tstv_create#:#Loo testi tunnistus
 tstv#:#tstv_create_info#:#Vali läbitud test tunnistuse loomiseks
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#Sisseloginud kasutajad
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#User Total
 trac#:#view_mode#:#View Mode
 tstv#:#tstv_create#:#Create Test Verification
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#کاربران حاضر در سیستم
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -16975,7 +16975,6 @@ ui#:#datatable_multiactionmodal_buttonlabel#:#Execute###31 10 2023 new variable
 ui#:#datatable_multiactionmodal_listentry#:#apply to all objects###31 10 2023 new variable
 ui#:#datatable_multiactionmodal_msg#:#<b>Caution!</b> multiple objects affected.###31 10 2023 new variable
 ui#:#datatable_multiactionmodal_title#:#Operation on multiple objects###31 10 2023 new variable
-ui#:#datetime_required#:#Time/Date required
 ui#:#duration_default_label_end#:#end###31 10 2023 new variable
 ui#:#duration_default_label_start#:#start###31 10 2023 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.
@@ -17145,6 +17144,7 @@ user#:#usr_public_profile_logged_in#:#Visible pour les utilisateurs connectés
 usr#:#user_action#:#Action de l’utilisateur
 usr#:#user_actions#:#Actions des utilisateurs
 usr#:#user_actions_activation_info#:#Les actions seront listées uniquement pour les utilisateurs si les services correspondants sont activés et que toutes les conditions préalables sont données (par ex. exigences des permissions).
+validation#:#datetime_required#:#Time/Date required
 validation#:#no_array#:#Given value is not an array###31 10 2023 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.
 validation#:#not_a_string#:#Value of type '%s' is not a string.

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#Ukupan broj korisnika
 trac#:#view_mode#:#Način prikaza
 tstv#:#tstv_create#:#Izradi certifikat za test
 tstv#:#tstv_create_info#:#Odaberite dovršeni test da biste generirali certifikat za njega.
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#Visible for logged in Users###04 06 2021 n
 usr#:#user_action#:#User Action###04 06 2021 new variable
 usr#:#user_actions#:#User Actions###04 06 2021 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###04 06 2021 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###04 06 2021 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###04 06 2021 new variable

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -16256,7 +16256,6 @@ trac#:#user_total#:#Felhasználók összesen
 trac#:#view_mode#:#Nézet
 tstv#:#tstv_create#:#Tesztigazolás létrehozása
 tstv#:#tstv_create_info#:#Válasszon ki egy befejezett tesztet, hogy igazolást generáljon hozzá.
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16413,6 +16412,7 @@ user#:#usr_public_profile_logged_in#:#Bejelentkezett felhasználók számára l�
 usr#:#user_action#:#Felhasználói művelet
 usr#:#user_actions#:#Felhasználói műveletek
 usr#:#user_actions_activation_info#:#A műveleteket csak akkor soroljuk fel a felhasználóknak, ha a kapcsolódó szolgáltatásokat bekapcsolták és az összes előfeltétel adott (például szükséges jogosultságok).
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#'%s' típus értéke nem üres.
 validation#:#not_a_string#:#'%s' típus értéke nem sztring.

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#Totale utenti
 trac#:#view_mode#:#Visualizza modalità
 tstv#:#tstv_create#:#Create Test Verification
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#Utenti connessi
 usr#:#user_action#:#Azione utente
 usr#:#user_actions#:#Azioni utente
 usr#:#user_actions_activation_info#:#Le azioni saranno elencate solo per gli utenti, se i servizi corrispondenti vengono attivati e vengono fornite tutte le condizioni preliminari (ad esempio, i requisiti di autorizzazione).
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.
 validation#:#not_a_string#:#Value of type '%s' is not a string.

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -16362,7 +16362,6 @@ trac#:#user_total#:#ユーザ合計
 trac#:#view_mode#:#表示モード
 tstv#:#tstv_create#:#テスト証明の作成
 tstv#:#tstv_create_info#:#完了したテストを選択して証明書を作成します
-ui#:#datetime_required#:#Time/Dateは必須
 ui#:#duration_default_label_end#:#end###19 08 2022 new variable
 ui#:#duration_default_label_start#:#start###19 08 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#開始は終了よりも遅くできません。
@@ -16519,6 +16518,7 @@ user#:#usr_public_profile_logged_in#:#ログイン済みのユーザ
 usr#:#user_action#:#ユーザアクション
 usr#:#user_actions#:#ユーザアクション
 usr#:#user_actions_activation_info#:#応答サービスが有効で全ての前提条件(例 アクセス要件)が与えられている場合はユーザへアクションがリストされるだけです。
+validation#:#datetime_required#:#Time/Dateは必須
 validation#:#no_array#:#Given value is not an array###19 08 2022 new variable
 validation#:#not_a_null#:#タイプ'%s'の値は null ではありあせん。
 validation#:#not_a_string#:#タイプ'%s'の値はストリングではありません。

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#ყველა მომხმარებელი (ჯა
 trac#:#view_mode#:#ხედვითი მდგომარეობა
 tstv#:#tstv_create#:#ტესტის სერთიფიკატის შექმნა
 tstv#:#tstv_create_info#:#მონიშნეთ დასრულებული ტესტი სერთიფიკატის შესაქმნელად
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#ხილვადია შესულ�
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -16256,7 +16256,6 @@ trac#:#user_total#:#User Total###06 08 2010 new variable
 trac#:#view_mode#:#Rodymo būdas
 tstv#:#tstv_create#:#Create Test Verification###12 06 2011 new variable
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it###12 06 2011 new variable
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16413,6 +16412,7 @@ user#:#usr_public_profile_logged_in#:#Logged in Users###24 07 2009 new variable
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#Gebruiker totaal
 trac#:#view_mode#:#Toon mode
 tstv#:#tstv_create#:#Aanmaken Toets Certificaat
 tstv#:#tstv_create_info#:#Selecteer een voltooide toets om het certificaat te genereren
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#Ingelogde gebruikers
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#Liczba użytkowników
 trac#:#view_mode#:#Tryb widoku
 tstv#:#tstv_create#:#Utwórz certyfikat testu
 tstv#:#tstv_create_info#:#Wybierz test, dla którego potrzebujesz certyfikatu
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#Zalogowani użytkownicy
 usr#:#user_action#:#Akcja użytkownika
 usr#:#user_actions#:#Akcje użytkowników
 usr#:#user_actions_activation_info#:#Te akcje oferowane są tylko wtedy, gdy aktywne są odpowiednie usługi i spełnione są odpowiednie warunki (np. uprawnienia).
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.
 validation#:#not_a_string#:#Value of type '%s' is not a string.

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#Total de utilizadores
 trac#:#view_mode#:#Vista modo
 tstv#:#tstv_create#:#Create Test Verification
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#Visível para usuários conectados.
 usr#:#user_action#:#Ação do utilizador
 usr#:#user_actions#:#Ações do utilizador
 usr#:#user_actions_activation_info#:#As ações serão listadas apenas para utilizadores, se os serviços correspondentes estiverem ativados e todas as pré-condições fornecidas (p. e. requisitos de permissões).
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#O valor do tipo '%s' não é zero.
 validation#:#not_a_string#:#O valor do tipo '%s' não é um string.

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -16256,7 +16256,6 @@ trac#:#user_total#:#User Total###06 08 2010 new variable
 trac#:#view_mode#:#View mode###10 Jul 2006 new variable
 tstv#:#tstv_create#:#Create Test Verification###12 06 2011 new variable
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it###12 06 2011 new variable
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16413,6 +16412,7 @@ user#:#usr_public_profile_logged_in#:#Logged in Users###24 07 2009 new variable
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -16255,7 +16255,6 @@ trac#:#user_total#:#User Total
 trac#:#view_mode#:#View mode
 tstv#:#tstv_create#:#Создать сертификат для теста
 tstv#:#tstv_create_info#:#Выберите выполненный тест для генерации сертификата по нему
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16412,6 +16411,7 @@ user#:#usr_public_profile_logged_in#:#Виден для авторизованн
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#Celkem uživatelů
 trac#:#view_mode#:#Mód zobrazení
 tstv#:#tstv_create#:#Create Test Verification###12 06 2011 new variable
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it###12 06 2011 new variable
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#Přihlášen k uživatelům
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -16359,7 +16359,6 @@ trac#:#user_total#:#Število uporabnikov
 trac#:#view_mode#:#Način prikaza
 tstv#:#tstv_create#:#Ustvari certifikat za test
 tstv#:#tstv_create_info#:#Izberite test, za katerega potrebujete certifikat
-ui#:#datetime_required#:#Time/Date required###19 08 2022 new variable
 ui#:#duration_default_label_end#:#end###19 08 2022 new variable
 ui#:#duration_default_label_start#:#start###19 08 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###19 08 2022 new variable
@@ -16516,6 +16515,7 @@ user#:#usr_public_profile_logged_in#:#Visible for logged in Users
 usr#:#user_action#:#User Action
 usr#:#user_actions#:#User Actions
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).
+validation#:#datetime_required#:#Time/Date required###19 08 2022 new variable
 validation#:#no_array#:#Given value is not an array###19 08 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.
 validation#:#not_a_string#:#Value of type '%s' is not a string.

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -16256,7 +16256,6 @@ trac#:#user_total#:#User Total###06 08 2010 new variable
 trac#:#view_mode#:#View mode###10 Jul 2006 new variable
 tstv#:#tstv_create#:#Create Test Verification###12 06 2011 new variable
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it###12 06 2011 new variable
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16413,6 +16412,7 @@ user#:#usr_public_profile_logged_in#:#Logged in Users###24 07 2009 new variable
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -16256,7 +16256,6 @@ trac#:#user_total#:#User Total###06 08 2010 new variable
 trac#:#view_mode#:#View mode###10 Jul 2006 new variable
 tstv#:#tstv_create#:#Create Test Verification###12 06 2011 new variable
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it###12 06 2011 new variable
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16413,6 +16412,7 @@ user#:#usr_public_profile_logged_in#:#Logged in Users###24 07 2009 new variable
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -16254,7 +16254,6 @@ trac#:#user_total#:#Kullanıcı Toplam
 trac#:#view_mode#:#Görünüm Modu
 tstv#:#tstv_create#:#Deney Belgesi Oluşturma
 tstv#:#tstv_create_info#:#bunun için bir sertifika oluşturmak için tamamlanmış bir test seçin
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16411,6 +16410,7 @@ user#:#usr_public_profile_logged_in#:#Giriş yapmış kullanıcılar görsün
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -16256,7 +16256,6 @@ trac#:#user_total#:#User Total###06 08 2010 new variable
 trac#:#view_mode#:#View mode###25 02 2007 new variable
 tstv#:#tstv_create#:#Create Test Verification###12 06 2011 new variable
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it###12 06 2011 new variable
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16413,6 +16412,7 @@ user#:#usr_public_profile_logged_in#:#Logged in Users###24 07 2009 new variable
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -16258,7 +16258,6 @@ trac#:#user_total#:#User Total###06 08 2010 new variable
 trac#:#view_mode#:#View mode###25 02 2007 new variable
 tstv#:#tstv_create#:#Create Test Verification###12 06 2011 new variable
 tstv#:#tstv_create_info#:#Select a completed test to generate a verification for it###12 06 2011 new variable
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16415,6 +16414,7 @@ user#:#usr_public_profile_logged_in#:#Logged in Users###24 07 2009 new variable
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -16253,7 +16253,6 @@ trac#:#user_total#:#用户总数
 trac#:#view_mode#:#视图模式
 tstv#:#tstv_create#:#创建测试验证
 tstv#:#tstv_create_info#:#选择一个已完成的测试来为它生成一个校验
-ui#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 ui#:#duration_default_label_end#:#end###29 07 2022 new variable
 ui#:#duration_default_label_start#:#start###29 07 2022 new variable
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.###29 07 2022 new variable
@@ -16410,6 +16409,7 @@ user#:#usr_public_profile_logged_in#:#已登录用户
 usr#:#user_action#:#User Action###25 10 2016 new variable
 usr#:#user_actions#:#User Actions###25 10 2016 new variable
 usr#:#user_actions_activation_info#:#Actions will only be listet for users, if the corresponding services are activated and all preconditions are given (e.g. permissions requirements).###25 10 2016 new variable
+validation#:#datetime_required#:#Time/Date required###29 07 2022 new variable
 validation#:#no_array#:#Given value is not an array###29 07 2022 new variable
 validation#:#not_a_null#:#Value of type '%s' is not a null.###10 11 2018 new variable
 validation#:#not_a_string#:#Value of type '%s' is not a string.###10 11 2018 new variable


### PR DESCRIPTION
The language variable datatime_required is in the module ui, but if I'm understanding the structure right it should be in validation.
See: https://mantis.ilias.de/view.php?id=38341