### PR TITLE
Remove array wrapper from data table token

### DIFF
--- a/src/UI/Implementation/Component/Table/Action/Action.php
+++ b/src/UI/Implementation/Component/Table/Action/Action.php
@@ -89,7 +89,7 @@ abstract class Action implements I\Action
         if ($target instanceof URI) {
             $target = $this->url_builder->withParameter(
                 $this->row_id_parameter,
-                [$row_id]
+                $row_id
             )
             ->buildURI();
         }

--- a/tests/UI/Component/Table/Action/ActionTest.php
+++ b/tests/UI/Component/Table/Action/ActionTest.php
@@ -90,7 +90,7 @@ class ActionTest extends ILIAS_UI_TestBase
     {
         $act = $this->link_action->withRowId('test-id');
         $this->assertEquals(
-            'ref_id=1&namespace_rowids[]=test-id',
+            'ref_id=1&namespace_rowids=test-id',
             urldecode($act->getTarget()->getQuery())
         );
     }

--- a/tests/UI/Component/Table/DataRendererTest.php
+++ b/tests/UI/Component/Table/DataRendererTest.php
@@ -464,8 +464,8 @@ EOT;
     <div class="dropdown">
         <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" id="id_3" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu"><span class="caret"></span></button>
         <ul id="id_3_menu" class="dropdown-menu">
-            <li><button class="btn btn-link" data-action="http://wwww.ilias.de?ref_id=1&namespace_param%5B%5D=row_id-1" id="id_1">label1</button></li>
-            <li><button class="btn btn-link" data-action="http://wwww.ilias.de?ref_id=1&namespace_param%5B%5D=row_id-1" id="id_2">label2</button></li>
+            <li><button class="btn btn-link" data-action="http://wwww.ilias.de?ref_id=1&namespace_param=row_id-1" id="id_1">label1</button></li>
+            <li><button class="btn btn-link" data-action="http://wwww.ilias.de?ref_id=1&namespace_param=row_id-1" id="id_2">label2</button></li>
         </ul>
     </div>
 </td>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40311

This seems to serve no purpose and as far as i can tell can be straight up removed since every consumer of the "Token Feature" in single actions has already a workaround implemented to handle array values and plain values.