### PR TITLE
NPM: Add `mocha` as dependency

### DIFF
--- a/public/package_new.json
+++ b/public/package_new.json
@@ -10,6 +10,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "mocha": "^10.2.0",
   },
   "scripts": {
     "test": "mocha --recursive"


### PR DESCRIPTION
This PR adds `mocha` as npm package.

Usage:
* Multiple (see e.g. `components/ILIAS/UI/tests/Client/`)

Wrapped By:
* Not applicable

Reasoning:
* This package is the unit test framework for JavaScript and is used for automated testing.

Maintenance:
* The package is NOT actively maintained anymore (last release 2022), see https://github.com/mochajs/mocha/releases

Links:
* Packagist: https://www.npmjs.com/package/mocha
* GitHub: https://github.com/mochajs/mocha
* Documentation: https://mochajs.org/