### PR TITLE
Cron: Fix timezone issues when determining due date

### DIFF
--- a/Services/Cron/classes/class.ilCronJob.php
+++ b/Services/Cron/classes/class.ilCronJob.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 abstract class ilCronJob
 {
@@ -89,8 +89,9 @@ abstract class ilCronJob
             return true;
         }
 
-        $now = new DateTimeImmutable('@' . time());
-        if ($this->date_time_provider !== null) {
+        if ($this->date_time_provider === null) {
+            $now = new DateTimeImmutable('@' . time(), new DateTimeZone(date_default_timezone_get()));
+        } else {
             $now = ($this->date_time_provider)();
         }
 
@@ -135,7 +136,7 @@ abstract class ilCronJob
     }
 
     /**
-     * @param Closure|null $date_time_provider
+     * @param Closure():DateTimeInterface|null $date_time_provider
      */
     public function setDateTimeProvider(?Closure $date_time_provider): void
     {

--- a/Services/Cron/classes/class.ilCronJobRepositoryImpl.php
+++ b/Services/Cron/classes/class.ilCronJobRepositoryImpl.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 class ilCronJobRepositoryImpl implements ilCronJobRepository
 {
@@ -245,7 +245,7 @@ class ilCronJobRepositoryImpl implements ilCronJobRepository
             );
 
             if ($job->hasAutoActivation()) {
-                $this->activateJob($job);
+                $this->activateJob($job, new DateTimeImmutable('@' . time()));
                 $job->activationWasToggled($this->db, $this->setting, true);
             } else {
                 // to overwrite dependent settings
@@ -314,6 +314,7 @@ class ilCronJobRepositoryImpl implements ilCronJobRepository
 
     public function updateJobResult(
         ilCronJob $job,
+        DateTimeImmutable $when,
         ilObjUser $actor,
         ilCronJobResult $result,
         bool $wasManualExecution = false
@@ -326,7 +327,7 @@ class ilCronJobRepositoryImpl implements ilCronJobRepository
             ' , job_result_code = ' . $this->db->quote($result->getCode(), 'text') .
             ' , job_result_message = ' . $this->db->quote($result->getMessage(), 'text') .
             ' , job_result_type = ' . $this->db->quote((int) $wasManualExecution, 'integer') .
-            ' , job_result_ts = ' . $this->db->quote(time(), 'integer') .
+            ' , job_result_ts = ' . $this->db->quote($when->getTimestamp(), 'integer') .
             ' , job_result_dur = ' . $this->db->quote($result->getDuration() * 1000, 'integer') .
             ' WHERE job_id = ' . $this->db->quote($job->getId(), 'text');
         $this->db->manipulate($query);
@@ -354,8 +355,12 @@ class ilCronJobRepositoryImpl implements ilCronJobRepository
         }
     }
 
-    public function activateJob(ilCronJob $job, ?ilObjUser $actor = null, bool $wasManuallyExecuted = false): void
-    {
+    public function activateJob(
+        ilCronJob $job,
+        DateTimeImmutable $when,
+        ?ilObjUser $actor = null,
+        bool $wasManuallyExecuted = false
+    ): void {
         $usrId = 0;
         if ($wasManuallyExecuted && $actor instanceof ilObjUser) {
             $usrId = $actor->getId();
@@ -365,20 +370,24 @@ class ilCronJobRepositoryImpl implements ilCronJobRepository
             ' job_status = ' . $this->db->quote(1, 'integer') .
             ' , job_status_user_id = ' . $this->db->quote($usrId, 'integer') .
             ' , job_status_type = ' . $this->db->quote($wasManuallyExecuted, 'integer') .
-            ' , job_status_ts = ' . $this->db->quote(time(), 'integer') .
+            ' , job_status_ts = ' . $this->db->quote($when->getTimestamp(), 'integer') .
             ' WHERE job_id = ' . $this->db->quote($job->getId(), 'text');
         $this->db->manipulate($query);
     }
 
-    public function deactivateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false): void
-    {
+    public function deactivateJob(
+        ilCronJob $job,
+        DateTimeImmutable $when,
+        ilObjUser $actor,
+        bool $wasManuallyExecuted = false
+    ): void {
         $usrId = $wasManuallyExecuted ? $actor->getId() : 0;
 
         $query = 'UPDATE cron_job SET ' .
             ' job_status = ' . $this->db->quote(0, 'integer') .
             ' , job_status_user_id = ' . $this->db->quote($usrId, 'integer') .
             ' , job_status_type = ' . $this->db->quote($wasManuallyExecuted, 'integer') .
-            ' , job_status_ts = ' . $this->db->quote(time(), 'integer') .
+            ' , job_status_ts = ' . $this->db->quote($when->getTimestamp(), 'integer') .
             ' WHERE job_id = ' . $this->db->quote($job->getId(), 'text');
         $this->db->manipulate($query);
     }

--- a/Services/Cron/interfaces/interface.ilCronJobRepository.php
+++ b/Services/Cron/interfaces/interface.ilCronJobRepository.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 interface ilCronJobRepository
 {
@@ -53,6 +53,7 @@ interface ilCronJobRepository
 
     public function updateJobResult(
         ilCronJob $job,
+        DateTimeImmutable $when,
         ilObjUser $actor,
         ilCronJobResult $result,
         bool $wasManualExecution = false
@@ -62,9 +63,9 @@ interface ilCronJobRepository
 
     public function updateJobSchedule(ilCronJob $job, ?int $scheduleType, ?int $scheduleValue): void;
 
-    public function activateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false): void;
+    public function activateJob(ilCronJob $job, DateTimeImmutable $when, ilObjUser $actor, bool $wasManuallyExecuted = false): void;
 
-    public function deactivateJob(ilCronJob $job, ilObjUser $actor, bool $wasManuallyExecuted = false): void;
+    public function deactivateJob(ilCronJob $job, DateTimeImmutable $when, ilObjUser $actor, bool $wasManuallyExecuted = false): void;
 
     public function findAll(): ilCronJobCollection;
 }

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -707,7 +707,8 @@ class ilInitialisation
                 $c['cron.repository'],
                 $c->database(),
                 $c->settings(),
-                $c->logger()->cron()
+                $c->logger()->cron(),
+                (new \ILIAS\Data\Factory())->clock()
             );
         };
     }


### PR DESCRIPTION
This PR fixes timezone issues when comparing the
"Last Run" datetime with the "Current" datetime.
Furthermore, this PR removes infrastructure dependencies to `time()` by using the `ClockInterface` type instead.

See: https://mantis.ilias.de/view.php?id=40302