### PR TITLE
UI: Fix Value Can be Empty String

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/DateTime.php
+++ b/src/UI/Implementation/Component/Input/Field/DateTime.php
@@ -86,6 +86,10 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
      */
     public function withValue($value): self
     {
+        // This is necessary, otherwise DateTimeImmutable will replace
+        // the empty string with the current date during rendering.
+        // The empty string is the default value posted by the input, if
+        // it is left empty.
         if ($value === '') {
             $value = null;
         }

--- a/src/UI/Implementation/Component/Input/Field/DateTime.php
+++ b/src/UI/Implementation/Component/Input/Field/DateTime.php
@@ -86,6 +86,9 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
      */
     public function withValue($value): self
     {
+        if ($value === '') {
+            $value = null;
+        }
         // TODO: It would be a lot nicer if the value would be held as DateTimeImmutable
         // internally, but currently this is just to much. Added to the roadmap.
         if ($value instanceof \DateTimeImmutable) {


### PR DESCRIPTION
I'm not completely sure when this happens, but when rendering a form containing a DateTime Field `->withRequest()` the value for the field can be an empty string. When applying this value, the `DateTimeImmutable` will contain the current date and things go sideways.

A report has been created for the test here:
See: https://mantis.ilias.de/view.php?id=38838
