### PR TITLE
Services/LegalDocuments: Remove default value for longtext

### DIFF
--- a/Services/LegalDocuments/classes/Repository/DatabaseDocumentRepository.php
+++ b/Services/LegalDocuments/classes/Repository/DatabaseDocumentRepository.php
@@ -167,8 +167,8 @@ class DatabaseDocumentRepository implements DocumentRepository, DocumentReposito
      *     modification_ts: string,
      *     owner_usr_id: string,
      *     sorting: string,
-     *     text: string,
-     *     title: string,
+     *     text: ?string,
+     *     title: ?string,
      * } $row
      * @param list<Criterion> $criteria
      */
@@ -178,7 +178,7 @@ class DatabaseDocumentRepository implements DocumentRepository, DocumentReposito
             (int) $row['sorting'],
             new Edit((int) $row['last_modified_usr_id'], new DateTimeImmutable('@' . $row['modification_ts'])),
             new Edit((int) $row['owner_usr_id'], new DateTimeImmutable('@' . $row['creation_ts']))
-        ), new DocumentContent($row['type'], $row['title'], $row['text'] ?? ''), $criteria);
+        ), new DocumentContent($row['type'], $row['title'] ?? '', $row['text'] ?? ''), $criteria);
     }
 
     public function documentTable(): string

--- a/Services/LegalDocuments/classes/Repository/DatabaseHistoryRepository.php
+++ b/Services/LegalDocuments/classes/Repository/DatabaseHistoryRepository.php
@@ -86,7 +86,7 @@ class DatabaseHistoryRepository implements HistoryRepository
             return new Error('Not found.');
         }
 
-        return new Ok(new DocumentContent($result['type'], $result['title'], $result['text']));
+        return new Ok(new DocumentContent($result['type'], $result['title'] ?? '', $result['text'] ?? ''));
     }
 
     /**
@@ -145,7 +145,7 @@ class DatabaseHistoryRepository implements HistoryRepository
             $this->document_meta->documentFromRow($row, []),
             new Edit((int) $row['usr_id'], new DateTimeImmutable('@' . $row['ts'])),
             array_map(fn(array $criterion) => new CriterionContent($criterion['id'], $criterion['value']), json_decode($row['criteria'], true)),
-            new DocumentContent($row['old_type'], $row['old_title'], $row['old_text'])
+            new DocumentContent($row['old_type'], $row['old_title'] ?? '', $row['old_text'] ?? '')
         );
     }
 

--- a/Services/LegalDocuments/classes/Setup/UpdateSteps.php
+++ b/Services/LegalDocuments/classes/Setup/UpdateSteps.php
@@ -66,12 +66,6 @@ class UpdateSteps implements ilDatabaseUpdateSteps
         }
     }
 
-    public function step_2(): void
-    {
-        $this->database->manipulate('UPDATE ldoc_documents SET `text` = "" WHERE `text` IS NULL');
-        $this->database->manipulate('ALTER TABLE ldoc_documents MODIFY COLUMN `text` longtext NOT NULL DEFAULT ""');
-    }
-
     /**
      * @param array<string, mixed> $attributes
      */


### PR DESCRIPTION
In MySQL it is not possible to set a default value "" for a field of type longtext, blob, etc. This PR removes this and adjusts the code to conform to this.