### PR TITLE
Init/ErrorHandling/SOAP: Use `SOAP` error handler ALWAYS in SOAP context

### DIFF
--- a/Services/Exceptions/classes/class.ilSoapExceptionHandler.php
+++ b/Services/Exceptions/classes/class.ilSoapExceptionHandler.php
@@ -22,6 +22,10 @@ class ilSoapExceptionHandler extends \Whoops\Handler\Handler
 {
     private function buildFaultString(): string
     {
+        if (!defined('DEVMODE') || DEVMODE !== 1) {
+            return htmlspecialchars($this->getInspector()->getException()->getMessage());
+        }
+
         $fault_string = \Whoops\Exception\Formatter::formatExceptionPlain($this->getInspector());
         $exception = $this->getInspector()->getException();
         $previous = $exception->getPrevious();
@@ -44,7 +48,7 @@ class ilSoapExceptionHandler extends \Whoops\Handler\Handler
         );
     }
 
-    public function handle()
+    public function handle(): ?int
     {
         echo $this->toXml();
 

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -103,10 +103,12 @@ class ilErrorHandling
      */
     public function getHandler(): HandlerInterface
     {
-        // TODO: * Use Whoops in production mode? This would require an appropriate
-        //		   error-handler.
-        //		 * Check for context? The current implementation e.g. would output HTML for
-        //		   for SOAP.
+        if (ilContext::getType() === ilContext::CONTEXT_SOAP) {
+            return new ilSoapExceptionHandler();
+        }
+
+        // TODO: There might be more specific execution contexts (WebDAV, REST, etc.) that need specific error handling. 
+
         if ($this->isDevmodeActive()) {
             return $this->devmodeHandler();
         }
@@ -302,10 +304,6 @@ class ilErrorHandling
     protected function devmodeHandler(): HandlerInterface
     {
         global $ilLog;
-
-        if (ilContext::getType() === ilContext::CONTEXT_SOAP) {
-            return new ilSoapExceptionHandler();
-        }
 
         switch (ERROR_HANDLER) {
             case 'TESTING':


### PR DESCRIPTION
This PR suggest to always use the `SOAP` error handler if ILIAS is executed in a `SOAP` context. Currently, the `SOAP` error handler is only used in `DEVMODE`.

After PR #7046 has been merged I thought about the error handling again and did not find a reason why we only use this error handler in `DEVMODE`.

If approved, this MUST be picked to `trunk` as well.