### PR TITLE
9/UI/COPage js needs content in p and surrounding section dropdown

### DIFF
--- a/Services/COPage/classes/class.ilPageObjectGUI.php
+++ b/Services/COPage/classes/class.ilPageObjectGUI.php
@@ -2033,7 +2033,7 @@ class ilPageObjectGUI
 
         if ($a_paragraph_styles) {
             $sel = new \ParagraphStyleSelector($ui_wrapper, $a_style_id);
-            $dd = $sel->getStyleSelector("");
+            $dd = $sel->getStyleSelector(" ");
             $btpl->setCurrentBlock("par_edit");
             $btpl->setVariable("TXT_PAR_FORMAT", $lng->txt("cont_par_format"));
 
@@ -2044,7 +2044,7 @@ class ilPageObjectGUI
 
         // block styles
         $sel = new \SectionStyleSelector($ui_wrapper, $a_style_id);
-        $dd = $sel->getStyleSelector("", $type = "par-action", $action = "sec.class", $attr = "class", true);
+        $dd = $sel->getStyleSelector(" ", $type = "par-action", $action = "sec.class", $attr = "class", true);
         $btpl->setVariable("TXT_BLOCK", $lng->txt("cont_sur_block_format"));
         $btpl->setVariable("BLOCK_STYLE_SELECTOR", $ui->renderer()->render($dd));
 


### PR DESCRIPTION
# Issue

Dropdowns in page editor for paragraph style and surrounding section appear broken.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/1dc68d78-baed-457d-88d3-fab7104bcedf)

This is because dropdown text is rendered into caret span which should be empty so it creates the triangle for the dropdown. Dropdown text should be in front of the caret span.

# Changes

It appears that the currently selected style name is placed into the dropdown via js. The js seems to have trouble finding the correct place to insert the text when the dropdown is rendered using `""` as a placeholder string. When using `" "` as a placeholder string the dropdown is the filled in the correct place as a sibling of the span, causing the empty span to correctly render a triangle.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/89905cc7-7748-44ed-921d-81a014046766)