### PR TITLE
#38953 fix awareness popups showing with disabled awareness tool

### DIFF
--- a/Services/Awareness/classes/Provider/AwarenessToastProvider.php
+++ b/Services/Awareness/classes/Provider/AwarenessToastProvider.php
@@ -47,6 +47,7 @@ class AwarenessToastProvider extends AbstractToastProvider
 
         $toasts = [];
         if (
+            $settings->get('awrn_enabled', 0) !== '1' ||
             $settings->get('use_osd', '0') !== '1' ||
             0 === $this->dic->user()->getId() ||
             $this->dic->user()->isAnonymous()


### PR DESCRIPTION
The awareness toast-provider ignores if awareness is disabled, as long as the popup is activated.  This commit should fix that.