### PR TITLE
NPM: Add `linkifyjs`

### DIFF
--- a/public/package_new.json
+++ b/public/package_new.json
@@ -8,6 +8,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "linkifyjs": "^4.1.3"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
This PR adds `linkifyjs` as NPM dependency.

Usage:
* CoPage: Used in paragraphs
* LearningModule: Used for the export
* OnScreenChat: Used to make links in chat messages clickable.
  * See: components/ILIAS/OnScreenChat/js/onscreenchat.js

Wrapped By:
* ./components/ILIAS/Link/js/ilExtLink.js

Reasoning:
* `linkifyjs` is used by the `OnScreenChat` to transform URL-like strings into clickable HTML link elements. Without this library all kind of URL-like strings (see: https://linkify.js.org/) are not transformed anymore and our users will have to copy the strings manually into the browser address input. I doubt we can support this feature with a few regular expressions maintained by the ILIAS community.

Maintenance:
* `linkifyjs` is actively maintained, although it is feature-complete. In the last months a few bug fixes and improvements have been committed.

Links:
* NPM: https://www.npmjs.com/package/linkifyjs
* GitHub: https://github.com/Hypercontext/linkifyjs
* Documentation: https://linkify.js.org/docs/