### PR TITLE
#39062 prevent 403 on loginpage

### DIFF
--- a/Services/Help/classes/class.ilHelpGUI.php
+++ b/Services/Help/classes/class.ilHelpGUI.php
@@ -51,6 +51,10 @@ class ilHelpGUI implements ilCtrlBaseClassInterface
         $this->user = $DIC->user();
         $ilCtrl = $DIC->ctrl();
 
+        if($this->user->getLogin() == "") {
+            return;
+        }
+        
         $this->ctrl = $ilCtrl;
         $this->ui = $DIC->ui();
         $this->help_request = new StandardGUIRequest(


### PR DESCRIPTION
Added a check for a valid user login, to prevent a failing access check on the login page, due to the HelpGUI

[#39062](https://mantis.ilias.de/view.php?id=39062)