### PR TITLE
chatserver bugfix: superflous colon in config.json example causes wrong parsing

### DIFF
--- a/Modules/Chatroom/README.md
+++ b/Modules/Chatroom/README.md
@@ -134,7 +134,7 @@ Examples:
     ...
     "chatroom": {
         ...
-        "https:" : {
+        "https" : {
             "cert" : "/etc/ssl/certs/server.pem",
             "key" : "/etc/ssl/private/server.key",
             "dhparam" : "/etc/ssl/private/dhparam.pem"


### PR DESCRIPTION
Hi Michael,

the trailing colon at the keyword "https" causes the parser to ignore this section. This leads to a incorrect server.cfg and subsequent to failing connections.

The problem was discovered during a discord chat here (ff):
https://discord.com/channels/819582183290437642/939179198487080970/1216075864954114138
