### PR TITLE
Chatroom: Prevent double HTML escaping when sending messages

### DIFF
--- a/Modules/Chatroom/js/chat.js
+++ b/Modules/Chatroom/js/chat.js
@@ -620,7 +620,7 @@
               }
 
               var messageSpan = $('<span class="chat content message"></span>');
-              messageSpan.text(messageSpan.text(content).text());
+              messageSpan.html(content);
               line.append($('<span class="chat content messageseparator">:</span>'))
                 .append(messageSpan);
 


### PR DESCRIPTION
Fix Mantis bug: https://mantis.ilias.de/view.php?id=40650