### PR TITLE
UI: Add label to datatable bulk actions. Add datatable requried flag

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -17088,6 +17088,7 @@ trac#:#user_total#:#Anzahl Benutzer
 trac#:#view_mode#:#Anzeigemodus
 tstv#:#tstv_create#:#Testzertifikat erstellen
 tstv#:#tstv_create_info#:#Wählen Sie einen Test, für den Sie ein Zertifikat benötigen.
+ui#:#datatable_multiaction_label#:#Sammelaktionen
 ui#:#datatable_multiactionmodal_actionlabel#:#Aktion
 ui#:#datatable_multiactionmodal_buttonlabel#:#Ausführen
 ui#:#datatable_multiactionmodal_listentry#:#Für alle ausführen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -17089,6 +17089,7 @@ trac#:#user_total#:#User Total
 trac#:#view_mode#:#View Mode
 tstv#:#tstv_create#:#Create Test Certificate
 tstv#:#tstv_create_info#:#Select a completed test to generate a certificate for it.
+ui#:#datatable_multiaction_label#:#Bulk Actions
 ui#:#datatable_multiactionmodal_actionlabel#:#operation
 ui#:#datatable_multiactionmodal_buttonlabel#:#Execute
 ui#:#datatable_multiactionmodal_listentry#:#apply to all objects

--- a/src/UI/Implementation/Component/Table/Renderer.php
+++ b/src/UI/Implementation/Component/Table/Renderer.php
@@ -409,7 +409,7 @@ class Renderer extends AbstractComponentRenderer
                 $actions
             ),
             ""
-        );
+        )->withRequired(true);
         $submit = $f->button()->primary($this->txt('datatable_multiactionmodal_buttonlabel'), '')
             ->withOnLoadCode(
                 static fn($id): string => "$('#{$id}').click(function() { il.UI.table.data.get('{$table_id}').doActionForAll(this); return false; });"
@@ -444,7 +444,7 @@ class Renderer extends AbstractComponentRenderer
         $buttons[] = $f->divider()->horizontal();
         $buttons[] = $f->button()->shy($this->txt('datatable_multiactionmodal_listentry'), '#')->withOnClick($modal_signal);
 
-        return $f->dropdown()->standard($buttons);
+        return $f->dropdown()->standard($buttons)->withLabel($this->txt('datatable_multiaction_label'));
     }
 
     protected function getAsyncActionHandler(Component\Signal $action_signal): \Closure


### PR DESCRIPTION
Fixing Mantis Bug: https://mantis.ilias.de/view.php?id=40594
In addition with the PR #7215 this fixes one part of Mantis Bug: https://mantis.ilias.de/view.php?id=39215

This PR adds a new language variable for the bulk action dropdown of the data table.

And secondly this PR makes the Select box in the Bulk Action Modal required. This only affects the label when PR #7215 is merged and nothing else, as previous to this PR you could not submit the modal form either when no action is selected.