### PR TITLE
OpenId: Fix post_logout_redirect_uri Relative

### DIFF
--- a/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
+++ b/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
@@ -60,7 +60,7 @@ class ilAuthProviderOpenIdConnect extends ilAuthProvider
             try {
                 $oidc->signOut(
                     $id_token,
-                    ilStartUpGUI::logoutUrl()
+                    ILIAS_HTTP_PATH . '/' . ilStartUpGUI::logoutUrl()
                 );
             } catch (\Jumbojett\OpenIDConnectClientException $e) {
                 $this->logger->warning("Logging out of OIDC provider failed with: " . $e->getMessage());


### PR DESCRIPTION
The post_logout_redirect_uri should not be relative, as far as I understand the protocol, otherwise the redirect can, one, not work and, two, not be checked.

See: https://mantis.ilias.de/view.php?id=38873