### PR TITLE
NPM/Chatroom: Add `node-schedule`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,7 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+  }
+}

--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -3,5 +3,6 @@
   "description": "ILIAS CHAT",
   "version": "2.0.0",
   "dependencies": {
+    "node-schedule": "^2.1.0",
   }
 }


### PR DESCRIPTION
This PR adds `node-schedule` as NPM dependency for the chatroom

Usage:
* `components/ILIAS/Chatroom/chat/Bootstrap/SetupClearMessagesProcess.js`
* `components/ILIAS/Chatroom/chat/Bootstrap/UserSettingsProcess.js`

Wrapped By:
* Not applicable

Reasoning:
* `node-schedule` is a flexible cron-like (and not-cron-like) job scheduler for `Node.js`. It allows us to schedule jobs (arbitrary functions) for execution at specific dates/times, with optional recurrence rules. It only uses a single timer at any given time (rather than reevaluating upcoming jobs every second/minute). It is used to cleanup messages (and correspoding/related data) according to the configured ILIAS deletion policy. Furthermore it is used to pull user preferences from the ILIAS backend.

Maintenance:
* `node-schedule` is a well maintained package with a lot of contributions. However, there were only few commits in the last months.

Links:
* NPM: https://www.npmjs.com/package/node-schedule
* GitHub: https://github.com/node-schedule/node-schedule
* Documentation: https://github.com/node-schedule/node-schedule#readme