### PR TITLE
[FEATURE] ilCtrl: remove deprecated methods `setCmd()` and `setCmdClass()`.

### DIFF
--- a/components/ILIAS/AccessControl/classes/class.ilPermissionGUI.php
+++ b/components/ILIAS/AccessControl/classes/class.ilPermissionGUI.php
@@ -150,7 +150,8 @@ class ilPermissionGUI extends ilPermission2GUI
     protected function confirmTemplateSwitch(): void
     {
         $this->ctrl->setReturn($this, 'perm');
-        $this->ctrl->setCmdClass('ildidactictemplategui');
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmdClass('ildidactictemplategui');
         $dtpl_gui = new ilDidacticTemplateGUI($this->gui_obj);
         $this->ctrl->forwardCommand($dtpl_gui);
     }

--- a/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
+++ b/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
@@ -155,7 +155,8 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
             $obj_type = $new_type;
             $class_name = $this->objDefinition->getClassName($obj_type);
             $next_class = strtolower("ilObj" . $class_name . "GUI");
-            $this->ctrl->setCmdClass($next_class);
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass($next_class);
         }
 
         // set next_class directly for page translations
@@ -173,8 +174,9 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
             $obj_type = ilObject::_lookupType($this->cur_ref_id, true);
             $class_name = $this->objDefinition->getClassName($obj_type);
             $next_class = strtolower("ilObj" . $class_name . "GUI");
-            $this->ctrl->setCmdClass($next_class);
-            $this->ctrl->setCmd("view");
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass($next_class);
+            // $this->ctrl->setCmd("view");
         }
 
         $cmd = $this->ctrl->getCmd("forward");

--- a/components/ILIAS/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
@@ -174,7 +174,8 @@ class ilAuthLoginPageEditorGUI
         //$page_gui->setTabHook($this, "addPageTabs");
 
         if ($this->ctrl->getCmd() === 'editPage') {
-            $this->ctrl->setCmd('edit');
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmd('edit');
         }
         $html = $this->ctrl->forwardCommand($page_gui);
 

--- a/components/ILIAS/Bibliographic/classes/class.ilObjBibliographicGUI.php
+++ b/components/ILIAS/Bibliographic/classes/class.ilObjBibliographicGUI.php
@@ -219,8 +219,9 @@ class ilObjBibliographicGUI extends ilObject2GUI implements ilDesktopItemHandlin
      */
     public function infoScreen(): void
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass(ilInfoScreenGUI::class);
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass(ilInfoScreenGUI::class);
         $this->infoScreenForward();
     }
 

--- a/components/ILIAS/Block/classes/class.ilColumnGUI.php
+++ b/components/ILIAS/Block/classes/class.ilColumnGUI.php
@@ -535,8 +535,9 @@ class ilColumnGUI
 
         $class = array_search($this->request->getBlockType(), self::$block_types);
 
-        $ilCtrl->setCmdClass($class);
-        $ilCtrl->setCmd("create");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $ilCtrl->setCmdClass($class);
+        // $ilCtrl->setCmd("create");
         $block_gui = new $class();
         $block_gui->setProperties($this->block_property[$this->request->getBlockType()]);
         $block_gui->setRepositoryMode($this->getRepositoryMode());

--- a/components/ILIAS/Blog/classes/class.ilObjBlogGUI.php
+++ b/components/ILIAS/Blog/classes/class.ilObjBlogGUI.php
@@ -859,7 +859,8 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
                         } else {
                             $cmd = "render";
                         }
-                        $ilCtrl->setCmd($cmd);
+                        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                        // $ilCtrl->setCmd($cmd);
                     }
                     $this->addHeaderActionForCommand($cmd);
                 }

--- a/components/ILIAS/COPage/PC/PlaceHolder/class.ilPCPlaceHolderGUI.php
+++ b/components/ILIAS/COPage/PC/PlaceHolder/class.ilPCPlaceHolderGUI.php
@@ -127,10 +127,11 @@ class ilPCPlaceHolderGUI extends ilPageContentGUI
     {
         switch ($this->content_obj->getContentClass()) {
             case self::TYPE_MEDIA:
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass("ilpcmediaobjectgui");
+                // $this->ctrl->setCmd("insert");
                 var_dump("1");
                 exit;
-                $this->ctrl->setCmdClass("ilpcmediaobjectgui");
-                $this->ctrl->setCmd("insert");
                 $media_gui = new ilPCMediaObjectGUI($this->pg_obj, null, "");
                 $this->ctrl->forwardCommand($media_gui);
                 break;
@@ -140,16 +141,18 @@ class ilPCPlaceHolderGUI extends ilPageContentGUI
                 break;
 
             case self::TYPE_QUESTION:
-                $this->ctrl->setCmdClass("ilpcquestiongui");
-                $this->ctrl->setCmd("insert");
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass("ilpcquestiongui");
+                // $this->ctrl->setCmd("insert");
                 $question_gui = new ilPCQuestionGUI($this->pg_obj, $this->content_obj, $this->hier_id, $this->pc_id);
                 $question_gui->setSelfAssessmentMode(true);
                 $this->ctrl->forwardCommand($question_gui);
                 break;
 
             case self::TYPE_VERIFICATION:
-                $this->ctrl->setCmdClass("ilpcverificationgui");
-                $this->ctrl->setCmd("insert");
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass("ilpcverificationgui");
+                // $this->ctrl->setCmd("insert");
                 /** @var ilPCVerification $ver */
                 $ver = $this->content_obj;
                 $cert_gui = new ilPCVerificationGUI($this->pg_obj, $ver, $this->hier_id, $this->pc_id);
@@ -240,8 +243,9 @@ class ilPCPlaceHolderGUI extends ilPageContentGUI
                     "insertJSAtPlaceholder"
                 );
 
-                $this->ctrl->setCmdClass("ilpcparagraphgui");
-                $this->ctrl->setCmd("insert");
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass("ilpcparagraphgui");
+                // $this->ctrl->setCmd("insert");
                 $paragraph_gui = new ilPCParagraphGUI($this->pg_obj, $this->content_obj, $this->hier_id, $this->pc_id);
                 $paragraph_gui->setStyleId($this->getStyleId());
                 $paragraph_gui->setPageConfig($this->getPageConfig());
@@ -249,37 +253,42 @@ class ilPCPlaceHolderGUI extends ilPageContentGUI
                 break;
 
             case 1:  //DataTable
-                $this->ctrl->setCmdClass("ilpcdatatablegui");
-                $this->ctrl->setCmd("insert");
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass("ilpcdatatablegui");
+                // $this->ctrl->setCmd("insert");
                 $dtable_gui = new ilPCDataTableGUI($this->pg_obj, $this->content_obj, $this->hier_id, $this->pc_id);
                 $this->ctrl->forwardCommand($dtable_gui);
                 break;
 
             case 2:  //Advanced Table
-                $this->ctrl->setCmdClass("ilpctablegui");
-                $this->ctrl->setCmd("insert");
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass("ilpctablegui");
+                // $this->ctrl->setCmd("insert");
                 $atable_gui = new ilPCTableGUI($this->pg_obj, $this->content_obj, $this->hier_id, $this->pc_id);
                 $this->ctrl->forwardCommand($atable_gui);
                 break;
 
             case 3:  //Advanced List
-                $this->ctrl->setCmdClass("ilpclistgui");
-                $this->ctrl->setCmd("insert");
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass("ilpclistgui");
+                // $this->ctrl->setCmd("insert");
                 $list_gui = new ilPCListGUI($this->pg_obj, $this->content_obj, $this->hier_id, $this->pc_id);
                 $this->ctrl->forwardCommand($list_gui);
                 break;
 
             case 4:  //File List
-                $this->ctrl->setCmdClass("ilpcfilelistgui");
-                $this->ctrl->setCmd("insert");
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass("ilpcfilelistgui");
+                // $this->ctrl->setCmd("insert");
                 $file_list_gui = new ilPCFileListGUI($this->pg_obj, $this->content_obj, $this->hier_id, $this->pc_id);
                 $file_list_gui->setStyleId($this->getStyleId());
                 $this->ctrl->forwardCommand($file_list_gui);
                 break;
 
             case 5:  //Tabs
-                $this->ctrl->setCmdClass("ilpctabsgui");
-                $this->ctrl->setCmd("insert");
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass("ilpctabsgui");
+                // $this->ctrl->setCmd("insert");
                 $tabs_gui = new ilPCTabsGUI($this->pg_obj, $this->content_obj, $this->hier_id, $this->pc_id);
                 $tabs_gui->setStyleId($this->getStyleId());
                 $this->ctrl->forwardCommand($tabs_gui);

--- a/components/ILIAS/COPage/PC/Question/class.ilPCQuestionGUI.php
+++ b/components/ILIAS/COPage/PC/Question/class.ilPCQuestionGUI.php
@@ -322,8 +322,9 @@ class ilPCQuestionGUI extends ilPageContentGUI
             }
         }
 
-        $ilCtrl->setCmdClass("ilquestioneditgui");
-        $ilCtrl->setCmd("feedback");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $ilCtrl->setCmdClass("ilquestioneditgui");
+        // $ilCtrl->setCmd("feedback");
         $edit_gui = new ilQuestionEditGUI();
         if ($q_id > 0) {
             $edit_gui->setQuestionId($q_id);

--- a/components/ILIAS/COPage/classes/class.ilPageEditorGUI.php
+++ b/components/ILIAS/COPage/classes/class.ilPageEditorGUI.php
@@ -302,7 +302,8 @@ class ilPageEditorGUI
 
         $this->ctrl->setParameter($this, "hier_id", $hier_id);
         $this->ctrl->setParameter($this, "pc_id", $pc_id);
-        $this->ctrl->setCmd($cmd);
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd($cmd);
         if ($next_class == "") {
             $pc_def = $this->pc_definition->getPCDefinitionByType($ctype);
             if (is_array($pc_def)) {

--- a/components/ILIAS/Calendar/classes/class.ilCalendarPresentationGUI.php
+++ b/components/ILIAS/Calendar/classes/class.ilCalendarPresentationGUI.php
@@ -419,7 +419,8 @@ class ilCalendarPresentationGUI
             $this->ctrl->getCmdClass() == ''
         ) {
             $cmd_class = $this->readLastClass();
-            $this->ctrl->setCmdClass($cmd_class);
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass($cmd_class);
             return $cmd_class;
         }
         return '';
@@ -460,7 +461,8 @@ class ilCalendarPresentationGUI
         // If cmd class == 'ilcalendarpresentationgui' the cmd class is set to the the new forwarded class
         // otherwise e.g ilcalendarmonthgui tries to forward (back) to ilcalendargui.
         if ($this->ctrl->getCmdClass() == strtolower(get_class($this))) {
-            $this->ctrl->setCmdClass(strtolower($a_class));
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass(strtolower($a_class));
         }
     }
 

--- a/components/ILIAS/Chatroom/classes/class.ilObjChatroomGUI.php
+++ b/components/ILIAS/Chatroom/classes/class.ilObjChatroomGUI.php
@@ -185,13 +185,15 @@ class ilObjChatroomGUI extends ilChatroomObjectGUI implements ilCtrlSecurityInte
 
         // #8701 - infoscreen actions
         if ($this->ctrl->getCmd() !== 'info' && strtolower($next_class) === strtolower(ilInfoScreenGUI::class)) {
-            $this->ctrl->setCmd('info-' . $this->ctrl->getCmd());
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmd('info-' . $this->ctrl->getCmd());
         }
 
         // repository info call
         if ($this->ctrl->getCmd() === 'infoScreen') {
-            $this->ctrl->setCmdClass(ilInfoScreenGUI::class);
-            $this->ctrl->setCmd('info');
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass(ilInfoScreenGUI::class);
+            // $this->ctrl->setCmd('info');
         }
 
         switch (strtolower($next_class)) {

--- a/components/ILIAS/Chatroom/classes/gui/class.ilChatroomInfoGUI.php
+++ b/components/ILIAS/Chatroom/classes/gui/class.ilChatroomInfoGUI.php
@@ -53,9 +53,11 @@ class ilChatroomInfoGUI extends ilChatroomGUIHandler
             $this->gui->getObject()->getType()
         );
         if ($requestedMethod === '') {
-            $this->ilCtrl->setCmd('showSummary');
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ilCtrl->setCmd('showSummary');
         } else {
-            $this->ilCtrl->setCmd($requestedMethod);
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ilCtrl->setCmd($requestedMethod);
         }
         $this->ilCtrl->forwardCommand($info);
     }

--- a/components/ILIAS/CmiXapi/classes/class.ilObjCmiXapiGUI.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilObjCmiXapiGUI.php
@@ -601,8 +601,9 @@ class ilObjCmiXapiGUI extends ilObject2GUI
 
         $DIC->tabs()->activateTab(self::TAB_ID_INFO);
 
-        $DIC->ctrl()->setCmd("showSummary");
-        $DIC->ctrl()->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $DIC->ctrl()->setCmd("showSummary");
+        // $DIC->ctrl()->setCmdClass("ilinfoscreengui");
         $this->infoScreenForward();
     }
 

--- a/components/ILIAS/ContentPage/classes/class.ilObjContentPageGUI.php
+++ b/components/ILIAS/ContentPage/classes/class.ilObjContentPageGUI.php
@@ -486,8 +486,9 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
 
     public function infoScreen(): void
     {
-        $this->ctrl->setCmd('showSummary');
-        $this->ctrl->setCmdClass(ilInfoScreenGUI::class);
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd('showSummary');
+        // $this->ctrl->setCmdClass(ilInfoScreenGUI::class);
 
         $this->infoScreenForward();
     }

--- a/components/ILIAS/Course/classes/class.ilObjCourseGUI.php
+++ b/components/ILIAS/Course/classes/class.ilObjCourseGUI.php
@@ -100,7 +100,8 @@ class ilObjCourseGUI extends ilContainerGUI
 
     public function renderObject(): void
     {
-        $this->ctrl->setCmd("view");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("view");
         $this->viewObject();
     }
 
@@ -140,7 +141,8 @@ class ilObjCourseGUI extends ilContainerGUI
             $this->tabs_gui->clearTargets();
             $this->ctrl->setReturn($this, 'view_content');
             $agreement = new ilMemberAgreementGUI($this->object->getRefId());
-            $this->ctrl->setCmdClass(get_class($agreement));
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass(get_class($agreement));
             $this->ctrl->forwardCommand($agreement);
             return;
         }
@@ -164,7 +166,8 @@ class ilObjCourseGUI extends ilContainerGUI
             parent::renderObject();
         } else {
             $course_content_obj = new ilCourseContentGUI($this);
-            $this->ctrl->setCmdClass(get_class($course_content_obj));
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass(get_class($course_content_obj));
             $this->ctrl->forwardCommand($course_content_obj);
         }
     }
@@ -182,8 +185,9 @@ class ilObjCourseGUI extends ilContainerGUI
      */
     public function infoScreenObject(): void
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass("ilinfoscreengui");
         $this->infoScreen();
     }
 

--- a/components/ILIAS/DataCollection/classes/class.ilObjDataCollectionGUI.php
+++ b/components/ILIAS/DataCollection/classes/class.ilObjDataCollectionGUI.php
@@ -300,8 +300,9 @@ class ilObjDataCollectionGUI extends ilObject2GUI
      */
     public function infoScreen(): void
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass(ilInfoScreenGUI::class);
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass(ilInfoScreenGUI::class);
         $this->infoScreenForward();
     }
 

--- a/components/ILIAS/File/classes/class.ilObjFileGUI.php
+++ b/components/ILIAS/File/classes/class.ilObjFileGUI.php
@@ -759,8 +759,9 @@ class ilObjFileGUI extends ilObject2GUI
      */
     public function infoScreen(): void
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass("ilinfoscreengui");
         $this->infoScreenForward();
     }
 

--- a/components/ILIAS/Forum/classes/class.ilObjForumGUI.php
+++ b/components/ILIAS/Forum/classes/class.ilObjForumGUI.php
@@ -615,8 +615,9 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
 
     public function infoScreenObject(): void
     {
-        $this->ctrl->setCmd('showSummary');
-        $this->ctrl->setCmdClass(ilInfoScreenGUI::class);
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd('showSummary');
+        // $this->ctrl->setCmdClass(ilInfoScreenGUI::class);
         $this->infoScreen();
     }
 
@@ -3893,8 +3894,9 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
 
                 $this->ctrl->redirect($this, 'showThreads');
             } elseif ($cmd === 'html') {
-                $this->ctrl->setCmd('exportHTML');
-                $this->ctrl->setCmdClass(ilForumExportGUI::class);
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmd('exportHTML');
+                // $this->ctrl->setCmdClass(ilForumExportGUI::class);
                 $this->executeCommand();
             } elseif ($cmd === 'confirmDeleteThreads') {
                 $this->confirmDeleteThreadsObject();

--- a/components/ILIAS/Group/classes/class.ilObjGroupGUI.php
+++ b/components/ILIAS/Group/classes/class.ilObjGroupGUI.php
@@ -448,7 +448,8 @@ class ilObjGroupGUI extends ilContainerGUI
             $this->tabs_gui->setTabActive('view_content');
             $this->ctrl->setReturn($this, 'view');
             $agreement = new ilMemberAgreementGUI($this->object->getRefId());
-            $this->ctrl->setCmdClass(get_class($agreement));
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass(get_class($agreement));
             $this->ctrl->forwardCommand($agreement);
             return;
         }

--- a/components/ILIAS/Imprint/classes/class.ilObjLegalNoticeGUI.php
+++ b/components/ILIAS/Imprint/classes/class.ilObjLegalNoticeGUI.php
@@ -74,7 +74,8 @@ class ilObjLegalNoticeGUI extends ilObject2GUI
 
     public function viewCmd(): string
     {
-        $this->ctrl->setCmd('preview');
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd('preview');
         return $this->ctrl->forwardCommand($this->legal_notice_gui);
     }
 }

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -161,15 +161,17 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
 
     private function jumpToRegistration(): void
     {
-        $this->ctrl->setCmdClass(ilAccountRegistrationGUI::class);
-        $this->ctrl->setCmd('');
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmdClass(ilAccountRegistrationGUI::class);
+        // $this->ctrl->setCmd('');
         $this->executeCommand();
     }
 
     private function jumpToPasswordAssistance(): void
     {
-        $this->ctrl->setCmdClass(ilPasswordAssistanceGUI::class);
-        $this->ctrl->setCmd('');
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmdClass(ilPasswordAssistanceGUI::class);
+        // $this->ctrl->setCmd('');
         $this->executeCommand();
     }
 

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -1024,8 +1024,9 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
 
         $DIC->tabs()->activateTab(self::TAB_ID_INFO);
 
-        $DIC->ctrl()->setCmd("showSummary");
-        $DIC->ctrl()->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $DIC->ctrl()->setCmd("showSummary");
+        // $DIC->ctrl()->setCmdClass("ilinfoscreengui");
         $this->infoScreenForward();
     }
 

--- a/components/ILIAS/LearningModule/classes/class.ilObjContentObjectGUI.php
+++ b/components/ILIAS/LearningModule/classes/class.ilObjContentObjectGUI.php
@@ -293,7 +293,8 @@ class ilObjContentObjectGUI extends ilObjectGUI
                     if ($this->requested_obj_id == 0) {
                         $this->ctrl->redirect($this, "chapters");
                     } else {
-                        $this->ctrl->setCmd("subchap");
+                        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                        // $this->ctrl->setCmd("subchap");
                         $this->executeCommand();
                     }
                 }

--- a/components/ILIAS/Repository/classes/class.ilRepositoryGUI.php
+++ b/components/ILIAS/Repository/classes/class.ilRepositoryGUI.php
@@ -169,7 +169,8 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
             ilLoggerFactory::getLogger('obj')->debug($this->ctrl->getNextClass() . ' <-> ' . $class_name);
 
             if ($this->ctrl->getNextClass() !== strtolower('ilObj' . $class_name . 'GUI')) {
-                $this->ctrl->setCmdClass($next_class);
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass($next_class);
             }
         } elseif ((($next_class = $this->ctrl->getNextClass($this)) == "")
             || ($next_class === "ilrepositorygui" && $this->ctrl->getCmd() === "return")) {
@@ -178,7 +179,8 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
             $class_name = $this->objDefinition->getClassName($obj_type);
             $next_class = strtolower("ilObj" . $class_name . "GUI");
 
-            $this->ctrl->setCmdClass($next_class);
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass($next_class);
             if ($this->ctrl->getCmd() === "return") {
                 //$this->ctrl->setCmd(null);    // this does not work anymore
                 $this->ctrl->redirectByClass($next_class, "");

--- a/components/ILIAS/ScormAicc/Editing/classes/class.ilSAHSEditGUI.php
+++ b/components/ILIAS/ScormAicc/Editing/classes/class.ilSAHSEditGUI.php
@@ -106,11 +106,13 @@ class ilSAHSEditGUI implements ilCtrlBaseClassInterface
         if ($next_class == "") {
             switch ($type) {
                 case "scorm2004":
-                    $this->ctrl->setCmdClass("ilobjscorm2004learningmodulegui");
+                    // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                    // $this->ctrl->setCmdClass("ilobjscorm2004learningmodulegui");
                     break;
 
                 case "scorm":
-                    $this->ctrl->setCmdClass("ilobjscormlearningmodulegui");
+                    // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                    // $this->ctrl->setCmdClass("ilobjscormlearningmodulegui");
                     break;
             }
             $next_class = $this->ctrl->getNextClass($this);
@@ -146,7 +148,8 @@ class ilSAHSEditGUI implements ilCtrlBaseClassInterface
                         }
                     }
                 }
-                $this->ctrl->setCmd("export");
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmd("export");
                 ilUtil::redirect("ilias.php?baseClass=ilSAHSEditGUI&cmd=export&ref_id=" . $this->refId);
                 break;
 

--- a/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
@@ -176,8 +176,9 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
 
     protected function infoScreen(): void
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass("ilinfoscreengui");
         $this->infoScreenForward();
     }
 
@@ -872,7 +873,8 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
     {
         $GLOBALS['DIC']->tabs()->setTabActive('export');
         $exp_gui = new ilExportGUI($this);
-        $this->ctrl->setCmd("listExportFiles");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("listExportFiles");
         $exp_gui->addFormat("xml");
         return $this->ctrl->forwardCommand($exp_gui);
     }

--- a/components/ILIAS/ScormAicc/classes/class.ilSAHSPresentationGUI.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilSAHSPresentationGUI.php
@@ -98,12 +98,14 @@ class ilSAHSPresentationGUI implements ilCtrlBaseClassInterface
             $next_class !== "illearningprogressgui") {
             switch ($type) {
                 case "scorm2004":
-                    $this->ctrl->setCmdClass("ilscorm13playergui");
+                    // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                    // $this->ctrl->setCmdClass("ilscorm13playergui");
                     $this->slm_gui = new ilObjSCORMLearningModuleGUI("", $this->refId, true, false);
                     break;
 
                 case "scorm":
-                    $this->ctrl->setCmdClass("ilscormpresentationgui");
+                    // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                    // $this->ctrl->setCmdClass("ilscormpresentationgui");
                     $this->slm_gui = new ilObjSCORMLearningModuleGUI("", $this->refId, true, false);
                     break;
             }
@@ -172,8 +174,9 @@ class ilSAHSPresentationGUI implements ilCtrlBaseClassInterface
      */
     public function infoScreen(): void
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass("ilinfoscreengui");
         $this->outputInfoScreen();
     }
 

--- a/components/ILIAS/Search/classes/class.ilSearchControllerGUI.php
+++ b/components/ILIAS/Search/classes/class.ilSearchControllerGUI.php
@@ -94,7 +94,8 @@ class ilSearchControllerGUI implements ilCtrlBaseClassInterface
     public function setCmdClass(string $a_cmd_class): void
     {
         if ($this->ctrl->getNextClass($this) === '') {
-            $this->ctrl->setCmdClass($a_cmd_class);
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass($a_cmd_class);
         }
     }
 

--- a/components/ILIAS/Session/classes/class.ilObjSessionGUI.php
+++ b/components/ILIAS/Session/classes/class.ilObjSessionGUI.php
@@ -489,8 +489,9 @@ class ilObjSessionGUI extends ilObjectGUI implements ilDesktopItemHandling
     */
     public function infoScreenObject(): void
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass("ilinfoscreengui");
         $this->infoScreen();
     }
 

--- a/components/ILIAS/Test/classes/class.ilAssQuestionPageCommandForwarder.php
+++ b/components/ILIAS/Test/classes/class.ilAssQuestionPageCommandForwarder.php
@@ -94,8 +94,9 @@ class ilAssQuestionPageCommandForwarder
 
         $page_gui->setEditPreview(true);
         if (strlen($ctrl->getCmd()) == 0) {
-            $ctrl->setCmdClass(get_class($page_gui));
-            $ctrl->setCmd("preview");
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $ctrl->setCmdClass(get_class($page_gui));
+            // $ctrl->setCmd("preview");
         }
         $page_gui->setQuestionHTML(array($q_gui->object->getId() => $q_gui->getPreview(true)));
         $page_gui->setTemplateTargetVar("ADM_CONTENT");

--- a/components/ILIAS/Test/classes/class.ilMyTestResultsGUI.php
+++ b/components/ILIAS/Test/classes/class.ilMyTestResultsGUI.php
@@ -86,7 +86,8 @@ class ilMyTestResultsGUI
         global $DIC;
 
         if (!$DIC->ctrl()->getCmd()) {
-            $DIC->ctrl()->setCmd(self::EVALGUI_CMD_SHOW_PASS_OVERVIEW);
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $DIC->ctrl()->setCmd(self::EVALGUI_CMD_SHOW_PASS_OVERVIEW);
         }
 
         switch ($DIC->ctrl()->getNextClass()) {

--- a/components/ILIAS/Test/classes/class.ilMyTestSolutionsGUI.php
+++ b/components/ILIAS/Test/classes/class.ilMyTestSolutionsGUI.php
@@ -73,7 +73,8 @@ class ilMyTestSolutionsGUI
         global $DIC;
 
         if (!$DIC->ctrl()->getCmd()) {
-            $DIC->ctrl()->setCmd(self::EVALGUI_CMD_SHOW_PASS_OVERVIEW);
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $DIC->ctrl()->setCmd(self::EVALGUI_CMD_SHOW_PASS_OVERVIEW);
         }
 
         switch ($DIC->ctrl()->getNextClass()) {

--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -704,8 +704,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                 $page_gui->setEditPreview(true);
                 $page_gui->setEnabledTabs(false);
                 if (strlen($this->ctrl->getCmd()) == 0) {
-                    $this->ctrl->setCmdClass(get_class($page_gui));
-                    $this->ctrl->setCmd("preview");
+                    // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                    // $this->ctrl->setCmdClass(get_class($page_gui));
+                    // $this->ctrl->setCmd("preview");
                 }
 
                 $page_gui->setQuestionHTML([$q_gui->object->getId() => $q_gui->getPreview(true)]);
@@ -1047,8 +1048,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
 
     private function userResultsGatewayObject()
     {
-        $this->ctrl->setCmdClass('ilTestEvaluationGUI');
-        $this->ctrl->setCmd('outUserResultsOverview');
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmdClass('ilTestEvaluationGUI');
+        // $this->ctrl->setCmd('outUserResultsOverview');
         $this->tabs_gui->clearTargets();
 
         $this->forwardToEvaluationGUI();
@@ -1061,8 +1063,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
         $this->prepareOutput();
         $this->addHeaderAction();
 
-        $this->ctrl->setCmdClass('ilParticipantsTestResultsGUI');
-        $this->ctrl->setCmd('showParticipants');
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmdClass('ilParticipantsTestResultsGUI');
+        // $this->ctrl->setCmd('showParticipants');
 
 
         $gui = new ilParticipantsTestResultsGUI(
@@ -2604,15 +2607,17 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
     */
     public function infoScreenObject()
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass("ilinfoscreengui");
         $this->infoScreen();
     }
 
     public function redirectToInfoScreenObject()
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass("ilinfoscreengui");
         $this->infoScreen($this->testrequest->raw('lock') ?? '');
     }
 

--- a/components/ILIAS/Test/classes/class.ilTestExpressPageObjectGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestExpressPageObjectGUI.php
@@ -146,7 +146,8 @@ class ilTestExpressPageObjectGUI extends ilAssQuestionPageGUI
             case 'iltestexpresspageobjectgui':
                 if ($cmd == 'view') {
                     $cmd = 'showPage';
-                    $this->ctrl->setCmd($cmd);
+                    // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                    // $this->ctrl->setCmd($cmd);
                 }
 
                 $q_gui = assQuestionGUI::_getQuestionGUI('', (int) $this->testrequest->raw('q_id'));

--- a/components/ILIAS/TestQuestionPool/classes/class.assImagemapQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assImagemapQuestionGUI.php
@@ -56,7 +56,8 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         if (isset($_POST["imagemap"]) ||
         isset($_POST["imagemap_x"]) ||
         isset($_POST["imagemap_y"])) {
-            $this->ctrl->setCmd("getCoords");
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmd("getCoords");
             $cmd = "getCoords";
         }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -371,8 +371,9 @@ class ilAssQuestionPreviewGUI
 
         // FOR WHICH SITUATION IS THIS WORKAROUND NECCESSARY? (sure .. imagemaps, but where this can be done?)
         if (strlen($this->ctrl->getCmd()) == 0 && !isset($_POST['editImagemapForward_x'])) { // workaround for page edit imagemaps, keep in mind
-            $this->ctrl->setCmdClass(get_class($pageGUI));
-            $this->ctrl->setCmd('preview');
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass(get_class($pageGUI));
+            // $this->ctrl->setCmd('preview');
         }
 
         $this->questionGUI->setPreviewSession($this->previewSession);
@@ -421,8 +422,9 @@ class ilAssQuestionPreviewGUI
 
         // FOR WHICH SITUATION IS THIS WORKAROUND NECCESSARY? (sure .. imagemaps, but where this can be done?)
         if (strlen($this->ctrl->getCmd()) == 0 && !isset($_POST['editImagemapForward_x'])) { // workaround for page edit imagemaps, keep in mind
-            $this->ctrl->setCmdClass(get_class($pageGUI));
-            $this->ctrl->setCmd('preview');
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass(get_class($pageGUI));
+            // $this->ctrl->setCmd('preview');
         }
 
         $this->questionGUI->setPreviewSession($this->previewSession);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -304,8 +304,9 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 if (strlen(
                     $this->ctrl->getCmd()
                 ) == 0 && !isset($_POST['editImagemapForward_x'])) { // workaround for page edit imagemaps, keep in mind
-                    $this->ctrl->setCmdClass(get_class($page_gui));
-                    $this->ctrl->setCmd('preview');
+                    // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                    // $this->ctrl->setCmdClass(get_class($page_gui));
+                    // $this->ctrl->setCmd('preview');
                 }
                 $page_gui->setQuestionHTML([$q_gui->object->getId() => $q_gui->getPreview(true)]);
                 $page_gui->setTemplateTargetVar('ADM_CONTENT');
@@ -1801,8 +1802,9 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
      */
     public function infoScreenObject(): void
     {
-        $this->ctrl->setCmd('showSummary');
-        $this->ctrl->setCmdClass('ilinfoscreengui');
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd('showSummary');
+        // $this->ctrl->setCmdClass('ilinfoscreengui');
         $this->infoScreenForward();
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilQuestionEditGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilQuestionEditGUI.php
@@ -154,7 +154,8 @@ class ilQuestionEditGUI
                         $this->main_tpl->setOnScreenMessage('info', sprintf($this->lng->txt('qpl_question_is_in_use'), $count));
                     }
                 }
-                $this->ctrl->setCmdClass(get_class($q_gui));
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass(get_class($q_gui));
                 $ret = (string) $this->ctrl->forwardCommand($q_gui);
                 break;
         }

--- a/components/ILIAS/Tracking/classes/class.ilLearningProgressGUI.php
+++ b/components/ILIAS/Tracking/classes/class.ilLearningProgressGUI.php
@@ -130,8 +130,10 @@ class ilLearningProgressGUI extends ilLearningProgressBaseGUI
     public function __setCmdClass(string $a_class): void
     {
         if (strcasecmp(ilLearningProgressGUI::class, $this->ctrl->getCmdClass()) === 0) {
-            $this->ctrl->setCmdClass($a_class);
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass($a_class);
         }
+        // note, this was removed prior to the deprecated ilCtrl methods already.
         //$this->ctrl->setCmdClass($a_class);
     }
 

--- a/components/ILIAS/UICore/classes/class.ilCtrl.php
+++ b/components/ILIAS/UICore/classes/class.ilCtrl.php
@@ -172,35 +172,9 @@ class ilCtrl implements ilCtrlInterface
     /**
      * @inheritDoc
      */
-    public function setCmd(?string $a_cmd): void
-    {
-        if (!empty($a_cmd)) {
-            $this->context->setCmd($a_cmd);
-            $this->command = $a_cmd;
-        } else {
-            $this->context->setCmd(null);
-            $this->command = null;
-        }
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function getCmdClass(): ?string
     {
         return $this->context->getCmdClass() ?? '';
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function setCmdClass($a_cmd_class): void
-    {
-        if (!empty($a_cmd_class)) {
-            $this->context->setCmdClass($a_cmd_class);
-        } else {
-            $this->context->setCmdClass(null);
-        }
     }
 
     /**

--- a/components/ILIAS/UICore/interfaces/interface.ilCtrlInterface.php
+++ b/components/ILIAS/UICore/interfaces/interface.ilCtrlInterface.php
@@ -105,31 +105,11 @@ interface ilCtrlInterface
     public function getCmd(string $fallback_command = null): ?string;
 
     /**
-     * Sets the current command.
-     *
-     * @deprecated this method should not be used anymore and will be
-     *             removed with ILIAS 10.
-     *
-     * @param string|null $a_cmd
-     */
-    public function setCmd(?string $a_cmd): void;
-
-    /**
      * Returns the command class which should be executed next.
      *
      * @return string|null
      */
     public function getCmdClass(): ?string;
-
-    /**
-     * Sets the command class that should be executed next.
-     *
-     * @deprecated this method should not be used anymore and will be
-     *             removed with ILIAS 10.
-     *
-     * @param object|string|null $a_cmd_class
-     */
-    public function setCmdClass($a_cmd_class): void;
 
     /**
      * Returns the classname of the next class in the control flow.

--- a/components/ILIAS/WebResource/classes/class.ilLinkResourceHandlerGUI.php
+++ b/components/ILIAS/WebResource/classes/class.ilLinkResourceHandlerGUI.php
@@ -63,7 +63,8 @@ class ilLinkResourceHandlerGUI implements ilCtrlBaseClassInterface
 
         $next_class = $this->ctrl->getNextClass($this);
         if ($next_class == "") {
-            $this->ctrl->setCmdClass(ilObjLinkResourceGUI::class);
+            // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+            // $this->ctrl->setCmdClass(ilObjLinkResourceGUI::class);
             $next_class = $this->ctrl->getNextClass($this);
         }
         if ($this->access->checkAccess("read", "", $ref_id)) {

--- a/components/ILIAS/WebResource/classes/class.ilObjLinkResourceGUI.php
+++ b/components/ILIAS/WebResource/classes/class.ilObjLinkResourceGUI.php
@@ -163,7 +163,8 @@ class ilObjLinkResourceGUI extends ilObject2GUI
 
             default:
                 if (!$cmd) {
-                    $this->ctrl->setCmd("view");
+                    // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                    // $this->ctrl->setCmd("view");
                 }
                 parent::executeCommand();
         }
@@ -1449,8 +1450,9 @@ class ilObjLinkResourceGUI extends ilObject2GUI
      */
     public function infoScreen(): void
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass("ilinfoscreengui");
         $this->infoScreenForward();
     }
 

--- a/components/ILIAS/WebServices/ECS/classes/class.ilObjECSSettingsGUI.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilObjECSSettingsGUI.php
@@ -66,7 +66,8 @@ class ilObjECSSettingsGUI extends ilObjectGUI
             default:
                 $this->tabs_gui->setTabActive('settings');
                 $settings = new ilECSSettingsGUI();
-                $this->ctrl->setCmdClass('ilecssettingsgui');
+                // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+                // $this->ctrl->setCmdClass('ilecssettingsgui');
                 $this->ctrl->forwardCommand($settings);
                 break;
         }

--- a/components/ILIAS/WebServices/ECS/classes/class.ilRemoteObjectBaseGUI.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilRemoteObjectBaseGUI.php
@@ -153,8 +153,9 @@ abstract class ilRemoteObjectBaseGUI extends ilObject2GUI
     */
     public function infoScreenObject(): void
     {
-        $this->ctrl->setCmd("showSummary");
-        $this->ctrl->setCmdClass("ilinfoscreengui");
+        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+        // $this->ctrl->setCmd("showSummary");
+        // $this->ctrl->setCmdClass("ilinfoscreengui");
         $this->infoScreen();
     }
 

--- a/public/confirmReg.php
+++ b/public/confirmReg.php
@@ -25,6 +25,7 @@ if (!file_exists(getcwd() . '/ilias.ini.php')) {
 ilInitialisation::initILIAS();
 
 /** @var ILIAS\DI\Container $DIC */
-$DIC->ctrl()->setCmd('confirmRegistration');
+// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+// $DIC->ctrl()->setCmd('confirmRegistration');
 $DIC->ctrl()->callBaseClass(ilStartUpGUI::class);
 $DIC->http()->close();

--- a/public/login.php
+++ b/public/login.php
@@ -22,7 +22,8 @@ if (!file_exists(getcwd() . "/../ilias.ini.php")) {
 
 ilInitialisation::initILIAS();
 
-$ilCtrl->setCmd('showLoginPageOrStartupPage');
+// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+// $ilCtrl->setCmd('showLoginPageOrStartupPage');
 $ilCtrl->callBaseClass('ilStartUpGUI');
 $ilBench->save();
 

--- a/public/logout.php
+++ b/public/logout.php
@@ -13,7 +13,8 @@
 
 ilInitialisation::initILIAS();
 
-$ilCtrl->setCmd('doLogout');
+// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+// $ilCtrl->setCmd('doLogout');
 $ilCtrl->callBaseClass('ilStartUpGUI');
 $ilBench->save();
 

--- a/public/lti.php
+++ b/public/lti.php
@@ -13,6 +13,7 @@ ilInitialisation::initILIAS();
 
 // authentication is done here ->
 global $DIC;
-$DIC->ctrl()->setCmd('doLTIAuthentication');
+// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+// $DIC->ctrl()->setCmd('doLTIAuthentication');
 $DIC->ctrl()->setTargetScript('ilias.php');
 $DIC->ctrl()->callBaseClass('ilStartUpGUI');

--- a/public/openidconnect.php
+++ b/public/openidconnect.php
@@ -20,6 +20,7 @@ global $DIC;
 
 
 // authentication is done here ->
-$DIC->ctrl()->setCmd('doOpenIdConnectAuthentication');
+// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+// $DIC->ctrl()->setCmd('doOpenIdConnectAuthentication');
 $DIC->ctrl()->setTargetScript('ilias.php');
 $DIC->ctrl()->callBaseClass(ilStartUpGUI::class);

--- a/public/pwassist.php
+++ b/public/pwassist.php
@@ -14,7 +14,8 @@
 
 ilInitialisation::initILIAS();
 
-$ilCtrl->setCmd('jumpToPasswordAssistance');
+// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+// $ilCtrl->setCmd('jumpToPasswordAssistance');
 $ilCtrl->callBaseClass('ilStartUpGUI');
 $ilBench->save();
 

--- a/public/register.php
+++ b/public/register.php
@@ -13,6 +13,7 @@
 
 ilInitialisation::initILIAS();
 
-$ilCtrl->setCmd("jumpToRegistration");
+// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+// $ilCtrl->setCmd("jumpToRegistration");
 $ilCtrl->callBaseClass('ilStartUpGUI');
 $ilBench->save();

--- a/public/saml.php
+++ b/public/saml.php
@@ -28,5 +28,6 @@ ilInitialisation::initILIAS();
 
 /** @var ILIAS\DI\Container $DIC */
 $DIC->ctrl()->setTargetScript('ilias.php');
-$DIC->ctrl()->setCmd('doSamlAuthentication');
+// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+// $DIC->ctrl()->setCmd('doSamlAuthentication');
 $DIC->ctrl()->callBaseClass(ilStartUpGUI::class);

--- a/public/shib_login.php
+++ b/public/shib_login.php
@@ -34,6 +34,7 @@ if (
     $DIC->ui()->mainTemplate()->printToStdout();
 } else {
     // authentication is done here ->
-    $DIC->ctrl()->setCmd('doShibbolethAuthentication');
+    // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+    // $DIC->ctrl()->setCmd('doShibbolethAuthentication');
     $DIC->ctrl()->callBaseClass(ilStartUpGUI::class);
 }

--- a/public/sso/index.php
+++ b/public/sso/index.php
@@ -27,5 +27,6 @@ ilContext::init(ilContext::CONTEXT_APACHE_SSO);
 
 ilInitialisation::initILIAS();
 
-$ilCtrl->setCmd('doApacheAuthentication');
+// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
+// $ilCtrl->setCmd('doApacheAuthentication');
 $ilCtrl->callBaseClass('ilStartUpGUI');


### PR DESCRIPTION
Hi everyone,

This PR is the follow up for #5100 and removes the deprecated methods `ilCtrl::setCmd()` and `ilCtrl::setCmdClass()`.

I have opened this PR for visibility. These changes will most likely lead to some unexpected behaviour in each affected controller as well as other ones which route through one or more of them. I have commented the usages of these methods and added an according `@todo` annotation, which most likely needs inspection by a maintainer.

There have been some heavy usages in the `COPage`, `TestQuestionPool` and `Test` services and modules as well as index files, such as `login.php`.

While going through the usages of these methods I also recognised a pattern across controllers which need to show an info-page:

```php
$ilCtrl->setCmd('showSummary');
$ilCtrl->setCmdClass(ilInfoScreenGUI::class);
```

This points into the direction of transforming this controller into a service rather than using it as an endpoint. However, this is just a realisation, this PR is not meant to discuss this particular issue.

Kind regards,
@thibsy