### PR TITLE
T&A: fix for mantis-Issue #35942

### DIFF
--- a/Modules/Test/classes/class.ilTestGradingMessageBuilder.php
+++ b/Modules/Test/classes/class.ilTestGradingMessageBuilder.php
@@ -116,7 +116,7 @@ class ilTestGradingMessageBuilder
         } elseif ($this->isPassed()) {
             $this->container->ui()->mainTemplate()->setOnScreenMessage('success', $this->getFullMessage());
         } else {
-            $this->container->ui()->mainTemplate()->setOnScreenMessage('failure', $this->getFullMessage());
+            $this->container->ui()->mainTemplate()->setOnScreenMessage('info', $this->getFullMessage());
         }
     }
 


### PR DESCRIPTION
After failing a test the user will see a info-messagebox instead of a failure-messagebox. 
If they are using a screenreader "information message" (Informationsmeldung) will be read instead of "failure message"(Fehlermeldung)