### PR TITLE
UI/Table: move Column::withIsInitiallyVisible to ::withIsOptional (#38070)

### DIFF
--- a/src/UI/Component/Table/Column/Column.php
+++ b/src/UI/Component/Table/Column/Column.php
@@ -30,8 +30,7 @@ interface Column extends \ILIAS\UI\Component\Component
     public function getType(): string;
     public function withIsSortable(bool $flag): self;
     public function isSortable(): bool;
-    public function withIsOptional(bool $flag): self;
+    public function withIsOptional(bool $is_optional, bool $is_initially_visible = true): self;
     public function isOptional(): bool;
-    public function withIsInitiallyVisible(bool $flag): self;
     public function isInitiallyVisible(): bool;
 }

--- a/src/UI/Implementation/Component/Table/Column/Column.php
+++ b/src/UI/Implementation/Component/Table/Column/Column.php
@@ -61,23 +61,17 @@ abstract class Column implements C\Column
         return $this->sortable;
     }
 
-    public function withIsOptional(bool $flag): self
+    public function withIsOptional(bool $is_optional, bool $is_initially_visible = true): self
     {
         $clone = clone $this;
-        $clone->optional = $flag;
+        $clone->optional = $is_optional;
+        $clone->initially_visible = $is_initially_visible;
         return $clone;
     }
 
     public function isOptional(): bool
     {
         return $this->optional;
-    }
-
-    public function withIsInitiallyVisible(bool $flag): self
-    {
-        $clone = clone $this;
-        $clone->initially_visible = $flag;
-        return $clone;
     }
 
     public function isInitiallyVisible(): bool

--- a/src/UI/examples/Table/Data/base.php
+++ b/src/UI/examples/Table/Data/base.php
@@ -44,8 +44,7 @@ function base()
             ->withUnit('£', I\Column\Number::UNIT_POSITION_FORE),
         'failure_txt' => $f->table()->column()->status("failure")
             ->withIsSortable(false)
-            ->withIsOptional(true)
-            ->withIsInitiallyVisible(false),
+            ->withIsOptional(true, false),
     ];
 
     /**

--- a/src/UI/examples/Table/Data/repo_implementation.php
+++ b/src/UI/examples/Table/Data/repo_implementation.php
@@ -115,8 +115,7 @@ class DataTableDemoRepo implements I\DataRetrieval
                 ->withUnit('£', I\Column\Number::UNIT_POSITION_FORE),
             'failure_txt' => $f->table()->column()->status("failure")
                 ->withIsSortable(false)
-                ->withIsOptional(true)
-                ->withIsInitiallyVisible(false),
+                ->withIsOptional(true, false),
             'sql_order' => $f->table()->column()->text("sql order part")
                 ->withIsSortable(false)
                 ->withIsOptional(true),

--- a/tests/UI/Component/Table/Column/ColumnTest.php
+++ b/tests/UI/Component/Table/Column/ColumnTest.php
@@ -44,8 +44,8 @@ class ColumnTest extends ILIAS_UI_TestBase
         $this->assertFalse($col->withIsOptional(false)->isOptional());
 
         $this->assertTrue($col->isInitiallyVisible());
-        $this->assertFalse($col->withIsInitiallyVisible(false)->isInitiallyVisible());
-        $this->assertTrue($col->withIsInitiallyVisible(true)->isInitiallyVisible());
+        $this->assertFalse($col->withIsOptional(true, false)->isInitiallyVisible());
+        $this->assertTrue($col->withIsOptional(true, true)->isInitiallyVisible());
 
         $this->assertFalse($col->isHighlighted());
         $this->assertTrue($col->withHighlight(true)->isHighlighted());

--- a/tests/UI/Component/Table/DataTest.php
+++ b/tests/UI/Component/Table/DataTest.php
@@ -47,12 +47,12 @@ class DataTest extends TableTestBase
             ): \Generator {
                 yield $row_builder->buildStandardRow('', []);
             }
-             public function getTotalRowCount(
-                 ?array $filter_data,
-                 ?array $additional_parameters
-             ): ?int {
-                 return null;
-             }
+            public function getTotalRowCount(
+                ?array $filter_data,
+                ?array $additional_parameters
+            ): ?int {
+                return null;
+            }
         };
     }
 
@@ -187,8 +187,7 @@ class DataTest extends TableTestBase
         $cols = [
             'f0' => $this->getTableFactory()->column()->text(''),
             'f1' => $this->getTableFactory()->column()->text('')
-                ->withIsOptional(true)
-                ->withIsInitiallyVisible(false),
+                ->withIsOptional(true, false),
             'f2' => $this->getTableFactory()->column()->text('')
         ];
         $table = $this->getTableFactory()->data('title', $cols, $data);


### PR DESCRIPTION
Hello everyone,

this should fix [#38070](https://mantis.ilias.de/view.php?id=38070) by making the interface a little more comprehensible.

Still, this is a breaking change and hence should not go unnoted.

Kind regards!