### PR TITLE
Exceptions: Fix `Plain Text` error handler

### DIFF
--- a/Services/Exceptions/classes/class.ilPlainTextHandler.php
+++ b/Services/Exceptions/classes/class.ilPlainTextHandler.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,7 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-use Whoops\Handler\Handler;
+declare(strict_types=1);
+
 use Whoops\Exception\Formatter;
 
 /**
@@ -26,44 +25,24 @@ use Whoops\Exception\Formatter;
  * This is used for better coexistence with xdebug, see #16627.
  * @author Richard Klees <richard.klees@concepts-and-training.de>
  */
-class ilPlainTextHandler extends Handler
+class ilPlainTextHandler extends \Whoops\Handler\PlainTextHandler
 {
     protected const KEY_SPACE = 25;
 
-    /**
-     * Last missing method from HandlerInterface.
-     */
-    public function handle(): ?int
+    private function stripNullBytes(string $ret): string
     {
-        header("Content-Type: text/plain");
-        echo "<pre>\n";
-        echo $this->content();
-        echo "</pre>\n";
-        return null;
+        return str_replace("\0", '', $ret);
     }
 
-    /**
-     * Assemble the output for this handler.
-     */
-    protected function content(): string
+    public function generateResponse(): string
     {
-        return $this->pageHeader()
-            . $this->exceptionContent()
-            . $this->tablesContent();
-    }
-
-    /**
-     * Get the header for the page.
-     */
-    protected function pageHeader(): string
-    {
-        return "";
+        return $this->getExceptionOutput() . $this->tablesContent() . "\n";
     }
 
     /**
      * Get a short info about the exception.
      */
-    protected function exceptionContent(): string
+    protected function getExceptionOutput(): string
     {
         return Formatter::formatExceptionPlain($this->getInspector());
     }
@@ -104,7 +83,8 @@ class ilPlainTextHandler extends Handler
                 $ret .= "empty\n";
             }
         }
-        return $ret;
+
+        return $this->stripNullBytes($ret);
     }
 
     /**

--- a/Services/Exceptions/classes/class.ilTestingHandler.php
+++ b/Services/Exceptions/classes/class.ilTestingHandler.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 /**
  * A Whoops error handler for testing.
  * This yields the same output as the plain text handler, but prints a nice message to the tester on top of
@@ -26,20 +26,9 @@ declare(strict_types=1);
  */
 class ilTestingHandler extends ilPlainTextHandler
 {
-    /**
-     * Get the header for the page.
-     */
-    protected function pageHeader(): string
+    public function generateResponse(): string
     {
-        return "DEAR TESTER! AN ERROR OCCURRED... PLEASE INCLUDE THE FOLLOWING OUTPUT AS ADDITIONAL INFORMATION IN YOUR BUG REPORT.\n\n";
-    }
-
-    /**
-     * Assemble the output for this handler.
-     */
-    protected function content(): string
-    {
-        return $this->pageHeader()
-            . $this->exceptionContent();
+        return "DEAR TESTER! AN ERROR OCCURRED... PLEASE INCLUDE THE FOLLOWING OUTPUT AS ADDITIONAL INFORMATION IN YOUR BUG REPORT.\n\n"
+            . $this->getExceptionOutput();
     }
 }


### PR DESCRIPTION
This commit fixes the `Plain Text` error handler. It is broken since
ILIAS overwrites the super global variables. When transforming those
back to arrays for debugging/output purposes, `NULL` bytes are introduced.
This breaks the HTTP response.
Furthermore, this commit fixes the `ilDelegationHandler` by also
returning the return value of `handle` of the current `HandlerInterface`
to the caller. The same applies for the `contentType` value provided by
the actual/wrapped handler.

If approved, this has to be picked to `trunk` and `release_8`.

See: https://mantis.ilias.de/view.php?id=39316