### PR TITLE
9/UI/repository add item dropdowns limit height add vertical scroll 38055

### DIFF
--- a/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
+++ b/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
@@ -71,7 +71,9 @@ $cursor-disabled: not-allowed !default;
 	z-index: $zindex-dropdown;
 	display: none; // none by default, but block on "open" of the menu
 	float: left;
+	overflow: auto;
 	min-width: 160px;
+	max-height: 50vh;
 	padding: 5px 0;
 	margin: 2px 0 0; // override default ul
 	font-size: s.$il-font-size-base;

--- a/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
+++ b/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
@@ -315,6 +315,7 @@ footer {
 	header {
 		position: -webkit-sticky;
 		position: sticky;
+		overflow-x: clip;
 		width: 100%;
 		top: 0;
 	}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1,4 +1,7 @@
 @charset "UTF-8";
+/*
+* Dependencies
+*/
 /*!
  * Datetimepicker for Bootstrap 3
  * version : 4.17.37
@@ -387,7 +390,9 @@
   z-index: 1000;
   display: none;
   float: left;
+  overflow: auto;
   min-width: 160px;
+  max-height: 50vh;
   padding: 5px 0;
   margin: 2px 0 0;
   font-size: 0.875rem;
@@ -681,8 +686,9 @@ table.mceToolbar tbody, table.mceToolbar tr, table.mceToolbar td {
 }
 
 /*
-* Dependencies
-*/ /* print less */
+* Normalize
+*/
+/* print less */
 @media print {
   * {
     /* see bug 0022342 */
@@ -890,9 +896,6 @@ th {
   padding: 0;
 }
 
-/*
-* Normalize
-*/
 .row {
   --bs-gutter-x: 30px;
   --bs-gutter-y: 0;
@@ -1972,6 +1975,9 @@ th {
     display: none !important;
   }
 }
+/*
+* Elements
+*/
 * {
   box-sizing: border-box;
 }
@@ -2347,8 +2353,9 @@ code {
   }
 }
 /*
-* Elements
+* Components
 */
+/* UI Framework */
 .c-tooltip__container {
   position: relative;
   display: inline-block;
@@ -5043,6 +5050,7 @@ footer {
   header {
     position: -webkit-sticky;
     position: sticky;
+    overflow-x: clip;
     width: 100%;
     top: 0;
   }
@@ -9546,6 +9554,7 @@ td.c-table-data__cell--highlighted {
   width: 5rem;
 }
 
+/* Component parts from old delos.scss */
 div#agreement {
   width: 100%;
   height: 375px;
@@ -10238,6 +10247,7 @@ div.il_info {
   border-color: #dddddd;
 }
 
+/* Adapted from Bootstrap 3 */
 .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
@@ -10865,6 +10875,7 @@ tbody.collapse.in {
   clip: auto;
 }
 
+/* Legacy Modules & Services */
 /* Modules/Bibliographic */
 span.bibl_text_inline_Emph {
   font-style: italic;
@@ -18547,13 +18558,6 @@ img.ilUserXXSmall {
   outline: 3px solid #0078D7;
 }
 
-/*
-* Components
-*/
-/* UI Framework */
-/* Component parts from old delos.scss */
-/* Adapted from Bootstrap 3 */
-/* Legacy Modules & Services */
 /*
 	These classes are used to limit the number of rows when displaying larger chunks of text.
 	The mixin receives $height-in-rows as an integer. The classes il-multi-line-cap-2,3,5,10


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38055

# Issues

The add item dropdown in the repository shows up awkwardly long on mobile and creates two vertical scrollbars, in the worst case even scrolling outside of the layout frame. In some cases there would also be horizontal scrollbars. This makes for a very poor user experience on narrow viewports.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/2790902a-ba6f-47c3-9bd7-3be19a6ee7fd)

# Changes

* dropdowns in general now have a max viewport height after which they stop expanding and the scrollbar appears on the dropdown menu itself rather than on the page content or layout grid
* a loosely connected issue of notification badges in the header causing horizontal scroll bars even when the width of the layout was capped at 100% width also has been fixed

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/4b87c1a4-a2c7-474e-a4d8-83a6cfc2feeb)