### PR TITLE
LDAP: Fix missing cast when determining "Auth Mode Name"

### DIFF
--- a/Services/Authentication/classes/class.ilAuthUtils.php
+++ b/Services/Authentication/classes/class.ilAuthUtils.php
@@ -204,7 +204,7 @@ class ilAuthUtils
      */
     public static function _getAuthModeName($a_auth_key): string
     {
-        switch ($a_auth_key) {
+        switch ((int) $a_auth_key) {
             case self::AUTH_LOCAL:
                 return "local";
                 break;


### PR DESCRIPTION
If approved, this has to be picked to `release_9` and `trunk` as well.

Mantis Issue: https://mantis.ilias.de/view.php?id=40676