### PR TITLE
Composer: Add `ramsey/uuid` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"ramsey/uuid": "^4.4.0",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `ramsey/uuid` as composer dependency.

Usage:
* `\ilObjCertificateSettings`
* `\ilPCSourceCodeGUI`
* `component/ILIAS/ResourceStorage`

Wrapped By:
* `\ILIAS\Data\UUID\RamseyUuidWrapper`

Reasoning:
* `ramsey/uuid` With 395,811,539 usages and 12,430 stars on packagist, ramsy is the most widely used library for creating UUIDs and is the basis for many other implementations.

Maintenance:
* `ramsey/uuid` is actively maintained by multiple contributors. There is recent activity in past weeks: https://github.com/ramsey/uuid/commits/4.x.

Links:
* Packagist: https://packagist.org/packages/ramsey/uuid
* GitHub: https://github.com/ramsey/uuid
* Documentation: https://uuid.ramsey.dev/en/stable/