### PR TITLE
UI: adjust presentation table layout. (#37754, #38126)

### DIFF
--- a/src/UI/examples/Table/Presentation/base.php
+++ b/src/UI/examples/Table/Presentation/base.php
@@ -76,7 +76,7 @@ function included_data()
             'bookings_available' => '3',
             'target_group' => 'Employees, Field Service',
             'goals' => 'Lorem Ipsum....',
-            'topics' => '<li>Tranportations</li><li>Europapolice</li>',
+            'topics' => '<ul><li>Tranportations</li><li>Europapolice</li></ul>',
             'date' => '30.09.2017 - 02.10.2017',
             'location' => 'Hamburg',
             'address' => 'Hauptstraße 123',

--- a/src/UI/templates/default/Table/tpl.presentationrow.html
+++ b/src/UI/templates/default/Table/tpl.presentationrow.html
@@ -1,6 +1,6 @@
 <div class="il-table-presentation-row row collapsed" id="{ID}">
 
-	<div class="il-table-presentation-row-controls">
+	<div class="il-table-presentation-row-controls col-lg-auto col-sm-12">
 		<div class="il-table-presentation-row-controls-expander inline">
 			{EXPANDER}
 		</div>
@@ -9,75 +9,73 @@
 		</div>
 	</div>
 
+	<div class="il-table-presentation-row-contents col-lg col-sm-12">
+		<div class="row">
+			<div class="il-table-presentation-row-header col-lg col-sm-12">
 
-	<div class="il-table-presentation-row-contents">
-
-		<!-- has to be in one line so :empty selector can check if there is a button in this div -->
-		<div class="il-table-presentation-actions"><!-- BEGIN button -->{BUTTON}<br /><!-- END button --></div>
-
-		<div class="il-table-presentation-row-header">
-
-			<h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('{TOGGLE_SIGNAL}');">
-				{SYMBOL}
-				{HEADLINE}
-				<!-- BEGIN subheadline -->
-				<br />
-				<small>
-					{SUBHEADLINE}
-				</small>
-				<!-- END subheadline -->
-			</h4>
-
-			<div class="il-table-presentation-row-header-fields">
-				<div class="l-bar__container">
-				<!-- BEGIN important_field -->
-					<div class="l-bar__group">
-						<!-- BEGIN important_field_label -->
-						<div class="il-table-presentation-row-header-fields-label l-bar__element">{IMPORTANT_FIELD_LABEL}</div>
-						<!-- END important_field_label -->
-						<!-- BEGIN important_field_value -->
-						<div class="il-table-presentation-row-header-fields-value l-bar__element">{IMPORTANT_FIELD_VALUE}</div>
-						<!-- END important_field_value -->
-					</div>
-				<!-- END important_field -->
-				</div>
-				{SHY_EXPANDER}
-			</div>
-
-		</div>
-
-
-		<div class="il-table-presentation-row-expanded">
-			<div class="il-table-presentation-desclist inline<!-- BEGIN has_further_fields --> desclist-column<!-- END has_further_fields -->">
-				{DESCLIST}
-			</div>
-
-			<!-- BEGIN further_fields_section -->
-			<div class="il-table-presentation-details inline">
-
-				<div class="il-table-presentation-fields">
-					<!-- BEGIN further_fields_headline -->
-					<h5>{FURTHER_FIELDS_HEADLINE}</h5>
-					<!-- END further_fields_headline -->
-
-					<!-- BEGIN further_field -->
-					<!-- BEGIN further_field_label -->
-					<span class="il-item-property-name">
-						{FIELD_LABEL}
-					</span>
-					<!-- END further_field_label -->
-
-					<span class="il-item-property-value">
-						{FIELD_VALUE}
-					</span>
+				<h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('{TOGGLE_SIGNAL}');">
+					{SYMBOL}
+					{HEADLINE}
+					<!-- BEGIN subheadline -->
 					<br />
-					<!-- END further_field -->
+					<small>
+						{SUBHEADLINE}
+					</small>
+					<!-- END subheadline -->
+				</h4>
+
+				<div class="il-table-presentation-row-header-fields">
+					<div class="l-bar__container">
+					<!-- BEGIN important_field -->
+						<div class="l-bar__group">
+							<!-- BEGIN important_field_label -->
+							<div class="il-table-presentation-row-header-fields-label l-bar__element">{IMPORTANT_FIELD_LABEL}</div>
+							<!-- END important_field_label -->
+							<!-- BEGIN important_field_value -->
+							<div class="il-table-presentation-row-header-fields-value l-bar__element">{IMPORTANT_FIELD_VALUE}</div>
+							<!-- END important_field_value -->
+						</div>
+					<!-- END important_field -->
+					</div>
+					{SHY_EXPANDER}
 				</div>
-
 			</div>
-			<!-- END further_fields_section -->
-		</div>
 
+			<div class="il-table-presentation-actions col-lg-auto col-sm-12"><!-- BEGIN button -->{BUTTON}<br /><!-- END button --></div>
+
+			<div class="il-table-presentation-row-expanded col-lg-12 col-sm-12">
+				<div class="row">
+					<div class="il-table-presentation-desclist col-lg col-sm-12<!-- BEGIN has_further_fields --> desclist-column<!-- END has_further_fields -->">
+						{DESCLIST}
+					</div>
+
+					<!-- BEGIN further_fields_section -->
+					<div class="il-table-presentation-details col-lg-5 col-sm-12">
+
+						<div class="il-table-presentation-fields">
+							<!-- BEGIN further_fields_headline -->
+							<h5>{FURTHER_FIELDS_HEADLINE}</h5>
+							<!-- END further_fields_headline -->
+
+							<!-- BEGIN further_field -->
+							<!-- BEGIN further_field_label -->
+							<span class="il-item-property-name">
+								{FIELD_LABEL}
+							</span>
+							<!-- END further_field_label -->
+
+							<span class="il-item-property-value">
+								{FIELD_VALUE}
+							</span>
+							<br />
+							<!-- END further_field -->
+						</div>
+
+					</div>
+					<!-- END further_fields_section -->
+				</div>
+			</div>
+		</div>
 	</div>
 
 </div>

--- a/templates/default/030-tools/_tool_highlighted-box.scss
+++ b/templates/default/030-tools/_tool_highlighted-box.scss
@@ -18,7 +18,6 @@ $min-height: auto !default;
 ) {
   min-height: $min-height;
   padding: $il-padding-xxxlarge-horizontal;
-  margin-bottom: $il-margin-xxlarge-vertical;
   background-color: $background-color;
   border: $border;
   border-radius: $il-border-radius-base;

--- a/templates/default/050-layout/_layout_breakpoints.scss
+++ b/templates/default/050-layout/_layout_breakpoints.scss
@@ -48,3 +48,12 @@ $grid-breakpoints: (
     xxl: 1400px) !default;
 
 // end of section based on bootstrap 3
+
+@mixin on-screen-size($size) {
+  @if $size == small {
+    @media screen and (max-width: $screen-sm) { @content; }
+  } @else if $size == large {
+    // note that this excludes print!
+    @media screen and (min-width: $screen-sm + 1px) { @content; }
+  }
+}

--- a/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
+++ b/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
@@ -3,6 +3,8 @@
 @use "../../../030-tools/_tool_browser-prefixes" as *;
 @use "../../../050-layout/basics" as *;
 @use "../../../050-layout/layout_grid" as l-grid;
+@use "../../../030-tools/tool_highlighted-box" as box;
+@use "../../../050-layout/layout_breakpoints" as brk;
 
 $table-border-color: $il-main-border-color;
 
@@ -27,26 +29,12 @@ $il-table-presentation-details-viewcontrols-btn-bg: white;
 .il-table-presentation-row {
     background-color: $il-main-bg;
     border-top: $il-table-presentation-rowborder-top;
-    margin: 0;
-    padding-top: $il-padding-large-vertical;
-    padding-bottom: $il-padding-large-vertical;
+    padding-top: $il-padding-xxlarge-vertical;
+    padding-bottom: $il-padding-xxlarge-vertical;
     position: relative;
     white-space: nowrap;
 
-    .il-table-presentation-actions {
-        right: 10px;
-        position: absolute;
-    }
-
-    .il-table-presentation-row-controls,
-    .il-table-presentation-row-contents {
-        display: inline-block;
-        vertical-align: top;
-    }
-
     .il-table-presentation-row-controls {
-        width: $il-table-presentation-rowcontrol-colwidth;
-        padding-left: $il-padding-small-horizontal;
         .il-table-presentation-row-controls-collapser {
             display: none; /*initially hidden*/
         }
@@ -58,16 +46,6 @@ $il-table-presentation-details-viewcontrols-btn-bg: white;
 
     .il-table-presentation-row-contents {
         white-space: normal;
-        width: $il-table-presentation-contents-colwidth;
-    }
-
-    .il-table-presentation-actions {
-        margin: 5px 0;
-
-        // if there is an action, row header text should not run over action button
-        &:not(:empty) + .il-table-presentation-row-header {
-            max-width: calc(100% - 11rem);
-        }
     }
 
     .il-table-presentation-row-header {
@@ -81,8 +59,19 @@ $il-table-presentation-details-viewcontrols-btn-bg: white;
             cursor: pointer;
         }
 
+        @include brk.on-screen-size('small') {
+            order: 1;
+        }
+
         .il-table-presentation-row-header-fields {
             display: block; /*initially visible*/
+        }
+    }
+
+    .il-table-presentation-actions {
+        @include brk.on-screen-size('small') {
+            order: 3;
+            margin-top: $il-margin-xxlarge-vertical;
         }
     }
 
@@ -93,47 +82,21 @@ $il-table-presentation-details-viewcontrols-btn-bg: white;
     }
 
     .il-table-presentation-row-expanded {
-        //Using row mixin, to make this responsive
-        @include l-grid.make-row;
         display: none; /*initially hidden*/
         margin-top:  $il-margin-large-vertical;
-        margin-left: 0;
-        margin-right: 0;
 
-        .il-table-presentation-desclist {
-            //Using column mixin, to make this responsive
-            padding-right: $il-padding-small-horizontal;
-            &.desclist-column {
-                @include l-grid.media-breakpoint-up(sm) {
-                    @include l-grid.make-col(7);
-                }
-                padding-left: 0;
-            }
+        @include brk.on-screen-size('small') {
+            order: 2;
         }
 
         .il-table-presentation-details {
-            //Using column mixin, to make this responsive
-            @include l-grid.media-breakpoint-up(sm) {
-                @include l-grid.make-col(5);
-            }
             .il-table-presentation-actions {
                 margin-bottom: $il-margin-large-vertical;
             }
 
             .il-table-presentation-fields {
-                //Inherit from Bootstrap Well
+                @include box.highlighted-box();
                 min-height: 20px;
-                padding: 19px;
-                margin-bottom: 20px;
-                background-color: $il-main-darker-bg;
-                border: 1px solid $il-main-border-dark-color;
-                border-radius: $il-border-radius-base;
-                @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, .05));
-                blockquote {
-                  border-color: #ddd;
-                  border-color: rgba(0, 0, 0, .15);
-                }
-                // end of Bootstrap Well
                 font-size: $il-font-size-small;
                 .il-item-property-name {
                     color: $il-text-light-color;
@@ -147,20 +110,6 @@ $il-table-presentation-details-viewcontrols-btn-bg: white;
 // DATA TABLE
 // ==========
 //
-
-//
-// Media Query Breakdowns
-//
-
-// this should become a general tool
-@mixin on-screen-size($size) {
-    @if $size == small {
-        @media screen and (max-width: $il-grid-float-breakpoint-max) { @content; }
-    } @else if $size == large {
-        // note that this excludes print!
-        @media screen and (min-width: $il-grid-float-breakpoint-max + 1px) { @content; }
-    }
-}
 
 //
 // Basic Table Design
@@ -188,7 +137,7 @@ $il-table-presentation-details-viewcontrols-btn-bg: white;
 
 // hover row on larger screens only
 .c-table-data__row:hover td.c-table-data__cell {
-    @include on-screen-size(large) {
+    @include brk.on-screen-size(large) {
         background-color: $il-main-darker-bg;
     }
 }
@@ -200,7 +149,7 @@ $il-table-presentation-details-viewcontrols-btn-bg: white;
 th.c-table-data__cell {
     padding: 0; // most of the header cells get padding from the resize wrapper
     // sticky header on large screens
-    @include on-screen-size(large) {
+    @include brk.on-screen-size(large) {
         position: -webkit-sticky;
         position: sticky;
         top: 0;
@@ -214,7 +163,7 @@ th.c-table-data__cell {
 
 // shadow below header when sticky (because borders and box shadow are left behind in tables)
 th.c-table-data__cell:after {
-    @include on-screen-size(large) {
+    @include brk.on-screen-size(large) {
         position: absolute;
         content: "";
         left: 0;
@@ -262,7 +211,7 @@ th.c-table-data__cell:after {
 
 // shadow that sticks to the right of action column (because borders and box shadow are left behind and do not stick)
 .c-table-data__rowselection:after {
-    @include on-screen-size(large) {
+    @include brk.on-screen-size(large) {
         position: absolute;
         content: "";
         top: 0;
@@ -359,7 +308,7 @@ td.c-table-data__cell--highlighted {
 }
 // hover on larger screens only
 .c-table-data__row:hover td.c-table-data__cell--highlighted {
-    @include on-screen-size(large) {
+    @include brk.on-screen-size(large) {
         background-color: darken($il-main-darker-bg, 7%);
     }
 }
@@ -374,7 +323,7 @@ td.c-table-data__cell--highlighted {
 }
 
 .c-table-data {
-    @include on-screen-size(small) {
+    @include brk.on-screen-size(small) {
         //
         // Basic Table Design
         //

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8819,24 +8819,10 @@ div.alert ul > li:before {
 .il-table-presentation-row {
   background-color: white;
   border-top: 1px solid #dddddd;
-  margin: 0;
-  padding-top: 6px;
-  padding-bottom: 6px;
+  padding-top: 12px;
+  padding-bottom: 12px;
   position: relative;
   white-space: nowrap;
-}
-.il-table-presentation-row .il-table-presentation-actions {
-  right: 10px;
-  position: absolute;
-}
-.il-table-presentation-row .il-table-presentation-row-controls,
-.il-table-presentation-row .il-table-presentation-row-contents {
-  display: inline-block;
-  vertical-align: top;
-}
-.il-table-presentation-row .il-table-presentation-row-controls {
-  width: 5%;
-  padding-left: 6px;
 }
 .il-table-presentation-row .il-table-presentation-row-controls .il-table-presentation-row-controls-collapser {
   display: none; /*initially hidden*/
@@ -8846,13 +8832,6 @@ div.alert ul > li:before {
 }
 .il-table-presentation-row .il-table-presentation-row-contents {
   white-space: normal;
-  width: 95%;
-}
-.il-table-presentation-row .il-table-presentation-actions {
-  margin: 5px 0;
-}
-.il-table-presentation-row .il-table-presentation-actions:not(:empty) + .il-table-presentation-row-header {
-  max-width: calc(100% - 11rem);
 }
 .il-table-presentation-row .il-table-presentation-row-header {
   min-height: 2rem;
@@ -8864,61 +8843,50 @@ div.alert ul > li:before {
   margin: 0;
   cursor: pointer;
 }
+@media screen and (max-width: 768px) {
+  .il-table-presentation-row .il-table-presentation-row-header {
+    order: 1;
+  }
+}
 .il-table-presentation-row .il-table-presentation-row-header .il-table-presentation-row-header-fields {
   display: block; /*initially visible*/
+}
+@media screen and (max-width: 768px) {
+  .il-table-presentation-row .il-table-presentation-actions {
+    order: 3;
+    margin-top: 12px;
+  }
 }
 .il-table-presentation-row .il-table-presentation-row-header-fields-label::after,
 .il-table-presentation-row .il-table-presentation-desclist .il-listing-characteristic-value-label::after {
   content: ":";
 }
 .il-table-presentation-row .il-table-presentation-row-expanded {
-  --bs-gutter-x: 30px;
-  --bs-gutter-y: 0;
-  display: flex;
-  flex-wrap: wrap;
-  margin-top: calc(-1 * var(--bs-gutter-y));
-  margin-right: calc(-0.5 * var(--bs-gutter-x));
-  margin-left: calc(-0.5 * var(--bs-gutter-x));
   display: none; /*initially hidden*/
   margin-top: 6px;
-  margin-left: 0;
-  margin-right: 0;
 }
-.il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-desclist {
-  padding-right: 6px;
-}
-.il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-desclist.desclist-column {
-  padding-left: 0;
-}
-@media (min-width: 480px) {
-  .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-desclist.desclist-column {
-    flex: 0 0 auto;
-    width: 58.3333333333%;
-  }
-}
-@media (min-width: 480px) {
-  .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details {
-    flex: 0 0 auto;
-    width: 41.6666666667%;
+@media screen and (max-width: 768px) {
+  .il-table-presentation-row .il-table-presentation-row-expanded {
+    order: 2;
   }
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-actions {
   margin-bottom: 6px;
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields {
-  min-height: 20px;
-  padding: 19px;
-  margin-bottom: 20px;
+  min-height: auto;
+  padding: 18px;
   background-color: #f0f0f0;
-  border: 1px solid #757575;
+  border: 1px solid #dddddd;
   border-radius: 0px;
+  text-color: white;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  min-height: 20px;
   font-size: 0.75rem;
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields blockquote {
-  border-color: #ddd;
-  border-color: rgba(0, 0, 0, 0.15);
+  border-color: #dddddd;
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields .il-item-property-name {
   color: #6f6f6f;
@@ -10196,7 +10164,6 @@ div.il_info {
 .well {
   min-height: auto;
   padding: 18px;
-  margin-bottom: 12px;
   background-color: #f0f0f0;
   border: 1px solid #dddddd;
   border-radius: 0px;
@@ -10211,7 +10178,6 @@ div.il_info {
 .php {
   min-height: auto;
   padding: 18px;
-  margin-bottom: 12px;
   background-color: #f9f9f9;
   border: 1px solid #dddddd;
   border-radius: 0px;

--- a/tests/UI/Component/Table/PresentationTest.php
+++ b/tests/UI/Component/Table/PresentationTest.php
@@ -151,7 +151,7 @@ class PresentationTest extends TableTestBase
     <div class="il-table-presentation-data">
         <div class="il-table-presentation-row row collapsed" id="id_4">
 
-            <div class="il-table-presentation-row-controls">
+            <div class="il-table-presentation-row-controls col-lg-auto col-sm-12">
                 <div class="il-table-presentation-row-controls-expander inline">
                     <a tabindex="0" class="glyph" href="#" aria-label="expand_content" id="id_5">
                         <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
@@ -164,48 +164,51 @@ class PresentationTest extends TableTestBase
                 </div>
             </div>
 
-            <div class="il-table-presentation-row-contents">
-                <div class="il-table-presentation-actions"><button class="btn btn-default" data-action="#" id="id_8">do</button><br /></div>
-                <div class="il-table-presentation-row-header">
-                    <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title<br /><small>some type</small>
-                    </h4>
-                    <div class="il-table-presentation-row-header-fields">
-                        <div class="l-bar__container">
-                            <div class="l-bar__group">
-                                <div class="il-table-presentation-row-header-fields-value l-bar__element">important-1</div>
+            <div class="il-table-presentation-row-contents col-lg col-sm-12">
+                <div class="row">
+                   <div class="il-table-presentation-row-header col-lg col-sm-12">
+                       <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title<br /><small>some type</small>
+                       </h4>
+                       <div class="il-table-presentation-row-header-fields">
+                          <div class="l-bar__container">
+                              <div class="l-bar__group">
+                                  <div class="il-table-presentation-row-header-fields-value l-bar__element">important-1</div>
+                              </div>
+                              <div class="l-bar__group">
+                                  <div class="il-table-presentation-row-header-fields-value l-bar__element">important-2</div>
+                              </div>
+                          </div>
+                          <button class="btn btn-link" id="id_7">presentation_table_more</button>
+                       </div>
+                   </div>
+                   <div class="il-table-presentation-actions col-lg-auto col-sm-12">
+                        <button class="btn btn-default" data-action="#" id="id_8">do</button><br />
+                   </div>
+                   <div class="il-table-presentation-row-expanded col-lg-12 col-sm-12">
+                        <div class="row">
+                            <div class="il-table-presentation-desclist col-lg col-sm-12 desclist-column">
+                                <dl>
+                                   <dt>1st</dt>
+                                   <dd>first content</dd>
+                                   <dt>2nd</dt>
+                                   <dd>second content</dd>
+                                </dl>
                             </div>
-                            <div class="l-bar__group">
-                                <div class="il-table-presentation-row-header-fields-value l-bar__element">important-2</div>
+                            <div class="il-table-presentation-details col-lg-5 col-sm-12">
+                                <div class="il-table-presentation-fields">
+                                    <h5>further fields</h5>
+                                    <span class="il-item-property-name">f-1</span>
+                                    <span class="il-item-property-value">further</span>
+                                    <br />
+                                    <span class="il-item-property-name">f-2</span>
+                                    <span class="il-item-property-value">way further</span>
+                                    <br />
+                                </div>
                             </div>
                         </div>
-                        <button class="btn btn-link" id="id_7">presentation_table_more</button>
-                    </div>
+                   </div>
                 </div>
-
-                <div class="il-table-presentation-row-expanded">
-                    <div class="il-table-presentation-desclist inline desclist-column">
-                        <dl>
-                            <dt>1st</dt>
-                            <dd>first content</dd>
-                            <dt>2nd</dt>
-                            <dd>second content</dd>
-                        </dl>
-                    </div>
-                    
-                    <div class="il-table-presentation-details inline">
-                        <div class="il-table-presentation-fields">
-                            <h5>further fields</h5>
-                            <span class="il-item-property-name">f-1</span>
-                            <span class="il-item-property-value">further</span>
-                            <br />
-                            <span class="il-item-property-name">f-2</span>
-                            <span class="il-item-property-value">way further</span>
-                            <br />
-                        </div>
-                    </div>
-                </div>
-
-            </div>
+            </div>       
         </div>
     </div>
 </div>
@@ -249,7 +252,7 @@ EXP;
     <div class="il-table-presentation-data">
         <div class="il-table-presentation-row row collapsed" id="id_4">
 
-            <div class="il-table-presentation-row-controls">
+            <div class="il-table-presentation-row-controls col-lg-auto col-sm-12">
                 <div class="il-table-presentation-row-controls-expander inline">
                     <a tabindex="0" class="glyph" href="#" aria-label="expand_content" id="id_5">
                         <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
@@ -262,23 +265,27 @@ EXP;
                 </div>
             </div>
 
-            <div class="il-table-presentation-row-contents">
-                <div class="il-table-presentation-actions"></div>
-                <div class="il-table-presentation-row-header">
-                    <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title</h4>
-                    <div class="il-table-presentation-row-header-fields">
-                        <div class="l-bar__container"></div>
-                        <button class="btn btn-link" id="id_7">presentation_table_more</button>
+            <div class="il-table-presentation-row-contents col-lg col-sm-12">
+                <div class="row">
+                    <div class="il-table-presentation-row-header col-lg col-sm-12">
+                        <h4 class="il-table-presentation-row-header-headline" onClick="$(document).trigger('il_signal...');">some title</h4>
+                        <div class="il-table-presentation-row-header-fields">
+                            <div class="l-bar__container"></div>
+                            <button class="btn btn-link" id="id_7">presentation_table_more</button>
+                        </div>
                     </div>
-                </div>
-                <div class="il-table-presentation-row-expanded">
-                    <div class="il-table-presentation-desclist inline">
-                        <dl>
-                            <dt>1st</dt>
-                            <dd>first content</dd>
-                            <dt>2nd</dt>
-                            <dd>second content</dd>
-                        </dl>
+                    <div class="il-table-presentation-actions col-lg-auto col-sm-12"></div>
+                    <div class="il-table-presentation-row-expanded col-lg-12 col-sm-12">
+                        <div class="row">
+                            <div class="il-table-presentation-desclist col-lg col-sm-12">
+                                <dl>
+                                    <dt>1st</dt>
+                                    <dd>first content</dd>
+                                    <dt>2nd</dt>
+                                    <dd>second content</dd>
+                                </dl>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38126
https://mantis.ilias.de/view.php?id=37754

Following issues were fixed =>

1. Correction of missing ul html in example
2. Setting cols and rows for presentation table layout in the template to get correct cols and widths
3. Deletion of margins and widths in children and also some paddings
4. Set order of elements depending on screen size
5. Moving 'on-screen-size' mixin to tool 'layout_breakpoint' 
6. Remove 'margin-bottom' from highlighted_box' tool as it shouldn't be set there
7. Adjust presentation table tests

Old layout desktop:
![pres-table-old-desktop](https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/6c5c2f38-939f-494f-b79c-1973dc306a8f)

New layout desktop:
![pres-table-new-desktop](https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/df406628-10b6-40a4-9b1c-48f2e3432fcb)

Old layout mobile:
<img width="310" alt="pres-table-old-mobile" src="https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/9899aae9-e225-4596-bccc-6c69c69a1b51">

New layout mobile:
![pres-table-new-mobile-2](https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/ea75ac74-f3d9-4398-b646-b4116d31e0c8)
![pres-table-new-mobile](https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/87f47361-0f91-4121-a95c-88823e73b29d)

This implementation was discussed with @catenglaender . We decided to solve both mantis tickets in one PR to avoid partly duplicated implementations.