### PR TITLE
Prevent toast from vanish when an interaction happens

### DIFF
--- a/src/UI/templates/default/Toast/tpl.toast.html
+++ b/src/UI/templates/default/Toast/tpl.toast.html
@@ -1,5 +1,5 @@
 <div class="il-toast-wrapper" <!-- BEGIN id -->id="{ID}"<!-- END id --> data-vanishurl="{VANISH_ASYNC}" data-vanish="{TOAST_VANISH}" data-delay="{TOAST_DELAY}">
-    <div class="il-toast">
+    <div class="il-toast" tabindex="0">
         <div class="icon">{ICON}</div>
         <div class="title">{TITLE}</div>
         {CLOSE}

--- a/src/UI/templates/js/Toast/toast.js
+++ b/src/UI/templates/js/Toast/toast.js
@@ -3,8 +3,9 @@ il.UI = il.UI || {};
 il.UI.toast = ((UI) => {
     let vanishTime = 5000;
     let delayTime = 500;
+    let queue = new WeakMap();
 
-    let setToastSettings = (element) => {
+    const setToastSettings = (element) => {
         if (element.hasAttribute('data-vanish')) {
             vanishTime = parseInt(element.dataset.vanish);
         }
@@ -13,11 +14,11 @@ il.UI.toast = ((UI) => {
         }
     }
 
-    let showToast = (element) => {
+    const showToast = (element) => {
         setTimeout(() => {appearToast(element);}, delayTime);
     }
 
-    let closeToast = (element, forced = false) => {
+    const closeToast = (element, forced = false) => {
         element.querySelector('.il-toast').addEventListener('transitionend', () => {
             if (forced && element.dataset.vanishurl !== '') {
                 let xhr = new XMLHttpRequest();
@@ -30,10 +31,22 @@ il.UI.toast = ((UI) => {
         element.querySelector('.il-toast').classList.remove('active');
     };
 
-    let appearToast = (element) => {
+    const appearToast = (element) => {
         element.querySelector('.il-toast').classList.add('active');
-        element.querySelector('.il-toast .close').addEventListener('click', () => {closeToast(element, true);});
-        setTimeout(() => {closeToast(element);}, vanishTime);
+        queueToast(element);
+        element.querySelector('.il-toast .close').addEventListener('click', () => closeToast(element, true));
+        element.querySelector('.il-toast').addEventListener('mouseenter', () => stopToast(element));
+        element.querySelector('.il-toast').addEventListener('focusin', () => stopToast(element));
+        element.querySelector('.il-toast').addEventListener('mouseleave', () => queueToast(element));
+        element.querySelector('.il-toast').addEventListener('focusout', () => queueToast(element));
+    }
+
+    const stopToast = (element) => {
+        clearTimeout(queue.get(element));
+    }
+
+    const queueToast = (element) => {
+        queue.set(element, setTimeout(() => closeToast(element), vanishTime));
     }
 
     return {

--- a/tests/UI/Client/Toast/ToastTest.html
+++ b/tests/UI/Client/Toast/ToastTest.html
@@ -6,7 +6,7 @@
 <body>
   <div class="il-toast-container" aria-live="polite">
     <div class="il-toast-wrapper" data-vanishurl="https://www.ilias.de" data-vanish="5000" data-delay="500">
-      <div class="il-toast">
+      <div class="il-toast" tabindex="0">
         <div class="icon">
           <img class="icon mail small" src="./templates/default/images/icon_mail.svg" alt="Test"/>
         </div>


### PR DESCRIPTION
(This PR was recreated since its origin fork was deleted: https://github.com/ILIAS-eLearning/ILIAS/pull/6166)

This PR prevent the vanishment of a toast when the user hovers it.
This is limited to the global refreshintervall of toasts. When another Intervall start the toast still disappears