### PR TITLE
[FIX] Tile Image Upload in Legacy Forms

### DIFF
--- a/Services/Object/classes/CommonSettings/class.ilObjectCommonSettingFormAdapter.php
+++ b/Services/Object/classes/CommonSettings/class.ilObjectCommonSettingFormAdapter.php
@@ -23,6 +23,8 @@ use ILIAS\FileUpload\DTO\UploadResult;
 use ILIAS\ResourceStorage\Services as ResourceStorageServices;
 use ILIAS\Object\Properties\CoreProperties\TileImage\ilObjectTileImageStakeholder;
 use ILIAS\Object\Properties\CoreProperties\TileImage\ilObjectTileImageFlavourDefinition;
+use ILIAS\HTTP\Services;
+use GuzzleHttp\Psr7\UploadedFile;
 
 /**
  *
@@ -38,6 +40,7 @@ class ilObjectCommonSettingFormAdapter implements ilObjectCommonSettingFormAdapt
         private ilObjectTileImageStakeholder $stakeholder,
         private ilObjectTileImageFlavourDefinition $flavour,
         private ilObjectCommonSettings $common_settings,
+        private Services $http,
         private ?ilPropertyFormGUI $legacy_form = null
     ) {
         $this->language->loadLanguageModule('obj');
@@ -107,9 +110,20 @@ class ilObjectCommonSettingFormAdapter implements ilObjectCommonSettingFormAdapt
             return;
         }
 
-        $this->upload->process();
+        // Determine Legacy Upload (since there can be more than one in this form). This is not best practice, because
+        // on the one hand we should actually use the wrapper, on the other hand with the conversion to the new forms
+        // this problem no longer have anyway. But at the moment we have to pick the right one out of all uploadResults,
+        // that's only possible with this way
+
+        /** @var UploadedFile $file */
+        $file = $this->http->request()->getUploadedFiles()['tile_image']; // Direct Access to the Psr7/UploadedFile
+        $temp_name = $file->getStream()->getMetadata('uri'); // Get the Path of the Temp. File
+        // In case of a parallel oather upload, the uploads may already have been processed. otherwise we have to do it
+        if (!$this->upload->hasBeenProcessed()) {
+            $this->upload->process();
+        }
         $result_array = $this->upload->getResults();
-        $result = end($result_array);
+        $result = $result_array[$temp_name] ?? null;
 
         if (!($result instanceof UploadResult) || !$result->isOK()) {
             return;

--- a/Services/Object/classes/CommonSettings/class.ilObjectCommonSettings.php
+++ b/Services/Object/classes/CommonSettings/class.ilObjectCommonSettings.php
@@ -23,6 +23,7 @@ use ILIAS\ResourceStorage\Services as ResourceStorageServices;
 use ILIAS\Object\Properties\CoreProperties\TileImage\ilObjectPropertyTileImage;
 use ILIAS\Object\Properties\CoreProperties\TileImage\ilObjectTileImageStakeholder;
 use ILIAS\Object\Properties\CoreProperties\TileImage\ilObjectTileImageFlavourDefinition;
+use ILIAS\HTTP\Services;
 
 /**
  * @deprecated 11 This class will be removed with ILIAS 11. Please use
@@ -37,6 +38,7 @@ class ilObjectCommonSettings
         private ilLanguage $language,
         private FileUpload $upload,
         private ResourceStorageServices $storage,
+        private Services $http,
         private ilObjectTileImageStakeholder $stakeholder,
         private ilObjectTileImageFlavourDefinition $flavour,
         private ilObjectCorePropertiesRepository $core_properties_repository,
@@ -114,6 +116,7 @@ class ilObjectCommonSettings
             $this->stakeholder,
             $this->flavour,
             $this,
+            $this->http,
             $form
         );
     }

--- a/Services/Object/classes/ilObjectDIC.php
+++ b/Services/Object/classes/ilObjectDIC.php
@@ -51,6 +51,7 @@ class ilObjectDIC extends PimpleContainer
             $DIC->language(),
             $DIC->upload(),
             $DIC->resourceStorage(),
+            $DIC->http(),
             $c['tile_image_stackholder'],
             $c['tile_image_flavour'],
             $c['core_properties_repository'],


### PR DESCRIPTION
In legacy forms with more than one upload, the tile upload may not work (depending on the order in which the uploads get temp-names...). The PR fixes the prblem, but for this the HTTP service must be pulled into the classes.