### PR TITLE
NPM/Chatroom: Add `winston`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,7 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+  }
+}

--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -3,5 +3,6 @@
   "description": "ILIAS CHAT",
   "version": "2.0.0",
   "dependencies": {
+    "winston": "^2.4.1",
   }
 }


### PR DESCRIPTION
This PR adds `winston` as NPM dependency for the chatroom

Usage:
* `components/ILIAS/Chatroom/chat/Bootstrap/SetupEnvironment.js` (instance creation and configuration)
* `components/ILIAS/Chatroom/chat/*` The `logger` instance is used in many JS files.

Wrapped By:
* Not applicable

Reasoning:
* `winston` is a logging library for the `Node.js` based ILIAS chat server, similar to `Monolog`, which we use in ILIAS for server-side logging. It supports multiple transport channels and logging levels (compliant to `RFC5424`, see: https://datatracker.ietf.org/doc/html/rfc5424).

Maintenance:
* `winston` is a well maintained package with major releases every few years. It is an active project, the latest changes are from November.

Links:
* NPM: https://www.npmjs.com/package/winston
* GitHub: https://github.com/winstonjs/winston
* Documentation: https://github.com/winstonjs/winston