### PR TITLE
ilias mantis ticket 39461

### DIFF
--- a/Services/Export/classes/ImportHandler/File/XML/Export/class.ilHandler.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Export/class.ilHandler.php
@@ -89,7 +89,12 @@ abstract class ilHandler extends ilXMLFileHandler implements ilXMLExportFileHand
         $matches = [];
         $pattern = '/([0-9]+)__([0-9]+)__([a-z_]+)_([0-9]+)/';
         $path_part = $this->getSubPathToDirBeginningAtPathEnd('temp')->getPathPart($pattern);
-        preg_match($pattern, $path_part, $matches);
+        if (
+            is_null($path_part) ||
+            preg_match($pattern, $path_part, $matches) !== 1
+        ) {
+            return 'No path found';
+        };
         $node = $component_tree->getFirstNodeWith(
             $this->attribute->collection()
                 ->withElement($this->attribute->pair()->withValue($matches[4])->withKey('Id'))


### PR DESCRIPTION
@alex40724

Link to ticket: https://mantis.ilias.de/view.php?id=39461

Additional changes to the 'Services/Style/set_1/export.xml' contained by style.zip, located in the directory 'libs/ilias/Style/basic_style/' are necessary. The export.xml uses the attribute 'TargetRelease'. The attribute is not allowed by the schema file. A possible could be to remove the attribute 'TargetRelease' from the export.xml.