### PR TITLE
LDAP: Fix possible non-strings when calling `readUserData`

### DIFF
--- a/Services/LDAP/classes/class.ilLDAPAttributeToUser.php
+++ b/Services/LDAP/classes/class.ilLDAPAttributeToUser.php
@@ -186,6 +186,8 @@ class ilLDAPAttributeToUser
 
         // Single users
         foreach ($this->user_data as $external_account => $user) {
+            $external_account = (string) $external_account;
+
             $user['ilExternalAccount'] = $external_account;
 
             // Required fields


### PR DESCRIPTION
In some cases it might occur that different
PHP type issues might occur when ...:

* `\ilLDAPQuery::readUserData` is called from multiple locations
* The keys of `$this->users` in `\ilLDAPQuery` might be of type `int`, resulting in problems when processing the data in `ilLDAPAttributeToUser`