### PR TITLE
HTML Learning Module in IRSS

### DIFF
--- a/components/ILIAS/HTMLLearningModule/classes/Setup/Migrations/class.ilHTLMMigration.php
+++ b/components/ILIAS/HTMLLearningModule/classes/Setup/Migrations/class.ilHTLMMigration.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\ResourceStorage\Collection\ResourceCollection;
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Migration;
+
+class ilHTLMMigration implements Migration
+{
+    protected ilResourceStorageMigrationHelper $helper;
+
+    public function getLabel(): string
+    {
+        return 'Migration of HTML Learning Modules to the Resource Storage Service.';
+    }
+
+    public function getDefaultAmountOfStepsPerRun(): int
+    {
+        return 10000;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return ilResourceStorageMigrationHelper::getPreconditions();
+    }
+
+    public function prepare(Environment $environment): void
+    {
+        $this->helper = new ilResourceStorageMigrationHelper(
+            new ilHTLMStakeholder(),
+            $environment
+        );
+    }
+
+    public function step(Environment $environment): void
+    {
+        $r = $this->helper->getDatabase()->query(
+            "SELECT id FROM file_based_lm WHERE rid IS NULL OR rid = '' LIMIT 1;"
+        );
+
+        $d = $this->helper->getDatabase()->fetchObject($r);
+        $object_id = (int) ($d->id ?? null);
+
+        $resource_owner_id = (int) ($d->owner_id ?? 6); // TODO JOIN
+
+        $lm_path = $this->buildBasePath($object_id);
+
+        $rid = $this->helper->moveDirectoryToContainerResource(
+            $lm_path,
+            $resource_owner_id
+        );
+
+        if ($rid !== null) {
+            $this->helper->getDatabase()->update(
+                'file_based_lm',
+                ['rid' => ['text', $rid->serialize()]],
+                ['id' => ['integer', $object_id],]
+            );
+
+            $this->recursiveRmDir($lm_path);
+        } else {
+            $this->helper->getDatabase()->update(
+                'file_based_lm',
+                ['rid' => ['text', '-']],
+                ['id' => ['integer', $object_id],]
+            );
+        }
+    }
+
+    private function recursiveRmDir(string $path): void
+    {
+        // recursively remove directory
+        $files = array_diff(scandir($path), ['.', '..']);
+        foreach ($files as $file) {
+            (is_dir("$path/$file")) ? $this->recursiveRmDir("$path/$file") : unlink("$path/$file");
+        }
+    }
+
+    public function getRemainingAmountOfSteps(): int
+    {
+        $r = $this->helper->getDatabase()->query(
+            "SELECT COUNT(id) AS amount FROM file_based_lm WHERE rid IS NULL OR rid = ''"
+        );
+        $d = $this->helper->getDatabase()->fetchObject($r) ?? new stdClass();
+
+        return (int) ($d->amount ?? 0);
+    }
+
+    protected function buildBasePath(int $object_id): string
+    {
+        return CLIENT_WEB_DIR . '/lm_data/lm_' . $object_id;
+    }
+
+    public function getFileNameCallback(string $pattern): Closure
+    {
+        return static function (string $file_name) use ($pattern): string {
+            if (preg_match($pattern, $file_name, $matches)) {
+                return $matches[1] ?? $file_name;
+            }
+            return $file_name;
+        };
+    }
+
+    public function getRevisionNameCallback(): Closure
+    {
+        return static function (string $file_name): string {
+            return md5($file_name);
+        };
+    }
+}

--- a/components/ILIAS/HTMLLearningModule/classes/Setup/class.ilHTLMDatabaseUpdateSteps10.php
+++ b/components/ILIAS/HTMLLearningModule/classes/Setup/class.ilHTLMDatabaseUpdateSteps10.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilHTLMDatabaseUpdateSteps10 implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        if ($this->db->tableExists('file_based_lm') && !$this->db->tableColumnExists('file_based_lm', 'rid')) {
+            $this->db->addTableColumn('file_based_lm', 'rid', [
+                'type' => 'text',
+                'length' => 64,
+                'notnull' => true,
+                'default' => ''
+            ]);
+        }
+    }
+
+}

--- a/components/ILIAS/HTMLLearningModule/classes/Setup/class.ilHTLMSetupAgent.php
+++ b/components/ILIAS/HTMLLearningModule/classes/Setup/class.ilHTLMSetupAgent.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+use ILIAS\Refinery;
+use ILIAS\Setup\Objective;
+
+class ilHTLMSetupAgent implements Setup\Agent
+{
+    use Setup\Agent\HasNoNamedObjective;
+
+    public function hasConfig(): bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation(): Refinery\Transformation
+    {
+        throw new LogicException("Agent has no config.");
+    }
+
+    public function getInstallObjective(Setup\Config $config = null): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
+    {
+        return new Setup\ObjectiveCollection(
+            'HTML Learning Module',
+            true,
+            new ilDatabaseUpdateStepsExecutedObjective(
+                new ilHTLMDatabaseUpdateSteps10()
+            )
+        );
+    }
+
+    public function getBuildArtifactObjective(): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getMigrations(): array
+    {
+        return [
+            new ilHTLMMigration()
+        ];
+    }
+
+    public function getBuildObjective(): Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+}

--- a/components/ILIAS/HTMLLearningModule/classes/class.ilHTLMStakeholder.php
+++ b/components/ILIAS/HTMLLearningModule/classes/class.ilHTLMStakeholder.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
+use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+
+/**
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class ilHTLMStakeholder extends AbstractResourceStakeholder
+{
+    public function __construct()
+    {
+    }
+
+    public function getId(): string
+    {
+        return 'htlm';
+    }
+
+    public function getOwnerOfNewResources(): int
+    {
+        return 0;
+    }
+
+    public function getLocationURIForResourceUsage(ResourceIdentification $identification): ?string
+    {
+        $db = $this->resolveDB();
+        if ($db === null) {
+            return null;
+        }
+        $res = $db->queryF(
+            'SELECT ref_id FROM file_based_lm
+                    JOIN object_reference ON file_based_lm.id = object_reference.obj_id
+                    WHERE rid = %s',
+            ['text'],
+            [$identification->serialize()]
+        );
+        if ($row = $db->fetchAssoc($res)) {
+            return ilLink::_getStaticLink((int) $row['ref_id']);
+        }
+    }
+
+    public function isResourceInUse(ResourceIdentification $identification): bool
+    {
+        $db = $this->resolveDB();
+        if ($db === null) {
+            return true; // we assume it is in use
+        }
+        $res = $db->queryF(
+            'SELECT ref_id FROM file_based_lm WHERE rid = %s',
+            ['text'],
+            [$identification->serialize()]
+        );
+        return $db->numRows($res) > 0;
+    }
+
+    private function resolveDB(): ?ilDBInterface
+    {
+        global $DIC;
+        if ($DIC->isDependencyAvailable('database')) {
+            return $DIC->database();
+        }
+        return null;
+    }
+
+}

--- a/components/ILIAS/HTMLLearningModule/classes/class.ilObjFileBasedLMListGUI.php
+++ b/components/ILIAS/HTMLLearningModule/classes/class.ilObjFileBasedLMListGUI.php
@@ -40,26 +40,24 @@ class ilObjFileBasedLMListGUI extends ilObjectListGUI
 
     public function getCommandLink(string $cmd): string
     {
-        $ilCtrl = $this->ctrl;
-
         switch ($cmd) {
             case "view":
                 $cmd_link = "ilias.php?baseClass=ilHTLMPresentationGUI&ref_id=" . $this->ref_id;
                 break;
 
             case "edit":
-                $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $this->ref_id);
-                $cmd_link = $ilCtrl->getLinkTargetByClass(
-                    ["ilrepositorygui", "ilObjFileBasedLMGUI", "ilFileSystemGUI"],
-                    "listFiles"
+                $this->ctrl->setParameterByClass("ilrepositorygui", "ref_id", $this->ref_id);
+                $cmd_link = $this->ctrl->getLinkTargetByClass(
+                    [ilRepositoryGUI::class, ilObjFileBasedLMGUI::class],
+                    ilObjFileBasedLMGUI::CMD_LIST_FILES
                 );
-                $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $this->ref_id);
+                $this->ctrl->setParameterByClass("ilrepositorygui", "ref_id", $this->ref_id);
                 break;
 
             default:
-                $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $this->ref_id);
-                $cmd_link = $ilCtrl->getLinkTargetByClass("ilrepositorygui", $cmd);
-                $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $this->requested_ref_id);
+                $this->ctrl->setParameterByClass("ilrepositorygui", "ref_id", $this->ref_id);
+                $cmd_link = $this->ctrl->getLinkTargetByClass("ilrepositorygui", $cmd);
+                $this->ctrl->setParameterByClass("ilrepositorygui", "ref_id", $this->requested_ref_id);
                 break;
         }
 


### PR DESCRIPTION
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/6661332/116ce911-2279-4d51-aeba-d52db119af4f)

This PR contains the implementation of the Container Resource GUI as decided yesterday: [IRSS: Container-Resource User-interface](https://docu.ilias.de/goto_docu_wiki_wpage_8127_1357.html)

The changes to the IRSS are in the following commit for your info, which I will cherry-pick in the next few days: https://github.com/ILIAS-eLearning/ILIAS/pull/7214/commits/cdbb7bcec5c8149bf54d76938c926380bb2b4a52

The following commit also contains a readme on how to use the container GUI in your component: https://github.com/ILIAS-eLearning/ILIAS/pull/7214/commits/93e0d7884cf83eccc1815ec1240943ebea6c2b52

as a first use I have already rebuilt the HTML learning module, incl. migration. after I have merged the other two commits, I would give you Alex the PR regarding the changes in the learning module: https://github.com/ILIAS-eLearning/ILIAS/pull/7214/commits/d3c735810ab2e851f9be16ca6d1792ae3d86bbf8

The adjustments to the breadcrumb will follow separately as PR