### PR TITLE
remove timing functions from toast

### DIFF
--- a/Services/Awareness/classes/Provider/AwarenessToastProvider.php
+++ b/Services/Awareness/classes/Provider/AwarenessToastProvider.php
@@ -84,9 +84,7 @@ class AwarenessToastProvider extends AbstractToastProvider
                     $this->if->identifier(self::PROVIDER_KEY . '_' . $this->dic->user()->getId()),
                     $this->dic->language()->txt('awareness_now_online')
                 )
-                ->withIcon($this->dic->ui()->factory()->symbol()->icon()->standard(Standard::USR, ''))
-                ->withVanishTime((int) $setting->get('osd_vanish', (string) Toast::DEFAULT_VANISH_TIME))
-                ->withDelayTime((int) $setting->get('osd_delay', (string) Toast::DEFAULT_DELAY_TIME));
+                ->withIcon($this->dic->ui()->factory()->symbol()->icon()->standard(Standard::USR, ''));
             $links = [];
             foreach ($new_users as $user) {
                 $uname = "[" . $user['login'] . "]";

--- a/Services/Init/classes/Dependencies/InitUIFramework.php
+++ b/Services/Init/classes/Dependencies/InitUIFramework.php
@@ -53,6 +53,18 @@ class InitUIFramework
                 $c["ui.factory.legacy"]
             );
         };
+        $c['ui.toast_settings'] = function(\ILIAS\DI\Container $c) {
+            $vanish_time = ILIAS\UI\Implementation\Component\Toast\Toast::DEFAULT_VANISH_TIME;
+            $delay_time = ILIAS\UI\Implementation\Component\Toast\Toast::DEFAULT_DELAY_TIME;
+            if (isset($c['ilSetting'])) {
+                $vanish_time = (int) $c->settings()::_lookupValue('notifications', 'osd_vanish') ?? $vanish_time;
+                $delay_time = (int) $c->settings()::_lookupValue('notifications', 'osd_delay') ?? $delay_time;
+            }
+            return [
+                'vanish_time' => $vanish_time,
+                'delay_time' => $delay_time
+            ];
+        };
         $c["ui.upload_limit_resolver"] = function ($c) {
             return new \ILIAS\UI\Implementation\Component\Input\UploadLimitResolver(
                 (int) \ilFileUtils::getUploadSizeLimitBytes()
@@ -260,6 +272,16 @@ class InitUIFramework
                             $c["ui.javascript_binding"],
                             $c["refinery"],
                             $c["ui.pathresolver"]
+                        ),
+                        new ILIAS\UI\Implementation\Component\Toast\ToastRendererFactory(
+                            $c['ui.factory'],
+                            $c['ui.template_factory'],
+                            $c['lng'],
+                            $c['ui.javascript_binding'],
+                            $c['refinery'],
+                            $c['ui.pathresolver'],
+                            $c['ui.toast_settings']['vanish_time'],
+                            $c['ui.toast_settings']['delay_time']
                         )
                     )
                 )

--- a/Services/Notifications/ROADMAP.md
+++ b/Services/Notifications/ROADMAP.md
@@ -4,11 +4,6 @@
 
 ### Refactoring
 
-#### Update of Toast Interface
-
-`VanishTime` and `DelayTime` should be moved to the interface, if the values could be configured in the respective consumers.
-As long as this is not the case, they keep an implementation detail.
-
 ## Mid Term
 
 ## Long Term

--- a/Services/Notifications/classes/Provider/NotificationToastProvider.php
+++ b/Services/Notifications/classes/Provider/NotificationToastProvider.php
@@ -70,8 +70,6 @@ class NotificationToastProvider extends AbstractToastProvider
                 )
                 ->withIcon($this->getIconByType($notification->getType()))
                 ->withDescription($notification->getObject()->shortDescription)
-                ->withVanishTime((int) $settings->get('osd_vanish', (string) Toast::DEFAULT_VANISH_TIME))
-                ->withDelayTime((int) $settings->get('osd_delay', (string) Toast::DEFAULT_DELAY_TIME))
                 ->withClosedCallable(static function () use ($osd_repository, $notification) {
                     $osd_repository->deleteOSDNotificationById($notification->getId());
                 });

--- a/src/GlobalScreen/Scope/Toast/Collector/Renderer/StandardToastRenderer.php
+++ b/src/GlobalScreen/Scope/Toast/Collector/Renderer/StandardToastRenderer.php
@@ -127,15 +127,6 @@ class StandardToastRenderer implements ToastRenderer
             $toast = $toast->withAdditionalLink($link);
         }
 
-        // Times (currently disbaled since these methods are not on the Interface of a Toast
-        if ($item->getVanishTime() !== null) {
-            // $toast = $toast->withVanishTime($item->getVanishTime());
-        }
-
-        if ($item->getDelayTime() !== null) {
-            // $toast = $toast->withDelayTime($item->getDelayTime());
-        }
-
         return $toast;
     }
 

--- a/src/GlobalScreen/Scope/Toast/Factory/StandardToastItem.php
+++ b/src/GlobalScreen/Scope/Toast/Factory/StandardToastItem.php
@@ -227,30 +227,6 @@ class StandardToastItem implements isStandardItem
         return $this->handle_vanished !== null;
     }
 
-    public function withVanishTime(int $miliseconds): isStandardItem
-    {
-        $clone = clone $this;
-        $clone->vanish_time = $miliseconds;
-        return $clone;
-    }
-
-    public function getVanishTime(): ?int
-    {
-        return $this->vanish_time;
-    }
-
-    public function withDelayTime(int $miliseconds): isStandardItem
-    {
-        $clone = clone $this;
-        $clone->delay_time = $miliseconds;
-        return $clone;
-    }
-
-    public function getDelayTime(): ?int
-    {
-        return $this->delay_time;
-    }
-
     final public function getRenderer(): ToastRenderer
     {
         return $this->renderer;

--- a/src/GlobalScreen/Scope/Toast/Factory/isStandardItem.php
+++ b/src/GlobalScreen/Scope/Toast/Factory/isStandardItem.php
@@ -102,13 +102,5 @@ interface isStandardItem extends isItem
      */
     public function hasVanishedAction(): bool;
 
-    public function withVanishTime(int $miliseconds): isStandardItem;
-
-    public function getVanishTime(): ?int;
-
-    public function withDelayTime(int $miliseconds): isStandardItem;
-
-    public function getDelayTime(): ?int;
-
     public function getRenderer(): ToastRenderer;
 }

--- a/src/UI/Implementation/Component/Toast/Renderer.php
+++ b/src/UI/Implementation/Component/Toast/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,18 +16,42 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Toast;
 
 use ILIAS\UI\Component\Button\Shy;
 use ILIAS\UI\Component\Link\Link;
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
+use ILIAS\UI\Implementation\Render\ImagePathResolver;
+use ILIAS\UI\Implementation\Render\JavaScriptBinding;
 use ILIAS\UI\Implementation\Render\ResourceRegistry;
+use ILIAS\UI\Implementation\Render\TemplateFactory;
 use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\UI\Component;
+use ilLanguage;
 use LogicException;
 
 class Renderer extends AbstractComponentRenderer
 {
+    protected int $vanish_time;
+    protected int $delay_time;
+
+    public function __construct(
+        \ILIAS\UI\Factory $ui_factory,
+        TemplateFactory $tpl_factory,
+        ilLanguage $lng,
+        JavaScriptBinding $js_binding,
+        \ILIAS\Refinery\Factory $refinery,
+        ImagePathResolver $image_path_resolver,
+        int $vanish_time,
+        int $delay_time
+    ){
+        $this->vanish_time = $vanish_time;
+        $this->delay_time = $delay_time;
+        parent::__construct($ui_factory, $tpl_factory, $lng, $js_binding, $refinery, $image_path_resolver);
+    }
+
     /**
      * @inheritdoc
      */
@@ -59,8 +81,8 @@ class Renderer extends AbstractComponentRenderer
         }
         $tpl->setVariable("TITLE", $title);
 
-        $tpl->setVariable("TOAST_DELAY", $component->getDelayTime());
-        $tpl->setVariable("TOAST_VANISH", $component->getVanishTime());
+        $tpl->setVariable("TOAST_VANISH", $this->vanish_time);
+        $tpl->setVariable("TOAST_DELAY", $this->delay_time);
         $tpl->setVariable("VANISH_ASYNC", $component->getAction());
 
         $desc = htmlentities($component->getDescription());

--- a/src/UI/Implementation/Component/Toast/Toast.php
+++ b/src/UI/Implementation/Component/Toast/Toast.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Toast;
 
@@ -48,8 +48,6 @@ class Toast implements ComponentInterface\Toast
     protected string $action = '';
     protected SignalGeneratorInterface $signal_generator;
     protected Signal $signal;
-    protected int $vanishTime = Toast::DEFAULT_VANISH_TIME;
-    protected int $delayTime = Toast::DEFAULT_DELAY_TIME;
 
     public function __construct($title, Icon $icon, SignalGeneratorInterface $signal_generator)
     {
@@ -125,29 +123,5 @@ class Toast implements ComponentInterface\Toast
     public function getShowSignal(): Signal
     {
         return $this->signal;
-    }
-
-    public function withVanishTime(int $vanishTime): Toast
-    {
-        $new = clone $this;
-        $new->vanishTime = $vanishTime;
-        return $new;
-    }
-
-    public function getVanishTime(): int
-    {
-        return $this->vanishTime;
-    }
-
-    public function withDelayTime(int $delayTime): Toast
-    {
-        $new = clone $this;
-        $new->delayTime = $delayTime;
-        return $new;
-    }
-
-    public function getDelayTime(): int
-    {
-        return $this->delayTime;
     }
 }

--- a/src/UI/Implementation/Component/Toast/ToastRendererFactory.php
+++ b/src/UI/Implementation/Component/Toast/ToastRendererFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Toast;
+
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Implementation\Render;
+use ILIAS\UI\Implementation\Render\ComponentRenderer;
+
+/**
+ * @author Ingmar Szmais <iszmais@databay.de>
+ */
+class ToastRendererFactory extends Render\DefaultRendererFactory
+{
+    protected int $vanish_time;
+    protected int $delay_time;
+
+    public function __construct($c, $c1, $lng, $c2, $refinery, $c3, int $vanish_time, int $delay_time)
+    {
+        $this->vanish_time = $vanish_time;
+        $this->delay_time = $delay_time;
+        parent::__construct($c, $c1, $lng, $c2, $refinery, $c3);
+    }
+
+    public function getRendererInContext(Component $component, array $contexts): ComponentRenderer
+    {
+        $name = $this->getRendererNameFor($component);
+        return new $name(
+            $this->ui_factory,
+            $this->tpl_factory,
+            $this->lng,
+            $this->js_binding,
+            $this->refinery,
+            $this->image_path_resolver,
+            $this->vanish_time,
+            $this->delay_time
+        );
+    }
+}

--- a/src/UI/Implementation/Render/AbstractComponentRenderer.php
+++ b/src/UI/Implementation/Render/AbstractComponentRenderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Render;
 
@@ -46,7 +46,7 @@ abstract class AbstractComponentRenderer implements ComponentRenderer
     private ImagePathResolver $image_path_resolver;
 
 
-    final public function __construct(
+    public function __construct(
         Factory $ui_factory,
         TemplateFactory $tpl_factory,
         ilLanguage $lng,

--- a/src/UI/Implementation/Render/FSLoader.php
+++ b/src/UI/Implementation/Render/FSLoader.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,12 +16,16 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Render;
 
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph;
 use ILIAS\UI\Implementation\Component\Symbol\Icon\Icon;
 use ILIAS\UI\Implementation\Component\Input\Field\Input;
+use ILIAS\UI\Implementation\Component\Toast\Toast;
+use ILIAS\UI\Implementation\Component\Toast\Container;
 
 /**
  * Loads renderers for components from the file system.
@@ -45,16 +47,20 @@ class FSLoader implements Loader
     private RendererFactory $icon_renderer_factory;
     private RendererFactory $field_renderer_factory;
 
+    private RendererFactory $toast_renderer_factory;
+
     public function __construct(
         RendererFactory $default_renderer_factory,
         RendererFactory $glyph_renderer_factory,
         RendererFactory $icon_renderer_factory,
-        RendererFactory $field_renderer_factory
+        RendererFactory $field_renderer_factory,
+        RendererFactory $toast_renderer_factory
     ) {
         $this->default_renderer_factory = $default_renderer_factory;
         $this->glyph_renderer_factory = $glyph_renderer_factory;
         $this->icon_renderer_factory = $icon_renderer_factory;
         $this->field_renderer_factory = $field_renderer_factory;
+        $this->toast_renderer_factory = $toast_renderer_factory;
     }
 
     /**
@@ -80,6 +86,9 @@ class FSLoader implements Loader
         }
         if ($component instanceof Input) {
             return $this->field_renderer_factory;
+        }
+        if ($component instanceof Toast || $component instanceof Container) {
+            return $this->toast_renderer_factory;
         }
         return $this->default_renderer_factory;
     }

--- a/tests/UI/Base.php
+++ b/tests/UI/Base.php
@@ -24,6 +24,7 @@ require_once(__DIR__ . "/../../Services/Language/classes/class.ilLanguage.php");
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Component\Component as IComponent;
 use ILIAS\UI\Implementaiton\Component as I;
+use ILIAS\UI\Implementation\Component\Toast\ToastRendererFactory;
 use ILIAS\UI\Implementation\Render\DecoratedRenderer;
 use ILIAS\UI\Implementation\Render\TemplateFactory;
 use ILIAS\UI\Implementation\Render\ResourceRegistry;
@@ -396,6 +397,16 @@ abstract class ILIAS_UI_TestBase extends TestCase
                         $js_binding,
                         $refinery,
                         $image_path_resolver
+                    ),
+                    new ToastRendererFactory(
+                        $ui_factory,
+                        $tpl_factory,
+                        $lng,
+                        $js_binding,
+                        $refinery,
+                        $image_path_resolver,
+                        5000,
+                        500
                     )
                 )
             )

--- a/tests/UI/Component/Input/Field/FileInputTest.php
+++ b/tests/UI/Component/Input/Field/FileInputTest.php
@@ -29,6 +29,7 @@ use ILIAS\UI\Implementation\Component\Input\Field\FieldRendererFactory;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphRendererFactory;
 use ILIAS\UI\Implementation\Component\Symbol\Icon\IconRendererFactory;
+use ILIAS\UI\Implementation\Component\Toast\ToastRendererFactory;
 use ILIAS\UI\Implementation\Render\DefaultRendererFactory;
 use ILIAS\UI\Implementation\Render\FSLoader;
 use ILIAS\UI\Implementation\Render\JavaScriptBinding;
@@ -579,6 +580,16 @@ class FileInputTest extends ILIAS_UI_TestBase
                             $js_binding,
                             $refinery,
                             $img_resolver
+                        ),
+                        new ToastRendererFactory(
+                            $ui_factory,
+                            $tpl_factory,
+                            $lng,
+                            $js_binding,
+                            $refinery,
+                            $img_resolver,
+                            5000,
+                            500
                         )
                     )
                 )

--- a/tests/UI/Component/Toast/ToastClientHtmlTest.php
+++ b/tests/UI/Component/Toast/ToastClientHtmlTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -14,6 +15,8 @@
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 require_once("libs/composer/vendor/autoload.php");
 
@@ -64,10 +67,8 @@ class ToastClientHtmlTest extends ILIAS_UI_TestBase
                 'Title',
                 $this->getIconFactory()->standard('mail', 'Test')
             )
-                                    ->withVanishTime(5000)
-                                    ->withDelayTime(500)
-                                    ->withDescription('Description')
-                                    ->withAction('https://www.ilias.de')
+                ->withDescription('Description')
+                ->withAction('https://www.ilias.de')
         );
 
         $rendered_html = str_replace('{CONTAINER}', $this->getDefaultRenderer()->render($container), $rendered_html);

--- a/tests/UI/Component/Toast/ToastTest.php
+++ b/tests/UI/Component/Toast/ToastTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 require_once("libs/composer/vendor/autoload.php");
 require_once(__DIR__ . "/../../Base.php");
@@ -55,20 +55,16 @@ class ToastTest extends ILIAS_UI_TestBase
     /**
      * @dataProvider toast_provider
      */
-    public function test_toast(string $title, string $description, int $vanish_time, int $delay_time, string $action): void
+    public function test_toast(string $title, string $description, string $action): void
     {
         $toast = $this->getToastFactory()->standard($title, $this->getIconFactory()->standard('', ''))
                       ->withDescription($description)
-                      ->withVanishTime($vanish_time)
-                      ->withDelayTime($delay_time)
                       ->withAction($action)
                       ->withAdditionalLink($this->getLinkFactory()->standard('', ''));
 
         $this->assertNotNull($toast);
         $this->assertEquals($title, $toast->getTitle());
         $this->assertEquals($description, $toast->getDescription());
-        $this->assertEquals($vanish_time, $toast->getVanishTime());
-        $this->assertEquals($delay_time, $toast->getDelayTime());
         $this->assertEquals($action, $toast->getAction());
         $this->assertCount(1, $toast->getLinks());
         $this->assertInstanceOf(Link::class, $toast->getLinks()[0]);
@@ -79,7 +75,7 @@ class ToastTest extends ILIAS_UI_TestBase
     /**
      * @dataProvider toast_provider
      */
-    public function test_toast_container(string $title, string $description, int $vanish_time): void
+    public function test_toast_container(): void
     {
         $container = $this->getToastFactory()->container()->withAdditionalToast(
             $this->getToastFactory()->standard('', $this->getIconFactory()->standard('', ''))
@@ -94,9 +90,9 @@ class ToastTest extends ILIAS_UI_TestBase
     public function toast_provider(): array
     {
         return [
-            ['title', 'description', 5000, 500, 'test.php'],
-            ['', '', -5000, -500, ''],
-            ['"/><script>alert("hack")</script>', '"/><script>alert("hack")</script>', PHP_INT_MAX, PHP_INT_MIN, 'test.php']
+            ['title', 'description','test.php'],
+            ['', '', ''],
+            ['"/><script>alert("hack")</script>', '"/><script>alert("hack")</script>', 'test.php']
         ];
     }
 }

--- a/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
+++ b/tests/UI/Renderer/ComponentRendererFSLoaderTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 require_once(__DIR__ . "/TestComponent.php");
 
@@ -63,7 +63,8 @@ class ComponentRendererFSLoaderTest extends TestCase
         $this->icon_renderer = $this->createMock(I\Render\RendererFactory::class);
 
         $field_renderer = $this->createMock(I\Render\RendererFactory::class);
-        return new FSLoader($default_renderer_factory, $this->glyph_renderer, $this->icon_renderer, $field_renderer);
+        $toast_renderer = $this->createMock(I\Render\RendererFactory::class);
+        return new FSLoader($default_renderer_factory, $this->glyph_renderer, $this->icon_renderer, $field_renderer, $toast_renderer);
     }
 
     public function test_getRenderer_successfully(): void


### PR DESCRIPTION
(This PR was recreated since its origin fork was deleted: https://github.com/ILIAS-eLearning/ILIAS/pull/6394)

In repsonse to the rejection of the proposal of individual timing function per toast (https://github.com/ILIAS-eLearning/ILIAS/pull/6164) this removes all occurences prepared for that in consequence.