### PR TITLE
AdvMD: redesign form for editing selects for better stability

### DIFF
--- a/Modules/Wiki/classes/class.ilPCAMDPageList.php
+++ b/Modules/Wiki/classes/class.ilPCAMDPageList.php
@@ -303,7 +303,7 @@ class ilPCAMDPageList extends ilPageContent
                 }
             }
             $fields = array(
-                "sdata" => array("text", serialize(serialize($updated_data)))
+                "sdata" => array("text", serialize(empty($updated_data) ? '' : serialize($updated_data)))
             );
             $primary = array(
                 "id" => array("integer", $row["id"]),

--- a/Services/ADT/classes/Types/Enum/class.ilADTEnumSearchBridgeSingle.php
+++ b/Services/ADT/classes/Types/Enum/class.ilADTEnumSearchBridgeSingle.php
@@ -100,7 +100,7 @@ class ilADTEnumSearchBridgeSingle extends ilADTSearchBridgeSingle
     public function setSerializedValue(string $a_value): void
     {
         $a_value = unserialize($a_value);
-        if (is_array($a_value)) {
+        if (is_array($a_value) && !empty($a_value)) {
             $this->getADT()->setSelection($a_value[0]);
         }
     }

--- a/Services/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionSelect.php
+++ b/Services/AdvancedMetaData/classes/Types/class.ilAdvancedMDFieldDefinitionSelect.php
@@ -142,22 +142,90 @@ class ilAdvancedMDFieldDefinitionSelect extends ilAdvancedMDFieldDefinition
             return;
         }
 
-        // if not the default language is chosen => no add/remove; no sorting
-        $field = new ilTextInputGUI($this->lng->txt("meta_advmd_select_options"), "opts");
-        $field->setRequired(true);
-        $field->setMulti(true, true);
-        $field->setMaxLength(255); // :TODO:
-        $a_form->addItem($field);
-
         $options = $this->getOptions();
-        if ($options) {
-            $field->setMultiValues($options);
-            $field->setValue(array_shift($options));
+
+        if (is_null($options)) {
+            $this->addCreateOptionsFieldsToDefinitionForm($a_form, $a_disabled);
+            return;
         }
 
-        if ($a_disabled) {
-            $field->setDisabled(true);
+        $this->addEditOptionsFieldsToDefinitionForm($options, $a_form, $a_disabled);
+    }
+
+    protected function addCreateOptionsFieldsToDefinitionForm(
+        ilPropertyFormGUI $a_form,
+        bool $a_disabled
+    ): void {
+        $field = new ilTextInputGUI($this->lng->txt('meta_advmd_select_options'), 'opts_new');
+        $field->setRequired(true);
+        $field->setMulti(true);
+        $field->setMaxLength(255);
+        $field->setDisabled($a_disabled);
+
+        $a_form->addItem($field);
+    }
+
+    protected function addEditOptionsFieldsToDefinitionForm(
+        array $options,
+        ilPropertyFormGUI $a_form,
+        bool $a_disabled
+    ): void {
+        $entries = new ilRadioGroupInputGUI(
+            $this->lng->txt('meta_advmd_select_options_edit'),
+            'opts_edit'
+        );
+
+        $position_identifiers = ['0' => $this->lng->txt('meta_advmd_select_first_position_identifier')];
+        $last_idx = 0;
+        foreach ($options as $idx => $option) {
+            $position_identifiers[$idx + 1] = sprintf(
+                $this->lng->txt('meta_advmd_select_position_identifier'),
+                $option
+            );
+            $last_idx = $idx + 1;
         }
+
+        $options[$last_idx] = $this->lng->txt('meta_advmd_select_new_option');
+
+        foreach ($options as $idx => $option) {
+            $radio = new ilRadioOption($option, (string) $idx);
+
+            $value = new ilTextInputGUI(
+                $this->lng->txt('meta_advmd_select_option_value'),
+                'value_' . $idx
+            );
+            $value->setRequired(true);
+            $value->setMaxLength(255);
+            $value->setValue($idx !== $last_idx ? $option : '');
+            $value->setDisabled($a_disabled);
+            $radio->addSubItem($value);
+
+            $position = new ilSelectInputGUI(
+                $this->lng->txt('meta_advmd_select_option_position'),
+                'position_' . $idx
+            );
+            $relevant_position_identifiers = $position_identifiers;
+            unset($relevant_position_identifiers[$idx + 1]);
+            $position->setOptions($relevant_position_identifiers);
+            $position->setValue($idx);
+            $position->setDisabled($a_disabled);
+            $radio->addSubItem($position);
+
+            if ($idx !== $last_idx && $last_idx > 1) {
+                $delete = new ilCheckboxInputGUI(
+                    $this->lng->txt('meta_advmd_select_delete_option'),
+                    'delete_me_' . $idx
+                );
+                $delete->setDisabled($a_disabled);
+                $radio->addSubItem($delete);
+            }
+
+            $radio->setDisabled($a_disabled);
+            $entries->addOption($radio);
+        }
+
+        $entries->setDisabled($a_disabled);
+        $a_form->addItem($entries);
     }
 
     protected function addCustomFieldToDefinitionFormInTranslationMode(
@@ -268,18 +336,52 @@ class ilAdvancedMDFieldDefinitionSelect extends ilAdvancedMDFieldDefinition
         }
 
         $old = $this->getOptionTranslation($language);
-        $new = $a_form->getInput("opts");
-
-        $missing = array_diff_assoc($old, $new);
-        // keep track of the indices of entries persisting through the operation
-        $index_map = [];
-        foreach ($missing as $missing_idx => $missing_value) {
-            if (in_array($missing_value, $new)) {
-                $index_map[$missing_idx] = array_search($missing_value, $new);
-            }
+        if ($new = $a_form->getInput('opts_new')) {
+            $this->setOptions($new);
+            $this->setOptionTranslationsForLanguage($new, $language);
+            return;
         }
 
-        if (sizeof($missing)) {
+        $edited_idx = $a_form->getInput('opts_edit');
+        if($edited_idx === '' || is_null($edited_idx)) {
+            return;
+        }
+
+        $new_value = (string) $a_form->getInput('value_' . $edited_idx);
+        $new_position = (int) $a_form->getInput('position_' . $edited_idx);
+        $delete = (bool) $a_form->getInput('delete_me_' . $edited_idx);
+
+        /*
+         * Build the new options, keeping track of how indices change in a map.
+         */
+        $new = [];
+        $index_map = [];
+        $new_idx = 0;
+        foreach ($old as $old_idx => $old_value) {
+            if ($new_idx === $edited_idx) {
+                continue;
+            }
+
+            if (!$delete && $new_idx === $new_position) {
+                $new[$new_idx] = $new_value;
+                if ($edited_idx !== $new_idx) {
+                    $index_map[$edited_idx] = $new_idx;
+                }
+                $new_idx++;
+            }
+
+            $new[$new_idx] = $old_value;
+            if ($old_idx !== $new_idx) {
+                $index_map[$old_idx] = $new_idx;
+            }
+            $new_idx++;
+        }
+
+        /*
+         * Prepare migration of existing values, prepare for confirmation if more
+         * user input is required.
+         */
+        if ($delete || count($index_map)) {
             $this->confirmed_objects = $this->buildConfirmedObjects($a_form);
             $already_confirmed = is_array($this->confirmed_objects);
 
@@ -288,28 +390,40 @@ class ilAdvancedMDFieldDefinitionSelect extends ilAdvancedMDFieldDefinition
                 false,
                 $multi
             );
-            foreach ($missing as $missing_idx => $missing_value) {
-                $in_use = $this->findBySingleValue($search, $missing_idx);
-                if (is_array($in_use)) {
-                    foreach ($in_use as $item) {
-                        if (array_key_exists($missing_idx, $index_map)) {
-                            $complete_id = $item[0] . "_" . $item[1] . "_" . $item[2];
-                            $new_index = $index_map[$missing_idx];
-                            $this->confirmed_objects[$missing_idx][$complete_id] = $new_index;
-                            continue;
-                        }
-                        if (!$already_confirmed) {
-                            $this->confirm_objects[$missing_idx][] = $item;
-                            $this->confirm_objects_values[$missing_idx] = $old[$missing_idx];
-                        }
+
+            /*
+             * If option is to be deleted, collect objects whith that value and
+             * and prepare confirmation of their migration.
+             */
+            if ($delete) {
+                $in_use = $this->findBySingleValue($search, $edited_idx);
+                foreach ($in_use as $item) {
+                    if (!$already_confirmed) {
+                        $this->confirm_objects[$edited_idx][] = $item;
+                        $this->confirm_objects_values[$edited_idx] = $old[$edited_idx];
                     }
+                }
+            }
+
+            /*
+             * Prepare objects that can be automatically migrated.
+             */
+            foreach ($index_map as $old_idx => $new_idx) {
+                $in_use = $this->findBySingleValue($search, $old_idx);
+                foreach ($in_use as $item) {
+                    $complete_id = $item[0] . "_" . $item[1] . "_" . $item[2];
+                    $this->confirmed_objects[$old_idx][$complete_id] = $new_idx;
                 }
             }
         }
         $this->old_options = $old;
 
-        // update the options along with their translations
+        /*
+         * Finally set the new options, and change the indices of translations
+         * according to the index map.
+         */
         $this->setOptionTranslationsForLanguage($new, $language);
+        $this->setOptions($new);
         foreach ($this->getOptionTranslations() as $current_lang => $options) {
             $current_lang = (string) $current_lang;
             if ($current_lang === $language) {
@@ -379,27 +493,30 @@ class ilAdvancedMDFieldDefinitionSelect extends ilAdvancedMDFieldDefinition
         $post_conf_det = (array) ($this->http->request()->getParsedBody()['conf_det'] ?? []);
         $post_conf = (array) ($this->http->request()->getParsedBody()['conf'] ?? []);
 
-        $a_form->getItemByPostVar("opts")->setDisabled(true);
-        if (is_array($this->confirm_objects) && count($this->confirm_objects) > 0) {
-            $new_options = $a_form->getInput("opts");
+        $custom_field = $a_form->getItemByPostVar('opts_edit');
+        $custom_field->setDisabled(true);
+        foreach ($custom_field->getSubInputItemsRecursive() as $sub_input) {
+            $sub_input->setDisabled(true);
+        }
 
+        if (is_array($this->confirm_objects) && count($this->confirm_objects) > 0) {
             $sec = new ilFormSectionHeaderGUI();
             $sec->setTitle($lng->txt("md_adv_confirm_definition_select_section"));
             $a_form->addItem($sec);
 
-            foreach ($this->confirm_objects as $old_option => $items) {
-                $old_option_value = $this->confirm_objects_values[$old_option];
+            foreach ($this->confirm_objects as $old_option_index => $items) {
+                $old_option_value = $this->confirm_objects_values[$old_option_index];
                 $details = new ilRadioGroupInputGUI(
                     $lng->txt("md_adv_confirm_definition_select_option") . ': "' . $old_option_value . '"',
-                    "conf_det[" . $this->getFieldId() . "][" . $old_option . "]"
+                    "conf_det[" . $this->getFieldId() . "][" . $old_option_index . "]"
                 );
                 $details->setRequired(true);
                 $details->setValue("sum");
                 $a_form->addItem($details);
 
                 // automatic reload does not work
-                if (isset($post_conf_det[$this->getFieldId()][$old_option])) {
-                    $details->setValue($post_conf_det[$this->getFieldId()][$old_option]);
+                if (isset($post_conf_det[$this->getFieldId()][$old_option_index])) {
+                    $details->setValue($post_conf_det[$this->getFieldId()][$old_option_index]);
                 }
 
                 $sum = new ilRadioOption($lng->txt("md_adv_confirm_definition_select_option_all"), "sum");
@@ -407,24 +524,27 @@ class ilAdvancedMDFieldDefinitionSelect extends ilAdvancedMDFieldDefinition
 
                 $sel = new ilSelectInputGUI(
                     $lng->txt("md_adv_confirm_definition_select_option_all_action"),
-                    "conf_det_act[" . $this->getFieldId() . "][" . $old_option . "]"
+                    "conf_det_act[" . $this->getFieldId() . "][" . $old_option_index . "]"
                 );
                 $sel->setRequired(true);
                 $options = array(
                     "" => $lng->txt("please_select"),
                     self::REMOVE_ACTION_ID => $lng->txt("md_adv_confirm_definition_select_option_remove")
                 );
-                foreach ($new_options as $new_option_index => $new_option) {
+                foreach ($this->getOptions() as $new_option_index => $new_option) {
+                    if ($new_option_index === $old_option_index) {
+                        continue;
+                    }
                     $options['idx_' . $new_option_index] = $lng->txt("md_adv_confirm_definition_select_option_overwrite") . ': "' . $new_option . '"';
                 }
                 $sel->setOptions($options);
                 $sum->addSubItem($sel);
 
                 // automatic reload does not work
-                if (isset($post_conf_det[$this->getFieldId()][$old_option])) {
-                    if ($post_conf_det[$this->getFieldId()][$old_option]) {
-                        $sel->setValue($post_conf_det[$this->getFieldId()][$old_option]);
-                    } elseif ($post_conf_det[$this->getFieldId()][$old_option] == "sum") {
+                if (isset($post_conf_det[$this->getFieldId()][$old_option_index])) {
+                    if ($post_conf_det[$this->getFieldId()][$old_option_index]) {
+                        $sel->setValue($post_conf_det[$this->getFieldId()][$old_option_index]);
+                    } elseif ($post_conf_det[$this->getFieldId()][$old_option_index] == "sum") {
                         $sel->setAlert($lng->txt("msg_input_is_required"));
                         $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', $lng->txt("form_input_not_valid"));
                     }
@@ -466,23 +586,26 @@ class ilAdvancedMDFieldDefinitionSelect extends ilAdvancedMDFieldDefinition
 
                     $sel = new ilSelectInputGUI(
                         $type_title . ' ' . $title,
-                        "conf[" . $this->getFieldId() . "][" . $old_option . "][" . $item_id . "]"
+                        "conf[" . $this->getFieldId() . "][" . $old_option_index . "][" . $item_id . "]"
                     );
                     $sel->setRequired(true);
                     $options = array(
                         "" => $lng->txt("please_select"),
                         self::REMOVE_ACTION_ID => $lng->txt("md_adv_confirm_definition_select_option_remove")
                     );
-                    foreach ($new_options as $new_option_index => $new_option) {
+                    foreach ($this->getOptions() as $new_option_index => $new_option) {
+                        if ($new_option_index === $old_option_index) {
+                            continue;
+                        }
                         $options['idx_' . $new_option_index] = $lng->txt("md_adv_confirm_definition_select_option_overwrite") . ': "' . $new_option . '"';
                     }
                     $sel->setOptions($options);
 
                     // automatic reload does not work
-                    if (isset($post_conf[$this->getFieldId()][$old_option][$item_id])) {
-                        if ($post_conf[$this->getFieldId()][$old_option][$item_id]) {
-                            $sel->setValue($post_conf[$this->getFieldId()][$old_option][$item_id]);
-                        } elseif ($post_conf_det[$this->getFieldId()][$old_option] == "sgl") {
+                    if (isset($post_conf[$this->getFieldId()][$old_option_index][$item_id])) {
+                        if ($post_conf[$this->getFieldId()][$old_option_index][$item_id]) {
+                            $sel->setValue($post_conf[$this->getFieldId()][$old_option_index][$item_id]);
+                        } elseif ($post_conf_det[$this->getFieldId()][$old_option_index] == "sgl") {
                             $sel->setAlert($lng->txt("msg_input_is_required"));
                             $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', $lng->txt("form_input_not_valid"));
                         }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11370,7 +11370,14 @@ meta#:#md_used#:#Verwendung (Anzahl)
 meta#:#meta_accessibility_restrictions#:#Zugangsbeschränkungen
 meta#:#meta_active#:#Aktiv
 meta#:#meta_add#:#Hinzufügen
+meta#:#meta_advmd_select_delete_option#:#Diesen Eintrag löschen
+meta#:#meta_advmd_select_first_position_identifier#:#An den Anfang
+meta#:#meta_advmd_select_new_option#:#Neuen Eintrag hinzufügen
+meta#:#meta_advmd_select_option_position#:#Position
+meta#:#meta_advmd_select_option_value#:#Wert
 meta#:#meta_advmd_select_options#:#Einträge
+meta#:#meta_advmd_select_options_edit#:#Einträge bearbeiten
+meta#:#meta_advmd_select_position_identifier#:#Nach %s
 meta#:#meta_annotation#:#Anmerkung
 meta#:#meta_atomic#:#Atomar
 meta#:#meta_author#:#Autor

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11370,7 +11370,14 @@ meta#:#md_used#:#Current Number of Usages
 meta#:#meta_accessibility_restrictions#:#Accessibility Restrictions
 meta#:#meta_active#:#Active
 meta#:#meta_add#:#Add
+meta#:#meta_advmd_select_delete_option#:#Delete This Entry
+meta#:#meta_advmd_select_first_position_identifier#:#First
+meta#:#meta_advmd_select_new_option#:#Add New Entry
+meta#:#meta_advmd_select_option_position#:#Position
+meta#:#meta_advmd_select_option_value#:#Value
 meta#:#meta_advmd_select_options#:#Entries
+meta#:#meta_advmd_select_options_edit#:#Edit Entries
+meta#:#meta_advmd_select_position_identifier#:#After %s
 meta#:#meta_annotation#:#Annotation
 meta#:#meta_atomic#:#Atomic
 meta#:#meta_author#:#Author


### PR DESCRIPTION
This PR makes some fundamental changes to the form for creating and editing Custom Metadata (multi-)select fields. The aim is to make working with these fields more robust and foolproof.

Currently, the entries of select fields can be edited in the Administration (Search And Find > Metadata > Custom Metadata > Edit Fields > Edit) via a multi-text input:

![Screenshot from 2024-02-28 16-16-43](https://github.com/ILIAS-eLearning/ILIAS/assets/104776863/0085dce1-3065-47ba-b234-0598c9132007)

This input allows the user to simultaneously move, rename and/or delete as many entries as required, as well as add arbitrarily many new ones. From this wide array of possible simultaneous manipulations it is almost impossible to reliably reverse-engineer user intent, and make the expected changes to the underlying data. In the past, this has contributed to sometimes data-destroying errors (see e.g. [40590](https://mantis.ilias.de/view.php?id=40590) for the newest such occurrence), and has made Custom Metadata select fields more unreliable in general.

This PR keeps the multi-text input when creating a new select field, but replaces it when editing an existing field: instead, a radio input is used, with one radio for each entry. Each radio offers in a subform a text input for changing the entry's value, a dropdown for changing the entry's position, and a checkbox to delete the entry.

![Screenshot from 2024-02-28 16-29-50](https://github.com/ILIAS-eLearning/ILIAS/assets/104776863/8a0c77b1-94d8-4250-8afe-04854e33afaf)

The final radio allows for adding a new entry, and does not offer the 'delete' checkbox:

![Screenshot from 2024-02-28 16-31-12](https://github.com/ILIAS-eLearning/ILIAS/assets/104776863/b3f1845e-1cee-4755-ae78-3a3f756b1dea)

Restricting manipulations to a single entry at a time takes the guesswork out of processing the form's output, and should contribute to a higher reliability for these kinds of metadata.

This construction is a bit unusual and as far as I can tell largely unprecedented in ILIAS. Due to the unique architecture of the Custom Metadata component, one is fairly restricted in what improvements one can make without refactoring large parts of it. In my opinion, what can be gained in stability with the changes proposed here is well worth a slightly clunky form.
