### PR TITLE
SETUP: fix 'register_nic' for the update process. (#40142)

### DIFF
--- a/setup/classes/class.ilNICKeyStoredObjective.php
+++ b/setup/classes/class.ilNICKeyStoredObjective.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 
@@ -40,7 +40,8 @@ class ilNICKeyStoredObjective extends ilSetupObjective
     public function getPreconditions(Setup\Environment $environment): array
     {
         return [
-            new \ilSettingsFactoryExistsObjective()
+            new \ilSettingsFactoryExistsObjective(),
+            new ilInstIdDefaultStoredObjective($this->config)
         ];
     }
 
@@ -68,6 +69,6 @@ class ilNICKeyStoredObjective extends ilSetupObjective
 
     protected function generateNICKey()
     {
-        return md5(uniqid((string) $this->getClientId(), true));
+        return md5(uniqid((string) $this->config->getClientId(), true));
     }
 }

--- a/setup/classes/class.ilSetupAgent.php
+++ b/setup/classes/class.ilSetupAgent.php
@@ -90,12 +90,7 @@ class ilSetupAgent implements Setup\Agent
                 new ilSetupConfigStoredObjective($config),
                 $config->getRegisterNIC()
                     ? new ilNICKeyRegisteredObjective($config)
-                    : new Setup\ObjectiveCollection(
-                        "",
-                        false,
-                        new ilNICKeyStoredObjective($config),
-                        new ilInstIdDefaultStoredObjective($config)
-                    )
+                    : new ilNICKeyStoredObjective($config)
             )
         );
     }
@@ -126,7 +121,8 @@ class ilSetupAgent implements Setup\Agent
             new Setup\Objective\ObjectiveWithPreconditions(
                 new ilVersionWrittenToSettingsObjective($this->data),
                 new ilNoMajorVersionSkippedConditionObjective($this->data),
-                new ilNoVersionDowngradeConditionObjective($this->data)
+                new ilNoVersionDowngradeConditionObjective($this->data),
+                new ilNICKeyRegisteredObjective($config)
             )
         ];
         if ($config !== null) {


### PR DESCRIPTION
This PR contains following adjustments/fixes:

- Before this change "nic_enabled" (true) wasn't set/updated
during the update process in the database table "settings" as it was
missing in the SetupAgent's "getUpdateObjective".

- adjust the "generateNICKey" function in ilNICKKeyStoredObjective.php
as the client id could not be found while trying to create a nic key in
case no key was saved in the database before.

- adjust "isApplicable" to run only when "inst_id" is "0".

- add a query to avoid deactivation of an registered NIC via the update
  process.

- insert "ilInstIdDefaultStoredObjective" to the NICKeyRegisteredObjective
and NICKeyStoredObjective as it the order of the steps were incorrect which
resulted to an emtpy value in the database.

- delete "ilInstIdDefaultStoredObjective" in SetupAgent's "getInstallObjective".

https://mantis.ilias.de/view.php?id=40140