### PR TITLE
T&A: fixes mantis-Issue #35942

### DIFF
--- a/Modules/Test/classes/class.ilTestGradingMessageBuilder.php
+++ b/Modules/Test/classes/class.ilTestGradingMessageBuilder.php
@@ -103,7 +103,7 @@ class ilTestGradingMessageBuilder
         } elseif ($this->isPassed()) {
             $this->main_tpl->setOnScreenMessage('success', $this->getFullMessage());
         } else {
-            $this->main_tpl->setOnScreenMessage('failure', $this->getFullMessage());
+            $this->main_tpl->setOnScreenMessage('info', $this->getFullMessage());
         }
     }
 


### PR DESCRIPTION
After failing a test the user will see a info-messagebox instead of a failure-messagebox. 
If they are using a screenreader "information message" (Informationsmeldung) will be read instead of "failure message"(Fehlermeldung)

There is also a PR for ilias8: #7059 