### PR TITLE
0040842: Argument 1 passed to ilSCORMObject::setTitle() must be of th…

### DIFF
--- a/Modules/ScormAicc/classes/SCORM/class.ilObjSCORMInitData.php
+++ b/Modules/ScormAicc/classes/SCORM/class.ilObjSCORMInitData.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
 * Class ilObjSCORMInitData

--- a/Modules/ScormAicc/classes/SCORM/class.ilObjSCORMInitData.php
+++ b/Modules/ScormAicc/classes/SCORM/class.ilObjSCORMInitData.php
@@ -234,7 +234,11 @@ class ilObjSCORMInitData
         );
         while ($val_rec = $ilDB->fetchAssoc($val_set)) {
             if (!strpos($val_rec["lvalue"], "._count")) {
-                $a_out[] = array( (int) $val_rec["sco_id"], $val_rec["lvalue"], self::encodeURIComponent($val_rec["rvalue"]) );
+                $a_out[] = array(
+                    (int) $val_rec["sco_id"],
+                    $val_rec["lvalue"],
+                    self::encodeURIComponent($val_rec["rvalue"] ?? '')
+                );
             }
         }
         return json_encode($a_out);
@@ -277,7 +281,12 @@ class ilObjSCORMInitData
         );
         while ($val_rec = $ilDB->fetchAssoc($val_set)) {
             //			$s_out.='['.$val_rec["lft"].','.$val_rec["child"].','.$val_rec["asset"].',"'.self::encodeURIComponent($val_rec["href"]).'"],';
-            $a_out[] = array( (int) $val_rec["lft"], (int) $val_rec["child"], (int) $val_rec["asset"], self::encodeURIComponent($val_rec["href"]) );
+            $a_out[] = array(
+                (int) $val_rec["lft"],
+                (int) $val_rec["child"],
+                (int) $val_rec["asset"],
+                self::encodeURIComponent($val_rec["href"] ?? '')
+            );
         }
         //		if(substr($s_out,(strlen($s_out)-1))==",") $s_out=substr($s_out,0,(strlen($s_out)-1));
         //		return "[".$s_out."]";
@@ -301,7 +310,12 @@ class ilObjSCORMInitData
             array($a_packageId)
         );
         while ($val_rec = $ilDB->fetchAssoc($val_set)) {
-            $a_out[] = array((int) $val_rec["child"],(int) $val_rec["depth"],self::encodeURIComponent($val_rec["title"]),$val_rec["c_type"]);
+            $a_out[] = array(
+                (int) $val_rec["child"],
+                (int) $val_rec["depth"],
+                self::encodeURIComponent($val_rec["title"] ?? ''),
+                $val_rec["c_type"]
+            );
         }
         return json_encode($a_out);
     }

--- a/Modules/ScormAicc/classes/SCORM/class.ilSCORMObject.php
+++ b/Modules/ScormAicc/classes/SCORM/class.ilSCORMObject.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -25,6 +24,8 @@ declare(strict_types=1);
 *
 * @ingroup ModulesScormAicc
 */
+
+declare(strict_types=1);
 class ilSCORMObject
 {
     public int $id;

--- a/Modules/ScormAicc/classes/SCORM/class.ilSCORMObject.php
+++ b/Modules/ScormAicc/classes/SCORM/class.ilSCORMObject.php
@@ -98,7 +98,7 @@ class ilSCORMObject
             array($this->getId())
         );
         $obj_rec = $ilDB->fetchAssoc($obj_set);
-        $this->setTitle($obj_rec["title"]);
+        $this->setTitle($obj_rec["title"] ?? '');
         $this->setType($obj_rec["c_type"]);
         $this->setSLMId((int) $obj_rec["slm_id"]);
     }


### PR DESCRIPTION
Fixes this bug: https://mantis.ilias.de/view.php?id=40842
TypeError thrown with message "Argument 1 passed to ilSCORMObject::setTitle() must be of the type string, null given, called in /ilias/Modules/ScormAicc/classes/SCORM/class.ilSCORMObject.php on line 101"

If approved, this MUST be picked to all maintained branches.