### PR TITLE
Move Deletion Confirmation to Modal

### DIFF
--- a/Modules/LearningSequence/classes/Content/class.ilObjLearningSequenceContentGUI.php
+++ b/Modules/LearningSequence/classes/Content/class.ilObjLearningSequenceContentGUI.php
@@ -111,31 +111,7 @@ class ilObjLearningSequenceContentGUI
      */
     protected function confirmDelete(): void
     {
-        $r = $this->refinery;
-        $ref_ids = $this->post_wrapper->retrieve(
-            "id",
-            $r->byTrying([
-                $r->kindlyTo()->listOf($r->kindlyTo()->int()),
-                $r->always([])
-            ])
-        );
-
-        if (!$ref_ids || count($ref_ids) < 1) {
-            $this->tpl->setOnScreenMessage("info", $this->lng->txt('no_entries_selected_for_delete'), true);
-            $this->ctrl->redirect($this, self::CMD_MANAGE_CONTENT);
-        }
-
-        foreach ($ref_ids as $ref_id) {
-            $obj = ilObjectFactory::getInstanceByRefId($ref_id);
-            $this->confirmation_gui->addItem("id[]", (string) $ref_id, $obj->getTitle());
-        }
-
-        $this->confirmation_gui->setFormAction($this->ctrl->getFormAction($this));
-        $this->confirmation_gui->setHeaderText($this->lng->txt("delete_confirmation"));
-        $this->confirmation_gui->setConfirm($this->lng->txt("confirm"), self::CMD_DELETE);
-        $this->confirmation_gui->setCancel($this->lng->txt("cancel"), self::CMD_CANCEL);
-
-        $this->tpl->setContent($this->confirmation_gui->getHTML());
+        $this->parent_gui->deleteObject();
     }
 
     protected function delete(): void

--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -743,9 +743,12 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
         }
     }
 
+    /**
+     * Redirects to Manage Content to make deletion screen work.
+     */
     public function renderObject(): void
     {
-        // disables this method in ilContainerGUI
+        $this->manageContent();
     }
 
 
@@ -900,26 +903,6 @@ class ilObjLearningSequenceGUI extends ilContainerGUI implements ilCtrlBaseClass
     {
         $gui = new ilObjectAddNewItemGUI($this->object->getRefId());
         $gui->render();
-    }
-
-    /**
-    * ATTENTION: This mostly is a copy of `ilObjectGUI::confirmDeleteObject`, but does not
-    * redirect to parent afterwards, because we are, in fact, the parent.
-    */
-    public function confirmedDeleteObject(): void
-    {
-        if ($this->post_wrapper->has("mref_id")) {
-            $mref_id = $this->post_wrapper->retrieve(
-                "mref_id",
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int())
-            );
-            $_SESSION["saved_post"] = array_unique(array_merge($_SESSION["saved_post"], $mref_id));
-        }
-
-        $ru = new ilRepositoryTrashGUI($this);
-        $ru->deleteObjects($this->requested_ref_id, ilSession::get("saved_post") ?? []);
-        ilSession::clear("saved_post");
-        $this->ctrl->redirect($this, self::CMD_CONTENT);
     }
 
     protected function enableDragDropFileUpload(): void

--- a/Services/Object/classes/class.ilObject2GUI.php
+++ b/Services/Object/classes/class.ilObject2GUI.php
@@ -494,10 +494,7 @@ abstract class ilObject2GUI extends ilObjectGUI
     {
         parent::showPossibleSubObjects();
     }
-    final public function cancelDelete(): void
-    {
-        parent::cancelDeleteObject();
-    }
+
     final protected function redirectToRefId(int $ref_id, string $cmd = ""): void
     {
         parent::redirectToRefId($ref_id, $cmd);

--- a/Services/Object/classes/class.ilObject2GUI.php
+++ b/Services/Object/classes/class.ilObject2GUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\HTTP\Wrapper\ArrayBasedRequestWrapper;
 use ILIAS\HTTP\Wrapper\RequestWrapper;

--- a/templates/default/tpl.page_content.html
+++ b/templates/default/tpl.page_content.html
@@ -92,5 +92,5 @@
 	</div>
 </div>
 {WEBDAV_MODAL}
-{AVAILABILITY_PERIOD_MODAL}
+{IL_OBJECT_MODALS}
 <!-- END content -->


### PR DESCRIPTION
This was reported as an issue and I kicked it down the road for a moment too long.

The issue can be found here: https://mantis.ilias.de/view.php?id=24765

I still think ILIAS 9 could profit from this change, so here it is.

I removed some code from the LSO and adapted some a little, so @klees I would kindly ask you to have a look at the changes in [this commit](2eb41c56be6bfb48d7571d60e778013a7ea8f710). Thanks!