### PR TITLE
Mantis #40625 fix external delivery of new course member mail

### DIFF
--- a/Modules/Course/classes/class.ilCourseMembershipMailNotification.php
+++ b/Modules/Course/classes/class.ilCourseMembershipMailNotification.php
@@ -134,8 +134,8 @@ class ilCourseMembershipMailNotification extends ilMailNotification
                     $this->appendBody("\n\n");
                     $this->appendBody($this->createPermanentLink());
                     $this->getMail()->appendInstallationSignature(true);
-
-                    $this->sendMail(array($rcp));
+                    $rcp = ilObjUser::_lookupEmail($rcp);
+                    $this->sendMail(array($rcp), false);
                 }
                 break;
 

--- a/Modules/Course/classes/class.ilCourseMembershipMailNotification.php
+++ b/Modules/Course/classes/class.ilCourseMembershipMailNotification.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=0);
 /**
  * This file is part of ILIAS, a powerful learning management system


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40625

Fixes CourseMembershipNotifications for new members not being sent to user's external mail adress.