### PR TITLE
9/UI fix focus outline for links across multiple lines 36738

### DIFF
--- a/templates/default/030-tools/_tool_buttons.scss
+++ b/templates/default/030-tools/_tool_buttons.scss
@@ -140,6 +140,9 @@ $button_active-transform: scale(.95) !default;
         font-size: inherit; // see set-size
         font-weight: $font-weight;
         text-decoration: $text-decoration;
+
+        // KEYBOARD FOCUS
+        @include focus.il-focus-outline-only();
     }
 
     @if $set-size {
@@ -176,9 +179,6 @@ $button_active-transform: scale(.95) !default;
             border-style: solid;
             border-color: $hover_border-color;
         }
-
-        // KEYBOARD FOCUS
-        @include focus.il-focus-outline-only();
 
         // ACTIVE (BEING PRESSED)
         &:active {

--- a/templates/default/030-tools/_tool_focus-outline.scss
+++ b/templates/default/030-tools/_tool_focus-outline.scss
@@ -15,8 +15,9 @@ $il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protectio
 	}
 	&:focus-visible {
 		position: relative;
-		outline: $il-focus-outline-inner;
-		outline-offset: $il-focus-outline-inner-width + $il-focus-outline-outer-width - 1px;
+		// outermost protection color line
+		outline: $il-focus-outline-outer;
+		outline-offset: $il-focus-outline-outer-width + $il-focus-outline-inner-width;
 		
 		&::after {
 			content: " ";
@@ -25,7 +26,9 @@ $il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protectio
 			left: -$il-focus-outline-outer-width;
 			right: -$il-focus-outline-outer-width;
 			bottom: -$il-focus-outline-outer-width;
+			// innermost protection color line
 			border: $il-focus-outline-outer;
+			// middle focus line
 			outline: $il-focus-outline-inner;
 		}
 	}
@@ -37,7 +40,7 @@ $il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protectio
 @mixin il-focus-outline-only($clearAfter: false) {
 	&:focus-visible{
 		outline: $il-focus-outline-inner;
-		box-shadow: inset 0px 0px 0px 2px $il-focus-protection-color, 0px 0px 0px 6px $il-focus-protection-color;
+		box-shadow: inset 0px 0px 0px $il-focus-outline-outer-width $il-focus-protection-color, 0px 0px 0px ($il-focus-outline-outer-width + $il-focus-outline-inner-width) $il-focus-protection-color;
 		@if $clearAfter {
 			&::after {
 				content: none;
@@ -61,14 +64,40 @@ $il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protectio
 	}
 }
 
-// KEYBOARD FOCUS FOR ELEMENTS AT THE EDGE
+// KEYBOARD FOCUS FOR ELEMENTS AT THE EDGE AND MULTI-LINE TEXT
 // some elements at the edge do not show the focus outline because it's already offscreen
-// in this case use this mixin instead
+// or for inline elements that break into multiple lines
+// in these cases use this mixin instead
 @mixin il-focus-border-only($clearAfter: false) {
 	&:focus-visible {
 		outline: none;
 		border: $il-focus-outline-inner;
 		box-shadow: inset 0px 0px 0px 2px $il-focus-protection-color, 0px 0px 0px 2px $il-focus-protection-color;
+		@if $clearAfter {
+			&::after {
+				content: none;
+			}
+		}
+	}
+}
+
+@mixin clear-focus-for-override($clearAfter: false) {
+	&:focus {
+		border: inherit;
+		box-shadow: inherit;
+		outline: none;
+    	outline-offset: 0px;
+		@if $clearAfter {
+			&::after {
+				content: none;
+			}
+		}
+	}
+	&:focus-visible {
+		border: inherit;
+		box-shadow: inherit;
+		outline: none;
+    	outline-offset: 0px;
 		@if $clearAfter {
 			&::after {
 				content: none;

--- a/templates/default/060-elements/_elements_typography.scss
+++ b/templates/default/060-elements/_elements_typography.scss
@@ -83,7 +83,7 @@ a {
     text-decoration: $il-link-hover-decoration;
   }
 
-  @include t-focus.il-focus();
+  @include t-focus.il-focus-border-only;
 }
 
 // Emphasis & misc

--- a/templates/default/070-components/UI-framework/Breadcrumbs/_ui-component_breadcrumbs.scss
+++ b/templates/default/070-components/UI-framework/Breadcrumbs/_ui-component_breadcrumbs.scss
@@ -25,7 +25,8 @@
 			&:hover {
 				color: $il-standard-page-breadcrumbs-active-color;
 			}
-			@include il-focus-outline-only($clearAfter: true);
+			@include clear-focus-for-override($clearAfter: true);
+			@include il-focus-outline-only();
 		}
 
 		&>span+span:before {

--- a/templates/default/070-components/legacy/Services/UIComponent/_component_tabs.scss
+++ b/templates/default/070-components/legacy/Services/UIComponent/_component_tabs.scss
@@ -1,4 +1,5 @@
 @use "../../../../010-settings/" as *;
+@use "../../../../030-tools/tool_focus-outline" as focus;
 @use "../../../../050-layout/basics" as *;
 
 $nav-tabs-active-link-hover-bg: $il-text-color !default;
@@ -31,6 +32,8 @@ $nav-tabs-border: 2px solid $nav-tabs-active-link-hover-bg !default;
 			&:hover {
 				border-color: $il-main-bg $il-main-bg $il-main-bg;
 			}
+			@include focus.clear-focus-for-override($clearAfter: true);
+			@include focus.il-focus();
 		}
 
 		// Active state, and its :hover to override normal :hover
@@ -76,6 +79,8 @@ $nav-tabs-border: 2px solid $nav-tabs-active-link-hover-bg !default;
 				text-decoration: underline;
 				background-color: transparent;
 			}
+			@include focus.clear-focus-for-override($clearAfter: true);
+			@include focus.il-focus();
 		}
 		&.active > a {
 			&,

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2195,24 +2195,10 @@ a:hover, a:focus {
   color: #3a4c65;
   text-decoration: underline;
 }
-a:focus {
-  outline: none;
-  outline-offset: 0px;
-}
 a:focus-visible {
-  position: relative;
-  outline: 3px solid #0078D7;
-  outline-offset: 4px;
-}
-a:focus-visible::after {
-  content: " ";
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  right: -2px;
-  bottom: -2px;
-  border: 2px solid #FFFFFF;
-  outline: 3px solid #0078D7;
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
 }
 
 small,
@@ -2449,12 +2435,27 @@ code {
 .breadcrumb_wrapper .breadcrumb span.crumb a:hover {
   color: #3a4c65;
 }
+.breadcrumb_wrapper .breadcrumb span.crumb a:focus {
+  border: inherit;
+  box-shadow: inherit;
+  outline: none;
+  outline-offset: 0px;
+}
+.breadcrumb_wrapper .breadcrumb span.crumb a:focus::after {
+  content: none;
+}
 .breadcrumb_wrapper .breadcrumb span.crumb a:focus-visible {
-  outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 6px #FFFFFF;
+  border: inherit;
+  box-shadow: inherit;
+  outline: none;
+  outline-offset: 0px;
 }
 .breadcrumb_wrapper .breadcrumb span.crumb a:focus-visible::after {
   content: none;
+}
+.breadcrumb_wrapper .breadcrumb span.crumb a:focus-visible {
+  outline: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
 }
 .breadcrumb_wrapper .breadcrumb > span + span:before {
   content: " \e606";
@@ -2523,6 +2524,11 @@ ol.breadcrumb > li + li:before {
 .il-drilldown .navbar-form > .menulevel + a, .navbar-form > a + a {
   margin-left: 3px;
 }
+.btn:focus-visible, .il-link.link-bulky:focus-visible,
+.il-drilldown .menulevel:focus-visible, .navbar-form > a:focus-visible {
+  outline: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
+}
 
 a.btn.disabled, a.disabled.il-link.link-bulky,
 .il-drilldown a.disabled.menulevel, .navbar-form > a.disabled, fieldset[disabled] a.btn, fieldset[disabled] a.il-link.link-bulky,
@@ -2562,10 +2568,6 @@ input.btn, input.il-link.link-bulky,
   border-width: 1px;
   border-style: solid;
   border-color: #3a4c65;
-}
-.btn-default:focus-visible, .navbar-form > a:focus-visible {
-  outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 6px #FFFFFF;
 }
 .btn-default:active, .navbar-form > a:active {
   transform: none;
@@ -2614,10 +2616,6 @@ input.btn, input.il-link.link-bulky,
   border-width: 1px;
   border-style: solid;
   border-color: #3b5620;
-}
-.btn-primary:focus-visible {
-  outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 6px #FFFFFF;
 }
 .btn-primary:active {
   transform: none;
@@ -3076,6 +3074,25 @@ input.btn, input.il-link.link-bulky,
 .il-table-presentation-viewcontrols .l-bar__container .l-bar__group .l-bar__element > .btn-default.btn + .btn-default.btn {
   margin-left: 3px;
 }
+.btn-ctrl:focus-visible, .il-viewcontrol-section > .btn-default:focus-visible, .il-viewcontrol-section > .btn-link:focus-visible,
+.il-viewcontrol-section .btn-group > .btn-default:focus-visible,
+.il-viewcontrol-section .btn-group > .btn-link:focus-visible,
+.il-viewcontrol-pagination__sectioncontrol > .btn-default:focus-visible,
+.il-viewcontrol-pagination__sectioncontrol > .btn-link:focus-visible,
+.il-viewcontrol-pagination__num-of-items > .btn-default:focus-visible,
+.il-viewcontrol-pagination__num-of-items > .btn-link:focus-visible,
+.il-viewcontrol-pagination > .btn-default:focus-visible,
+.il-viewcontrol-pagination > .btn-link:focus-visible,
+.il-viewcontrol-pagination .dropdown > .btn-default:focus-visible,
+.il-viewcontrol-pagination .dropdown > .btn-link:focus-visible,
+.il-viewcontrol-pagination .last > .btn-default:focus-visible,
+.il-viewcontrol-pagination .last > .btn-link:focus-visible,
+.il-viewcontrol-mode > .btn-default:focus-visible,
+.il-viewcontrol-mode > .btn-link:focus-visible, .il-viewcontrol-sortation .dropdown > .btn-default.btn:focus-visible,
+.il-table-presentation-viewcontrols .l-bar__container .l-bar__group .l-bar__element > .btn-default.btn:focus-visible {
+  outline: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
+}
 .btn-ctrl:hover, .il-viewcontrol-section > .btn-default:hover, .il-viewcontrol-section > .btn-link:hover,
 .il-viewcontrol-section .btn-group > .btn-default:hover,
 .il-viewcontrol-section .btn-group > .btn-link:hover,
@@ -3098,25 +3115,6 @@ input.btn, input.il-link.link-bulky,
   border-width: 1px;
   border-style: solid;
   border-color: #4c6586;
-}
-.btn-ctrl:focus-visible, .il-viewcontrol-section > .btn-default:focus-visible, .il-viewcontrol-section > .btn-link:focus-visible,
-.il-viewcontrol-section .btn-group > .btn-default:focus-visible,
-.il-viewcontrol-section .btn-group > .btn-link:focus-visible,
-.il-viewcontrol-pagination__sectioncontrol > .btn-default:focus-visible,
-.il-viewcontrol-pagination__sectioncontrol > .btn-link:focus-visible,
-.il-viewcontrol-pagination__num-of-items > .btn-default:focus-visible,
-.il-viewcontrol-pagination__num-of-items > .btn-link:focus-visible,
-.il-viewcontrol-pagination > .btn-default:focus-visible,
-.il-viewcontrol-pagination > .btn-link:focus-visible,
-.il-viewcontrol-pagination .dropdown > .btn-default:focus-visible,
-.il-viewcontrol-pagination .dropdown > .btn-link:focus-visible,
-.il-viewcontrol-pagination .last > .btn-default:focus-visible,
-.il-viewcontrol-pagination .last > .btn-link:focus-visible,
-.il-viewcontrol-mode > .btn-default:focus-visible,
-.il-viewcontrol-mode > .btn-link:focus-visible, .il-viewcontrol-sortation .dropdown > .btn-default.btn:focus-visible,
-.il-table-presentation-viewcontrols .l-bar__container .l-bar__group .l-bar__element > .btn-default.btn:focus-visible {
-  outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 6px #FFFFFF;
 }
 .btn-ctrl:active, .il-viewcontrol-section > .btn-default:active, .il-viewcontrol-section > .btn-link:active,
 .il-viewcontrol-section .btn-group > .btn-default:active,
@@ -3333,11 +3331,6 @@ input.btn, input.il-link.link-bulky,
   border-style: solid;
   border-color: #e2e8ef;
 }
-.btn-bulky:focus-visible, .il-link.link-bulky:focus-visible,
-.il-drilldown .menulevel:focus-visible {
-  outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 6px #FFFFFF;
-}
 .btn-bulky:active, .il-link.link-bulky:active,
 .il-drilldown .menulevel:active {
   background-color: #bdbdbd;
@@ -3512,10 +3505,6 @@ button .minimize, button .close {
   border-width: 1px;
   border-style: solid;
   border-color: #3a4c65;
-}
-.btn-tag:focus-visible {
-  outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 6px #FFFFFF;
 }
 .btn-tag:active {
   transform: none;
@@ -4771,10 +4760,6 @@ td.form-inline > div.form-group {
   border-width: 1px;
   border-style: solid;
   border-color: #3b5620;
-}
-.c-launcher .btn-bulky:focus-visible {
-  outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 6px #FFFFFF;
 }
 .c-launcher .btn-bulky:active {
   transform: none;
@@ -13327,8 +13312,8 @@ div.ilc_va_icont_VAccordICont {
 }
 .ilAwarenessItem > div[role=button]:focus-visible:focus-visible {
   position: relative;
-  outline: 3px solid #0078D7;
-  outline-offset: 4px;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
 }
 .ilAwarenessItem > div[role=button]:focus-visible:focus-visible::after {
   content: " ";
@@ -15173,8 +15158,8 @@ p#copg-auto-save {
 }
 .ilPageVideo button:focus-visible, .ilPageAudio button:focus-visible {
   position: relative;
-  outline: 3px solid #0078D7;
-  outline-offset: 4px;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
 }
 .ilPageVideo button:focus-visible::after, .ilPageAudio button:focus-visible::after {
   content: " ";
@@ -15260,8 +15245,8 @@ input[type=file]:focus-visible,
 input[type=radio]:focus-visible,
 input[type=checkbox]:focus-visible {
   position: relative;
-  outline: 3px solid #0078D7;
-  outline-offset: 4px;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
 }
 input[type=file]:focus-visible::after,
 input[type=radio]:focus-visible::after,
@@ -15296,7 +15281,7 @@ input[type=checkbox]:focus-visible::after {
 }
 .form-control:focus-visible {
   outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 6px #FFFFFF;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
 }
 .form-control::-moz-placeholder {
   color: #6f6f6f;
@@ -17983,6 +17968,43 @@ a.ilMediaLightboxClose:hover {
 #ilTab > li > a:hover {
   border-color: white white white;
 }
+#ilTab > li > a:focus {
+  border: inherit;
+  box-shadow: inherit;
+  outline: none;
+  outline-offset: 0px;
+}
+#ilTab > li > a:focus::after {
+  content: none;
+}
+#ilTab > li > a:focus-visible {
+  border: inherit;
+  box-shadow: inherit;
+  outline: none;
+  outline-offset: 0px;
+}
+#ilTab > li > a:focus-visible::after {
+  content: none;
+}
+#ilTab > li > a:focus {
+  outline: none;
+  outline-offset: 0px;
+}
+#ilTab > li > a:focus-visible {
+  position: relative;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
+}
+#ilTab > li > a:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
+  outline: 3px solid #0078D7;
+}
 #ilTab > li.active > a, #ilTab > li.active > a:hover, #ilTab > li.active > a:focus {
   color: white;
   cursor: default;
@@ -18014,6 +18036,43 @@ a.ilMediaLightboxClose:hover {
 #ilSubTab > li > a:hover {
   text-decoration: underline;
   background-color: transparent;
+}
+#ilSubTab > li > a:focus {
+  border: inherit;
+  box-shadow: inherit;
+  outline: none;
+  outline-offset: 0px;
+}
+#ilSubTab > li > a:focus::after {
+  content: none;
+}
+#ilSubTab > li > a:focus-visible {
+  border: inherit;
+  box-shadow: inherit;
+  outline: none;
+  outline-offset: 0px;
+}
+#ilSubTab > li > a:focus-visible::after {
+  content: none;
+}
+#ilSubTab > li > a:focus {
+  outline: none;
+  outline-offset: 0px;
+}
+#ilSubTab > li > a:focus-visible {
+  position: relative;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
+}
+#ilSubTab > li > a:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
+  outline: 3px solid #0078D7;
 }
 #ilSubTab > li.active > a, #ilSubTab > li.active > a:hover, #ilSubTab > li.active > a:focus {
   color: #4c6586;
@@ -18091,8 +18150,8 @@ a.ilMediaLightboxClose:hover {
 }
 .ilToolbar .navbar-toggle:focus-visible {
   position: relative;
-  outline: 3px solid #0078D7;
-  outline-offset: 4px;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
 }
 .ilToolbar .navbar-toggle:focus-visible::after {
   content: " ";
@@ -18606,8 +18665,8 @@ img.ilUserXXSmall {
 }
 .webdav-view-control:focus-visible {
   position: relative;
-  outline: 3px solid #0078D7;
-  outline-offset: 4px;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
 }
 .webdav-view-control:focus-visible::after {
   content: " ";


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=36738

# Issue

Keyboard selection focus outlines created with the mixin il-focus look strange when the selected element is inline and spans over multiple lines.

release_9 Chrome:
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/e4403846-37b2-46c0-b77d-cc6b2695ebe5)

release_9 Firefox:
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/7d66310a-b6c5-4c00-86cf-7049b681e4f9)

# Changes

Links (and all inline elements) should not use the default il-focus mixin for keyboard focus as the two lines constructed by the ::after pseudo element will draw a different path than a real border would take. Therefor we will no be using il-focus-border-only for managing the focus of an inline element like a link.

Furthermore, I added a mixin for clearing that can clear all traces of a previously applied focus mixin when overriding with another focus mixing is necessary.

Ironically, il-focus which used to be the default mixin is now barely used by non-legacy components. Most modern components use the il-focus-border-only and ...-outline-only variants to avoid some specific bugs. 

release_9 Chrome:
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/f836fb75-37c7-423e-8ab0-f4105e4d9a41)

release_9 Firefox:
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/acd94b1f-d661-4593-b979-1b659cfbdc62)

# Outlook

Maybe we should try to retire il-focus in ILIAS 10 and decide to use il-focus-border-only or ...-outline-only as the default? Further testing will be necessary. I have not tested on Safari yet.

WIP porting il-focus-border-only down to release_7 and release_8 as the same (and some worse) visual issues happen there with focus lines on multi-line links. 