### PR TITLE
T&A 0040614: Starting test with "Use Previous Answers" activated leads to fatal type error

### DIFF
--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1309,16 +1309,16 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
                 $previousPass = $questionGui->object->getSolutionMaxPass(
                     $this->testSession->getActiveId()
                 );
-                if (!is_null($previousPass)){
-                    $previousSolutionAvailable = $questionGui->object->authorizedSolutionExists(
-                        $this->testSession->getActiveId(),
-                        $previousPass
-                    );
 
-                    if ($previousSolutionAvailable) {
-                        return $previousPass;
-                    }
+                $previousSolutionAvailable = $questionGui->object->authorizedSolutionExists(
+                    $this->testSession->getActiveId(),
+                    $previousPass
+                );
+
+                if ($previousSolutionAvailable) {
+                    return $previousPass;
                 }
+
             }
         }
 

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1309,14 +1309,15 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
                 $previousPass = $questionGui->object->getSolutionMaxPass(
                     $this->testSession->getActiveId()
                 );
+                if (!is_null($previousPass)){
+                    $previousSolutionAvailable = $questionGui->object->authorizedSolutionExists(
+                        $this->testSession->getActiveId(),
+                        $previousPass
+                    );
 
-                $previousSolutionAvailable = $questionGui->object->authorizedSolutionExists(
-                    $this->testSession->getActiveId(),
-                    $previousPass
-                );
-
-                if ($previousSolutionAvailable) {
-                    return $previousPass;
+                    if ($previousSolutionAvailable) {
+                        return $previousPass;
+                    }
                 }
             }
         }

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -3899,8 +3899,11 @@ abstract class assQuestion
         return (bool) $solutionAvailability['intermediate'];
     }
 
-    public function authorizedSolutionExists(int $active_id, int $pass): bool
+    public function authorizedSolutionExists(int $active_id, ?int $pass): bool
     {
+        if (is_null($pass)) {
+            return false;
+        }
         $solutionAvailability = $this->lookupForExistingSolutions($active_id, $pass);
         return (bool) $solutionAvailability['authorized'];
     }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40614

Add a null check to prevent the crash.

tested on: ILIAS 8
Same code on: ILIAS 8, 9