### PR TITLE
Composer: Add friendsofphp/php-cs-fixer as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -46,6 +46,7 @@
 		"ext-imagick": "*",
 	},
 	"require-dev": {
+		"friendsofphp/php-cs-fixer": "^3.40",
 	},
 	"autoload": {
 		"psr-4" : {


### PR DESCRIPTION
This PR adds `friendsofphp/php-cs-fixer ` as composer dependency.

Usage:
* Used in CI and dev processes to check and correct coding style.

Wrapped By:
* Not applicable, provides the binary and classes for cs-fixing.

Reasoning:
* We need some cli-tool to check and correct coding style.

Maintenance:
* The library is under active maintenance.
* It would be non-critical (although quite sad...) to lose this lib.

Links:
* Packagist: https://packagist.org/packages/friendsofphp/php-cs-fixer
* GitHub: github.com/PHP-CS-Fixer/PHP-CS-Fixer