### PR TITLE
8/UI fix focus outline for links across multiple lines 36738 

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -12288,24 +12288,18 @@ a:hover {
   color: #3a4c65;
   text-decoration: underline;
 }
-a:focus-visible {
-  position: relative;
-  outline: 2px solid #FFFFFF;
-  outline-offset: 4px;
-}
-a:focus-visible::after {
-  content: " ";
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  right: -2px;
-  bottom: -2px;
-  border: 2px solid #FFFFFF;
-  outline: 3px solid #0078D7;
-}
-a:active,
-a.engaged {
+a:focus:focus-visible {
   outline: none;
+}
+a:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
+  outline-offset: initial;
+}
+a::after,
+a:focus:focus-visible::after {
+  content: none;
 }
 hr {
   margin-bottom: 0.8em;
@@ -15118,6 +15112,25 @@ li.ilWikiBlockItem {
   padding: 6px 15px 3px;
   font-size: 0.875rem;
   margin: 0;
+}
+.nav-tabs > li > a:focus-visible {
+  position: relative;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 4px;
+}
+.nav-tabs > li > a:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
+  outline: 3px solid #0078D7;
+}
+.nav-tabs > li > a:active,
+.nav-tabs > li > a.engaged {
+  outline: none;
 }
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:hover,
@@ -20001,3 +20014,4 @@ table.mceToolbar td {
     width: auto !important;
   }
 }
+/*# sourceMappingURL=./delos.css.map */

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -11191,7 +11191,7 @@ footer {
   grid-template-areas: "icon title close" "none description description" "none actions actions";
   grid-template-columns: 20px 1fr 20px;
   grid-gap: 9px;
-  box-shadow: 3px 9px 9px 0 rgb(0 0 0);
+  box-shadow: 3px 9px 9px 0 rgba(0, 0, 0, 0.3);
   transform: translateX(150%);
   transition: all 0.25s ease-in-out;
 }
@@ -15171,6 +15171,29 @@ li.ilWikiBlockItem {
 #ilSubTab > li > a:hover {
   text-decoration: underline;
   background-color: transparent;
+}
+#ilSubTab > li > a:focus-visible {
+  border: none;
+  box-shadow: none;
+}
+#ilSubTab > li > a:focus-visible {
+  position: relative;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 4px;
+}
+#ilSubTab > li > a:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
+  outline: 3px solid #0078D7;
+}
+#ilSubTab > li > a:active,
+#ilSubTab > li > a.engaged {
+  outline: none;
 }
 #ilSubTab > li.active > a,
 #ilSubTab > li.active > a:hover,

--- a/templates/default/delos.less
+++ b/templates/default/delos.less
@@ -1,4 +1,4 @@
-//out: delos.css, sourcemap: true, compress: false
+//out: delos.css, sourceMap: true, compress: false
 
 @import "less/font.less";
  /* rtl-review is this font safe for RTL languages? */
@@ -491,8 +491,10 @@ a {
 		color: @link-hover-color;
 		text-decoration: underline;
 	}
-	
-	.il-focus();
+	&:focus:focus-visible {
+		outline: none;
+	}
+	.il-focus-border-only();
 }
 
 hr {

--- a/templates/default/less/Services/UIComponent/Tabs/delos.less
+++ b/templates/default/less/Services/UIComponent/Tabs/delos.less
@@ -65,6 +65,11 @@
 				text-decoration: underline;
 				background-color: transparent;
 			}
+			&:focus-visible {
+				border: none;
+				box-shadow: none;
+			}
+			.il-focus()
 		}
 		&.active > a {
 			&,

--- a/templates/default/less/Services/UIComponent/Tabs/delos.less
+++ b/templates/default/less/Services/UIComponent/Tabs/delos.less
@@ -9,6 +9,7 @@
 			padding: @il-padding-large-vertical @il-padding-xlarge-horizontal @il-padding-base-vertical;
 			font-size: @il-font-size-base;
 			margin: 0;
+			.il-focus();
 		}
 		&.active > a {
 			&,

--- a/templates/default/less/bootstrap/focus-mixin.less
+++ b/templates/default/less/bootstrap/focus-mixin.less
@@ -28,6 +28,21 @@
 	}
 }
 
+// ported from ILIAS 9
+.il-focus-border-only() {
+	&:focus-visible {
+		outline: none;
+		border: @il-focus-outline-inner;
+		box-shadow: inset 0px 0px 0px 2px @il-focus-protection-color, 0px 0px 0px 2px @il-focus-protection-color;
+		outline-offset: initial;
+	}
+	&::after,
+	&:focus:focus-visible::after {
+		content: none;
+	}
+}
+
+
 .il-focus-after() {
 	&::after {
 		content: " ";


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=36738
ported down from release_9 version: https://github.com/ILIAS-eLearning/ILIAS/pull/6961

# Issue
Keyboard selection focus outlines created with the mixin il-focus look strange when the selected element is inline and spans over multiple lines.

## release_8 Firefox
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/fa1d0d2c-0768-42b6-a81f-629ca40780cd)

## release_8 Chrome
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/8325e781-990a-4c8f-a55f-1c85e0a9fb42)

# Changes
Ported down mixin il-focus-border-only and use it for links.
Overriding nav-tabs and sub-tabs so they still use the unmodified mixin il-focus. The advantage of the classic il-focus is that it doesn't shift text.

## Firefox
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/4be1f51b-a525-4938-815f-4d1aaa7441ca)
## Chrome
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/751a7b1b-a4fc-4d08-852d-6129779fb10e)
