### PR TITLE
Composer: getid3 lib

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"james-heinrich/getid3": "^1.9.23"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Usage:

The lib provides  methods to extract media length from common media files like mp3 or mp4.

Wrapped By:

components/ILIAS/MediaObjects (used internally)

Reasoning:

The length of media files is being presented in several views, e.g. the mediacasts. Entering this value manually would downgrade user experience when creating the media objects.

Maintenance:

The lib is on github since > 10 years, always got maintenance (last changes a month ago), has around 50 contributors, James Heinrich is still the main contributor

Links:

Packagist: https://packagist.org/packages/james-heinrich/getid3
GitHub: https://github.com/JamesHeinrich/getID3
