### PR TITLE
Composer: Add symfony/console as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"symfony/console" : "^7.0",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `symfony/console` as composer dependency.

Usage:
* Provides the TUI for the setup console application.

Wrapped By:
* Not applicable, functionality is only used internally in the setup and not provided to other ILIAS components.

Reasoning:
* The library can provide nice interfaces for console applications. The setup is the first thing administrators will encounter when installing ILIAS, hence we should try to look and feel good there to not put people off.
* The library only provides plumbing to access actual setup functionality, the setup only depends on the library for its user interface. Usage of the library is encapsulate tightly.

Maintenance:
* The library is under active development. 7.0.1 has been released 2023-12-01.
* The library is part of the Symfony-Framework, a widely used framework which is backed by an active community and various companies.

Links:
* Packagist: https://packagist.org/packages/symfony/console
* GitHub: https://github.com/symfony/console
* Documentation: https://symfony.com/doc/current/console.html