### PR TITLE
new language variable for removing members from a mailing list

### DIFF
--- a/Services/Contact/classes/class.ilMailingListsGUI.php
+++ b/Services/Contact/classes/class.ilMailingListsGUI.php
@@ -514,7 +514,7 @@ class ilMailingListsGUI
         $c_gui = new ilConfirmationGUI();
         $this->ctrl->setParameter($this, 'ml_id', $this->mlists->getCurrentMailingList()->getId());
         $c_gui->setFormAction($this->ctrl->getFormAction($this, 'performDeleteMembers'));
-        $c_gui->setHeaderText($this->lng->txt('mail_sure_delete_entry'));
+        $c_gui->setHeaderText($this->lng->txt('mail_sure_remove_user'));
         $c_gui->setCancel($this->lng->txt('cancel'), 'showMembersList');
         $c_gui->setConfirm($this->lng->txt('confirm'), 'performDeleteMembers');
 

--- a/Services/Contact/classes/class.ilMailingListsGUI.php
+++ b/Services/Contact/classes/class.ilMailingListsGUI.php
@@ -488,7 +488,7 @@ class ilMailingListsGUI
                 ++$counter;
             }
 
-            $tbl->addMultiCommand('confirmDeleteMembers', $this->lng->txt('delete'));
+            $tbl->addMultiCommand('confirmDeleteMembers', $this->lng->txt('remove'));
         } else {
             $tbl->disable('header');
             $tbl->disable('footer');
@@ -570,7 +570,7 @@ class ilMailingListsGUI
                     $this->mlists->getCurrentMailingList()->deleteEntry($id);
                 }
             }
-            $this->tpl->setOnScreenMessage('success', $this->lng->txt('mail_deleted_entry'));
+            $this->tpl->setOnScreenMessage('success', $this->lng->txt('mail_success_removed_user'));
         } else {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('mail_delete_error'));
         }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11406,10 +11406,12 @@ mail#:#mail_smtp_user#:#Benutzer
 mail#:#mail_subject_prefix#:#Mail-Betreff
 mail#:#mail_subject_prefix_info#:#Sie können hier einen Text eingeben, der der Betreffzeile ausgehender, automatisch generierter E-Mails vorangestellt wird. Es wird empfohlen einen Präfix anzugeben, um Nutzern das Filtern der Nachrichten zu vereinfachen.
 mail#:#mail_subject_too_long#:#Der Betreff ist zu lang.
+mail#:#mail_success_removed_user#:#Benutzer/innen aus der Liste entfernt.
 mail#:#mail_sure_delete#:#Sind Sie sicher, dass die markierten Mails gelöscht werden sollen?
 mail#:#mail_sure_delete_entry#:#Sind Sie sicher, dass die markierten Einträge gelöscht werden sollen?
 mail#:#mail_sure_delete_file#:#Sind Sie sicher, dass die ausgewählten Dateien gelöscht werden sollen?
 mail#:#mail_sure_delete_folder#:#Der Ordner und sein Inhalt werden unwiderruflich gelöscht!
+mail#:#mail_sure_remove_user#:#Möchten Sie die folgenden Benutzer/innen aus der Liste entfernen?
 mail#:#mail_system_sys_env_from_addr#:#Technische Absendeadresse („SENDER“)###Modified as part of gender mainstreaming activities for ILIAS 8
 mail#:#mail_system_sys_env_from_addr_info#:#Tragen Sie hier die technische Absendeadresse („SENDER”-Header) ein. Lassen Sie das Feld leer, wird bei externem Versand die E-Mail-Adresse der absendenden Person („FROM“-Header) genutzt. Andernfalls ist es die Aufgabe der Server-Administration, den Header zu konfigurieren.###Modified as part of gender mainstreaming activities for ILIAS 8
 mail#:#mail_system_sys_from_addr#:#„FROM”-Adresse für automatisch versendete E-Mails

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11411,6 +11411,7 @@ mail#:#mail_sure_delete#:#Are you sure you want to delete the selected mail(s)?
 mail#:#mail_sure_delete_entry#:#Are you sure you want to delete the following entries?
 mail#:#mail_sure_delete_file#:#Are you sure you want to delete the selected file(s)?
 mail#:#mail_sure_delete_folder#:#The folder and its contents will be irrevocably deleted.
+mail#:#mail_sure_remove_user#:#Are you sure you want to remove the following user(s) from the members list?
 mail#:#mail_system_sys_env_from_addr#:#Technical Sender
 mail#:#mail_system_sys_env_from_addr_info#:#If you leave this field empty, the sender e-mail address will be used if SMTP transfer is enabled. Otherwise it is the server administrator's responsibility to configure this value.
 mail#:#mail_system_sys_from_addr#:#Sender E-Mail (From)

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11412,6 +11412,7 @@ mail#:#mail_sure_delete_entry#:#Are you sure you want to delete the following en
 mail#:#mail_sure_delete_file#:#Are you sure you want to delete the selected file(s)?
 mail#:#mail_sure_delete_folder#:#The folder and its contents will be irrevocably deleted.
 mail#:#mail_sure_remove_user#:#Are you sure you want to remove the following user(s) from the members list?
+mail#:#mail_success_removed_user#:#User(s) successfully removed from mailing list.
 mail#:#mail_system_sys_env_from_addr#:#Technical Sender
 mail#:#mail_system_sys_env_from_addr_info#:#If you leave this field empty, the sender e-mail address will be used if SMTP transfer is enabled. Otherwise it is the server administrator's responsibility to configure this value.
 mail#:#mail_system_sys_from_addr#:#Sender E-Mail (From)

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11407,12 +11407,12 @@ mail#:#mail_smtp_user#:#User
 mail#:#mail_subject_prefix#:#Mail Subject
 mail#:#mail_subject_prefix_info#:#Enter a text which will be prepended to the subject line of outgoing auto-generated e-mails. The usage of a prefix is recommended, as it makes it easier for users to filter messages.
 mail#:#mail_subject_too_long#:#The subject is too long.
+mail#:#mail_success_removed_user#:#User(s) successfully removed from mailing list.
 mail#:#mail_sure_delete#:#Are you sure you want to delete the selected mail(s)?
 mail#:#mail_sure_delete_entry#:#Are you sure you want to delete the following entries?
 mail#:#mail_sure_delete_file#:#Are you sure you want to delete the selected file(s)?
 mail#:#mail_sure_delete_folder#:#The folder and its contents will be irrevocably deleted.
 mail#:#mail_sure_remove_user#:#Are you sure you want to remove the following user(s) from the members list?
-mail#:#mail_success_removed_user#:#User(s) successfully removed from mailing list.
 mail#:#mail_system_sys_env_from_addr#:#Technical Sender
 mail#:#mail_system_sys_env_from_addr_info#:#If you leave this field empty, the sender e-mail address will be used if SMTP transfer is enabled. Otherwise it is the server administrator's responsibility to configure this value.
 mail#:#mail_system_sys_from_addr#:#Sender E-Mail (From)


### PR DESCRIPTION
Chris Potter would like to change the 'Are you sure' message for removing members from a mailing list. The language variable, however, is also used for deleting mailing lists themselves. So we need to introduce a separate language variable.