### PR TITLE
UI: adjust the z-index for popover elements to avoid scrolling above …

### DIFF
--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -388,6 +388,30 @@ abilities of Modals should be improved; it should be possible:
 - alter the target-URL of the RPC-call by a previous response
 - probably alter the Labels and functions of Buttons
 
+### Exchange webui-popover library (advanced)
+
+The current webui-popover library by Sandy Duan wasn't updated for quite a while now, 
+therefore it should get exchanged. 
+
+Following tasks have to be done:
+- researching which library should be used in the future
+- researching wich ILIAS elements will be affected from the changes (e.g. UI popover)
+- exchange the library
+- adjust/customize the code accordingly to make sure that the ILIAS elements are working
+
+Preconditions:
+- if possible a documentary should be available
+- regulary updates from the author(s) are available
+- adjustments from ILIAS developers should be possible
+- there should be no jQuery dependency
+
+Following advantages will be gained:
+- being able to get security fixes, bug fixes and adjustments from the author(s)
+- being able to use modern code
+- getting rid of some jQuery dependencies as it was decided to avoid those
+
+Note: the package can be found in the node_modules directory. With ILIAS 10 it will be found in the public/node_modules directory.
+
 
 ## Ideas and Food for Thought
 

--- a/templates/default/020-dependencies/modifications/webui-popover/jquery.webui-popover.scss
+++ b/templates/default/020-dependencies/modifications/webui-popover/jquery.webui-popover.scss
@@ -46,7 +46,7 @@ $popover-font-size-small:         ceil(($popover-font-size-base * 0.85)); // ~12
 $popover-close-size:                16px;
 $popover-close-color:               #000;
 
-$popover-z-index: 9999;
+$popover-z-index: 997;
 $popover-backdrop-z-index: ($popover-z-index - 1);
 
 @mixin box-shadow($shadow){

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7105,7 +7105,7 @@ div.alert ul > li:before {
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 9999;
+  z-index: 997;
   display: none;
   min-width: 50px;
   min-height: 32px;
@@ -7371,7 +7371,7 @@ div.alert ul > li:before {
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 9998;
+  z-index: 996;
 }
 
 .webui-popover .dropdown-menu {


### PR DESCRIPTION
…the metabar. (#32769)

https://mantis.ilias.de/view.php?id=32769

This mantis ticket is solved partly. After consideration it was decided
to exchange the current webui popover library with another library in the
future, because it's not maintained anymore and hasn't been for a few
years. For this task an entry was written in the UI ROADMAP.