### PR TITLE
Services/Init, Services/COPage: Split DataProtection and ToS into separate placeholders (ILIAS 9)

### DIFF
--- a/Services/COPage/classes/class.ilPCLoginPageElement.php
+++ b/Services/COPage/classes/class.ilPCLoginPageElement.php
@@ -32,6 +32,7 @@ class ilPCLoginPageElement extends ilPageContent
         'registration-link' => 'registration_link',
         'language-selection' => 'language_selection',
         'user-agreement' => 'user_agreement_link',
+        'dpro-agreement' => 'dpro_agreement_link',
         'saml-login' => 'saml_login'
     );
 

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -22,6 +22,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\UICore\PageContentProvider;
 use ILIAS\Refinery\Factory as RefineryFactory;
 use ILIAS\HTTP\Services as HTTPServices;
+use ILIAS\TermsOfService\Consumer as TermsOfService;
+use ILIAS\DataProtection\Consumer as DataProtection;
 
 /**
  * @ilCtrl_Calls ilStartUpGUI: ilAccountRegistrationGUI, ilPasswordAssistanceGUI, ilLoginPageGUI, ilDashboardGUI
@@ -266,7 +268,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         $page_editor_html = $this->showShibbolethLoginForm($page_editor_html);
         $page_editor_html = $this->showSamlLoginForm($page_editor_html);
         $page_editor_html = $this->showRegistrationLinks($page_editor_html);
-        $page_editor_html = $this->showLegalDocumentsLink($page_editor_html);
+        $page_editor_html = $this->showLegalDocumentsLinks($page_editor_html);
         $page_editor_html = $this->purgePlaceholders($page_editor_html);
 
         // check expired session and send message
@@ -1009,7 +1011,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         );
     }
 
-    private function showLegalDocumentsLink(string $page_editor_html): string
+    private function showLegalDocumentsLinks(string $page_editor_html): string
     {
         global $tpl;
         global $DIC;
@@ -1018,13 +1020,22 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             $this->user->setId(ANONYMOUS_USER_ID);
         }
 
-        return $this->substituteLoginPageElements(
+        $page_editor_html = $this->substituteLoginPageElements(
             $tpl,
             $page_editor_html,
-            $DIC['legalDocuments']->loginPageHTML(),
+            $DIC['legalDocuments']->loginPageHTML(TermsOfService::ID),
             '[list-user-agreement]',
             'USER_AGREEMENT'
         );
+        $page_editor_html = $this->substituteLoginPageElements(
+            $tpl,
+            $page_editor_html,
+            $DIC['legalDocuments']->loginPageHTML(DataProtection::ID),
+            '[list-dpro-agreement]',
+            'DPRO_AGREEMENT'
+        );
+
+        return $page_editor_html;
     }
 
     private function purgePlaceholders(string $page_editor_html): string
@@ -1034,6 +1045,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
                 '[list-language-selection] ',
                 '[list-registration-link]',
                 '[list-user-agreement]',
+                '[list-dpro-agreement]',
                 '[list-login-form]',
                 '[list-cas-login-form]',
                 '[list-saml-login]',

--- a/Services/Init/templates/default/tpl.login.html
+++ b/Services/Init/templates/default/tpl.login.html
@@ -35,6 +35,7 @@
 	<!-- BEGIN agreement -->
 	<div class="ilStartupSection">
 		{USER_AGREEMENT}
+		{DPRO_AGREEMENT}
 	</div>
 	<!-- END agreement -->
 </div>

--- a/Services/LegalDocuments/classes/Conductor.php
+++ b/Services/LegalDocuments/classes/Conductor.php
@@ -65,14 +65,13 @@ class Conductor
         }
     }
 
-    public function loginPageHTML(): string
+    public function loginPageHTML(string $id): string
     {
-        $space = $this->container->ui()->factory()->legacy(' ');
-
-        return $this->container->ui()->renderer()->render(array_merge(...array_map(
-            fn($proc): array => [...$proc(), $space],
-            $this->internal->all('show-on-login-page')
-        )));
+        $create = $this->internal->get('show-on-login-page', $id);
+        if (!$create) {
+            return '';
+        }
+        return $this->container->ui()->renderer()->render($create());
     }
 
     public function logoutText(): string

--- a/Services/LegalDocuments/classes/Wiring.php
+++ b/Services/LegalDocuments/classes/Wiring.php
@@ -76,7 +76,7 @@ class Wiring implements UseSlot
 
     public function showOnLoginPage(callable $show): self
     {
-        return $this->addTo('show-on-login-page', Closure::fromCallable($show));
+        return $this->addTo('show-on-login-page', $this->slot->id(), Closure::fromCallable($show));
     }
 
     public function hasPublicPage(callable $public_page): self

--- a/Services/LegalDocuments/test/ConductorTest.php
+++ b/Services/LegalDocuments/test/ConductorTest.php
@@ -101,21 +101,17 @@ class ConductorTest extends TestCase
 
         $container = $this->mockTree(Container::class, [
             'ui' => [
-                'factory' => $this->mockMethod(UIFactory::class, 'legacy', [' '], $space),
                 'renderer' => $this->mockMethod(Renderer::class, 'render', [
-                    [...$components, $space, ...$components, $space],
+                    $components,
                 ], 'rendered'),
             ],
         ]);
 
-        $internal = $this->mockMethod(Internal::class, 'all', ['show-on-login-page'], [
-            fn() => $components,
-            fn() => $components,
-        ]);
+        $internal = $this->mockMethod(Internal::class, 'get', ['show-on-login-page', 'foo'], fn() => $components);
 
         $instance = new Conductor($container, $internal, $this->mock(Clock::class));
 
-        $this->assertSame('rendered', $instance->loginPageHTML());
+        $this->assertSame('rendered', $instance->loginPageHTML('foo'));
     }
 
     public function testLogoutText(): void

--- a/Services/LegalDocuments/test/WiringTest.php
+++ b/Services/LegalDocuments/test/WiringTest.php
@@ -87,8 +87,8 @@ class WiringTest extends TestCase
     public function testShowOnLoginPage(): void
     {
         $proc = $this->fail(...);
-        $instance = new Wiring($this->mock(SlotConstructor::class), new Map());
-        $this->assertSame(['show-on-login-page' => [$proc]], $instance->showOnLoginPage($proc)->map()->value());
+        $instance = new Wiring($this->mockTree(SlotConstructor::class, ['id'=> 'foo']), new Map());
+        $this->assertSame(['show-on-login-page' => ['foo' => $proc]], $instance->showOnLoginPage($proc)->map()->value());
     }
 
     public function testHasAgreement(): void

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -6682,6 +6682,7 @@ content#:#cont_localization#:#Sprache
 content#:#cont_localization_info#:#Die Einstellung wird für vordefinierte Texte im Modul (z.B. "Vor" / "Zurück") benötigt.
 content#:#cont_location#:#Position
 content#:#cont_lpe_cas_login_form#:#CAS-Login-Maske
+content#:#cont_lpe_dpro_agreement_link#:#Link zur Datenschutzerklärung
 content#:#cont_lpe_language_selection#:#Sprachauswahl
 content#:#cont_lpe_login_form#:#Login-Maske
 content#:#cont_lpe_openid_connect_login#:#OpenId-Connect-Login

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -6673,6 +6673,7 @@ content#:#cont_localization#:#Localization
 content#:#cont_localization_info#:#Language used for predefined texts, e.g. ‘Previous’ and ’Next’.
 content#:#cont_location#:#Location
 content#:#cont_lpe_cas_login_form#:#CAS Login Form
+content#:#cont_lpe_dpro_agreement_link#:#Declaration of Data Protection Link
 content#:#cont_lpe_language_selection#:#Language Selection
 content#:#cont_lpe_login_form#:#Login Form
 content#:#cont_lpe_openid_connect_login#:#OpenId Connect Login


### PR DESCRIPTION
This PR adds a new placeholder DPRO_AGREEMENT next to USER_AGREEMENT and the corresponding placeholder for the COPage Login Element.

@alex40724
One line is added in `Services/COPage/classes/ilPCLoginPageElement` to register the new placeholder.