### PR TITLE
9/UI/forms alert help block spacing 38867

### DIFF
--- a/Services/Form/templates/default/tpl.prop_datetime_duration.html
+++ b/Services/Form/templates/default/tpl.prop_datetime_duration.html
@@ -1,38 +1,40 @@
-<!-- BEGIN toggle_fullday -->
-<div class="ilFormInnerCol">
-	<div class="form-group form-inline">		
-		<div class="input-group">		
-			<input type="checkbox" name="{DATE_TOGGLE_ID}" id="{FULLDAY_TOGGLE_ID}" value="1"{FULLDAY_TOGGLE_CHECKED} {FULLDAY_TOGGLE_DISABLED} />
+<div class="row">
+	<!-- BEGIN toggle_fullday -->
+	<div class="ilFormInnerCol">
+		<div class="form-group form-inline">		
+			<div class="input-group">		
+				<input type="checkbox" name="{DATE_TOGGLE_ID}" id="{FULLDAY_TOGGLE_ID}" value="1"{FULLDAY_TOGGLE_CHECKED} {FULLDAY_TOGGLE_DISABLED} />
+			</div>
+			<label class=control-label" for="{FULLDAY_TOGGLE_ID}">{TXT_TOGGLE_FULLDAY}</label>
 		</div>
-		<label class=control-label" for="{FULLDAY_TOGGLE_ID}">{TXT_TOGGLE_FULLDAY}</label>
 	</div>
-</div>
-<!-- END toggle_fullday -->
-<div class="col-sm-6 ilFormInnerCol">
-	<div class="form-group form-inline">
-		<!-- BEGIN start_label_bl -->
-		<!-- END start_label_bl -->
-		<div class="input-group date<!-- BEGIN start_width_bl --> noop<!-- END start_width_bl -->" id="{DATEPICKER_START_ID}">
-			<input aria-label="{START_ARIA_LABEL}" aria-describedby="start_date_desc_{DATE_START_ID}" type="text" class="form-control" placeholder="{START_PLACEHOLDER}" value="{DATEPICKER_START_VALUE}" id="{DATE_START_ID}" name="{DATE_START_ID}"{DATEPICKER_START_DISABLED} {START_REQUIRED}/>
-			<p class="sr-only" id="start_date_desc_{DATE_START_ID}">{DESCRIPTION}</p>
-			<span class="input-group-addon">
-				<span class="glyphicon glyphicon-calendar"></span>
-			</span>
+	<!-- END toggle_fullday -->
+	<div class="col-sm-6 ilFormInnerCol">
+		<div class="form-group form-inline">
+			<!-- BEGIN start_label_bl -->
+			<!-- END start_label_bl -->
+			<div class="input-group date<!-- BEGIN start_width_bl --> noop<!-- END start_width_bl -->" id="{DATEPICKER_START_ID}">
+				<input aria-label="{START_ARIA_LABEL}" aria-describedby="start_date_desc_{DATE_START_ID}" type="text" class="form-control" placeholder="{START_PLACEHOLDER}" value="{DATEPICKER_START_VALUE}" id="{DATE_START_ID}" name="{DATE_START_ID}"{DATEPICKER_START_DISABLED} {START_REQUIRED}/>
+				<p class="sr-only" id="start_date_desc_{DATE_START_ID}">{DESCRIPTION}</p>
+				<span class="input-group-addon">
+					<span class="glyphicon glyphicon-calendar"></span>
+				</span>
+			</div>
+			<br /><label class="control-label">{START_LABEL}</label>
 		</div>
-		<br /><label class="control-label">{START_LABEL}</label>
 	</div>
-</div>
-<div class="col-sm-6 ilFormInnerCol">
-	<div class="form-group form-inline">
-		<!-- BEGIN end_label_bl -->
-		<!-- END end_label_bl -->
-		<div class="input-group date<!-- BEGIN end_width_bl --> noop<!-- END end_width_bl -->" id="{DATEPICKER_END_ID}">
-			<input aria-label="{END_ARIA_LABEL}" aria-describedby="end_date_desc_{DATE_END_ID}" type="text" class="form-control" placeholder="{END_PLACEHOLDER}" value="{DATEPICKER_END_VALUE}" name="{DATE_END_ID}"{DATEPICKER_END_DISABLED} {END_REQUIRED} />
-			<p class="sr-only" id="end_date_desc_{DATE_END_ID}">{DESCRIPTION}</p>
-			<span class="input-group-addon">
-				<span class="glyphicon glyphicon-calendar"></span>
-			</span>
+	<div class="col-sm-6 ilFormInnerCol">
+		<div class="form-group form-inline">
+			<!-- BEGIN end_label_bl -->
+			<!-- END end_label_bl -->
+			<div class="input-group date<!-- BEGIN end_width_bl --> noop<!-- END end_width_bl -->" id="{DATEPICKER_END_ID}">
+				<input aria-label="{END_ARIA_LABEL}" aria-describedby="end_date_desc_{DATE_END_ID}" type="text" class="form-control" placeholder="{END_PLACEHOLDER}" value="{DATEPICKER_END_VALUE}" name="{DATE_END_ID}"{DATEPICKER_END_DISABLED} {END_REQUIRED} />
+				<p class="sr-only" id="end_date_desc_{DATE_END_ID}">{DESCRIPTION}</p>
+				<span class="input-group-addon">
+					<span class="glyphicon glyphicon-calendar"></span>
+				</span>
+			</div>
+					<br /><label class="control-label">{END_LABEL}</label>
 		</div>
-                <br /><label class="control-label">{END_LABEL}</label>
 	</div>
 </div>

--- a/Services/Form/templates/default/tpl.property_form.html
+++ b/Services/Form/templates/default/tpl.property_form.html
@@ -25,7 +25,7 @@
 <!-- BEGIN std_prop_start -->
 <div class="form-group row" id="il_prop_cont_{LAB_ID}">
 	<label {FOR_ID} class="col-lg-2 col-md-3 col-sm-4 control-label">{PROPERTY_TITLE}<!-- BEGIN std_hid_title --> <span class="ilAccHeadingHidden">{PHID_TITLE}</span><!-- END std_hid_title --><!-- BEGIN required --> <span class="asterisk">*</span><!-- END required --></label>
-	<div class="col-lg-10 col-md-9 col-sm-8 row">
+	<div class="col-lg-10 col-md-9 col-sm-8">
 <!-- END std_prop_start -->
 <!-- BEGIN sub_prop_start -->
 <div class="form-group row" id="il_prop_cont_{LAB_ID}">

--- a/templates/default/070-components/legacy/Services/_component_form.scss
+++ b/templates/default/070-components/legacy/Services/_component_form.scss
@@ -349,12 +349,7 @@ input[type="checkbox"] {
 	}
 
 	&.alert-danger {
-		margin: $il-margin-small-vertical 0 0;
-		padding: 0 $il-padding-small-vertical 0 $il-padding-small-vertical;
-
-		color: $il-alert-danger-text;
-		background-color: $il-alert-danger-bg;
-		border-color: $il-alert-danger-border;
+		margin-bottom: $il-margin-small-vertical;
 	}
 }
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1,4 +1,7 @@
 @charset "UTF-8";
+/*
+* Dependencies
+*/
 /*!
  * Datetimepicker for Bootstrap 3
  * version : 4.17.37
@@ -679,8 +682,9 @@ table.mceToolbar tbody, table.mceToolbar tr, table.mceToolbar td {
 }
 
 /*
-* Dependencies
-*/ /* print less */
+* Normalize
+*/
+/* print less */
 @media print {
   * {
     /* see bug 0022342 */
@@ -888,9 +892,6 @@ th {
   padding: 0;
 }
 
-/*
-* Normalize
-*/
 .row {
   --bs-gutter-x: 30px;
   --bs-gutter-y: 0;
@@ -1970,6 +1971,9 @@ th {
     display: none !important;
   }
 }
+/*
+* Elements
+*/
 * {
   box-sizing: border-box;
 }
@@ -2331,8 +2335,9 @@ code {
   }
 }
 /*
-* Elements
+* Components
 */
+/* UI Framework */
 .c-tooltip__container {
   position: relative;
   display: inline-block;
@@ -9561,6 +9566,7 @@ td.c-table-data__cell--highlighted {
   width: 5rem;
 }
 
+/* Component parts from old delos.scss */
 div#agreement {
   width: 100%;
   height: 375px;
@@ -10253,6 +10259,7 @@ div.il_info {
   border-color: #dddddd;
 }
 
+/* Adapted from Bootstrap 3 */
 .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
@@ -10880,6 +10887,7 @@ tbody.collapse.in {
   clip: auto;
 }
 
+/* Legacy Modules & Services */
 /* Modules/Bibliographic */
 span.bibl_text_inline_Emph {
   font-style: italic;
@@ -15395,11 +15403,7 @@ fieldset[disabled] .checkbox label {
   margin: 2px 0 10px;
 }
 .help-block.alert-danger {
-  margin: 3px 0 0;
-  padding: 0 3px 0 3px;
-  color: #161616;
-  background-color: #ffd7d7;
-  border-color: #ffd7d7;
+  margin-bottom: 3px;
 }
 
 @media (min-width: 768px) {
@@ -18673,13 +18677,6 @@ img.ilUserXXSmall {
   outline: 3px solid #0078D7;
 }
 
-/*
-* Components
-*/
-/* UI Framework */
-/* Component parts from old delos.scss */
-/* Adapted from Bootstrap 3 */
-/* Legacy Modules & Services */
 /*
 	These classes are used to limit the number of rows when displaying larger chunks of text.
 	The mixin receives $height-in-rows as an integer. The classes il-multi-line-cap-2,3,5,10


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38867

# Issue

When focusing on an input field, the focus outline covers up error messages for that field.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/36840ef6-aeb0-43cc-8246-c00b9f2c6104)

# Change

With this PR, we suggest keeping the default look of alert messages in forms for the following reasons:
* Because these are critical alerts, blocking the user to proceed, it should have the breathing room these messages deserve.
* The resulting breathing room solves the visual issue with the focus outline
* It's less CSS. Less overrides are likely to lead to less bugs.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/3921924b-e846-4c0c-bdb6-57a6bc526e4f)

## Conflicts resolved
There has been a conflict with a previous fix adding row to an existing div for date-and-time fields. Instead of adding the class to an existing div, the date-and-time html template now has its own row div with no other class applied to it.