### PR TITLE
9/UI/viewcontrols nav arrows shifted for section 40648

### DIFF
--- a/templates/default/070-components/UI-framework/ViewControl/_ui-component_viewcontrol.scss
+++ b/templates/default/070-components/UI-framework/ViewControl/_ui-component_viewcontrol.scss
@@ -72,25 +72,6 @@ $il-vc-pagination-btn-active-bg: $il-main-bg;
 		display: inline-block;
 	}
 }
-.il-viewcontrol-section {
-	.glyphicon {
-		vertical-align: middle;
-		&::before {
-			top: 0;
-			vertical-align: middle;
-		}
-	}
-}
-.il-viewcontrol-pagination {
-	.glyph {
-		.glyphicon {
-			vertical-align: middle;
-			&::before {
-				top: 0;
-			}
-		}
-	}
-}
 
 .il-viewcontrol-fieldselection .dropdown-menu {
 	padding: $il-padding-xlarge-horizontal $il-padding-xlarge-vertical;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9758,21 +9758,6 @@ td.c-table-data__cell--highlighted {
   display: inline-block;
 }
 
-.il-viewcontrol-section .glyphicon {
-  vertical-align: middle;
-}
-.il-viewcontrol-section .glyphicon::before {
-  top: 0;
-  vertical-align: middle;
-}
-
-.il-viewcontrol-pagination .glyph .glyphicon {
-  vertical-align: middle;
-}
-.il-viewcontrol-pagination .glyph .glyphicon::before {
-  top: 0;
-}
-
 .il-viewcontrol-fieldselection .dropdown-menu {
   padding: 15px 9px;
 }


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=40648

# Issue

Viewcontrol section navigation glyph arrows appear shifted in Firefox:

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/1dfa1b88-7b18-4595-ac59-4e9a9b62e6cf)

This is because two nested vertical-align declarations seem to be rendered differently in Firefox vs. Chromium based browsers.

# Change

Removed the offending vertical-align overrides and discovered that the buttons work fine with just the UI component glyph's default values. 

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/0791099b-989a-4d0e-b345-76b18e90617c)

It's not pixel perfect, there could be +/- a pixel here and there, but I would rather tweak the UI component glyph in general to ensure a perfect centered vertical align using flexbox rather than bloating the consumer code with overrides.