### PR TITLE
Fix #37778: Fix for SOAP Plugin Reinitialization Issue in ILIAS 8

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1528,6 +1528,9 @@ class ilInitialisation
         );
 
         if ($replace_super_globals) {
+            if(ilContext::getType() == ilContext::CONTEXT_SOAP_NO_AUTH){
+                return;
+            }
             $throwOnValueAssignment = defined('DEVMODE') && DEVMODE;
 
             $_GET = new SuperGlobalDropInReplacement($container['refinery'], $_GET, $throwOnValueAssignment);


### PR DESCRIPTION
This PR addresses a bug identified in ILIAS 8, specifically concerning the malfunctioning of SOAP plugins. The issue originated from a series of interconnected bugs:

- https://mantis.ilias.de/view.php?id=37778
- https://mantis.ilias.de/view.php?id=37781
- https://mantis.ilias.de/view.php?id=37780

 They  can all be  traced back to the  reinitialization performed by the SOAP administration. During the initial Initialisation, certain superglobals are replaced within the system. However, when reinitialization occurs, ILIAS attempts to replace these superglobals again, leading to a cascade of errors.  This PR solves this issue but only considers SOAP contexts.


