### PR TITLE
[FIX] 0039688: KitchenSink-Dokumentation nicht erreichbar » "Undefined array key 5"

### DIFF
--- a/Services/Style/System/test/Documentation/ilKSDocumentationGotoLinkTest.php
+++ b/Services/Style/System/test/Documentation/ilKSDocumentationGotoLinkTest.php
@@ -39,7 +39,7 @@ class ilKSDocumentationGotoLinkTest extends TestCase
     public function testGenerateGotoLink(): void
     {
         $link = $this->goto_link->generateGotoLink('nodeId', 'skinId', 'styleId');
-        $this->assertEquals('_nodeId_skinId_styleId', $link);
+        $this->assertEquals('nodeId/skinId/styleId', $link);
     }
 
     public function testRedirectWithGotoLink(): void
@@ -47,11 +47,12 @@ class ilKSDocumentationGotoLinkTest extends TestCase
         $ctrl_observer = $this->getMockBuilder(ilCtrl::class)->disableOriginalConstructor()->onlyMethods([
             'setParameterByClass',
             'setTargetScript',
-            'redirectByClass'
+            'getLinkTargetByClass'
         ])->getMock();
 
+
         $ctrl_observer->expects($this->once())
-                      ->method('redirectByClass')
+                      ->method('getLinkTargetByClass')
                       ->with([
                           'ilAdministrationGUI',
                           'ilObjStyleSettingsGUI',
@@ -60,6 +61,6 @@ class ilKSDocumentationGotoLinkTest extends TestCase
                       ], 'entries');
 
         $params = ['something', 'something', 'something', 'nodeId', 'skinId', 'styleId'];
-        $this->goto_link->redirectWithGotoLink('ref_id', $params, $ctrl_observer);
+        $this->goto_link->generateRedirectURL($ctrl_observer, 1, $params[3], $params[4], $params[5]);
     }
 }

--- a/src/StaticURL/Handler/LegacyGotoHandler.php
+++ b/src/StaticURL/Handler/LegacyGotoHandler.php
@@ -223,11 +223,6 @@ class LegacyGotoHandler implements Handler
                 \ilCertificate::_goto($target_id);
                 break;
 
-                // links to the documentation of the kitchen sink in the administration
-            case 'stys':
-                (new \ilKSDocumentationGotoLink())->redirectWithGotoLink($target_id, $target_arr, $DIC->ctrl());
-                break;
-
                 //
                 // default implementation (should be used by all new object types)
                 //


### PR DESCRIPTION

This PR fixes the issue https://mantis.ilias.de/view.php?id=39688 (old goto-links did not work).
This changes the static URL for KS docu from

http://9.ilias.localhost/go/stys/21/__default_delos
http://9.ilias.localhost/go/stys/21/_default_delos