### PR TITLE
Composer: Add `simplesamlphp/simplesamlphp` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"simplesamlphp/simplesamlphp": "^1.19.8",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `simplesamlphp/simplesamlphp` as composer dependency.

Usage:
* `components/ILIAS/Saml`

Wrapped By:
* `\ilSimpleSAMLphpWrapper` (implements `\ilSamlAuth`)
* `\ilSimpleSAMLphplIdpDiscovery` (implements `\ilSamlIdpDiscovery`)

Reasoning:
* `SimpleSAMLphp` is an award-winning application written in native PHP that deals with secure authentication. The main focus of `SimpleSAMLphp` is providing support for SAML 2.0 as both "Service Provider" and "Identity Provider".
* SAML is a very complex standard (in my personal opinion, see https://datatracker.ietf.org/doc/html/rfc7522 and linked documents) and we should not try to/do not want to reinvent the wheel in ILIAS. So we should rely on this library crafted by these authentication/security standard specialists.

Maintenance:
* `SimpleSAMLphp` is actively maintained by multiple contributors (see: https://simplesamlphp.org/contrib/). There is recent activity (even this week, see: https://github.com/simplesamlphp/simplesamlphp/commits/master).
* Security issues are always fixed in a timely manner followed by new releases. A proper security process is implemented: https://simplesamlphp.org/security/ .

Outlook:
* We are currently working on upgrading the library to the new major release (2.x) to receive all future (security) bugfixes and to be compliant with future PHP versions.

Links:
* Packagist: https://packagist.org/packages/simplesamlphp/simplesamlphp
* GitHub: https://github.com/simplesamlphp/simplesamlphp
* Documentation: https://simplesamlphp.org/docs/