### PR TITLE
AdvMD/Wiki: fix updating page lists on reordering select options

### DIFF
--- a/Services/AdvancedMetaData/ROADMAP.md
+++ b/Services/AdvancedMetaData/ROADMAP.md
@@ -1,0 +1,11 @@
+# Roadmap
+
+## Short Term
+
+## Mid Term
+
+Enum entries (for select and multiselect fields) should get an actual ID.
+The current ID acts more like a ordering parameter, which makes mapping entries
+during editing of the fields unnecessarily tedious and error prone.
+
+## Long Term

--- a/Services/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionSelect.php
+++ b/Services/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionSelect.php
@@ -547,6 +547,8 @@ class ilAdvancedMDFieldDefinitionSelect extends ilAdvancedMDFieldDefinition
             $search = ilADTFactory::getInstance()->getSearchBridgeForDefinitionInstance($def, false, true);
             ilADTFactory::initActiveRecordByType();
 
+            $page_list_mappings = [];
+
             foreach ($this->confirmed_objects as $old_option => $item_ids) {
                 // get complete old values
                 $old_values = array();
@@ -603,15 +605,16 @@ class ilAdvancedMDFieldDefinitionSelect extends ilAdvancedMDFieldDefinition
 
                     if ($sub_type == "wpg") {
                         // #15763 - adapt advmd page lists
-                        ilPCAMDPageList::migrateField(
-                            (int) $obj_id,
-                            $this->getFieldId(),
-                            (string) $old_option,
-                            (string) $new_option,
-                            true
-                        );
+                        $page_list_mappings[(string) $old_option] = (string) $new_option;
                     }
                 }
+            }
+
+            if (!empty($page_list_mappings)) {
+                ilPCAMDPageList::migrateField(
+                    $this->getFieldId(),
+                    $page_list_mappings
+                );
             }
 
             $this->confirmed_objects = array();


### PR DESCRIPTION
This PR fixes an issue where Page Lists filtering for specific values of a (multi-)select Custom Metadata field in a Wiki get scrambled when the options of the select are reordered.

The issue also seems to occur in R7 (but I haven't checked this fix there).