### PR TITLE
Setup: add missing status objects in setups of components. (#40139)

### DIFF
--- a/Modules/Bibliographic/classes/Setup/class.ilBibliographicSetupAgent.php
+++ b/Modules/Bibliographic/classes/Setup/class.ilBibliographicSetupAgent.php
@@ -84,7 +84,7 @@ final class ilBibliographicSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilBibliograficDB80());
     }
 
     /**

--- a/Modules/Chatroom/classes/Setup/class.ilChatroomSetupAgent.php
+++ b/Modules/Chatroom/classes/Setup/class.ilChatroomSetupAgent.php
@@ -240,7 +240,12 @@ class ilChatroomSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new ilChatroomMetricsCollectedObjective($storage);
+        return new Setup\ObjectiveCollection(
+            'Component Chatroom',
+            true,
+            new ilChatroomMetricsCollectedObjective($storage),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new UpdateSteps())
+        );
     }
 
     public function getMigrations(): array

--- a/Modules/ContentPage/classes/Setup/class.ilContentPageSetupAgent.php
+++ b/Modules/ContentPage/classes/Setup/class.ilContentPageSetupAgent.php
@@ -56,7 +56,7 @@ class ilContentPageSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilContentPageUpdateSteps());
     }
 
     public function getMigrations(): array

--- a/Modules/EmployeeTalk/classes/Setup/class.ilEmployeeTalkSetupAgent.php
+++ b/Modules/EmployeeTalk/classes/Setup/class.ilEmployeeTalkSetupAgent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\EmployeeTalk\Setup;
 
@@ -58,7 +58,7 @@ final class ilEmployeeTalkSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Metrics\Storage $storage): Objective
     {
-        return new Objective\NullObjective();
+        return new \ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilEmployeeTalkDBUpdateSteps());
     }
 
     public function getMigrations(): array

--- a/Modules/File/classes/Setup/class.ilFileObjectAgent.php
+++ b/Modules/File/classes/Setup/class.ilFileObjectAgent.php
@@ -93,7 +93,12 @@ class ilFileObjectAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new Setup\ObjectiveCollection(
+            'Component File',
+            true,
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilFileObjectDatabaseObjective()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilFileObjectRBACDatabaseSteps())
+        );
     }
 
     /**

--- a/Modules/Forum/classes/Setup/class.ilForumSetupAgent.php
+++ b/Modules/Forum/classes/Setup/class.ilForumSetupAgent.php
@@ -64,7 +64,12 @@ class ilForumSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new Setup\ObjectiveCollection(
+            'Component Forum',
+            true,
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilForumDatabaseUpdateSteps()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilForumDatabaseUpdateSteps9())
+        );
     }
 
     public function getMigrations(): array

--- a/Modules/IndividualAssessment/classes/Setup/class.ilIndividualAssessmentSetupAgent.php
+++ b/Modules/IndividualAssessment/classes/Setup/class.ilIndividualAssessmentSetupAgent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\Refinery;
@@ -72,7 +72,7 @@ class ilIndividualAssessmentSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilIndividualAssessmentRectifyMembersTableDBUpdateSteps());
     }
 
     /**

--- a/Modules/LTIConsumer/classes/Setup/class.ilLTIConsumerSetupAgent.php
+++ b/Modules/LTIConsumer/classes/Setup/class.ilLTIConsumerSetupAgent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\Refinery;
@@ -55,7 +55,7 @@ class ilLTIConsumerSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilLTIConsumerDatabaseUpdateSteps());
     }
 
     /**

--- a/Modules/LearningSequence/classes/Setup/class.ilLearningSequenceSetupAgent.php
+++ b/Modules/LearningSequence/classes/Setup/class.ilLearningSequenceSetupAgent.php
@@ -82,7 +82,12 @@ class ilLearningSequenceSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new Setup\ObjectiveCollection(
+            'Component LearningSequence',
+            true,
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilLearningSequenceRectifyPostConditionsTableDBUpdateSteps()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilLearningSequenceRegisterNotificationType())
+        );
     }
 
     /**

--- a/Modules/ScormAicc/classes/Setup/class.ilScormAiccSetupAgent.php
+++ b/Modules/ScormAicc/classes/Setup/class.ilScormAiccSetupAgent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\Refinery;
@@ -55,7 +55,7 @@ class ilScormAiccSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilScormAiccDatabaseUpdateSteps());
     }
 
     /**

--- a/Modules/WebResource/classes/Setup/class.ilWebResourceSetupAgent.php
+++ b/Modules/WebResource/classes/Setup/class.ilWebResourceSetupAgent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\Setup\Config;
@@ -38,6 +38,11 @@ class ilWebResourceSetupAgent extends Setup\Agent\NullAgent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilWebResourceDropValidSteps());
+        return new Setup\ObjectiveCollection(
+            'Component WebResource',
+            true,
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilWebResourceDropValidSteps()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilWebResourceDBUpdateSteps())
+        );
     }
 }

--- a/Services/AccessControl/classes/Setup/class.ilAccessRBACSetupAgent.php
+++ b/Services/AccessControl/classes/Setup/class.ilAccessRBACSetupAgent.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\Setup;
 use ILIAS\Setup\Config;
 
@@ -24,20 +26,19 @@ use ILIAS\Setup\Config;
  */
 class ilAccessRBACSetupAgent extends Setup\Agent\NullAgent
 {
-
     /**
      * @inheritdoc
      */
-    public function getUpdateObjective(Setup\Config $config = null) : Setup\Objective
+    public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
     {
-        return new ilDatabaseUpdateStepsExecutedObjective(new ilAccessRBACDeleteDbkSteps);
+        return new ilDatabaseUpdateStepsExecutedObjective(new ilAccessRBACDeleteDbkSteps());
     }
 
     /**
      * @inheritdoc
      */
-    public function getStatusObjective(Setup\Metrics\Storage $storage) : Setup\Objective
+    public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilAccessRBACDeleteDbkSteps);
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilAccessRBACDeleteDbkSteps());
     }
 }

--- a/Services/AdministrativeNotification/classes/Setup/class.ilADNAgent.php
+++ b/Services/AdministrativeNotification/classes/Setup/class.ilADNAgent.php
@@ -76,7 +76,7 @@ class ilADNAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilADNDatabaseObjective());
     }
 
 

--- a/Services/Authentication/classes/Setup/class.ilAuthenticationSetupAgent.php
+++ b/Services/Authentication/classes/Setup/class.ilAuthenticationSetupAgent.php
@@ -54,7 +54,7 @@ class ilAuthenticationSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilAuthenticationDatabaseUpdateSteps8());
     }
 
     public function getMigrations(): array

--- a/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
+++ b/Services/BackgroundTasks/classes/Setup/class.ilBackgroundTasksSetupAgent.php
@@ -46,7 +46,7 @@ class ilBackgroundTasksSetupAgent implements Setup\Agent
      */
     public function getArrayToConfigTransformation(): Refinery\Transformation
     {
-        return $this->refinery->custom()->transformation(fn ($data): \ilBackgroundTasksSetupConfig => new \ilBackgroundTasksSetupConfig(
+        return $this->refinery->custom()->transformation(fn($data): \ilBackgroundTasksSetupConfig => new \ilBackgroundTasksSetupConfig(
             $data["type"] ?? \ilBackgroundTasksSetupConfig::TYPE_SYNCHRONOUS,
             $data["max_number_of_concurrent_tasks"] ?? 1
         ));
@@ -86,7 +86,12 @@ class ilBackgroundTasksSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new ilBackgroundTasksMetricsCollectedObjective($storage);
+        return new Setup\ObjectiveCollection(
+            'Component BackgroundTasks',
+            true,
+            new ilBackgroundTasksMetricsCollectedObjective($storage),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilBackgroundTasksDB80())
+        );
     }
 
     /**

--- a/Services/Certificate/classes/Setup/class.ilCertificatSetupAgent.php
+++ b/Services/Certificate/classes/Setup/class.ilCertificatSetupAgent.php
@@ -54,7 +54,7 @@ class ilCertificatSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilCertificateDatabaseUpdateSteps());
     }
 
     public function getMigrations(): array

--- a/Services/Component/classes/Setup/class.ilComponentsSetupAgent.php
+++ b/Services/Component/classes/Setup/class.ilComponentsSetupAgent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -82,7 +83,7 @@ class ilComponentsSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilIntroduceComponentArtifactDBUpdateSteps());
     }
 
     /**

--- a/Services/EventHandling/classes/Setup/class.ilEventHandlingSetupAgent.php
+++ b/Services/EventHandling/classes/Setup/class.ilEventHandlingSetupAgent.php
@@ -79,7 +79,7 @@ class ilEventHandlingSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilIntroduceEventHandlingArtifactDBUpdateSteps());
     }
 
     /**

--- a/Services/LTI/classes/Setup/class.ilLTISetupAgent.php
+++ b/Services/LTI/classes/Setup/class.ilLTISetupAgent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\Refinery;
@@ -55,7 +55,7 @@ class ilLTISetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilLTIDatabaseUpdateSteps());
     }
 
     /**

--- a/Services/LegalDocuments/classes/Setup/Agent.php
+++ b/Services/LegalDocuments/classes/Setup/Agent.php
@@ -62,7 +62,7 @@ class Agent implements AgentInterface
 
     public function getStatusObjective(Storage $storage): Objective
     {
-        return new NullObjective();
+        return new \ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new UpdateSteps());
     }
 
     public function getMigrations(): array

--- a/Services/LegalDocuments/test/Setup/AgentTest.php
+++ b/Services/LegalDocuments/test/Setup/AgentTest.php
@@ -69,7 +69,7 @@ class AgentTest extends TestCase
 
     public function testGetStatusObjective(): void
     {
-        $this->assertInstanceOf(NullObjective::class, (new Agent($this->mock(Refinery::class)))->getStatusObjective($this->mock(Storage::class)));
+        $this->assertInstanceOf(\ilDatabaseUpdateStepsMetricsCollectedObjective::class, (new Agent($this->mock(Refinery::class)))->getStatusObjective($this->mock(Storage::class)));
     }
 
     public function testGetMigrations(): void

--- a/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
+++ b/Services/Logging/classes/Setup/class.ilLoggingSetupAgent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,7 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\Setup\Config;
@@ -100,7 +99,12 @@ class ilLoggingSetupAgent implements Setup\Agent
      */
     public function getStatusObjective(Storage $storage): Objective
     {
-        return new ilLoggingMetricsCollectedObjective($storage);
+        return new Setup\ObjectiveCollection(
+            'Component Logging',
+            true,
+            new ilLoggingMetricsCollectedObjective($storage),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilLoggingUpdateSteps8())
+        );
     }
 
     /**

--- a/Services/Mail/classes/Setup/class.ilMailSetupAgent.php
+++ b/Services/Mail/classes/Setup/class.ilMailSetupAgent.php
@@ -57,7 +57,7 @@ class ilMailSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilMailDatabaseUpdateSteps());
     }
 
     public function getMigrations(): array

--- a/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
+++ b/Services/MediaObjects/classes/Setup/class.ilMediaObjectSetupAgent.php
@@ -80,7 +80,12 @@ class ilMediaObjectSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new ilMediaObjectMetricsCollectedObjective($storage);
+        return new Setup\ObjectiveCollection(
+            'Component MediaObjects',
+            true,
+            new ilMediaObjectMetricsCollectedObjective($storage),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new \ILIAS\MediaObjects\Setup\ilMediaObjectsDBUpdateSteps())
+        );
     }
 
     public function getMigrations(): array

--- a/Services/MetaData/classes/Setup/class.ilMDSetupAgent.php
+++ b/Services/MetaData/classes/Setup/class.ilMDSetupAgent.php
@@ -35,7 +35,12 @@ class ilMDSetupAgent extends Setup\Agent\NullAgent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new Setup\ObjectiveCollection(
+            'Component MetaData',
+            true,
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilMDCopyrightUpdateSteps()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilMDLOMUpdateSteps())
+        );
     }
 
     public function getMigrations(): array

--- a/Services/Notifications/classes/Setup/ilNotificationUpdateAgent.php
+++ b/Services/Notifications/classes/Setup/ilNotificationUpdateAgent.php
@@ -63,7 +63,7 @@ class ilNotificationUpdateAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilNotificationUpdateSteps());
     }
 
     public function getMigrations(): array

--- a/Services/PDFGeneration/Setup/class.ilPDFGenerationSetupAgent.php
+++ b/Services/PDFGeneration/Setup/class.ilPDFGenerationSetupAgent.php
@@ -61,7 +61,7 @@ class ilPDFGenerationSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilPDFGenerationDB90());
     }
 
     public function getMigrations(): array

--- a/Services/ResourceStorage/classes/Setup/class.ilResourceStorageSetupAgent.php
+++ b/Services/ResourceStorage/classes/Setup/class.ilResourceStorageSetupAgent.php
@@ -77,7 +77,12 @@ class ilResourceStorageSetupAgent implements Agent
 
     public function getStatusObjective(Metrics\Storage $storage): Objective
     {
-        return new Objective\NullObjective();
+        return new ObjectiveCollection(
+            'Component ResourceStorage',
+            true,
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilResourceStorageDB80()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilResourceStorageDB90())
+        );
     }
 
     /**

--- a/Services/WOPI/classes/Setup/class.ilWOPISetupAgent.php
+++ b/Services/WOPI/classes/Setup/class.ilWOPISetupAgent.php
@@ -56,7 +56,7 @@ class ilWOPISetupAgent implements Agent
 
     public function getStatusObjective(Metrics\Storage $storage): Objective
     {
-        return new Objective\NullObjective();
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilWOPIDB90());
     }
 
     public function getMigrations(): array

--- a/Services/WebServices/ECS/classes/Setup/class.ilECSAgent.php
+++ b/Services/WebServices/ECS/classes/Setup/class.ilECSAgent.php
@@ -26,6 +26,11 @@ class ilECSAgent extends Setup\Agent\NullAgent
 
     public function getStatusObjective(\ILIAS\Setup\Metrics\Storage $storage): \ILIAS\Setup\Objective
     {
-        return new \ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilECSDBUpdateSteps());
+        return new Setup\ObjectiveCollection(
+            'Component WebServices',
+            true,
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilECSDBUpdateSteps()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilECSUpdateSteps8())
+        );
     }
 }


### PR DESCRIPTION
 https://mantis.ilias.de/view.php?id=40139

This fix resolves the issue of database update steps not getting listed after using the command `setup.php status` before `setup.php update`.