### PR TITLE
Refinery/MarkdownToHtml: Escape HTML and don't accept and unsafe links

### DIFF
--- a/src/Refinery/String/Group.php
+++ b/src/Refinery/String/Group.php
@@ -141,8 +141,8 @@ class Group
      * This method returns an instance of the MarkdownFormattingToHTML class which can be used to tranform a markdown
      * formatted string to HTML.
      */
-    public function markdown(): MarkdownFormattingToHTML
+    public function markdown(bool $escape = true): MarkdownFormattingToHTML
     {
-        return new MarkdownFormattingToHTML();
+        return new MarkdownFormattingToHTML($escape);
     }
 }

--- a/src/Refinery/String/MarkdownFormattingToHTML.php
+++ b/src/Refinery/String/MarkdownFormattingToHTML.php
@@ -29,9 +29,18 @@ class MarkdownFormattingToHTML
 {
     private \League\CommonMark\CommonMarkConverter $converter;
 
-    public function __construct()
+    public function __construct(bool $escape = true)
     {
-        $this->converter = new \League\CommonMark\CommonMarkConverter();
+        $config = [
+            'allow_unsafe_links' => false,
+            'max_nesting_level' => 42 // https://commonmark.thephpleague.com/1.5/security/#nesting-level
+        ];
+
+        if ($escape === true) {
+            $config['html_input'] = 'escape';
+        }
+
+        $this->converter = new \League\CommonMark\CommonMarkConverter($config);
     }
 
     /**

--- a/tests/Refinery/String/MarkdownFormattingToHTMLTest.php
+++ b/tests/Refinery/String/MarkdownFormattingToHTMLTest.php
@@ -24,13 +24,12 @@ use ILIAS\Data\Factory;
 use ILIAS\Refinery\String\Group;
 use ILIAS\Tests\Refinery\TestCase;
 use ilLanguage;
-use InvalidArgumentException;
-use ILIAS\Refinery\String\Transformation\UTFNormalTransformation;
 use ILIAS\Refinery\Transformation;
 
 class MarkdownFormattingToHTMLTest extends TestCase
 {
     private Transformation $markdown;
+    private Transformation $markdown_with_escaped_html;
 
     protected function setUp(): void
     {
@@ -39,7 +38,8 @@ class MarkdownFormattingToHTMLTest extends TestCase
                          ->getMock();
         $group = new Group(new Factory(), $language);
 
-        $this->markdown = $group->markdown()->toHTML();
+        $this->markdown = $group->markdown(false)->toHTML();
+        $this->markdown_with_escaped_html = $group->markdown()->toHTML();
     }
 
     public function stringProvider(): array
@@ -65,5 +65,32 @@ class MarkdownFormattingToHTMLTest extends TestCase
         string $expected_html,
     ): void {
         $this->assertEquals($expected_html, $this->markdown->transform($markdown_string));
+    }
+
+    public function testHtmlInputIsRendered(): void
+    {
+        $markdown_with_html = "lorem **ipsum**\n<ul><li>phpunit</li></ul>";
+
+        $expected = "<p>lorem <strong>ipsum</strong></p>\n<ul><li>phpunit</li></ul>\n";
+
+        $this->assertSame($expected, $this->markdown->transform($markdown_with_html));
+    }
+
+    public function testUntrustedLinksAreRemoved(): void
+    {
+        $markdown_with_html = "lorem **ipsum**\n[xss](javascript:alert(1))";
+
+        $expected = "<p>lorem <strong>ipsum</strong>\n<a>xss</a></p>\n";
+
+        $this->assertSame($expected, $this->markdown->transform($markdown_with_html));
+    }
+
+    public function testHtmlInputIsEscapedIfDesired(): void
+    {
+        $markdown_with_html = "lorem **ipsum**\n<ul><li>phpunit</li></ul>";
+
+        $expected = "<p>lorem <strong>ipsum</strong></p>\n&lt;ul&gt;&lt;li&gt;phpunit&lt;/li&gt;&lt;/ul&gt;\n";
+
+        $this->assertSame($expected, $this->markdown_with_escaped_html->transform($markdown_with_html));
     }
 }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=40204

If approved, this has to be picked to `trunk` as well.