### PR TITLE
Services/Mail: Add missing namespace

### DIFF
--- a/Services/Mail/classes/Recipient.php
+++ b/Services/Mail/classes/Recipient.php
@@ -18,10 +18,14 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Mail;
+
 use ILIAS\Data\Result\Ok;
 use ILIAS\Data\Result\Error;
 use ILIAS\Data\Result;
 use ILIAS\LegalDocuments\Conductor;
+use ilObjUser;
+use ilMailOptions;
 
 final class Recipient
 {
@@ -45,7 +49,7 @@ final class Recipient
 
     public function isUser(): bool
     {
-        return ! is_null($this->user);
+        return !is_null($this->user);
     }
 
     public function isUserActive(): bool

--- a/Services/Mail/classes/class.ilMail.php
+++ b/Services/Mail/classes/class.ilMail.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\BackgroundTasks\Implementation\Bucket\BasicBucket;
 use ILIAS\Mail\Autoresponder\AutoresponderService;
 use ILIAS\LegalDocuments\Conductor;
+use ILIAS\Mail\Recipient;
 
 /**
  * @author Stefan Meyer <meyer@leifos.com>

--- a/Services/Mail/test/RecipientTest.php
+++ b/Services/Mail/test/RecipientTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\LegalDocuments\Conductor;
 use ILIAS\Refinery\Transformation;
 use ILIAS\Data\Result;
+use ILIAS\Mail\Recipient;
 
 class RecipientTest extends ilMailBaseTest
 {


### PR DESCRIPTION
Add missing namespace for class `Recipient` as it was previously in the top namespace without a prefix.