### PR TITLE
Services/Contact: Readd inviteToChat method (ILIAS 9)

### DIFF
--- a/Modules/Chatroom/classes/class.ilObjChatroomGUI.php
+++ b/Modules/Chatroom/classes/class.ilObjChatroomGUI.php
@@ -258,7 +258,7 @@ class ilObjChatroomGUI extends ilChatroomObjectGUI implements ilCtrlSecurityInte
                 break;
         }
 
-        if ($this->object->getType() !== 'chta') {
+        if ($this->object?->getType() !== 'chta') {
             $this->addHeaderAction();
         }
 

--- a/Modules/Chatroom/js/iliaschat.jquery.js
+++ b/Modules/Chatroom/js/iliaschat.jquery.js
@@ -547,7 +547,6 @@
                 const body = document.querySelector('#invite_users_container');
                 input.value = '';
                 const modal = window.il.Modal.dialogue({
-                    id: 'heja',
                     header: txt('invite_users'),
                     show: true,
                     body: body,

--- a/Modules/Chatroom/test/class.ilObjChatroomAccessTest.php
+++ b/Modules/Chatroom/test/class.ilObjChatroomAccessTest.php
@@ -50,6 +50,7 @@ class ilObjChatroomAccessTest extends ilChatroomAbstractTest
         )->getMock();
         $user->method('getId')->willReturn(6);
 
+        $this->setGlobalVariable('ilObjDataCache', $this->createMock(ilObjectDataCache::class));
         $this->setGlobalVariable('ilUser', $user);
 
         $chatroomSettings = $this->createMock(ilDBStatement::class);
@@ -105,6 +106,7 @@ class ilObjChatroomAccessTest extends ilChatroomAbstractTest
         )->getMock();
         $user->method('getId')->willReturn(6);
 
+        $this->setGlobalVariable('ilObjDataCache', $this->createMock(ilObjectDataCache::class));
         $this->setGlobalVariable('ilUser', $user);
 
         $chatroomSettings = $this->createMock(ilDBStatement::class);

--- a/Services/Contact/BuddySystem/classes/tables/class.ilBuddySystemRelationsTableGUI.php
+++ b/Services/Contact/BuddySystem/classes/tables/class.ilBuddySystemRelationsTableGUI.php
@@ -207,7 +207,7 @@ class ilBuddySystemRelationsTableGUI extends ilTable2GUI
     protected function fillRow(array $a_set): void
     {
         if ($this->hasAccessToMailSystem) {
-            $a_set['chb'] = ilLegacyFormElementsUtil::formCheckbox(false, 'usr_id[]', (string) $a_set['usr_id']);
+            $a_set['chb'] = ilLegacyFormElementsUtil::formCheckbox(false, 'usr_ids[]', (string) $a_set['usr_id']);
         }
 
         $public_profile = ilObjUser::_lookupPref($a_set['usr_id'], 'public_profile');

--- a/Services/Contact/classes/class.ilContactGUI.php
+++ b/Services/Contact/classes/class.ilContactGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Refinery\Factory as Refinery;
+
 /**
 * @author Jens Conze
 * @ingroup ServicesMail
@@ -41,7 +43,7 @@ class ilContactGUI
     protected ilErrorHandling $error;
     protected ilRbacSystem $rbacsystem;
     protected bool $has_sub_tabs = false;
-    protected ILIAS\Refinery\Factory $refinery;
+    protected Refinery $refinery;
     protected \ILIAS\UI\Factory $ui_factory;
     protected \ILIAS\UI\Renderer $ui_renderer;
     /** @var array<string, string> */
@@ -335,22 +337,18 @@ class ilContactGUI
         $this->activateTab('my_contacts');
 
         if ($this->http->wrapper()->query()->has('inv_room_ref_id') &&
-            $this->http->wrapper()->query()->has('inv_room_scope') &&
             $this->http->wrapper()->query()->has('inv_usr_ids')) {
             $inv_room_ref_id = $this->http->wrapper()->query()->retrieve(
                 'inv_room_ref_id',
-                $this->refinery->kindlyTo()->int()
-            );
-            $inv_room_scope = $this->http->wrapper()->query()->retrieve(
-                'inv_room_scope',
                 $this->refinery->kindlyTo()->int()
             );
             $inv_usr_ids = $this->http->wrapper()->query()->retrieve(
                 'inv_usr_ids',
                 $this->refinery->in()->series([
                     $this->refinery->kindlyTo()->string(),
-                    $this->refinery->custom()->transformation(fn (string $value): array => explode(',', $value)),
-                    $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int())
+                    $this->refinery->custom()->transformation(fn(string $s): array => explode(',', $s)),
+                    $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                    $this->refinery->custom()->constraint(fn(array $a) => $a !== [], fn() => 'Empty array.'),
                 ])
             );
 
@@ -361,8 +359,7 @@ class ilContactGUI
             }
 
             if ($userlist !== []) {
-                $url = $inv_room_scope !== 0 ? ilLink::_getStaticLink($inv_room_ref_id, 'chtr', true, '_' . $inv_room_scope) : ilLink::_getStaticLink($inv_room_ref_id, 'chtr');
-
+                $url = ilLink::_getStaticLink($inv_room_ref_id, 'chtr');
                 $content[] = $this->ui_factory->messageBox()->success(
                     $this->lng->txt('chat_users_have_been_invited') . $this->ui_renderer->render(
                         $this->ui_factory->listing()->unordered($userlist)
@@ -408,7 +405,7 @@ class ilContactGUI
 
         try {
             $usr_ids = $this->http->wrapper()->post()->retrieve(
-                'usr_id',
+                'usr_ids',
                 $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int())
             );
 
@@ -449,5 +446,153 @@ class ilContactGUI
         }
 
         $this->ctrl->redirectToURL('ilias.php?baseClass=ilMailGUI&type=search_res');
+    }
+
+    public function submitInvitation(): void
+    {
+        try {
+            $usr_ids = $this->http->wrapper()->post()->retrieve('usr_ids', $this->refinery->in()->series([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->custom()->transformation(fn(string $s) => explode(',', $s)),
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->custom()->constraint(fn(array $a) => $a !== [], fn() => 'Empty array.'),
+            ]));
+        } catch (Exception) {
+            $this->tpl->setOnScreenMessage('info', $this->lng->txt('select_one'), true);
+            $this->ctrl->redirect($this);
+        }
+
+        try {
+            $room_id = $this->http->wrapper()->post()->retrieve('room_id', $this->refinery->kindlyTo()->int());
+        } catch (Exception) {
+            $this->tpl->setOnScreenMessage('info', $this->lng->txt('select_one'));
+            $this->inviteToChat($usr_ids);
+            return;
+        }
+
+        $room = ilChatroom::byRoomId($room_id, true);
+
+        $no_access = [];
+        $no_login = [];
+        $valid_users = [];
+        $ref_id = $room->getRefIdByRoomId($room_id);
+
+        foreach ($usr_ids as $usr_id) {
+            $login = ilObjUser::_lookupLogin($usr_id);
+            if ($login === '') {
+                $no_login[] = $usr_id;
+            } elseif (
+                !ilChatroom::checkPermissionsOfUser($usr_id, 'read', $ref_id) ||
+                $room->isUserBanned($usr_id)
+            ) {
+                $no_access[] = $login;
+            } else {
+                $valid_users[] = $usr_id;
+            }
+        }
+
+        $message = join('', [
+            $this->asErrorMessage($no_access, $this->lng->txt('chat_users_without_permission')),
+            $this->asErrorMessage($no_login, $this->lng->txt('chat_users_without_login')),
+        ]);
+
+        if ($message !== '') {
+            $this->tpl->setOnScreenMessage('failure', $message);
+            $this->inviteToChat($usr_ids);
+            return;
+        }
+
+        foreach ($valid_users as $id) {
+            $room->sendInvitationNotification(
+                null,
+                $this->user->getId(),
+                $id,
+                ilLink::_getStaticLink($ref_id, 'chtr')
+            );
+        }
+
+        $this->ctrl->setParameter($this, 'inv_room_ref_id', $ref_id);
+        $this->ctrl->setParameter($this, 'inv_usr_ids', implode(',', $valid_users));
+
+        $this->ctrl->redirect($this);
+    }
+
+    /**
+     * @param null|list<int> $usr_ids
+     */
+    protected function inviteToChat(?array $usr_ids = null): void
+    {
+        $this->tabs_gui->activateSubTab('buddy_view_table');
+        $this->activateTab('my_contacts');
+
+        $this->lng->loadLanguageModule('chatroom');
+
+        $usr_ids ??= $this->http->wrapper()->post()->retrieve('usr_ids', $this->refinery->byTrying([
+            $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+            $this->refinery->always([])
+        ]));
+
+        if ([] === $usr_ids) {
+            $this->tpl->setOnScreenMessage('info', $this->lng->txt('select_one'), true);
+            $this->ctrl->redirect($this);
+        }
+
+        $chat_rooms = (new ilChatroom())->getAccessibleRoomIdByTitleMap($this->user->getId());
+
+        $options = array_filter(
+            $chat_rooms,
+            fn(int $room_id) => !(ilChatroom::byRoomId($room_id))->isUserBanned($this->user->getId()),
+            ARRAY_FILTER_USE_KEY
+        );
+
+        asort($options);
+
+        $this->tpl->setTitle($this->lng->txt('mail_invite_users_to_chat'));
+        $this->tpl->setContent($this->inviteToChatForm($options, $usr_ids)->getHTML());
+        $this->tpl->printToStdout();
+    }
+
+    /**
+     * @param list<string|int> $array
+     */
+    private function asErrorMessage(array $array, string $title): string
+    {
+        if ($array === []) {
+            return '';
+        }
+
+        $items = array_map(
+            fn($s) => '<li>' . htmlspecialchars((string) $s) . '</li>',
+            $array
+        );
+
+        return sprintf(
+            '%s<br><ul>%s</ul>',
+            $title,
+            join('', $items)
+        );
+    }
+
+    /**
+     * @param array<string, string> $options
+     * @param list<int> $usr_ids
+     */
+    private function inviteToChatForm(array $options, array $usr_ids): ilPropertyFormGUI
+    {
+        $form = new ilPropertyFormGUI();
+        $form->setTitle($this->lng->txt('mail_invite_users_to_chat'));
+        $form->addCommandButton('submitInvitation', $this->lng->txt('submit'));
+        $form->addCommandButton('showContacts', $this->lng->txt('cancel'));
+        $form->setFormAction($this->ctrl->getFormAction($this, 'showContacts'));
+
+        $sel = new ilSelectInputGUI($this->lng->txt('chat_select_room'), 'room_id');
+        $sel->setOptions($options);
+        $form->addItem($sel);
+
+        $hidden = new ilHiddenInputGUI('usr_ids');
+        $hidden->setValue(implode(',', $usr_ids));
+        $form->addItem($hidden);
+
+        return $form;
     }
 }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2920,6 +2920,7 @@ chatroom#:#chat_osc_sure_to_leave_grp_conv#:#Sind Sie sicher, dass Sie den Grupp
 chatroom#:#chat_osc_user#:#Benutzer
 chatroom#:#chat_osc_user_left_grp_conv#:#Der Benutzer '%s' hat den Gruppenchat verlassen.
 chatroom#:#chat_osc_write_a_msg#:#Eine Nachricht verfassen …
+chatroom#:#chat_select_room#:#Chatraum auswählen
 chatroom#:#chat_settings#:#Chat-Einstellungen
 chatroom#:#chat_settings_functions_header#:#Funktionen des Chats
 chatroom#:#chat_show_auto_messages#:#Automatische Meldungen anzeigen
@@ -11166,10 +11167,14 @@ lti#:#user_provider_subtab#:#Von Benutzern definierte Provider
 ltiv#:#ltiv_create#:#Zertifikat für LTI-Konsument-Objekt erstellen
 ltiv#:#ltiv_create_info#:#Wählen Sie ein abgeschlossenes LTI-Konsument-Objekt aus, um ein Zertifikat dafür zu generieren.
 mail#:#back_to_folder#:#Zurück zum Ordner
+mail#:#chat_users_have_been_invited#:#Die Benutzer wurden eingeladen:
+mail#:#chat_users_without_login#:#Die folgenden Benutzer haben kein ILIAS-Konto und können nicht eingeladen werden:
+mail#:#chat_users_without_permission#:#Die folgenden Benutzer haben keinen Zugriff zum ausgewählten Raum:
 mail#:#current_folder#:#Aktueller Ordner: %s
 mail#:#deleteTemplate#:#Löschen
 mail#:#first_email_missing_info#:#Auswahl nicht möglich, da keine E-Mail-Adresse eingetragen wurde
 mail#:#forward#:#Weiterleiten
+mail#:#goto_invitation_chat#:#Chatraum öffnen
 mail#:#invite_to_chat#:#in Chat einladen
 mail#:#link_check_affected_links#:#Betroffene Links
 mail#:#link_check_introduction#:#die folgenden Externen Links sind ungültig:
@@ -11274,6 +11279,7 @@ mail#:#mail_incoming_mail#:#Maileingang
 mail#:#mail_incoming_smtp#:#An eingetragene E-Mail-Adresse weiterleiten
 mail#:#mail_insert_folder_name#:#Bitte geben Sie einen Ordnernamen ein
 mail#:#mail_insert_query#:#Bitte geben Sie einen Suchbegriff ein
+mail#:#mail_invite_users_to_chat#:#Benutzer in Chat einladen
 mail#:#mail_is_read#:#gelesen
 mail#:#mail_is_unread#:#ungelesen
 mail#:#mail_list_members#:#Mitglieder auflisten

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2920,6 +2920,7 @@ chatroom#:#chat_osc_sure_to_leave_grp_conv#:#Are you sure you want to leave the 
 chatroom#:#chat_osc_user#:#User
 chatroom#:#chat_osc_user_left_grp_conv#:#User '%s' has left the group conversation.
 chatroom#:#chat_osc_write_a_msg#:#Write a Message ...
+chatroom#:#chat_select_room#:#Select Chat Room
 chatroom#:#chat_settings#:#Chat Settings
 chatroom#:#chat_settings_functions_header#:#Chat Room Functions
 chatroom#:#chat_show_auto_messages#:#Show Status Messages
@@ -11155,10 +11156,14 @@ lti#:#user_provider_subtab#:#Providers Defined by Users
 ltiv#:#ltiv_create#:#Create Certificate for LTI Consumer Object
 ltiv#:#ltiv_create_info#:#Select a completed LTI consumer object to generate a certificate for it
 mail#:#back_to_folder#:#Back to Folder
+mail#:#chat_users_have_been_invited#:#The following users have been invited:
+mail#:#chat_users_without_login#:#The following users don't have an ILIAS account and can't be invited to a chat room:
+mail#:#chat_users_without_permission#:#The following users don't have access to the selected chat room:
 mail#:#current_folder#:#Current Folder: %s
 mail#:#deleteTemplate#:#Delete
 mail#:#first_email_missing_info#:#Selection not possible because no e-mail address has been entered
 mail#:#forward#:#Forward
+mail#:#goto_invitation_chat#:#Open Chat Room
 mail#:#invite_to_chat#:#Invite to Chat
 mail#:#link_check_affected_links#:#Affected Links
 mail#:#link_check_introduction#:#the following weblinks are invalid:
@@ -11263,6 +11268,7 @@ mail#:#mail_incoming_mail#:#Incoming Mail
 mail#:#mail_incoming_smtp#:#Forward to E-mail Address:
 mail#:#mail_insert_folder_name#:#Please insert a folder name
 mail#:#mail_insert_query#:#Please insert a query
+mail#:#mail_invite_users_to_chat#:#Invite Users to Chat
 mail#:#mail_is_read#:#gelesen
 mail#:#mail_is_unread#:#ungelesen
 mail#:#mail_list_members#:#List members


### PR DESCRIPTION
This fixes bug: https://mantis.ilias.de/view.php?id=38520
And additionally some other issues:
- Undefined variable `$active` in `ilChatroom::checkPermissions`
- remove id `heja`
- remove `scope` (was used for the removed private rooms)
- rename `usr_id` to `usr_ids` in `ilBuddySystemRelationsTableGUI`