### PR TITLE
IASS: fix action link to iass settings. (#39835)

### DIFF
--- a/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentListGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentListGUI.php
@@ -17,8 +17,6 @@
  *********************************************************************/
 declare(strict_types=1);
 
-declare(strict_types=1);
-
 class ilObjIndividualAssessmentListGUI extends ilObjectListGUI
 {
     public function init(): void
@@ -55,12 +53,6 @@ class ilObjIndividualAssessmentListGUI extends ilObjectListGUI
     public function getCommandLink(string $cmd): string
     {
         switch ($cmd) {
-            case 'edit':
-                $return = $this->ctrl->getLinkTargetByClass(
-                    array($this->gui_class_name,'ilIndividualassessmentsettingsgui'),
-                    "edit"
-                );
-                break;
             case 'infoScreen':
                 $return = $this->ctrl->getLinkTargetByClass($this->gui_class_name, "view");
                 break;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=39835

The implementation removes some code which was not needed and resulted to using the wrong ref_id and object (Course Object instead of Individual Assessment Object) and therefore could not find the iass access handler.