### PR TITLE
Dashboard refactor for ILIAS9 / PHP8.1

### DIFF
--- a/Services/Dashboard/Access/DashboardAccess.php
+++ b/Services/Dashboard/Access/DashboardAccess.php
@@ -3,28 +3,31 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\Dashboard\Access;
 
-/**
- * Dashboard permission wrapper
- *
- * @author Alexander Killing <killing@leifos.de>
- */
+use ilDBInterface;
+use ilRbacSystem;
+
 class DashboardAccess
 {
-    protected \ilRbacSystem $rbac_system;
-    protected \ilDBInterface $db;
-    protected static int $setting_ref_id = 0;
+    protected readonly ilRbacSystem $rbac_system;
+    protected readonly ilDBInterface $db;
+    private int $setting_ref_id = 0;
 
     public function __construct()
     {
@@ -34,29 +37,26 @@ class DashboardAccess
         $this->rbac_system = $DIC->rbac()->system();
     }
 
-    /**
-     * Get dashboard settings ref id
-     */
     protected function getSettingsRefId(): int
     {
-        if (self::$setting_ref_id == 0) {
+        if ($this->setting_ref_id == 0) {
             $set = $this->db->queryF(
                 'SELECT object_reference.ref_id FROM object_reference, tree, object_data
                 WHERE tree.parent = %s
                 AND object_data.type = %s
                 AND object_reference.ref_id = tree.child
                 AND object_reference.obj_id = object_data.obj_id',
-                array('integer', 'text'),
-                array(SYSTEM_FOLDER_ID, 'dshs')
+                ['integer', 'text'],
+                [SYSTEM_FOLDER_ID, 'dshs']
             );
             $rec = $this->db->fetchAssoc($set);
-            self::$setting_ref_id = (int) $rec["ref_id"];
+            $this->setting_ref_id = (int) $rec['ref_id'];
         }
-        return self::$setting_ref_id;
+        return $this->setting_ref_id;
     }
 
     public function canChangePresentation(int $user_id): bool
     {
-        return $this->rbac_system->checkAccessOfUser($user_id, "change_presentation", $this->getSettingsRefId());
+        return $this->rbac_system->checkAccessOfUser($user_id, 'change_presentation', $this->getSettingsRefId());
     }
 }

--- a/Services/Dashboard/Achievements/classes/class.ilAchievementsGUI.php
+++ b/Services/Dashboard/Achievements/classes/class.ilAchievementsGUI.php
@@ -3,35 +3,40 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\DI\Container;
 
 /**
  * @ilCtrl_Calls ilAchievementsGUI: ilLearningProgressGUI, ilPersonalSkillsGUI, ilBadgeProfileGUI, ilLearningHistoryGUI
- * @author Alexander Killing <killing@leifos.de>
  */
 class ilAchievementsGUI
 {
-    protected ilCtrl $ctrl;
-    protected ilAchievements $achievements;
-    protected ilLanguage $lng;
-    protected ilTabsGUI $tabs;
-    private ilGlobalTemplateInterface $main_tpl;
+    protected readonly ilCtrl $ctrl;
+    protected readonly ilAchievements $achievements;
+    protected readonly ilLanguage $lng;
+    private readonly ilGlobalTemplateInterface $main_tpl;
 
     public function __construct()
     {
         global $DIC;
+
         $this->ctrl = $DIC->ctrl();
         $this->achievements = new ilAchievements();
         $this->lng = $DIC->language();
-        $this->tabs = $DIC->tabs();
         $this->main_tpl = $DIC->ui()->mainTemplate();
     }
 
@@ -40,129 +45,71 @@ class ilAchievementsGUI
      */
     public function executeCommand(): void
     {
-        $ctrl = $this->ctrl;
-        $main_tpl = $this->main_tpl;
-        $lng = $this->lng;
+        $this->lng->loadLanguageModule('lhist');
 
-        $lng->loadLanguageModule("lhist");
-
-        $next_class = $ctrl->getNextClass($this);
-        $cmd = $ctrl->getCmd("show");
-
+        $next_class = $this->ctrl->getNextClass($this);
+        $cmd = $this->ctrl->getCmd('show');
 
         switch ($next_class) {
-            case "illearningprogressgui":
-                $main_tpl->setTitle($lng->txt("learning_progress"));
-                $main_tpl->setTitleIcon(ilUtil::getImagePath("icon_trac.svg"));
+            case 'illearningprogressgui':
+                $this->main_tpl->setTitle($this->lng->txt('learning_progress'));
+                $this->main_tpl->setTitleIcon(ilUtil::getImagePath('icon_trac.svg'));
                 $new_gui = new ilLearningProgressGUI(ilLearningProgressGUI::LP_CONTEXT_PERSONAL_DESKTOP, 0);
-                $ctrl->forwardCommand($new_gui);
+                $this->ctrl->forwardCommand($new_gui);
                 break;
 
             case 'illearninghistorygui':
-                $main_tpl->setTitle($lng->txt("lhist_learning_history"));
-                $main_tpl->setTitleIcon(ilUtil::getImagePath("icon_lhist.svg"));
+                $this->main_tpl->setTitle($this->lng->txt('lhist_learning_history'));
+                $this->main_tpl->setTitleIcon(ilUtil::getImagePath('icon_lhist.svg'));
                 $lhistgui = new ilLearningHistoryGUI();
-                $ctrl->forwardCommand($lhistgui);
+                $this->ctrl->forwardCommand($lhistgui);
                 $this->main_tpl->printToStdout();
                 break;
 
             case 'ilpersonalskillsgui':
-                $main_tpl->setTitle($lng->txt("skills"));
-                $main_tpl->setTitleIcon(ilUtil::getImagePath("icon_skmg.svg"));
+                $this->main_tpl->setTitle($this->lng->txt('skills'));
+                $this->main_tpl->setTitleIcon(ilUtil::getImagePath('icon_skmg.svg'));
                 $skgui = new ilPersonalSkillsGUI();
-                $ctrl->forwardCommand($skgui);
+                $this->ctrl->forwardCommand($skgui);
                 $this->main_tpl->printToStdout();
                 break;
 
             case 'ilbadgeprofilegui':
-                $main_tpl->setTitle($lng->txt("obj_bdga"));
-                $main_tpl->setTitleIcon(ilUtil::getImagePath("icon_bdga.svg"));
+                $this->main_tpl->setTitle($this->lng->txt('obj_bdga'));
+                $this->main_tpl->setTitleIcon(ilUtil::getImagePath('icon_bdga.svg'));
                 $bgui = new ilBadgeProfileGUI();
-                $ctrl->forwardCommand($bgui);
+                $this->ctrl->forwardCommand($bgui);
                 $this->main_tpl->printToStdout();
                 break;
 
             case 'ilusercertificategui':
-                $main_tpl->setTitle($lng->txt("obj_cert"));
-                $main_tpl->setTitleIcon(ilUtil::getImagePath("icon_cert.svg"));
+                $this->main_tpl->setTitle($this->lng->txt('obj_cert'));
+                $this->main_tpl->setTitleIcon(ilUtil::getImagePath('icon_cert.svg'));
                 $cgui = new ilUserCertificateGUI();
-                $ctrl->forwardCommand($cgui);
+                $this->ctrl->forwardCommand($cgui);
                 $this->main_tpl->printToStdout();
                 break;
 
             default:
-                if (in_array($cmd, array("show"))) {
-                    $this->$cmd();
+                if ($cmd === 'show') {
+                    $this->show();
                 }
                 $this->main_tpl->printToStdout();
                 break;
         }
     }
 
-    /**
-     * Show (redirects to first active service)
-     */
     protected function show(): void
     {
-        $ctrl = $this->ctrl;
-
         $gui_classes = $this->getGUIClasses();
         $first_service = current($this->achievements->getActiveServices());
         if ($first_service) {
-            $ctrl->redirectByClass(["ildashboardgui", "ilachievementsgui", $gui_classes[$first_service]]);
+            $this->ctrl->redirectByClass(['ildashboardgui', 'ilachievementsgui', $gui_classes[$first_service]]);
         }
-    }
-
-    protected function setTabs(string $activate): void
-    {
-        $tabs = $this->tabs;
-        $links = $this->getLinks();
-
-        foreach ($this->achievements->getActiveServices() as $s) {
-            $tabs->addTab("achieve_" . $s, $links[$s]["txt"], $links[$s]["link"]);
-        }
-        $tabs->activateTab("achieve_" . $activate);
     }
 
     /**
-     * @return array[]
-     */
-    protected function getLinks(): array
-    {
-        $ctrl = $this->ctrl;
-        $lng = $this->lng;
-
-        $lng->loadLanguageModule("lhist");
-        $gui_classes = $this->getGUIClasses();
-
-        $links = [
-            ilAchievements::SERV_LEARNING_HISTORY => [
-                "txt" => $lng->txt("lhist_learning_history")
-            ],
-            ilAchievements::SERV_COMPETENCES => [
-                "txt" => $lng->txt("skills")
-            ],
-            ilAchievements::SERV_LEARNING_PROGRESS => [
-                "txt" => $lng->txt("learning_progress")
-            ],
-            ilAchievements::SERV_BADGES => [
-                "txt" => $lng->txt('obj_bdga')
-            ],
-            ilAchievements::SERV_CERTIFICATES => [
-                "txt" => $lng->txt("obj_cert")
-            ]
-        ];
-
-        foreach ($links as $k => $v) {
-            $links[$k]["link"] = $ctrl->getLinkTargetByClass(["ildashboardgui", "ilachievementsgui", $gui_classes[$k]]);
-        }
-
-        return $links;
-    }
-
-    /**
-     * Get GUI class
-     * @return string[]
+     * @return array<int, string>
      */
     protected function getGUIClasses(): array
     {

--- a/Services/Dashboard/Achievements/classes/ilAchievements.php
+++ b/Services/Dashboard/Achievements/classes/ilAchievements.php
@@ -3,36 +3,32 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
-/**
- * Maybe a separate service in the future. Needs a generic approach.
- *
- * Currently only the main menu (and personal desktop) should use this.
- *
- * @author Alexander Killing <killing@leifos.de>
- */
+declare(strict_types=1);
+
+use ILIAS\DI\Container;
+
 class ilAchievements
 {
-    private ilCertificateActiveValidator $validator;
-    protected ilLearningHistoryService $learing_history;
-
-    // all services being covered under the achievements menu item
     public const SERV_LEARNING_HISTORY = 1;
     public const SERV_COMPETENCES = 2;
     public const SERV_LEARNING_PROGRESS = 3;
     public const SERV_BADGES = 4;
     public const SERV_CERTIFICATES = 5;
 
-    // this also determines the order of tabs
+    protected readonly ilLearningHistoryService $learing_history;
     protected array $services = [
         self::SERV_LEARNING_HISTORY,
         self::SERV_COMPETENCES,
@@ -40,51 +36,40 @@ class ilAchievements
         self::SERV_BADGES,
         self::SERV_CERTIFICATES
     ];
-
-    protected ilSetting $setting;
-    protected ilSetting $skmg_setting;
+    protected readonly ilSetting $skmg_setting;
+    private readonly ilCertificateActiveValidator $validator;
 
     public function __construct()
     {
-        /** @var ILIAS\DI\Container $DIC */
         global $DIC;
 
-        $this->setting = $DIC->settings();
         $this->learing_history = $DIC->learningHistory();
-        $this->skmg_setting = new ilSetting("skmg");
+        $this->skmg_setting = new ilSetting('skmg');
         $this->validator = new ilCertificateActiveValidator();
     }
 
-    /**
-     * Is sub-service active?
-     */
     public function isActive(int $service): bool
     {
         switch ($service) {
             case self::SERV_LEARNING_HISTORY:
                 return $this->learing_history->isActive();
-
             case self::SERV_COMPETENCES:
-                return (bool) $this->skmg_setting->get("enable_skmg");
-
+                return (bool) $this->skmg_setting->get('enable_skmg');
             case self::SERV_LEARNING_PROGRESS:
                 return ilObjUserTracking::_enabledLearningProgress() &&
-                    (ilObjUserTracking::_hasLearningProgressOtherUsers() ||
-                        ilObjUserTracking::_hasLearningProgressLearner());
-
+                    (
+                        ilObjUserTracking::_hasLearningProgressOtherUsers() ||
+                        ilObjUserTracking::_hasLearningProgressLearner()
+                    );
             case self::SERV_BADGES:
                 return ilBadgeHandler::getInstance()->isActive();
-
             case self::SERV_CERTIFICATES:
                 return $this->validator->validate();
         }
         return false;
     }
 
-    /**
-     * Is any sub-service active?
-     */
-    public function isAnyActive(): bool
+    final public function isAnyActive(): bool
     {
         foreach ($this->services as $s) {
             if ($this->isActive($s)) {
@@ -95,13 +80,10 @@ class ilAchievements
     }
 
     /**
-     * Get active services
      * @return int[]
      */
-    public function getActiveServices(): array
+    final public function getActiveServices(): array
     {
-        return array_filter($this->services, function ($s) {
-            return $this->isActive($s);
-        });
+        return array_filter($this->services, $this->isActive(...));
     }
 }

--- a/Services/Dashboard/Administration/classes/class.ilDashboardSortationTableGUI.php
+++ b/Services/Dashboard/Administration/classes/class.ilDashboardSortationTableGUI.php
@@ -23,27 +23,25 @@ use ILIAS\UI\Renderer;
 
 class ilDashboardSortationTableGUI extends ilTable2GUI
 {
-    private Renderer $uiRenderer;
-    private Factory $uiFactory;
+    private readonly Renderer $uiRenderer;
+    private readonly Factory $uiFactory;
+    private readonly ilDashboardSidePanelSettingsRepository $side_panel_settings;
     private ilPDSelectedItemsBlockViewSettings $viewSettings;
-    private ilDashboardSidePanelSettingsRepository $side_panel_settings;
 
-    public function __construct($a_parent_obj, $a_parent_cmd)
+    public function __construct(ilObjDashboardSettingsGUI $parent_obj, string $parent_cmd)
     {
         global $DIC;
+
         $this->uiFactory = $DIC->ui()->factory();
         $this->uiRenderer = $DIC->ui()->renderer();
         $this->viewSettings = new ilPDSelectedItemsBlockViewSettings($DIC->user());
         $this->side_panel_settings = new ilDashboardSidePanelSettingsRepository();
-        parent::__construct($a_parent_obj, $a_parent_cmd);
+        parent::__construct($parent_obj, $parent_cmd);
         $this->lng->loadLanguageModule('mme');
         $this->initColumns();
         $this->setFormAction($this->ctrl->getFormAction($this->parent_obj));
         $this->addCommandButton('saveSettings', $this->lng->txt('save'));
-        $this->setRowTemplate(
-            'tpl.dashboard_sortation_row.html',
-            'Services/Dashboard'
-        );
+        $this->setRowTemplate('tpl.dashboard_sortation_row.html', 'Services/Dashboard');
         $this->setEnableNumInfo(false);
         $this->initData();
     }

--- a/Services/Dashboard/Administration/classes/ilObjDashboardSettings.php
+++ b/Services/Dashboard/Administration/classes/ilObjDashboardSettings.php
@@ -3,28 +3,28 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
-
-/**
- * Dashboard settings
  *
- * @author Alexander Killing <killing@leifos.de>
- */
+ *********************************************************************/
+
+declare(strict_types=1);
+
 class ilObjDashboardSettings extends ilObject
 {
-    public function __construct(
-        int $a_id = 0,
-        bool $a_call_by_reference = true
-    ) {
-        $this->type = "dshs";
-        parent::__construct($a_id, $a_call_by_reference);
+    public const TYPE = 'dshs';
+
+    public function __construct(int $id = 0, bool $call_by_reference = true)
+    {
+        $this->type = self::TYPE;
+        parent::__construct($id, $call_by_reference);
     }
 }

--- a/Services/Dashboard/Administration/classes/ilObjDashboardSettingsAccess.php
+++ b/Services/Dashboard/Administration/classes/ilObjDashboardSettingsAccess.php
@@ -3,21 +3,21 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
-
-/**
- * Dashboard settings access
  *
- * @author Alexander Killing <killing@leifos.de>
- */
+ *********************************************************************/
+
+declare(strict_types=1);
+
 class ilObjDashboardSettingsAccess extends ilObjectAccess
 {
 }

--- a/Services/Dashboard/Block/classes/BlockDTO.php
+++ b/Services/Dashboard/Block/classes/BlockDTO.php
@@ -27,24 +27,15 @@ class BlockDTO
     public function __construct(
         private string $type,
         private int $ref_id,
-        private int $obj_id,
+        private readonly int $obj_id,
         private string $title,
         private string $description,
         private ?ilDateTime $startDate = null,
         private ?ilDateTime $endDate = null,
         private array $additional_data = []
-    ) {
-        $this->type = $type;
-        $this->ref_id = $ref_id;
-        $this->obj_id = $obj_id;
-        $this->title = $title;
-        $this->description = $description;
-        $this->startDate = $startDate;
-        $this->endDate = $endDate;
-        $this->additional_data = $additional_data;
-    }
+    ) {}
 
-    public function getType(): string
+    final public function getType(): string
     {
         return $this->type;
     }
@@ -54,7 +45,7 @@ class BlockDTO
         $this->type = $type;
     }
 
-    public function getRefId(): int
+    final public function getRefId(): int
     {
         return $this->ref_id;
     }
@@ -64,17 +55,12 @@ class BlockDTO
         $this->ref_id = $ref_id;
     }
 
-    public function getObjId(): int
+    final public function getObjId(): int
     {
         return $this->obj_id;
     }
 
-    public function setObjId(int $obj_id): void
-    {
-        $this->obj_id = $obj_id;
-    }
-
-    public function getTitle(): string
+    final public function getTitle(): string
     {
         return $this->title;
     }
@@ -84,7 +70,7 @@ class BlockDTO
         $this->title = $title;
     }
 
-    public function getDescription(): string
+    final public function getDescription(): string
     {
         return $this->description;
     }
@@ -94,7 +80,7 @@ class BlockDTO
         $this->description = $description;
     }
 
-    public function getStartDate(): ?ilDateTime
+    final public function getStartDate(): ?ilDateTime
     {
         return $this->startDate;
     }
@@ -104,7 +90,7 @@ class BlockDTO
         $this->startDate = $startDate;
     }
 
-    public function getEndDate(): ?ilDateTime
+    final public function getEndDate(): ?ilDateTime
     {
         return $this->endDate;
     }
@@ -114,27 +100,27 @@ class BlockDTO
         $this->endDate = $endDate;
     }
 
-    public function hasNotStarted(): bool
+    final public function hasNotStarted(): bool
     {
         return $this->startDate && $this->startDate->get(IL_CAL_UNIX) > time();
     }
 
-    public function hasEnded(): bool
+    final public function hasEnded(): bool
     {
         return $this->endDate && $this->endDate->get(IL_CAL_UNIX) < time();
     }
 
-    public function isRunning(): bool
+    final public function isRunning(): bool
     {
         return !$this->hasNotStarted() && !$this->hasEnded();
     }
 
-    public function isDated(): bool
+    final public function isDated(): bool
     {
         return $this->startDate || $this->endDate;
     }
 
-    public function getAdditionalData(): array
+    final public function getAdditionalData(): array
     {
         return $this->additional_data;
     }

--- a/Services/Dashboard/Block/classes/class.ilMembershipBlockGUI.php
+++ b/Services/Dashboard/Block/classes/class.ilMembershipBlockGUI.php
@@ -22,7 +22,7 @@ use ILIAS\Services\Dashboard\Block\BlockDTO;
 
 class ilMembershipBlockGUI extends ilDashboardBlockGUI
 {
-    private ilFavouritesManager $favourites;
+    private readonly ilFavouritesManager $favourites;
 
     public function __construct()
     {
@@ -47,7 +47,7 @@ class ilMembershipBlockGUI extends ilDashboardBlockGUI
         return $this->renderer->render(
             $this->factory->panel()->standard(
                 $this->getTitle(),
-                $this->factory->legacy($this->lng->txt("rep_mo_mem_dash"))
+                $this->factory->legacy($this->lng->txt('rep_mo_mem_dash'))
             )
         );
     }
@@ -81,18 +81,18 @@ class ilMembershipBlockGUI extends ilDashboardBlockGUI
     public function addToDeskObject(): void
     {
         $this->favourites->add($this->user->getId(), $this->requested_item_ref_id);
-        $this->main_tpl->setOnScreenMessage('success', $this->lng->txt("rep_added_to_favourites"), true);
+        $this->main_tpl->setOnScreenMessage('success', $this->lng->txt('rep_added_to_favourites'), true);
         $this->returnToContext();
     }
 
     public function addCustomCommandsToActionMenu(ilObjectListGUI $itemListGui, int $ref_id): void
     {
-        $this->ctrl->setParameter($this, "item_ref_id", $ref_id);
+        $this->ctrl->setParameter($this, 'item_ref_id', $ref_id);
         $itemListGui->addCustomCommand(
-            $this->ctrl->getLinkTarget($this, "addToDesk"),
-            "rep_add_to_favourites"
+            $this->ctrl->getLinkTarget($this, 'addToDesk'),
+            'rep_add_to_favourites'
         );
-        $this->ctrl->clearParameterByClass(self::class, "item_ref_id");
+        $this->ctrl->clearParameterByClass(self::class, 'item_ref_id');
     }
 
     public function confirmedRemoveObject(): void

--- a/Services/Dashboard/Block/classes/class.ilSelectedItemsBlockGUI.php
+++ b/Services/Dashboard/Block/classes/class.ilSelectedItemsBlockGUI.php
@@ -25,7 +25,7 @@ use ILIAS\Services\Dashboard\Block\BlockDTO;
  */
 class ilSelectedItemsBlockGUI extends ilDashboardBlockGUI
 {
-    private ilFavouritesManager $favourites;
+    private readonly ilFavouritesManager $favourites;
 
     public function __construct()
     {
@@ -46,12 +46,12 @@ class ilSelectedItemsBlockGUI extends ilDashboardBlockGUI
     public function emptyHandling(): string
     {
         $this->lng->loadLanguageModule('rep');
-        $txt = $this->lng->txt("rep_fav_intro1") . "<br>";
+        $txt = $this->lng->txt('rep_fav_intro1') . '<br>';
         $txt .= sprintf(
             $this->lng->txt('rep_fav_intro2'),
             $this->getRepositoryTitle()
-        ) . "<br>";
-        $txt .= $this->lng->txt("rep_fav_intro3");
+        ) . '<br>';
+        $txt .= $this->lng->txt('rep_fav_intro3');
         $mbox = $this->ui->factory()->messageBox()->info($txt);
         $mbox = $mbox->withLinks(
             [
@@ -99,8 +99,8 @@ class ilSelectedItemsBlockGUI extends ilDashboardBlockGUI
     {
         $this->ctrl->setParameter($this, 'item_ref_id', $ref_id);
         $itemListGui->addCustomCommand(
-            $this->ctrl->getLinkTarget($this, "removeFromDesk"),
-            "rep_remove_from_favourites",
+            $this->ctrl->getLinkTarget($this, 'removeFromDesk'),
+            'rep_remove_from_favourites',
         );
         $this->ctrl->clearParameterByClass(self::class, 'item_ref_id');
     }
@@ -122,9 +122,9 @@ class ilSelectedItemsBlockGUI extends ilDashboardBlockGUI
 
     public function removeFromDeskObject(): void
     {
-        $this->lng->loadLanguageModule("rep");
+        $this->lng->loadLanguageModule('rep');
         $this->favourites->remove($this->user->getId(), $this->requested_item_ref_id);
-        $this->main_tpl->setOnScreenMessage('success', $this->lng->txt("rep_removed_from_favourites"), true);
+        $this->main_tpl->setOnScreenMessage('success', $this->lng->txt('rep_removed_from_favourites'), true);
         $this->returnToContext();
     }
 

--- a/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
+++ b/Services/Dashboard/GlobalScreen/classes/DashboardLayoutProvider.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
 use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
@@ -24,12 +26,7 @@ use ILIAS\GlobalScreen\Scope\Layout\Factory\MainBarModification;
 use ILIAS\UI\Component\MainControls\MainBar;
 use ILIAS\GlobalScreen\ScreenContext\AdditionalData\Collection;
 
-/**
- * Class DashboardLayoutProvider
- *
- * @author Nils Haagen <nils.haagen@concepts-and-training.de>
- */
-class DashboardLayoutProvider extends AbstractModificationProvider implements ModificationProvider
+class DashboardLayoutProvider extends AbstractModificationProvider
 {
     protected ?Collection $data_collection;
 
@@ -41,15 +38,13 @@ class DashboardLayoutProvider extends AbstractModificationProvider implements Mo
     public function getMainBarModification(CalledContexts $screen_context_stack): ?MainBarModification
     {
         $this->data_collection = $screen_context_stack->current()->getAdditionalData();
-        if (!$this->data_collection->is(\ilDashboardGUI::DISENGAGE_MAINBAR, true)) {
+        if (!$this->data_collection->is(ilDashboardGUI::DISENGAGE_MAINBAR, true)) {
             return null;
         }
 
         return $this->globalScreen()->layout()->factory()->mainbar()
             ->withModification(
-                function (?MainBar $mainbar): ?MainBar {
-                    return $mainbar !== null ? $mainbar->withActive($mainbar::NONE_ACTIVE) : null;
-                }
+                static fn (?MainBar $mainbar): ?MainBar => ($mainbar !== null) ? $mainbar->withActive($mainbar::NONE_ACTIVE) : null
             )
             ->withLowPriority();
     }

--- a/Services/Dashboard/ItemsBlock/classes/class.ilDashObjectsTableGUI.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilDashObjectsTableGUI.php
@@ -3,56 +3,53 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
-
-/**
- * Classic table for rep object lists, including checkbox
  *
- * @author Alexander Killing <killing@leifos.de>
- */
+ *********************************************************************/
+
+declare(strict_types=1);
+
 class ilDashObjectsTableGUI extends ilTable2GUI
 {
     public function __construct(
-        object $a_parent_obj,
-        string $a_parent_cmd,
+        object $parent_obj,
+        string $parent_cmd,
         int $sub_id
     ) {
         global $DIC;
 
-        $this->id = "dash_obj_" . $sub_id;
+        $this->id = 'dash_obj_' . $sub_id;
         $this->lng = $DIC->language();
         $this->ctrl = $DIC->ctrl();
 
-        parent::__construct($a_parent_obj, $a_parent_cmd);
+        parent::__construct($parent_obj, $parent_cmd);
 
-        $this->setTitle($this->lng->txt(""));
+        $this->setTitle($this->lng->txt(''));
 
-        $this->addColumn("", "", "", true);
+        $this->addColumn('', '', '', true);
 
         $this->setEnableNumInfo(false);
         $this->setEnableHeader(false);
 
-        $this->setRowTemplate("tpl.dash_obj_row.html", "Services/Dashboard");
+        $this->setRowTemplate('tpl.dash_obj_row.html', 'Services/Dashboard');
 
         $this->setLimit(9999);
     }
 
-    /**
-     * Fill table row
-     */
-    protected function fillRow(array $a_set): void
+    protected function fillRow(array $set): void
     {
         $tpl = $this->tpl;
-        $tpl->setVariable("ID", $a_set["ref_id"]);
-        $tpl->setVariable("ICON", ilObject::_getIcon((int) $a_set["obj_id"]));
-        $tpl->setVariable("TITLE", $a_set["title"]);
+        $tpl->setVariable('ID', $set['ref_id']);
+        $tpl->setVariable('ICON', ilObject::_getIcon((int) $set['obj_id']));
+        $tpl->setVariable('TITLE', $set['title']);
     }
 }

--- a/Services/Dashboard/ItemsBlock/classes/class.ilDashObjectsTableRenderer.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilDashObjectsTableRenderer.php
@@ -1,23 +1,23 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
-/**
- * Dashboard objects table renderer
- */
+declare(strict_types=1);
+
 class ilDashObjectsTableRenderer
 {
     protected object $parent_gui;
@@ -30,11 +30,11 @@ class ilDashObjectsTableRenderer
     public function render(array $groupedItems): string
     {
         $cnt = 0;
-        $html = "";
+        $html = '';
         foreach ($groupedItems as $group) {
             $items = $group->getItems();
             if (count($items) > 0) {
-                $table = new ilDashObjectsTableGUI($this->parent_gui, "render", $cnt++);
+                $table = new ilDashObjectsTableGUI($this->parent_gui, 'render', $cnt++);
                 $table->setTitle($group->getLabel());
                 $table->setData($group->getItems());
                 $html .= $table->getHTML();

--- a/Services/Dashboard/ItemsBlock/classes/class.ilDashboardSidePanelSettingsRepository.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilDashboardSidePanelSettingsRepository.php
@@ -18,24 +18,19 @@
 
 declare(strict_types=1);
 
-/**
- * Dashboard side panel settings Repo
- *
- * @author Alexander Killing <killing@leifos.de>
- */
 class ilDashboardSidePanelSettingsRepository
 {
-    public const CALENDAR = "cal";
-    public const NEWS = "news";
-    public const MAIL = "mail";
-    public const TASKS = "task";
+    public const CALENDAR = 'cal';
+    public const NEWS = 'news';
+    public const MAIL = 'mail';
+    public const TASKS = 'task';
 
     protected ilSetting $setting;
 
     public function __construct(ilSetting $dashboard_settings = null)
     {
         $this->setting = is_null($dashboard_settings)
-            ? new ilSetting("dash")
+            ? new ilSetting('dash')
             : $dashboard_settings;
     }
 
@@ -65,8 +60,8 @@ class ilDashboardSidePanelSettingsRepository
      */
     public function getPositions(): array
     {
-        $positions = $this->setting->get('side_panel_positions', "");
-        if ($positions !== "") {
+        $positions = $this->setting->get('side_panel_positions', '');
+        if ($positions !== '') {
             return unserialize($positions, ['allowed_classes' => false]);
         }
         return $this->getValidModules();
@@ -77,19 +72,17 @@ class ilDashboardSidePanelSettingsRepository
         return in_array($mod, $this->getValidModules());
     }
 
-    // Enable module
     public function enable(string $mod, bool $active): void
     {
         if ($this->isValidModule($mod)) {
-            $this->setting->set("enable_" . $mod, $active ? '1' : '0');
+            $this->setting->set('enable_' . $mod, $active ? '1' : '0');
         }
     }
 
-    // Is module enabled?
     public function isEnabled(string $mod): bool
     {
         if ($this->isValidModule($mod)) {
-            return (bool) $this->setting->get("enable_" . $mod, '1');
+            return (bool) $this->setting->get('enable_' . $mod, '1');
         }
         return false;
     }

--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemBlockMembershipsDTO.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemBlockMembershipsDTO.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +14,10 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+
+declare(strict_types=1);
+
 final class ilPDSelectedItemBlockMembershipsDTO
 {
     private int $refId;

--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockGroup.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockGroup.php
@@ -3,25 +3,27 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
-/**
- * Class ilPDSelectedItemsBlockGroup
- */
+declare(strict_types=1);
+
 class ilPDSelectedItemsBlockGroup
 {
     protected bool $has_icon = false;
     protected string $icon_path = '';
     protected string $label = '';
-    protected array $items = array();
+    protected array $items = [];
 
     public function getLabel(): string
     {
@@ -46,9 +48,6 @@ class ilPDSelectedItemsBlockGroup
         $this->items = $items;
     }
 
-    /**
-     * @param array $item
-     */
     public function pushItem(array $item): void
     {
         $this->items[] = $item;

--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockMembershipsObjectDatabaseRepository.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockMembershipsObjectDatabaseRepository.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +14,9 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+
+declare(strict_types=1);
 
 final class ilPDSelectedItemsBlockMembershipsObjectDatabaseRepository implements ilPDSelectedItemsBlockMembershipsObjectRepository
 {

--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockMembershipsProvider.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockMembershipsProvider.php
@@ -3,15 +3,20 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 class ilPDSelectedItemsBlockMembershipsProvider implements ilPDSelectedItemsBlockProvider
 {
@@ -35,13 +40,10 @@ class ilPDSelectedItemsBlockMembershipsProvider implements ilPDSelectedItemsBloc
         );
     }
 
-    /**
-     * Gets all objects the current user is member of
-     */
     protected function getObjectsByMembership(array $objTypes = []): array
     {
-        $short_desc = $this->settings->get("rep_shorten_description");
-        $short_desc_max_length = (int) $this->settings->get("rep_shorten_description_length");
+        $short_desc = $this->settings->get('rep_shorten_description');
+        $short_desc_max_length = (int) $this->settings->get('rep_shorten_description_length');
 
         if (!is_array($objTypes) || $objTypes === []) {
             $objTypes = $this->repository->getValidObjectTypes();
@@ -54,7 +56,7 @@ class ilPDSelectedItemsBlockMembershipsProvider implements ilPDSelectedItemsBloc
             $parentRefId = $item->getParentRefId();
             $title = $item->getTitle();
             $parentTreeLftValue = $item->getParentLftTree();
-            $parentTreeLftValue = sprintf("%010d", $parentTreeLftValue);
+            $parentTreeLftValue = sprintf('%010d', $parentTreeLftValue);
 
             if (!$this->access->checkAccess('visible', '', $refId)) {
                 continue;
@@ -92,7 +94,7 @@ class ilPDSelectedItemsBlockMembershipsProvider implements ilPDSelectedItemsBloc
         return $references;
     }
 
-    public function getItems(array $object_type_white_list = array()): array
+    public function getItems(array $object_type_white_list = []): array
     {
         return $this->getObjectsByMembership($object_type_white_list);
     }

--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockSelectedItemsProvider.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockSelectedItemsProvider.php
@@ -3,15 +3,20 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 class ilPDSelectedItemsBlockSelectedItemsProvider implements ilPDSelectedItemsBlockProvider
 {
@@ -30,10 +35,10 @@ class ilPDSelectedItemsBlockSelectedItemsProvider implements ilPDSelectedItemsBl
         $this->settings = $DIC->settings();
     }
 
-    public function getItems(array $object_type_white_list = array()): array
+    public function getItems(array $object_type_white_list = []): array
     {
-        $short_desc = $this->settings->get("rep_shorten_description");
-        $short_desc_max_length = (int) $this->settings->get("rep_shorten_description_length");
+        $short_desc = $this->settings->get('rep_shorten_description');
+        $short_desc_max_length = (int) $this->settings->get('rep_shorten_description_length');
 
         $favourites = $this->fav_manager->getFavouritesOfUser(
             $this->actor->getId(),

--- a/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockViewSettings.php
+++ b/Services/Dashboard/ItemsBlock/classes/class.ilPDSelectedItemsBlockViewSettings.php
@@ -15,6 +15,7 @@
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
 declare(strict_types=1);
 
 use ILIAS\Administration\Setting;
@@ -30,8 +31,7 @@ class ilPDSelectedItemsBlockViewSettings implements ilPDSelectedItemsBlockConsta
         self::VIEW_LEARNING_SEQUENCES,
         self::VIEW_MY_STUDYPROGRAMME,
     ];
-
-    /** @var string[] */
+    /** @var array<int, string> */
     protected static array $viewNames = [
         self::VIEW_SELECTED_ITEMS => 'favourites',
         self::VIEW_RECOMMENDED_CONTENT => 'recommended_content',
@@ -39,7 +39,6 @@ class ilPDSelectedItemsBlockViewSettings implements ilPDSelectedItemsBlockConsta
         self::VIEW_LEARNING_SEQUENCES => 'learning_sequences',
         self::VIEW_MY_STUDYPROGRAMME => 'study_programmes',
     ];
-
     /** @var string[] */
     protected static array $availablePresentations = [
         self::PRESENTATION_LIST,
@@ -52,10 +51,7 @@ class ilPDSelectedItemsBlockViewSettings implements ilPDSelectedItemsBlockConsta
         self::SORT_BY_START_DATE,
         self::SORT_BY_ALPHABET,
     ];
-
-    /**
-     * @var array<int, string[]>
-     */
+    /** @var array<int, string[]> */
     protected static array $availableSortOptionsByView = [
         self::VIEW_SELECTED_ITEMS => [
             self::SORT_BY_LOCATION,
@@ -257,7 +253,7 @@ class ilPDSelectedItemsBlockViewSettings implements ilPDSelectedItemsBlockConsta
     public function getActiveSortingsByView(int $view): array
     {
         $val = $this->settings->get('pd_active_sort_view_' . $view);
-        if ($val === "" || $val === null) {
+        if ($val === '' || $val === null) {
             $active_sortings = $this->getAvailableSortOptionsByView($view);
         } else {
             $active_sortings = unserialize($val, ['allowed_classes' => false]);
@@ -547,12 +543,12 @@ class ilPDSelectedItemsBlockViewSettings implements ilPDSelectedItemsBlockConsta
 
     public function enableLearningSequences(bool $status): void
     {
-        $this->settings->set('disable_learning_sequences', $status ? "0" : "1");
+        $this->settings->set('disable_learning_sequences', $status ? '0' : '1');
     }
 
     public function enableStudyProgrammes(bool $status): void
     {
-        $this->settings->set('disable_study_programmes', $status ? "0" : "1");
+        $this->settings->set('disable_study_programmes', $status ? '0' : '1');
     }
 
     public function getViewName(int $view): string

--- a/Services/Dashboard/ItemsBlock/interfaces/interface.ilPDSelectedItemsBlockConstants.php
+++ b/Services/Dashboard/ItemsBlock/interfaces/interface.ilPDSelectedItemsBlockConstants.php
@@ -31,6 +31,6 @@ interface ilPDSelectedItemsBlockConstants
     public const SORT_BY_START_DATE = 'start_date';
     public const SORT_BY_ALPHABET = 'alphabet';
 
-    public const PRESENTATION_LIST = "list";
-    public const PRESENTATION_TILE = "tile";
+    public const PRESENTATION_LIST = 'list';
+    public const PRESENTATION_TILE = 'tile';
 }

--- a/Services/Dashboard/ItemsBlock/interfaces/interface.ilPDSelectedItemsBlockMembershipsObjectRepository.php
+++ b/Services/Dashboard/ItemsBlock/interfaces/interface.ilPDSelectedItemsBlockMembershipsObjectRepository.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,16 +14,14 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+
+declare(strict_types=1);
 
 interface ilPDSelectedItemsBlockMembershipsObjectRepository
 {
     /**
-     * @param ilObjUser $user
      * @param string[] $objTypes
-     * @param string $actorLanguageCode
-     * @return Generator|ilPDSelectedItemBlockMembershipsDTO[]|Generator<ilPDSelectedItemBlockMembershipsDTO>
      */
     public function getForUser(ilObjUser $user, array $objTypes, string $actorLanguageCode): Generator;
 }

--- a/Services/Dashboard/ItemsBlock/interfaces/interface.ilPDSelectedItemsBlockProvider.php
+++ b/Services/Dashboard/ItemsBlock/interfaces/interface.ilPDSelectedItemsBlockProvider.php
@@ -3,24 +3,22 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
-/**
- * Interface ilPDSelectedItemsBlockProvider
- */
+declare(strict_types=1);
+
 interface ilPDSelectedItemsBlockProvider
 {
-    /**
-     * @param array $object_type_white_list An optional array of object_types used for filter purposes
-     * @return array An array of repository items, each given as a structured array
-     */
-    public function getItems(array $object_type_white_list = array()): array;
+    public function getItems(array $object_type_white_list = []): array;
 }

--- a/Services/Dashboard/classes/Setup/ilDashboardUpdateAgent.php
+++ b/Services/Dashboard/classes/Setup/ilDashboardUpdateAgent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\Dashboard\Setup;
 

--- a/Services/Dashboard/classes/Setup/ilDashboardUpdateSteps.php
+++ b/Services/Dashboard/classes/Setup/ilDashboardUpdateSteps.php
@@ -56,7 +56,7 @@ class ilDashboardUpdateSteps implements ilDatabaseUpdateSteps
             'value' => ['text', '0']
         ]);
 
-        $sql = "SELECT * FROM settings WHERE keyword = %s";
+        $sql = 'SELECT * FROM settings WHERE keyword = %s';
         for ($view = 0; $view <= 4; $view++) {
             if ($this->db->numRows($this->db->queryF($sql, ['text'], ['pd_active_pres_view_' . $view])) === 0) {
                 $this->db->insert('settings', [

--- a/Services/Dashboard/classes/class.ilDashboardContentBlockGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardContentBlockGUI.php
@@ -3,35 +3,29 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
-
-/**
- * BlockGUI class for (centered) Content on Personal Desktop
  *
- * @author Alexander Killing <killing@leifos.de>
- */
+ *********************************************************************/
+
+declare(strict_types=1);
+
 class ilDashboardContentBlockGUI extends ilBlockGUI
 {
-    public static string $block_type = "dashcontent";
+    public const BLOCK_TYPE = 'dashcontent';
     protected int $currentitemnumber;
     protected string $content;
 
     public function __construct()
     {
-        global $DIC;
-
-        $this->ctrl = $DIC->ctrl();
-        $this->lng = $DIC->language();
-        $this->user = $DIC->user();
-
         parent::__construct();
 
         $this->setEnableNumInfo(false);
@@ -40,17 +34,17 @@ class ilDashboardContentBlockGUI extends ilBlockGUI
         $this->allow_moving = false;
     }
 
-    public function getBlockType(): string
+    final public function getBlockType(): string
     {
-        return self::$block_type;
+        return self::BLOCK_TYPE;
     }
 
-    public function setCurrentItemNumber(int $a_currentitemnumber): void
+    public function setCurrentItemNumber(int $currentitemnumber): void
     {
-        $this->currentitemnumber = $a_currentitemnumber;
+        $this->currentitemnumber = $currentitemnumber;
     }
 
-    public function getCurrentItemNumber(): int
+    final public function getCurrentItemNumber(): int
     {
         return $this->currentitemnumber;
     }
@@ -60,42 +54,35 @@ class ilDashboardContentBlockGUI extends ilBlockGUI
         return false;
     }
 
-    public function getHTML(): string
-    {
-        return parent::getHTML();
-    }
-
-    public function getContent(): string
+    final public function getContent(): string
     {
         return $this->content;
     }
 
-    public function setContent(string $a_content): void
+    public function setContent(string $content): void
     {
-        $this->content = $a_content;
+        $this->content = $content;
     }
 
     public function fillDataSection(): void
     {
-        $this->tpl->setVariable("BLOCK_ROW", $this->getContent());
+        $this->tpl->setVariable('BLOCK_ROW', $this->getContent());
     }
 
     public function fillFooter(): void
     {
-        //$this->fillFooterLinks();
         $lng = $this->lng;
 
         if (is_array($this->data)) {
             $this->max_count = count($this->data);
         }
 
-        // table footer numinfo
         if ($this->getEnableNumInfo()) {
-            $numinfo = "(" . $this->getCurrentItemNumber() . " " .
-                strtolower($lng->txt("of")) . " " . $this->max_count . ")";
+            $numinfo = '(' . $this->getCurrentItemNumber() . ' ' .
+                strtolower($lng->txt('of')) . ' ' . $this->max_count . ')';
 
             if ($this->max_count > 0) {
-                $this->tpl->setVariable("NUMINFO", $numinfo);
+                $this->tpl->setVariable('NUMINFO', $numinfo);
             }
         }
     }

--- a/Services/Dashboard/classes/class.ilDashboardGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardGUI.php
@@ -18,9 +18,9 @@
 
 declare(strict_types=1);
 
+use ILIAS\GlobalScreen\ScreenContext\ContextServices;
+
 /**
- * Dashboard UI
- * @author Alexander Killing <killing@leifos.de>
  * @ilCtrl_Calls ilDashboardGUI: ilPersonalProfileGUI
  * @ilCtrl_Calls ilDashboardGUI: ilObjUserGUI, ilPDNotesGUI
  * @ilCtrl_Calls ilDashboardGUI: ilColumnGUI, ilPDNewsGUI, ilCalendarPresentationGUI
@@ -31,22 +31,20 @@ declare(strict_types=1);
  * @ilCtrl_Calls ilDashboardGUI: ilGroupUserActionsGUI, ilAchievementsGUI
  * @ilCtrl_Calls ilDashboardGUI: ilPDMailBlockGUI
  * @ilCtrl_Calls ilDashboardGUI: ilSelectedItemsBlockGUI, ilDashboardRecommendedContentGUI, ilMembershipBlockGUI, ilDashboardLearningSequenceGUI, ilStudyProgrammeDashboardViewGUI, ilObjStudyProgrammeGUI
- *
  */
 class ilDashboardGUI implements ilCtrlBaseClassInterface
 {
-    public const CMD_JUMP_TO_MY_STAFF = "jumpToMyStaff";
-    public const DISENGAGE_MAINBAR = "dash_mb_disengage";
+    public const CMD_JUMP_TO_MY_STAFF = 'jumpToMyStaff';
+    public const DISENGAGE_MAINBAR = 'dash_mb_disengage';
 
-    protected ilCtrl $ctrl;
+    protected readonly ilCtrl $ctrl;
+    protected readonly ilSetting $settings;
+    protected readonly ilRbacSystem $rbacsystem;
+    protected readonly ilHelpGUI $help;
+    public readonly ilGlobalTemplateInterface $tpl;
+    public readonly ilLanguage $lng;
+    protected readonly ContextServices $tool_context;
     protected ilObjUser $user;
-    protected ilSetting $settings;
-    protected ilRbacSystem $rbacsystem;
-    protected ilHelpGUI $help;
-    public \ilGlobalTemplateInterface $tpl;
-    public \ilLanguage $lng;
-    public string $cmdClass = '';
-    protected \ILIAS\GlobalScreen\ScreenContext\ContextServices $tool_context;
     protected int $requested_view;
     protected int $requested_prt_id;
     protected int $requested_gtp;
@@ -61,79 +59,65 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
         $this->user = $DIC->user();
         $this->settings = $DIC->settings();
         $this->rbacsystem = $DIC->rbac()->system();
-        $this->help = $DIC["ilHelp"];
-        $tpl = $DIC["tpl"];
+        $this->help = $DIC['ilHelp'];
+        $this->tpl = $DIC->ui()->mainTemplate();
         $this->lng = $DIC->language();
         $this->ctrl = $DIC->ctrl();
 
         if ($this->user->getId() === ANONYMOUS_USER_ID) {
-            $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', $this->lng->txt("msg_not_available_for_anon"), true);
-            $DIC->ctrl()->redirectToURL("login.php?cmd=force_login");
+            $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', $this->lng->txt('msg_not_available_for_anon'), true);
+            $DIC->ctrl()->redirectToURL('login.php?cmd=force_login');
         }
 
-        $this->tpl = $tpl;
+        $this->ctrl->setContextObject($this->user->getId(), 'user');
 
-        $this->ctrl->setContextObject(
-            $this->user->getId(),
-            "user"
-        );
-
-        $this->lng->loadLanguageModule("pdesk");
-        $this->lng->loadLanguageModule("pd"); // #16813
-        $this->lng->loadLanguageModule("dash");
-        $this->lng->loadLanguageModule("mmbr");
+        $this->lng->loadLanguageModule('pdesk');
+        $this->lng->loadLanguageModule('pd');
+        $this->lng->loadLanguageModule('dash');
+        $this->lng->loadLanguageModule('mmbr');
 
         $params = $DIC->http()->request()->getQueryParams();
-        $this->cmdClass = ($params['cmdClass'] ?? "");
         $this->requested_view = (int) ($params['view'] ?? 0);
-        $this->requested_prt_id = (int) ($params["prt_id"] ?? 0);
-        $this->requested_gtp = (int) ($params["gtp"] ?? 0);
-        $this->requested_dsh = (string) ($params["dsh"] ?? null);
-        $this->requested_wsp_id = (int) ($params["wsp_id"] ?? 0);
+        $this->requested_prt_id = (int) ($params['prt_id'] ?? 0);
+        $this->requested_gtp = (int) ($params['gtp'] ?? 0);
+        $this->requested_dsh = (string) ($params['dsh'] ?? null);
+        $this->requested_wsp_id = (int) ($params['wsp_id'] ?? 0);
 
-        $this->ctrl->saveParameter($this, array("view"));
+        $this->ctrl->saveParameter($this, ['view']);
     }
 
     public function executeCommand(): void
     {
-        $context = $this->tool_context;
-        $context->stack()->desktop();
-        $ilSetting = $this->settings;
+        $this->tool_context->stack()->desktop();
 
         $next_class = $this->ctrl->getNextClass();
-        $this->ctrl->setReturn($this, "show");
+        $this->ctrl->setReturn($this, 'show');
         switch ($next_class) {
-            // profile
-            case "ilpersonalprofilegui":
+            case strtolower(ilPersonalProfileGUI::class):
                 $this->getStandardTemplates();
                 $this->setTabs();
                 $profile_gui = new ilPersonalProfileGUI();
                 $this->ctrl->forwardCommand($profile_gui);
                 break;
-
-                // settings
-            case "ilpersonalsettingsgui":
+            case strtolower(ilPersonalSettingsGUI::class):
                 $this->getStandardTemplates();
                 $this->setTabs();
                 $settings_gui = new ilPersonalSettingsGUI();
                 $this->ctrl->forwardCommand($settings_gui);
                 break;
-
-            case 'ilcalendarpresentationgui':
+            case strtolower(ilCalendarPresentationGUI::class):
                 $this->getStandardTemplates();
                 $this->displayHeader();
-                $this->tpl->setTitle($this->lng->txt("calendar"));
+                $this->tpl->setTitle($this->lng->txt('calendar'));
                 $this->setTabs();
                 $cal = new ilCalendarPresentationGUI();
                 $this->ctrl->forwardCommand($cal);
                 $this->tpl->printToStdout();
                 break;
-
-                // pd notes
-            case "ilpdnotesgui":
-                if ($ilSetting->get('disable_notes') && $ilSetting->get('disable_comments')) {
+            case strtolower(ilPDNotesGUI::class):
+                if ($this->settings->get('disable_notes') && $this->settings->get('disable_comments')) {
                     $this->tpl->setOnScreenMessage('failure', $this->lng->txt('permission_denied'), true);
-                    ilUtil::redirect('ilias.php?baseClass=ilDashboardGUI');
+                    ilUtil::redirect('ilias.php?baseClass=' . self::class);
                     return;
                 }
 
@@ -142,20 +126,17 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
                 $pd_notes_gui = new ilPDNotesGUI();
                 $this->ctrl->forwardCommand($pd_notes_gui);
                 break;
-
-                // pd news
-            case "ilpdnewsgui":
+            case strtolower(ilPDNewsGUI::class):
                 $this->getStandardTemplates();
                 $this->setTabs();
                 $pd_news_gui = new ilPDNewsGUI();
                 $this->ctrl->forwardCommand($pd_news_gui);
                 break;
-
-            case "ilcolumngui":
+            case strtolower(ilColumnGUI::class):
                 if (strtolower($cmdClass = $this->ctrl->getCmdClass()) === strtolower(ilSelectedItemsBlockGUI::class)) {
                     $gui = new $cmdClass();
                     $ret = $this->ctrl->forwardCommand($gui);
-                    if ($ret !== "") {
+                    if ($ret !== '') {
                         $this->tpl->setContent($ret);
                         $this->tpl->printToStdout();
                     }
@@ -163,10 +144,10 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
                 }
                 $this->getStandardTemplates();
                 $this->setTabs();
-                $column_gui = new ilColumnGUI("pd");
+                $column_gui = new ilColumnGUI('pd');
                 $this->show();
                 break;
-            case 'ilcontactgui':
+            case strtolower(ilContactGUI::class):
                 if (!ilBuddySystem::getInstance()->isEnabled()) {
                     throw new ilPermissionException($this->lng->txt('msg_no_perm_read'));
                 }
@@ -177,34 +158,30 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
 
                 $this->ctrl->forwardCommand(new ilContactGUI());
                 break;
-
-            case 'ilpersonalworkspacegui':
+            case strtolower(ilPersonalWorkspaceGUI::class):
                 $wsgui = new ilPersonalWorkspaceGUI();
                 $this->ctrl->forwardCommand($wsgui);
                 $this->tpl->printToStdout();
                 break;
-
-            case 'ilportfoliorepositorygui':
+            case strtolower(ilPortfolioRepositoryGUI::class):
                 $this->getStandardTemplates();
                 $this->setTabs();
                 $pfgui = new ilPortfolioRepositoryGUI();
                 $this->ctrl->forwardCommand($pfgui);
                 $this->tpl->printToStdout();
                 break;
-
-            case 'ilachievementsgui':
+            case strtolower(ilAchievementsGUI::class):
                 $this->getStandardTemplates();
                 $this->setTabs();
                 $achievegui = new ilAchievementsGUI();
                 $this->ctrl->forwardCommand($achievegui);
                 break;
-
             case strtolower(ilMyStaffGUI::class):
                 $this->getStandardTemplates();
                 $mstgui = new ilMyStaffGUI();
                 $this->ctrl->forwardCommand($mstgui);
                 break;
-            case 'ilgroupuseractionsgui':
+            case strtolower(ilGroupUserActionsGUI::class):
                 $this->getStandardTemplates();
                 $this->setTabs();
                 $ggui = new ilGroupUserActionsGUI();
@@ -218,7 +195,7 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
             case strtolower(ilStudyProgrammeDashboardViewGUI::class):
                 $gui = new $next_class();
                 $ret = $this->ctrl->forwardCommand($gui);
-                if ($ret !== "" && $ret !== null) {
+                if ($ret !== '' && $ret !== null) {
                     $this->tpl->setContent($ret);
                 }
                 $this->tpl->printToStdout();
@@ -229,10 +206,10 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
                 $this->tpl->printToStdout();
                 break;
             default:
-                $context->current()->addAdditionalData(self::DISENGAGE_MAINBAR, true);
+                $this->tool_context->current()->addAdditionalData(self::DISENGAGE_MAINBAR, true);
                 $this->getStandardTemplates();
                 $this->setTabs();
-                $cmd = $this->ctrl->getCmd("show");
+                $cmd = $this->ctrl->getCmd('show');
                 $this->$cmd();
                 break;
         }
@@ -245,12 +222,11 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
 
     public function show(): void
     {
-        // preload block settings
         ilBlockSetting::preloadPDBlockSettings();
 
-        $this->tpl->setTitle($this->lng->txt("dash_dashboard"));
-        $this->tpl->setTitleIcon(ilUtil::getImagePath("icon_dshs.svg"), $this->lng->txt("dash_dashboard"));
-        $this->tpl->setVariable("IMG_SPACE", ilUtil::getImagePath("spacer.png"));
+        $this->tpl->setTitle($this->lng->txt('dash_dashboard'));
+        $this->tpl->setTitleIcon(ilUtil::getImagePath('icon_dshs.svg'), $this->lng->txt('dash_dashboard'));
+        $this->tpl->setVariable('IMG_SPACE', ilUtil::getImagePath('spacer.png'));
 
         $this->tpl->setContent($this->getCenterColumnHTML());
         $this->tpl->setRightContent($this->getRightColumnHTML());
@@ -259,39 +235,30 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
 
     public function getCenterColumnHTML(): string
     {
-        $ilCtrl = $this->ctrl;
+        $html = '';
+        $column_gui = new ilColumnGUI('pd', IL_COL_CENTER);
 
-        $html = "";
-        $column_gui = new ilColumnGUI("pd", IL_COL_CENTER);
-
-        if ($ilCtrl->getNextClass() == "ilcolumngui" &&
-            $column_gui->getCmdSide() == IL_COL_CENTER) {
-            $html = $ilCtrl->forwardCommand($column_gui);
+        if ($column_gui->getCmdSide() == IL_COL_CENTER && $this->ctrl->getNextClass() == strtolower(ilColumnGUI::class)) {
+            $html = $this->ctrl->forwardCommand($column_gui);
         } else {
-            if (!$ilCtrl->isAsynch()) {
+            if (!$this->ctrl->isAsynch()) {
                 if ($column_gui->getScreenMode() != IL_SCREEN_SIDE) {
-                    // right column wants center
                     if ($column_gui->getCmdSide() == IL_COL_RIGHT) {
-                        $column_gui = new ilColumnGUI("pd", IL_COL_RIGHT);
-                        $html = $ilCtrl->forwardCommand($column_gui);
+                        $column_gui = new ilColumnGUI('pd', IL_COL_RIGHT);
+                        $html = $this->ctrl->forwardCommand($column_gui);
                     }
-                    // left column wants center
                     if ($column_gui->getCmdSide() == IL_COL_LEFT) {
-                        $column_gui = new ilColumnGUI("pd", IL_COL_LEFT);
-                        $html = $ilCtrl->forwardCommand($column_gui);
+                        $column_gui = new ilColumnGUI('pd', IL_COL_LEFT);
+                        $html = $this->ctrl->forwardCommand($column_gui);
                     }
                 } else {
-                    $html = "";
-
-                    // user interface plugin slot + default rendering
                     $uip = new ilUIHookProcessor(
-                        "Services/Dashboard",
-                        "center_column",
-                        array("personal_desktop_gui" => $this)
+                        'Services/Dashboard',
+                        'center_column',
+                        ['personal_desktop_gui' => $this]
                     );
                     if (!$uip->replaced()) {
                         $html = $this->getMainContent();
-                        //$html = $ilCtrl->getHTML($column_gui);
                     }
                     $html = $uip->getHTML($html);
                 }
@@ -302,32 +269,28 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
 
     public function getRightColumnHTML(): string
     {
-        $ilCtrl = $this->ctrl;
+        $html = '';
+        $column_gui = new ilColumnGUI('pd', IL_COL_RIGHT);
 
-        $html = "";
-
-        $column_gui = new ilColumnGUI("pd", IL_COL_RIGHT);
-
-        if ($column_gui->getScreenMode() == IL_SCREEN_FULL) {
-            return "";
+        if ($column_gui::getScreenMode() == IL_SCREEN_FULL) {
+            return '';
         }
 
-        if ($ilCtrl->getNextClass() == "ilcolumngui" &&
-            $column_gui->getCmdSide() == IL_COL_RIGHT &&
-            $column_gui->getScreenMode() == IL_SCREEN_SIDE) {
-            $html = $ilCtrl->forwardCommand($column_gui);
+        if (
+            $column_gui::getCmdSide() == IL_COL_RIGHT &&
+            $column_gui::getScreenMode() == IL_SCREEN_SIDE &&
+            $this->ctrl->getNextClass() == strtolower(ilColumnGUI::class)
+        ) {
+            $html = $this->ctrl->forwardCommand($column_gui);
         } else {
-            if (!$ilCtrl->isAsynch()) {
-                $html = "";
-
-                // user interface plugin slot + default rendering
+            if (!$this->ctrl->isAsynch()) {
                 $uip = new ilUIHookProcessor(
-                    "Services/Dashboard",
-                    "right_column",
-                    array("personal_desktop_gui" => $this)
+                    'Services/Dashboard',
+                    'right_column',
+                    ['personal_desktop_gui' => $this]
                 );
                 if (!$uip->replaced()) {
-                    $html = $ilCtrl->getHTML($column_gui);
+                    $html = $this->ctrl->getHTML($column_gui);
                 }
                 $html = $uip->getHTML($html);
             }
@@ -340,108 +303,99 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
     {
         $this->tpl->loadStandardTemplate();
 
-        $this->tpl->setTitleIcon(ilUtil::getImagePath("icon_pd.svg"));
-        $this->tpl->setTitle($this->lng->txt("personal_desktop"));
+        $this->tpl->setTitleIcon(ilUtil::getImagePath('icon_pd.svg'));
+        $this->tpl->setTitle($this->lng->txt('personal_desktop'));
         $this->tpl->setVariable('IMG_SPACE', ilUtil::getImagePath('spacer.png'));
     }
 
     public function setTabs(): void
     {
-        $ilHelp = $this->help;
-
-        $ilHelp->setScreenIdComponent("pd");
+        $this->help->setScreenIdComponent('pd');
     }
 
     public function jumpToMemberships(): void
     {
         $viewSettings = new ilPDSelectedItemsBlockViewSettings($GLOBALS['DIC']->user(), $this->requested_view);
         if ($viewSettings->enabledMemberships()) {
-            $this->ctrl->setParameter($this, "view", $viewSettings->getMembershipsView());
+            $this->ctrl->setParameter($this, 'view', $viewSettings->getMembershipsView());
         }
-        $this->ctrl->redirect($this, "show");
+        $this->ctrl->redirect($this, 'show');
     }
 
     public function jumpToSelectedItems(): void
     {
         $viewSettings = new ilPDSelectedItemsBlockViewSettings($GLOBALS['DIC']->user(), $this->requested_view);
         if ($viewSettings->enabledSelectedItems()) {
-            $this->ctrl->setParameter($this, "view", $viewSettings->getSelectedItemsView());
+            $this->ctrl->setParameter($this, 'view', $viewSettings->getSelectedItemsView());
         }
         $this->show();
     }
 
     public function jumpToProfile(): void
     {
-        $this->ctrl->redirectByClass("ilpersonalprofilegui");
+        $this->ctrl->redirectByClass(strtolower(ilPersonalProfileGUI::class));
     }
 
     public function jumpToPortfolio(): void
     {
-        // incoming back link from shared resource
-        $cmd = "";
-        if ($this->requested_dsh != "") {
-            $this->ctrl->setParameterByClass("ilportfoliorepositorygui", "shr_id", $this->requested_dsh);
-            $cmd = "showOther";
+        $cmd = '';
+        if ($this->requested_dsh != '') {
+            $this->ctrl->setParameterByClass(ilPortfolioRepositoryGUI::class, 'shr_id', $this->requested_dsh);
+            $cmd = 'showOther';
         }
 
-        // used for goto links
         if ($this->requested_prt_id > 0) {
-            $this->ctrl->setParameterByClass("ilobjportfoliogui", "prt_id", $this->requested_prt_id);
-            $this->ctrl->setParameterByClass("ilobjportfoliogui", "gtp", $this->requested_gtp);
-            $this->ctrl->redirectByClass(array("ilportfoliorepositorygui", "ilobjportfoliogui"), "preview");
+            $this->ctrl->setParameterByClass(ilObjPortfolioGUI::class, 'prt_id', $this->requested_prt_id);
+            $this->ctrl->setParameterByClass(ilObjPortfolioGUI::class, 'gtp', $this->requested_gtp);
+            $this->ctrl->redirectByClass([ilPortfolioRepositoryGUI::class, ilObjPortfolioGUI::class], 'preview');
         } else {
-            $this->ctrl->redirectByClass("ilportfoliorepositorygui", $cmd);
+            $this->ctrl->redirectByClass(ilPortfolioRepositoryGUI::class, $cmd);
         }
     }
 
     public function jumpToSettings(): void
     {
-        $this->ctrl->redirectByClass("ilpersonalsettingsgui");
+        $this->ctrl->redirectByClass(ilPersonalSettingsGUI::class);
     }
 
     public function jumpToNews(): void
     {
-        $this->ctrl->redirectByClass("ilpdnewsgui");
+        $this->ctrl->redirectByClass(ilPDNewsGUI::class);
     }
 
     public function jumpToCalendar(): void
     {
         global $DIC;
-        $request = $DIC->http()->request();
 
-        $query_params = $request->getQueryParams();
+        $query_params = $DIC->http()->request()->getQueryParams();
 
-        if (array_key_exists("cal_view", $query_params) && $query_params["cal_view"]) {
-            $cal_view = $query_params["cal_view"];
-            $this->ctrl->setParameter($this, "cal_view", $cal_view);
+        if (!empty($query_params['cal_view'])) {
+            $cal_view = $query_params['cal_view'];
+            $this->ctrl->setParameter($this, 'cal_view', $cal_view);
         }
 
-        if (!empty($query_params["cal_agenda_per"])) {
-            $cal_period = $query_params["cal_agenda_per"];
-            $this->ctrl->setParameter($this, "cal_agenda_per", $cal_period);
+        if (!empty($query_params['cal_agenda_per'])) {
+            $cal_period = $query_params['cal_agenda_per'];
+            $this->ctrl->setParameter($this, 'cal_agenda_per', $cal_period);
         }
 
-        $this->ctrl->redirectByClass("ilcalendarpresentationgui");
+        $this->ctrl->redirectByClass(ilCalendarPresentationGUI::class);
     }
 
     public function jumpToWorkspace(): void
     {
-        // incoming back link from shared resource
-        $cmd = "";
-        if ($this->requested_dsh != "") {
-            $this->ctrl->setParameterByClass("ilpersonalworkspacegui", "shr_id", $this->requested_dsh);
-            $cmd = "share";
+        $cmd = '';
+        if ($this->requested_dsh != '') {
+            $this->ctrl->setParameterByClass(ilPersonalWorkspaceGUI::class, 'shr_id', $this->requested_dsh);
+            $cmd = 'share';
         }
-
         if ($this->requested_wsp_id > 0) {
-            $this->ctrl->setParameterByClass("ilpersonalworkspacegui", "wsp_id", $this->requested_wsp_id);
+            $this->ctrl->setParameterByClass(ilPersonalWorkspaceGUI::class, 'wsp_id', $this->requested_wsp_id);
         }
-
         if ($this->requested_gtp) {
-            $this->ctrl->setParameterByClass("ilpersonalworkspacegui", "gtp", $this->requested_gtp);
+            $this->ctrl->setParameterByClass(ilPersonalWorkspaceGUI::class, 'gtp', $this->requested_gtp);
         }
-
-        $this->ctrl->redirectByClass("ilpersonalworkspacegui", $cmd);
+        $this->ctrl->redirectByClass(ilPersonalWorkspaceGUI::class, $cmd);
     }
 
     protected function jumpToMyStaff(): void
@@ -451,33 +405,33 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
 
     public function jumpToBadges(): void
     {
-        $this->ctrl->redirectByClass(["ilAchievementsGUI", "ilbadgeprofilegui"]);
+        $this->ctrl->redirectByClass([ilAchievementsGUI::class, ilBadgeProfileGUI::class]);
     }
 
     public function jumpToSkills(): void
     {
-        $this->ctrl->redirectByClass("ilpersonalskillsgui");
+        $this->ctrl->redirectByClass(ilPersonalSkillsGUI::class);
     }
 
     public function displayHeader(): void
     {
-        $this->tpl->setTitle($this->lng->txt("dash_dashboard"));
+        $this->tpl->setTitle($this->lng->txt('dash_dashboard'));
     }
 
     protected function toggleHelp(): void
     {
-        if (ilSession::get("show_help_tool") == "1") {
-            ilSession::set("show_help_tool", "0");
+        if (ilSession::get('show_help_tool') === '1') {
+            ilSession::set('show_help_tool', '0');
         } else {
-            ilSession::set("show_help_tool", "1");
+            ilSession::set('show_help_tool', '1');
         }
-        $this->ctrl->redirect($this, "show");
+        $this->ctrl->redirect($this, 'show');
     }
 
     protected function getMainContent(): string
     {
-        $html = "";
-        $tpl = new ilTemplate("tpl.dashboard.html", true, true, "Services/Dashboard");
+        $html = '';
+        $tpl = new ilTemplate('tpl.dashboard.html', true, true, 'Services/Dashboard');
         $settings = new ilPDSelectedItemsBlockViewSettings($this->user);
 
         foreach ($settings->getViewPositions() as $view_position) {
@@ -486,8 +440,7 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
             }
         }
 
-
-        $tpl->setVariable("CONTENT", $html);
+        $tpl->setVariable('CONTENT', $html);
 
         return $tpl->get();
     }

--- a/Services/Dashboard/classes/ilDashboardSettingsRepository.php
+++ b/Services/Dashboard/classes/ilDashboardSettingsRepository.php
@@ -3,120 +3,109 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
-
-/**
- * Personal desktop settings repo
  *
- * @author Alexander Killing <killing@leifos.de>
- */
-class ilPersonalDesktopSettingsRepository
-{
-    protected \ILIAS\Administration\Setting $settings;
+ *********************************************************************/
 
-    public function __construct(\ILIAS\Administration\Setting $settings)
+declare(strict_types=1);
+
+use ILIAS\Administration\Setting;
+
+class ilDashboardSettingsRepository
+{
+    public function __construct(protected readonly Setting $settings)
     {
-        $this->settings = $settings;
     }
 
-
-    // Notes enabled?
     public function ifNotesEnabled(): bool
     {
-        return !$this->settings->get("disable_notes");
+        return !$this->settings->get('disable_notes');
     }
 
     public function enableNotes(bool $active = true): void
     {
-        $this->settings->set("disable_notes", (int) !$active);
+        $this->settings->set('disable_notes', $active ? '0' : '1');
     }
 
-    // Comments enabled?
     public function ifCommentsEnabled(): bool
     {
-        return !$this->settings->get("disable_comments");
+        return !$this->settings->get('disable_comments');
     }
 
     public function enableComments(bool $active = true): void
     {
-        $this->settings->set("disable_comments", (int) !$active);
+        $this->settings->set('disable_comments', $active ? '0' : '1');
     }
 
-    // Can authors delete their comments
     public function ifAuthorsCanDelete(): bool
     {
-        return (bool) $this->settings->get("comments_del_user", '0');
+        return (bool) $this->settings->get('comments_del_user', '0');
     }
 
     public function enableAuthorsCanDelete(bool $active = true): void
     {
-        $this->settings->set("comments_del_user", (int) $active);
+        $this->settings->set('comments_del_user', $active ? '1' : '0');
     }
 
-    // Can tutors delete comments of others
     public function ifTutorsCanDelete(): bool
     {
-        return (bool) $this->settings->get("comments_del_tutor", '1');
+        return (bool) $this->settings->get('comments_del_tutor', '1');
     }
 
     public function enableTutorsCanDelete(bool $active = true): void
     {
-        $this->settings->set("comments_del_tutor", (int) $active);
+        $this->settings->set('comments_del_tutor', $active ? '1' : '0');
     }
 
-    // Get recipients of comments notification
     public function getCommentsNotificationRecipients(): string
     {
-        return (string) $this->settings->get("comments_noti_recip");
+        return (string) $this->settings->get('comments_noti_recip');
     }
 
-    // Update recipients of comments notification
     public function updateCommentsNotificationRecipients(string $recipients): void
     {
-        $this->settings->set("comments_noti_recip", $recipients);
+        $this->settings->set('comments_noti_recip', $recipients);
     }
 
-    // learning history enabled?
     public function ifLearningHistoryEnabled(): bool
     {
-        return (bool) $this->settings->get("enable_learning_history");
+        return (bool) $this->settings->get('enable_learning_history');
     }
 
     public function enableLearningHistory(bool $active = true): void
     {
-        $this->settings->set("enable_learning_history", (int) $active);
+        $this->settings->set('enable_learning_history', $active ? '1' : '0');
     }
 
-    // chat viewer enabled?
     public function ifChatViewerEnabled(): bool
     {
-        return (bool) $this->settings->get("block_activated_chatviewer");
+        return (bool) $this->settings->get('block_activated_chatviewer');
     }
 
     public function enableChatViewer(bool $active = true): void
     {
-        $this->settings->set("block_activated_chatviewer", (int) $active);
+        $this->settings->set('block_activated_chatviewer', $active ? '1' : '0');
     }
 
     public function getSystemMessagePresentation(): int
     {
-        return (int) $this->settings->get("pd_sys_msg_mode");
+        return (int) $this->settings->get('pd_sys_msg_mode');
     }
 
     public function updateSystemMessagePresentation(int $mode): void
     {
-        $this->settings->set("pd_sys_msg_mode", $mode);
+        $this->settings->set('pd_sys_msg_mode', (string) $mode);
     }
 
-    // forum draft block enabled?
     public function ifForumDrafts(): bool
     {
         return (bool) $this->settings->get('block_activated_pdfrmpostdraft', '0');
@@ -124,6 +113,6 @@ class ilPersonalDesktopSettingsRepository
 
     public function enableForumDrafts(bool $active = true): void
     {
-        $this->settings->set("block_activated_pdfrmpostdraft", (int) $active);
+        $this->settings->set('block_activated_pdfrmpostdraft', $active ? '1' : '0');
     }
 }

--- a/Services/Dashboard/interfaces/interface.ilDesktopItemHandling.php
+++ b/Services/Dashboard/interfaces/interface.ilDesktopItemHandling.php
@@ -3,32 +3,24 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
-
-/**
- * Interface for gui classes (e.g ilLuceneSearchGUI) that offer add/remove to/from desktop
  *
- * @author Stefan Meyer <meyer@leifos.com>
- */
+ *********************************************************************/
+
+declare(strict_types=1);
+
 interface ilDesktopItemHandling
 {
-    /**
-     * Add desktop item
-     * @access public
-     */
     public function addToDeskObject(): void;
 
-    /**
-     * Remove from desktop
-     * @access public
-     */
     public function removeFromDeskObject(): void;
 }

--- a/Services/Dashboard/test/DashboardViewSettingsTest.php
+++ b/Services/Dashboard/test/DashboardViewSettingsTest.php
@@ -1,12 +1,25 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 
-/**
- * Test dashboard settings repository
- *
- * @author Alexander Killing <killing@leifos.de>
- */
 class DashboardViewSettingsTest extends TestCase
 {
     protected ilPDSelectedItemsBlockViewSettings $view_settings;

--- a/Services/Dashboard/test/ilServicesDashboardSuite.php
+++ b/Services/Dashboard/test/ilServicesDashboardSuite.php
@@ -1,35 +1,35 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use PHPUnit\Framework\TestSuite;
 
 require_once 'libs/composer/vendor/autoload.php';
 
-/**
- * @author Alexander Killing <killing@leifos.de>
- */
 class ilServicesDashboardSuite extends TestSuite
 {
     public static function suite()
     {
         $suite = new self();
 
-        require_once("./Services/Dashboard/test/DashboardViewSettingsTest.php");
-        $suite->addTestSuite("DashboardViewSettingsTest");
+        require_once('./Services/Dashboard/test/DashboardViewSettingsTest.php');
+        $suite->addTestSuite('DashboardViewSettingsTest');
 
         return $suite;
     }


### PR DESCRIPTION
(This PR was recreated since its origin fork was deleted: https://github.com/ILIAS-eLearning/ILIAS/pull/5931)

Major Changes:
- [x] Fixed Licencse Header
- [x] Remove/updated trivila/missleading docs
- [x] and `final` and `readonly`
- [x] update constructors
- [x] applied single quitation
- [x] applied short array syntax
- [x] removed trivial local variables
- [x] applied dynamic called classnames
- [ ] removed unused functions
- [ ] enhanced type safety
- [ ] removed `class` prefixes
- [ ] removed `a_` prefixes
- [ ] partially changed names from desktop to dashboard
- [ ] minor bugfixes
- [ ] applied PSR-12