### PR TITLE
9/UI/DataTable sticky select all rows header column  39210

### DIFF
--- a/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
+++ b/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
@@ -157,6 +157,13 @@ th.c-table-data__cell {
         &.c-table-data__header__rowselection {
             padding: $il-padding-xxlarge-vertical $il-padding-large-horizontal;
             text-align: center;
+            // row selection also sticks to the left
+            position: sticky;
+            left: -2px; // so text doesn't glitch through on left edge
+            z-index: 4;
+            // gradient to fade row selection into header text
+            background: rgb(255,255,255);
+            background: linear-gradient(90deg, rgba(255,255,255,1) 85%, rgba(255,255,255,0) 100%);
         }
     }
 }
@@ -224,19 +231,23 @@ th.c-table-data__cell:after {
 }
 
 //
-// Multiaction Dropdown below table
+// Column rowselection
 //
-
-.c-table-data__multiaction-triggerer {
-    width: fit-content;
-}
 
 .c-table-data__rowselection,
 .c-table-data__multiaction-triggerer {
     position: -webkit-sticky;
     position: sticky;
-    left: 0;
+    left: -1px; // so text doesn't glitch through on left edge
     z-index: 2;
+}
+
+//
+// Multiaction Dropdown below table
+//
+
+.c-table-data__multiaction-triggerer {
+    width: fit-content;
 }
 
 .c-table-data__multiaction-triggerer {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -8952,6 +8952,11 @@ th.c-table-data__cell {
   th.c-table-data__cell.c-table-data__header__rowselection {
     padding: 12px 12px;
     text-align: center;
+    position: sticky;
+    left: -2px;
+    z-index: 4;
+    background: rgb(255, 255, 255);
+    background: linear-gradient(90deg, rgb(255, 255, 255) 85%, rgba(255, 255, 255, 0) 100%);
   }
 }
 
@@ -9007,16 +9012,16 @@ th.c-table-data__cell {
   }
 }
 
-.c-table-data__multiaction-triggerer {
-  width: fit-content;
-}
-
 .c-table-data__rowselection,
 .c-table-data__multiaction-triggerer {
   position: -webkit-sticky;
   position: sticky;
-  left: 0;
+  left: -1px;
   z-index: 2;
+}
+
+.c-table-data__multiaction-triggerer {
+  width: fit-content;
 }
 
 .c-table-data__multiaction-triggerer {


### PR DESCRIPTION
Mantis https://mantis.ilias.de/view.php?id=39210

# Issue

* "Select all rows" header column didn't stick to the left border.
* Sometimes text is peaking through on the left edge of the sticky elements

![data-table_non-sticky-row-selection](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/ff247793-80e1-48ba-989b-ab90599c16de)

# Changes

* "Select all rows" header column now also sticks to left edge
* gradient to white as a gentle transition to the other header columns
* negative left positioning for sticky elements, so no text from below can glitch through

![data-table_sticky-row-selection](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/ca6138ed-a923-42ec-a237-44b810a0edce)
