### PR TITLE
Bugfix: Missing parameter for getOriginalId() in multiple choice

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -789,7 +789,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
 
     public function syncWithOriginal(): void
     {
-        if ($this->questioninfo->getOriginalId()) {
+        if ($this->questioninfo->getOriginalId($this->getId())) {
             $this->syncImages();
             parent::syncWithOriginal();
         }
@@ -962,8 +962,8 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         global $DIC;
         $ilLog = $DIC['ilLog'];
         $imagepath = $this->getImagePath();
-        $question_id = $this->questioninfo->getOriginalId();
-        $originalObjId = parent::lookupParentObjId($this->questioninfo->getOriginalId());
+        $question_id = $this->questioninfo->getOriginalId($this->getId());
+        $originalObjId = parent::lookupParentObjId($this->questioninfo->getOriginalId($this->getId()));
         $imagepath_original = $this->getImagePath($question_id, $originalObjId);
 
         ilFileUtils::delDir($imagepath_original);


### PR DESCRIPTION
Bugfix for missing question id parameter that leads to fatal error if you are editing a question and want to save the changes also  to the parent question of a TestQuestionPool