### PR TITLE
T&A Bugfix #0039405: Failed Tests: Buttonlabel missing for Hints

### DIFF
--- a/Modules/Test/classes/class.ilTestQuestionNavigationGUI.php
+++ b/Modules/Test/classes/class.ilTestQuestionNavigationGUI.php
@@ -464,7 +464,7 @@ class ilTestQuestionNavigationGUI
             $this->renderSubmitButton(
                 $tpl,
                 $this->getShowHintsCommand(),
-                'button_show_requested_question_hints'
+                $this->lng->txt('button_show_requested_question_hints')
             );
         }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=39405