### PR TITLE
[FIX] 0040540: Unzip behaviour changed in ILIAS 9

### DIFF
--- a/Modules/CmiXapi/classes/class.ilCmiXapiImporter.php
+++ b/Modules/CmiXapi/classes/class.ilCmiXapiImporter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 /**
  * Class ilCmiXapiImporter
  *
@@ -30,6 +30,7 @@ declare(strict_types=1);
 class ilCmiXapiImporter extends ilXmlImporter
 {
     private array $_moduleProperties = [];
+    private \ILIAS\Filesystem\Util\Archive\LegacyArchives $archives;
 
     public array $manifest = [];
 
@@ -64,6 +65,7 @@ class ilCmiXapiImporter extends ilXmlImporter
         $this->dic = $DIC;
         $this->filesystemWeb = $DIC->filesystem()->web();
         $this->filesystemTemp = $DIC->filesystem()->temp();
+        $this->archives = $DIC->legacyArchives();
         $this->_dataset = new ilCmiXapiDataSet();
         $this->_dataset->_cmixSettingsProperties['Title'] = '';
         $this->_dataset->_cmixSettingsProperties['Description'] = '';
@@ -150,7 +152,7 @@ class ilCmiXapiImporter extends ilXmlImporter
                 $this->filesystemWeb->createDir($this->_relWebDir);
                 $this->filesystemWeb->put($this->_relWebDir . '/content.zip', $this->filesystemTemp->read($this->_relImportDir . '/content.zip'));
                 $webDataDir = ilFileUtils::getWebspaceDir();
-                ilFileUtils::unzip($webDataDir . "/" . $this->_relWebDir . "/content.zip");
+                $this->archives->unzip($webDataDir . "/" . $this->_relWebDir . "/content.zip");
                 $this->filesystemWeb->delete($this->_relWebDir . '/content.zip');
             }
         }

--- a/Modules/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
+++ b/Modules/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling;
+
 /**
 * SCORM Learning Modules
 *
@@ -32,6 +34,7 @@ declare(strict_types=1);
 class ilObjSAHSLearningModuleGUI extends ilObjectGUI
 {
     private ilPropertyFormGUI $form;
+    private $archives;
 
     /**
     * Constructor
@@ -39,6 +42,7 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
     public function __construct($data, int $id, bool $call_by_reference, bool $prepare_output = true)//missing typehint because mixed
     {
         global $DIC;
+        $this->archives = $DIC->legacyArchives();
         $lng = $DIC->language();
         $rbacsystem = $DIC->access();
         $lng->loadLanguageModule("content");
@@ -462,8 +466,13 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
                 $scormFilePath = $import_dirname . "/" . $scormFile;
                 $file_path = $newObj->getDataDirectory() . "/" . $scormFile;
                 ilFileUtils::rename($scormFilePath, $file_path);
-                $DIC->legacyArchives()->unzip($file_path, $newObj->getDataDirectory(), false, false, false);
-                //                ilFileUtils::unzip($file_path);
+                $this->archives->unzip(
+                    $file_path,
+                    $newObj->getDataDirectory(),
+                    false,
+                    false,
+                    false
+                );
                 unlink($file_path);
                 ilFileUtils::delDir($lmTempDir, false);
             } else {
@@ -474,16 +483,26 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
                     $_FILES["scormfile"]["name"],
                     $file_path
                 );
-                $DIC->legacyArchives()->unzip($file_path, $newObj->getDataDirectory(), false, false, false);
-                //                ilFileUtils::unzip($file_path);
+                $this->archives->unzip(
+                    $file_path,
+                    $newObj->getDataDirectory(),
+                    false,
+                    false,
+                    false
+                );
             }
         } else {
             // copy uploaded file to data directory
             $uploadedFile = $DIC->http()->wrapper()->post()->retrieve('uploaded_file', $DIC->refinery()->kindlyTo()->string());
             $file_path = $newObj->getDataDirectory() . "/" . $uploadedFile;
             ilUploadFiles::_copyUploadFile($uploadedFile, $file_path);
-            $DIC->legacyArchives()->unzip($file_path, $newObj->getDataDirectory(), false, false, false);
-            //            ilFileUtils::unzip($file_path);
+            $this->archives->unzip(
+                $file_path,
+                $newObj->getDataDirectory(),
+                false,
+                false,
+                ZipDirectoryHandling::KEEP_STRUCTURE
+            );
         }
         ilFileUtils::renameExecutables($newObj->getDataDirectory());
 

--- a/Modules/ScormAicc/classes/class.ilObjSCORMLearningModuleGUI.php
+++ b/Modules/ScormAicc/classes/class.ilObjSCORMLearningModuleGUI.php
@@ -555,7 +555,7 @@ class ilObjSCORMLearningModuleGUI extends ilObjSAHSLearningModuleGUI
             }
 
             //unzip and replace old extracted files
-            ilFileUtils::unzip($file_path, true);
+            $DIC->legacyArchives()->unzip($file_path, null, true);
             ilFileUtils::renameExecutables($this->object->getDataDirectory()); //(security)
 
             //increase module version

--- a/Modules/ScormAicc/classes/class.ilScormAiccImporter.php
+++ b/Modules/ScormAicc/classes/class.ilScormAiccImporter.php
@@ -179,7 +179,8 @@ class ilScormAiccImporter extends ilXmlImporter
                     $xml_directory,
                     $a_id,
                     $a_mapping,
-                    $new_object
+                    $new_object,
+                    $DIC
                 ): ?\ILIAS\Data\Result {
                     if ($a_id !== '' &&
                         $a_mapping !== null &&
@@ -203,7 +204,7 @@ class ilScormAiccImporter extends ilXmlImporter
                         $file_path = $targetPath;
 
                         ilFileUtils::rename($scormFilePath, $targetPath);
-                        ilFileUtils::unzip($file_path);
+                        $DIC->legacyArchives()->unzip($file_path);
                         unlink($file_path);
                         ilFileUtils::renameExecutables($new_object->getDataDirectory());
 

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -80,6 +80,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
     private ilTestPlayerFactory $test_player_factory;
     private ilTestSessionFactory $test_session_factory;
     private QuestionInfoService $questioninfo;
+    private \ILIAS\Filesystem\Util\Archive\LegacyArchives $archives;
     protected ilTestTabsManager $tabs_manager;
     private ilTestObjectiveOrientedContainer $objective_oriented_container;
     protected ilTestAccess $test_access;
@@ -122,6 +123,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
         $this->questioninfo = $DIC->testQuestionPool()->questionInfo();
         $this->type = 'tst';
         $this->testrequest = $DIC->test()->internal()->request();
+        $this->archives = $DIC->legacyArchives();
 
         $ref_id = 0;
         if ($this->testrequest->hasRefId() && is_numeric($this->testrequest->getRefId())) {
@@ -1255,7 +1257,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
             return false;
         }
 
-        ilFileUtils::unzip($full_path);
+        $this->archives->unzip($full_path);
 
         ilObjTest::_setImportDirectory($basedir);
         $xml_file = ilObjTest::_getImportDirectory() . '/' . $subdir . '/' . $subdir . ".xml";

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -55,6 +55,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     private ilObjectCommonSettings $common_settings;
     private HttpRequest $http_request;
     private QuestionInfoService $questioninfo;
+    private \ILIAS\Filesystem\Util\Archive\LegacyArchives $archives;
     protected Service $taxonomy;
     public ?ilObject $object;
     protected ILIAS\TestQuestionPool\InternalRequestService $qplrequest;
@@ -90,6 +91,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->taxonomy = $DIC->taxonomy();
         $this->http_request = $DIC->http()->request();
         $this->data_factory = new DataFactory();
+        $this->archives = $DIC->legacyArchives();
         parent::__construct('', $this->qplrequest->raw('ref_id'), true, false);
 
         $this->ctrl->saveParameter($this, [
@@ -715,7 +717,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             $qti_file = $full_path;
             ilObjTest::_setImportDirectory($basedir);
         } else {
-            ilFileUtils::unzip($full_path);
+            $this->archives->unzip($full_path);
 
             $subdir = basename($file['basename'], '.' . $file['extension']);
             ilObjQuestionPool::_setImportDirectory($basedir);

--- a/Services/Certificate/classes/Helper/ilCertificateUtilHelper.php
+++ b/Services/Certificate/classes/Helper/ilCertificateUtilHelper.php
@@ -90,7 +90,11 @@ class ilCertificateUtilHelper
 
     public function unzip(string $file, bool $overwrite): void
     {
-        ilFileUtils::unzip($file, $overwrite);
+        $this->archives->unzip(
+            $file,
+            $this->archives->unzipOptions()
+                           ->withOverwrite($overwrite)
+        )->extract();
     }
 
     public function delDir(string $path): void

--- a/Services/Export/classes/class.ilExportContainer.php
+++ b/Services/Export/classes/class.ilExportContainer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,10 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
+use ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling;
+
 /**
  * Export Container
  * @author    Stefan Meyer <meyer@leifos.com>
@@ -27,6 +29,7 @@ class ilExportContainer extends ilExport
     private string $cont_export_dir = '';
     private ?ilXmlWriter $cont_manifest_writer = null;
     private ilExportOptions $eo;
+    private \ILIAS\Filesystem\Util\Archive\Archives $archives;
 
     /**
      * Constructor
@@ -36,6 +39,8 @@ class ilExportContainer extends ilExport
     {
         $this->eo = $eo;
         parent::__construct();
+        global $DIC;
+        $this->archives = $DIC->archives();
     }
 
     /**
@@ -112,7 +117,13 @@ class ilExportContainer extends ilExport
             $this->log->debug('Zip path ' . $exp_full);
 
             // Unzip
-            ilFileUtils::unzip($exp_full, true, false);
+            $this->archives->unzip(
+                $exp_full,
+                $this->archives
+                    ->unzipOptions()
+                    ->withOverwrite(true)
+                    ->getDirectoryHandling(ZipDirectoryHandling::KEEP_STRUCTURE)
+            )->extract();
 
             // create set directory
             ilFileUtils::makeDirParents($this->cont_export_dir . DIRECTORY_SEPARATOR . 'set_' . $set_number);

--- a/Services/Export/classes/class.ilImport.php
+++ b/Services/Export/classes/class.ilImport.php
@@ -29,6 +29,7 @@ use ILIAS\Export\ImportStatus\ilFactory as ilImportStatusFactory;
 use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusHandlerCollectionInterface;
 use ILIAS\Export\ImportStatus\StatusType;
 use ILIAS\Export\ImportStatus\Exception\ilException as ilImportStatusException;
+use ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling;
 
 /**
  * Import class
@@ -156,11 +157,9 @@ class ilImport
         /** @var Unzip $unzip **/
         $unzip = $this->archives->unzip(
             Streams::ofResource(fopen($target_file_path_str, 'rb')),
-            (new UnzipOptions())
+            $this->archives->unzipOptions()
                 ->withZipOutputPath($tmp_dir_info->getRealPath())
-                ->withOverwrite(false)
-                ->withFlat(false)
-                ->withEnsureTopDirectoy(true)
+                ->withDirectoryHandling(ZipDirectoryHandling::ENSURE_SINGLE_TOP_DIR)
         );
         return $unzip->extract()
             ? $import_status_collection->withAddedStatus(

--- a/Services/FileSystem/classes/class.ilFileSystemGUI.php
+++ b/Services/FileSystem/classes/class.ilFileSystemGUI.php
@@ -22,6 +22,7 @@ use ILIAS\FileUpload\MimeType;
 use ILIAS\Filesystem\Util\LegacyPathHelper;
 
 use ILIAS\ResourceStorage\Preloader\SecureString;
+use ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling;
 
 /**
  * File System Explorer GUI class
@@ -856,11 +857,13 @@ class ilFileSystemGUI
             $cur_files = array_keys(ilFileUtils::getDir($cur_dir));
             $cur_files_r = iterator_to_array(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($cur_dir)));
 
-            if ($this->getAllowDirectories()) {
-                $this->unzip->unzip($a_file, null, true, false, false);
-            } else {
-                $this->unzip->unzip($a_file, null, true, true, false);
-            }
+            $this->unzip->unzip(
+                $a_file,
+                null,
+                true,
+                !$this->getAllowDirectories(),
+                false
+            );
 
             $new_files = array_keys(ilFileUtils::getDir($cur_dir));
             $new_files_r = iterator_to_array(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($cur_dir)));

--- a/Services/Repository/Service/Resources/ZipAdapter.php
+++ b/Services/Repository/Service/Resources/ZipAdapter.php
@@ -25,6 +25,7 @@ use ILIAS\Filesystem\Util\Archive\UnzipOptions;
 use ILIAS\Filesystem\Stream\Streams;
 use ILIAS\Export\ImportStatus\Exception\ilException;
 use ILIAS\Filesystem\Util\Archive\LegacyArchives;
+use ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling;
 
 class ZipAdapter
 {
@@ -43,11 +44,10 @@ class ZipAdapter
     {
         $unzip = $this->archives->unzip(
             Streams::ofResource(fopen($filepath, 'rb')),
-            (new UnzipOptions())
+            $this->archives->unzipOptions()
                 ->withZipOutputPath(dirname($filepath))
                 ->withOverwrite(false)
-                ->withFlat(false)
-                ->withEnsureTopDirectoy(false)
+                ->withDirectoryHandling(ZipDirectoryHandling::KEEP_STRUCTURE)
         );
         if (!$unzip->extract()) {
             throw new ilException("Unzip failed.");

--- a/Services/ResourceStorage/classes/Collections/class.ilResourceCollectionGUI.php
+++ b/Services/ResourceStorage/classes/Collections/class.ilResourceCollectionGUI.php
@@ -33,6 +33,7 @@ use ILIAS\Services\ResourceStorage\Collections\View\PreviewDefinition;
 use ILIAS\Filesystem\Util\Archive\UnzipOptions;
 use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Services\ResourceStorage\Collections\View\EditForm;
+use ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
@@ -275,7 +276,8 @@ class ilResourceCollectionGUI implements UploadHandler
 
         $collection = $this->view_request->getCollection();
 
-        $unzip_options = (new UnzipOptions())->withFlat(true);
+        $unzip_options = $this->archive->unzipOptions()
+                                       ->withDirectoryHandling(ZipDirectoryHandling::FLAT_STRUCTURE);
 
         foreach ($this->archive->unzip($zip_stream, $unzip_options)->getFileStreams() as $stream) {
             $rid = $this->irss->manage()->stream(

--- a/Services/User/classes/class.ilObjUserFolderGUI.php
+++ b/Services/User/classes/class.ilObjUserFolderGUI.php
@@ -1472,7 +1472,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
                 // Workaround: unzip function needs full path to file. Should be replaced once Filesystem has own unzip implementation
                 $full_path = ilFileUtils::getDataDir() . '/user_import/usr_'
                     . $this->user->getId() . '_' . session_id() . '/' . $file_name;
-                ilFileUtils::unzip($full_path);
+                $this->dic->legacyArchives()->unzip($full_path);
 
                 $xml_file = null;
                 $file_list = $this->filesystem->listContents($import_dir);

--- a/docs/development/file-handling.md
+++ b/docs/development/file-handling.md
@@ -306,6 +306,23 @@ The legacy varaints should no longer be used because they always presuppose that
 
 ```
 
+## Directory Handling
+The unzip implementation allows you to define how unzipping should proceed with directories in the ZIP. By default, the structure as it is in the ZIP is retained. there are also the following options:
+
+```\ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling::KEEP_STRUCTURE``` (default)
+
+As mentioned, the zip directory structure is retained when unpacking.
+
+```\ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling::ENSURE_SINGLE_TOP_DIR```
+
+When unzipping, a directory is always created first, which has the name of 
+the zip to be unzipped. the rest of the structure is created within this 
+directory. If the ZIP only contains exactly one directory on the first level, which already has the same name as the ZIP, no additional directory is created.
+
+```\ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling::FLAT_STRUCTURE```
+
+Directories within the zip are ignored and all files in the zip are recursively created as a flat structure directly in the target directory.
+
 
 # Contribute
 If there is anything wrong or missing here, or if there are any uncertainties, please open a ticket in Mantis (https://mantis.ilias.de). Errors or missing content in the documentation are treated as bugs.

--- a/src/Filesystem/Util/Archive/Archives.php
+++ b/src/Filesystem/Util/Archive/Archives.php
@@ -25,7 +25,7 @@ use ILIAS\Filesystem\Stream\FileStream;
 use ILIAS\ResourceStorage\StorageHandler\StorageHandlerFactory;
 
 /**
- * @author Fabian Schmid <fabian@sr.solutions>
+ * @author      Fabian Schmid <fabian@sr.solutions>
  *
  * @description This class is used to create a zip archive from a list of file-streams.
  * In most cases this will be used inside other Services such as the Filesystem Service or the IRSS.
@@ -33,15 +33,15 @@ use ILIAS\ResourceStorage\StorageHandler\StorageHandlerFactory;
 final class Archives
 {
     use PathHelper;
+
     private ZipOptions $zip_options;
     private UnzipOptions $unzip_options;
 
     public function __construct()
     {
-        $this->zip_options = new ZipOptions();
-        $this->unzip_options = new UnzipOptions();
+        $this->zip_options = $this->zipOptions();
+        $this->unzip_options = $this->unzipOptions();
     }
-
 
     public function zip(array $file_streams, ?ZipOptions $zip_options = null): Zip
     {
@@ -59,6 +59,15 @@ final class Archives
         );
     }
 
+    public function unzipOptions(): UnzipOptions
+    {
+        return new UnzipOptions();
+    }
+
+    public function zipOptions(): ZipOptions
+    {
+        return new ZipOptions();
+    }
 
     protected function mergeZipOptions(?ZipOptions $zip_options): ZipOptions
     {
@@ -68,7 +77,7 @@ final class Archives
         return $this->zip_options
             ->withZipOutputName($zip_options->getZipOutputName())
             ->withZipOutputPath($zip_options->getZipOutputPath())
-            ->withEnsureTopDirectoy($zip_options->ensureTopDirectory());
+            ->withDirectoryHandling($zip_options->getDirectoryHandling());
     }
 
     protected function mergeUnzipOptions(?UnzipOptions $unzip_options): UnzipOptions
@@ -82,7 +91,6 @@ final class Archives
 
         return $this->unzip_options
             ->withOverwrite($unzip_options->isOverwrite())
-            ->withFlat($unzip_options->isFlat())
-            ->withEnsureTopDirectoy($unzip_options->ensureTopDirectory());
+            ->withDirectoryHandling($unzip_options->getDirectoryHandling());
     }
 }

--- a/src/Filesystem/Util/Archive/Options.php
+++ b/src/Filesystem/Util/Archive/Options.php
@@ -31,7 +31,7 @@ abstract class Options
         '__MACOSX',
     ];
 
-    protected bool $ensure_top_directory = false;
+    protected ZipDirectoryHandling $top_directory_handling = ZipDirectoryHandling::KEEP_STRUCTURE;
 
     /**
      * @description like __MACOSX, will filter out all paths which contain one of those snippets
@@ -41,15 +41,15 @@ abstract class Options
         return $this->ignore;
     }
 
-    public function withEnsureTopDirectoy(bool $ensure): self
+    public function withDirectoryHandling(ZipDirectoryHandling $top_dir_handling): self
     {
         $clone = clone $this;
-        $clone->ensure_top_directory = $ensure;
+        $clone->top_directory_handling = $top_dir_handling;
         return $clone;
     }
 
-    public function ensureTopDirectory(): bool
+    public function getDirectoryHandling(): ZipDirectoryHandling
     {
-        return $this->ensure_top_directory;
+        return $this->top_directory_handling;
     }
 }

--- a/src/Filesystem/Util/Archive/PathHelper.php
+++ b/src/Filesystem/Util/Archive/PathHelper.php
@@ -33,7 +33,7 @@ trait PathHelper
     protected function isPathIgnored(string $path, Options $options): bool
     {
         $regex = '(' . implode('|', $options->getIgnoredPathSnippets()) . ')';
-        return preg_match($regex, $path) === 1;
+        return preg_match($regex, $path) > 0;
     }
 
     protected function ensureDirectorySeperator(string $path): string

--- a/src/Filesystem/Util/Archive/UnzipOptions.php
+++ b/src/Filesystem/Util/Archive/UnzipOptions.php
@@ -41,21 +41,9 @@ final class UnzipOptions extends Options
         return $clone;
     }
 
-    public function isFlat(): bool
-    {
-        return $this->flat;
-    }
-
     public function isOverwrite(): bool
     {
         return $this->overwrite;
-    }
-
-    public function withFlat(bool $flat): self
-    {
-        $clone = clone $this;
-        $clone->flat = $flat;
-        return $clone;
     }
 
     public function withOverwrite(bool $overwrite): self
@@ -64,6 +52,5 @@ final class UnzipOptions extends Options
         $clone->overwrite = $overwrite;
         return $clone;
     }
-
 
 }

--- a/src/Filesystem/Util/Archive/Zip.php
+++ b/src/Filesystem/Util/Archive/Zip.php
@@ -192,12 +192,19 @@ class Zip
             new \RecursiveDirectoryIterator($directory_to_zip),
             \RecursiveIteratorIterator::SELF_FIRST
         );
-        $pattern = null;
-        $prefix = '';
-        if ($this->options->ensureTopDirectory()) {
-            $prefix = basename($directory_to_zip) . '/';
-            $pattern = '/^' . preg_quote($prefix, '/') . '/';
+
+
+        switch ($this->options->getDirectoryHandling()) {
+            case ZipDirectoryHandling::KEEP_STRUCTURE:
+                $pattern = null;
+                $prefix = '';
+                break;
+            case ZipDirectoryHandling::ENSURE_SINGLE_TOP_DIR:
+                $prefix = basename($directory_to_zip) . '/';
+                $pattern = '/^' . preg_quote($prefix, '/') . '/';
+                break;
         }
+
 
         foreach ($files as $file) {
             $pathname = $file->getPathname();

--- a/src/Filesystem/Util/Archive/ZipDirectoryHandling.php
+++ b/src/Filesystem/Util/Archive/ZipDirectoryHandling.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Filesystem\Util\Archive;
+
+use ILIAS\Filesystem\Stream\FileStream;
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\Filesystem\Util;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+enum ZipDirectoryHandling: int
+{
+    /**
+     * @description Will keep the top directory of the ZIP file if there is one (simple unzip).
+     * This is the most common case and per default.
+     */
+    case KEEP_STRUCTURE = 1;
+
+    /**
+     * @description When unzipping, a directory is always created first, which has the name of
+     * the zip to be unzipped. the rest of the structure is created within this
+     * directory. If the ZIP only contains exactly one directory on the first level, which already has
+     * the same name as the ZIP, no additional directory is created.
+     */
+    case ENSURE_SINGLE_TOP_DIR = 2;
+    /**
+     * @description Will strip the top directory if there is only one inside the ZIP.
+     */
+    // case STRIP_IF_ONLY_ONE = 4;
+    /**
+     * @description Will strip all directories and and will result in a flat structure with files only.
+     */
+    case FLAT_STRUCTURE = 8;
+    /**
+     * @description Will strip all directories and and will result in a flat structure with files only but inside
+     * a directory with the zips name.
+     */
+    // case FLAT_STRUCTURE_WITH_SINGLE_TOP_DIR = 16;
+}

--- a/src/ResourceStorage/Consumer/ContainerZIPAccessConsumer.php
+++ b/src/ResourceStorage/Consumer/ContainerZIPAccessConsumer.php
@@ -23,6 +23,7 @@ use ILIAS\ResourceStorage\Consumer\StreamAccess\StreamAccess;
 use ILIAS\ResourceStorage\Resource\StorableContainerResource;
 use ILIAS\Filesystem\Util\Archive\Unzip;
 use ILIAS\Filesystem\Util\Archive\UnzipOptions;
+use ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions.ch>
@@ -57,6 +58,13 @@ class ContainerZIPAccessConsumer implements ContainerConsumer
         $zip = new \ZipArchive();
         $zip->open($zip_stream->getMetadata()['uri'], \ZipArchive::RDONLY);
 
-        return $this->archives->unzip($zip_stream, (new UnzipOptions())->withFlat(true));
+        $unzip_options = $this->archives
+            ->unzipOptions()
+            ->withDirectoryHandling(ZipDirectoryHandling::FLAT_STRUCTURE);
+
+        return $this->archives->unzip(
+            $zip_stream,
+            $unzip_options
+        );
     }
 }

--- a/tests/Filesystem/Util/LegacyZipTest.php
+++ b/tests/Filesystem/Util/LegacyZipTest.php
@@ -25,6 +25,7 @@ use ILIAS\Filesystem\Util\Archive\UnzipOptions;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Filesystem\Util\Archive\Zip;
 use ILIAS\Filesystem\Util\Archive\ZipOptions;
+use ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling;
 
 /**
  * @author                      Fabian Schmid <fabian@sr.solutions>

--- a/tests/Filesystem/Util/UnzipTest.php
+++ b/tests/Filesystem/Util/UnzipTest.php
@@ -25,6 +25,7 @@ use ILIAS\Filesystem\Util\Archive\UnzipOptions;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Filesystem\Util\Archive\Archives;
 use ILIAS\Filesystem\Stream\Stream;
+use ILIAS\Filesystem\Util\Archive\ZipDirectoryHandling;
 
 /**
  * @author                      Fabian Schmid <fabian@sr.solutions>


### PR DESCRIPTION
Hello @alex40724 , hello everyone else (see below)

thanks for the feedback! i have taken this as an opportunity to replace all existing calls of `ilFileUtils::unzip` with `\ILIAS\Filesystem\Util\Archive\Archives` or `\ILIAS\Filesystem\Util\Archive\LegacyArchives`, because this was only a wrapper anyway. it also allows consumers to make finer settings in the future as to how unzip should behave if it needs adjustments. i have restored the default that NO top-directory is created but the structure is kept. the behavior with ZIP is also relevant, which i have also restored. i have tried to test as many of the locations as possible, so far i have not noticed any errors.

@alex40724  here a hint: in `ilFileUtils` (formerly in `ilUtil`) there was also a method `processZipFile`. this was used exclusively in `ilExSubmission`. i have therefore moved the method there, but i think you can simply replace it later.

here are the affected components:
- Modules/CmiXapi: @Uwe-Kohnle 
- Modules/Exercise: @alex40724 
- Modules/ScormAicc: @Uwe-Kohnle 
- Modules/Survey: @alex40724 
- Services/Certificate: @mjansenDatabay 
- Services/Export: @smeyer-ilias 
- Services/FileServices: @chfsx 
- Services/FileSystem: @chfsx 
- Services/MediaObjects: @alex40724 
- Services/Style/Content: @alex40724 
- Services/Style/System: @Amstutz 
- Services/User: @kergomard 

I would merge this PR next thursday if there is no objection.

Info: Failing tests are due to License-Header, but the header seems correct in the file mentioned
----

Former text of PR:
@alex40724 this should fix the issues in exercise concerning unzip, https://mantis.ilias.de/view.php?id=40540
