### PR TITLE
WAC: Send 404 if resource could not be found

### DIFF
--- a/Services/Exceptions/classes/class.ilException.php
+++ b/Services/Exceptions/classes/class.ilException.php
@@ -27,8 +27,8 @@ class ilException extends Exception
     /**
      * A code isn't optional as in build in class Exception
      */
-    public function __construct($a_message, $a_code = 0)
+    public function __construct($a_message, $a_code = 0, Throwable $previous = null)
     {
-        parent::__construct($a_message, $a_code);
+        parent::__construct($a_message, $a_code, $previous);
     }
 }

--- a/Services/WebAccessChecker/class.ilWACException.php
+++ b/Services/WebAccessChecker/class.ilWACException.php
@@ -56,12 +56,12 @@ class ilWACException extends ilException
      * @param int $code
      * @param string $additional_message
      */
-    public function __construct($code, $additional_message = '')
+    public function __construct($code, $additional_message = '', Throwable $previous = null)
     {
         $message = self::$messages[$code] ?? 'Unknown error';
         if (!empty($additional_message)) {
             $message .= ': ' . $additional_message;
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
+++ b/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
@@ -51,13 +51,22 @@ class ilWebAccessChecker
     protected array $applied_checking_methods = [];
     private Services $http;
     private CookieFactory $cookieFactory;
+    private ?ilWACException $ressource_not_found;
 
     /**
      * ilWebAccessChecker constructor.
      */
     public function __construct(Services $httpState, CookieFactory $cookieFactory)
     {
-        $this->setPathObject(new ilWACPath($httpState->request()->getRequestTarget()));
+        try {
+            $this->setPathObject(new ilWACPath($httpState->request()->getRequestTarget()));
+        } catch (ilWACException $e) {
+            if ($e->getCode() !== ilWACException::ACCESS_DENIED) {
+                throw $e;
+            }
+            $this->ressource_not_found = $e;
+        }
+
         $this->http = $httpState;
         $this->cookieFactory = $cookieFactory;
     }
@@ -68,6 +77,10 @@ class ilWebAccessChecker
     public function check(): bool
     {
         if ($this->getPathObject() === null) {
+            if ($this->ressource_not_found !== null) {
+                throw new ilWACException(ilWACException::ACCESS_DENIED, '', $this->ressource_not_found);
+            }
+
             throw new ilWACException(ilWACException::CODE_NO_PATH);
         }
 

--- a/Services/WebAccessChecker/classes/class.ilWebAccessCheckerDelivery.php
+++ b/Services/WebAccessChecker/classes/class.ilWebAccessCheckerDelivery.php
@@ -75,6 +75,8 @@ class ilWebAccessCheckerDelivery
         } catch (ilWACException $e) {
             switch ($e->getCode()) {
                 case ilWACException::ACCESS_DENIED:
+                    $this->handleNotFoundError($e);
+                    break;
                 case ilWACException::ACCESS_DENIED_NO_PUB:
                 case ilWACException::ACCESS_DENIED_NO_LOGIN:
                     $this->handleAccessErrors($e);
@@ -116,6 +118,14 @@ class ilWebAccessCheckerDelivery
         $ilFileDelivery->stream();
     }
 
+    protected function handleNotFoundError(ilWACException $e): void
+    {
+        $response = $this->http
+            ->response()
+            ->withStatus(404);
+
+        $this->http->saveResponse($response);
+    }
 
     protected function handleAccessErrors(ilWACException $e): void
     {


### PR DESCRIPTION
This PR adds a workaround for: https://mantis.ilias.de/view.php?id=40611 . I doubt that it will be merged without changes.

There are two cases when the WAC throws a `ilWACException` with code `ACCESS_DENIED`.

1. If the realpath check in `\ilWACPath::normalizePath` fails
2. If `\ilWebAccessCheckerDelivery::deny` is called and the internal state of `ilWebAccessChecker` is **not** `checked`

So the problem to handle 1. is, that the `ilWACPath` instance is created in the constructor of `ilWebAccessChecker`, which again is created in the constructor of `ilWebAccessCheckerDelivery` (called by `\ilWebAccessCheckerDelivery::run`).

To be able to handle 1. properly, **all** these instances MUST be created (which is not the case if an exception is thrown) and `\ilWebAccessCheckerDelivery::handleRequest` must be called for proper response handling in the context of the existing `ilWebAccessCheckerDelivery` instance.

So my approach is to catch the exception in `\ilWebAccessChecker::__construct` and store it in the internal state of the `WAC`. If `\ilWebAccessChecker::check` is called afterwards and no path is given, the state is checked and and the exception is raised again, so it can be properly handled by `\ilWebAccessCheckerDelivery::handleRequest`.

Furthermore, I added a new method to handle the "Not Found" error by just sending a `HTTP 404` error without the "Dummy Images". Of course this is also debatable.

----

I guess @chfsx will implement another approach. I am sure this will require some restructuring of the component.