### PR TITLE
NPM/Chatroom: Add `socket.io` and `socket.io-client`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,7 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+  }
+}

--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -3,5 +3,7 @@
   "description": "ILIAS CHAT",
   "version": "2.0.0",
   "dependencies": {
+    "socket.io": "^4.6.1",
+    "socket.io-client": "^4.6.1",
   }
 }


### PR DESCRIPTION
NPM/Chatroom: Add `socket.io` and `socket.io-client`

This PR adds `socket.io` and `socket.io-client` as NPM dependency for the chatroom

Usage:
* `components/ILIAS/Chatroom`
* `components/ILIAS/OnScreenChat`


Wrapped By:
* il.Chat (see: components/ILIAS/OnScreenChat/js/chat.js)
* ServerConnector (internal scope of $.chat, see: components/ILIAS/Chatroom/js/iliaschat.jquery.js)

Reasoning:
* `Socket.IO` is a library that enables low-latency, bidirectional and event-based communication between a client and a server. It is used in the `Node.js` based ILIAS chat server, which relies on the provided `WebSocket` low-level transport mechanisms. `Socket.IO` offers HTTP long-polling as a fallback option, which is useful in environments that don't support WebSockets.

Maintenance:
* `Socket.IO` is a well maintained package with major releases every few years and recent activities.

Links:
* NPM: https://www.npmjs.com/package/socket.io / https://www.npmjs.com/package/socket.io-client
* GitHub: https://github.com/socketio/socket.io / https://github.com/socketio/socket.io-client
* Documentation: https://socket.io/docs/