### PR TITLE
UIComponent: File Upload Input: Replace mime type with file extension

### DIFF
--- a/components/ILIAS/UI/src/Component/Input/Field/FileUpload.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/FileUpload.php
@@ -43,12 +43,12 @@ interface FileUpload
     public function getMaxFiles(): int;
 
     /**
-     * @param string[] $mime_types
+     * @param string[] $extensions
      */
-    public function withAcceptedMimeTypes(array $mime_types): FileUpload;
+    public function withAcceptedExtensions(array $extensions): FileUpload;
 
     /**
      * @return string[]
      */
-    public function getAcceptedMimeTypes(): array;
+    public function getAcceptedExtensions(): array;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
@@ -29,6 +29,7 @@ use ILIAS\UI\Component as C;
 use ILIAS\Refinery\Constraint;
 use Closure;
 use ilLanguage;
+use ILIAS\UI\NotImplementedException;
 
 /**
  * Class File
@@ -122,6 +123,16 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
     public function getAcceptedMimeTypes(): array
     {
         return $this->accepted_mime_types;
+    }
+
+    public function withAcceptedExtensions(?array $extensions): FileUpload
+    {
+        throw new NotImplementedException();
+    }
+
+    public function getAcceptedExtensions(): array
+    {
+        throw new NotImplementedException();
     }
 
     // ===============================================


### PR DESCRIPTION
This PR addresses Mantis bug: https://mantis.ilias.de/view.php?id=39689

This PR proposes a change to the `ILIAS\UI\Component\Input\Field\FileUpload` interface.

Currently the file upload can be given a list of mime types to be accepted.
But as the mantis bug requests, a list of file extensions should be shown to the user when rendering the component, to indicate which file types are allowed.
With `ILIAS\FileUpload\MimeType` we can determine the list of file extensions for a given mime type but this list is not viable to show to a user.
For e.g. `text/plain` this gives us a list of ~26 file extensions (bat, c, c++, cc, com, conf, ... etc.) which will be shown to the user.

For this reason this PR proposes to be able to set the file extensions directly.

Additionally to prevent more complexity, this PR suggests to remove the methods to set and get the mime types and use the file extensions only.

@chfsx Please comment if this PR is not in line with the discussion we had for the file upload.

Furthermore if this PR is accepted follow up PR's will be created to implement these changes and adjust the file renderer accordingly.
