### PR TITLE
[FIX] 0038947: Update from Ilias 5.4 -> 7.26 fails because of Quotation of WHERE `1` = 1

### DIFF
--- a/setup/sql/dbupdate_04.php
+++ b/setup/sql/dbupdate_04.php
@@ -24790,11 +24790,7 @@ ilDBUpdate3136::addStyleClass(
 ?>
 <#5430>
 <?php
-$ilDB->update("style_data", array(
-    "uptodate" => array("integer", 0)
-), array(
-    "1" => array("integer", 1)
-));
+$ilDB->manipulate("UPDATE style_data SET uptodate = 0 WHERE 1 = 1");
 ?>
 <#5431>
 <?php


### PR DESCRIPTION
This fixes the issue https://mantis.ilias.de/view.php?id=38947 and should be cherry-picked to release_8 at least