### PR TITLE
UI: adjust SCSS for Apply and Reset Input Filter Buttons. (#38425)

### DIFF
--- a/templates/default/070-components/UI-framework/Input/_ui-component_filter.scss
+++ b/templates/default/070-components/UI-framework/Input/_ui-component_filter.scss
@@ -124,7 +124,6 @@ $il-standard-filter-add-input-popover-list-button-width: 100%;
 }
 
 .il-filter-controls {
-	position: absolute;
 	bottom: $il-standard-filter-controls-bottom;
 	padding-left: $il-standard-filter-controls-padding-left;
 	padding-bottom: $il-standard-filter-controls-padding-bottom;
@@ -164,7 +163,6 @@ $il-standard-filter-add-input-popover-list-button-width: 100%;
 .il-filter-input-section {
 	border-top: $il-standard-filter-input-section-border-top;
 	position: relative;
-	padding-bottom: $il-standard-filter-input-section-padding-bottom;
 	padding-right: $il-padding-large-horizontal;
 	margin: $il-standard-filter-input-section-margin;
 	background: $il-main-dark-bg;


### PR DESCRIPTION
[Mantis Ticket 38425](https://mantis.ilias.de/view.php?id=38425)

The position of those buttons was adjusted as the background padding for bottom removed. It looked good in the documentation but not for e.g. in Users and Roles > Didactic Templates - therefore an adjustment was needed.