### PR TITLE
Services/Init: Store correct goto url for redirection

### DIFF
--- a/Services/Init/classes/StartupSequence/StartUpSequenceDispatcher.php
+++ b/Services/Init/classes/StartupSequence/StartUpSequenceDispatcher.php
@@ -29,6 +29,7 @@ use ilTermsOfServiceWithdrawalStartUpStep;
 use ilUserProfileStartUpStep;
 use SplQueue;
 use ILIAS\LegalDocuments\StartUpStep;
+use ILIAS\StaticURL\Builder\StandardURIBuilder;
 
 /**
  * Class StartupSequenceDispatcher
@@ -69,7 +70,17 @@ class StartUpSequenceDispatcher
     {
         if (!ilSession::get('orig_request_target')) {
             //#16324 don't use the complete REQUEST_URI
-            $url = substr($_SERVER['REQUEST_URI'], (strrpos($_SERVER['REQUEST_URI'], '/') + 1));
+
+            $url = $_SERVER['REQUEST_URI'];
+            $short = strpos($url, StandardURIBuilder::SHORT);
+
+            if (preg_match('@/([^/]+\\.php[?/].*)$@', $url, $matches)) {
+                $url = $matches[1];
+            } elseif ($short !== false) {
+                $url = substr($url, $short + 1);
+            } else {
+                $url = substr($url, strrpos($url, '/') + 1);
+            }
 
             ilSession::set('orig_request_target', $url);
         }


### PR DESCRIPTION
Fix Mantis Bug \#39411.
URL's like `/goto.php/cat/123` where truncated to `/123` when saving as the original request target.

@chfsx AFAIK your recent changes in the goto link behaviour might have broken this, as this code assumes that there are no slashes after the target php script.