### PR TITLE
T&A 0039949 ideographic space and other Non-Printable-Characters

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -61,6 +61,8 @@ abstract class assQuestion
     protected const DEFAULT_THUMB_SIZE = 150;
     protected const MINIMUM_THUMB_SIZE = 20;
 
+    public const TRIM_PATTERN = '/^[\p{C}\p{Z}]+|[\p{C}\p{Z}]+$/u';
+
     protected ILIAS\HTTP\Services $http;
     protected ILIAS\Refinery\Factory $refinery;
 
@@ -4199,4 +4201,24 @@ abstract class assQuestion
         $res = $this->db->query($query);
         return $res->numRows() > 0;
     }
+
+    /**
+     * Trim non-printable characters from the beginning and end of a string.
+     *
+     * Note: The PHP trim() function is not fully Unicode-compatible and may not handle
+     * non-printable characters effectively. As a result, it may not trim certain Unicode
+     * characters, such as control characters, zero width characters or ideographic space as expected.
+     *
+     * This method provides a workaround for trimming non-printable characters until PHP 8.4,
+     * where the mb_trim() function is introduced. Users are encouraged to migrate to mb_trim()
+     * for proper Unicode and non-printable character handling.
+     *
+     * @param string $value The string to trim.
+     * @return string The trimmed string.
+     */
+    public static function extendedTrim(string $value): string
+    {
+        return preg_replace(self::TRIM_PATTERN, '', $value);
+    }
+
 }

--- a/Modules/TestQuestionPool/classes/class.assTextSubset.php
+++ b/Modules/TestQuestionPool/classes/class.assTextSubset.php
@@ -853,7 +853,7 @@ class assTextSubset extends assQuestion implements ilObjQuestionScoringAdjustabl
                     $this->dic->refinery()->kindlyTo()->string()
                 );
                 if ($value) {
-                    $value = trim($value);
+                    $value = $this->extendedTrim($value);
                     $value = $purifier->purify($value);
                     $solutionSubmit[] = $value;
                 }

--- a/Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php
@@ -316,7 +316,8 @@ class assTextSubsetGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
         // Delete all existing answers and create new answers from the form data
         $this->object->flushAnswers();
         foreach ($this->answers_from_post as $index => $answertext) {
-            $this->object->addAnswer(htmlentities(trim($answertext)), $_POST['answers']['points'][$index], $index);
+            $answertext = assQuestion::extendedTrim($answertext);
+            $this->object->addAnswer(htmlentities($answertext), $_POST['answers']['points'][$index], $index);
         }
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=39949

This is a, dear I say it, "temporary" fix that should be removed with PHP 8.4 where mb_trim() will be introduced.
The provided method trims all Unicode characters of the [category](https://www.php.net/manual/de/regexp.reference.unicode.php)  "other" and "seperator".

Note: Using the provided method on Multi-line input is not recommended. 

Tested on ILIAS: 8, 9 
Same code on ILIAS: 8, 9
