### PR TITLE
Composer: Add sabre/dav As Dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"sabre/dav": "^4.5",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Usage:
```components/ILIAS/WebDAV```

Reasoning:
```Sabre/DAV``` is used in big projects e.g. in Nextcloud.

Maintenance:
- Release 4.5 released in 2023, approximately one minor
and one major release per year.
- Irregular, but continuous commit activity be multiple contributors
(see: https://github.com/sabre-io/dav/commits/master)
- Not much information on Security.

Links:
Packagist: https://packagist.org/packages/sabre/dav
GitHub: https://github.com/sabre-io/dav
Documentation: https://sabre.io/dav/