### PR TITLE
Change language variables for the data table bulk actions and modal

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -17153,11 +17153,11 @@ trac#:#view_mode#:#Anzeigemodus
 tstv#:#tstv_create#:#Testzertifikat erstellen
 tstv#:#tstv_create_info#:#Wählen Sie einen Test, für den Sie ein Zertifikat benötigen.
 ui#:#datatable_multiaction_label#:#Sammelaktionen
-ui#:#datatable_multiactionmodal_actionlabel#:#Aktion
-ui#:#datatable_multiactionmodal_buttonlabel#:#Ausführen
-ui#:#datatable_multiactionmodal_listentry#:#Für alle ausführen
-ui#:#datatable_multiactionmodal_msg#:#<b>Achtung!</b> mehrere Objekte betroffen
-ui#:#datatable_multiactionmodal_title#:#Aktion für mehrere Objekte
+ui#:#datatable_multiactionmodal_actionlabel#:#Aktion für alle Einträge
+ui#:#datatable_multiactionmodal_apply#:#Ausführen
+ui#:#datatable_multiactionmodal_listentry#:#Aktionen für gesamte Tabelle
+ui#:#datatable_multiactionmodal_msg#:#Die ausgewählte Aktion wirkt sich auf alle Einträge in diser Tabelle aus.
+ui#:#datatable_multiactionmodal_title#:#Aktionen für gesamte Tabelle
 ui#:#duration_default_label_end#:#Ende
 ui#:#duration_default_label_start#:#Beginn
 ui#:#duration_end_must_not_be_earlier_than_start#:#Der Beginn muss zeitlich vor dem Ende liegen.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -17154,11 +17154,11 @@ trac#:#view_mode#:#View Mode
 tstv#:#tstv_create#:#Create Test Certificate
 tstv#:#tstv_create_info#:#Select a completed test to generate a certificate for it.
 ui#:#datatable_multiaction_label#:#Bulk Actions
-ui#:#datatable_multiactionmodal_actionlabel#:#operation
-ui#:#datatable_multiactionmodal_buttonlabel#:#Execute
-ui#:#datatable_multiactionmodal_listentry#:#apply to all objects
-ui#:#datatable_multiactionmodal_msg#:#<b>Caution!</b> multiple objects affected.
-ui#:#datatable_multiactionmodal_title#:#Operation on multiple objects
+ui#:#datatable_multiactionmodal_actionlabel#:#Action for All Entries
+ui#:#datatable_multiactionmodal_apply#:#Apply
+ui#:#datatable_multiactionmodal_listentry#:#Actions for Entire Table
+ui#:#datatable_multiactionmodal_msg#:#Selected action will affect all entries in this table.
+ui#:#datatable_multiactionmodal_title#:#Actions for Entire Table
 ui#:#duration_default_label_end#:#end
 ui#:#duration_default_label_start#:#start
 ui#:#duration_end_must_not_be_earlier_than_start#:#Start must not be later than end.

--- a/src/UI/Implementation/Component/Table/Renderer.php
+++ b/src/UI/Implementation/Component/Table/Renderer.php
@@ -412,7 +412,7 @@ class Renderer extends AbstractComponentRenderer
             ),
             ""
         )->withRequired(true);
-        $submit = $f->button()->primary($this->txt('datatable_multiactionmodal_buttonlabel'), '')
+        $submit = $f->button()->primary($this->txt('datatable_multiactionmodal_apply'), '')
             ->withOnLoadCode(
                 static fn($id): string => "$('#{$id}').click(function() { il.UI.table.data.get('{$table_id}').doActionForAll(this); return false; });"
             );


### PR DESCRIPTION
This PR changes the existing language variables for the data table bulk actions and modal according to the following Mantis tickets:
For the bulk actions: https://mantis.ilias.de/view.php?id=39214
and
for the modal: https://mantis.ilias.de/view.php?id=39215