### PR TITLE
T&A 0017930 & 0033898

### DIFF
--- a/Modules/Test/classes/class.ilTestServiceGUI.php
+++ b/Modules/Test/classes/class.ilTestServiceGUI.php
@@ -406,7 +406,13 @@ class ilTestServiceGUI
 
                         if ($show_best_solution) {
                             $compare_template = new ilTemplate('tpl.il_as_tst_answers_compare.html', true, true, 'Modules/Test');
-                            $compare_template->setVariable("HEADER_PARTICIPANT", $this->lng->txt('tst_header_participant'));
+                            $test_session = $this->testSessionFactory->getSession($active_id);
+                            if ($pass <= $test_session->getLastFinishedPass()) {
+                                $compare_template->setVariable("HEADER_PARTICIPANT", $this->lng->txt('tst_header_participant'));
+                            } else {
+                                $compare_template->setVariable("HEADER_PARTICIPANT", $this->lng->txt('tst_header_participant_no_answer'));
+                            }
+
                             $compare_template->setVariable("HEADER_SOLUTION", $this->lng->txt('tst_header_solution'));
                             $result_output = $question_gui->getSolutionOutput($active_id, $pass, $show_graphical_output, false, $show_question_only, $show_feedback);
                             $best_output = $question_gui->getSolutionOutput($active_id, $pass, false, false, $show_question_only, false, true);

--- a/Modules/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
@@ -412,7 +412,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
      * @param boolean $result_output         Show the reached points for parts of the question
      * @param boolean $show_question_only    Show the question without the ILIAS content around
      * @param boolean $show_feedback         Show the question feedback
-     * @param boolean $show_correct_solution Show the correct solution instead of the user solution
+     * @param boolean $show_correct_solution  Show the correct solution instead of the user solution
      * @param boolean $show_manual_scoring   Show specific information for the manual scoring output
      * @param bool    $show_question_text
      *
@@ -425,12 +425,12 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $result_output = false,
         $show_question_only = true,
         $show_feedback = false,
-        $forceCorrectSolution = false,
+        $show_correct_solution = false,
         $show_manual_scoring = false,
         $show_question_text = true
     ) {
         $solutionOrderingList = $this->object->getOrderingElementListForSolutionOutput(
-            $forceCorrectSolution,
+            $show_correct_solution,
             $active_id,
             $pass,
             $this->getUseIntermediateSolution()
@@ -438,20 +438,21 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
         $answers_gui = $this->object->buildNestedOrderingElementInputGui();
 
-        if ($forceCorrectSolution) {
+        if ($show_correct_solution) {
             $answers_gui->setContext(ilAssNestedOrderingElementsInputGUI::CONTEXT_CORRECT_SOLUTION_PRESENTATION);
         } else {
             $answers_gui->setContext(ilAssNestedOrderingElementsInputGUI::CONTEXT_USER_SOLUTION_PRESENTATION);
         }
 
         $answers_gui->setInteractionEnabled(false);
-
         $answers_gui->setElementList($solutionOrderingList);
 
         $answers_gui->setCorrectnessTrueElementList(
             $solutionOrderingList->getParityTrueElementList($this->object->getOrderingElementList())
         );
-
+        if (!$show_correct_solution) {
+            $answers_gui->setShowCorrectnessIconsEnabled(true);
+        }
         $solution_html = $answers_gui->getHTML();
 
         $template = new ilTemplate("tpl.il_as_qpl_nested_ordering_output_solution.html", true, true, "Modules/TestQuestionPool");

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssNestedOrderingElementsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssNestedOrderingElementsInputGUI.php
@@ -18,7 +18,9 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     
     const ILC_CSS_CLASS_LIST = 'ilc_qordul_OrderList';
     const ILC_CSS_CLASS_ITEM = 'ilc_qordli_OrderListItem';
-    
+
+    const DEFAULT_THUMBNAIL_PREFIX = 'thumb.';
+
     /**
      * @var string
      */
@@ -34,8 +36,6 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
      */
     protected $orderingType = null;
     
-    const DEFAULT_THUMBNAIL_PREFIX = 'thumb.';
-    
     /**
      * @var string
      */
@@ -45,27 +45,7 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
      * @var string
      */
     protected $elementImagePath = null;
-    
-    const CORRECTNESS_ICON_TRUE = 'icon_ok.svg';
-    const CORRECTNESS_LNGVAR_TRUE = 'answer_is_right';
-    
-    const CORRECTNESS_ICON_FALSE = 'icon_not_ok.svg';
-    const CORRECTNESS_LNGVAR_FALSE = 'answer_is_wrong';
-    
-    /**
-     * @var array
-     */
-    protected $correctnessIcons = array(
-        true => self::CORRECTNESS_ICON_TRUE, false => self::CORRECTNESS_ICON_FALSE
-    );
-    
-    /**
-     * @var array
-     */
-    protected $correctnessLngVars = array(
-        true => self::CORRECTNESS_LNGVAR_TRUE, false => self::CORRECTNESS_LNGVAR_FALSE
-    );
-    
+
     /**
      * @var bool
      */
@@ -241,36 +221,12 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
      */
     public function getCorrectnessIconFilename($correctness)
     {
-        return $this->correctnessIcons[(bool) $correctness];
+        if((bool) $correctness){
+            return ilUtil::getImagePath('icon_ok.svg');
+        }
+        return ilUtil::getImagePath('icon_not_ok.svg');
     }
-    
-    /**
-     * @param bool $correctness
-     * @param string $iconFilename
-     */
-    public function setCorrectnessIconFilename($correctness, $iconFilename)
-    {
-        $this->correctnessIcons[(bool) $correctness] = $iconFilename;
-    }
-    
-    /**
-     * @param bool $correctness
-     * @return string
-     */
-    public function getCorrectnessLangVar($correctness)
-    {
-        return $this->correctnessLngVars[(bool) $correctness];
-    }
-    
-    /**
-     * @param bool $correctness
-     * @param string $langVar
-     */
-    public function setCorrectnessLangVar($correctness, $langVar)
-    {
-        $this->correctnessLngVars[(bool) $correctness] = $langVar;
-    }
-    
+
     /**
      * @param bool $correctness
      * @return string
@@ -279,7 +235,11 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
     {
         global $DIC; /* @var ILIAS\DI\Container $DIC */
         $lng = $DIC['lng'];
-        return $lng->txt($this->correctnessLngVars[(bool) $correctness]);
+        if ((bool) $correctness){
+            return $lng->txt('answer_is_right');
+        }
+        return $lng->txt('answer_is_wrong');
+
     }
     
     /**
@@ -366,8 +326,9 @@ class ilAssNestedOrderingElementsInputGUI extends ilMultipleNestedOrderingElemen
         
         if ($this->isShowCorrectnessIconsEnabled()) {
             $tpl->setCurrentBlock('correctness_icon');
-            $tpl->setVariable("ICON_SRC", $this->getCorrectnessIconFilename($this->getCorrectness($identifier)));
-            $tpl->setVariable("ICON_TEXT", $this->getCorrectnessText($this->getCorrectness($identifier)));
+            $correctness = $this->getCorrectness($element['random_id']);
+            $tpl->setVariable("ICON_SRC", $this->getCorrectnessIconFilename($correctness));
+            $tpl->setVariable("ICON_TEXT", $this->getCorrectnessText($correctness));
             $tpl->parseCurrentBlock();
         }
         

--- a/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElementList.php
+++ b/Modules/TestQuestionPool/classes/questions/class.ilAssOrderingElementList.php
@@ -282,13 +282,10 @@ class ilAssOrderingElementList implements Iterator
     public function getElementByRandomIdentifier($randomIdentifier)
     {
         foreach ($this as $element) {
-            if ($element->getRandomIdentifier() != $randomIdentifier) {
-                continue;
+            if ($element->getRandomIdentifier() === intval($randomIdentifier)) {
+                return $element;
             }
-            
-            return $element;
         }
-        
         return null;
     }
     

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1460,7 +1460,8 @@ assessment#:#tst_finished#:#Beendet
 assessment#:#tst_form_dynamic_question_set_config#:#Fortlaufende Fragenauswahl
 assessment#:#tst_gap_analysis#:#Gap-Analyse
 assessment#:#tst_general_properties#:#Einstellungen des Tests
-assessment#:#tst_header_participant#:#Ihre Antwort:
+assessment#:#tst_header_participant#:#Frage und Ihre Antwort:
+assessment#:#tst_header_participant_no_answer#:#Frage - nicht beantwortet:
 assessment#:#tst_header_solution#:#Bestmögliche Lösung:
 assessment#:#tst_heading_scoring#:#Bewertung
 assessment#:#tst_hide_side_list#:#Fragenliste aus

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1461,7 +1461,8 @@ assessment#:#tst_finished#:#Finished
 assessment#:#tst_form_dynamic_question_set_config#:#Continues Question Selection
 assessment#:#tst_gap_analysis#:#Gap Analysis
 assessment#:#tst_general_properties#:#General Settings
-assessment#:#tst_header_participant#:#Your Answer:
+assessment#:#tst_header_participant#:#Question and your answer:
+assessment#:#tst_header_participant_no_answer#:#Question - not answered
 assessment#:#tst_header_solution#:#Best Solution:
 assessment#:#tst_heading_scoring#:#Scoring
 assessment#:#tst_hide_side_list#:#Hide List of Questions


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=33898
https://mantis.ilias.de/view.php?id=17930

With the PR, the right or wrong icons should now work and be displayed again. In addition, the desired change to the display text for the answers. Let me know if you have any change requests.
