### PR TITLE
StudyProgramme: fix internal links in custom md (28060)

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
@@ -32,6 +32,7 @@ require_once("./Services/Repository/classes/class.ilRepUtil.php");
  * @ilCtrl_Calls ilObjStudyProgrammeGUI: ilObjectTranslationGUI
  * @ilCtrl_Calls ilObjStudyProgrammeGUI: ilCertificateGUI
  * @ilCtrl_Calls ilObjStudyProgrammeGUI: ilObjStudyProgrammeAutoCategoriesGUI
+ * @ilCtrl_Calls ilObjStudyProgrammeGUI: ilPropertyFormGUI
  */
 
 class ilObjStudyProgrammeGUI extends ilContainerGUI
@@ -296,6 +297,24 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI
                 $guiFactory = new ilCertificateGUIFactory();
                 $output_gui = $guiFactory->create($this->object);
                 $this->ctrl->forwardCommand($output_gui);
+                break;
+            case strtolower(ilPropertyFormGUI::class):
+                /*
+                 * Only used for async loading of the repository tree in custom md
+                 * internal links (see #28060, #37974). This is necessary since StudyProgrammes don't
+                 * use ilObjectMetaDataGUI.
+                 */
+                $form = $this->initAdvancedSettingsForm();
+                $gui = new ilAdvancedMDRecordGUI(
+                    ilAdvancedMDRecordGUI::MODE_EDITOR,
+                    'prg',
+                    $this->object->getId(),
+                    'prg_type',
+                    $this->object->getSettings()->getTypeSettings()->getTypeId()
+                );
+                $gui->setPropertyForm($form);
+                $gui->parse();
+                $this->ctrl->forwardCommand($form);
                 break;
             case false:
                 $this->getSubTabs($cmd);


### PR DESCRIPTION
This PR fixes [28060](https://mantis.ilias.de/view.php?id=28060) by having `ilObjStudyProgrammeGUI` forward commands to `ilPropertyFormGUI`, similar to #6690.