### PR TITLE
Add additional ignores to implementation finder

### DIFF
--- a/src/Setup/ImplementationOfInterfaceFinder.php
+++ b/src/Setup/ImplementationOfInterfaceFinder.php
@@ -33,9 +33,13 @@ class ImplementationOfInterfaceFinder
      * @var string[]
      */
     protected array $ignore = [
+        '.*/data/',
+        '.*/docs/',
+        '.*/lang/',
+        '.*/templates/',
+        '.*/node_modules/',
         '.*/src/',
         '.*/libs/',
-        '.*/test/',
         '.*/tests/',
         '.*/setup/',
         // Classes using removed Auth-class from PEAR


### PR DESCRIPTION
As far as i know the directories:
- docs
- lang 

should be safe to be added to the finder.

Additional, the directories (but im not 100% sure about this):
- data
- templates
- node_modules

too

`test` can be removed since it doesnt exist.

This may need some customization for the new trunk.

Further i might would consider using a white-list instead of a blacklist for this process since it seems to me the we know the specific scopes that should be searched but defining them by excluding all other, wich may cause further maintainance effort in future. But thats just an idea of mine.