### PR TITLE
NPM: Add `jest`

### DIFF
--- a/public/package_new.json
+++ b/public/package_new.json
@@ -10,6 +10,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "jest": "^29.7.0",
   },
   "scripts": {
     "test": "mocha --recursive"


### PR DESCRIPTION
This PR adds `jest` as `npm` package.

Usage:
- `components/ILIAS/UI/tests/Client/*` (once unit-tests are migrated)

Wrapped By:
- Not applicable.

Reasoning:
- Uses syntax we are already familiar with, like `describe()` and `it()`.
- `mocha` unit-tests can be easily migrated.
- We desperately need a JavaScript unit-testing framework.

Maintenance:
- The package is maintained actively, see [GitHub releases](https://github.com/jestjs/jest/releases).
- The package is widely used (11.5M on GitHub).

Links:
- Package manager: https://www.npmjs.com/package/jest
- GitHub: https://github.com/jestjs/jest
- Documentation: https://jestjs.io/docs/getting-started
