### PR TITLE
T&A Bugfix #0038404: Last scored access column can not be sorted

### DIFF
--- a/Modules/Test/classes/class.ilTestParticipantList.php
+++ b/Modules/Test/classes/class.ilTestParticipantList.php
@@ -350,7 +350,7 @@ class ilTestParticipantList implements Iterator
                 $row['percent_result'] = $participant->getScoring()->getPercentResult();
                 $row['passed_status'] = $participant->getScoring()->isPassed();
                 $row['final_mark'] = $participant->getScoring()->getFinalMark();
-                $row['scored_pass_finished_timestamp'] = ilObjTest::lookupLastTestPassAccess(
+                $row['pass_finished'] = ilObjTest::lookupLastTestPassAccess(
                     $participant->getActiveId(),
                     $participant->getScoring()->getScoredPass()
                 );

--- a/Modules/Test/classes/tables/class.ilParticipantsTestResultsTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilParticipantsTestResultsTableGUI.php
@@ -249,8 +249,8 @@ class ilParticipantsTestResultsTableGUI extends ilTable2GUI
 
     protected function buildScoredPassFinishedString(array $data): string
     {
-        if (isset($data['scored_pass_finished_timestamp'])) {
-            return ilDatePresentation::formatDate(new ilDateTime($data['scored_pass_finished_timestamp'], IL_CAL_UNIX));
+        if (isset($data['pass_finished'])) {
+            return ilDatePresentation::formatDate(new ilDateTime($data['pass_finished'], IL_CAL_UNIX));
         }
         return '';
     }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38404