### PR TITLE
fix 0038490: Failed test: MathJax im Zertifikat anzeigen

### DIFF
--- a/Services/Certificate/classes/File/Certificate/class.ilPdfGenerator.php
+++ b/Services/Certificate/classes/File/Certificate/class.ilPdfGenerator.php
@@ -24,13 +24,15 @@ declare(strict_types=1);
 class ilPdfGenerator
 {
     private readonly ilCertificateRpcClientFactoryHelper $rpcHelper;
+    private readonly ilCertificateMathJaxHelper $mathJaxHelper;
     private readonly ilCertificatePdfFileNameFactory $pdfFilenameFactory;
 
     public function __construct(
         private readonly ilUserCertificateRepository $certificateRepository,
         ?ilCertificateRpcClientFactoryHelper $rpcHelper = null,
         ?ilCertificatePdfFileNameFactory $pdfFileNameFactory = null,
-        ?ilLanguage $lng = null
+        ?ilLanguage $lng = null,
+        ?ilCertificateMathJaxHelper $mathJaxHelper = null
     ) {
         global $DIC;
 
@@ -38,6 +40,11 @@ class ilPdfGenerator
             $rpcHelper = new ilCertificateRpcClientFactoryHelper();
         }
         $this->rpcHelper = $rpcHelper;
+
+        if (null === $mathJaxHelper) {
+            $mathJaxHelper = new ilCertificateMathJaxHelper();
+        }
+        $this->mathJaxHelper = $mathJaxHelper;
 
         if (null === $lng) {
             $lng = $DIC->language();
@@ -95,6 +102,8 @@ class ilPdfGenerator
             ['[CLIENT_WEB_DIR]' . $certificate->getBackgroundImagePath(), 'file://' . CLIENT_WEB_DIR],
             $certificateContent
         );
+        
+        $certificateContent = $this->mathJaxHelper->fillXlsFoContent($certificateContent);
 
         $pdf_base64 = $this->rpcHelper->ilFO2PDF('RPCTransformationHandler', $certificateContent);
 

--- a/Services/Certificate/test/ilPdfGeneratorTest.php
+++ b/Services/Certificate/test/ilPdfGeneratorTest.php
@@ -64,6 +64,12 @@ class ilPdfGeneratorTest extends ilCertificateBaseTestCase
         $rpcHelper->method('ilFO2PDF')
             ->willReturn($pdf);
 
+        $mathJaxHelper = $this->getMockBuilder(ilCertificateMathJaxHelper::class)
+            ->getMock();
+
+        $mathJaxHelper->method('fillXlsFoContent')
+            ->willReturn('<xml> Some filled XML content </xml>');
+        
         $pdfFileNameFactory = $this->getMockBuilder(ilCertificatePdfFileNameFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -76,7 +82,8 @@ class ilPdfGeneratorTest extends ilCertificateBaseTestCase
             $userCertificateRepository,
             $rpcHelper,
             $pdfFileNameFactory,
-            $language
+            $language,
+            $mathJaxHelper
         );
 
         $pdfGenerator->generate(100);

--- a/Services/Certificate/test/ilPdfGeneratorTest.php
+++ b/Services/Certificate/test/ilPdfGeneratorTest.php
@@ -130,6 +130,12 @@ class ilPdfGeneratorTest extends ilCertificateBaseTestCase
         $rpcHelper->method('ilFO2PDF')
             ->willReturn($pdf);
 
+        $mathJaxHelper = $this->getMockBuilder(ilCertificateMathJaxHelper::class)
+            ->getMock();
+
+        $mathJaxHelper->method('fillXlsFoContent')
+            ->willReturn('<xml> Some filled XML content </xml>');
+
         $pdfFileNameFactory = $this->getMockBuilder(ilCertificatePdfFileNameFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -142,7 +148,8 @@ class ilPdfGeneratorTest extends ilCertificateBaseTestCase
             $userCertificateRepository,
             $rpcHelper,
             $pdfFileNameFactory,
-            $language
+            $language,
+            $mathJaxHelper
         );
 
         $pdfGenerator->generateCurrentActiveCertificate(100, 200);


### PR DESCRIPTION
Added MathJax processing to PDF generation for real certificates, not only in preview