### PR TITLE
OpenIdConnect: Add string cast in case of integer user info property

### DIFF
--- a/Services/OpenIdConnect/classes/class.ilOpenIdConnectUserSync.php
+++ b/Services/OpenIdConnect/classes/class.ilOpenIdConnectUserSync.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
@@ -260,6 +260,6 @@ class ilOpenIdConnectUserSync
             return '';
         }
 
-        return $this->user_info->{$connect_name};
+        return (string) $this->user_info->{$connect_name};
     }
 }


### PR DESCRIPTION
Fix mantis bug: \#39813.