### PR TITLE
Composer: Add phpunit/phpunit as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -46,6 +46,7 @@
 		"ext-imagick": "*",
 	},
 	"require-dev": {
+		"phpunit/phpunit": "^10.5",
 	},
 	"autoload": {
 		"psr-4" : {


### PR DESCRIPTION
This PR adds `phpunit/phpunit` as composer dependency.

Usage:
* We use it to run unit tests.

Wrapped By:
* Not applicable, provides the binary and classes for test management.

Reasoning:
* Its the standard PHP testing framework.

Maintenance:
* Won't go away any time soon.

Links:
* Documentation: https://phpunit.de