### PR TITLE
Composer: Add firebase/php-jwt as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"firebase/php-jwt": "^6.10"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds firebase/php-jwt as composer dependency.

Usage:
* components/ILIAS/LTI

Reasoning:
* ILIAS uses this library for jwt handling (JSON Web Token: https://jwt.io/)

Maintenance:
* frequently commits (https://github.com/firebase/php-jwt/commits/main/).
* There are several people contributing to the software

Links:
* Packagist: https://packagist.org/packages/firebase/php-jwt
* GitHub: https://github.com/firebase/php-jwt
* Documentation: https://github.com/firebase/php-jwt/blob/main/README.md