### PR TITLE
NPM/Chatroom: Add `uuid`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,7 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+  }
+}

--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -3,5 +3,6 @@
   "description": "ILIAS CHAT",
   "version": "2.0.0",
   "dependencies": {
+    "node-uuid": "^1.4.8",
   }
 }


### PR DESCRIPTION
This PR adds `uuid` as NPM dependency for the chatroom

Usage:
* `components/ILIAS/Chatroom/chat/Persistence/Conversation.js`
* `components/ILIAS/Chatroom/chat/Persistence/ConversationAddUser.js`
* `components/ILIAS/Chatroom/chat/Persistence/ConversationMessage.js`

Wrapped By:
* Not applicable

Reasoning:
* `uuid` will be used to retrieve `UUID` values for the `Node.js` based ILIAS chat server, similar to the `ramsey/uuid` library we use in PHP for the ILIAS backend. It will replace the `node-uui` library (which is still used for that chat server).

Maintenance:
* `uuid`  is a well maintained package with a lot of contributions. It is an active project, the latest changes are from October.

Links:
* NPM: https://www.npmjs.com/package/uuid
* GitHub: https://github.com/uuidjs/uuid
* Documentation: https://github.com/redblaze/node-mysql/blob/master/README.md