### PR TITLE
UI DataTable: Fix total row count in examples

### DIFF
--- a/src/UI/examples/Table/Action/Multi/base.php
+++ b/src/UI/examples/Table/Action/Multi/base.php
@@ -105,7 +105,7 @@ function getExampleTable($f)
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return 6;
         }
     };
     return $f->table()->data('a data table with actions', $columns, $data_retrieval);

--- a/src/UI/examples/Table/Action/Single/base.php
+++ b/src/UI/examples/Table/Action/Single/base.php
@@ -103,7 +103,7 @@ function getExampleTable($f)
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return 6;
         }
     };
     return $f->table()->data('a data table with actions', $columns, $data_retrieval);

--- a/src/UI/examples/Table/Action/Standard/base.php
+++ b/src/UI/examples/Table/Action/Standard/base.php
@@ -109,7 +109,7 @@ function getExampleTable($f)
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return 6;
         }
     };
     return $f->table()->data('a data table with actions', $columns, $data_retrieval);

--- a/src/UI/examples/Table/Column/Boolean/base.php
+++ b/src/UI/examples/Table/Column/Boolean/base.php
@@ -57,7 +57,7 @@ function base()
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return count($this->records);
         }
     };
 

--- a/src/UI/examples/Table/Column/Date/base.php
+++ b/src/UI/examples/Table/Column/Date/base.php
@@ -43,7 +43,7 @@ function base()
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return 1;
         }
     };
 

--- a/src/UI/examples/Table/Column/EMail/base.php
+++ b/src/UI/examples/Table/Column/EMail/base.php
@@ -43,7 +43,7 @@ function base()
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return count($this->records);
         }
     };
 

--- a/src/UI/examples/Table/Column/LinkListing/base.php
+++ b/src/UI/examples/Table/Column/LinkListing/base.php
@@ -52,7 +52,7 @@ function base(): string
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return count($this->records);
         }
     };
 

--- a/src/UI/examples/Table/Column/Number/base.php
+++ b/src/UI/examples/Table/Column/Number/base.php
@@ -57,7 +57,7 @@ function base()
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return count($this->records);
         }
     };
 

--- a/src/UI/examples/Table/Column/Status/base.php
+++ b/src/UI/examples/Table/Column/Status/base.php
@@ -46,7 +46,7 @@ function base()
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return count($this->records);
         }
     };
 

--- a/src/UI/examples/Table/Column/StatusIcon/base.php
+++ b/src/UI/examples/Table/Column/StatusIcon/base.php
@@ -54,7 +54,7 @@ function base()
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return count($this->records);
         }
     };
 

--- a/src/UI/examples/Table/Column/Text/base.php
+++ b/src/UI/examples/Table/Column/Text/base.php
@@ -50,7 +50,7 @@ function base()
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return count($this->records);
         }
     };
 

--- a/src/UI/examples/Table/Column/TimeSpan/base.php
+++ b/src/UI/examples/Table/Column/TimeSpan/base.php
@@ -44,7 +44,7 @@ function base()
             ?array $filter_data,
             ?array $additional_parameters
         ): ?int {
-            return null;
+            return 1;
         }
     };
 


### PR DESCRIPTION
Since the ViewControls are implemented in the DataTable now, `getTotalRowCount` in the KS examples of the DataTable should not stay `null` anymore.

Please also cherry-pick to ILIAS 9.