### PR TITLE
Calendar: display consultation hours in repository in additional block (37245)

### DIFF
--- a/Services/Block/classes/class.ilColumnGUI.php
+++ b/Services/Block/classes/class.ilColumnGUI.php
@@ -76,6 +76,7 @@ class ilColumnGUI
         "ilNewsForContextBlockGUI" => "Services/News/",
         "ilCalendarBlockGUI" => "Services/Calendar/",
         "ilPDCalendarBlockGUI" => "Services/Calendar/",
+        "ilConsultationHoursCalendarBlockGUI" => "Services/Calendar/",
         "ilPDTasksBlockGUI" => "Services/Tasks/",
         "ilPDMailBlockGUI" => "Services/Mail/",
         "ilPDSelectedItemsBlockGUI" => "Services/Dashboard/ItemsBlock/",
@@ -95,6 +96,7 @@ class ilColumnGUI
         "ilNewsForContextBlockGUI" => "news",
         "ilCalendarBlockGUI" => "cal",
         "ilPDCalendarBlockGUI" => "pdcal",
+        "ilConsultationHoursCalendarBlockGUI" => "chcal",
         "ilExternalFeedBlockGUI" => "feed",
         "ilPDExternalFeedBlockGUI" => "pdfeed",
         "ilPDSelectedItemsBlockGUI" => "pditems",
@@ -113,11 +115,13 @@ class ilColumnGUI
         "crs" => array(
             "ilNewsForContextBlockGUI" => IL_COL_RIGHT,
             "ilCalendarBlockGUI" => IL_COL_RIGHT,
+            "ilConsultationHoursCalendarBlockGUI" => IL_COL_RIGHT,
             "ilClassificationBlockGUI" => IL_COL_RIGHT
             ),
         "grp" => array(
             "ilNewsForContextBlockGUI" => IL_COL_RIGHT,
             "ilCalendarBlockGUI" => IL_COL_RIGHT,
+            "ilConsultationHoursCalendarBlockGUI" => IL_COL_RIGHT,
             "ilClassificationBlockGUI" => IL_COL_RIGHT
             ),
         "frm" => array("ilNewsForContextBlockGUI" => IL_COL_RIGHT),
@@ -157,6 +161,7 @@ class ilColumnGUI
         array("news" => true,
             "cal" => true,
             "pdcal" => true,
+            "chcal" => true,
             "pdnews" => true,
             "pdtag" => true,
             "pdmail" => true,
@@ -765,6 +770,9 @@ class ilColumnGUI
                     if ($type == "cal") {
                         $nr = -8;
                     }
+                    if ($type == "chcal") {         // consultation hours always directly below calendar
+                        $nr = -7;
+                    }
                     if ($type == "pdfeedb") {		// always show feedback request second
                         $nr = -10;
                     }
@@ -922,7 +930,7 @@ class ilColumnGUI
                     );
             } elseif ($ilSetting->get("block_activated_" . $a_type)) {
                 return true;
-            } elseif ($a_type == 'cal') {
+            } elseif ($a_type == 'cal' || $a_type == 'chcal') {
                 return ilCalendarSettings::lookupCalendarContentPresentationEnabled($ilCtrl->getContextObjId());
             } elseif ($a_type == 'pdcal') {
                 if (!$this->dash_side_panel_settings->isEnabled($this->dash_side_panel_settings::CALENDAR)) {

--- a/Services/Calendar/classes/ConsultationHours/class.ilConsultationHourUtils.php
+++ b/Services/Calendar/classes/ConsultationHours/class.ilConsultationHourUtils.php
@@ -27,7 +27,6 @@ class ilConsultationHourUtils
         $now = new \ilDateTime(time(), IL_CAL_UNIX);
         $links = [];
         foreach ($users as $user_id) {
-
             $next_entry = null;
             $appointments = \ilConsultationHourAppointments::getAppointments($user_id);
             foreach ($appointments as $entry) {
@@ -52,7 +51,7 @@ class ilConsultationHourUtils
             }
             $current_link = [
                 'link' => $ctrl->getLinkTargetByClass($ctrl_class_structure, 'selectCHCalendarOfUser'),
-                'txt' => str_replace("%1", ilObjUser::_lookupFullname($user_id), $lng->txt("cal_consultation_hours_for_user"))
+                'txt' => ilObjUser::_lookupFullname($user_id)
             ];
             $links[] = $current_link;
         }
@@ -79,7 +78,7 @@ class ilConsultationHourUtils
 
         $query = 'select ce.cal_id from cal_entries ce ' .
             'join cal_cat_assignments cca on ce.cal_id = cca.cal_id ' .
-            'join cal_categories cc on cca.cat_id = cc.cat_id '.
+            'join cal_categories cc on cca.cat_id = cc.cat_id ' .
             'where context_id = ' . $db->quote($booking->getId(), 'integer') . ' ' .
             'and starta = ' . $db->quote($start->get(IL_CAL_DATETIME, '', \ilTimeZone::UTC), \ilDBConstants::T_TIMESTAMP) . ' ' .
             'and enda = ' . $db->quote($end->get(IL_CAL_DATETIME, '', \ilTimeZone::UTC), \ilDBConstants::T_TIMESTAMP) . ' ' .

--- a/Services/Calendar/classes/class.ilCalendarBlockGUI.php
+++ b/Services/Calendar/classes/class.ilCalendarBlockGUI.php
@@ -951,7 +951,6 @@ class ilCalendarBlockGUI extends ilBlockGUI
             'Services/Calendar'
         );
 
-        $this->addConsultationHourButtons($panel_tpl);
         $this->addSubscriptionButton($panel_tpl);
 
         return $tpl->get() . $panel_tpl->get();
@@ -977,44 +976,6 @@ class ilCalendarBlockGUI extends ilBlockGUI
     protected function getNoItemFoundContent() : string
     {
         return $this->lng->txt("cal_no_events_block");
-    }
-
-
-    /**
-     * Add consultation hour buttons
-     */
-    protected function addConsultationHourButtons(ilTemplate $panel_template) : void
-    {
-        global $DIC;
-
-        $user = $DIC->user();
-
-        if (!$this->getRepositoryMode()) {
-            return;
-        }
-
-        $links = \ilConsultationHourUtils::getConsultationHourLinksForRepositoryObject(
-            (int) $_GET['ref_id'],
-            (int) $user->getId(),
-            $this->getTargetGUIClassPath()
-        );
-        $counter = 0;
-        foreach ($links as $link) {
-            $ui_factory = $DIC->ui()->factory();
-            $ui_renderer = $DIC->ui()->renderer();
-
-            $link_button = $ui_factory->button()->shy(
-                $link['txt'],
-                $link['link']
-            );
-            if ($counter) {
-                $panel_template->touchBlock('consultation_hour_buttons_multi');
-            }
-            $panel_template->setCurrentBlock('consultation_hour_buttons');
-            $panel_template->setVariable('SHY_BUTTON', $ui_renderer->render([$link_button]));
-            $panel_template->parseCurrentBlock();
-            $counter++;
-        }
     }
 
     /**

--- a/Services/Calendar/classes/class.ilConsultationHoursCalendarBlockGUI.php
+++ b/Services/Calendar/classes/class.ilConsultationHoursCalendarBlockGUI.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\UI\Component\Item\Item;
+
+class ilConsultationHoursCalendarBlockGUI extends ilBlockGUI
+{
+    protected $new_rendering = true;
+    protected $consultation_hour_links;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->lng->loadLanguageModule("dateplaner");
+
+        $this->setBlockId('ch_' . $this->ctrl->getContextObjId());
+        $this->setLimit(5);
+        $this->setEnableNumInfo(false);
+        $this->setTitle($this->lng->txt('consultation_hours_block_title'));
+        $this->setPresentation(self::PRES_SEC_LIST);
+    }
+
+    public function getBlockType() : string
+    {
+        return 'chcal';
+    }
+
+    protected function isRepositoryObject() : bool
+    {
+        return false;
+    }
+
+    /**
+     * Get target gui class path (for presenting the calendar)
+     */
+    public function getTargetGUIClassPath() : array
+    {
+        $target_class = [];
+        if (!$this->getRepositoryMode()) {
+            $target_class = ["ildashboardgui", "ilcalendarpresentationgui"];
+        } else {
+            switch (ilObject::_lookupType((int) $_GET["ref_id"], true)) {
+                case "crs":
+                    $target_class = ["ilobjcoursegui", "ilcalendarpresentationgui"];
+                    break;
+
+                case "grp":
+                    $target_class = ["ilobjgroupgui", "ilcalendarpresentationgui"];
+                    break;
+            }
+        }
+        return $target_class;
+    }
+
+    public function getData() : array
+    {
+        if (isset($this->consultation_hour_links)) {
+            return $this->consultation_hour_links;
+        }
+        return $this->consultation_hour_links = \ilConsultationHourUtils::getConsultationHourLinksForRepositoryObject(
+            (int) $_GET['ref_id'],
+            $this->user->getId(),
+            $this->getTargetGUIClassPath()
+        );
+    }
+
+    protected function getListItemForData(array $data) : Item
+    {
+        $button = $this->ui->factory()->button()->shy(
+            $data['txt'] ?? '',
+            $data['link'] ?? ''
+        );
+        return $this->ui->factory()->item()->standard($button);
+    }
+
+    public function getHTMLNew() : string
+    {
+        if (empty($this->getData())) {
+            return '';
+        }
+        return parent::getHTMLNew();
+    }
+}

--- a/Services/Calendar/classes/class.ilConsultationHoursCalendarBlockGUI.php
+++ b/Services/Calendar/classes/class.ilConsultationHoursCalendarBlockGUI.php
@@ -18,6 +18,9 @@
 
 use ILIAS\UI\Component\Item\Item;
 
+/**
+ * @ilCtrl_IsCalledBy ilConsultationHoursCalendarBlockGUI: ilColumnGUI
+ */
 class ilConsultationHoursCalendarBlockGUI extends ilBlockGUI
 {
     protected $new_rendering = true;

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -8334,6 +8334,7 @@ dateplaner#:#cal_weekly#:#Wöchentlich
 dateplaner#:#cal_where#:#Ort
 dateplaner#:#cal_year_s#:#Jahr(e)
 dateplaner#:#cal_yearly#:#Jährlich
+dateplaner#:#consultation_hours_block_title#:#Sprechstunden
 dateplaner#:#created#:#erstellt am
 dateplaner#:#crs_cal_activation_end#:#Kursende
 dateplaner#:#crs_cal_activation_start#:#Kursbeginn

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8335,6 +8335,7 @@ dateplaner#:#cal_weekly#:#Weekly
 dateplaner#:#cal_where#:#Location
 dateplaner#:#cal_year_s#:#Year(s)
 dateplaner#:#cal_yearly#:#Yearly
+dateplaner#:#consultation_hours_block_title#:#Consultation Hours
 dateplaner#:#created#:#Created
 dateplaner#:#crs_cal_activation_end#:#Course Availability ends
 dateplaner#:#crs_cal_activation_start#:#Course Availability starts


### PR DESCRIPTION
This PR fixes [38040](https://mantis.ilias.de/view.php?id=38040) by adding an additional block for the consultation hours when in repository, as decided in the JF. 

 I'd like to merge this myself, there is some cleaning up to do when picking this up to R8 and beyond.