### PR TITLE
NPM: Add `jQuery`

### DIFF
--- a/public/package_new.json
+++ b/public/package_new.json
@@ -8,6 +8,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "jquery": "^3.6.0"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
This PR adds `jQuery` as NPM dependency.

Usage:
* In many components, searching for `$(` results in 2414 occurrences

Wrapped By:
* Not applicable

Reasoning:
* `jQuery` has been introduced many years ago as a DOM abstraction and utility (XMLHttpRequest, Event Handling etc.) library. Nowadays, many of this functions could be replaced by the "Vanilla JS" API. Nevertheless, I doubt that we could tackle the migration in a timely manner for ILIAS 10. It is unlikely to remove this dependency for all components outside of a big project with according funding and organisational resources.

Maintenance:
* `jQuery` is actively maintained and has an existing security policy (https://github.com/jquery/jquery/blob/e06ff08849057cd099365bf43598c8952fe9956d/SECURITY.md).

**Important:** It might be necessary to also include `"jquery-migrate": "^3.0.0",`, maybe the developer who introduced this can explain this further.

Links:
* NPM: https://www.npmjs.com/package/jquery
* GitHub: https://github.com/jquery/jquery
* Documentation: https://api.jquery.com/