### PR TITLE
0040826: Unable to open "News Settings" in forum of an older thread

### DIFF
--- a/components/ILIAS/Forum/classes/Notification/class.ilForumNotification.php
+++ b/components/ILIAS/Forum/classes/Notification/class.ilForumNotification.php
@@ -183,6 +183,8 @@ class ilForumNotification
     public function insertAdminForce(): void
     {
         $next_id = $this->db->nextId('frm_notification');
+        $this->setNotificationId($next_id);
+
         $this->db->manipulateF(
             '
 			INSERT INTO frm_notification
@@ -538,6 +540,20 @@ class ilForumNotification
             $this->readAllForcedEvents();
         }
 
+        if (!isset(self::$forced_events_cache[$user_id])) {
+            self::$forced_events_cache[$user_id] = $this->createMissingNotification($user_id);
+        }
+
         return self::$forced_events_cache[$user_id];
+    }
+
+    private function createMissingNotification(int $user_id): self
+    {
+        $new_object = new self($this->ref_id);
+        $new_object->setUserId($user_id);
+        $new_object->setForumId($this->forum_id);
+        $new_object->insertAdminForce();
+
+        return $new_object;
     }
 }


### PR DESCRIPTION
Fixes the bug of a missing notification object, if the user wasn't added by the regular course assignment process and the event "addParticipant" is not raised. This occurs, i.e. if the user gets the role assignment via role administration.
