### PR TITLE
LDAP: Fix type for object lookup when reading group mapping

### DIFF
--- a/Services/LDAP/classes/class.ilLDAPRoleGroupMappingSettings.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleGroupMappingSettings.php
@@ -95,6 +95,7 @@ class ilLDAPRoleGroupMappingSettings
         global $DIC;
 
         $ilDB = $DIC['ilDB'];
+        /** @var ilRbacReview $rbacreview */
         $rbacreview = $DIC['rbacreview'];
 
         $query = "SELECT rgm.* FROM ldap_rg_mapping rgm JOIN ldap_server_settings lss " .
@@ -113,7 +114,7 @@ class ilLDAPRoleGroupMappingSettings
             $data['info'] = $row->mapping_info;
             $data['info_type'] = $row->mapping_info_type;
             // read assigned object
-            $data['object_id'] = $rbacreview->getObjectOfRole($row->role);
+            $data['object_id'] = $rbacreview->getObjectOfRole((int) $row->role);
 
             $active[$row->role][] = $data;
         }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=39497

Of course it is debatable if it is the desired behaviour calling `\ilRbacReview::getObjectOfRole` with a `0` (casted `NULL`) and retrieving a `0` (because no object could be found for `0`) for furthere processing (internally in the LDAP component).

If approved, this has to be picked to `release_9` and `trunk` as well.