### PR TITLE
Use spec-aligned date format when parsing LTI score timestamp

### DIFF
--- a/Modules/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -157,7 +157,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
 
         ilLPStatus::writeStatus($objId, $userId, $lp_status, $lp_percentage, true);
 
-        $ltiTimestamp = DateTimeImmutable::createFromFormat(DateTimeInterface::ISO8601, $score->timestamp);
+        $ltiTimestamp = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $score->timestamp);
         $gradeValues = [
             'id' => array('integer', $DIC->database()->nextId('lti_consumer_grades')),
             'obj_id' => array('integer', $objId),


### PR DESCRIPTION
This  changes the parsed data format for LTI score timestamps to PHP's RFC3339_EXTENDED format, which allows milliseconds and timezone offsets with colons. 

The LTI spec demands timestamps to have "ISO 8601 with a sub-second precision" format (See section 3.4.9 of the LTI Assignment & Grade Service spec (v2.0)). However, PHP's ISO8601 is not aligned with that.

### Context
- [LTI AGS spec](https://www.imsglobal.org/spec/lti-ags/v2p0/#timestamp)
- [PHP DateTimeInterface](https://www.php.net/manual/en/class.datetimeinterface.php#datetimeinterface.constants.iso8601)