### PR TITLE
UI: Fix Substr on MB-String

### DIFF
--- a/src/UI/Implementation/Component/Symbol/Avatar/Letter.php
+++ b/src/UI/Implementation/Component/Symbol/Avatar/Letter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Symbol\Avatar;
 

--- a/src/UI/Implementation/Component/Symbol/Avatar/Letter.php
+++ b/src/UI/Implementation/Component/Symbol/Avatar/Letter.php
@@ -26,7 +26,7 @@ class Letter extends Avatar implements C\Symbol\Avatar\Letter
 {
     public function getAbbreviation(): string
     {
-        return (substr($this->getUsername(), 0, 2));
+        return (mb_substr($this->getUsername(), 0, 2));
     }
 
     public function getBackgroundColorVariant(): int


### PR DESCRIPTION
In the Letter-Avatar `getAbbreviation()` function a `substr` is applied to a value that might contain mb-strings, thus potentially breaking the letter avatar.

See: https://mantis.ilias.de/view.php?id=39468

If accepted this should to be cherry-picked to all supported versions.