### PR TITLE
Survey: Fix a small bug that leads to a non-empty array

### DIFF
--- a/Modules/Survey/classes/class.ilObjSurvey.php
+++ b/Modules/Survey/classes/class.ilObjSurvey.php
@@ -458,7 +458,7 @@ class ilObjSurvey extends ilObject
     {
         $ilDB = $this->db;
         
-        $user_ids[] = array();
+        $user_ids = array();
         
         foreach ($finished_ids as $finished_id) {
             $result = $ilDB->queryF(


### PR DESCRIPTION
If `$user_ids` is not really empty, but contains an empty array, `ilObjectLP::resetLPDataForUserIds()` will be called with that value. In some situations this leads to `ilChangeEvent::hasAccessed()` being called with an array instead of a string as `$a_user_id`, which results in an '**illegal offset type**' error.

This only happens if a survey is contained in another object and adds to its learning progress, as `ilLPStatusCollection::determineStatus()` will be called in this case.

PS: This is already fixed in release_8.