### PR TITLE
Container: Fix PHP types in `\ilContainer::getSubItems`

### DIFF
--- a/Services/Container/classes/class.ilContainer.php
+++ b/Services/Container/classes/class.ilContainer.php
@@ -693,7 +693,7 @@ class ilContainer extends ilObject
                 $object['type'],
                 ['file', 'fold', 'cat'],
                 true
-            ) && ilObjFileAccess::_isFileHidden($object['title'])) {
+            ) && ilObjFileAccess::_isFileHidden($object['title'] ?? '')) {
                 $this->setHiddenFilesFound(true);
                 if (!$a_admin_panel_enabled) {
                     continue;
@@ -703,7 +703,7 @@ class ilContainer extends ilObject
 
             // including event items!
             if (!self::$data_preloaded) {
-                $preloader->addItem($object["obj_id"], $object["type"], $object["child"]);
+                $preloader->addItem((int) $object["obj_id"], $object["type"], (int) $object["child"]);
             }
 
             // filter side block items
@@ -711,7 +711,7 @@ class ilContainer extends ilObject
                 continue;
             }
 
-            $all_ref_ids[] = $object["child"];
+            $all_ref_ids[] = (int) $object["child"];
         }
 
         // data preloader


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=40238

If approved, this has to be picked to `release_9` and `trunk`.