### PR TITLE
NPM: Add `chai` as dependency

### DIFF
--- a/public/package_new.json
+++ b/public/package_new.json
@@ -10,6 +10,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "chai": "^4.2.0",
   },
   "scripts": {
     "test": "mocha --recursive"


### PR DESCRIPTION
This PR adds `chai` as npm package.

Usage:
* Multiple (see e.g. `components/ILIAS/UI/tests/Client/`)

Wrapped By:
* Not applicable

Reasoning:
* This package is used as an assertion library in combination with `mocha` for JavaScript unit tests.

Maintenance:
* The package is actively maintained, see https://github.com/chaijs/chai/releases

Links:
* Packagist: https://www.npmjs.com/package/chai
* GitHub: https://github.com/chaijs/chai
* Documentation: https://www.chaijs.com/guide/