### PR TITLE
Mantis Bug 38443: Import language file error

### DIFF
--- a/Services/Language/classes/class.ilObjLanguage.php
+++ b/Services/Language/classes/class.ilObjLanguage.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,10 +14,9 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
-require_once "./Services/Object/classes/class.ilObject.php";
+declare(strict_types=1);
 
 /**
  * Class ilObjLanguage

--- a/Services/Language/classes/class.ilObjLanguageDBAccess.php
+++ b/Services/Language/classes/class.ilObjLanguageDBAccess.php
@@ -85,12 +85,11 @@ class ilObjLanguageDBAccess
             }
             if ($double_checker[$separated[0]][$separated[1]][$this->key] ?? false) {
                 global $DIC;
-                /** @var ilErrorHandling $ilErr */
-                $ilErr = $DIC["ilErr"];
-                $ilErr->raiseError(
+                $DIC->ui()->mainTemplate()->setOnScreenMessage(
+                    'failure',
                     "Duplicate Language Entry in $lang_file:\n$val",
-                    $ilErr->MESSAGE
-                );
+                    true);
+                $DIC->ctrl()->redirectByClass(ilobjlanguagefoldergui::class, 'view');
             }
             $double_checker[$separated[0]][$separated[1]][$this->key] = true;
 
@@ -167,13 +166,12 @@ class ilObjLanguageDBAccess
             $unserialied = unserialize($module["lang_array"], ["allowed_classes" => false]);
             if (!is_array($unserialied)) {
                 global $DIC;
-                /** @var ilErrorHandling $ilErr */
-                $ilErr = $DIC["ilErr"];
-                $ilErr->raiseError(
+                $DIC->ui()->mainTemplate()->setOnScreenMessage(
+                    'failure',
                     "Data for module '" . $module["module"] . "' of  language '" . $this->key . "' is not correctly saved. " .
                     "Please check the collation of your database tables lng_data and lng_modules. It must be utf8_unicode_ci.",
-                    $ilErr->MESSAGE
-                );
+                    true);
+                $DIC->ctrl()->redirectByClass(ilobjlanguagefoldergui::class, 'view');
             }
         }
     }

--- a/Services/Language/classes/class.ilObjLanguageExt.php
+++ b/Services/Language/classes/class.ilObjLanguageExt.php
@@ -409,11 +409,10 @@ class ilObjLanguageExt extends ilObjLanguage
         if (!is_array($a_values)) {
             return;
         }
-        $save_array = array();
-        $save_date = date("Y-m-d H:i:s", time());
+        $save_array = [];
+        $save_date = (new DateTime())->format("Y-m-d H:i:s");
 
         // read and get the global values
-        require_once "./Services/Language/classes/class.ilLanguageFile.php";
         $global_file_obj = ilLanguageFile::_getGlobalLanguageFile($a_lang_key);
         $file_values = $global_file_obj->getAllValues();
         $file_comments = $global_file_obj->getAllComments();
@@ -425,24 +424,26 @@ class ilObjLanguageExt extends ilObjLanguage
         // save the single translations in lng_data
         foreach ($a_values as $key => $value) {
             $keys = explode($lng->separator, $key);
-            if (count($keys) === 2) {
-                $module = $keys[0];
-                $topic = $keys[1];
-                $save_array[$module][$topic] = $value;
+            
+            if (count($keys) !== 2) {
+                continue;
+            }
+            
+            list($module, $topic) = $keys;
+            $save_array[$module][$topic] = $value;
 
-                $are_comments_set = isset($global_comments[$key]) && isset($a_remarks[$key]);
-                $are_changes_made = (isset($global_values[$key]) ? $global_values[$key] != $value : true) || (isset($db_values[$key]) ? $db_values[$key] != $value : true);
-                if ($are_changes_made || ($are_comments_set ? $global_comments[$key] != $a_remarks[$key] : $are_comments_set)) {
-                    $local_change = (isset($db_values[$key]) ? $db_values[$key] == $value : true) || (isset($global_values[$key]) ? $global_values[$key] != $value : true) ? $save_date : null;
-                    ilObjLanguage::replaceLangEntry(
-                        $module,
-                        $topic,
-                        $a_lang_key,
-                        $value,
-                        $local_change,
-                        $a_remarks[$key] ?? null
-                    );
-                }
+            $are_comments_set = array_key_exists($key, $global_comments) && array_key_exists($key, $a_remarks);
+            $are_changes_made = (isset($global_values[$key]) ? $global_values[$key] != $value : true) || (isset($db_values[$key]) ? $db_values[$key] != $value : true);
+            if ($are_changes_made || ($are_comments_set ? $global_comments[$key] != $a_remarks[$key] : $are_comments_set)) {
+                $local_change = (isset($db_values[$key]) ? $db_values[$key] == $value : true) || (isset($global_values[$key]) ? $global_values[$key] != $value : true) ? $save_date : null;
+                ilObjLanguage::replaceLangEntry(
+                    $module,
+                    $topic,
+                    $a_lang_key,
+                    $value,
+                    $local_change,
+                    $a_remarks[$key] ?? null
+                );
             }
         }
 

--- a/Services/Language/classes/class.ilObjLanguageExt.php
+++ b/Services/Language/classes/class.ilObjLanguageExt.php
@@ -18,8 +18,6 @@
 
 declare(strict_types=1);
 
-require_once "./Services/Language/classes/class.ilObjLanguage.php";
-
 /**
 * Class ilObjLanguageExt
 *
@@ -432,11 +430,10 @@ class ilObjLanguageExt extends ilObjLanguage
                 $topic = $keys[1];
                 $save_array[$module][$topic] = $value;
 
-                if (!isset($global_values[$key])) continue;
                 $are_comments_set = isset($global_comments[$key]) && isset($a_remarks[$key]);
-                $are_changes_made = $global_values[$key] != $value || $db_values[$key] != $value;
+                $are_changes_made = (isset($global_values[$key]) ? $global_values[$key] != $value : true) || (isset($db_values[$key]) ? $db_values[$key] != $value : true);
                 if ($are_changes_made || ($are_comments_set ? $global_comments[$key] != $a_remarks[$key] : $are_comments_set)) {
-                    $local_change = $db_values[$key] == $value || $global_values[$key] != $value ? $save_date : null;
+                    $local_change = $are_changes_made ? $save_date : null;
                     ilObjLanguage::replaceLangEntry(
                         $module,
                         $topic,

--- a/Services/Language/classes/class.ilObjLanguageExt.php
+++ b/Services/Language/classes/class.ilObjLanguageExt.php
@@ -433,7 +433,7 @@ class ilObjLanguageExt extends ilObjLanguage
                 $are_comments_set = isset($global_comments[$key]) && isset($a_remarks[$key]);
                 $are_changes_made = (isset($global_values[$key]) ? $global_values[$key] != $value : true) || (isset($db_values[$key]) ? $db_values[$key] != $value : true);
                 if ($are_changes_made || ($are_comments_set ? $global_comments[$key] != $a_remarks[$key] : $are_comments_set)) {
-                    $local_change = $are_changes_made ? $save_date : null;
+                    $local_change = (isset($db_values[$key]) ? $db_values[$key] == $value : true) || (isset($global_values[$key]) ? $global_values[$key] != $value : true) ? $save_date : null;
                     ilObjLanguage::replaceLangEntry(
                         $module,
                         $topic,

--- a/Services/Language/classes/class.ilObjLanguageFolder.php
+++ b/Services/Language/classes/class.ilObjLanguageFolder.php
@@ -67,16 +67,13 @@ class ilObjLanguageFolder extends ilObject
     */
     public function __construct(int $a_id, bool $a_call_by_reference = true)
     {
-        global $DIC;
-        $lng = $DIC->language();
-
         $this->type = "lngf";
         parent::__construct($a_id, $a_call_by_reference);
 
-        $this->lang_path = $lng->lang_path;
-        $this->lang_default = $lng->lang_default;
-        $this->lang_user = $lng->lang_user;
-        $this->separator = $lng->separator;
+        $this->lang_path = $this->lng->lang_path;
+        $this->lang_default = $this->lng->lang_default;
+        $this->lang_user = $this->lng->lang_user;
+        $this->separator = $this->lng->separator;
     }
 
     /**
@@ -95,10 +92,7 @@ class ilObjLanguageFolder extends ilObject
     */
     public function getLanguages(): array
     {
-        global $DIC;
-        $lng = $DIC->language();
-
-        $lng->loadLanguageModule("meta");
+        $this->lng->loadLanguageModule("meta");
 
         // set path to directory where lang-files reside
         $d = dir($this->lang_path);
@@ -165,7 +159,7 @@ class ilObjLanguageFolder extends ilObject
 
         // setting language's full names
         foreach ($languages as $lang_key => $lang_data) {
-            $languages[$lang_key]["name"] = $lng->txt("meta_l_" . $lang_key);
+            $languages[$lang_key]["name"] = $this->lng->txt("meta_l_" . $lang_key);
         }
 
         $this->languages = $languages;
@@ -219,9 +213,6 @@ class ilObjLanguageFolder extends ilObject
     */
     public function removeLanguages(array $a_languages): array
     {
-        global $DIC;
-        $ilDB = $DIC->database();
-
         foreach ($a_languages as $lang_key => $lang_data) {
             if ($lang_data["desc"] === "not_installed" && $lang_data["info"] === "file_not_found") {
                 // update languages array
@@ -229,9 +220,9 @@ class ilObjLanguageFolder extends ilObject
 
                 // update object_data table
                 $query = "DELETE FROM object_data " .
-                         "WHERE type = " . $ilDB->quote("lng", "text") . " " .
-                         "AND title = " . $ilDB->quote($lang_key, "text");
-                $ilDB->manipulate($query);
+                         "WHERE type = " . $this->db->quote("lng", "text") . " " .
+                         "AND title = " . $this->db->quote($lang_key, "text");
+                $this->db->manipulate($query);
             }
         }
 
@@ -248,10 +239,6 @@ class ilObjLanguageFolder extends ilObject
     */
     public function checkAllLanguages(): string
     {
-        global $DIC;
-        // TODO: lng object should not be used in this class
-        $lng = $DIC->language();
-
         // set path to directory where lang-files reside
         $d = dir($this->lang_path);
         $tmpPath = getcwd();
@@ -265,7 +252,7 @@ class ilObjLanguageFolder extends ilObject
         while ($entry = $d->read()) {
             if (is_file($entry) && (preg_match("~(^ilias_.{2}\.lang$)~", $entry))) {
                 // textmeldung, wenn langfile gefunden wurde
-                $output .= "<br/><br/>" . $lng->txt("langfile_found") . ": " . $entry;
+                $output .= "<br/><br/>" . $this->lng->txt("langfile_found") . ": " . $entry;
                 $content = file($entry);
                 $lines_full = count($content);
                 $found = true;
@@ -283,29 +270,29 @@ class ilObjLanguageFolder extends ilObject
                         if ($num !== 3) {
                             $error_param = true;
 
-                            $output .= "<br/><b/>" . $lng->txt("err_in_line") . " " . $line . " !</b>&nbsp;&nbsp;";
+                            $output .= "<br/><b/>" . $this->lng->txt("err_in_line") . " " . $line . " !</b>&nbsp;&nbsp;";
 
                             switch ($num) {
                                 case 1:
                                     if (empty($separated[0])) {
-                                        $output .= "<br/>" . $lng->txt("err_no_param") . " " . $lng->txt("check_langfile");
+                                        $output .= "<br/>" . $this->lng->txt("err_no_param") . " " . $this->lng->txt("check_langfile");
                                     } else {
-                                        $output .= $lng->txt("module") . ": " . $separated[0];
-                                        $output .= "<br/>" . $lng->txt("err_1_param") . " " . $lng->txt("check_langfile");
+                                        $output .= $this->lng->txt("module") . ": " . $separated[0];
+                                        $output .= "<br/>" . $this->lng->txt("err_1_param") . " " . $this->lng->txt("check_langfile");
                                     }
                                     break;
 
                                 case 2:
-                                    $output .= $lng->txt("module") . ": " . $separated[0];
-                                    $output .= ", " . $lng->txt("identifier") . ": " . $separated[1];
-                                    $output .= "<br/>" . $lng->txt("err_2_param") . " " . $lng->txt("check_langfile");
+                                    $output .= $this->lng->txt("module") . ": " . $separated[0];
+                                    $output .= ", " . $this->lng->txt("identifier") . ": " . $separated[1];
+                                    $output .= "<br/>" . $this->lng->txt("err_2_param") . " " . $this->lng->txt("check_langfile");
                                     break;
 
                                 default:
-                                    $output .= $lng->txt("module") . ": " . $separated[0];
-                                    $output .= ", " . $lng->txt("identifier") . ": " . $separated[1];
-                                    $output .= ", " . $lng->txt("value") . ": " . $separated[2];
-                                    $output .= "<br/>" . $lng->txt("err_over_3_param") . " " . $lng->txt("check_langfile");
+                                    $output .= $this->lng->txt("module") . ": " . $separated[0];
+                                    $output .= ", " . $this->lng->txt("identifier") . ": " . $separated[1];
+                                    $output .= ", " . $this->lng->txt("value") . ": " . $separated[2];
+                                    $output .= "<br/>" . $this->lng->txt("err_over_3_param") . " " . $this->lng->txt("check_langfile");
                                     break;
                             }
                             continue;
@@ -313,10 +300,10 @@ class ilObjLanguageFolder extends ilObject
                         if ($double_checker[strtolower($separated[0])][strtolower($separated[1])] ?? false) {
                             $error_double = true;
                             
-                            $output .= "<br/><b/>" . $lng->txt("err_in_line") . " " . $double_checker[strtolower($separated[0])][strtolower($separated[1])] . " " . $lng->txt("and") . " " . $line . " !</b>&nbsp;&nbsp;";
-                            $output .= $lng->txt("module") . ": " . $separated[0];
-                            $output .= ", " . $lng->txt("identifier") . ": " . $separated[1];
-                            $output .= ", " . $lng->txt("value") . ": " . $separated[2];
+                            $output .= "<br/><b/>" . $this->lng->txt("err_in_line") . " " . $double_checker[strtolower($separated[0])][strtolower($separated[1])] . " " . $this->lng->txt("and") . " " . $line . " !</b>&nbsp;&nbsp;";
+                            $output .= $this->lng->txt("module") . ": " . $separated[0];
+                            $output .= ", " . $this->lng->txt("identifier") . ": " . $separated[1];
+                            $output .= ", " . $this->lng->txt("value") . ": " . $separated[2];
                         }
                         $double_checker[strtolower($separated[0])][strtolower($separated[1])] = $line;
                     }
@@ -324,17 +311,17 @@ class ilObjLanguageFolder extends ilObject
                     if ($error_param || $error_double) {
                         $reason = "";
                         if ($error_param) {
-                            $reason .= " " . $lng->txt("err_count_param");
+                            $reason .= " " . $this->lng->txt("err_count_param");
                         }
                         if ($error_double) {
-                            $reason .= " " . $lng->txt("err_double_entries");
+                            $reason .= " " . $this->lng->txt("err_double_entries");
                         }
-                        $output .= "<br/>" . $lng->txt("file_not_valid") . $reason;
+                        $output .= "<br/>" . $this->lng->txt("file_not_valid") . $reason;
                     } else {
-                        $output .= "<br/>" . $lng->txt("file_valid");
+                        $output .= "<br/>" . $this->lng->txt("file_valid");
                     }
                 } else {
-                    $output .= "<br/>" . $lng->txt("file_not_valid") . " " . $lng->txt("err_wrong_header");
+                    $output .= "<br/>" . $this->lng->txt("file_not_valid") . " " . $this->lng->txt("err_wrong_header");
                 }
             }
         }
@@ -342,7 +329,7 @@ class ilObjLanguageFolder extends ilObject
         $d->close();
 
         if (!$found) {
-            $output .= "<br/>" . $lng->txt("err_no_langfile_found");
+            $output .= "<br/>" . $this->lng->txt("err_no_langfile_found");
         }
 
         chdir($tmpPath);

--- a/Services/Language/classes/class.ilObjLanguageFolderGUI.php
+++ b/Services/Language/classes/class.ilObjLanguageFolderGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +14,9 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\HTTP\Services as HTTPServices;
 use ILIAS\Refinery\Factory as Refinery;
@@ -32,10 +31,6 @@ use ILIAS\Refinery\Factory as Refinery;
  *
  * @extends ilObject
  */
-
-require_once "./Services/Language/classes/class.ilObjLanguage.php";
-require_once "./Services/Object/classes/class.ilObjectGUI.php";
-
 class ilObjLanguageFolderGUI extends ilObjectGUI
 {
     protected HTTPServices $http;

--- a/Services/Language/classes/class.ilObjLanguageFolderGUI.php
+++ b/Services/Language/classes/class.ilObjLanguageFolderGUI.php
@@ -252,6 +252,7 @@ class ilObjLanguageFolderGUI extends ilObjectGUI
 
         $this->data = $this->lng->txt("selected_languages_updated");
         $this->lng->loadLanguageModule("meta");
+        $refreshed = [];
 
         foreach ($this->getPostId() as $id) {
             $langObj = new ilObjLanguage((int) $id, false);
@@ -263,13 +264,14 @@ class ilObjLanguageFolderGUI extends ilObjectGUI
                     $langObj->setTitle($langObj->getKey());
                     $langObj->setDescription("installed");
                     $langObj->update();
+                    $refreshed[] = $langObj->getKey();
                 }
                 $this->data .= "<br />" . $this->lng->txt("meta_l_" . $langObj->getKey());
             }
 
             unset($langObj);
         }
-
+        ilObjLanguage::refreshPlugins($refreshed);
         $this->out();
     }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -3980,6 +3980,7 @@ common#:#err_auth_mode_inactive#:#Zur Zeit ist leider keine Anmeldung möglich.
 common#:#err_auth_soap_no_ilias_user#:#Anmeldung fehlgeschlagen! Die SOAP-Authentifizierung war erfolgreich, aber es existiert kein entsprechender ILIAS-Benutzer. Bitte kontaktieren Sie Ihren Systemadministrator.
 common#:#err_check_input#:#Die Einstellungen konnten nicht gespeichert werden. Bitte überprüfen Sie Ihre Eingaben.
 common#:#err_count_param#:#Grund: Falsche Parameteranzahl
+common#:#err_double_entries#:#Grund: Doppelte Einträge
 common#:#err_in_line#:#Fehler in Zeile
 common#:#err_inactive#:#Dieses ILIAS-Konto ist nicht aktiv bzw. noch nicht aktiviert worden. Bitte kontaktieren Sie den Technischen Support (siehe Link unten) für weitere Unterstützung.
 common#:#err_inactive_login_attempts#:#Ihr ILIAS-Konto wurde wegen falscher Login-Versuche deaktiviert. Klicken Sie auf „Technische Betreuung kontaktieren“ am Fuße dieser Seite, um die Administratoren zu informieren, dass diese Ihr ILIAS-Konto wieder aktivieren sollen.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -3980,6 +3980,7 @@ common#:#err_auth_mode_inactive#:#Your authentication method is deactivated.
 common#:#err_auth_soap_no_ilias_user#:#Login failed. SOAP authentication successful, but no corresponding ILIAS user exists. Please contact your system administrator.
 common#:#err_check_input#:#The settings could not be saved. Please check your input.
 common#:#err_count_param#:#Reason: Wrong parameter count
+common#:#err_double_entries#:#Reason: Duplicate Entries
 common#:#err_in_line#:#Error in line
 common#:#err_inactive#:#This account has not been activated. Please contact the system administrator for access.
 common#:#err_inactive_login_attempts#:#Your user account has been deactivated due too many failed login attempts. Click 'Contact Technical Support' at the footer of this page to notify the administrator about the need to re-activate your account.


### PR DESCRIPTION
This bug was caused by duplicate language entries in the lang-files.
This PR is fixing these issues, but the duplicate entries should be removed asap. There are already mantis bug reports regarding duplicate entries (https://mantis.ilias.de/view.php?id=37355 and https://mantis.ilias.de/view.php?id=37356).

All lang-files are therefore not valid since release_7. 
I added a stricter check for duplicate entries when you click "check all languages", but I did not imlement this into the install or update language methods. 
When the duplicate entries in all files are removed, I will add this into the code.