### PR TITLE
Composer: add symfony/yaml as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"symfony/yaml": "^5.3"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This adds symfony/yaml as composer dependency.

Usage:
 - parses and converts YAML strings to PHP arrays (or the other way round)

Wrapped By:
 - Not applicable, this is only used internally (e.g. by the UIComponents Crawler)

Reasoning:
 - yaml is a well established format. We use it to structure descriptions of UI Components and check for their completeness.

Maintenance:
 - The library is around since 2010 and continually receives updates and new releases.
 - It's part of the symfony framework, a widely used open source project with backing from [SensioLabs](https://sensiolabs.com/) and an active community.
 
Links:
 - Packagist: https://packagist.org/packages/symfony/yaml
 - GitHub: https://github.com/symfony/yaml
 - Documentation: https://symfony.com/doc/current/components/yaml.html