### PR TITLE
LegalDocuments: Add default radio option

### DIFF
--- a/Services/DataProtection/classes/class.ilObjDataProtectionGUI.php
+++ b/Services/DataProtection/classes/class.ilObjDataProtectionGUI.php
@@ -173,8 +173,8 @@ final class ilObjDataProtectionGUI extends ilObject2GUI
             'type' => $this->radio('mode', [
                 'once' => 'once',
                 'eval_on_login' => 'reevaluate_on_login',
-                'no_acceptance' => 'no_acceptance'
-            ])->withRequired(true),
+                'no_acceptance' => 'no_acceptance',
+            ])->withValue('once')->withRequired(true),
         ]);
 
         $enabled = $enabled->withValue($this->data_protection_settings->enabled()->value() ? [
@@ -215,7 +215,7 @@ final class ilObjDataProtectionGUI extends ilObject2GUI
         );
     }
 
-    private function radio(string $prefix, $options): Component
+    private function radio(string $prefix, array $options): Component
     {
         $field = $this->ui->create()->input()->field()->radio($this->ui->txt($prefix), $this->ui->txt($prefix . '_desc'));
         foreach ($options as $key => $label) {

--- a/Services/LegalDocuments/classes/Administration.php
+++ b/Services/LegalDocuments/classes/Administration.php
@@ -226,10 +226,12 @@ class Administration
     public function criterionForm(string $url, $criterion = null)
     {
         $groups = $this->config->legalDocuments()->document()->conditionGroups($criterion);
-        $group = $this->ui->create()->input()->field()->switchableGroup($groups, $this->ui->txt('form_criterion'));
-        if ($criterion) {
-            $group = $group->withValue($criterion->type());
+        $group = $this->ui->create()->input()->field()->switchableGroup($groups->choices(), $this->ui->txt('form_criterion'));
+        $value = $criterion ? $criterion->type() : $groups->defaultSelection();
+        if ($value) {
+            $group = $group->withValue($value);
         }
+
         return $this->ui->create()->input()->container()->form()->standard($url, [
             'content' => $group,
         ]);

--- a/Services/LegalDocuments/classes/Condition/Definitions/RoleDefinition.php
+++ b/Services/LegalDocuments/classes/Condition/Definitions/RoleDefinition.php
@@ -48,13 +48,13 @@ class RoleDefinition implements ConditionDefinition
     {
         $roles = $this->review->getGlobalRoles();
         $roles = array_combine($roles, array_map($this->translatedRole(...), $roles));
-
+        $default_role = isset($roles[SYSTEM_ROLE_ID]) ? SYSTEM_ROLE_ID : key($roles);
 
         return $this->ui->create()->input()->field()->group([
             'role_id' => $this->radio(
                 $this->ui->txt('perm_global_role'),
                 $roles,
-                $arguments['role_id'] ?? null
+                $arguments['role_id'] ?? $default_role
             )->withRequired(true, ($this->required)($roles)),
         ], $this->ui->txt('crit_type_usr_global_role'), $this->ui->txt('crit_type_usr_global_role_info'));
     }

--- a/Services/LegalDocuments/classes/Condition/Definitions/UserLanguageDefinition.php
+++ b/Services/LegalDocuments/classes/Condition/Definitions/UserLanguageDefinition.php
@@ -46,12 +46,13 @@ class UserLanguageDefinition implements ConditionDefinition
     public function formGroup(array $arguments = []): Group
     {
         $languages = array_combine($this->installed_languages, array_map($this->translatedLanguage(...), $this->installed_languages));
+        $default = key($languages);
 
         return $this->ui->create()->input()->field()->group([
             'lng' => $this->radio(
                 $this->ui->txt('language'),
                 $languages,
-                $arguments['lng'] ?? null
+                $arguments['lng'] ?? $default
             )->withRequired(true, ($this->required)($languages))
         ], $this->ui->txt('crit_type_usr_language'), $this->ui->txt('crit_type_usr_language_info'));
     }

--- a/Services/LegalDocuments/classes/DefaultMappings.php
+++ b/Services/LegalDocuments/classes/DefaultMappings.php
@@ -35,7 +35,10 @@ class DefaultMappings
     ) {
     }
 
-    public function conditionDefinitions(): array
+    /**
+     * @return SelectionMap<ConditionDefinition>
+     */
+    public function conditionDefinitions(): SelectionMap
     {
         $ui = new UI(
             $this->id,
@@ -52,11 +55,11 @@ class DefaultMappings
             static fn(): string => $ui->txt('msg_input_is_required')
         );
 
-        return [
+        return new SelectionMap([
             'usr_global_role' => new RoleDefinition($ui, $this->container['ilObjDataCache'], $this->container->rbac()->review(), $required),
             'usr_language' => new UserLanguageDefinition($ui, $this->container->language()->getInstalledLanguages(), $required),
             'usr_country' => new UserCountryDefinition($ui, $required),
-        ];
+        ], 'usr_country');
     }
 
     public function contentAsComponent(): array

--- a/Services/LegalDocuments/classes/SelectionMap.php
+++ b/Services/LegalDocuments/classes/SelectionMap.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\LegalDocuments;
+
+/**
+ * @template A
+ */
+class SelectionMap
+{
+    private readonly ?string $default_selection;
+
+    /**
+     * @param array<string, A> $conditions
+     */
+    public function __construct(
+        private readonly array $conditions = [],
+        ?string $default_selection = null
+    ) {
+        $this->default_selection = $default_selection ?? key($this->conditions);
+    }
+
+    /**
+     * @return array<string, A>
+     */
+    public function choices(): array
+    {
+        return $this->conditions;
+    }
+
+    public function defaultSelection(): ?string
+    {
+        return $this->default_selection;
+    }
+}

--- a/Services/LegalDocuments/classes/SlotConstructor.php
+++ b/Services/LegalDocuments/classes/SlotConstructor.php
@@ -60,10 +60,10 @@ class SlotConstructor
     }
 
     /**
-     * @param array<string, ConditionDefinition> $conditions
+     * @param SelectionMap<ConditionDefinition> $conditions
      * @param array<string, Closure(DocumentContent): Component $content_as_component
      */
-    public function document(DocumentRepository $document_repository, array $conditions, array $content_as_component): ProvideDocument
+    public function document(DocumentRepository $document_repository, SelectionMap $conditions, array $content_as_component): ProvideDocument
     {
         return new ProvideDocument($this->id(), $document_repository, $conditions, $content_as_component, $this->container);
     }

--- a/Services/LegalDocuments/classes/UseSlot.php
+++ b/Services/LegalDocuments/classes/UseSlot.php
@@ -53,9 +53,9 @@ interface UseSlot
 
     /**
      * @param array<string, callable(DocumentContent): Component> $content_as_component
-     * @param array<string, ConditionDefinition> $available_conditions
+     * @param null|SelectionMap<ConditionDefinition> $available_conditions
      */
-    public function hasDocuments(array $content_as_component = [], array $available_conditions = []): self;
+    public function hasDocuments(array $content_as_component = [], ?SelectionMap $available_conditions = null): self;
 
     /**
      * @param callable(ilObjUser): array<string, string|ilNonEditableValueGUI> $fields

--- a/Services/LegalDocuments/classes/Wiring.php
+++ b/Services/LegalDocuments/classes/Wiring.php
@@ -125,8 +125,9 @@ class Wiring implements UseSlot
         return $this->addTo('use-soap-api', $constraint);
     }
 
-    public function hasDocuments(array $content_as_component = [], array $available_conditions = []): self
+    public function hasDocuments(array $content_as_component = [], ?SelectionMap $available_conditions = null): self
     {
+        $available_conditions = $available_conditions ?? new SelectionMap();
         $repository = $this->slot->documentRepository();
         $document = $this->slot->document($this->slot->readOnlyDocuments($repository), $available_conditions, $content_as_component);
 

--- a/Services/LegalDocuments/test/Condition/Definitions/RoleDefinitionTest.php
+++ b/Services/LegalDocuments/test/Condition/Definitions/RoleDefinitionTest.php
@@ -49,6 +49,10 @@ class RoleDefinitionTest extends TestCase
 
     public function testFormGroup(): void
     {
+        if (!defined('SYSTEM_ROLE_ID')) {
+            define('SYSTEM_ROLE_ID', 2);
+        }
+
         $instance = new RoleDefinition(
             $this->mock(UI::class),
             $this->mock(ilObjectDataCache::class),

--- a/Services/LegalDocuments/test/DefaultMappingsTest.php
+++ b/Services/LegalDocuments/test/DefaultMappingsTest.php
@@ -61,7 +61,9 @@ class DefaultMappingsTest extends TestCase
         $container->method('offsetGet')->with('ilObjDataCache')->willReturn($this->mock(ilObjectDataCache::class));
 
         $instance = new DefaultMappings('foo', $container);
-        $definitions = $instance->conditionDefinitions();
+        $result = $instance->conditionDefinitions();
+        $definitions = $result->choices();
+        $this->assertSame('usr_country', $result->defaultSelection());
         $this->assertSame(3, count($definitions));
         $this->assertInstanceOf(RoleDefinition::class, $definitions['usr_global_role']);
         $this->assertInstanceOf(UserLanguageDefinition::class, $definitions['usr_language']);

--- a/Services/LegalDocuments/test/SlotConstructorTest.php
+++ b/Services/LegalDocuments/test/SlotConstructorTest.php
@@ -31,6 +31,7 @@ use ILIAS\DI\Container;
 use ILIAS\LegalDocuments\test\ContainerMock;
 use PHPUnit\Framework\TestCase;
 use ILIAS\LegalDocuments\SlotConstructor;
+use ILIAS\LegalDocuments\SelectionMap;
 
 require_once __DIR__ . '/ContainerMock.php';
 
@@ -58,7 +59,7 @@ class SlotConstructorTest extends TestCase
     public function testDocument(): void
     {
         $instance = new SlotConstructor('foo', $this->mock(Container::class), $this->mock(UserAction::class));
-        $this->assertInstanceOf(ProvideDocument::class, $instance->document($this->mock(DocumentRepository::class), [], []));
+        $this->assertInstanceOf(ProvideDocument::class, $instance->document($this->mock(DocumentRepository::class), new SelectionMap(), []));
     }
 
     public function testDocumentRepository(): void

--- a/Services/LegalDocuments/test/WiringTest.php
+++ b/Services/LegalDocuments/test/WiringTest.php
@@ -31,6 +31,7 @@ use ILIAS\LegalDocuments\Map;
 use ILIAS\LegalDocuments\SlotConstructor;
 use PHPUnit\Framework\TestCase;
 use ILIAS\LegalDocuments\Wiring;
+use ILIAS\LegalDocuments\SelectionMap;
 
 require_once __DIR__ . '/ContainerMock.php';
 
@@ -161,7 +162,7 @@ class WiringTest extends TestCase
     public function testHasDocuments(): void
     {
         $instance = new Wiring($this->mock(SlotConstructor::class), new Map());
-        $map = $instance->hasDocuments([], [])->map()->value();
+        $map = $instance->hasDocuments([], new SelectionMap())->map()->value();
 
         $this->assertSame([
             'document',


### PR DESCRIPTION
Fix mantis bug: https://mantis.ilias.de/view.php?id=38986.
This PR adds default selections to all radio fields in `Services/LegalDocuments/`, `Services/DataProtection` and `Services/TermsOfService`.