### PR TITLE
Composer: Add `guzzlehttp/psr7` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"guzzlehttp/psr7": "^2.6.1",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `guzzlehttp/psr7` as npm package.

Usage:
* Nearly every GUI class in ILIAS

Wrapped By:
* HTTP-Service

Reasoning:
* This package is the quasi standard for abstracted HTTP-requests in PHP and is well defined by the PSR7.

Maintenance:
* The package is actively maintained, see https://github.com/guzzle/psr7

Links:
* Packagist: https://packagist.org/packages/guzzlehttp/psr7
* GitHub: https://github.com/guzzle/psr7
* Documentation: https://www.php-fig.org/psr/psr-7/