### PR TITLE
Object: fix array access (38657)

### DIFF
--- a/Services/Object/classes/class.ilObjectActivation.php
+++ b/Services/Object/classes/class.ilObjectActivation.php
@@ -527,8 +527,8 @@ class ilObjectActivation
             $new_item->toggleChangeable((bool) $item['changeable']);
             $new_item->toggleVisible((bool) $item['visible']);
             $new_item->update($new_item_id, $new_parent);
-            $new_item->setSuggestionStartRelative((int) $item['suggestion_start_rel']);
-            $new_item->setSuggestionEndRelative((int) $item['suggestion_end_rel']);
+            $new_item->setSuggestionStartRelative((int) ($item['suggestion_start_rel'] ?? 0));
+            $new_item->setSuggestionEndRelative((int) ($item['suggestion_end_rel'] ?? 0));
             $new_item->createDefaultEntry($new_item_id);
             $new_item->update($new_item_id);
         }


### PR DESCRIPTION
This PR is a potential fix for [38657](https://mantis.ilias.de/view.php?id=38657), the array access issue makes the copying of some folders fail.