### PR TITLE
NPM: Add `eslint-config-airbnb-base` as dependency

### DIFF
--- a/public/package_new.json
+++ b/public/package_new.json
@@ -10,6 +10,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "eslint-config-airbnb-base": "^15.0.0",
   },
   "scripts": {
     "test": "mocha --recursive"


### PR DESCRIPTION
This PR adds `eslint-config-airbnb-base` as npm package.

Usage:
* `.eslintrc.json`

Wrapped By:
* Not applicable

Reasoning:
* This package provides the airbnb code-style configuration for the `eslint` package.

Maintenance:
* The package is not actively maintained (last release 2021), see https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/CHANGELOG.md.
* I think this package does not need much maintenance, as it mostly provides the configuration for the `eslint` package.

Links:
* Packagist: https://www.npmjs.com/package/eslint-config-airbnb-base
* GitHub: https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base
* Documentation: https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/README.md