### PR TITLE
Fix error in rbac log table

### DIFF
--- a/Services/AccessControl/classes/class.ilRbacLogTableGUI.php
+++ b/Services/AccessControl/classes/class.ilRbacLogTableGUI.php
@@ -163,7 +163,7 @@ class ilRbacLogTableGUI extends ilTable2GUI
         if (isset($raw["inht"])) {
             foreach ($raw["inht"] as $action => $role_ids) {
                 foreach ((array) $role_ids as $role_id) {
-                    $result[] = array("action" => sprintf($this->lng->txt("rbac_log_inheritance_" . $action), ilObjRole::_getTranslation(ilObject::_lookupTitle($role_id))));
+                    $result[] = array("action" => sprintf($this->lng->txt("rbac_log_inheritance_" . $action), ilObjRole::_getTranslation(ilObject::_lookupTitle((int) $role_id))));
                 }
             }
         }


### PR DESCRIPTION
Fixes a missing integer cast in the role log table, that can sometimes result in a hard error.

Mantis: https://mantis.ilias.de/view.php?id=40664