### PR TITLE
9/legacy-UI/toolbar fix inline form 39565

### DIFF
--- a/templates/default/070-components/legacy/Services/UIComponent/_component_toolbar.scss
+++ b/templates/default/070-components/legacy/Services/UIComponent/_component_toolbar.scss
@@ -128,13 +128,17 @@ $il-toolbar-border: 1px solid $il-main-border-color !default;
 		padding: 0;
 	}
 
-	> .form-control {
+	.navbar-form > .form-control {
 		width: auto;
 		display: inline-block;
 		vertical-align: middle;
 	}
-	.input-group  {
+	.navbar-form > .input-group  {
+		display: inline-table;
 		vertical-align: middle;
+		> .input-group-btn {
+			width: auto;
+		}
 	}
 
 	input[type="file"] {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -18017,13 +18017,17 @@ a.ilMediaLightboxClose:hover {
 .ilToolbar .ilToolbarItems {
   padding: 0;
 }
-.ilToolbar > .form-control {
+.ilToolbar .navbar-form > .form-control {
   width: auto;
   display: inline-block;
   vertical-align: middle;
 }
-.ilToolbar .input-group {
+.ilToolbar .navbar-form > .input-group {
+  display: inline-table;
   vertical-align: middle;
+}
+.ilToolbar .navbar-form > .input-group > .input-group-btn {
+  width: auto;
 }
 .ilToolbar input[type=file] {
   display: inline-block;
@@ -18120,6 +18124,18 @@ a.ilMediaLightboxClose:hover {
     padding-left: 0;
   }
 }
+.ilToolbar .navbar-form > .input-group > .input-group-btn {
+  width: auto;
+}
+
+.ilToolbar .navbar-form > .input-group {
+  display: inline-table;
+}
+
+.ilToolbar .navbar-form > .form-control {
+  display: inline-block;
+}
+
 .navbar {
   position: relative;
   min-height: 40px;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=39565

# Issue

Toolbar form in media pool > video item edit > subtitles is misaligned

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/3f7f8c1f-13d7-45d1-bd24-a87799675b16)

# Changes

Toolbar is in conflict with a previous fix which made only direct children be subject of the toolbar's special styling for forms. https://github.com/ILIAS-eLearning/ILIAS/pull/6688
However, simply reverting was also out of the question. Too general of a styling could affect modals with forms popping up from "within" the toolbar. So this very specific, local styling should fix the problem without breaking modals triggered from the toolbar.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/68b83ac2-9707-44cd-b075-37d23514f638)


