### PR TITLE
9/UI/Panel Header ViewControls dynamic stacking 38937

### DIFF
--- a/Services/Block/classes/class.ilBlockGUI.php
+++ b/Services/Block/classes/class.ilBlockGUI.php
@@ -765,7 +765,7 @@ abstract class ilBlockGUI
             ->withTargetURL($href, $this->getNavParameter() . "page")
             ->withTotalEntries($this->max_count)
             ->withPageSize($this->getLimit())
-            ->withMaxPaginationButtons(5)
+            ->withMaxPaginationButtons(1)
             ->withCurrentPage($this->getOffset() / $this->getLimit());
     }
 
@@ -977,8 +977,6 @@ abstract class ilBlockGUI
             )->withTargetURL(
                 $this->sort_target,
                 'sorting'
-            )->withLabel(
-                $this->activeSortOption
             );
             $viewControls[] = $sortation;
         }

--- a/src/UI/examples/Panel/Listing/Standard/with_all_view_controls.php
+++ b/src/UI/examples/Panel/Listing/Standard/with_all_view_controls.php
@@ -61,6 +61,7 @@ function with_all_view_controls(): string
         ->withTargetURL($url, "page")
         ->withTotalEntries(98)
         ->withPageSize(10)
+        ->withMaxPaginationButtons(1)
         ->withCurrentPage($current_page);
 
     $view_controls = [

--- a/src/UI/examples/Panel/Secondary/Listing/with_all_view_controls.php
+++ b/src/UI/examples/Panel/Secondary/Listing/with_all_view_controls.php
@@ -61,6 +61,7 @@ function with_all_view_controls(): string
                     ->withTargetURL($url, "page")
                     ->withTotalEntries(98)
                     ->withPageSize(10)
+                    ->withMaxPaginationButtons(1)
                     ->withCurrentPage($current_page);
 
     $view_controls = [

--- a/src/UI/templates/default/Panel/tpl.listing_standard.html
+++ b/src/UI/templates/default/Panel/tpl.listing_standard.html
@@ -2,11 +2,11 @@
     <!-- BEGIN heading -->
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>{TITLE}</h2></div>
+        <!-- BEGIN vc_container -->
+        <div class="panel-viewcontrols l-bar__container"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
+        <!-- END vc_container -->
         <div class="panel-controls">{ACTIONS}</div>
     </div>
-    <!-- BEGIN vc_container -->
-    <div class="panel-viewcontrols l-bar__container"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
-    <!-- END vc_container -->
     <!-- END heading -->
     <!-- BEGIN group -->
     {ITEM_GROUP}

--- a/src/UI/templates/default/Panel/tpl.secondary.html
+++ b/src/UI/templates/default/Panel/tpl.secondary.html
@@ -2,12 +2,11 @@
 	<!-- BEGIN heading -->
 	<div class="panel-heading ilHeader">
 		<div class="panel-title"><h2>{TITLE}</h2></div>
+		<!-- BEGIN vc_container -->
+		<div class="panel-viewcontrols l-bar__container"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
+		<!-- END vc_container -->
 		<div class="panel-controls">{ACTIONS}</div>
 	</div>
-	<!-- BEGIN vc_container -->
-	<div class="panel-viewcontrols l-bar__container"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
-	<!-- END vc_container -->
-
 	<!-- END heading -->
 
 	<div class="panel-body">

--- a/src/UI/templates/default/Panel/tpl.standard.html
+++ b/src/UI/templates/default/Panel/tpl.standard.html
@@ -1,10 +1,10 @@
 <div class="panel panel-primary panel-flex">
 	<div class="panel-heading ilHeader">
 		<div class="panel-title"><h2>{TITLE}</h2></div>
+		<!-- BEGIN vc_container -->
+		<div class="panel-viewcontrols l-bar__container"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
+		<!-- END vc_container -->
 		<div class="panel-controls">{ACTIONS}</div>
 	</div>
-	<!-- BEGIN vc_container -->
-	<div class="panel-viewcontrols l-bar__container"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
-	<!-- END vc_container -->
 	<div class="panel-body">{BODY}</div>
 </div>

--- a/templates/default/010-settings/_settings_button.scss
+++ b/templates/default/010-settings/_settings_button.scss
@@ -31,8 +31,8 @@ $il-btn-ctrl-bg: s-color.$il-highlight-bg !default;
 //** Border color of the primary button (most important button on the screen)
 $il-btn-ctrl-border: s-color.$il-highlight-bg !default;
 $il-btn-ctrl-engaged-border: s-color.$il-link-color !default;
-$il-btn-ctrl-outer-height: 2.6rem !default;
-$il-btn-ctrl-inner-btn-height: 1.9rem !default;
+$il-btn-ctrl-outer-height: 2.2rem !default;
+$il-btn-ctrl-inner-btn-height: 1.7rem !default;
 
 //** Colors of inactive buttons
 $il-disabled-btn-color: darken(s-color.$il-text-color, 20%) !default;

--- a/templates/default/050-layout/_layout_breakpoints.scss
+++ b/templates/default/050-layout/_layout_breakpoints.scss
@@ -49,11 +49,15 @@ $grid-breakpoints: (
 
 // end of section based on bootstrap 3
 
+// note that this excludes print!
 @mixin on-screen-size($size) {
   @if $size == small {
-    @media screen and (max-width: $screen-sm) { @content; }
+    @media screen and (max-width: $screen-sm) { @content; };
+  } @else if $size == medium {
+    @media screen and (min-width: $screen-sm + 1px) { @content; };
   } @else if $size == large {
-    // note that this excludes print!
-    @media screen and (min-width: $screen-sm + 1px) { @content; }
+    @media screen and (min-width: $screen-md + 1px) { @content; };
+  } @else {
+    @error("Invalid input for on-screen-size mixin.");
   }
 }

--- a/templates/default/070-components/UI-framework/Panel/_ui-component_panel.scss
+++ b/templates/default/070-components/UI-framework/Panel/_ui-component_panel.scss
@@ -5,6 +5,7 @@
 @use "../../../030-tools/tool_clearfix" as *;
 @use "../../../050-layout/basics" as *;
 @use "../../../050-layout/standardpage/" as *;
+@use "../../../050-layout/layout_breakpoints" as break;
 
 //== Panel
 //
@@ -50,10 +51,23 @@
 		}
 	}
 
-	.panel-viewcontrols:not(:empty) {
-		justify-content: center;
-		margin: $il-margin-xxxlarge-vertical $il-margin-xlarge-horizontal;
-		margin-bottom: $il-margin-xxxlarge-vertical - $il-margin-xlarge-vertical; // to compensate margin of inner elements - see l-bar system
+	.panel-viewcontrols {
+		@include break.on-screen-size(small) {
+			order: 3;
+			width: 100%;
+			justify-content: center;
+		}
+		@include break.on-screen-size(medium) {
+			order: 3;
+			width: 100%;
+			justify-content: center;
+		}
+		@include break.on-screen-size(large) {
+			order: 2;
+			width: auto;
+			flex-grow: 1;
+			justify-content: flex-end;
+		}
 	}
 
 	.panel-body {
@@ -73,20 +87,29 @@
 //Special assignments for Panels using Flex layouts (Standard, Secondary, Report and Sub)
 .panel-flex{
 	.panel-heading {
-		display: grid;
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: $il-margin-base-horizontal;
 	}
 	.panel-title{
-		margin-right: auto;
+		flex-shrink: 0;
+		order: 1;
 	}
 	.panel-controls {
-		margin-left: auto;
-		float: right;
 		display: flex;
 		gap: $il-margin-base-horizontal;
 		justify-content: flex-end;
-	}
-	.ilHeader{
-		display: flex;
+		margin-left: auto;
+		@include break.on-screen-size(small) {
+			order: 2;
+		}
+		@include break.on-screen-size(medium) {
+			order: 2;
+		}
+		@include break.on-screen-size(large) {
+			order: 3;
+		}
 	}
 	h2.ilHeader {
 		flex-grow: 99;

--- a/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
+++ b/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
@@ -138,7 +138,7 @@ $il-table-presentation-details-viewcontrols-btn-bg: white;
 
 // hover row on larger screens only
 .c-table-data__row:hover td.c-table-data__cell {
-    @include brk.on-screen-size(large) {
+    @include brk.on-screen-size(medium) {
         background-color: $il-main-darker-bg;
     }
 }
@@ -150,7 +150,7 @@ $il-table-presentation-details-viewcontrols-btn-bg: white;
 th.c-table-data__cell {
     padding: 0; // most of the header cells get padding from the resize wrapper
     // sticky header on large screens
-    @include brk.on-screen-size(large) {
+    @include brk.on-screen-size(medium) {
         position: -webkit-sticky;
         position: sticky;
         top: 0;
@@ -172,7 +172,7 @@ th.c-table-data__cell {
 
 // shadow below header when sticky (because borders and box shadow are left behind in tables)
 th.c-table-data__cell:after {
-    @include brk.on-screen-size(large) {
+    @include brk.on-screen-size(medium) {
         position: absolute;
         content: "";
         left: 0;
@@ -220,7 +220,7 @@ th.c-table-data__cell:after {
 
 // shadow that sticks to the right of action column (because borders and box shadow are left behind and do not stick)
 .c-table-data__rowselection:after {
-    @include brk.on-screen-size(large) {
+    @include brk.on-screen-size(medium) {
         position: absolute;
         content: "";
         top: 0;
@@ -317,7 +317,7 @@ td.c-table-data__cell--highlighted {
 }
 // hover on larger screens only
 .c-table-data__row:hover td.c-table-data__cell--highlighted {
-    @include brk.on-screen-size(large) {
+    @include brk.on-screen-size(medium) {
         background-color: darken($il-main-darker-bg, 7%);
     }
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2662,8 +2662,8 @@ input.btn, input.il-link.link-bulky,
   font-size: inherit;
   font-weight: 400;
   text-decoration: none;
-  min-height: 2.6rem;
-  min-width: 2.6rem;
+  min-height: 2.2rem;
+  min-width: 2.2rem;
   font-size: 0.75rem;
   padding: 3px 6px;
   gap: 6px;
@@ -6849,10 +6849,27 @@ div.alert ul > li:before {
   color: #161616;
   font-size: 0.875rem;
 }
-.panel .panel-viewcontrols:not(:empty) {
-  justify-content: center;
-  margin: 15px 15px;
-  margin-bottom: 6px;
+@media screen and (max-width: 768px) {
+  .panel .panel-viewcontrols {
+    order: 3;
+    width: 100%;
+    justify-content: center;
+  }
+}
+@media screen and (min-width: 769px) {
+  .panel .panel-viewcontrols {
+    order: 3;
+    width: 100%;
+    justify-content: center;
+  }
+}
+@media screen and (min-width: 993px) {
+  .panel .panel-viewcontrols {
+    order: 2;
+    width: auto;
+    flex-grow: 1;
+    justify-content: flex-end;
+  }
 }
 .panel .panel-body {
   padding: 15px 15px;
@@ -6873,20 +6890,35 @@ div.alert ul > li:before {
 }
 
 .panel-flex .panel-heading {
-  display: grid;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 9px;
 }
 .panel-flex .panel-title {
-  margin-right: auto;
+  flex-shrink: 0;
+  order: 1;
 }
 .panel-flex .panel-controls {
-  margin-left: auto;
-  float: right;
   display: flex;
   gap: 9px;
   justify-content: flex-end;
+  margin-left: auto;
 }
-.panel-flex .ilHeader {
-  display: flex;
+@media screen and (max-width: 768px) {
+  .panel-flex .panel-controls {
+    order: 2;
+  }
+}
+@media screen and (min-width: 769px) {
+  .panel-flex .panel-controls {
+    order: 2;
+  }
+}
+@media screen and (min-width: 993px) {
+  .panel-flex .panel-controls {
+    order: 3;
+  }
 }
 .panel-flex h2.ilHeader {
   flex-grow: 99;
@@ -9222,8 +9254,8 @@ td.c-table-data__cell--highlighted {
 .il-viewcontrol-pagination,
 .il-viewcontrol-mode {
   width: fit-content;
-  min-height: 2.6rem;
-  min-width: 2.6rem;
+  min-height: 2.2rem;
+  min-width: 2.2rem;
   border: 1px solid #e2e8ef;
   padding: 3px;
   background-color: #e2e8ef;
@@ -9407,8 +9439,8 @@ td.c-table-data__cell--highlighted {
 .il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-mode > .btn-default,
 .il-viewcontrol-mode > .btn-link {
-  min-height: 1.9rem;
-  min-width: 1.9rem;
+  min-height: 1.7rem;
+  min-width: 1.7rem;
   border-radius: 10px;
 }
 

--- a/tests/UI/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/tests/UI/Component/Panel/PanelSecondaryLegacyTest.php
@@ -231,21 +231,21 @@ EOT;
 <div class="panel panel-secondary panel-flex">
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>Title</h2></div>
+        <div class="panel-viewcontrols l-bar__container">
+            <div class="il-viewcontrol-sortation l-bar__element" id="id_1">
+                <div class="dropdown">
+                    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="id_4" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_4_menu">
+                        <span class="caret"></span>
+                    </button>
+                    <ul id="id_4_menu" class="dropdown-menu">
+                        <li><button class="btn btn-link" data-action="?sortation=a" id="id_2">A</button></li>
+                        <li><button class="btn btn-link" data-action="?sortation=b" id="id_3">B</button></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
         <div class="panel-controls"></div>
     </div>
-    <div class="panel-viewcontrols l-bar__container">
-        <div class="il-viewcontrol-sortation l-bar__element" id="id_1">
-			<div class="dropdown">
-				<button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="id_4" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_4_menu">
-					<span class="caret"></span>
-				</button>
-				<ul id="id_4_menu" class="dropdown-menu">
-					<li><button class="btn btn-link" data-action="?sortation=a" id="id_2">A</button></li>
-					<li><button class="btn btn-link" data-action="?sortation=b" id="id_3">B</button></li>
-				</ul>
-			</div>
-		</div>
-	</div>
 	<div class="panel-body">
 		Legacy content
 	</div>
@@ -273,18 +273,18 @@ EOT;
 <div class="panel panel-secondary panel-flex">
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>Title</h2></div>
-        <div class="panel-controls"></div>
-    </div>
-    <div class="panel-viewcontrols l-bar__container">
-        <div class="il-viewcontrol-pagination l-bar__element">
-            <span class="btn btn-ctrl browse previous"><a tabindex="0" class="glyph" href="http://ilias.de?page=0" aria-label="back"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></a></span>
-            <button class="btn btn-link" data-action="http://ilias.de?page=0" id="id_1">1</button>
-            <button class="btn btn-link engaged" aria-pressed="true" data-action="http://ilias.de?page=1" id="id_2">2</button>
-            <button class="btn btn-link" data-action="http://ilias.de?page=2" id="id_3">3</button>
-            <button class="btn btn-link" data-action="http://ilias.de?page=3" id="id_4">4</button>
-            <button class="btn btn-link" data-action="http://ilias.de?page=4" id="id_5">5</button>
-            <span class="btn btn-ctrl browse next"><a tabindex="0" class="glyph" href="http://ilias.de?page=2" aria-label="next"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></a></span>
+        <div class="panel-viewcontrols l-bar__container">
+            <div class="il-viewcontrol-pagination l-bar__element">
+                <span class="btn btn-ctrl browse previous"><a tabindex="0" class="glyph" href="http://ilias.de?page=0" aria-label="back"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></a></span>
+                <button class="btn btn-link" data-action="http://ilias.de?page=0" id="id_1">1</button>
+                <button class="btn btn-link engaged" aria-pressed="true" data-action="http://ilias.de?page=1" id="id_2">2</button>
+                <button class="btn btn-link" data-action="http://ilias.de?page=2" id="id_3">3</button>
+                <button class="btn btn-link" data-action="http://ilias.de?page=3" id="id_4">4</button>
+                <button class="btn btn-link" data-action="http://ilias.de?page=4" id="id_5">5</button>
+                <span class="btn btn-ctrl browse next"><a tabindex="0" class="glyph" href="http://ilias.de?page=2" aria-label="next"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></a></span>
+            </div>
         </div>
+        <div class="panel-controls"></div>
     </div>
     <div class="panel-body">Legacy content</div>
 </div>
@@ -309,14 +309,14 @@ EOT;
 <div class="panel panel-secondary panel-flex">
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>Title</h2></div>
-        <div class="panel-controls"></div>
-    </div>
-    <div class="panel-viewcontrols l-bar__container">
-        <div class="il-viewcontrol-section l-bar__element">
-            <a class="btn btn-ctrl browse previous" href="http://www.ilias.de" aria-label="previous" data-action="http://www.ilias.de" id="id_1"><span class="glyphicon glyphicon-chevron-left"></span></a>
-            <button class="btn btn-default" data-action="">current</button>
-            <a class="btn btn-ctrl browse next" href="http://www.github.com" aria-label="next" data-action="http://www.github.com" id="id_2"><span class="glyphicon glyphicon-chevron-right"></span></a>
+        <div class="panel-viewcontrols l-bar__container">
+            <div class="il-viewcontrol-section l-bar__element">
+                <a class="btn btn-ctrl browse previous" href="http://www.ilias.de" aria-label="previous" data-action="http://www.ilias.de" id="id_1"><span class="glyphicon glyphicon-chevron-left"></span></a>
+                <button class="btn btn-default" data-action="">current</button>
+                <a class="btn btn-ctrl browse next" href="http://www.github.com" aria-label="next" data-action="http://www.github.com" id="id_2"><span class="glyphicon glyphicon-chevron-right"></span></a>
+            </div>
         </div>
+        <div class="panel-controls"></div>
     </div>
     <div class="panel-body">Legacy content</div>
 </div>

--- a/tests/UI/Component/Panel/PanelSecondaryListingTest.php
+++ b/tests/UI/Component/Panel/PanelSecondaryListingTest.php
@@ -188,22 +188,21 @@ EOT;
 <div class="panel panel-secondary panel-flex">
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>Title</h2></div>
-        <div class="panel-controls"></div>
-    </div>
-    <div class="panel-viewcontrols l-bar__container">
-        <div class="il-viewcontrol-sortation l-bar__element" id="id_1">
-            <div class="dropdown">
-                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="id_4" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_4_menu">
-                    <span class="caret"></span>
-                </button>
-                <ul id="id_4_menu" class="dropdown-menu">
-                    <li><button class="btn btn-link" data-action="?sortation=a" id="id_2">A</button></li>
-                    <li><button class="btn btn-link" data-action="?sortation=b" id="id_3">B</button></li>
-                </ul>
+        <div class="panel-viewcontrols l-bar__container">
+            <div class="il-viewcontrol-sortation l-bar__element" id="id_1">
+                <div class="dropdown">
+                    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="id_4" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_4_menu">
+                        <span class="caret"></span>
+                    </button>
+                    <ul id="id_4_menu" class="dropdown-menu">
+                        <li><button class="btn btn-link" data-action="?sortation=a" id="id_2">A</button></li>
+                        <li><button class="btn btn-link" data-action="?sortation=b" id="id_3">B</button></li>
+                    </ul>
+                </div>
             </div>
         </div>
+        <div class="panel-controls"></div>
     </div>
-    
     <div class="panel-body">
     </div>
 </div>
@@ -231,26 +230,26 @@ EOT;
 <div class="panel panel-secondary panel-flex">
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>Title</h2></div>
-        <div class="panel-controls"></div>
-    </div>
-    <div class="panel-viewcontrols l-bar__container">
-        <div class="il-viewcontrol-pagination l-bar__element">
-            <span class="btn btn-ctrl browse previous">
-                <a tabindex="0" class="glyph" href="http://ilias.de?page=0" aria-label="back">
-                    <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-                </a>
-            </span>
-            <button class="btn btn-link" data-action="http://ilias.de?page=0" id="id_1">1</button>
-            <button class="btn btn-link engaged" aria-pressed="true" data-action="http://ilias.de?page=1" id="id_2">2</button>
-            <button class="btn btn-link" data-action="http://ilias.de?page=2" id="id_3">3</button>
-            <button class="btn btn-link" data-action="http://ilias.de?page=3" id="id_4">4</button>
-            <button class="btn btn-link" data-action="http://ilias.de?page=4" id="id_5">5</button>
-            <span class="btn btn-ctrl browse next">
-                <a tabindex="0" class="glyph" href="http://ilias.de?page=2" aria-label="next">
-                    <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-                </a>
-            </span>
+        <div class="panel-viewcontrols l-bar__container">
+            <div class="il-viewcontrol-pagination l-bar__element">
+                <span class="btn btn-ctrl browse previous">
+                    <a tabindex="0" class="glyph" href="http://ilias.de?page=0" aria-label="back">
+                        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+                    </a>
+                </span>
+                <button class="btn btn-link" data-action="http://ilias.de?page=0" id="id_1">1</button>
+                <button class="btn btn-link engaged" aria-pressed="true" data-action="http://ilias.de?page=1" id="id_2">2</button>
+                <button class="btn btn-link" data-action="http://ilias.de?page=2" id="id_3">3</button>
+                <button class="btn btn-link" data-action="http://ilias.de?page=3" id="id_4">4</button>
+                <button class="btn btn-link" data-action="http://ilias.de?page=4" id="id_5">5</button>
+                <span class="btn btn-ctrl browse next">
+                    <a tabindex="0" class="glyph" href="http://ilias.de?page=2" aria-label="next">
+                        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+                    </a>
+                </span>
+            </div>
         </div>
+        <div class="panel-controls"></div>
     </div>
     <div class="panel-body">
     </div>
@@ -278,18 +277,18 @@ EOT;
 <div class="panel panel-secondary panel-flex">
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>Title</h2></div>
-        <div class="panel-controls"></div>
-    </div>
-    <div class="panel-viewcontrols l-bar__container">
-        <div class="il-viewcontrol-section l-bar__element">
-            <a class="btn btn-ctrl browse previous" href="http://www.ilias.de" aria-label="previous" data-action="http://www.ilias.de" id="id_1">
-                <span class="glyphicon glyphicon-chevron-left"></span>
-            </a>
-            <button class="btn btn-default" data-action="">current</button>
-            <a class="btn btn-ctrl browse next" href="http://www.github.com" aria-label="next" data-action="http://www.github.com" id="id_2">
-                <span class="glyphicon glyphicon-chevron-right"></span>
-            </a>
+        <div class="panel-viewcontrols l-bar__container">
+            <div class="il-viewcontrol-section l-bar__element">
+                <a class="btn btn-ctrl browse previous" href="http://www.ilias.de" aria-label="previous" data-action="http://www.ilias.de" id="id_1">
+                    <span class="glyphicon glyphicon-chevron-left"></span>
+                </a>
+                <button class="btn btn-default" data-action="">current</button>
+                <a class="btn btn-ctrl browse next" href="http://www.github.com" aria-label="next" data-action="http://www.github.com" id="id_2">
+                    <span class="glyphicon glyphicon-chevron-right"></span>
+                </a>
+            </div>
         </div>
+        <div class="panel-controls"></div>
     </div>
     <div class="panel-body">
     </div>

--- a/tests/UI/Component/Panel/PanelTest.php
+++ b/tests/UI/Component/Panel/PanelTest.php
@@ -384,17 +384,17 @@ EOT;
 <div class="panel panel-primary panel-flex">
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>Title</h2></div>
-        <div class="panel-controls"></div>
-    </div>
-    <div class="panel-viewcontrols l-bar__container">
-        <div class="il-viewcontrol-sortation l-bar__element" id="id_1">
-            <div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="id_4"  aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_4_menu"><span class="caret"></span></button>
-                <ul id="id_4_menu" class="dropdown-menu">
-                   <li><button class="btn btn-link" data-action="?sortation=a" id="id_2">A</button></li>
-                   <li><button class="btn btn-link" data-action="?sortation=b" id="id_3">B</button></li>
-                </ul>
+        <div class="panel-viewcontrols l-bar__container">
+            <div class="il-viewcontrol-sortation l-bar__element" id="id_1">
+                <div class="dropdown"><button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="id_4"  aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_4_menu"><span class="caret"></span></button>
+                    <ul id="id_4_menu" class="dropdown-menu">
+                       <li><button class="btn btn-link" data-action="?sortation=a" id="id_2">A</button></li>
+                       <li><button class="btn btn-link" data-action="?sortation=b" id="id_3">B</button></li>
+                    </ul>
+                </div>
             </div>
         </div>
+        <div class="panel-controls"></div>
     </div>
     <div class="panel-body"></div>
 </div>
@@ -426,26 +426,26 @@ EOT;
 <div class="panel panel-primary panel-flex">
     <div class="panel-heading ilHeader">
         <div class="panel-title"><h2>Title</h2></div>
-        <div class="panel-controls"></div>
-    </div>
-    <div class="panel-viewcontrols l-bar__container">
-		<div class="il-viewcontrol-pagination l-bar__element">
-                <span class="btn btn-ctrl browse previous">
-                    <a tabindex="0" class="glyph" href="http://ilias.de?page=0" aria-label="back">
-                        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+        <div class="panel-viewcontrols l-bar__container">
+            <div class="il-viewcontrol-pagination l-bar__element">
+                    <span class="btn btn-ctrl browse previous">
+                        <a tabindex="0" class="glyph" href="http://ilias.de?page=0" aria-label="back">
+                            <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+                        </a>
+                    </span>
+                    <button class="btn btn-link" data-action="http://ilias.de?page=0" id="id_1">1</button>
+                    <button class="btn btn-link engaged" aria-pressed="true" data-action="http://ilias.de?page=1" id="id_2">2</button>
+                    <button class="btn btn-link" data-action="http://ilias.de?page=2" id="id_3">3</button>
+                    <button class="btn btn-link" data-action="http://ilias.de?page=3" id="id_4">4</button>
+                    <button class="btn btn-link" data-action="http://ilias.de?page=4" id="id_5">5</button>
+                    <span class="btn btn-ctrl browse next">
+                    <a tabindex="0" class="glyph" href="http://ilias.de?page=2" aria-label="next">
+                        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
                     </a>
                 </span>
-                <button class="btn btn-link" data-action="http://ilias.de?page=0" id="id_1">1</button>
-                <button class="btn btn-link engaged" aria-pressed="true" data-action="http://ilias.de?page=1" id="id_2">2</button>
-                <button class="btn btn-link" data-action="http://ilias.de?page=2" id="id_3">3</button>
-                <button class="btn btn-link" data-action="http://ilias.de?page=3" id="id_4">4</button>
-                <button class="btn btn-link" data-action="http://ilias.de?page=4" id="id_5">5</button>
-                <span class="btn btn-ctrl browse next">
-                <a tabindex="0" class="glyph" href="http://ilias.de?page=2" aria-label="next">
-                    <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-                </a>
-            </span>
+            </div>
         </div>
+        <div class="panel-controls"></div>
     </div>
     <div class="panel-body"></div>
 </div>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38937

# Issue

New view controls in panel are too prominently placed: centered and below the panel header

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/9f0c2c84-5203-4e42-b194-1802450b5ef4)

# Changes

View Controls are now in panel header
View Controls button size is now reduced using the exact values suggested by @yvseiler (Thank you! :slightly_smiling_face: )
View Controls drop into a bottom header row on smaller screen sizes
Sortation uses only a glyph to save space

![ViewControl_Pabel_Listing](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/4eea36b1-82ac-4d02-b288-486bf6a2980d)

# Outlook

A PR to make glyphs possible in the Dashboard View Control Mode will follow in January.
