### PR TITLE
[FIX] #39318 UI: improve Modal\Interruptive label handling.

### DIFF
--- a/src/UI/Component/Modal/Interruptive.php
+++ b/src/UI/Component/Modal/Interruptive.php
@@ -53,7 +53,7 @@ interface Interruptive extends Modal
     /**
      * Get the label of the action button in the footer
      */
-    public function getActionButtonLabel(): string;
+    public function getActionButtonLabel(): ?string;
 
     /**
      * Get a modal like this with the action button labeled
@@ -65,7 +65,7 @@ interface Interruptive extends Modal
     /**
      * Get the label of the cancel button in the footer
      */
-    public function getCancelButtonLabel(): string;
+    public function getCancelButtonLabel(): ?string;
 
     /**
      * Get a modal like this with the cancel button labeled

--- a/src/UI/Implementation/Component/Modal/Interruptive.php
+++ b/src/UI/Implementation/Component/Modal/Interruptive.php
@@ -34,8 +34,8 @@ class Interruptive extends Modal implements M\Interruptive
     protected array $items = array();
     protected string $title;
     protected string $message;
-    protected string $action_button_label = 'delete';
-    protected string $cancel_button_label = 'cancel';
+    protected ?string $action_button_label = null;
+    protected ?string $cancel_button_label = null;
     protected string $form_action;
 
     public function __construct(
@@ -94,7 +94,7 @@ class Interruptive extends Modal implements M\Interruptive
     /**
      * @inheritdoc
      */
-    public function getActionButtonLabel(): string
+    public function getActionButtonLabel(): ?string
     {
         return $this->action_button_label;
     }
@@ -113,7 +113,7 @@ class Interruptive extends Modal implements M\Interruptive
     /**
      * @inheritdoc
      */
-    public function getCancelButtonLabel(): string
+    public function getCancelButtonLabel(): ?string
     {
         return $this->cancel_button_label;
     }

--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -140,10 +140,8 @@ class Renderer extends AbstractComponentRenderer
                 $tpl->parseCurrentBlock();
             }
         }
-        $tpl->setVariable('ACTION_BUTTON_LABEL', $this->txt($modal->getActionButtonLabel()));
-        $tpl->setVariable('ACTION_BUTTON', $modal->getActionButtonLabel());
-        $tpl->setVariable('CANCEL_BUTTON_LABEL', $this->txt($modal->getCancelButtonLabel()));
-        $tpl->setVariable('CLOSE_LABEL', $this->txt($modal->getCancelButtonLabel()));
+        $tpl->setVariable('ACTION_BUTTON_LABEL', $modal->getActionButtonLabel() ?? $this->txt('delete'));
+        $tpl->setVariable('CANCEL_BUTTON_LABEL', $modal->getCancelButtonLabel() ?? $this->txt('cancel'));
 
         return $tpl->get();
     }

--- a/src/UI/examples/Modal/Interruptive/with_custom_labels.php
+++ b/src/UI/examples/Modal/Interruptive/with_custom_labels.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Modal\Interruptive;
+
+/**
+ * Example showing an interruptive modal with custom labels.
+ */
+function with_custom_labels(): string
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $modal = $factory->modal()->interruptive(
+        'You are about to perform a dangerous action',
+        'Are you sure you want to continue? Use these very descriptive buttons below to continue/abort.',
+        '#'
+    );
+
+    $modal = $modal->withActionButtonLabel('yes, continue with this action')
+                   ->withCancelButtonLabel('no, cancel this dangerous action!');
+
+    $trigger = $DIC->ui()->factory()->button()->standard(
+        'perform dangerous action',
+        $modal->getShowSignal()
+    );
+
+    return $renderer->render([$modal, $trigger]);
+}

--- a/src/UI/templates/default/Modal/tpl.interruptive.html
+++ b/src/UI/templates/default/Modal/tpl.interruptive.html
@@ -3,7 +3,7 @@
 		<form action="{FORM_ACTION}" method="POST">
 			<div class="modal-content">
 				<div class="modal-header">
-					<button type="button" class="close" data-dismiss="modal" aria-label="{CLOSE_LABEL}"><span aria-hidden="true">&times;</span></button>
+					<button type="button" class="close" data-dismiss="modal" aria-label="{CANCEL_BUTTON_LABEL}"><span aria-hidden="true">&times;</span></button>
 					<span class="modal-title">{TITLE}</span>
 				</div>
 				<div class="modal-body">
@@ -31,7 +31,7 @@
 					<!-- END with_items -->
 				</div>
 				<div class="modal-footer">
-					<input type="submit" class="btn btn-primary" value="{ACTION_BUTTON_LABEL}" name="cmd[{ACTION_BUTTON}]">
+					<input type="submit" class="btn btn-primary" value="{ACTION_BUTTON_LABEL}">
 					<button class="btn btn-default" data-dismiss="modal">{CANCEL_BUTTON_LABEL}</button>
 				</div>
 			</div>

--- a/tests/UI/Component/Modal/InterruptiveTest.php
+++ b/tests/UI/Component/Modal/InterruptiveTest.php
@@ -100,7 +100,7 @@ class InterruptiveTest extends ModalBase
 					<div class="alert alert-warning il-modal-interruptive-message" role="alert">Message</div>
 				</div>
 				<div class="modal-footer">
-					<input type="submit" class="btn btn-primary" value="delete" name="cmd[delete]">
+					<input type="submit" class="btn btn-primary" value="delete">
 					<button class="btn btn-default" data-dismiss="modal">cancel</button>
 				</div>
 			</div>
@@ -114,20 +114,18 @@ EOT;
 
     public function testLabels(): void
     {
-        $action_label = 'actionlabel';
-        $cancel_label = 'cancellabel';
+        $action_label = sha1('actionlabel');
+        $cancel_label = sha1('cancellabel');
         $interruptive = $this->getModalFactory()->interruptive('Title', 'Message', 'someaction')
             ->withActionButtonLabel($action_label)
             ->withCancelButtonLabel($cancel_label);
 
-        $this->assertEquals(
-            $action_label,
-            $interruptive->getActionButtonLabel()
-        );
-        $this->assertEquals(
-            $cancel_label,
-            $interruptive->getCancelButtonLabel()
-        );
+        $html = $this->getDefaultRenderer()->render($interruptive);
+
+        // cancel label should be used for button and close glyph (x).
+        $this->assertEquals(2, substr_count($html, $cancel_label));
+        // action label should be used exactly once.
+        $this->assertEquals(1, substr_count($html, $action_label));
     }
 }
 


### PR DESCRIPTION
Hi all,

This PR should solve the following mantis issue: https://mantis.ilias.de/view.php?id=39318.
In addition this fixes labels being translated in the renderer, which has led to custom labels being translated twice so they were wrapped by `-` characters.

Please note this might be a breaking change, because I removed the `name` attribute from the submit button entirely, which used to set the `cmd` parameter to the language variable of the action button. If this is an issue for the productive release, we probably need to come up with an alternative, but I still suggest to remove the attribute for ILIAS 9 onwards.

Kind regards,
@thibsy