### PR TITLE
Services/LegalDocuments: Fix wrong name for Wiring::hasPublicPage

### DIFF
--- a/Services/LegalDocuments/classes/Setup/UpdateSteps.php
+++ b/Services/LegalDocuments/classes/Setup/UpdateSteps.php
@@ -66,6 +66,11 @@ class UpdateSteps implements ilDatabaseUpdateSteps
         }
     }
 
+    public function step_2(): void
+    {
+        // Keep
+    }
+
     /**
      * @param array<string, mixed> $attributes
      */

--- a/Services/LegalDocuments/classes/Wiring.php
+++ b/Services/LegalDocuments/classes/Wiring.php
@@ -81,7 +81,7 @@ class Wiring implements UseSlot
 
     public function hasPublicPage(callable $public_page): self
     {
-        return $this->addTo('agreement-public', $this->slot->id(), fn(...$args) => new Ok($public_page(...$args)));
+        return $this->addTo('public-page', $this->slot->id(), fn(...$args) => new Ok($public_page(...$args)));
     }
 
     public function hasAgreement(Agreement $on_login, ?string $goto_name = null): self


### PR DESCRIPTION
Fix bug: https://mantis.ilias.de/view.php?id=38556
and fix issue mentioned in here: https://github.com/ILIAS-eLearning/ILIAS/pull/6512#issuecomment-1790206759