### PR TITLE
Use Skill Usage Service in `Survey` and `Container` classes

### DIFF
--- a/Modules/Survey/Skills/class.ilSurveySkill.php
+++ b/Modules/Survey/Skills/class.ilSurveySkill.php
@@ -32,6 +32,7 @@ class ilSurveySkill
     protected ilLogger $log;
     protected \ILIAS\Skill\Service\SkillProfileService $skill_profile_service;
     protected \ILIAS\Skill\Service\SkillPersonalService $skill_personal_service;
+    protected \ILIAS\Skill\Service\SkillUsageService $skill_usage_service;
 
     public function __construct(ilObjSurvey $a_survey)
     {
@@ -43,6 +44,7 @@ class ilSurveySkill
         $this->log = ilLoggerFactory::getLogger("svy");
         $this->skill_profile_service = $DIC->skills()->profile();
         $this->skill_personal_service = $DIC->skills()->personal();
+        $this->skill_usage_service = $DIC->skills()->usage();
     }
 
     public function read(): void
@@ -124,7 +126,7 @@ class ilSurveySkill
         );
 
         // add usage
-        ilSkillUsage::setUsage($this->survey->getId(), $a_base_skill_id, $a_tref_id);
+        $this->skill_usage_service->addUsage($this->survey->getId(), $a_base_skill_id, $a_tref_id);
     }
 
     public function removeQuestionSkillAssignment(
@@ -196,7 +198,7 @@ class ilSurveySkill
         // now remove all usages that have been confirmed
         foreach ($a_skills as $skill) {
             if (!in_array($skill["skill_id"] . ":" . $skill["tref_id"], $used_skills, true)) {
-                ilSkillUsage::setUsage($this->survey->getId(), $skill["skill_id"], $skill["tref_id"], false);
+                $this->skill_usage_service->removeUsage($this->survey->getId(), $skill["skill_id"], $skill["tref_id"]);
             }
         }
     }

--- a/Services/Container/Skills/classes/class.ilContSkillAdminGUI.php
+++ b/Services/Container/Skills/classes/class.ilContSkillAdminGUI.php
@@ -23,6 +23,7 @@ use ILIAS\Skill\Service\SkillTreeService;
 use ILIAS\Skill\Access\SkillTreeAccess;
 use ILIAS\Skill\Service\SkillProfileService;
 use ILIAS\Container\Skills as ContainerSkills;
+use ILIAS\Skill\Service\SkillUsageService;
 
 /**
  * Container skills administration
@@ -48,6 +49,7 @@ class ilContSkillAdminGUI
     protected SkillTreeAccess $tree_access_manager;
     protected SkillProfileService $profile_service;
     protected ContainerSkills\ContainerSkillManager $cont_skill_manager;
+    protected SkillUsageService $usage_service;
     protected array $params = [];
     protected ContainerSkills\SkillContainerGUIRequest $container_gui_request;
     protected int $requested_usr_id = 0;
@@ -82,6 +84,7 @@ class ilContSkillAdminGUI
             $this->container->getId(),
             $this->container->getRefId()
         );
+        $this->usage_service = $DIC->skills()->usage();
 
         $this->skmg_settings = new ilSkillManagementSettings();
         $this->container_gui_request = $DIC->skills()->internalContainer()->gui()->request();
@@ -390,7 +393,7 @@ class ilContSkillAdminGUI
         $s = explode(":", ($this->requested_selected_skill));
 
         $this->cont_skill_manager->addSkillForContainer((int) $s[0], (int) $s[1]);
-        ilSkillUsage::setUsage($this->container->getId(), (int) $s[0], (int) $s[1]);
+        $this->usage_service->addUsage($this->container->getId(), (int) $s[0], (int) $s[1]);
 
         $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
 
@@ -434,7 +437,7 @@ class ilContSkillAdminGUI
             foreach ($this->requested_combined_skill_ids as $id) {
                 $s = explode(":", $id);
                 $this->cont_skill_manager->removeSkillFromContainer((int) $s[0], (int) $s[1]);
-                ilSkillUsage::setUsage($this->container->getId(), (int) $s[0], (int) $s[1], false);
+                $this->usage_service->removeUsage($this->container->getId(), (int) $s[0], (int) $s[1]);
             }
         }
         $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);


### PR DESCRIPTION
Hi @alex40724 ,
after some refactoring, I would like to get rid of the static function `ilSkillUsage::setUsage` (and the class `ilSkillUsage` as a whole). That's why I now want to use the new `SkillUsageService` instead.

Because this change is quite trivial, I would also like to cherry-pick it to release 9.