### PR TITLE
Init/ErrorHandler: Support previous exceptions in plain text handlers

### DIFF
--- a/Services/Exceptions/classes/class.ilPlainTextHandler.php
+++ b/Services/Exceptions/classes/class.ilPlainTextHandler.php
@@ -36,15 +36,37 @@ class ilPlainTextHandler extends \Whoops\Handler\PlainTextHandler
 
     public function generateResponse(): string
     {
-        return $this->getExceptionOutput() . $this->tablesContent() . "\n";
+        return $this->getPlainTextExceptionOutput() . $this->tablesContent() . "\n";
+    }
+
+    protected function getSimpleExceptionOutput(Throwable $exception): string
+    {
+        return sprintf(
+            '%s: %s in file %s on line %d',
+            get_class($exception),
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine()
+        );
     }
 
     /**
      * Get a short info about the exception.
      */
-    protected function getExceptionOutput(): string
+    protected function getPlainTextExceptionOutput(bool $with_previous = true): string
     {
-        return Formatter::formatExceptionPlain($this->getInspector());
+        $message = Formatter::formatExceptionPlain($this->getInspector());
+
+        if ($with_previous) {
+            $exception = $this->getInspector()->getException();
+            $previous = $exception->getPrevious();
+            while ($previous) {
+                $message .= "\n\nCaused by\n" . $this->getSimpleExceptionOutput($previous);
+                $previous = $previous->getPrevious();
+            }
+        }
+
+        return $message;
     }
 
     /**

--- a/Services/Exceptions/classes/class.ilTestingHandler.php
+++ b/Services/Exceptions/classes/class.ilTestingHandler.php
@@ -29,6 +29,6 @@ class ilTestingHandler extends ilPlainTextHandler
     public function generateResponse(): string
     {
         return "DEAR TESTER! AN ERROR OCCURRED... PLEASE INCLUDE THE FOLLOWING OUTPUT AS ADDITIONAL INFORMATION IN YOUR BUG REPORT.\n\n"
-            . $this->getExceptionOutput();
+            . $this->getPlainTextExceptionOutput();
     }
 }

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -137,9 +137,9 @@ class ilErrorHandling
 
         $session_failure = ilSession::get('failure');
         if ($session_failure && strpos($message, 'Cannot find this block') !== 0) {
-            $m = "Fatal Error: Called raise error two times.<br>" .
-                "First error: " . $session_failure . '<br>' .
-                "Last Error:" . $message;
+            $m = 'Fatal Error: Called raise error two times.<br>' .
+                'First error: ' . $session_failure . '<br>' .
+                'Last Error:' . $message;
             $log->write($m);
             ilSession::clear('failure');
             die($m);
@@ -147,22 +147,22 @@ class ilErrorHandling
 
         if (strpos($message, 'Cannot find this block') === 0) {
             if (defined('DEVMODE') && DEVMODE) {
-                echo "<b>DEVMODE</b><br><br>";
-                echo "<b>Template Block not found.</b><br>";
-                echo "You used a template block in your code that is not available.<br>";
-                echo "Native Messge: <b>" . $message . "</b><br>";
-                echo "Backtrace:<br>";
+                echo '<b>DEVMODE</b><br><br>';
+                echo '<b>Template Block not found.</b><br>';
+                echo 'You used a template block in your code that is not available.<br>';
+                echo 'Native Messge: <b>' . $message . '</b><br>';
+                echo 'Backtrace:<br>';
                 foreach ($backtrace as $b) {
-                    if ($b["function"] === "setCurrentBlock" &&
-                        basename($b["file"]) !== "class.ilTemplate.php") {
-                        echo "<b>";
+                    if ($b['function'] === 'setCurrentBlock' &&
+                        basename($b['file']) !== 'class.ilTemplate.php') {
+                        echo '<b>';
                     }
-                    echo "File: " . $b["file"] . ", ";
-                    echo "Line: " . $b["line"] . ", ";
-                    echo $b["function"] . "()<br>";
-                    if ($b["function"] === "setCurrentBlock" &&
-                        basename($b["file"]) !== "class.ilTemplate.php") {
-                        echo "</b>";
+                    echo 'File: ' . $b['file'] . ', ';
+                    echo 'Line: ' . $b['line'] . ', ';
+                    echo $b['function'] . '()<br>';
+                    if ($b['function'] === 'setCurrentBlock' &&
+                        basename($b['file']) !== 'class.ilTemplate.php') {
+                        echo '</b>';
                     }
                 }
                 exit;
@@ -180,42 +180,42 @@ class ilErrorHandling
 
         if ($code === $this->WARNING) {
             if (!$this->DEBUG_ENV) {
-                $message = "Under Construction";
+                $message = 'Under Construction';
             }
 
             ilSession::set('failure', $message);
 
-            if (!defined("ILIAS_MODULE")) {
-                ilUtil::redirect("error.php");
+            if (!defined('ILIAS_MODULE')) {
+                ilUtil::redirect('error.php');
             } else {
-                ilUtil::redirect("../error.php");
+                ilUtil::redirect('../error.php');
             }
         }
         $updir = '';
         if ($code === $this->MESSAGE) {
             ilSession::set('failure', $message);
             // save post vars to session in case of error
-            $_SESSION["error_post_vars"] = $_POST;
+            $_SESSION['error_post_vars'] = $_POST;
 
-            if (empty($_SESSION["referer"])) {
-                $dirname = dirname($_SERVER["PHP_SELF"]);
+            if (empty($_SESSION['referer'])) {
+                $dirname = dirname($_SERVER['PHP_SELF']);
                 $ilurl = parse_url(ilUtil::_getHttpPath());
 
                 $subdir = '';
-                if (is_array($ilurl) && array_key_exists('path', $ilurl) && strlen($ilurl['path'])) {
-                    $subdir = substr(strstr($dirname, (string) $ilurl["path"]), strlen((string) $ilurl["path"]));
-                    $updir = "";
+                if (is_array($ilurl) && array_key_exists('path', $ilurl) && $ilurl['path'] !== '') {
+                    $subdir = substr(strstr($dirname, (string) $ilurl['path']), strlen((string) $ilurl['path']));
+                    $updir = '';
                 }
                 if ($subdir) {
-                    $num_subdirs = substr_count($subdir, "/");
+                    $num_subdirs = substr_count($subdir, '/');
 
                     for ($i = 1; $i <= $num_subdirs; $i++) {
-                        $updir .= "../";
+                        $updir .= '../';
                     }
                 }
-                ilUtil::redirect($updir . "index.php");
+                ilUtil::redirect($updir . 'index.php');
             }
-            ilUtil::redirect($_SESSION["referer"]);
+            ilUtil::redirect($_SESSION['referer']);
         }
     }
 
@@ -232,7 +232,7 @@ class ilErrorHandling
     public function appendMessage(string $a_message): void
     {
         if ($this->getMessage()) {
-            $this->message .= "<br /> ";
+            $this->message .= '<br /> ';
         }
         $this->message .= $a_message;
     }
@@ -249,23 +249,18 @@ class ilErrorHandling
 
     protected function isDevmodeActive(): bool
     {
-        return defined("DEVMODE") && (int) DEVMODE === 1;
+        return defined('DEVMODE') && (int) DEVMODE === 1;
     }
 
     protected function defaultHandler(): HandlerInterface
     {
-        // php7-todo : alex, 1.3.2016: Exception -> Throwable, please check
         return new CallbackHandler(function ($exception, Inspector $inspector, Run $run) {
             global $DIC;
 
-            require_once("Services/Logging/classes/error/class.ilLoggingErrorSettings.php");
-            require_once("Services/Logging/classes/error/class.ilLoggingErrorFileStorage.php");
-            require_once("Services/Utilities/classes/class.ilUtil.php");
-
             $session_id = substr(session_id(), 0, 5);
-            $random = new \ilRandom();
+            $random = new ilRandom();
             $err_num = $random->int(1, 9999);
-            $file_name = $session_id . "_" . $err_num;
+            $file_name = $session_id . '_' . $err_num;
 
             $logger = ilLoggingErrorSettings::getInstance();
             if (!empty($logger->folder())) {
@@ -276,11 +271,11 @@ class ilErrorHandling
             //Use $lng if defined or fallback to english
             if ($DIC->isDependencyAvailable('language')) {
                 $DIC->language()->loadLanguageModule('logging');
-                $message = sprintf($DIC->language()->txt("log_error_message"), $file_name);
+                $message = sprintf($DIC->language()->txt('log_error_message'), $file_name);
 
                 if ($logger->mail()) {
-                    $message .= " " . sprintf(
-                        $DIC->language()->txt("log_error_message_send_mail"),
+                    $message .= ' ' . sprintf(
+                        $DIC->language()->txt('log_error_message_send_mail'),
                         $logger->mail(),
                         $file_name,
                         $logger->mail()
@@ -295,36 +290,33 @@ class ilErrorHandling
             }
             if ($DIC->isDependencyAvailable('ui') && $DIC->isDependencyAvailable('ctrl')) {
                 $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', $message, true);
-                $DIC->ctrl()->redirectToURL("error.php");
+                $DIC->ctrl()->redirectToURL('error.php');
             } else {
                 ilSession::set('failure', $message);
-                header("Location: error.php");
+                header('Location: error.php');
                 exit;
             }
         });
     }
 
-    /**
-     * Get the handler to be used in DEVMODE.
-     */
     protected function devmodeHandler(): HandlerInterface
     {
         global $ilLog;
 
         switch (ERROR_HANDLER) {
-            case "TESTING":
+            case 'TESTING':
                 return new ilTestingHandler();
 
-            case "PLAIN_TEXT":
+            case 'PLAIN_TEXT':
                 return new ilPlainTextHandler();
 
-            case "PRETTY_PAGE":
+            case 'PRETTY_PAGE':
                 // fallthrough
             default:
                 if ((!defined('ERROR_HANDLER') || ERROR_HANDLER !== 'PRETTY_PAGE') && $ilLog) {
                     $ilLog->write(
                         "Unknown or undefined error handler '" . ERROR_HANDLER . "'. " .
-                        "Falling back to PrettyPageHandler."
+                        'Falling back to PrettyPageHandler.'
                     );
                 }
 
@@ -382,7 +374,9 @@ class ilErrorHandling
 
     protected function loggingHandler(): HandlerInterface
     {
-        // php7-todo : alex, 1.3.2016: Exception -> Throwable, please check
+        /**
+         * @var 
+         */
         return new CallbackHandler(function ($exception, Inspector $inspector, Run $run) {
             /**
              * Don't move this out of this callable
@@ -391,8 +385,21 @@ class ilErrorHandling
             global $ilLog;
 
             if (is_object($ilLog)) {
-                $message = $exception->getMessage() . ' in ' . $exception->getFile() . ":" . $exception->getLine();
+                $message = $exception->getMessage() . ' in ' . $exception->getFile() . ':' . $exception->getLine();
                 $message .= $exception->getTraceAsString();
+
+                $previous = $exception->getPrevious();
+                while ($previous) {
+                    $message .= "\n\nCaused by\n" . sprintf(
+                            '%s: %s in file %s on line %d',
+                            get_class($previous),
+                            $previous->getMessage(),
+                            $previous->getFile(),
+                            $previous->getLine()
+                        );
+                    $previous = $previous->getPrevious();
+                }
+                
                 $ilLog->error($exception->getCode() . ' ' . $message);
             }
 
@@ -415,20 +422,17 @@ class ilErrorHandling
                 if ($level >= E_USER_NOTICE) {
                     if ($ilLog) {
                         $severity = Whoops\Util\Misc::translateErrorCode($level);
-                        $ilLog->write("\n\n" . $severity . " - " . $message . "\n" . $file . " - line " . $line . "\n");
+                        $ilLog->write("\n\n" . $severity . ' - ' . $message . "\n" . $file . ' - line ' . $line . "\n");
                     }
                     return true;
                 }
             }
 
-            // trigger whoops error handling
             if ($this->whoops instanceof RunInterface) {
                 return $this->whoops->handleError($level, $message, $file, $line);
             }
-            if ($this->whoops) {
-                return $this->whoops->handleError($level, $message, $file, $line);
-            }
         }
+
         return true;
     }
 }

--- a/Services/Logging/classes/error/class.ilLoggingErrorFileStorage.php
+++ b/Services/Logging/classes/error/class.ilLoggingErrorFileStorage.php
@@ -16,23 +16,19 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use Whoops\Exception\Formatter;
 use Whoops\Exception\Inspector;
 
-/**
- * Saves error informations into file
- *
- * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
- */
 class ilLoggingErrorFileStorage
 {
     protected const KEY_SPACE = 25;
-    protected const FILE_FORMAT = ".log";
+    protected const FILE_FORMAT = '.log';
 
     protected Inspector $inspector;
     protected string $file_path;
     protected string $file_name;
-
 
     public function __construct(Inspector $inspector, string $file_path, string $file_name)
     {
@@ -41,7 +37,12 @@ class ilLoggingErrorFileStorage
         $this->file_name = $file_name;
     }
 
-    protected function createDir(string $path): void
+    private function stripNullBytes(string $ret): string
+    {
+        return str_replace("\0", '', $ret);
+    }
+
+    protected function createDir(): void
     {
         if (!is_dir($this->file_path)) {
             ilFileUtils::makeDirParents($this->file_path);
@@ -51,17 +52,16 @@ class ilLoggingErrorFileStorage
     protected function content(): string
     {
         return $this->pageHeader()
-              . $this->exceptionContent()
-              . $this->tablesContent()
-        ;
+            . $this->exceptionContent()
+            . $this->tablesContent();
     }
 
     public function write(): void
     {
-        $this->createDir($this->file_path);
+        $this->createDir();
 
-        $file_name = $this->file_path . "/" . $this->file_name . self::FILE_FORMAT;
-        $stream = fopen($file_name, 'w+');
+        $file_name = $this->file_path . '/' . $this->file_name . self::FILE_FORMAT;
+        $stream = fopen($file_name, 'wb+');
         fwrite($stream, $this->content());
         fclose($stream);
         chmod($file_name, 0755);
@@ -69,23 +69,32 @@ class ilLoggingErrorFileStorage
 
     protected function pageHeader(): string
     {
-        return "";
+        return '';
     }
 
-    /**
-     * Get a short info about the exception.
-     */
     protected function exceptionContent(): string
     {
-        return Formatter::formatExceptionPlain($this->inspector);
+        $message = Formatter::formatExceptionPlain($this->inspector);
+
+        $exception = $this->inspector->getException();
+        $previous = $exception->getPrevious();
+        while ($previous) {
+            $message .= "\n\nCaused by\n" . sprintf(
+                    '%s: %s in file %s on line %d',
+                    get_class($previous),
+                    $previous->getMessage(),
+                    $previous->getFile(),
+                    $previous->getLine()
+                );
+            $previous = $previous->getPrevious();
+        }
+
+        return $message;
     }
 
-    /**
-     * Get the header for the page.
-     */
     protected function tablesContent(): string
     {
-        $ret = "";
+        $ret = '';
         foreach ($this->tables() as $title => $content) {
             $ret .= "\n\n-- $title --\n\n";
             if (count($content) > 0) {
@@ -95,8 +104,8 @@ class ilLoggingErrorFileStorage
                     // indent multiline values, first print_r, split in lines,
                     // indent all but first line, then implode again.
                     $first = true;
-                    $indentation = str_pad("", self::KEY_SPACE);
-                    $value = implode("\n", array_map(function ($line) use (&$first, $indentation) {
+                    $indentation = str_pad('', self::KEY_SPACE);
+                    $value = implode("\n", array_map(static function ($line) use (&$first, $indentation): string {
                         if ($first) {
                             $first = false;
                             return $line;
@@ -110,12 +119,10 @@ class ilLoggingErrorFileStorage
                 $ret .= "empty\n";
             }
         }
-        return $ret;
+
+        return $this->stripNullBytes($ret);
     }
 
-    /**
-     * Get the tables that should be rendered.
-     */
     protected function tables(): array
     {
         $post = $_POST;
@@ -124,48 +131,43 @@ class ilLoggingErrorFileStorage
         $post = $this->hidePassword($post);
         $server = $this->shortenPHPSessionId($server);
 
-        return array( "GET Data" => $_GET
-            , "POST Data" => $post
-            , "Files" => $_FILES
-            , "Cookies" => $_COOKIE
-            , "Session" => $_SESSION ?? array()
-            , "Server/Request Data" => $server
-            , "Environment Variables" => $_ENV
-            );
+        return [
+            'GET Data' => $_GET,
+            'POST Data' => $post,
+            'Files' => $_FILES,
+            'Cookies' => $_COOKIE,
+            'Session' => $_SESSION ?? [],
+            'Server/Request Data' => $server,
+            'Environment Variables' => $_ENV
+        ];
     }
 
-    /**
-     * Replace passwort from post array with security message
-     */
     private function hidePassword(array $post): array
     {
-        if (isset($post["password"])) {
-            $post["password"] = "REMOVED FOR SECURITY";
+        if (isset($post['password'])) {
+            $post['password'] = 'REMOVED FOR SECURITY';
         }
 
         return $post;
     }
 
-    /**
-     * Shorts the php session id
-     */
     private function shortenPHPSessionId(array $server): array
     {
-        if (!isset($server["HTTP_COOKIE"])) {
+        if (!isset($server['HTTP_COOKIE'])) {
             return $server;
         }
-        $cookie_content = $server["HTTP_COOKIE"];
-        $cookie_content = explode(";", $cookie_content);
+        $cookie_content = $server['HTTP_COOKIE'];
+        $cookie_content = explode(';', $cookie_content);
 
         foreach ($cookie_content as $key => $content) {
-            $content_array = explode("=", $content);
-            if (trim($content_array[0]) == session_name()) {
-                $content_array[1] = substr($content_array[1], 0, 5) . " (SHORTENED FOR SECURITY)";
-                $cookie_content[$key] = implode("=", $content_array);
+            $content_array = explode('=', $content);
+            if (trim($content_array[0]) === session_name()) {
+                $content_array[1] = substr($content_array[1], 0, 5) . ' (SHORTENED FOR SECURITY)';
+                $cookie_content[$key] = implode('=', $content_array);
             }
         }
 
-        $server["HTTP_COOKIE"] = implode(";", $cookie_content);
+        $server['HTTP_COOKIE'] = implode(';', $cookie_content);
 
         return $server;
     }


### PR DESCRIPTION
This PR enhances our plain/text(-like) error handlers by providing details regarding "Previous Exceptions" (if given). Currently, this information is missing in the error handler response.

Furthermore, it strips NULL bytes from the file logging error handler (caused by the "Drop-In-Replacement" of super global variables).

Minor code style changes were automatically applied with the help of `PhpStorm`.

If approved, this has to be picked to `trunk` as well.