### PR TITLE
Block: fix path to component-specific block classes (40822)

### DIFF
--- a/components/ILIAS/Block/classes/class.ilColumnGUI.php
+++ b/components/ILIAS/Block/classes/class.ilColumnGUI.php
@@ -433,7 +433,7 @@ class ilColumnGUI
 
             // get block for custom blocks
             if ($block["custom"]) {
-                $path = "./" . self::$locations[$gui_class] . "classes/" .
+                $path = "./../" . self::$locations[$gui_class] . "classes/" .
                     "class." . $block_class . ".php";
                 if (file_exists($path)) {
                     $app_block = new $block_class((int) $block["id"]);


### PR DESCRIPTION
This PR fixes [40822](https://mantis.ilias.de/view.php?id=40822) by adapting a file path to the new directory structure.