### PR TITLE
ItemGroup: Fix PHP types in `\ilItemGroupItems::getAssignableItems`

### DIFF
--- a/Modules/ItemGroup/classes/class.ilItemGroupItems.php
+++ b/Modules/ItemGroup/classes/class.ilItemGroupItems.php
@@ -152,6 +152,10 @@ class ilItemGroupItems
                 continue;
             }
 
+            if (!isset($node['title'])) {
+                $node['title'] = '';
+            }
+
             // filter hidden files
             // see http://www.ilias.de/mantis/view.php?id=10269
             if ($node['type'] == "file" &&


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=40238

If approved, this has to be picked to `release_9` and `trunk`.