### PR TITLE
NPM/Chatroom: Add `mysql`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,7 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+  }
+}

--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -3,5 +3,6 @@
   "description": "ILIAS CHAT",
   "version": "2.0.0",
   "dependencies": {
+    "mysql": "^2.18.1"
   }
 }


### PR DESCRIPTION
This PR adds `mysql` as NPM dependency for the chatroom

Usage:
* `components/ILIAS/Chatroom/chat/Persistence/Database.js`

Wrapped By:
* `Database` (see: components/ILIAS/Chatroom/chat/Persistence/Database.js)

Reasoning:
* `mysql` is a mysql driver for `Node.js`. It is used to communicate with a mysql (or mariadb) server.

Maintenance:
* `mysql` has a lot of contributions. However, the last activity is from 2022. This could be a potential risk for new releases of `Node.js` in the future or potential security issues. If we could not rely on this library anymore, we will have to check if there are good alternatives, or we will have to switch to an API based approach on the ILIAS side instead of using a direct database connection.

Links:
* NPM: https://www.npmjs.com/package/mysql
* GitHub: https://github.com/mysqljs/mysql
* Documentation: https://github.com/mysqljs/mysql#readme