### PR TITLE
UI: adjust position and width of column(s) in bulk action of the book…

### DIFF
--- a/templates/default/070-components/legacy/Services/UIComponent/_component_toolbar.scss
+++ b/templates/default/070-components/legacy/Services/UIComponent/_component_toolbar.scss
@@ -208,7 +208,7 @@ $il-toolbar-border: 1px solid $il-main-border-color !default;
 		padding: 0;
 	}
 
-	.form-control {
+	> .form-control {
 		width: auto;
 		display: inline-block;
 		vertical-align: middle;
@@ -347,14 +347,6 @@ $il-toolbar-border: 1px solid $il-main-border-color !default;
 			}
 		}
 	}
-}
-
-.ilToolbar .navbar-form .modal .radio {
-	display: block;
-}
-
-.ilToolbar .navbar-form .modal .form-group {
-	display: block;
 }
 
 //

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -18031,7 +18031,7 @@ a.ilMediaLightboxClose:hover {
 .ilToolbar .ilToolbarItems {
   padding: 0;
 }
-.ilToolbar .form-control {
+.ilToolbar > .form-control {
   width: auto;
   display: inline-block;
   vertical-align: middle;
@@ -18134,14 +18134,6 @@ a.ilMediaLightboxClose:hover {
     padding-left: 0;
   }
 }
-.ilToolbar .navbar-form .modal .radio {
-  display: block;
-}
-
-.ilToolbar .navbar-form .modal .form-group {
-  display: block;
-}
-
 .navbar {
   position: relative;
   min-height: 40px;


### PR DESCRIPTION
…ing pool modal. (#38840)

https://mantis.ilias.de/view.php?id=38840
https://mantis.ilias.de/view.php?id=38921

Old layout:
![bulk-style-modal-booking-pool](https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/d2ffd78e-f5d3-4bbc-97cb-5edeadef910d)

New layout:
![booking-pool_bulk-modal-new](https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/87d08745-8cf3-4897-95dd-74a0a813dceb)

Notice: The labels should not be full width as suggested first as they are part of the legacy ui and therefore in a column directly beside the input field. The issue was a false display setting in the "old" layout. Now the label + input fields are positioned correctly. 

This implementation was discussed with @catenglaender today.