### PR TITLE
T&A 0040488 save and return' returns to question list instead of question page for questions from pool test 

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -626,14 +626,13 @@ abstract class assQuestionGUI
                 $ref_id = (int) $this->request->raw('calling_consumer');
                 $consumer = ilObjectFactory::getInstanceByRefId($ref_id);
                 if ($consumer instanceof ilQuestionEditingFormConsumer) {
-                    ilUtil::redirect($consumer->getQuestionEditingFormBackTarget($this->request->raw('consumer_context')));
+                    $this->ctrl->redirectToURL($consumer->getQuestionEditingFormBackTarget($this->request->raw('consumer_context')));
                 }
-
-                ilUtil::redirect(ilLink::_getLink($ref_id));
+                $this->ctrl->redirectToURL(ilLink::_getLink($ref_id));
             }
 
             if ($this->request->raw('test_express_mode')) {
-                ilUtil::redirect(ilTestExpressPage::getReturnToPageLink($this->object->getId()));
+                $this->ctrl->redirectToURL(ilTestExpressPage::getReturnToPageLink($this->object->getId()));
             } else {
                 $this->ctrl->redirectByClass('ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_SHOW);
             }
@@ -654,13 +653,13 @@ abstract class assQuestionGUI
                 $ref_id = (int) $this->request->raw('calling_consumer');
                 $consumer = ilObjectFactory::getInstanceByRefId($ref_id);
                 if ($consumer instanceof ilQuestionEditingFormConsumer) {
-                    ilUtil::redirect($consumer->getQuestionEditingFormBackTarget($this->request->raw('consumer_context')));
+                    $this->ctrl->redirectToURL($consumer->getQuestionEditingFormBackTarget($this->request->raw('consumer_context')));
                 }
-                ilUtil::redirect(ilLink::_getLink($ref_id));
+                $this->ctrl->redirectToURL(ilLink::_getLink($ref_id));
             }
 
             if ($this->request->raw('test_express_mode')) {
-                ilUtil::redirect(ilTestExpressPage::getReturnToPageLink($this->object->getId()));
+                $this->ctrl->redirectToURL(ilTestExpressPage::getReturnToPageLink($this->object->getId()));
             } else {
                 $this->ctrl->redirectByClass('ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_SHOW);
             }

--- a/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -635,7 +635,7 @@ abstract class assQuestionGUI
             if ($this->request->raw('test_express_mode')) {
                 ilUtil::redirect(ilTestExpressPage::getReturnToPageLink($this->object->getId()));
             } else {
-                ilUtil::redirect("ilias.php?baseClass=ilObjTestGUI&cmd=questions&ref_id=" . $this->request->raw("calling_test"));
+                $this->ctrl->redirectByClass('ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_SHOW);
             }
         }
     }
@@ -662,7 +662,7 @@ abstract class assQuestionGUI
             if ($this->request->raw('test_express_mode')) {
                 ilUtil::redirect(ilTestExpressPage::getReturnToPageLink($this->object->getId()));
             } else {
-                ilUtil::redirect("ilias.php?baseClass=ilObjTestGUI&cmd=questions&ref_id=" . $this->request->raw("calling_test"));
+                $this->ctrl->redirectByClass('ilAssQuestionPreviewGUI', ilAssQuestionPreviewGUI::CMD_SHOW);
             }
         }
     }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40488

Change the redirect after sync and sync cancellation.

Tested on: ILIAS 8 
Same code: ILIAS 7, 8, 9
