### PR TITLE
Composer: Add filp/whoops  as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"filp/whoops": "^2.15.4",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `filp/whoops ` as composer dependency.

Usage:
* Used for formatting error messages for consumation by developers via browser and for error reports.

Wrapped By:
* Not applicable. This is used in error handling code that does not provide interfaces to other ILIAS code.

Reasoning:
* `filp/whoops` is a mature and stable library that produces comprehensible output of errors, exceptions and the environment they have been created in. Good error reporting boosts productivity of developers and admins alike.

Maintenance:
* The library and its are stable for a long time now. Major version hasn't been bumped for > 7 years now.
* Patch version is bumped regularly to deliver fixes. Last version has been published 2023-11-03. Hence maintenance seems to be stable.
* There is a corporate sponsor of this library.

Links:
* Packagist: https://packagist.org/packages/filp/whoops
* GitHub: https://github.com/filp/whoops