### PR TITLE
NPM: Add `@rollup/plugin-node-resolve` as dependency

### DIFF
--- a/public/package_new.json
+++ b/public/package_new.json
@@ -10,6 +10,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "@rollup/plugin-node-resolve": "^15.1.0",
   },
   "scripts": {
     "test": "mocha --recursive"


### PR DESCRIPTION
This PR adds `@rollup/plugin-node-resolve` as npm package.

Usage:
* None yet, but this will be important in the future

Wrapped By:
* Not applicable

Reasoning:
* This is a plugin for the `rollup` package which allows to include dependency files in our own files that will be bundled. The plugin then resolves these imports accordingly (importing from node.js is different) and adds them to the bundle. This is not yet used in ILIAS, but I am currently working on a project that will depend on this mechanic. In future we must send only one JavaScript file to the client.

Maintenance:
* The package is actively maintained, see https://github.com/rollup/plugins/blob/master/packages/node-resolve/CHANGELOG.md

Links:
* Packagist: https://www.npmjs.com/package/@rollup/plugin-node-resolve
* GitHub: https://github.com/rollup/plugins/blob/master/packages/node-resolve
* Documentation: https://github.com/rollup/plugins/blob/master/packages/node-resolve/README.md