### PR TITLE
NPM/Chatroom: Add `node-mysql`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,7 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+  }
+}

--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -3,5 +3,6 @@
   "description": "ILIAS CHAT",
   "version": "2.0.0",
   "dependencies": {
+    "node-mysql": "^0.4.2"
   }
 }


### PR DESCRIPTION
This PR adds `node-mysql` as NPM dependency for the chatroom

Usage:
* `components/ILIAS/Chatroom/chat/Persistence/Database.js`

Wrapped By:
* `Database` (see: components/ILIAS/Chatroom/chat/Persistence/Database.js)

Reasoning:
* `node-mysql` is an enhancement/extension to the `mysql` library to make it a bit easier to use. It is based on the existing functionalities of (npm) `mysql`.

Maintenance:
* `node-mysql` has contributions provided by only one maintainer. The last activity is from 2015. This could be a potential risk for new releases of `Node.js` in the future or potential security issues. If we could not rely on this library anymore, we will have to check if there are good alternatives, or we just have to remove it from out dependencies and use the original interfaces provided by the `mysql` library. 

Links:
* NPM: https://www.npmjs.com/package/node-mysql
* GitHub: https://github.com/redblaze/node-mysql
* Documentation: https://github.com/redblaze/node-mysql/blob/master/README.md