### PR TITLE
9/UI/print no general display block 39256

### DIFF
--- a/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
+++ b/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
@@ -509,8 +509,7 @@ footer {
 				display: none !important;
 			}
 		}
-		.il-layout-page-content,
-		.il-layout-page-content div	{
+		.il-layout-page-content {
 			display: block;
 		}
 	}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1,4 +1,7 @@
 @charset "UTF-8";
+/*
+* Dependencies
+*/
 /*!
  * Datetimepicker for Bootstrap 3
  * version : 4.17.37
@@ -681,8 +684,9 @@ table.mceToolbar tbody, table.mceToolbar tr, table.mceToolbar td {
 }
 
 /*
-* Dependencies
-*/ /* print less */
+* Normalize
+*/
+/* print less */
 @media print {
   * {
     /* see bug 0022342 */
@@ -890,9 +894,6 @@ th {
   padding: 0;
 }
 
-/*
-* Normalize
-*/
 .row {
   --bs-gutter-x: 30px;
   --bs-gutter-y: 0;
@@ -1972,6 +1973,9 @@ th {
     display: none !important;
   }
 }
+/*
+* Elements
+*/
 * {
   box-sizing: border-box;
 }
@@ -2347,8 +2351,9 @@ code {
   }
 }
 /*
-* Elements
+* Components
 */
+/* UI Framework */
 .c-tooltip__container {
   position: relative;
   display: inline-block;
@@ -5177,8 +5182,7 @@ footer {
   html body .il-layout-page .ilFileDropTargetOverlay {
     display: none !important;
   }
-  html body .il-layout-page-content,
-  html body .il-layout-page-content div {
+  html body .il-layout-page-content {
     display: block;
   }
 }
@@ -9524,6 +9528,7 @@ td.c-table-data__cell--highlighted {
   width: 5rem;
 }
 
+/* Component parts from old delos.scss */
 div#agreement {
   width: 100%;
   height: 375px;
@@ -10216,6 +10221,7 @@ div.il_info {
   border-color: #dddddd;
 }
 
+/* Adapted from Bootstrap 3 */
 .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
@@ -10843,6 +10849,7 @@ tbody.collapse.in {
   clip: auto;
 }
 
+/* Legacy Modules & Services */
 /* Modules/Bibliographic */
 span.bibl_text_inline_Emph {
   font-style: italic;
@@ -18533,13 +18540,6 @@ img.ilUserXXSmall {
   outline: 3px solid #0078D7;
 }
 
-/*
-* Components
-*/
-/* UI Framework */
-/* Component parts from old delos.scss */
-/* Adapted from Bootstrap 3 */
-/* Legacy Modules & Services */
 /*
 	These classes are used to limit the number of rows when displaying larger chunks of text.
 	The mixin receives $height-in-rows as an integer. The classes il-multi-line-cap-2,3,5,10


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=39256

# Issue

Most grids and complex layouts look terrible in print e.g. the kprim question:

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/3a1e2ebc-6aa6-401f-b60b-76049d420628)

This is mostly due to all divs under .il-layout-page-content being set to "display: block", which makes css grids and flex-box layouts no longer functional.

# Changes

As discussed during the CSS Squad we would prefer to not apply such a general one size fits all solution and rather only apply locally optimized print styling when the browser default print styling actually needs fixing.

Therefor we removed the far too general styling of .il-layout-page-content div.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/e54d3e89-fa4a-4086-8a05-39e55a5b137a)

If a flex-box layout doesn't work in print we might want to consider using flex-box options to fix the issue.
