### PR TITLE
9/UI/DataTable multi select footer col 40593

### DIFF
--- a/src/UI/Implementation/Component/Table/Renderer.php
+++ b/src/UI/Implementation/Component/Table/Renderer.php
@@ -262,6 +262,8 @@ class Renderer extends AbstractComponentRenderer
                     $component->getMultiActionSignal(),
                     $modal->getShowSignal()
                 );
+                $total_number_of_cols = count($component->getVisibleColumns()) + 2; // + selection column and action dropdown column
+                $tpl->setVariable('COLUMN_COUNT', (string) $total_number_of_cols);
                 $tpl->setVariable('MULTI_ACTION_TRIGGERER', $default_renderer->render($multi_actions_dropdown));
                 $tpl->setVariable('MULTI_ACTION_ALL_MODAL', $default_renderer->render($modal));
             }

--- a/src/UI/templates/default/Table/tpl.datatable.html
+++ b/src/UI/templates/default/Table/tpl.datatable.html
@@ -42,15 +42,17 @@
 					{CELLS}
 				</tr>
 				<!-- END row -->
+				<!-- BEGIN multi_action -->
+				<tr>
+					<td class="c-table-data__cell c-table-data__cell--multiaction" colspan="{COLUMN_COUNT}">
+						<div class="c-table-data__multiaction-triggerer">{MULTI_ACTION_TRIGGERER}</div>
+						{MULTI_ACTION_ALL_MODAL}
+					</td>
+				</tr>
+				<!-- END multi_action -->
 			</tbody>
-	
 		</table>
 	</div>
-
-	<!-- BEGIN multi_action -->
-	<div class="c-table-data__multiaction-triggerer">{MULTI_ACTION_TRIGGERER}</div>
-	{MULTI_ACTION_ALL_MODAL}
-	<!-- END multi_action -->
 
 	<div class="c-table-data__async_modal_container"></div>
 

--- a/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
+++ b/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
@@ -134,6 +134,9 @@ $il-table-presentation-details-viewcontrols-btn-bg: white;
     background-color: $il-main-bg; // so sticky cells can cover up cells underneath them
     padding: $il-padding-large-vertical $il-padding-large-horizontal;
     border: 1px solid $il-main-border-color;
+    &--multiaction {
+        padding-bottom: $il-padding-xlarge-vertical;
+    }
 }
 
 // hover row on larger screens only
@@ -260,11 +263,6 @@ th.c-table-data__cell:after {
 
 .c-table-data__multiaction-triggerer {
     width: fit-content;
-}
-
-.c-table-data__multiaction-triggerer {
-    padding-top: $il-margin-large-vertical;
-    padding-left: $il-margin-large-horizontal;
 }
 
 //
@@ -412,15 +410,6 @@ td.c-table-data__cell--highlighted {
         }
         .c-table-data__rowaction {
             margin-left: auto;
-        }
-
-        //
-        // Multiaction Dropdown below table
-        //
-
-        .c-table-data__multiaction-triggerer {
-            padding-top: $il-padding-xxlarge-vertical;
-            padding-left: 0;
         }
     }
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9238,6 +9238,9 @@ div.alert ul > li:before {
   padding: 6px 12px;
   border: 1px solid #dddddd;
 }
+.c-table-data__cell--multiaction {
+  padding-bottom: 9px;
+}
 
 @media screen and (min-width: 769px) {
   .c-table-data__row:hover td.c-table-data__cell {
@@ -9339,11 +9342,6 @@ th.c-table-data__cell {
   width: fit-content;
 }
 
-.c-table-data__multiaction-triggerer {
-  padding-top: 6px;
-  padding-left: 12px;
-}
-
 .c-table-data__cell--link .c-table-data__header__resize-wrapper,
 .c-table-data__cell--linklisting .c-table-data__header__resize-wrapper,
 .c-table-data__cell--text .c-table-data__header__resize-wrapper {
@@ -9436,10 +9434,6 @@ td.c-table-data__cell--highlighted {
   }
   .c-table-data .c-table-data__rowaction {
     margin-left: auto;
-  }
-  .c-table-data .c-table-data__multiaction-triggerer {
-    padding-top: 12px;
-    padding-left: 0;
   }
 }
 


### PR DESCRIPTION
Partly fixes https://mantis.ilias.de/view.php?id=40593

# Issue

Some users have troubles recognizing that the multi-select batch action dropdown below the table belongs to it.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/1e9cd90c-b129-47f6-9b56-7d182cb66130)

# Change

The multi-select batch action dropdown is now part of the table in its own cell and row.
Exact col-span is filled into html template via php. Despite this not purely using css for a visual choice, this solution was discussed and accepted by the weekly CSS Squad in the ILIAS Discord server today.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/a09e050d-57ca-4516-9228-6b317dea49ff)

# Outlook

Lable and info text mentioned in the ticket still have to be implemented and are not included in this PR.

Unit tests do not fail despite some changes to the html structure. Maybe at least one test should be added that includes this multi-select batch actions?