### PR TITLE
Node: Test and change the nodejs versions (ILIAS 9)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2]
-        nodejs: [ 19.x ]
+        nodejs: [ 20.x ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -73,7 +73,7 @@ For best results we recommend:
   * Apache 2.4.x with `mod_php`
   * php-gd, php-xml, php-mysql, php-mbstring, php-imagick, php-zip, php-intl
   * OpenJDK 11
-  * Node.js: 14 (LTS)
+  * Node.js: 20-LTS (and 18, 19, 21)
   * git
   * composer v2
   * a contemporary browser supporting ES6, CSS3 and HTML 5


### PR DESCRIPTION
This PR adjusts the required nodejs version in `docs/configuration/install.md` and changes the github ci builds to use the node LTS version **20**.