### PR TITLE
UI: change text color of placeholder when field input is required. (#…

### DIFF
--- a/templates/default/070-components/legacy/Services/_component_form.scss
+++ b/templates/default/070-components/legacy/Services/_component_form.scss
@@ -136,6 +136,10 @@ input[type="checkbox"] {
 
 	// Placeholder
 	@include placeholder;
+	
+	&[required] {
+		@include placeholder($il-input-color);
+	}
 
 	// Unstyle the caret on `<select>`s in IE10+.
 	&::-ms-expand {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1,4 +1,7 @@
 @charset "UTF-8";
+/*
+* Dependencies
+*/
 /*!
  * Datetimepicker for Bootstrap 3
  * version : 4.17.37
@@ -688,8 +691,9 @@ table.mceToolbar tbody, table.mceToolbar tr, table.mceToolbar td {
 }
 
 /*
-* Dependencies
-*/ /* print less */
+* Normalize
+*/
+/* print less */
 @media print {
   * {
     /* see bug 0022342 */
@@ -897,9 +901,6 @@ th {
   padding: 0;
 }
 
-/*
-* Normalize
-*/
 .row {
   --bs-gutter-x: 30px;
   --bs-gutter-y: 0;
@@ -1979,6 +1980,9 @@ th {
     display: none !important;
   }
 }
+/*
+* Elements
+*/
 * {
   box-sizing: border-box;
 }
@@ -2340,8 +2344,9 @@ code {
   }
 }
 /*
-* Elements
+* Components
 */
+/* UI Framework */
 .c-tooltip__container {
   position: relative;
   display: inline-block;
@@ -6115,8 +6120,6 @@ footer {
   .il-mainbar-triggers .il-link.link-bulky:hover .bulky-label {
     color: white;
   }
-}
-@media (hover: none) {
   .il-mainbar-triggers .btn-bulky.engaged,
   .il-mainbar-triggers .il-link.link-bulky.engaged {
     background-color: white;
@@ -9680,6 +9683,7 @@ td.c-table-data__cell--highlighted {
   width: 5rem;
 }
 
+/* Component parts from old delos.scss */
 div#agreement {
   width: 100%;
   height: 375px;
@@ -10372,6 +10376,7 @@ div.il_info {
   border-color: #dddddd;
 }
 
+/* Adapted from Bootstrap 3 */
 .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
@@ -11004,6 +11009,7 @@ tbody.collapse.in {
   clip: auto;
 }
 
+/* Legacy Modules & Services */
 /* Modules/Bibliographic */
 span.bibl_text_inline_Emph {
   font-style: italic;
@@ -15381,6 +15387,16 @@ input[type=checkbox]:focus-visible::after {
 .form-control::-webkit-input-placeholder {
   color: #6f6f6f;
 }
+.form-control[required]::-moz-placeholder {
+  color: #161616;
+  opacity: 1;
+}
+.form-control[required]:-ms-input-placeholder {
+  color: #161616;
+}
+.form-control[required]::-webkit-input-placeholder {
+  color: #161616;
+}
 .form-control::-ms-expand {
   border: 0;
   background-color: transparent;
@@ -18804,13 +18820,6 @@ img.ilUserXXSmall {
   outline: 3px solid #0078D7;
 }
 
-/*
-* Components
-*/
-/* UI Framework */
-/* Component parts from old delos.scss */
-/* Adapted from Bootstrap 3 */
-/* Legacy Modules & Services */
 /*
 	These classes are used to limit the number of rows when displaying larger chunks of text.
 	The mixin receives $height-in-rows as an integer. The classes il-multi-line-cap-2,3,5,10


### PR DESCRIPTION
…36768)

https://mantis.ilias.de/view.php?id=36768

This change will provide a better contrast for all placeholder texts where a required field is implemented.

![placeholder-required-field-color-with-alert-box](https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/cb78879f-4ffb-4a27-9882-dedad54b6841)

![placeholder-required-field-color](https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/2e36395c-8696-4b3c-bcee-095679f67fb3)

Placeholder texts in input fields without required inputs aren't changed as the background is still light instead of reddish:
![placeholder-without-required-field-color](https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/7b8ef8f0-c4c6-4578-b317-656f5d89f0f0)