### PR TITLE
T&A 0040337 Fix zero input on file upload questions

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFileUploadGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUploadGUI.php
@@ -141,7 +141,7 @@ class assFileUploadGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
         $points->setRequired(true);
         $points->setSize(3);
         $points->setMinValue(0.0);
-        $points->setMinvalueShouldBeGreater(false);
+        $points->setMinvalueShouldBeGreater(true);
         $form->addItem($points);
 
         $subcompl = new ilCheckboxInputGUI($this->lng->txt(
@@ -522,7 +522,7 @@ class assFileUploadGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
         $points->setRequired(true);
         $points->setSize(3);
         $points->setMinValue(0.0);
-        $points->setMinvalueShouldBeGreater(false);
+        $points->setMinvalueShouldBeGreater(true);
         $form->addItem($points);
 
         $subcompl = new ilCheckboxInputGUI($this->lng->txt(


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40337

should prevent people from creating zero point file upload questions

Same code on ILIAS 7, 8, 9 
Tested on ILIAS 7, 8