### PR TITLE
Composer: Add `jumbojett/openid-connect-php` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"jumbojett/openid-connect-php": "^0.9.10"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds jumbojett/openid-connect-php as composer dependency.

Usage:
* components/ILIAS/OpenIdConnect

Reasoning:
* ILIAS uses this library to enable login via oidc. It is the defact standard when using oidc with php

Maintenance:
* Not to many commits in the last years, but there are automatic tests for php up to 8.2.
* There are several people contributing to the software

Links:
* Packagist: https://packagist.org/packages/jumbojett/openid-connect-php
* GitHub: https://github.com/jumbojett/OpenID-Connect-PHP
* Documentation: https://github.com/jumbojett/OpenID-Connect-PHP/blob/master/README.md