### PR TITLE
NPM: Add `rollup` as dependency

### DIFF
--- a/public/package_new.json
+++ b/public/package_new.json
@@ -10,6 +10,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "rollup": "^2.18.0",
   },
   "scripts": {
     "test": "mocha --recursive"


### PR DESCRIPTION
This PR adds `rollup` as npm package.

Usage:
* Multiple (data-table, main-controls, WOPI, ...)

Wrapped By:
* Not applicable

Reasoning:
* This package is a module bundler that can be used via CLI to generate one JavaScript file out of many different ones.

Maintenance:
* The package is actively maintained, see https://github.com/rollup/rollup/releases

Links:
* Packagist: https://www.npmjs.com/package/rollup
* GitHub: https://github.com/rollup/rollup
* Documentation: https://rollupjs.org/introduction/