### PR TITLE
Fix of #39992 und #37178

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -3773,6 +3773,8 @@ common#:#copy_of#:#Kopie von
 common#:#copy_of_suffix#:#- Kopie
 common#:#copy_selected_items#:#Kopieren
 common#:#count#:#Anzahl
+common#:#counter_novelty#:#Neuigkeiten
+common#:#counter_status#:#Status
 common#:#country#:#Land
 common#:#country_free_text#:#Land (Freitext)
 common#:#country_selection#:#Land (Selektionsliste)

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -3773,6 +3773,8 @@ common#:#copy_of#:#Copy of
 common#:#copy_of_suffix#:#- Copy
 common#:#copy_selected_items#:#Copy
 common#:#count#:#Count
+common#:#counter_novelty#:#News
+common#:#counter_status#:#Status
 common#:#country#:#Country
 common#:#country_free_text#:#Country (Free Text Input)
 common#:#country_selection#:#Country (Drop Down Selection)

--- a/src/UI/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
@@ -37,6 +37,17 @@ class ButtonContextRenderer extends Renderer
 
     protected function renderLabel(Component\Component $component, Template $tpl): Template
     {
+        $aria_label = "";
+        foreach ($component->getCounters() as $counter) {
+            if($counter->getNumber() > 0) {
+                $aria_label .= $this->txt("counter_".$counter->getType()). " ".$counter->getNumber(). "; ";
+            }
+        }
+
+        if($aria_label != "") {
+            $tpl->setVariable("LABEL", $aria_label);
+        }
+
         return $tpl;
     }
 }

--- a/src/UI/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
+++ b/src/UI/Implementation/Component/Symbol/Glyph/ButtonContextRenderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Symbol\Glyph;
 

--- a/src/UI/templates/default/Symbol/tpl.glyph.context_btn.html
+++ b/src/UI/templates/default/Symbol/tpl.glyph.context_btn.html
@@ -1,3 +1,3 @@
-<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->" <!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --> role="img"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
+<span class="glyph<!-- BEGIN highlighted --> highlighted<!-- END highlighted --><!-- BEGIN disabled --> disabled<!-- END disabled -->" <!-- BEGIN with_aria_disabled --> aria-disabled="{ARIA_DISABLED}"<!-- END with_aria_disabled --><!-- BEGIN aria_label --> aria-label="{LABEL}"<!-- END aria_label --> role="img"<!-- BEGIN with_id --> id="{ID}"<!-- END with_id -->>
 {GLYPH}
 </span>

--- a/tests/UI/Client/Item/Notification/NotificationItemTest.html
+++ b/tests/UI/Client/Item/Notification/NotificationItemTest.html
@@ -1,7 +1,7 @@
 <ul class="il-maincontrols-metabar" role="menubar" style="visibility: hidden" aria-label="metabar_aria_label" id="id_11">
     <li role="none">
         <button class="btn btn-bulky" id="id_1" role="menuitem" aria-haspopup="true">
-            <span class="glyph" role="img">
+            <span class="glyph" aria-label="counter_novelty 2; " role="img">
                 <span class="glyphicon glyphicon-bell" aria-hidden="true"></span>
                 <span class="il-counter">
                     <span class="badge badge-notify il-counter-novelty">2</span>


### PR DESCRIPTION
Currently we have 2 Issues spawning from different A11y Audits, #https://mantis.ilias.de/view.php?id=39992 and https://mantis.ilias.de/view.php?id=37178 .

In its core, both are caused by the counters being missed by screenreaders if they are placed within bulky buttons. Cause of the issue is the role="img" given to glyphs if they are rendered in the context button. role="img" leads to all descendents of the element being "presentational", see: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role .

"Accessibility APIs do not have a way of representing semantic elements contained in an img. To deal with this limitation, browsers, automatically apply role [presentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) to all descendant elements of any img element as it is a role that does not support semantic children."

The recommendation is: "An accessible name is required. For the HTML [<img>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) element, use the alt attribute. For all other elements with the img role, use aria-labelledby if a visible label is present, otherwise use aria-label."

I opted for extending adding an aria-label of the glyph carrying the role="img". So screenreaders should catch the counters again.

