### PR TITLE
NPM: Add `eslint-plugin-import` as dependency

### DIFF
--- a/public/package_new.json
+++ b/public/package_new.json
@@ -10,6 +10,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "eslint-plugin-import": "^2.27.5",
   },
   "scripts": {
     "test": "mocha --recursive"


### PR DESCRIPTION
This PR adds `eslint-plugin-import` as npm package.

Usage:
* Airbnb code-style base

Wrapped By:
* Not applicable

Reasoning:
* This package is responsible to validate import/export statements and is primarily used by the Airbnb code-style base (`eslint-config-airbnb-base`).

Maintenance:
* The package is actively maintained, see https://github.com/import-js/eslint-plugin-import/releases

Links:
* Packagist: https://www.npmjs.com/package/eslint-plugin-import
* GitHub: https://github.com/import-js/eslint-plugin-import
* Documentation: https://github.com/import-js/eslint-plugin-import/blob/main/README.md