### PR TITLE
9/UI/DataTable breadcrumbs cover up header fix

### DIFF
--- a/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
+++ b/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
@@ -80,6 +80,7 @@ header {
 .breadcrumbs {
 	position: sticky;
 	top: 0;
+	min-height: $il-standard-page-breadcrumbs-height;
 	align-items: center;
 	background-color: $il-standard-page-breadcrumbs-bg-color;
 	display: flex;

--- a/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
+++ b/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
@@ -2,6 +2,7 @@
 @use "../../../030-tools/_tool_buttons" as *;
 @use "../../../030-tools/_tool_browser-prefixes" as *;
 @use "../../../050-layout/basics" as *;
+@use "../../../050-layout/standardpage/layout_standardpage" as spage;
 @use "../../../050-layout/layout_grid" as l-grid;
 @use "../../../030-tools/tool_highlighted-box" as box;
 @use "../../../050-layout/layout_breakpoints" as brk;
@@ -158,6 +159,14 @@ th.c-table-data__cell {
             padding: $il-padding-xxlarge-vertical $il-padding-large-horizontal;
             text-align: center;
         }
+    }
+}
+
+// stick under breadcrumbs when they are present
+
+.breadcrumbs + #mainspacekeeper th.c-table-data__cell {
+    @include brk.on-screen-size(large) {
+        top: spage.$il-standard-page-breadcrumbs-height - 1px;
     }
 }
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -4859,6 +4859,7 @@ header {
 .breadcrumbs {
   position: sticky;
   top: 0;
+  min-height: 33px;
   align-items: center;
   background-color: white;
   display: flex;
@@ -8952,6 +8953,12 @@ th.c-table-data__cell {
   th.c-table-data__cell.c-table-data__header__rowselection {
     padding: 12px 12px;
     text-align: center;
+  }
+}
+
+@media screen and (min-width: 769px) {
+  .breadcrumbs + #mainspacekeeper th.c-table-data__cell {
+    top: 32px;
   }
 }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=39204

# Issue

Breadcrumbs cover up the sticky data table header.

![data-table_breadcrumb-covers-header](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/42a17d32-def6-4bfe-bfd2-365603fcfd4e)

# Changes

Sticky header gets pushed down by the height of the breadcrumbs, if the breadcrumbs div is present. Might break special edge cases where breadcrumbs are hidden using display: none rather than actually not rendering them.

Standardpage variable for breadcrumb height wasn't used anywhere, now it defines the min-height.

![data-table_breadcrumb-fix](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/a09f65f4-025f-4b53-89ff-bc6e80ec0b69)

