### PR TITLE
#39893 define -ui before using it

### DIFF
--- a/Services/Help/classes/class.ilHelpGUI.php
+++ b/Services/Help/classes/class.ilHelpGUI.php
@@ -60,6 +60,8 @@ class ilHelpGUI implements ilCtrlBaseClassInterface
 
     protected function initUI(): void
     {
+        global $DIC;
+        $this->ui = $DIC->ui();
         $gui = $this->internal()->gui();
         $this->ctrl = $gui->ctrl();
         $this->help_request = $gui->standardRequest();


### PR DESCRIPTION
ilHelpGUI::ui was not initialised and preventing help to be shown.