### PR TITLE
Ildcl unique f01

### DIFF
--- a/components/ILIAS/DataCollection/classes/Fields/class.ilDclFieldFactory.php
+++ b/components/ILIAS/DataCollection/classes/Fields/class.ilDclFieldFactory.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 class ilDclFieldFactory
 {
-    public static string $field_base_path_patter = "./components/ILIAS/DataCollection/classes/Fields/%s/";
+    public static string $field_base_path_patter = "../components/ILIAS/DataCollection/classes/Fields/%s/";
     public static string $default_prefix = "ilDcl";
     public static string $record_field_class_patter = "%sRecordFieldModel";
     public static string $field_class_patter = "%sFieldModel";

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -8577,6 +8577,7 @@ dcl#:#dcl_description#:#Beschreibung
 dcl#:#dcl_detailed_view#:#Einzelansicht
 dcl#:#dcl_display_action_menu#:#Kopieren
 dcl#:#dcl_display_record_alt#:#Diesen Eintrag anzeigen
+dcl#:#dcl_duplicate_non_unique_entries_exist#:#Es kann sich auch um bereits vorhandene Einträge handeln.###23 02 2024 new variable
 dcl#:#dcl_edit#:#Datensammlung bearbeiten
 dcl#:#dcl_edit_entry_rules#:#Eintragsbearbeitung
 dcl#:#dcl_edit_field#:#Feld bearbeiten

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8571,6 +8571,7 @@ dcl#:#dcl_description#:#Field Description
 dcl#:#dcl_detailed_view#:#Single
 dcl#:#dcl_display_action_menu#:#Enable possibility to copy or link the referenced module
 dcl#:#dcl_display_record_alt#:#Display this entry
+dcl#:#dcl_duplicate_non_unique_entries_exist#:#This may also concern existing records.###23 02 2024 new variable
 dcl#:#dcl_edit#:#Edit Data Collection
 dcl#:#dcl_edit_entry_rules#:#Entry Editing
 dcl#:#dcl_edit_field#:#Edit Field


### PR DESCRIPTION
this is the uniqueness check when updating field settings:
more precisely, this means that if a field is initially set to 'non-unique' and there are already records, the field values of all existing records have to be checked. an error message must appear if values occur more than once and the field property is to be changed to 'unique'.