### PR TITLE
SOAP/Init: Fix support for SOAP plugins (at least partly)

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1123,6 +1123,18 @@ class ilInitialisation
         self::initILIAS();
     }
 
+    public static function reInitUser(): void
+    {
+        if (ilContext::initClient() && ilContext::hasUser()) {
+            self::initSession();
+            self::initUser();
+
+            if (ilContext::supportsPersistentSessions()) {
+                self::resumeUserSession();
+            }
+        }
+    }
+
     /**
      * ilias initialisation
      */

--- a/Services/WebServices/SOAP/classes/class.ilAbstractSoapMethod.php
+++ b/Services/WebServices/SOAP/classes/class.ilAbstractSoapMethod.php
@@ -44,8 +44,8 @@ abstract class ilAbstractSoapMethod extends ilSoapAdministration implements ilSo
      */
     protected function initIliasAndCheckSession(string $session_id): void
     {
-        $this->initAuth($session_id);
-        $this->initIlias();
+        $this->initAuth($session_id, true);
+        $this->reInitUser();
         if (!$this->checkSession($session_id)) {
             throw new ilSoapPluginException($this->getMessage());
         }

--- a/webservice/soap/classes/class.ilSoapAdministration.php
+++ b/webservice/soap/classes/class.ilSoapAdministration.php
@@ -135,17 +135,17 @@ class ilSoapAdministration
         return $this->message_code;
     }
 
-    protected function initAuth(string $sid): void
+    protected function initAuth(string $sid, bool $mutate_super_global_cookies = false): void
     {
         global $DIC;
 
         [$sid, $client] = $this->explodeSid($sid);
 
-        if (isset($DIC)) {
-            ilUtil::setCookie(session_name(), $sid);
-        } else {
+        if ($mutate_super_global_cookies || !isset($DIC)) {
             $_COOKIE['ilClientId'] = $client;
             $_COOKIE[session_name()] = $sid;
+        } else {
+            ilUtil::setCookie(session_name(), $sid);
         }
     }
 
@@ -155,6 +155,17 @@ class ilSoapAdministration
             try {
                 require_once("Services/Init/classes/class.ilInitialisation.php");
                 ilInitialisation::reinitILIAS();
+            } catch (Exception $e) {
+            }
+        }
+    }
+    
+    public function reInitUser(): void
+    {
+        if (ilContext::getType() === ilContext::CONTEXT_SOAP) {
+            try {
+                require_once("Services/Init/classes/class.ilInitialisation.php");
+                ilInitialisation::reInitUser();
             } catch (Exception $e) {
             }
         }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=37780

If approved, this has to be picked to `release_9` and `trunk` as well.