### PR TITLE
Bugfix #0040454: Backtarget 'All threads' redirects to repository

### DIFF
--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -1724,7 +1724,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
         $this->tpl->setTitleIcon(ilObject::_getIcon(0, "big", "frm"));
 
         $ref_id = $this->retrieveRefId();
-        
         $this->tabs_gui->setBackTarget(
             $this->lng->txt('frm_all_threads'),
             $this->ctrl->getLinkTarget(

--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -1724,10 +1724,13 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
         $this->tpl->setTitleIcon(ilObject::_getIcon(0, "big", "frm"));
 
         $ref_id = $this->retrieveRefId();
-
+        
         $this->tabs_gui->setBackTarget(
             $this->lng->txt('frm_all_threads'),
-            'ilias.php?baseClass=ilRepositoryGUI&amp;ref_id=' . $ref_id
+            $this->ctrl->getLinkTarget(
+                $this,
+                'showThreads'
+            )
         );
 
         /** @var ilForum $frm */


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40454 and
https://mantis.ilias.de/view.php?id=40333
Fixes the backtarget to the threads overview of a forum