### PR TITLE
LegalDocuments: Fix filter, pagination, self registration, change messages

### DIFF
--- a/Services/LegalDocuments/classes/ConsumerToolbox/Blocks.php
+++ b/Services/LegalDocuments/classes/ConsumerToolbox/Blocks.php
@@ -143,7 +143,7 @@ class Blocks
             $this->container->language()->loadLanguageModule('ldoc');
             $user = $build_user($user);
 
-            $value = $user->acceptedDocument()->map(function (DocumentContent $content) use ($lang_key, $user): ilNonEditableValueGUI {
+            $value = $user->acceptedVersion()->map(function (DocumentContent $content) use ($lang_key, $user): ilNonEditableValueGUI {
                 $input = new ilNonEditableValueGUI($this->ui()->txt($lang_key), $lang_key);
                 $input->setValue($this->formatDate($user->agreeDate()->value()));
                 $modal = $this->ui()->create()->modal()->lightbox([

--- a/Services/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/Agreement.php
+++ b/Services/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/Agreement.php
@@ -61,9 +61,13 @@ final class Agreement implements AgreementInterface
 
     public function showAgreementForm(string $gui, string $cmd): PageFragment
     {
+        $form = $this->user->matchingDocument()->isOk() ?
+              $this->agreementForm($gui, $cmd) :
+              $this->ui->create()->divider()->horizontal();
+
         return (new PageContent($this->ui->txt('accept_usr_agreement'), [
             $this->showDocument(),
-            $this->agreementForm($gui, $cmd),
+            $form,
             $this->logoutLink(),
         ]))->withOnScreenMessage('info', $this->ui->txt('accept_usr_agreement_intro'));
     }
@@ -71,7 +75,7 @@ final class Agreement implements AgreementInterface
     public function needsToAgree(): bool
     {
         return !$this->user->cannotAgree()
-            && ($this->user->neverAgreed() || $this->user->didNotAcceptCurrentVersion());
+            && ($this->user->neverAgreed() || $this->user->needsToAcceptNewDocument());
     }
 
     private function showDocument(): Component

--- a/Services/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/ModifyFooter.php
+++ b/Services/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/ModifyFooter.php
@@ -52,7 +52,7 @@ final class ModifyFooter
 
     public function __invoke(Footer $footer): Footer
     {
-        return $this->user->acceptedDocument()->map(
+        return $this->user->acceptedVersion()->map(
             $this->renderModal($footer)
         )->except(
             fn() => new Ok($footer)

--- a/Services/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/SelfRegistration.php
+++ b/Services/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/SelfRegistration.php
@@ -62,8 +62,18 @@ final class SelfRegistration implements SelfRegistrationInterface
 
     public function saveLegacyForm(ilPropertyFormGUI $form): bool
     {
-        if (!$form->getInput($this->checkboxVariableName())) {
-            $form->getItemByPostVar($this->checkboxVariableName())->setAlert($this->ui->txt('force_accept_usr_agreement'));
+        if ($this->user->matchingDocument()->isError()) {
+            $this->ui->loadLanguageModule($this->id);
+            $this->ui->loadLanguageModule('ldoc');
+            $this->ui->mainTemplate()->setOnScreenMessage('failure', sprintf(
+                $this->ui->txt('account_reg_not_possible'),
+                'mailto:' . \ilLegacyFormElementsUtil::prepareFormOutput(\ilSystemSupportContacts::getMailsToAddress())
+            ), true);
+            return false;
+        }
+        $input = $form->getItemByPostVar($this->checkboxVariableName());
+        if ($input && !$form->getInput($this->checkboxVariableName())) {
+            $input->setAlert($this->ui->txt('force_accept_usr_agreement'));
             return false;
         }
 

--- a/Services/LegalDocuments/classes/ConsumerToolbox/UI.php
+++ b/Services/LegalDocuments/classes/ConsumerToolbox/UI.php
@@ -45,6 +45,11 @@ class UI
         return $this->main_template;
     }
 
+    public function loadLanguageModule(string $module): void
+    {
+        $this->language->loadLanguageModule($module);
+    }
+
     public function txt(string $name): string
     {
         return $this->language->txt($this->firstExisting([

--- a/Services/LegalDocuments/classes/ConsumerToolbox/User.php
+++ b/Services/LegalDocuments/classes/ConsumerToolbox/User.php
@@ -84,16 +84,30 @@ class User
         return $this->settings->validateOnLogin()->value() && $this->matchingDocument()->map($this->didNotAccept(...))->except($false)->value();
     }
 
+    public function needsToAcceptNewDocument(): bool
+    {
+        $true = fn() => new Ok(true);
+        $db = $this->legal_documents->history();
+
+        return $this->settings->validateOnLogin()->value()
+            && $db->currentDocumentOfAcceptedVersion($this->user)->map($this->doesntMatch(...))->except($true)->value();
+    }
+
+    public function doesntMatch(Document $document): bool
+    {
+        return !$this->legal_documents->document()->documentMatches($document, $this->user);
+    }
+
     public function matchingDocument(): Result
     {
         return ($this->matching_document)();
     }
 
-    public function acceptedDocument(): Result
+    public function acceptedVersion(): Result
     {
         return $this->cannotAgree() || $this->neverAgreed() ?
             new Error('User never agreed.') :
-            $this->legal_documents->history()->acceptedDocument($this->user);
+            $this->legal_documents->history()->acceptedVersion($this->user);
     }
 
     public function acceptMatchingDocument(): void

--- a/Services/LegalDocuments/classes/Legacy/ResettingDurationInputGUI.php
+++ b/Services/LegalDocuments/classes/Legacy/ResettingDurationInputGUI.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\LegalDocuments\Legacy;
+
+use ilDateDurationInputGUI;
+
+/**
+ * The ilDateDurationInputGUI class doesn't set it's value back to an empty value when called with an empty array, in contrast to e.g. ilTextInputGUI.
+ * This prevents that the value is cleared when a ilTable2GUI is reset.
+ * To prevent that the whole table needs to be recreated just to clear this input GUI, this class directly clears the value instead.
+ */
+class ResettingDurationInputGUI extends ilDateDurationInputGUI
+{
+    public function setValueByArray(array $a_values): void
+    {
+        if (array_filter($a_values) === []) {
+            $this->setStart(null);
+            $this->setEnd(null);
+            return;
+        }
+        parent::setValueByArray($a_values);
+    }
+}

--- a/Services/LegalDocuments/classes/Provide/ProvideDocument.php
+++ b/Services/LegalDocuments/classes/Provide/ProvideDocument.php
@@ -25,9 +25,6 @@ use ILIAS\DI\Container;
 use ILIAS\Data\Result;
 use ILIAS\Data\Result\Error;
 use ILIAS\Data\Result\Ok;
-use ILIAS\LegalDocuments\ChangeSet;
-use ILIAS\LegalDocuments\Change\AcceptedDocument;
-use ILIAS\LegalDocuments\Change\AddDocument;
 use ILIAS\LegalDocuments\Condition;
 use ILIAS\LegalDocuments\Legacy\Table;
 use ILIAS\LegalDocuments\Repository\DocumentRepository;
@@ -94,12 +91,18 @@ class ProvideDocument
 
     public function chooseDocumentFor(ilObjUser $user): Result
     {
-        $document_matches = fn(Document $document): bool => $this->all(
+        return $this->find(
+            fn(Document $document): bool => $this->documentMatches($document, $user),
+            $this->document_repository->all()
+        );
+    }
+
+    public function documentMatches(Document $document, ilObjUser $user): bool
+    {
+        return $this->all(
             fn($c) => $this->toCondition($c->content())->eval($user),
             $document->criteria()
         );
-
-        return $this->find($document_matches, $this->document_repository->all());
     }
 
     public function repository(): DocumentRepository

--- a/Services/LegalDocuments/classes/Provide/ProvideHistory.php
+++ b/Services/LegalDocuments/classes/Provide/ProvideHistory.php
@@ -86,8 +86,16 @@ class ProvideHistory
     /**
      * @return Result<DocumentContent>
      */
-    public function acceptedDocument(ilObjUser $user): Result
+    public function acceptedVersion(ilObjUser $user): Result
     {
-        return $this->repository->acceptedDocument($user);
+        return $this->repository->acceptedVersion($user);
+    }
+
+    /**
+     * @return Result<Document>
+     */
+    public function currentDocumentOfAcceptedVersion(ilObjUser $user): Result
+    {
+        return $this->repository->currentDocumentOfAcceptedVersion($user);
     }
 }

--- a/Services/LegalDocuments/classes/Repository/HistoryRepository.php
+++ b/Services/LegalDocuments/classes/Repository/HistoryRepository.php
@@ -44,5 +44,10 @@ interface HistoryRepository
     /**
      * @return Result<DocumentContent>
      */
-    public function acceptedDocument(ilObjUser $user): Result;
+    public function acceptedVersion(ilObjUser $user): Result;
+
+    /**
+     * @return Result<Document>
+     */
+    public function currentDocumentOfAcceptedVersion(ilObjUser $user): Result;
 }

--- a/Services/LegalDocuments/classes/Setup/UpdateSteps.php
+++ b/Services/LegalDocuments/classes/Setup/UpdateSteps.php
@@ -71,6 +71,19 @@ class UpdateSteps implements ilDatabaseUpdateSteps
         // Keep
     }
 
+    public function step_3(): void
+    {
+        $this->ensureColumn('ldoc_versions', 'provider', [
+            'type' => ilDBConstants::T_TEXT,
+            'notnull' => true,
+            'default' => '',
+            'length' => 255,
+        ]);
+
+        $select_provider = '(SELECT d.provider FROM ldoc_documents AS d WHERE v.doc_id = d.id)';
+        $this->database->manipulate("UPDATE ldoc_versions AS v SET provider = $select_provider WHERE provider = '' AND EXISTS $select_provider");
+    }
+
     /**
      * @param array<string, mixed> $attributes
      */

--- a/Services/LegalDocuments/classes/Table/HistoryTable.php
+++ b/Services/LegalDocuments/classes/Table/HistoryTable.php
@@ -29,6 +29,7 @@ use ILIAS\LegalDocuments\TableSelection;
 use ILIAS\LegalDocuments\Table\DocumentModal;
 use ILIAS\LegalDocuments\ConsumerToolbox\UI;
 use ILIAS\LegalDocuments\Provide\ProvideDocument;
+use ILIAS\LegalDocuments\Legacy\ResettingDurationInputGUI;
 use ilLanguage;
 use ilTextInputGUI;
 use ilDateDurationInputGUI;
@@ -134,13 +135,14 @@ class HistoryTable implements Table
     private function time(): ilDateDurationInputGUI
     {
         class_exists(ilDateTime::class); // Trigger autoloader to ensure IL_CAL_UNIX is defined.
-        $duration = ($this->create)(ilDateDurationInputGUI::class, $this->ui->txt('period'), 'period');
+        $duration = ($this->create)(ResettingDurationInputGUI::class, $this->ui->txt('period'), 'period');
         $duration->setAllowOpenIntervals(true);
         $duration->setShowTime(true);
         $duration->setStartText($this->ui->txt('period_from'));
         $duration->setEndText($this->ui->txt('period_until'));
         $duration->setStart(($this->create)(ilDateTime::class, null, IL_CAL_UNIX));
         $duration->setEnd(($this->create)(ilDateTime::class, null, IL_CAL_UNIX));
+
         return $duration;
     }
 

--- a/Services/LegalDocuments/test/AdministrationTest.php
+++ b/Services/LegalDocuments/test/AdministrationTest.php
@@ -58,7 +58,7 @@ class AdministrationTest extends TestCase
     {
         $config = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
         $container = $this->getMockBuilder(Container::class)->disableOriginalConstructor()->getMock();
-        $ui = $this->mockMethod(UI::class, 'txt', ['sure_reset_tos'], 'translated');
+        $ui = $this->mockMethod(UI::class, 'txt', ['sure_delete_documents_p'], 'translated');
 
         $documents = [$this->doc(9, 'First title'), $this->doc(49, 'Second title')];
 

--- a/Services/LegalDocuments/test/ConsumerToolbox/BlocksTest.php
+++ b/Services/LegalDocuments/test/ConsumerToolbox/BlocksTest.php
@@ -157,7 +157,7 @@ class BlocksTest extends TestCase
         $date = new DateTimeImmutable();
         $ldoc_user = $this->mockTree(User::class, [
             'agreeDate' => ['value' => $date],
-            'acceptedDocument' => $result,
+            'acceptedVersion' => $result,
         ]);
 
         $language = $this->mock(ilLanguage::class);

--- a/Services/LegalDocuments/test/ConsumerToolbox/ConsumerSlots/AgreementTest.php
+++ b/Services/LegalDocuments/test/ConsumerToolbox/ConsumerSlots/AgreementTest.php
@@ -114,7 +114,7 @@ class AgreementTest extends TestCase
             $this->mockTree(User::class, [
                 'cannotAgree' => false,
                 'neverAgreed' => false,
-                'didNotAcceptCurrentVersion' => true,
+                'needsToAcceptNewDocument' => true,
             ]),
             $this->mock(Settings::class),
             $this->mock(UI::class),
@@ -131,7 +131,7 @@ class AgreementTest extends TestCase
             $this->mockTree(User::class, [
                 'cannotAgree' => false,
                 'neverAgreed' => true,
-                'didNotAcceptCurrentVersion' => false,
+                'needsToAcceptNewDocument' => false,
             ]),
             $this->mock(Settings::class),
             $this->mock(UI::class),

--- a/Services/LegalDocuments/test/ConsumerToolbox/ConsumerSlots/ModifyFooterTest.php
+++ b/Services/LegalDocuments/test/ConsumerToolbox/ConsumerSlots/ModifyFooterTest.php
@@ -56,7 +56,7 @@ class ModifyFooterTest extends TestCase
 
         $instance = new ModifyFooter(
             $this->mock(UI::class),
-            $this->mockTree(User::class, ['acceptedDocument' => new Ok($this->mock(DocumentContent::class))]),
+            $this->mockTree(User::class, ['acceptedVersion' => new Ok($this->mock(DocumentContent::class))]),
             $this->mock(Provide::class),
             fn() => 'rendered',
             fn() => $this->mock(ilTemplate::class)

--- a/Services/LegalDocuments/test/Provide/ProvideDocumentTest.php
+++ b/Services/LegalDocuments/test/Provide/ProvideDocumentTest.php
@@ -138,6 +138,24 @@ class ProvideDocumentTest extends TestCase
         $this->assertSame($document, $result->value());
     }
 
+    public function testDocumentMatches(): void
+    {
+        $criterion = $this->mockTree(Criterion::class, ['content' => ['type' => 'bar']]);
+        $document = $this->mockMethod(Document::class, 'criteria', [], [$criterion]);
+        $user = $this->mock(ilObjUser::class);
+
+        $instance = new ProvideDocument('doo', $this->mock(DocumentRepository::class), new SelectionMap([
+            'bar' => $this->mockMethod(ConditionDefinition::class, 'withCriterion', [$criterion->content()], $this->mockMethod(
+                Condition::class,
+                'eval',
+                [$user],
+                true
+            )),
+        ]), [], $this->mock(Container::class));
+
+        $this->assertTrue($instance->documentMatches($document, $user));
+    }
+
     public function testRepository(): void
     {
         $repository = $this->mock(DocumentRepository::class);

--- a/Services/LegalDocuments/test/Provide/ProvideHistoryTest.php
+++ b/Services/LegalDocuments/test/Provide/ProvideHistoryTest.php
@@ -101,15 +101,25 @@ class ProvideHistoryTest extends TestCase
         $this->assertTrue($instance->alreadyAccepted($user, $document));
     }
 
-    public function testAcceptedDocument(): void
+    public function testAcceptedVersion(): void
     {
         $user = $this->mock(ilObjUser::class);
 
         $result = $this->mock(Result::class);
 
-        $repository = $this->mockMethod(HistoryRepository::class, 'acceptedDocument', [$user], $result);
+        $repository = $this->mockMethod(HistoryRepository::class, 'acceptedVersion', [$user], $result);
 
         $instance = new ProvideHistory('foo', $repository, $this->mock(ProvideDocument::class), $this->mock(Container::class));
-        $this->assertSame($result, $instance->acceptedDocument($user));
+        $this->assertSame($result, $instance->acceptedVersion($user));
+    }
+
+    public function testCurrentDocumentOfAcceptedVersion(): void
+    {
+        $user = $this->mock(ilObjUser::class);
+        $result = $this->mock(Result::class);
+        $repository = $this->mockMethod(HistoryRepository::class, 'currentDocumentOfAcceptedVersion', [$user], $result);
+        $instance = new ProvideHistory('foo', $repository, $this->mock(ProvideDocument::class), $this->mock(Container::class));
+
+        $this->assertSame($result, $instance->currentDocumentOfAcceptedVersion($user));
     }
 }

--- a/Services/LegalDocuments/test/Table/DocumentTableTest.php
+++ b/Services/LegalDocuments/test/Table/DocumentTableTest.php
@@ -94,14 +94,9 @@ class DocumentTableTest extends TestCase
     {
         $ui = $this->mock(UI::class);
 
-        $select = $this->mockTree(TableSelection::class, [
-            'getLimit' => 7,
-            'getOffset' => 23,
-        ]);
-        $select->expects(self::once())->method('setMaxCount')->with(2);
+        $select = $this->mock(TableSelection::class);
 
-        $repository = $this->mockMethod(DocumentRepository::class, 'countAll', [], 2);
-        $repository->expects(self::once())->method('all')->with(23, 7)->willReturn([
+        $repository = $this->mockMethod(DocumentRepository::class, 'all', [], [
             $this->mock(Document::class),
             $this->mock(Document::class)
         ]);
@@ -136,14 +131,8 @@ class DocumentTableTest extends TestCase
             $this->mock(Document::class)
         ];
 
-        $select = $this->mockTree(TableSelection::class, [
-            'getLimit' => 7,
-            'getOffset' => 23,
-        ]);
-        $select->expects(self::once())->method('setMaxCount')->with(2);
-
-        $repository = $this->mockMethod(DocumentRepository::class, 'countAll', [], 2);
-        $repository->expects(self::once())->method('all')->with(23, 7)->willReturn($rows);
+        $select = $this->mock(TableSelection::class);
+        $repository = $this->mockMethod(DocumentRepository::class, 'all', [], $rows);
 
         $instance = new DocumentTable(
             $this->fail(...),
@@ -172,7 +161,7 @@ class DocumentTableTest extends TestCase
             'created',
             'change',
             'criteria',
-        ], array_keys($instance->row($this->mock(Document::class))));
+        ], array_keys($instance->row($this->mock(Document::class), 1)));
     }
 
     public function testShowEmptyCriteria(): void
@@ -285,7 +274,7 @@ class DocumentTableTest extends TestCase
             $create
         );
 
-        $result = $instance->orderInputGui($this->mock(Document::class));
+        $result = $instance->orderInputGui($this->mock(Document::class), 1);
         $this->assertSame($input, $result);
     }
 

--- a/Services/LegalDocuments/test/Table/EditableDocumentTableTest.php
+++ b/Services/LegalDocuments/test/Table/EditableDocumentTableTest.php
@@ -79,24 +79,19 @@ class EditableDocumentTableTest extends TestCase
         $document = $this->mock(Document::class);
         $table = $this->mock(DocumentTable::class);
 
-        $table->expects(self::once())->method('select')->with($select)->willReturn([$document]);
-        $table->expects(self::once())->method('row')->with($document)->willReturn([
-            'foo' => 'bar',
-            'a' => 'b'
-        ]);
+        $table->expects(self::once())->method('mapSelection')->willReturn([$document]);
 
         $instance = new EditableDocumentTable($table, $this->mock(EditLinks::class));
 
         $rows = $instance->rows($select);
-        $this->assertSame(1, count($rows));
-        $this->assertSame(['delete', 'order', 'a', 'criteria', 'actions'], array_keys(current($rows)));
+        $this->assertSame([$document], $rows);
     }
 
     public function testRow(): void
     {
         $instance = new EditableDocumentTable($this->mock(DocumentTable::class), $this->mock(EditLinks::class));
 
-        $row = $instance->row($this->mock(Document::class));
+        $row = $instance->row($this->mock(Document::class), 1);
         $this->assertSame(['delete', 'order', 'criteria', 'actions'], array_keys($row));
     }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -8827,12 +8827,12 @@ didactic#:#sess_closed_info#:#Die Sitzung ist für Nicht-Teilnehmer unsichtbar.
 dpro#:#dpro_account_reg_not_possible#:#Eine Selbstregistrierung ist aktuell nicht möglich, da in dieser Installation keine Datenschutzerklärung angeboten wird. Bitte kontaktieren Sie Ihren <a href="%1$s">Systemadministrator</a> für weitere Informationen.
 dpro#:#dpro_agree_date#:#Datenschutzerklärung zugestimmt am
 dpro#:#dpro_last_reset_date#:#Die Datenschutzerklärung wurden zuletzt am %s zurückgesetzt. Setzen Sie die Datenschutzerklärung nur zurück, wenn sich diese in der Zwischenzeit geändert haben und eine Zustimmung zu dieser geänderten Vereinbarung gewünscht ist.
-dpro#:#dpro_mode#:#Modus
+dpro#:#dpro_mode#:#Zustimmungsmodus
 dpro#:#dpro_mode_desc#:#Stellen Sie hier ein wann und wie die Datenschutzerklärung akzeptiert werden muss.
-dpro#:#dpro_no_acceptance#:#Nie aktzeptieren, nur anzeigen
+dpro#:#dpro_no_acceptance#:#Bereitstellung der Dokumente ohne Zustimmung
 dpro#:#dpro_no_documents_exist#:#Aktuell liegen keine Dokumente der Datenschutzerklärung vor.
 dpro#:#dpro_no_documents_exist_cant_save#:#Aktuell liegen keine Dokumente der Datenschutzerklärung vor. Bitte erstellen Sie mindestens ein Dokument um den Service zu aktivieren.
-dpro#:#dpro_once#:#Einmalig akzeptieren
+dpro#:#dpro_once#:#Einmaliges Akzeptieren des Dokumentes
 dpro#:#dpro_reset_for_all_users#:#Datenschutzerklärung zurücksetzen
 dpro#:#dpro_status_enable#:#Datenschutzerklärung aktivieren
 dpro#:#dpro_status_enable_desc#:#Benutzer werden zum Unterzeichnen der Datenschutzerklärung aufgefordert, bevor sie ILIAS nutzen können.
@@ -10692,7 +10692,7 @@ ldoc#:#ldoc_ldoc_settings#:#Einstellungen
 ldoc#:#ldoc_period#:#Zeitraum
 ldoc#:#ldoc_period_from#:#Von
 ldoc#:#ldoc_period_until#:#Bis
-ldoc#:#ldoc_reevaluate_on_login#:#Erneut prüfen beim Login
+ldoc#:#ldoc_reevaluate_on_login#:#Erneutes Prüfen der Vorlagekriterien beim Login
 ldoc#:#ldoc_reevaluate_on_login_desc#:#Falls aktiviert, wird nach erfolgreicher Anmeldung über die Weboberfläche geprüft, ob ein ggf. bereits akzeptiertes Dokument keine Gültigkeit mehr hat, da sich die Vorlagekriterien des Benutzers geändert haben. Ist dies der Fall und kann ILIAS ein neues Dokument finden, so muss der Benutzer dieses neu akzeptieren.
 ldoc#:#ldoc_saved_sorting#:#Die Sortierung wurde gespeichert.
 ldoc#:#ldoc_sure_delete_documents_p#:#Sind Sie sicher, dass Sie die gewählten Dokumente löschen möchten?

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8827,7 +8827,7 @@ didactic#:#sess_closed_info#:#Session is not visible for non-participants.
 dpro#:#dpro_account_reg_not_possible#:#Self-registration is currently not possible because there is no Data Protection agreement available. Please contact your <a href="%1$s">system administrator</a> for further information.
 dpro#:#dpro_agree_date#:#Data Protection agreed on
 dpro#:#dpro_last_reset_date#:#The Data Protection were reset on %s. Only reset the Data Protection if changes have been made to the document(s) and you require all users to agree to the documents.
-dpro#:#dpro_mode#:#Mode
+dpro#:#dpro_mode#:#Agreement Mode
 dpro#:#dpro_mode_desc#:#Please configure when and how the Data Protection should be accepted.
 dpro#:#dpro_no_acceptance#:#Never, only informative
 dpro#:#dpro_no_documents_exist#:#There are currently no Declaration of Data Protection documents available.
@@ -10672,7 +10672,7 @@ ldoc#:#ldoc_doc_crit_changed#:#The criterion for displaying your document has be
 ldoc#:#ldoc_doc_crit_detached#:#The criterion has been removed.
 ldoc#:#ldoc_doc_delete#:#Delete Document
 ldoc#:#ldoc_doc_detach_crit_confirm_title#:#Remove Criterion
-ldoc#:#ldoc_doc_sure_detach_crit#:#Are you sure that you want to remove this as the criterion for displaying your Terms of Service document?
+ldoc#:#ldoc_doc_sure_detach_crit#:#Are you sure that you want to remove this as the criterion for displaying your document?
 ldoc#:#ldoc_document#:#Document
 ldoc#:#ldoc_enabled#:#Enabled
 ldoc#:#ldoc_form_attach_criterion_head#:#Select Criterion for Displaying your Document


### PR DESCRIPTION
This PR fixes the following mantis issues:
- \#39385
- \#39387
- \#39414
- \#39415
- \#39418
- \#39422
- \#39477
- \#39667
- \#39668
- \#39670
- \#39690
- \#39691
- \#39692
- \#39693
- \#39696
- \#39706

Additionally the following things are changed:
- Deletion of a document doesn't hide all the corresponding versions in the "Acceptance History" Tab.
- Updating a document will not trigger a resigning of the document. This is now the **same** behaviour as in ILIAS8.
- Deleting all documents will automatically disable the service (ToS or Dpro). This is now the **same** behaviour as in ILIAS 8.