### PR TITLE
Mantis 40783 - Group Type Hint Update

### DIFF
--- a/webservice/soap/include/inc.soap_functions.php
+++ b/webservice/soap/include/inc.soap_functions.php
@@ -383,7 +383,7 @@ class ilSoapFunctions
     /**
      * @return soap_fault|SoapFault|string|null
      */
-    public static function addGroup(string $sid, int $target_id, int $group_xml)
+    public static function addGroup(string $sid, int $target_id, string $group_xml)
     {
         include_once './webservice/soap/classes/class.ilSoapGroupAdministration.php';
         $soa = new ilSoapGroupAdministration();


### PR DESCRIPTION
Changes type hint for addGroup $group_xml from int to string so that this function will work correctly.