### PR TITLE
Composer: Add celtic/lti as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"celtic/lti": "^5.0"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds celtic/lti as composer dependency.

Usage:
* components/ILIAS/LTI

Reasoning:
* ILIAS uses this library for basic LTI feature

Maintenance:
* Not to many but frequently commits
* Not to many but experienced persons

Links:
* Packagist: https://packagist.org/packages/celtic/lti
* GitHub: https://github.com/celtic-project/LTI-PHP
* Documentation: https://github.com/celtic-project/LTI-PHP/blob/master/README.md