### PR TITLE
IRSS: Fix Write Access to Storage on Migration

### DIFF
--- a/Services/ResourceStorage/classes/Setup/class.ilResourceStorageMigrationHelper.php
+++ b/Services/ResourceStorage/classes/Setup/class.ilResourceStorageMigrationHelper.php
@@ -81,6 +81,10 @@ class ilResourceStorageMigrationHelper
         $this->client_data_dir = $client_data_dir;
         $this->database = $db;
 
+        if (!is_writable("{$data_dir}/{$client_id}/storage/fsv2")) {
+            throw new Exception('storage directory is not writable, abort...');
+        }
+
         // Build Container
         $init = new InitResourceStorage();
         $container = new Container();


### PR DESCRIPTION
Hi @chfsx 

This is one possible fix for:
https://mantis.ilias.de/view.php?id=38993

I think this should actually be enough, but it also happens really early and thus stops listing of migrations with users who do not have write access to storage. I do actually believe that this is the right behavior though. The check is also slightly more specific than the one in the Migration of the Files-Module as I think we should be sure to have write rights on the fsv2-folder.

Best,
@kergomard 