### PR TITLE
#40301 Forum Bugfix: Missing user_noti_id for cloning notification settings

### DIFF
--- a/Modules/Forum/classes/Notification/class.ilForumNotification.php
+++ b/Modules/Forum/classes/Notification/class.ilForumNotification.php
@@ -406,6 +406,7 @@ class ilForumNotification
             $result[(int) $row['user_id']]['admin_force_noti'] = (int) $row['admin_force_noti'];
             $result[(int) $row['user_id']]['user_toggle_noti'] = (int) $row['user_toggle_noti'];
             $result[(int) $row['user_id']]['interested_events'] = (int) $row['interested_events'];
+            $result[(int) $row['user_id']]['user_id_noti'] = (int) $row['user_id_noti'];
         }
 
         return $result;

--- a/Modules/Forum/test/ilForumNotificationTest.php
+++ b/Modules/Forum/test/ilForumNotificationTest.php
@@ -333,6 +333,7 @@ class ilForumNotificationTest extends TestCase
             'admin_force_noti' => 20,
             'user_toggle_noti' => 90,
             'interested_events' => 8,
+            'user_id_noti' => 6,
         ];
         $mockStatement = $this->getMockBuilder(ilDBStatement::class)->disableOriginalConstructor()->getMock();
         $this->database->expects(self::exactly(2))->method('fetchAssoc')->willReturn(


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40301
Added a missing notification setting, that caused a fatal error on cloning a forum object   