### PR TITLE
[IMPROVEMENT] added event-system to IRSS

### DIFF
--- a/Services/ResourceStorage/classes/CollectionDBRepository.php
+++ b/Services/ResourceStorage/classes/CollectionDBRepository.php
@@ -22,6 +22,9 @@ use ILIAS\ResourceStorage\Collection\Repository\CollectionRepository;
 use ILIAS\ResourceStorage\Collection\ResourceCollection;
 use ILIAS\ResourceStorage\Identification\ResourceCollectionIdentification;
 use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+use ILIAS\ResourceStorage\Events\Subject;
+use ILIAS\ResourceStorage\Events\Event;
+use ILIAS\ResourceStorage\Events\Data;
 
 /**
  * Class CollectionDBRepository
@@ -100,7 +103,7 @@ class CollectionDBRepository implements CollectionRepository
         $r = $this->db->manipulateF($q, ['text'], [$identification->serialize()]);
     }
 
-    public function update(ResourceCollection $collection): void
+    public function update(ResourceCollection $collection, Subject $events): void
     {
         $identification = $collection->getIdentification();
         $resource_identifications = $collection->getResourceIdentifications();
@@ -108,7 +111,7 @@ class CollectionDBRepository implements CollectionRepository
         $title = $collection->getTitle();
 
         $resource_identification_strings = array_map(
-            fn (ResourceIdentification $i): string => $i->serialize(),
+            fn(ResourceIdentification $i): string => $i->serialize(),
             $resource_identifications
         );
 
@@ -126,6 +129,10 @@ class CollectionDBRepository implements CollectionRepository
                 self::R_IDENTIFICATION => ['text', $resource_identification_string],
                 'position' => ['integer', (int)$position + 1],
             ]);
+            $events->notify(
+                Event::COLLECTION_RESOURCE_ADDED,
+                new Data(['rid' => $resource_identification_string, 'rcid' => $identification->serialize()])
+            );
         }
         foreach ($resource_identification_strings as $position => $resource_identification_string) {
             $this->db->update(

--- a/Services/ResourceStorage/classes/Setup/class.ilResourceStorageMigrationHelper.php
+++ b/Services/ResourceStorage/classes/Setup/class.ilResourceStorageMigrationHelper.php
@@ -34,6 +34,7 @@ use ILIAS\ResourceStorage\Manager\Manager;
 use ILIAS\ResourceStorage\Preloader\StandardRepositoryPreloader;
 use ILIAS\ResourceStorage\Repositories;
 use ILIAS\ResourceStorage\Flavour\FlavourBuilder;
+use ILIAS\ResourceStorage\Events\Subject;
 
 /**
  * Class ilResourceStorageMigrationHelper
@@ -92,7 +93,8 @@ class ilResourceStorageMigrationHelper
         $this->resource_builder = $init->getResourceBuilder($container);
         $this->flavour_builder = $init->getFlavourBuilder($container);
         $this->collection_builder = new CollectionBuilder(
-            new CollectionDBRepository($db)
+            new CollectionDBRepository($db),
+            new Subject()
         );
 
         $this->repositories = $container[InitResourceStorage::D_REPOSITORIES];

--- a/src/ResourceStorage/Collection/CollectionBuilder.php
+++ b/src/ResourceStorage/Collection/CollectionBuilder.php
@@ -25,6 +25,7 @@ use ILIAS\ResourceStorage\Identification\ResourceCollectionIdentification;
 use ILIAS\ResourceStorage\Identification\ResourceIdentification;
 use ILIAS\ResourceStorage\Identification\UniqueIDCollectionIdentificationGenerator;
 use ILIAS\ResourceStorage\Preloader\SecureString;
+use ILIAS\ResourceStorage\Events\Subject;
 
 /**
  * Class CollectionBuilder
@@ -43,6 +44,7 @@ class CollectionBuilder
 
     public function __construct(
         Repository\CollectionRepository $collection_repository,
+        private Subject $events,
         ?CollectionIdentificationGenerator $id_generator = null,
         ?\ILIAS\ResourceStorage\Lock\LockHandler $lock_handler = null
     ) {
@@ -107,12 +109,12 @@ class CollectionBuilder
             $result = $this->lock_handler->lockTables(
                 $this->collection_repository->getNamesForLocking(),
                 function () use ($collection): void {
-                    $this->collection_repository->update($collection);
+                    $this->collection_repository->update($collection, $this->events);
                 }
             );
             $result->runAndUnlock();
         } else {
-            $this->collection_repository->update($collection);
+            $this->collection_repository->update($collection, $this->events);
         }
 
         return true;

--- a/src/ResourceStorage/Collection/Collections.php
+++ b/src/ResourceStorage/Collection/Collections.php
@@ -26,6 +26,7 @@ use ILIAS\ResourceStorage\Identification\ResourceIdentification;
 use ILIAS\ResourceStorage\Preloader\RepositoryPreloader;
 use ILIAS\ResourceStorage\Resource\ResourceBuilder;
 use ILIAS\ResourceStorage\Stakeholder\ResourceStakeholder;
+use ILIAS\ResourceStorage\Events\Subject;
 
 /**
  * Class Collections
@@ -47,7 +48,8 @@ class Collections
     public function __construct(
         ResourceBuilder $resource_builder,
         CollectionBuilder $collection_builder,
-        RepositoryPreloader $preloader
+        RepositoryPreloader $preloader,
+        private Subject $events
     ) {
         $this->resource_builder = $resource_builder;
         $this->collection_builder = $collection_builder;

--- a/src/ResourceStorage/Collection/Repository/CollectionRepository.php
+++ b/src/ResourceStorage/Collection/Repository/CollectionRepository.php
@@ -24,6 +24,7 @@ use ILIAS\ResourceStorage\Collection\ResourceCollection;
 use ILIAS\ResourceStorage\Identification\ResourceCollectionIdentification;
 use ILIAS\ResourceStorage\Identification\ResourceIdentification;
 use ILIAS\ResourceStorage\Lock\LockingRepository;
+use ILIAS\ResourceStorage\Events\Subject;
 
 /**
  * Interface CollectionRepository
@@ -45,7 +46,7 @@ interface CollectionRepository extends LockingRepository
      */
     public function getResourceIdStrings(ResourceCollectionIdentification $identification): \Generator;
 
-    public function update(ResourceCollection $collection): void;
+    public function update(ResourceCollection $collection, Subject $events): void;
 
     public function delete(ResourceCollectionIdentification $identification): void;
 

--- a/src/ResourceStorage/Events/CollectionData.php
+++ b/src/ResourceStorage/Events/CollectionData.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Events;
+
+/**
+ * @author       Fabian Schmid <fabian@sr.solutions>
+ */
+class CollectionData extends Data
+{
+    public function __construct(array $data = [])
+    {
+        // check fopr array to have two keys: rcid and rid
+        if (!array_key_exists('rcid', $data) || !array_key_exists('rid', $data)) {
+            throw new \InvalidArgumentException('CollectionData must contain rcid and rid');
+        }
+
+        parent::__construct($data, \ArrayObject::ARRAY_AS_PROPS);
+    }
+
+    public function getRcid(): string
+    {
+        return $this['rcid'];
+    }
+
+    public function getRid(): string
+    {
+        return $this['rid'];
+    }
+}

--- a/src/ResourceStorage/Events/Data.php
+++ b/src/ResourceStorage/Events/Data.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Events;
+
+/**
+ * @author       Fabian Schmid <fabian@sr.solutions>
+ */
+class Data extends \ArrayObject
+{
+}

--- a/src/ResourceStorage/Events/Event.php
+++ b/src/ResourceStorage/Events/Event.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Events;
+
+/**
+ * @author       Fabian Schmid <fabian@sr.solutions>
+ */
+enum Event: string
+{
+    /**
+     * event string being used if a new Resource has been stored to the IRSS.
+     */
+    //    case RESOURCE_CREATED = 'resource:created'; // will follow later
+    /**
+     * event string being used if a Resource has been deleted from the IRSS.
+     */
+    //    case RESOURCE_DELETED = 'resource:deleted'; // will follow later
+
+    /**
+     * event string being used if a new Resource has been assigned and stored to a collection.
+     */
+    case COLLECTION_RESOURCE_ADDED = 'collection:resource:added';
+    /**
+     * event string being used if a Resource has been deassigned from collection.
+     */
+    // case COLLECTION_RESOURCE_REMOVED = 'collection:resource:removed'; // will follow later
+
+    /**
+     * event string for all possible events.
+     */
+    case ALL = '*';
+}

--- a/src/ResourceStorage/Events/Observer.php
+++ b/src/ResourceStorage/Events/Observer.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Events;
+
+/**
+ * @author       Fabian Schmid <fabian@sr.solutions>
+ */
+interface Observer
+{
+    /**
+     * Unique identifier of the implementing event-listener. e.g. FQCN
+     */
+    public function getId(): string;
+
+    /**
+     * Recieves an event and handles it appropriately.
+     */
+    public function update(Event $event, ?Data $data): void;
+}

--- a/src/ResourceStorage/Events/Subject.php
+++ b/src/ResourceStorage/Events/Subject.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\ResourceStorage\Events;
+
+/**
+ * @author       Fabian Schmid <fabian@sr.solutions>
+ */
+class Subject
+{
+    /**
+     * @var array<Event, Observer[]>
+     */
+    protected array $observer_groups = [];
+
+    public function __construct()
+    {
+        $this->initObserverGroup((Event::ALL)->value);
+    }
+
+    public function attach(Observer $observer, Event $event): void
+    {
+        $this->initObserverGroup($event->value);
+
+        $this->observer_groups[$event->value][] = $observer;
+    }
+
+    public function detach(Observer $observer, Event $event = Event::ALL): void
+    {
+        $this->initObserverGroup($event->value);
+
+        foreach ($this->observer_groups[$event->value] as $index => $attached_observer) {
+            if ($attached_observer->getId() === $observer->getId()) {
+                unset($this->observer_groups[$event->value][$index]);
+            }
+        }
+    }
+
+    public function notify(Event $event, ?Data $data): void
+    {
+        $this->initObserverGroup($event->value);
+
+        $observers = array_merge(
+            $this->observer_groups[(Event::ALL)->value],
+            $this->observer_groups[$event->value],
+        );
+
+        foreach ($observers as $interessted_observer) {
+            $interessted_observer->update($event, $data);
+        }
+    }
+
+    protected function initObserverGroup(string $group): void
+    {
+        if (!isset($this->observer_groups[$group])) {
+            $this->observer_groups[$group] = [];
+        }
+    }
+}

--- a/src/ResourceStorage/README.md
+++ b/src/ResourceStorage/README.md
@@ -457,3 +457,17 @@ As I said, if you are a consumer of the IRSS, you use the Consumers approach any
 
 Please see the roapmap of the service in [README.md](ROADMAP.md)
 
+# Events
+The IRSS offers an interface for events, which follows the general observer pattern. To be informed about events, a separate class is implemented with the interface `\ILIAS\ResourceStorage\Events\Observer`. This can be registered via the IRSS service:
+
+```php
+global $DIC;
+$observer = new MyObserver(); // implements \ILIAS\ResourceStorage\Events\Observer
+$DIC->resourceStorage()->events()->attach(
+    $observer, 
+    \ILIAS\ResourceStorage\Events\Event::COLLECTION_RESOURCE_ADDED
+);
+```
+
+For the example of the event `\ILIAS\ResourceStorage\Events\Event::COLLECTION_RESOURCE_ADDED`, the data obtained is the class `\ILIAS\ResourceStorage\Events\CollectionData` with the ResourceIdentification and the ResourceCollectionIdentification each as a string.
+As soon as further events are available, these are described in the enum `\ILIAS\ResourceStorage\Events\Event` and here in the README.

--- a/src/ResourceStorage/Services.php
+++ b/src/ResourceStorage/Services.php
@@ -41,6 +41,7 @@ use ILIAS\ResourceStorage\Preloader\StandardRepositoryPreloader;
 use ILIAS\ResourceStorage\Resource\ResourceBuilder;
 use ILIAS\ResourceStorage\StorageHandler\StorageHandler;
 use ILIAS\ResourceStorage\StorageHandler\StorageHandlerFactory;
+use ILIAS\ResourceStorage\Events\Subject;
 
 /**
  * Class Services
@@ -49,6 +50,7 @@ use ILIAS\ResourceStorage\StorageHandler\StorageHandlerFactory;
  */
 class Services
 {
+    protected Subject $events;
     protected \ILIAS\ResourceStorage\Manager\Manager $manager;
     protected \ILIAS\ResourceStorage\Consumer\Consumers $consumers;
     protected \ILIAS\ResourceStorage\Collection\Collections $collections;
@@ -69,6 +71,7 @@ class Services
         SrcBuilder $src_builder = null,
         RepositoryPreloader $preloader = null
     ) {
+        $this->events = new Subject();
         $src_builder ??= new InlineSrcBuilder();
         $file_name_policy_stack = new FileNamePolicyStack();
         $file_name_policy_stack->addPolicy($file_name_policy);
@@ -81,6 +84,7 @@ class Services
         );
         $collection_builder = new CollectionBuilder(
             $repositories->getCollectionRepository(),
+            $this->events,
             new UniqueIDCollectionIdentificationGenerator(),
             $lock_handler
         );
@@ -102,7 +106,8 @@ class Services
         $this->collections = new Collections(
             $resource_builder,
             $collection_builder,
-            $this->preloader
+            $this->preloader,
+            $this->events
         );
 
         $flavour_builder = new FlavourBuilder(
@@ -142,5 +147,10 @@ class Services
     public function preload(array $identification_strings): void
     {
         $this->preloader->preload($identification_strings);
+    }
+
+    public function events(): Subject
+    {
+        return $this->events;
     }
 }

--- a/tests/ResourceStorage/Collection/CollectionBuilderTest.php
+++ b/tests/ResourceStorage/Collection/CollectionBuilderTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use ILIAS\ResourceStorage\Collection\Collections;
 use ILIAS\ResourceStorage\Preloader\RepositoryPreloader;
 use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+use ILIAS\ResourceStorage\Events\Subject;
 
 /**
  * Class CollectionBuilderTest
@@ -42,12 +43,14 @@ class CollectionBuilderTest extends TestCase
     {
         $this->collection_builder = new CollectionBuilder(
             $this->collection_repo = $this->createMock(CollectionRepository::class),
+            new Subject(),
             new DummyIDGenerator(self::DUMMY_RCID)
         );
         $this->collections = new Collections(
             $this->resource_builder = $this->createMock(ResourceBuilder::class),
             $this->collection_builder,
-            $this->createMock(RepositoryPreloader::class)
+            $this->createMock(RepositoryPreloader::class),
+            new Subject()
         );
     }
 

--- a/tests/ResourceStorage/Collection/CollectionRepositoryTest.php
+++ b/tests/ResourceStorage/Collection/CollectionRepositoryTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 use ILIAS\ResourceStorage\Resource\Repository\CollectionDBRepository;
 use ILIAS\ResourceStorage\DummyIDGenerator;
 use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+use ILIAS\ResourceStorage\Events\Subject;
 
 /**
  * Class CollectionTest
@@ -82,7 +83,7 @@ class CollectionRepositoryTest extends TestCase
                           )
                       );
 
-        $this->repo->update($collection);
+        $this->repo->update($collection, new Subject());
     }
 
 }

--- a/tests/ResourceStorage/Collection/CollectionTest.php
+++ b/tests/ResourceStorage/Collection/CollectionTest.php
@@ -30,6 +30,7 @@ use ILIAS\ResourceStorage\Identification\ResourceCollectionIdentification;
 use ILIAS\ResourceStorage\Identification\ResourceIdentification;
 use ILIAS\ResourceStorage\Preloader\RepositoryPreloader;
 use PHPUnit\Framework\MockObject\MockObject;
+use ILIAS\ResourceStorage\Events\Subject;
 
 /**
  * Class CollectionTest
@@ -60,6 +61,7 @@ class CollectionTest extends AbstractBaseResourceBuilderTest
 
         $this->collection_builder = new CollectionBuilder(
             $this->collection_repository,
+            new Subject(),
             $this->rcid_generator
         );
 
@@ -77,7 +79,8 @@ class CollectionTest extends AbstractBaseResourceBuilderTest
         $this->collections = new Collections(
             $this->resource_builder,
             $this->collection_builder,
-            $this->preloader
+            $this->preloader,
+            new Subject()
         );
     }
 
@@ -243,7 +246,8 @@ class CollectionTest extends AbstractBaseResourceBuilderTest
         $collections_service = new Collections(
             $this->resource_builder,
             $this->collection_builder,
-            $this->preloader
+            $this->preloader,
+            new Subject()
         );
 
         $this->collection_repository


### PR DESCRIPTION
Issue [39642](https://mantis.ilias.de/view.php?id=39642) shows that the IRSS needs an event system in order to be informed as a component about certain operations. however, the event system must remain very general (e.g. as an event only "resource was added to collection") and can only provide trivial data. the components must decide for themselves on the basis of this data whether they want to react to it. the system follows the general observer pattern.

in a first step, only this first event is offered, but further events can be added later.