### PR TITLE
Composer: Add `cweagans/composer-patches` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"cweagans/composer-patches": "^1.7",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `cweagans/composer-patches` as composer dependency.

Usage:
* During `composer install` and `composer upgrade`

Wrapped By:
* Not applicable

Reasoning:
* `Composer Patches` is a composer plugin which allows us to apply patches to our libraries.
* ILIAS still requires a few patches to be applied after the libraries have been fetched, see: vendor/composer/patches

Maintenance:
* `Composer Patches` is still maintained, mostly by "cweagans (Cameron Eagans)" and supported by other contributors. There is not much activity in general, but the plugin is so to speak "feature-complete". There is activity if there are security vulnerabilities (`Dependabot` pull requests are merged) and if changes were made in `Composer` itself which require the plugin to adapt.
* The risk of relying on this library is not big. It is only used after the installation/upgrade of our composer libraries. If we could not use this library anymore (because the project is not active anymore of if there are major security issues), we will find another way to apply the patches.

Links:
* Packagist: https://packagist.org/packages/cweagans/composer-patches
* GitHub: https://github.com/cweagans/composer-patches
* Documentation: https://docs.cweagans.net/composer-patches/