### PR TITLE
Object: handle reloading table in creation via copy better (33815)

### DIFF
--- a/Services/Object/classes/class.ilObjectCopyGUI.php
+++ b/Services/Object/classes/class.ilObjectCopyGUI.php
@@ -594,19 +594,20 @@ class ilObjectCopyGUI
             ilSession::set('source_query', $this->post_wrapper->retrieve("tit", $this->refinery->kindlyTo()->string()));
         }
 
-        $this->initFormSearch();
-        $this->form->setValuesByPost();
-
-        if (!$this->form->checkInput()) {
-            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('msg_no_search_string'), true);
-            $this->ctrl->returnToParent($this);
-            return;
-        }
-
-        $tit = $this->form->getInput('tit');
+        $tit = ilSession::get('source_query', '');
         if ($tit === "") {
-            $tit = ilSession::get('source_query', '');
+            $this->initFormSearch();
+            $this->form->setValuesByPost();
+
+            if (!$this->form->checkInput()) {
+                $this->tpl->setOnScreenMessage('failure', $this->lng->txt('msg_no_search_string'), true);
+                $this->ctrl->returnToParent($this);
+                return;
+            }
+
+            $tit = $this->form->getInput('tit');
         }
+
         $query_parser = new ilQueryParser($tit);
         $query_parser->setMinWordLength(1);
         $query_parser->setCombination(ilQueryParser::QP_COMBINATION_AND);


### PR DESCRIPTION
This PR fixes [33815](https://mantis.ilias.de/view.php?id=33815) by only trying to grab the search term of the copy process from the form when it isn't in the session.
This is only a quick fix, and there is a lot more refactoring one could do here. Feel free to close this PR if you want to take this opportunity to do so.