### PR TITLE
LegacyForms: Add `aria-describedby` for (not all) legacy form elements (`il*InputGUI`)

### DIFF
--- a/Services/Form/classes/class.ilCheckboxInputGUI.php
+++ b/Services/Form/classes/class.ilCheckboxInputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * This class represents a checkbox property in a property form.
@@ -148,6 +148,9 @@ class ilCheckboxInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolba
         }
 
         $tpl->setVariable("ARIA_LABEL", ilLegacyFormElementsUtil::prepareFormOutput($this->getTitle()));
+        if ($this->getInfo() !== '') {
+            $tpl->setVariable('DESCRIBED_BY_FIELD_ID', $this->getFieldId());
+        }
 
         return $tpl->get();
     }

--- a/Services/Form/classes/class.ilNumberInputGUI.php
+++ b/Services/Form/classes/class.ilNumberInputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * This class represents a number property in a property form.
@@ -279,6 +279,35 @@ class ilNumberInputGUI extends ilSubEnabledFormPropertyGUI
             $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput((string) $this->getValue()));
             $tpl->parseCurrentBlock();
         }
+
+        if ($this->getInfo() !== '') {
+            $tpl->setCurrentBlock('described_by_description');
+            $tpl->setVariable('DESCRIBED_BY_DESCRIPTION_FIELD_ID', $this->getFieldId());
+            $tpl->parseCurrentBlock();
+        }
+
+        // constraints
+        $constraints = "";
+        $delim = "";
+        if ($this->areDecimalsAllowed() && $this->getDecimals() > 0) {
+            $constraints = $lng->txt("form_format") . ": ###." . str_repeat("#", $this->getDecimals());
+            $delim = ", ";
+        }
+        if ($this->getMinValue() !== null && $this->minvalue_visible) {
+            $constraints .= $delim . $lng->txt("form_min_value") . ": " . (($this->minvalueShouldBeGreater()) ? "&gt; " : "") . $this->getMinValue();
+            $delim = ", ";
+        }
+        if ($this->getMaxValue() !== null && $this->maxvalue_visible) {
+            $constraints .= $delim . $lng->txt("form_max_value") . ": " . (($this->maxvalueShouldBeLess()) ? "&lt; " : "") . $this->getMaxValue();
+            $delim = ", ";
+        }
+
+        if ($constraints !== "") {
+            $tpl->setCurrentBlock('described_by_constraint');
+            $tpl->setVariable('DESCRIBED_BY_CONSTRAINT_FIELD_ID', $this->getFieldId());
+            $tpl->parseCurrentBlock();
+        }
+
         $tpl->setCurrentBlock("prop_number");
 
         $tpl->setVariable("POST_VAR", $this->getPostVar());
@@ -300,24 +329,12 @@ class ilNumberInputGUI extends ilSubEnabledFormPropertyGUI
             $tpl->setVariable("JS_ID", $this->getFieldId());
         }
 
-
-        // constraints
-        $constraints = "";
-        $delim = "";
-        if ($this->areDecimalsAllowed() && $this->getDecimals() > 0) {
-            $constraints = $lng->txt("form_format") . ": ###." . str_repeat("#", $this->getDecimals());
-            $delim = ", ";
-        }
-        if ($this->getMinValue() !== null && $this->minvalue_visible) {
-            $constraints .= $delim . $lng->txt("form_min_value") . ": " . (($this->minvalueShouldBeGreater()) ? "&gt; " : "") . $this->getMinValue();
-            $delim = ", ";
-        }
-        if ($this->getMaxValue() !== null && $this->maxvalue_visible) {
-            $constraints .= $delim . $lng->txt("form_max_value") . ": " . (($this->maxvalueShouldBeLess()) ? "&lt; " : "") . $this->getMaxValue();
-            $delim = ", ";
-        }
-        if ($constraints != "") {
+        if ($constraints !== '') {
             $tpl->setVariable("TXT_NUMBER_CONSTRAINTS", $constraints);
+            $tpl->setVariable(
+                "CONSTRAINT_FOR_ID",
+                $this->getFieldId()
+            );
         }
 
         if ($this->getRequired()) {

--- a/Services/Form/classes/class.ilPropertyFormGUI.php
+++ b/Services/Form/classes/class.ilPropertyFormGUI.php
@@ -680,6 +680,10 @@ class ilPropertyFormGUI extends ilFormGUI
                     "PROPERTY_DESCRIPTION",
                     $item->getInfo()
                 );
+                $this->tpl->setVariable(
+                    "DESCRIPTION_FOR_ID",
+                    $item->getFieldId()
+                );
                 $this->tpl->parseCurrentBlock();
             }
 

--- a/Services/Form/classes/class.ilRadioGroupInputGUI.php
+++ b/Services/Form/classes/class.ilRadioGroupInputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * This class represents a property in a property form.
@@ -116,6 +116,9 @@ class ilRadioGroupInputGUI extends ilSubEnabledFormPropertyGUI implements ilTabl
             if ($option->getInfo() != "") {
                 $tpl->setCurrentBlock("radio_option_desc");
                 $tpl->setVariable("RADIO_OPTION_DESC", $option->getInfo());
+                if ($option->getInfo() !== '') {
+                    $tpl->setVariable('DESCRIPTION_FOR_ID', $this->getFieldId() . "_" . $option->getValue());
+                }
                 $tpl->parseCurrentBlock();
             }
 
@@ -154,6 +157,9 @@ class ilRadioGroupInputGUI extends ilSubEnabledFormPropertyGUI implements ilTabl
             $tpl->setVariable("POST_VAR", $this->getPostVar());
             $tpl->setVariable("VAL_RADIO_OPTION", $option->getValue());
             $tpl->setVariable("OP_ID", $this->getFieldId() . "_" . $option->getValue());
+            if ($option->getInfo() !== '') {
+                $tpl->setVariable('DESCRIBED_BY_FIELD_ID', $this->getFieldId() . "_" . $option->getValue());
+            }
             $tpl->setVariable("FID", $this->getFieldId());
             if ($this->getDisabled() or $option->getDisabled()) {
                 $tpl->setVariable('DISABLED', 'disabled="disabled" ');

--- a/Services/Form/classes/class.ilTextAreaInputGUI.php
+++ b/Services/Form/classes/class.ilTextAreaInputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * This class represents a text area property in a property form.
@@ -314,6 +314,12 @@ class ilTextAreaInputGUI extends ilSubEnabledFormPropertyGUI
         $lng = $this->lng;
 
         $ttpl = new ilTemplate("tpl.prop_textarea.html", true, true, "Services/Form");
+
+        if ($this->getInfo() !== '') {
+            $ttpl->setCurrentBlock('described_by_description');
+            $ttpl->setVariable('DESCRIBED_BY_DESCRIPTION_FIELD_ID', $this->getFieldId());
+            $ttpl->parseCurrentBlock();
+        }
 
         // disabled rte
         if ($this->getUseRte() && $this->getDisabled()) {

--- a/Services/Form/classes/class.ilTextInputGUI.php
+++ b/Services/Form/classes/class.ilTextInputGUI.php
@@ -414,6 +414,9 @@ class ilTextInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableFilte
         }
 
         $tpl->setVariable("ARIA_LABEL", ilLegacyFormElementsUtil::prepareFormOutput($this->getTitle()));
+        if ($this->getInfo() !== '') {
+            $tpl->setVariable('DESCRIBED_BY_FIELD_ID', $this->getFieldId());
+        }
 
         return $tpl->get();
     }

--- a/Services/Form/templates/default/tpl.prop_checkbox.html
+++ b/Services/Form/templates/default/tpl.prop_checkbox.html
@@ -1,5 +1,5 @@
 <div class="checkbox">
 <div class="checkbox-inline">
-<input aria-label="{ARIA_LABEL}" onclick="il.Form.showSubForm('subform_{ID}','il_prop_cont_{ID}', this);" type="checkbox" id="{ID}" name="{POST_VAR}" value="{PROPERTY_VALUE}" {PROPERTY_CHECKED} {DISABLED} {PROP_CHECK_ATTRS} />
+<input aria-label="{ARIA_LABEL}" <!-- BEGIN described_by -->aria-describedby="desc_{DESCRIBED_BY_FIELD_ID}" <!-- END described_by -->onclick="il.Form.showSubForm('subform_{ID}','il_prop_cont_{ID}', this);" type="checkbox" id="{ID}" name="{POST_VAR}" value="{PROPERTY_VALUE}" {PROPERTY_CHECKED} {DISABLED} {PROP_CHECK_ATTRS} />
 {OPTION_TITLE}&nbsp;</div>
 </div>

--- a/Services/Form/templates/default/tpl.prop_number.html
+++ b/Services/Form/templates/default/tpl.prop_number.html
@@ -1,7 +1,10 @@
 <!-- BEGIN prop_number -->
 <div class="form-inline">
-		<input style="text-align:right;" class="form-control" type="text" size="{SIZE}" id="{ID}" maxlength="{MAXLENGTH}" name="{POST_VAR}" <!-- BEGIN prop_number_propval -->value="{PROPERTY_VALUE}" <!-- END prop_number_propval -->{DISABLED} {REQUIRED} /> {INPUT_SUFFIX}
-		<div class="help-block">{TXT_NUMBER_CONSTRAINTS}</div>
+		<input 
+			style="text-align:right;" class="form-control" type="text" size="{SIZE}" id="{ID}" maxlength="{MAXLENGTH}" name="{POST_VAR}"
+			<!-- BEGIN described_by -->aria-describedby="<!-- BEGIN described_by_description -->desc_{DESCRIBED_BY_DESCRIPTION_FIELD_ID}<!-- END described_by_description --><!-- BEGIN described_by_constraint --> con_{DESCRIBED_BY_CONSTRAINT_FIELD_ID}<!-- END described_by_constraint -->" <!-- END described_by -->
+			<!-- BEGIN prop_number_propval -->value="{PROPERTY_VALUE}" <!-- END prop_number_propval -->{DISABLED} {REQUIRED} /> {INPUT_SUFFIX}
+		<!-- BEGIN constraint --><div id="con_{CONSTRAINT_FOR_ID}" class="help-block">{TXT_NUMBER_CONSTRAINTS}</div><!-- END constraint -->
 </div>
 <!-- END prop_number -->
 

--- a/Services/Form/templates/default/tpl.prop_radio.html
+++ b/Services/Form/templates/default/tpl.prop_radio.html
@@ -1,10 +1,10 @@
 <div id="{ID}">
 	<!-- BEGIN prop_radio_option -->
 		<div class="radio">
-			<label class="radio-inline"><input type="radio" onclick="il.Form.showSubForm('subform_{OP_ID}', '{FID}', null);" name="{POST_VAR}" id="{OP_ID}" value="{VAL_RADIO_OPTION}" {CHK_RADIO_OPTION} {DISABLED}/>
+			<label class="radio-inline"><input <!-- BEGIN described_by -->aria-describedby="desc_{DESCRIBED_BY_FIELD_ID}" <!-- END described_by -->type="radio" onclick="il.Form.showSubForm('subform_{OP_ID}', '{FID}', null);" name="{POST_VAR}" id="{OP_ID}" value="{VAL_RADIO_OPTION}" {CHK_RADIO_OPTION} {DISABLED}/>
 			{TXT_RADIO_OPTION}</label>
 			<!-- BEGIN radio_option_desc -->
-			<div class="help-block">{RADIO_OPTION_DESC}</div>
+			<div id="desc_{DESCRIPTION_FOR_ID}" class="help-block">{RADIO_OPTION_DESC}</div>
 			<!-- END radio_option_desc -->
 		</div>
 		<!-- BEGIN radio_option_subform -->

--- a/Services/Form/templates/default/tpl.prop_textarea.html
+++ b/Services/Form/templates/default/tpl.prop_textarea.html
@@ -1,5 +1,8 @@
 <!-- BEGIN prop_textarea -->
-<textarea class="form-control <!-- BEGIN no_rteditor --> noRTEditor<!-- END no_rteditor -->" name="{POST_VAR}" id="{ID}"   <!-- BEGIN prop_ta_c --><!-- END prop_ta_c --> rows="{ROWS}" <!-- BEGIN prop_ta_w --><!-- END prop_ta_w --> {DISABLED} {REQUIRED} onKeyUp="return il.Form.showCharCounterTextarea('{POST_VAR}','textarea_feedback_{ID}','{MINCHARS}','{MAXCHARS}')" >{PROPERTY_VALUE}</textarea>
+<textarea
+	<!-- BEGIN described_by -->aria-describedby="<!-- BEGIN described_by_description -->desc_{DESCRIBED_BY_DESCRIPTION_FIELD_ID}<!-- END described_by_description -->"<!-- END described_by -->
+	class="form-control <!-- BEGIN no_rteditor --> noRTEditor<!-- END no_rteditor -->"
+	name="{POST_VAR}" id="{ID}"   <!-- BEGIN prop_ta_c --><!-- END prop_ta_c --> rows="{ROWS}" <!-- BEGIN prop_ta_w --><!-- END prop_ta_w --> {DISABLED} {REQUIRED} onKeyUp="return il.Form.showCharCounterTextarea('{POST_VAR}','textarea_feedback_{ID}','{MINCHARS}','{MAXCHARS}')" >{PROPERTY_VALUE}</textarea>
 <!-- END prop_textarea -->
 <!-- BEGIN disabled_rte -->
 <div style="overflow: auto; width:400px; height:100px; color:#888888; border: 1px solid; border-color:#C0C0C0; padding: 5px;">

--- a/Services/Form/templates/default/tpl.prop_textinput.html
+++ b/Services/Form/templates/default/tpl.prop_textinput.html
@@ -1,7 +1,7 @@
 <!-- BEGIN inline_in_bl -->
 <div class="form-inline">
 <!-- END inline_in_bl -->	
-	<input aria-label="{ARIA_LABEL}" class="form-control" <!-- BEGIN submit_form_on_enter -->onkeypress="return il.Util.submitOnEnter(event, this.form);"<!-- END submit_form_on_enter --> type="{PROP_INPUT_TYPE}" <!-- BEGIN stylecss -->style="{CSS_STYLE}" <!-- END stylecss --> id="{ID}" <!-- BEGIN classcss -->  <!-- END classcss --> maxlength="{MAXLENGTH}" name="{POST_VAR}" <!-- BEGIN prop_text_propval -->value="{PROPERTY_VALUE}" <!-- END prop_text_propval -->{DISABLED} {AUTOCOMPLETE} {REQUIRED}/> {INPUT_SUFFIX}
+	<input aria-label="{ARIA_LABEL}" <!-- BEGIN described_by -->aria-describedby="desc_{DESCRIBED_BY_FIELD_ID}" <!-- END described_by -->class="form-control" <!-- BEGIN submit_form_on_enter -->onkeypress="return il.Util.submitOnEnter(event, this.form);"<!-- END submit_form_on_enter --> type="{PROP_INPUT_TYPE}" <!-- BEGIN stylecss -->style="{CSS_STYLE}" <!-- END stylecss --> id="{ID}" <!-- BEGIN classcss -->  <!-- END classcss --> maxlength="{MAXLENGTH}" name="{POST_VAR}" <!-- BEGIN prop_text_propval -->value="{PROPERTY_VALUE}" <!-- END prop_text_propval -->{DISABLED} {AUTOCOMPLETE} {REQUIRED}/> {INPUT_SUFFIX}
 	{HIDDEN_INPUT}
 <!-- BEGIN inline_out_bl -->
 	{MULTI_ICONS}

--- a/Services/Form/templates/default/tpl.property_form.html
+++ b/Services/Form/templates/default/tpl.property_form.html
@@ -82,7 +82,7 @@
 		</div>
 <!-- END prop_color -->
 <!-- BEGIN description -->
-		<div class="help-block">{PROPERTY_DESCRIPTION}</div>
+		<div id="desc_{DESCRIPTION_FOR_ID}" class="help-block">{PROPERTY_DESCRIPTION}</div>
 <!-- END description -->
 <!-- BEGIN sub_form -->
 		<div class="ilSubForm" id="subform_{SFID}">{PROP_SUB_FORM}</div>


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=36764

Issues/Quesions:
* First of all I do not see a generic approach to add the support of the `aria-describedby` attribute, other then investing many resources (time/money) for a revision of the legacy form component. For many input fields the "byline" is rendered in the `ilPropertyFormGUI` and the corresponding HTML template (`tpl.property_form.html`).
The input element itself is rendered in the respective `il*InputGUI`. But there are (several) exceptions, where both elements are rendered in `il*InputGUI`. Furthmore some elements have multiple "bylines" (this is supported by the specification, multiple IDs can be passed as a space-separated list), and some elements do have multiple HTML input elements. Which of those elements should be described by the one (or multiple) "byline(s)"?
* Currently I prefixed the HTML `id` element with `desc_` (maybe better?: rename the prefix to `byline_`). This could be moved to the server-side (by trying to centralize this code as well) to prevent code-duplication in multiple/different HTML templates.

Fields:
* `ilTextInputGUI`: Straight forward implementation ...
* `ilCheckboxInputGUI`: Straight forward implementation ...
* `ilTextareaGUI`: This component has 0 - 2 "bylines", depending on whether the consumer called `setInfo` and/or the consumer enabled the "Character Counter". There were several issues with this "Character Counter" (no unique ID, then I went down the rabbit hole and also fixed an error in the forum `TinyMCE` usage of it). if prefixed the element with `counter_`.
* `ilNumberInputGUI`: This component has 0 - 2 "bylines", depending on whether the consumer called `setInfo` and/or the consumer wants this component to display the "constraints" (min/max). I prefixed the "constraints" block with `con_`.
* `ilRadioGroupInputGUI`: Although I added the support for the **options** of `ilRadioGroupInputGUI`, there is no support for the "byline" of the outer radio group itself. Reason: Which element does this "byline" describe? The first? None? Some kind of new introduced pseudo element?

If approved, this has to be picked to `release_9` and `trunk` as well.