### PR TITLE
9/UI/drilldown: white bg, icon placeholder 32568

### DIFF
--- a/templates/default/070-components/UI-framework/Button/_ui-component_button.scss
+++ b/templates/default/070-components/UI-framework/Button/_ui-component_button.scss
@@ -219,11 +219,6 @@ input.btn {
     }
   }
 }
-.il-drilldown .menulevel {
-  justify-content: space-between;
-  text-align: left;
-  margin-bottom: l-spage.$il-slate-content-spacing;
-}
 
 // Button Sizes
 // --------------------------------------------------

--- a/templates/default/070-components/UI-framework/Menu/_ui-component_drilldown.scss
+++ b/templates/default/070-components/UI-framework/Menu/_ui-component_drilldown.scss
@@ -1,21 +1,23 @@
+@use "sass:math";
 @use "../../../010-settings/" as *;
+@use "../../../010-settings/legacy-settings/legacy-settings_symbol" as s-symbol;
 @use "../../../010-settings/legacy-settings/legacy-settings_form" as *;
-@use "../../../050-layout/basics" as *;
-@use "../../../050-layout/standardpage/" as *;
-
+@use "../../../050-layout/basics" as l;
+@use "../../../050-layout/standardpage/" as l-spage;
 
 //== Drilldown Menu
 //
 //##
 $il-drilldown-header-height: 80px;
-$il-drilldown-spacing-vertical: $il-padding-large-vertical;
-$il-drilldown-spacing-horizontal: $il-padding-large-horizontal;
+$il-drilldown-spacing-vertical: l.$il-padding-large-vertical;
+$il-drilldown-spacing-horizontal: l.$il-padding-large-horizontal;
 $il-drilldown-menulevel-bg: $il-bulky-bg-color;
 $il-drilldown-bulky-bg: transparent;
 $il-drilldown-item-hover-bg: $il-bulky-bg-color-engaged;
 $il-drilldown-item-font-size: $il-bulky-label-size;
-$il-drilldown-item-spacing: $il-slate-content-spacing;
+$il-drilldown-item-spacing: l-spage.$il-slate-content-spacing;
 $il-drilldown-item-font-line-height: $il-bulky-label-size * 1.133333333333333; // line-height of slate bulky btn/link
+$il-drilldown-left-indent: l.$il-padding-large-horizontal + s-symbol.$il-icon-size-small + math.div(l.$il-padding-large-horizontal, 2);
 
 .il-drilldown {
 	// reset user agent CSS for lists
@@ -31,11 +33,12 @@ $il-drilldown-item-font-line-height: $il-bulky-label-size * 1.133333333333333; /
 		align-items: center;
 		min-height: $il-drilldown-header-height; // content is centered by flex-box, not through padding
 		margin-bottom: $il-drilldown-item-spacing;
-		padding: $il-padding-xlarge-vertical $il-padding-xlarge-horizontal;
+		padding: l.$il-padding-xlarge-vertical l.$il-padding-xlarge-horizontal l.$il-padding-xlarge-vertical $il-drilldown-left-indent;
 		z-index: initial; // so slate can cover up this specific header
 		h2 {
 			font-size: $il-font-size-xlarge;
 			margin: 0;
+			padding: 0;
 		}
 		.backnav {
 			display: none;
@@ -53,7 +56,7 @@ $il-drilldown-item-font-line-height: $il-bulky-label-size * 1.133333333333333; /
 		}
 	}
 	header.show-backnav {
-		padding-left: $il-drilldown-spacing-horizontal * 3.25; // make room for back arrow icon
+		padding-left: $il-drilldown-left-indent;
 		.backnav {
 			display: block;
 		}
@@ -79,7 +82,8 @@ $il-drilldown-item-font-line-height: $il-bulky-label-size * 1.133333333333333; /
 		margin: $il-drilldown-spacing-vertical 0;
 	}
 	.btn-bulky,
-	.link-bulky {
+	.link-bulky,
+	.menulevel {
 		background-color: $il-drilldown-bulky-bg;
 		border-color: $il-drilldown-bulky-bg;
 		&:hover {
@@ -89,5 +93,11 @@ $il-drilldown-item-font-line-height: $il-bulky-label-size * 1.133333333333333; /
 		.icon {
 			filter: invert(50%);
 		}
+	}
+	.menulevel {
+		justify-content: space-between;
+		text-align: left;
+		padding-left: $il-drilldown-left-indent; // bulky-btn left padding + space for small icon + gap 
+		margin-bottom: l-spage.$il-slate-content-spacing;
 	}
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -3643,12 +3643,6 @@ input.btn, input.il-link.link-bulky,
   text-align: left;
 }
 
-.il-drilldown .menulevel {
-  justify-content: space-between;
-  text-align: left;
-  margin-bottom: 2px;
-}
-
 .btn-lg, .btn-group-lg > .btn {
   min-height: 50.4px;
   min-width: 50.4px;
@@ -6770,12 +6764,13 @@ footer {
   align-items: center;
   min-height: 80px;
   margin-bottom: 2px;
-  padding: 9px 15px;
+  padding: 9px 15px 9px 38px;
   z-index: initial;
 }
 .il-drilldown header h2 {
   font-size: 1.115rem;
   margin: 0;
+  padding: 0;
 }
 .il-drilldown header .backnav {
   display: none;
@@ -6791,7 +6786,7 @@ footer {
   border: none;
 }
 .il-drilldown header.show-backnav {
-  padding-left: 39px;
+  padding-left: 38px;
 }
 .il-drilldown header.show-backnav .backnav {
   display: block;
@@ -6814,18 +6809,27 @@ footer {
   margin: 6px 0;
 }
 .il-drilldown .btn-bulky,
-.il-drilldown .link-bulky {
+.il-drilldown .link-bulky,
+.il-drilldown .menulevel {
   background-color: transparent;
   border-color: transparent;
 }
 .il-drilldown .btn-bulky:hover,
-.il-drilldown .link-bulky:hover {
+.il-drilldown .link-bulky:hover,
+.il-drilldown .menulevel:hover {
   background-color: #e2e8ef;
   color: inherit;
 }
 .il-drilldown .btn-bulky .icon,
-.il-drilldown .link-bulky .icon {
+.il-drilldown .link-bulky .icon,
+.il-drilldown .menulevel .icon {
   filter: invert(50%);
+}
+.il-drilldown .menulevel {
+  justify-content: space-between;
+  text-align: left;
+  padding-left: 38px;
+  margin-bottom: 2px;
 }
 
 div.alert div {


### PR DESCRIPTION
# Issue

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/92119753-e9f7-48e2-b73e-742fc850bf33)

Design of the Drilldown was discussed in this ticket:
https://mantis.ilias.de/view.php?id=32568

Thanks to @yvseiler for doing research and providing helpful mockups.

# Change

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/acb3362b-cae1-4da4-88da-e1a79eaff0f8)

New design:
* left indent on header, menulevel
* all bgs have the main bg color (white) now - we might want to change the slate as well for a more minimal look: https://mantis.ilias.de/view.php?id=38988