### PR TITLE
Mantis #40873 - Fix representation of unfinalized kprim questions in ILIAS learning module

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assKprimChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assKprimChoice.php
@@ -972,7 +972,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
             }
 
             $answers[] = array(
-                'answertext' => $this->formatSAQuestion($answer->getAnswertext()),
+                'answertext' => $this->formatSAQuestion($answer->getAnswertext() ?? ''),
                 'correctness' => (bool) $answer->getCorrectness(),
                 'order' => (int) $answer->getPosition(),
                 'image' => (string) $answer->getImageFile(),


### PR DESCRIPTION
Fixes an exception, that occurs when leaving creation of a kprim question within an ILIAS learning module midway