### PR TITLE
Fix failing pdf uploads du to page count preprocessor

### DIFF
--- a/Modules/File/classes/PreProcessors/class.ilCountPDFPages.php
+++ b/Modules/File/classes/PreProcessors/class.ilCountPDFPages.php
@@ -69,6 +69,6 @@ class ilCountPDFPages
         $arg = "-q -dNODISPLAY -dNOSAFER -c \"($path_to_pdf) (r) file runpdfbegin pdfpagecount = quit\";";
         $return = ilShellUtil::execQuoted(PATH_TO_GHOSTSCRIPT, $arg);
 
-        return (int) $return[0] ?? null;
+        return isset($return[0]) ? (int) $return[0] : 0;
     }
 }


### PR DESCRIPTION
Pdf uploads can currently fail due to either an invalid array key or a type error (if null was returned).

Mantis: https://mantis.ilias.de/view.php?id=40665