### PR TITLE
Fix for Survery detailexport (#37733)

### DIFF
--- a/Modules/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
+++ b/Modules/Survey/Evaluation/class.ilSurveyEvaluationGUI.php
@@ -594,7 +594,7 @@ class ilSurveyEvaluationGUI
             $a_excel->setCell($a_excel_row, 0, $this->lng->txt("freetext_answers"));
 
             // mc/sc
-            if (!is_array($a_text_answers[""])) {
+            if (isset($a_text_answers[""])&&!is_array($a_text_answers[""])) {
                 $a_excel->setColors("B" . $a_excel_row . ":C" . $a_excel_row, self::EXCEL_SUBTITLE);
                 $a_excel->setCell($a_excel_row, 1, $this->lng->txt("title"));
                 $a_excel->setCell($a_excel_row++, 2, $this->lng->txt("answer"));
@@ -607,7 +607,7 @@ class ilSurveyEvaluationGUI
 
             foreach ($a_text_answers as $var => $items) {
                 foreach ($items as $item) {
-                    if (!is_array($a_text_answers[""])) {
+                    if (isset($a_text_answers[""])&&!is_array($a_text_answers[""])) {
                         $a_excel->setCell($a_excel_row, 1, $var);
                         $a_excel->setCell($a_excel_row++, 2, $item);
                     } else {


### PR DESCRIPTION
excel detail export didnt function when trying to export surverys containing freetext answers - tried to access an array without checking wether the array key is set.