### PR TITLE
Init/ErrorHandler: Add SOAP error handler for SOAP context

### DIFF
--- a/Services/Exceptions/classes/class.ilSoapExceptionHandler.php
+++ b/Services/Exceptions/classes/class.ilSoapExceptionHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilSoapExceptionHandler extends \Whoops\Handler\Handler
+{
+    private function buildFaultString(): string
+    {
+        $fault_string = \Whoops\Exception\Formatter::formatExceptionPlain($this->getInspector());
+        $exception = $this->getInspector()->getException();
+        $previous = $exception->getPrevious();
+        while ($previous) {
+            $fault_string .= "\n\nCaused by\n" . $this->getSimpleExceptionOutput($previous);
+            $previous = $previous->getPrevious();
+        }
+
+        return htmlspecialchars($fault_string);
+    }
+
+    private function getSimpleExceptionOutput(Throwable $exception): string
+    {
+        return sprintf(
+            '%s: %s in file %s on line %d',
+            get_class($exception),
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine()
+        );
+    }
+
+    public function handle()
+    {
+        echo $this->toXml();
+
+        return \Whoops\Handler\Handler::QUIT;
+    }
+
+    private function toXml(): string
+    {
+        $fault_code = htmlspecialchars((string) $this->getInspector()->getException()->getCode());
+        $fault_string = $this->buildFaultString();
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>';
+        $xml .= '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">';
+        $xml .= '  <SOAP-ENV:Body>';
+        $xml .= '    <SOAP-ENV:Fault>';
+        $xml .= '      <faultcode>' . $fault_code . '</faultcode>';
+        $xml .= '      <faultstring>' . $fault_string . '</faultstring>';
+        $xml .= '    </SOAP-ENV:Fault>';
+        $xml .= '  </SOAP-ENV:Body>';
+        $xml .= '</SOAP-ENV:Envelope>';
+
+        return $xml;
+    }
+}

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -311,6 +311,10 @@ class ilErrorHandling
     {
         global $ilLog;
 
+        if (ilContext::getType() === ilContext::CONTEXT_SOAP) {
+            return new ilSoapExceptionHandler();
+        }
+
         switch (ERROR_HANDLER) {
             case "TESTING":
                 return new ilTestingHandler();


### PR DESCRIPTION
This PR adds an error handler for the
SOAP context when running in `DEVMODE`.

Without a specific error handler,
debugging is extremely painful, especially
since strict types are introduced everywhere.
This can lead to opaque error messages like
"Internal Server Error" or error strings
without stacktrace.

If approved, this MUST be picked to `trunk` as well.