### PR TITLE
Use Skill Usage Service in `TestQuestionPool` classes

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -20,6 +20,7 @@ use ILIAS\Refinery\Transformation;
 use ILIAS\TA\Questions\assQuestionSuggestedSolution;
 use ILIAS\TA\Questions\assQuestionSuggestedSolutionsDatabaseRepository;
 use ILIAS\DI\Container;
+use ILIAS\Skill\Service\SkillUsageService;
 
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
 
@@ -156,6 +157,8 @@ abstract class assQuestion
 
     protected ilObjUser $current_user;
 
+    protected SkillUsageService $skillUsageService;
+
     /**
      * assQuestion constructor
      */
@@ -203,6 +206,7 @@ abstract class assQuestion
         $this->export_image_path = '';
         $this->shuffler = $DIC->refinery()->random()->dontShuffle();
         $this->lifecycle = ilAssQuestionLifecycle::getDraftInstance();
+        $this->skillUsageService = $DIC->skills()->usage();
     }
 
     protected static $forcePassResultsUpdateEnabled = false;
@@ -1025,11 +1029,10 @@ abstract class assQuestion
 
             // remove skill usage
             if (!$assignment->isSkillUsed()) {
-                ilSkillUsage::setUsage(
+                $this->skillUsageService->removeUsage(
                     $assignment->getParentObjId(),
                     $assignment->getSkillBaseId(),
-                    $assignment->getSkillTrefId(),
-                    false
+                    $assignment->getSkillTrefId()
                 );
             }
         }
@@ -2265,7 +2268,7 @@ abstract class assQuestion
             $assignment->saveToDb();
 
             // add skill usage
-            ilSkillUsage::setUsage(
+            $this->skillUsageService->addUsage(
                 $trgParentId,
                 $assignment->getSkillBaseId(),
                 $assignment->getSkillTrefId()
@@ -2285,11 +2288,10 @@ abstract class assQuestion
 
             // remove skill usage
             if (!$assignment->isSkillUsed()) {
-                ilSkillUsage::setUsage(
+                $this->skillUsageService->removeUsage(
                     $assignment->getParentObjId(),
                     $assignment->getSkillBaseId(),
-                    $assignment->getSkillTrefId(),
-                    false
+                    $assignment->getSkillTrefId()
                 );
             }
         }

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Skill\Service\SkillUsageService;
+
 /**
  * User interface for assignment of questions from a test question pool (or
  * directly from a test) to competences.
@@ -76,6 +78,8 @@ class ilAssQuestionSkillAssignmentsGUI
 
     private \ILIAS\TestQuestionPool\InternalRequestService $request;
 
+    private SkillUsageService $skillUsageService;
+
     /**
      * @param ilCtrl $ctrl
      * @param ilAccessHandler $access
@@ -92,6 +96,7 @@ class ilAssQuestionSkillAssignmentsGUI
         $this->db = $db;
         global $DIC;
         $this->request = $DIC->testQuestionPool()->internal()->request();
+        $this->skillUsageService = $DIC->skills()->usage();
     }
 
     public function getQuestionOrderSequence(): ?array
@@ -244,7 +249,7 @@ class ilAssQuestionSkillAssignmentsGUI
                                 $assignment->saveToDb();
 
                                 // add skill usage
-                                ilSkillUsage::setUsage($this->getQuestionContainerId(), $skillBaseId, $skillTrefId);
+                                $this->skillUsageService->addUsage($this->getQuestionContainerId(), $skillBaseId, $skillTrefId);
                             }
                         }
                     }
@@ -295,7 +300,7 @@ class ilAssQuestionSkillAssignmentsGUI
                         $assignment->saveToDb();
 
                         // add skill usage
-                        ilSkillUsage::setUsage($this->getQuestionContainerId(), $skillBaseId, $skillTrefId);
+                        $this->skillUsageService->addUsage($this->getQuestionContainerId(), $skillBaseId, $skillTrefId);
                     }
 
                     $handledSkills[$skillId] = $skill;
@@ -311,11 +316,10 @@ class ilAssQuestionSkillAssignmentsGUI
 
                 // remove skill usage
                 if (!$assignment->isSkillUsed()) {
-                    ilSkillUsage::setUsage(
+                    $this->skillUsageService->removeUsage(
                         $assignment->getParentObjId(),
                         $assignment->getSkillBaseId(),
-                        $assignment->getSkillTrefId(),
-                        false
+                        $assignment->getSkillTrefId()
                     );
                 }
             }
@@ -447,7 +451,7 @@ class ilAssQuestionSkillAssignmentsGUI
             $assignment->saveToDb();
 
             // add skill usage
-            ilSkillUsage::setUsage(
+            $this->skillUsageService->addUsage(
                 $this->getQuestionContainerId(),
                 (int) $this->request->raw('skill_base_id'),
                 (int) $this->request->raw('skill_tref_id')

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImporter.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssQuestionSkillAssignmentImporter.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Skill\Service\SkillUsageService;
+
 /**
  * @author        Björn Heyser <bheyser@databay.de>
  * @version        $Id$
@@ -60,6 +62,8 @@ class ilAssQuestionSkillAssignmentImporter
      */
     protected $successImportAssignmentList;
 
+    protected SkillUsageService $skillUsageService;
+
     /**
      * ilAssQuestionSkillAssignmentImporter constructor.
      */
@@ -75,6 +79,7 @@ class ilAssQuestionSkillAssignmentImporter
         $this->importAssignmentList = null;
         $this->failedImportAssignmentList = new ilAssQuestionSkillAssignmentImportList();
         $this->successImportAssignmentList = new ilAssQuestionSkillAssignmentList($this->db);
+        $this->skillUsageService = $DIC->skills()->usage();
     }
 
     /**
@@ -227,7 +232,7 @@ class ilAssQuestionSkillAssignmentImporter
             $importableAssignment->saveComparisonExpressions();
 
             // add skill usage
-            ilSkillUsage::setUsage($this->getTargetParentObjId(), $foundSkillId['skill_id'], $foundSkillId['tref_id']);
+            $this->skillUsageService->addUsage($this->getTargetParentObjId(), $foundSkillId['skill_id'], $foundSkillId['tref_id']);
 
             $this->getSuccessImportAssignmentList()->addAssignment($importableAssignment);
         }

--- a/Modules/TestQuestionPool/test/assBaseTestCase.php
+++ b/Modules/TestQuestionPool/test/assBaseTestCase.php
@@ -63,6 +63,9 @@ abstract class assBaseTestCase extends TestCase
         $rbacsystem_mock = $this->getMockBuilder(ilRbacSystem::class)->disableOriginalConstructor()->getMock();
         $this->setGlobalVariable('rbacsystem', $rbacsystem_mock);
 
+        $rbacreview_mock = $this->getMockBuilder(ilRbacReview::class)->disableOriginalConstructor()->getMock();
+        $this->setGlobalVariable('rbacreview', $rbacreview_mock);
+
         $refineryMock = $this->getMockBuilder(RefineryFactory::class)->disableOriginalConstructor()->getMock();
         $refineryMock->method('random')->willReturn($this->getMockBuilder(RandomGroup::class)->getMock());
         $this->setGlobalVariable('refinery', $refineryMock);


### PR DESCRIPTION
Hi @kergomard,
after some refactoring, I would like to get rid of the static function `ilSkillUsage::setUsage` (and the class `ilSkillUsage` as a whole). That's why I now want to use the new `SkillUsageService` instead.

Because this change is quite trivial, I would also like to cherry-pick it to release 9.