### PR TITLE
Composer: Add `apereo/phpcas` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"apereo/phpcas": "^1.6.1"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `apereo/phpcas` as composer dependency.

Usage:
* `components/ILIAS/CAS`

Reasoning:
* ILIAS uses this library to enable login via CAS. This lib is provided by the same foundation that is also maintaining CAS

Maintenance:
* Not to many commits in the last years, but there are automatic tests for php up to 8.2.
* Security issues are always fixed in a timely manner followed by new releases.

Links:
* Packagist: https://packagist.org/packages/apereo/phpcas
* GitHub: https://github.com/apereo/phpCAS
* Documentation: https://apereo.github.io/phpCAS/