### PR TITLE
LegacyForms: Don't show empty `maxlength` attribute for text fields

### DIFF
--- a/Services/Form/templates/default/tpl.prop_textinput.html
+++ b/Services/Form/templates/default/tpl.prop_textinput.html
@@ -1,7 +1,7 @@
 <!-- BEGIN inline_in_bl -->
 <div class="form-inline">
 <!-- END inline_in_bl -->	
-	<input aria-label="{ARIA_LABEL}" <!-- BEGIN described_by -->aria-describedby="desc_{DESCRIBED_BY_FIELD_ID}" <!-- END described_by -->class="form-control" <!-- BEGIN submit_form_on_enter -->onkeypress="return il.Util.submitOnEnter(event, this.form);"<!-- END submit_form_on_enter --> type="{PROP_INPUT_TYPE}" <!-- BEGIN stylecss -->style="{CSS_STYLE}" <!-- END stylecss --> id="{ID}" <!-- BEGIN classcss -->  <!-- END classcss --> maxlength="{MAXLENGTH}" name="{POST_VAR}" <!-- BEGIN prop_text_propval -->value="{PROPERTY_VALUE}" <!-- END prop_text_propval -->{DISABLED} {AUTOCOMPLETE} {REQUIRED}/> {INPUT_SUFFIX}
+	<input aria-label="{ARIA_LABEL}" <!-- BEGIN described_by -->aria-describedby="desc_{DESCRIBED_BY_FIELD_ID}" <!-- END described_by -->class="form-control" <!-- BEGIN submit_form_on_enter -->onkeypress="return il.Util.submitOnEnter(event, this.form);"<!-- END submit_form_on_enter --> type="{PROP_INPUT_TYPE}" <!-- BEGIN stylecss -->style="{CSS_STYLE}" <!-- END stylecss --> id="{ID}" <!-- BEGIN classcss -->  <!-- END classcss --> <!-- BEGIN max_length -->maxlength="{MAXLENGTH}" <!-- END max_length --> name="{POST_VAR}"<!-- BEGIN prop_text_propval -->value="{PROPERTY_VALUE}" <!-- END prop_text_propval -->{DISABLED} {AUTOCOMPLETE} {REQUIRED}/> {INPUT_SUFFIX}
 	{HIDDEN_INPUT}
 <!-- BEGIN inline_out_bl -->
 	{MULTI_ICONS}


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=39878

If approved, this should be picked to `trunk` and `release_8` as well.