### PR TITLE
Fix strict type paramener

### DIFF
--- a/Services/Notifications/classes/ilNotificationSystem.php
+++ b/Services/Notifications/classes/ilNotificationSystem.php
@@ -103,7 +103,7 @@ class ilNotificationSystem
                 $handler = $this->handler[$handler];
                 foreach ($h_users as $userId) {
                     if (!isset($userCache[$userId]) || !$userCache[$userId]) {
-                        $user = ilObjectFactory::getInstanceByObjId($userId, false);
+                        $user = ilObjectFactory::getInstanceByObjId((int) $userId, false);
                         if (!($user instanceof ilObjUser)) {
                             continue;
                         }


### PR DESCRIPTION
```
[oejgu] [2023-11-04 13:31:41.094410] ilias_root.ERROR: Whoops\Handler\CallbackHandler::handle:398 0 Argument 1 passed to ilObjectFactory::getInstanceByObjId() must be of the type int or null, string given, called in /server/test8/public_html/ilias/Services/Notifications/classes/ilNotificationSystem.php on line 107 in /server/test8/public_html/ilias/Services/Object/classes/class.ilObjectFactory.php:84#0 /server/test8/public_html/ilias/Services/Notifications/classes/ilNotificationSystem.php(107): ilObjectFactory::getInstanceByObjId()
#1 /server/test8/public_html/ilias/Services/Notifications/classes/ilNotificationSystem.php(159): ILIAS\Notifications\ilNotificationSystem->toUsers()
#2 /server/test8/public_html/ilias/Services/Notifications/classes/Model/ilNotificationConfig.php(204): ILIAS\Notifications\ilNotificationSystem::sendNotificationToUsers()
#3 /server/test8/public_html/ilias/Customizing/global/plugins/Services/Repository/RepositoryObject/Nolej/classes/class.ilNolejWebhook.php(597): ILIAS\Notifications\Model\ilNotificationConfig->notifyByUsers()
```