### PR TITLE
7/UI fix focus outline for links across multiple lines 36738

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -12038,24 +12038,18 @@ a:hover {
   color: #3a4c65;
   text-decoration: underline;
 }
-a:focus-visible {
-  position: relative;
-  outline: 2px solid #FFFFFF;
-  outline-offset: 4px;
-}
-a:focus-visible::after {
-  content: " ";
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  right: -2px;
-  bottom: -2px;
-  border: 2px solid #FFFFFF;
-  outline: 3px solid #0078D7;
-}
-a:active,
-a.engaged {
+a:focus:focus-visible {
   outline: none;
+}
+a:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
+  outline-offset: initial;
+}
+a::after,
+a:focus:focus-visible::after {
+  content: none;
 }
 hr {
   margin-bottom: 0.8em;
@@ -15517,6 +15511,25 @@ ul.il-mm-selfloading {
   font-size: 13px;
   margin: 0;
 }
+.nav-tabs > li > a:focus-visible {
+  position: relative;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 4px;
+}
+.nav-tabs > li > a:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
+  outline: 3px solid #0078D7;
+}
+.nav-tabs > li > a:active,
+.nav-tabs > li > a.engaged {
+  outline: none;
+}
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus {
@@ -15556,6 +15569,29 @@ ul.il-mm-selfloading {
 }
 #ilSubTab > li > a:hover {
   color: #3a4c65;
+}
+#ilSubTab > li > a:focus-visible {
+  border: none;
+  box-shadow: none;
+}
+#ilSubTab > li > a:focus-visible {
+  position: relative;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 4px;
+}
+#ilSubTab > li > a:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
+  outline: 3px solid #0078D7;
+}
+#ilSubTab > li > a:active,
+#ilSubTab > li > a.engaged {
+  outline: none;
 }
 #ilSubTab > li.active > a,
 #ilSubTab > li.active > a:hover,
@@ -20164,3 +20200,4 @@ table.mceToolbar td {
   border: 1px solid #dddddd;
   border-radius: 0.25em;
 }
+/*# sourceMappingURL=./delos.css.map */

--- a/templates/default/delos.less
+++ b/templates/default/delos.less
@@ -1,4 +1,4 @@
-//out: delos.css, sourcemap: true, compress: false
+//out: delos.css, sourceMap: true, compress: false
 
 @import "less/font.less";
  /* rtl-review is this font safe for RTL languages? */
@@ -535,8 +535,10 @@ a {
 		color: @link-hover-color;
 		text-decoration: underline;
 	}
-	
-	.il-focus();
+	&:focus:focus-visible {
+		outline: none;
+	}
+	.il-focus-border-only();
 }
 
 hr {

--- a/templates/default/less/Services/UIComponent/Tabs/delos.less
+++ b/templates/default/less/Services/UIComponent/Tabs/delos.less
@@ -14,6 +14,7 @@
 				//background-color: transparent;
 				//border-color: transparent;
 			}
+			.il-focus();
 		}
 		&.active {
 			//border-top: 4px solid lighten(@brand-primary, 25%);
@@ -71,6 +72,11 @@
 			&:hover {
 				color: @il-link-hover-color;
 			}
+			&:focus-visible {
+				border: none;
+				box-shadow: none;
+			}
+			.il-focus()
 		}
 		&.active > a {
 			&,

--- a/templates/default/less/focus-mixin.less
+++ b/templates/default/less/focus-mixin.less
@@ -28,6 +28,21 @@
 	}
 }
 
+// ported from ILIAS 9
+.il-focus-border-only() {
+	&:focus-visible {
+		outline: none;
+		border: @il-focus-outline-inner;
+		box-shadow: inset 0px 0px 0px 2px @il-focus-protection-color, 0px 0px 0px 2px @il-focus-protection-color;
+		outline-offset: initial;
+	}
+	&::after,
+	&:focus:focus-visible::after {
+		content: none;
+	}
+}
+
+
 .il-focus-after() {
 	&::after {
 		content: " ";


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=36738
ported down from release_9 version: https://github.com/ILIAS-eLearning/ILIAS/pull/6961

# Issue

Keyboard selection focus outlines created with the mixin il-focus look strange when the selected element is inline and spans over multiple lines.

## release_7 in Firefox
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/45cdd22f-5540-43a2-bcc2-7f4b78cbca55)
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/d9db9ade-7036-436c-936f-d7e7829fb03e)

## release_7 in Chrome
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/98219903-f608-4018-88d3-eb894e8cd9c6)
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/cefa62f3-c9ea-4d00-b56d-3ce8e9136d1f)

# Changes

Ported down mixin il-focus-border-only and use it for links.
Overriding nav-tabs and sub-tabs <a> so they still use the unmodified mixin il-focus. The advantage of the classic il-focus is that it doesn't shift text.

## Firefox
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/ab9640fa-660e-4526-b915-d2a002a16f1f)
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/994d1a61-9e45-4094-a217-866791cc3e8b)

## Chrome
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/73c69b6a-cacb-4339-b11a-c9fbb02f11eb)
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/3983ff81-0621-4f76-a379-a84c687aeee0)

# Outlook

Port to release_8 is WIP