### PR TITLE
UI: Change text for the default option of a required Selectbox

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -17126,6 +17126,7 @@ ui#:#ui_link_label#:#Label
 ui#:#ui_link_url#:#URL
 ui#:#ui_md_input_edit#:#Bearbeiten
 ui#:#ui_md_input_view#:#Vorschau
+ui#:#ui_select_dropdown_label#:#Bitte auswählen
 ui#:#ui_table_no_records#:#Keine Einträge
 ui#:#ui_transcription#:#Abschrift
 user#:#all_roles_has_starting_point#:#Alle Rollen mit definierter Startseite

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -17127,6 +17127,7 @@ ui#:#ui_link_label#:#Label
 ui#:#ui_link_url#:#URL
 ui#:#ui_md_input_edit#:#Edit
 ui#:#ui_md_input_view#:#View
+ui#:#ui_select_dropdown_label#:#Please select
 ui#:#ui_table_no_records#:#No records
 ui#:#ui_transcription#:#Transcript
 user#:#all_roles_has_starting_point#:#All the roles have starting points

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -450,7 +450,7 @@ class Renderer extends AbstractComponentRenderer
 
         if(!($value && $component->isRequired())) {
             $tpl->setVariable("VALUE", null);
-            $tpl->setVariable("VALUE_STR", "-");
+            $tpl->setVariable("VALUE_STR", $component->isRequired() ? $this->txt('ui_select_dropdown_label') : '-');
             $tpl->parseCurrentBlock();
         }
 

--- a/tests/UI/Component/Input/Field/SelectTest.php
+++ b/tests/UI/Component/Input/Field/SelectTest.php
@@ -225,7 +225,7 @@ class SelectInputTest extends ILIAS_UI_TestBase
         $select = $select->withRequired(true);
         $html_with_required = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($select));
 
-        $this->assertTrue(str_contains($html_with_required, ">-</option>"));
+        $this->assertTrue(str_contains($html_with_required, ">ui_select_dropdown_label</option>"));
         $this->assertTrue(str_contains($html_with_required, "value=\"\""));
 
         $select = $select->withRequired(false)->withValue("something_value");


### PR DESCRIPTION
Fixing one part of Mantis bug: https://mantis.ilias.de/view.php?id=39215

As discussed with @yvseiler and @oliversamoila this PR changes the text for the default value of required select boxes.
Instead of a minus symbol "-" a new language variable _ui_select_dropdown_label_ is shown.

The translations for the new language variable are taken from here: https://mantis.ilias.de/view.php?id=39215#c100356