### PR TITLE
[FIX] #39872 ilCtrl: support namespaced command classes

### DIFF
--- a/Services/UICore/classes/class.ilCtrl.php
+++ b/Services/UICore/classes/class.ilCtrl.php
@@ -296,7 +296,11 @@ class ilCtrl implements ilCtrlInterface
      */
     public function getCmdClass(): ?string
     {
-        return $this->context->getCmdClass() ?? '';
+        if (null !== ($cmd_class = $this->context->getCmdClass())) {
+            return strtolower($this->structure->getObjNameByName($cmd_class));
+        }
+
+        return '';
     }
 
     /**
@@ -329,7 +333,7 @@ class ilCtrl implements ilCtrlInterface
         );
 
         if (null !== $next_cid) {
-            return $this->structure->getClassNameByCid($next_cid) ?? '';
+            return strtolower($this->structure->getObjNameByCid($next_cid) ?? '');
         }
 
         return '';
@@ -942,7 +946,7 @@ class ilCtrl implements ilCtrlInterface
         $target_url = $this->appendParameterString(
             $target_url,
             self::PARAM_BASE_CLASS,
-            $base_class,
+            urlencode($base_class), // encode in case of namespaced classes
             $is_escaped
         );
 
@@ -963,7 +967,7 @@ class ilCtrl implements ilCtrlInterface
             $target_url = $this->appendParameterString(
                 $target_url,
                 self::PARAM_CMD_CLASS,
-                $cmd_class,
+                urlencode($cmd_class), // encode in case of namespaced classes
                 $is_escaped
             );
         }

--- a/Services/UICore/interfaces/interface.ilCtrlInterface.php
+++ b/Services/UICore/interfaces/interface.ilCtrlInterface.php
@@ -111,7 +111,8 @@ interface ilCtrlInterface
     public function setCmd(?string $a_cmd): void;
 
     /**
-     * Returns the command class which should be executed next.
+     * Returns the fully-qualified classname of the requested command class.
+     * Note this will be lowercase for backwards compatibility.
      *
      * @return string|null
      */
@@ -128,7 +129,8 @@ interface ilCtrlInterface
     public function setCmdClass($a_cmd_class): void;
 
     /**
-     * Returns the classname of the next class in the control flow.
+     * Returns the fully-qualified classname of the next class in the control flow.
+     * Note this will be lowercase for backwards compatibility.
      *
      * @param object|string|null $a_gui_class
      * @return string|null


### PR DESCRIPTION
Hi all,

This adds support for namespaced command classes to the `ilCtrl` link target generation and its methods `ilCtrl::getCmdClass()` and `ilCtrl::getNextClass()`. The mantis ticket for this can be found here: https://mantis.ilias.de/view.php?id=39872

Since changes to `ilCtrl` are somewhat unpredictable, I'll merge this once the next ILIAS 8 version has been published.

Kind regards,
@thibsy 