### PR TITLE
COPage, RTE: Enable browser spellcheck in TinyMCE

### DIFF
--- a/components/ILIAS/COPage/Editor/js/src/components/paragraph/ui/tiny-wrapper.js
+++ b/components/ILIAS/COPage/Editor/js/src/components/paragraph/ui/tiny-wrapper.js
@@ -208,6 +208,7 @@ export default class TinyWrapper {
         menubar: false,
         statusbar: false,
         language: 'en',
+        browser_spellcheck: true,
         height: '100%',
         plugins: 'save,paste,lists',
         smart_paste: false,

--- a/components/ILIAS/RTE/templates/default/tpl.tinymce.js
+++ b/components/ILIAS/RTE/templates/default/tpl.tinymce.js
@@ -173,6 +173,7 @@ tinymce.init({
     editor_deselector: "noRTEditor",
     branding: false,
     language: "{LANG}",
+    browser_spellcheck: true,
     //blockformats has changed it's definition in 5.x. please fix the translations
     block_formats: ilTinyMCETranslateFormats(),
     plugins: "{ADDITIONAL_PLUGINS}",

--- a/components/ILIAS/RTE/templates/default/tpl.tinymce_frm_post.js
+++ b/components/ILIAS/RTE/templates/default/tpl.tinymce_frm_post.js
@@ -149,6 +149,7 @@ tinymce.init({
     editor_deselector: "noRTEditor",
     branding: false,
     language: "{LANG}",
+    browser_spellcheck: true,
     block_formats: ilTinyMCETranslateFormats(),
     plugins: "{ADDITIONAL_PLUGINS}",
     menubar: false,

--- a/components/ILIAS/RTE/templates/default/tpl.usereditor.js
+++ b/components/ILIAS/RTE/templates/default/tpl.usereditor.js
@@ -10,6 +10,7 @@ tinymce.init({
     branding: false,
     editor_selector: "{SELECTOR}",
     language: "{LANG}",
+    browser_spellcheck: true,
     plugins: "save",
     fix_list_elements: true,
     block_formats: "{BLOCKFORMATS}",


### PR DESCRIPTION
This PR enables the browser spellcheck feature for CO Page Elements using the TinyMCE and the RTE.