### PR TITLE
[FIX] 0040447: Object creation fails – Part 2

### DIFF
--- a/components/ILIAS/Repository/classes/class.ilRepositoryGUI.php
+++ b/components/ILIAS/Repository/classes/class.ilRepositoryGUI.php
@@ -169,6 +169,7 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
             ilLoggerFactory::getLogger('obj')->debug($this->ctrl->getNextClass() . ' <-> ' . $class_name);
 
             if ($this->ctrl->getNextClass() !== strtolower('ilObj' . $class_name . 'GUI')) {
+                $this->ctrl->setParameterByClass($next_class, "new_type", $new_type);
                 $this->ctrl->redirectByClass($next_class, $this->ctrl->getCmd());
             }
         } elseif ((($next_class = $this->ctrl->getNextClass($this)) == "")


### PR DESCRIPTION
The Parameter new_type seems missing, see https://mantis.ilias.de/view.php?id=40447, seems to come from this commit: https://github.com/ILIAS-eLearning/ILIAS/commit/b5d9dbc3ab6f234c5c57a4080ee03a52b9257f88