### PR TITLE
Saml: Enable Unitests

### DIFF
--- a/Services/Saml/phpunit.xml
+++ b/Services/Saml/phpunit.xml
@@ -10,8 +10,8 @@
       <html outputDirectory="build/coverage" highLowerBound="80"/>
     </report>
   </coverage>
-  <testsuite name="ilServicesSamlTestSuite">
-    <file>./test/ilServicesSamlTestSuite.php</file>
+  <testsuite name="ilServicesSamlSuite">
+    <file>./test/ilServicesSamlSuite.php</file>
   </testsuite>
   <logging>
     <testdoxHtml outputFile="build/dox.html"/>

--- a/Services/Saml/test/ilSamlIdpXmlMetadataParserTest.php
+++ b/Services/Saml/test/ilSamlIdpXmlMetadataParserTest.php
@@ -35,12 +35,12 @@ class ilSamlIdpXmlMetadataParserTest extends TestCase
 
     public function testErrorsCanBeRetrievedWhenParsingNonXmlDocument(): void
     {
-        $this->parser->parse('phpunit');
+        $result = $this->parser->parse('phpunit');
 
-        $this->assertTrue($this->parser->result()->isError());
-        $this->assertFalse($this->parser->result()->isOK());
+        $this->assertTrue($result->isError());
+        $this->assertFalse($result->isOK());
 
-        $this->assertNotEmpty($this->parser->result()->error());
+        $this->assertNotEmpty($result->error());
     }
 
     /**
@@ -95,12 +95,11 @@ class ilSamlIdpXmlMetadataParserTest extends TestCase
 </md:EntityDescriptor>
 EOT;
 
-        $this->parser->parse($xml);
+        $result = $this->parser->parse($xml);
 
-        $this->assertFalse($this->parser->result()->isError(), $this->parser->result()->isError() ? $this->parser->result()->error() : '');
-        $this->assertTrue($this->parser->result()->isOK());
+        $this->assertTrue($result->isOK());
 
-        $this->assertSame('https://sso.example.org/idp', $this->parser->result()->value());
+        $this->assertSame('https://sso.example.org/idp', $result->value());
     }
 
     /**
@@ -154,11 +153,11 @@ EOT;
 </md:EntityDescriptor>
 EOT;
 
-        $this->parser->parse($xml);
+        $result = $this->parser->parse($xml);
 
-        $this->assertTrue($this->parser->result()->isError());
-        $this->assertFalse($this->parser->result()->isOK());
+        $this->assertTrue($result->isError());
+        $this->assertFalse($result->isOK());
 
-        $this->assertNotEmpty($this->parser->result()->error());
+        $this->assertNotEmpty($result->error());
     }
 }

--- a/Services/Saml/test/ilServicesSamlSuite.php
+++ b/Services/Saml/test/ilServicesSamlSuite.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestSuite;
  * Class ilServicesSamlTestSuite
  * @author Michael Jansen <mjansen@databay.de>
  */
-class ilServicesSamlTestSuite extends TestSuite
+class ilServicesSamlSuite extends TestSuite
 {
     public static function suite(): self
     {


### PR DESCRIPTION
The class name of the `Services/Saml` Test Suite was wrong, which is why the suite never got added. This PR fixes this.