### PR TITLE
Composer: Add pimple/pimple as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"pimple/pimple" : "^3.0",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `pimple/pimple` as composer dependency.

Usage:
* Provides the dependency injection container that is used as a service locator throughout the system.
* Will most likely be used as the DIC solution for the new initialisation scheme introduced with the [component revision](docs/development/components-and-directories.md).

Wrapped By:
* ILIAS\DI\Container

Reasoning:
* Pimple provides a light weight and simple dependency injection container, which is yet quite powerful. The interface is modelled along \ArrayAccess, hence it can be easily mocked for testing.
* Dependency injection is ILIAS' future way to express dependencies between services and components.

Maintenance:
* The library has been stable for a long time and didn't receive updates since 2021.
* The actual code is only about 150 LOC and hence could be easily maintained by us, if necessary.

Links:
* Packagist: https://packagist.org/packages/pimple/pimple
* GitHub: https://github.com/silexphp/Pimple