### PR TITLE
Composer: Add `league/commonmark` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"league/commonmark": "^2.4",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `league/commonmark` as composer package.

Usage:
* `ilUIMarkdownPreviewGUI`

Wrapped By:
* `ILIAS\UI\Component\Input\Field\MarkdownRenderer`

Reasoning:
* This package is used to compile markdown text into HTML. There is a new markdown editor, which expects a `MarkdownRenderer` wrapper for a library like this. I suggested this library back then, because of its flexibility and ability to add custom markdown flavours easily.

Maintenance:
* The package is actively maintained, see https://github.com/thephpleague/commonmark/releases

Links:
* Packagist: https://packagist.org/packages/league/commonmark
* GitHub: https://github.com/thephpleague/commonmark
* Documentation: https://commonmark.thephpleague.com/2.4/