### PR TITLE
9 import validation errmsg xsd missing

### DIFF
--- a/Services/Export/classes/ImportHandler/File/Path/Comparison/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/Path/Comparison/class.ilFactory.php
@@ -20,10 +20,10 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\Path\Comparison;
 
-use ILIAS\Export\ImportHandler\I\File\Path\Comparison\ilFactoryInterface as ilFilePathComparisonFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\Path\Comparison\ilHandlerInterface as ilFilePathComparisonHandlerInterface;
 use ILIAS\Export\ImportHandler\File\Path\Comparison\ilHandler as ilFilePathComparisonHandler;
 use ILIAS\Export\ImportHandler\File\Path\Comparison\Operator as ilFilePathComparisonOperator;
+use ILIAS\Export\ImportHandler\I\File\Path\Comparison\ilFactoryInterface as ilFilePathComparisonFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\Path\Comparison\ilHandlerInterface as ilFilePathComparisonHandlerInterface;
 
 class ilFactory implements ilFilePathComparisonFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/File/Path/Node/class.ilAnyElement.php
+++ b/Services/Export/classes/ImportHandler/File/Path/Node/class.ilAnyElement.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 namespace ILIAS\Export\ImportHandler\File\Path\Node;
 
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilAnyElementInterface as ilAnyElementFilePathNodeInterface;
-use XMLReader;
 
 class ilAnyElement implements ilAnyElementFilePathNodeInterface
 {

--- a/Services/Export/classes/ImportHandler/File/Path/Node/class.ilAnyNode.php
+++ b/Services/Export/classes/ImportHandler/File/Path/Node/class.ilAnyNode.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 namespace ILIAS\Export\ImportHandler\File\Path\Node;
 
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilAnyNodeInterface as ilAnyNodeFilePathNodeInterface;
-use XMLReader;
 
 class ilAnyNode implements ilAnyNodeFilePathNodeInterface
 {

--- a/Services/Export/classes/ImportHandler/File/Path/Node/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/Path/Node/class.ilFactory.php
@@ -20,7 +20,13 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\Path\Node;
 
-use ilLogger;
+use ILIAS\Export\ImportHandler\File\Path\Node\ilAnyElement as ilAnyElementFilePathNode;
+use ILIAS\Export\ImportHandler\File\Path\Node\ilAnyNode as ilAnyNodeFilePathNode;
+use ILIAS\Export\ImportHandler\File\Path\Node\ilAttribute as ilAttributeFilePathNode;
+use ILIAS\Export\ImportHandler\File\Path\Node\ilCloseRoundBracked as ilCloseRoundBrackedFilePathNode;
+use ILIAS\Export\ImportHandler\File\Path\Node\ilIndex as ilIndexFilePathNode;
+use ILIAS\Export\ImportHandler\File\Path\Node\ilOpenRoundBracked as ilOpenRoundBrackedFilePathNode;
+use ILIAS\Export\ImportHandler\File\Path\Node\ilSimple as ilSimpleFilePathNode;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilAnyElementInterface as ilAnyElementFilePathNodeInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilAnyNodeInterface as ilAnyNodeFilePathNodeInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilAttributeInterface as ilAttributeFilePathNodeInterface;
@@ -29,14 +35,7 @@ use ILIAS\Export\ImportHandler\I\File\Path\Node\ilFactoryInterface as ilFilePath
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilIndexInterface as ilIndexFilePathNodeInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilOpenRoundBrackedInterface as ilOpenRoundBrackedFilePathNodeInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilSimpleInterface as ilSimpleFilePathNodeInterface;
-use ILIAS\Export\ImportHandler\File\Path\Node\ilAnyElement as ilAnyElementFilePathNode;
-use ILIAS\Export\ImportHandler\File\Path\Node\ilAnyNode as ilAnyNodeFilePathNode;
-use ILIAS\Export\ImportHandler\File\Path\Node\ilAttribute as ilAttributeFilePathNode;
-use ILIAS\Export\ImportHandler\File\Path\Node\ilFactory as ilFilePathNodeFactory;
-use ILIAS\Export\ImportHandler\File\Path\Node\ilIndex as ilIndexFilePathNode;
-use ILIAS\Export\ImportHandler\File\Path\Node\ilSimple as ilSimpleFilePathNode;
-use ILIAS\Export\ImportHandler\File\Path\Node\ilOpenRoundBracked as ilOpenRoundBrackedFilePathNode;
-use ILIAS\Export\ImportHandler\File\Path\Node\ilCloseRoundBracked as ilCloseRoundBrackedFilePathNode;
+use ilLogger;
 
 class ilFactory implements ilFilePathNodeFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/File/Path/Node/class.ilSimple.php
+++ b/Services/Export/classes/ImportHandler/File/Path/Node/class.ilSimple.php
@@ -20,9 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\Path\Node;
 
-use ilLogger;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilSimpleInterface as ilSimpleFilePathNodeInterface;
-use XMLReader;
 
 class ilSimple implements ilSimpleFilePathNodeInterface
 {

--- a/Services/Export/classes/ImportHandler/File/Path/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/Path/class.ilFactory.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\Path;
 
-use ilLogger;
 use ILIAS\Export\ImportHandler\File\Path\Comparison\ilHandler as ilFilePathComparison;
 use ILIAS\Export\ImportHandler\File\Path\Comparison\Operator as ilFilePathComparisonOperator;
 use ILIAS\Export\ImportHandler\File\Path\ilHandler as ilFilePathHandler;
@@ -29,6 +28,7 @@ use ILIAS\Export\ImportHandler\I\File\Path\Comparison\ilHandlerInterface as ilFi
 use ILIAS\Export\ImportHandler\I\File\Path\ilFactoryInterface as ilFilePAthFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilFilePathHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilFactoryInterface as ilFilePathNodeFactoryInterface;
+use ilLogger;
 
 class ilFactory implements ilFilePathFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/File/Path/class.ilHandler.php
+++ b/Services/Export/classes/ImportHandler/File/Path/class.ilHandler.php
@@ -20,8 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\Path;
 
-use ILIAS\Export\ImportHandler\I\File\Path\Node\ilNodeInterface as ilFilePathNodeInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilParserPathHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\Path\Node\ilNodeInterface as ilFilePathNodeInterface;
 
 class ilHandler implements ilParserPathHandlerInterface
 {

--- a/Services/Export/classes/ImportHandler/File/Validation/Set/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/Validation/Set/class.ilFactory.php
@@ -20,11 +20,11 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\Validation\Set;
 
+use ILIAS\Export\ImportHandler\File\Validation\Set\ilCollection as ilFileValidationSetCollection;
+use ILIAS\Export\ImportHandler\File\Validation\Set\ilHandler as ilFileValidationSetHandler;
 use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilCollectionInterface as ilFileValidationSetCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilFactoryInterface as ilFileValidationSetFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilHandlerInterface as ilFileValidationSetInterface;
-use ILIAS\Export\ImportHandler\File\Validation\Set\ilCollection as ilFileValidationSetCollection;
-use ILIAS\Export\ImportHandler\File\Validation\Set\ilHandler as ilFileValidationSetHandler;
 
 class ilFactory implements ilFileValidationSetFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/File/Validation/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/Validation/class.ilFactory.php
@@ -20,39 +20,33 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\Validation;
 
-use ilLogger;
+use ILIAS\Export\ImportHandler\File\Path\ilFactory as ilFilePathFactory;
 use ILIAS\Export\ImportHandler\File\Validation\ilHandler as ilFileValidationHandler;
-use ILIAS\Export\ImportHandler\I\File\Path\ilFactoryInterface as ilFilePathFactoryInterface;
+use ILIAS\Export\ImportHandler\File\Validation\Set\ilFactory as ilFileValidationSetFactory;
 use ILIAS\Export\ImportHandler\I\File\Validation\ilFactoryInterface as ilFileValidationFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\Validation\ilHandlerInterface as ilFileValidationHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilFactoryInterface as ilFileValidationSetFactoryInterface;
-use ILIAS\Export\ImportHandler\I\Parser\ilFactoryInterface as ilParserFactoryInterface;
+use ILIAS\Export\ImportHandler\Parser\ilFactory as ilParserFactory;
 use ILIAS\Export\ImportStatus\ilFactory as ilImportStatusFactory;
-use ILIAS\Export\ImportHandler\File\Validation\Set\ilFactory as ilFileValidationSetFactory;
+use ilLogger;
 
 class ilFactory implements ilFileValidationFactoryInterface
 {
     protected ilLogger $logger;
-    protected ilParserFactoryInterface $parser;
-    protected ilFilePathFactoryInterface $path;
 
     public function __construct(
         ilLogger $logger,
-        ilParserFactoryInterface $parser,
-        ilFilePathFactoryInterface $path
     ) {
         $this->logger = $logger;
-        $this->parser = $parser;
-        $this->path = $path;
     }
 
     public function handler(): ilFileValidationHandlerInterface
     {
         return new ilFileValidationHandler(
             $this->logger,
-            $this->parser,
+            new ilParserFactory($this->logger),
             new ilImportStatusFactory(),
-            $this->path
+            new ilFilePathFactory($this->logger)
         );
     }
 

--- a/Services/Export/classes/ImportHandler/File/Validation/class.ilHandler.php
+++ b/Services/Export/classes/ImportHandler/File/Validation/class.ilHandler.php
@@ -22,27 +22,27 @@ namespace ILIAS\Export\ImportHandler\File\Validation;
 
 use DOMDocument;
 use Exception;
-use ilLogger;
-use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilCollectionInterface as ilFileValidationSetCollectionInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilCollectionInterface as ilXMLFileNodeInfoCollection;
 use ILIAS\Export\ImportHandler\I\File\ilHandlerInterface as ilFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\ilFactoryInterface as ilFilePathFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilFilePathHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\Validation\ilHandlerInterface as ilFileValidationHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilCollectionInterface as ilFileValidationSetCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilCollectionInterface as ilXMLFileNodeInfoCollection;
 use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\Parser\ilFactoryInterface as ilParserFactoryInterface;
 use ILIAS\Export\ImportStatus\Exception\ilException as ilImportStatusException;
-use ILIAS\Export\ImportStatus\I\ilFactoryInterface as ilImportStatusFactoryInterface;
 use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusHandlerCollectionInterface;
+use ILIAS\Export\ImportStatus\I\ilFactoryInterface as ilImportStatusFactoryInterface;
 use ILIAS\Export\ImportStatus\I\ilHandlerInterface as ilImportStatusHandlerInterface;
 use ILIAS\Export\ImportStatus\StatusType;
+use ilLogger;
 use LibXMLError;
 
 class ilHandler implements ilFileValidationHandlerInterface
 {
-    protected const TMP_DIR_NAME = 'temp';
-    protected const XML_DIR_NAME = 'xml';
+    public const TMP_DIR_NAME = 'temp';
+    public const XML_DIR_NAME = 'xml';
 
     protected ilLogger $logger;
     protected ilImportStatusFactoryInterface $import_status;

--- a/Services/Export/classes/ImportHandler/File/XML/Export/Component/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Export/Component/class.ilFactory.php
@@ -20,29 +20,34 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Export\Component;
 
-use ilLogger;
 use ILIAS\Export\ImportHandler\File\Namespace\ilFactory as ilFileNamespaceFactory;
 use ILIAS\Export\ImportHandler\File\Path\ilFactory as ilFilePathFactory;
-use ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute\ilFactory as ilXMLNodeInfoAttributeFactory;
-use ILIAS\Export\ImportHandler\File\XSD\ilFactory as ilXSDFileFactory;
-use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilFilePathHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Export\Component\ilFactoryInterface as ilComponentXMLExportFileFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Export\Component\ilHandlerInterface as ilComponentXMLExportFileHandlerInterface;
+use ILIAS\Export\ImportHandler\File\Validation\Set\ilFactory as ilFileValidationSetFactory;
 use ILIAS\Export\ImportHandler\File\XML\Export\Component\ilHandler as ilComponentXMLExportFileHandler;
+use ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute\ilFactory as ilXMLNodeInfoAttributeFactory;
+use ILIAS\Export\ImportHandler\File\XML\Schema\ilFactory as ilXMLFileSchemaFactory;
+use ILIAS\Export\ImportHandler\I\File\XML\Export\Component\ilFactoryInterface as ilComponentXMLExportFileFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Export\Component\ilHandlerInterface as ilComponentXMLExportFileHandlerInterface;
 use ILIAS\Export\ImportHandler\Parser\ilFactory as ilParserFactory;
 use ILIAS\Export\ImportStatus\ilFactory as ilImportStatusFactory;
 use ILIAS\Export\Schema\ilXmlSchemaFactory;
-use ILIAS\Export\ImportHandler\File\Validation\Set\ilFactory as ilFileValidationSetFactory;
+use ilLanguage;
+use ilLogger;
 
 class ilFactory implements ilComponentXMLExportFileFactoryInterface
 {
     protected ilLogger $logger;
+    protected ilLanguage $lng;
+    protected ilXmlSchemaFactory $schema_factory;
 
     public function __construct(
-        ilLogger $logger
+        ilLogger $logger,
+        ilLanguage $lng,
+        ilXmlSchemaFactory $schema_factory
     ) {
         $this->logger = $logger;
+        $this->lng = $lng;
+        $this->schema_factory = $schema_factory;
     }
 
     public function handler(): ilComponentXMLExportFileHandlerInterface
@@ -50,13 +55,17 @@ class ilFactory implements ilComponentXMLExportFileFactoryInterface
         return new ilComponentXMLExportFileHandler(
             new ilFileNamespaceFactory(),
             new ilImportStatusFactory(),
-            new ilXmlSchemaFactory(),
+            new ilXMLFileSchemaFactory(
+                $this->logger,
+                $this->lng,
+                $this->schema_factory
+            ),
             new ilParserFactory($this->logger),
-            new ilXSDFileFactory(),
             new ilFilePathFactory($this->logger),
             $this->logger,
             new ilXMLNodeInfoAttributeFactory($this->logger),
-            new ilFileValidationSetFactory()
+            new ilFileValidationSetFactory(),
+            $this->lng
         );
     }
 }

--- a/Services/Export/classes/ImportHandler/File/XML/Export/DataSet/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Export/DataSet/class.ilFactory.php
@@ -20,27 +20,34 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Export\DataSet;
 
-use ilLogger;
 use ILIAS\Export\ImportHandler\File\Namespace\ilFactory as ilFileNamespaceFactory;
 use ILIAS\Export\ImportHandler\File\Path\ilFactory as ilFilePathFactory;
+use ILIAS\Export\ImportHandler\File\Validation\Set\ilFactory as ilFileValidationSetFactory;
+use ILIAS\Export\ImportHandler\File\XML\Export\DataSet\ilHandler as ilDatasetXMLExportFileHandler;
 use ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute\ilFactory as ilXMLNodeInfoAttributeFactory;
-use ILIAS\Export\ImportHandler\File\XSD\ilFactory as ilXSDFileFactory;
+use ILIAS\Export\ImportHandler\File\XML\Schema\ilFactory as ilXMLFileSchemaFactory;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\DataSet\ilFactoryInterface as ilDataSetXMLExportFileFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\DataSet\ilHandlerInterface as ilDatasetXMLExportFileHandlerInterface;
-use ILIAS\Export\ImportHandler\File\XML\Export\DataSet\ilHandler as ilDatasetXMLExportFileHandler;
 use ILIAS\Export\ImportHandler\Parser\ilFactory as ilParserFactory;
 use ILIAS\Export\ImportStatus\ilFactory as ilImportStatusFactory;
-use ILIAS\Export\ImportHandler\File\Validation\Set\ilFactory as ilFileValidationSetFactory;
 use ILIAS\Export\Schema\ilXmlSchemaFactory;
+use ilLanguage;
+use ilLogger;
 
 class ilFactory implements ilDataSetXMLExportFileFactoryInterface
 {
     protected ilLogger $logger;
+    protected ilLanguage $lng;
+    protected ilXmlSchemaFactory $schema_factory;
 
     public function __construct(
-        ilLogger $logger
+        ilLogger $logger,
+        ilLanguage $lng,
+        ilXmlSchemaFactory $schema_factory
     ) {
         $this->logger = $logger;
+        $this->lng = $lng;
+        $this->schema_factory = $schema_factory;
     }
 
     public function handler(): ilDatasetXMLExportFileHandlerInterface
@@ -48,13 +55,17 @@ class ilFactory implements ilDataSetXMLExportFileFactoryInterface
         return new ilDatasetXMLExportFileHandler(
             new ilFileNamespaceFactory(),
             new ilImportStatusFactory(),
-            new ilXmlSchemaFactory(),
+            new ilXMLFileSchemaFactory(
+                $this->logger,
+                $this->lng,
+                $this->schema_factory
+            ),
             new ilParserFactory($this->logger),
-            new ilXSDFileFactory(),
             new ilFilePathFactory($this->logger),
             $this->logger,
             new ilXMLNodeInfoAttributeFactory($this->logger),
-            new ilFileValidationSetFactory()
+            new ilFileValidationSetFactory(),
+            $this->lng
         );
     }
 }

--- a/Services/Export/classes/ImportHandler/File/XML/Export/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Export/class.ilFactory.php
@@ -20,32 +20,33 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Export;
 
-use ilLogger;
+use ILIAS\Export\ImportHandler\File\XML\Export\Component\ilFactory as ilComponentXMLExportFileFactory;
+use ILIAS\Export\ImportHandler\File\XML\Export\DataSet\ilFactory as ilDataSetXMLExportFileFactory;
+use ILIAS\Export\ImportHandler\File\XML\Export\ilCollection as ilXMLExportFileHandlerCollection;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\Component\ilFactoryInterface as ilComponentXMLExportFileHandlerFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\DataSet\ilFactoryInterface as ilDataSetXMLExportFileHandlerFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\ilCollectionInterface as ilXMLExportFileCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\ilFactoryInterface as ilXMLExportFileFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\ilHandlerInterface as ilXMLExportFileHandlerInterface;
-use ILIAS\Export\ImportHandler\File\XML\Export\ilHandler as ilXMLExportFileHanlder;
-use ILIAS\Export\ImportStatus\ilFactory as ilImportStatusFactory;
-use ILIAS\Export\ImportHandler\File\Path\ilFactory as ilFilePathFactory;
-use ILIAS\Export\ImportHandler\Parser\ilFactory as ilParserFactory;
-use ILIAS\Export\ImportHandler\File\XSD\ilFactory as ilXSDFileFactory;
-use ILIAS\Export\ImportHandler\File\XML\Export\ilCollection as ilXMLExportFileHandlerCollection;
 use ILIAS\Export\Schema\ilXmlSchemaFactory;
-use ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute\ilFactory as ilXMLNodeInfoAttributeFactory;
-use ILIAS\Export\ImportHandler\File\Namespace\ilFactory as ilFileNamespaceFactory;
+use ilLanguage;
+use ilLogger;
 use SplFileInfo;
-use ILIAS\Export\ImportHandler\File\XML\Export\Component\ilFactory as ilComponentXMLExportFileFactory;
-use ILIAS\Export\ImportHandler\File\XML\Export\DataSet\ilFactory as ilDataSetXMLExportFileFactory;
 
 class ilFactory implements ilXMLExportFileFactoryInterface
 {
-    public ilLogger $logger;
+    protected ilLogger $logger;
+    protected ilLanguage $lng;
+    protected ilXmlSchemaFactory $schema_factory;
 
-    public function __construct(ilLogger $logger)
-    {
+    public function __construct(
+        ilLogger $logger,
+        ilLanguage $lng,
+        ilXmlSchemaFactory $schema_factory
+    ) {
         $this->logger = $logger;
+        $this->lng = $lng;
+        $this->schema_factory = $schema_factory;
     }
 
     public function withFileInfo(SplFileInfo $file_info): ilXMLExportFileHandlerInterface
@@ -65,11 +66,19 @@ class ilFactory implements ilXMLExportFileFactoryInterface
 
     public function component(): ilComponentXMLExportFileHandlerFactoryInterface
     {
-        return new ilComponentXMLExportFileFactory($this->logger);
+        return new ilComponentXMLExportFileFactory(
+            $this->logger,
+            $this->lng,
+            $this->schema_factory
+        );
     }
 
     public function dataSet(): ilDataSetXMLExportFileHandlerFactoryInterface
     {
-        return new ilDataSetXMLExportFileFactory($this->logger);
+        return new ilDataSetXMLExportFileFactory(
+            $this->logger,
+            $this->lng,
+            $this->schema_factory
+        );
     }
 }

--- a/Services/Export/classes/ImportHandler/File/XML/Export/class.ilHandler.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Export/class.ilHandler.php
@@ -69,6 +69,7 @@ abstract class ilHandler extends ilXMLFileHandler implements ilXMLExportFileHand
         $this->path = $path;
         $this->attribute = $attribute;
         $this->set = $set;
+        $this->lng = $lng;
     }
 
     /**
@@ -129,7 +130,7 @@ abstract class ilHandler extends ilXMLFileHandler implements ilXMLExportFileHand
     ): ilImportStatusHandlerInterface {
         $xml_str = "<br>XML-File: " . $xml_file_handler->getSubPathToDirBeginningAtPathEnd(ilFileValidationHandler::TMP_DIR_NAME)->getFilePath();
         $xsd_str = "<br>XSD-File: " . $xsd_file_handler->getSubPathToDirBeginningAtPathEnd(ilFileValidationHandler::XML_DIR_NAME)->getFilePath();
-        $msg = "No valid schema file for version " . $version_str . " exists.";
+        $msg = sprintf($this->lng->txt('exp_import_validation_err_no_matching_xsd'), $version_str);
         $content = $this->status->content()->builder()->string()->withString(
             "Validation FAILED"
             . $xml_str

--- a/Services/Export/classes/ImportHandler/File/XML/Export/class.ilHandler.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Export/class.ilHandler.php
@@ -21,54 +21,50 @@ declare(strict_types=1);
 namespace ILIAS\Export\ImportHandler\File\XML\Export;
 
 use ilDataSet;
-use ILIAS\BookingManager\getObjectSettingsCommand;
-use ilLogger;
+use ILIAS\Export\ImportHandler\File\Validation\ilHandler as ilFileValidationHandler;
 use ILIAS\Export\ImportHandler\File\XML\ilHandler as ilXMLFileHandler;
-use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilCollectionInterface as ilFileValidationSetCollectionInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Export\ilHandlerInterface as ilXMLExportFileHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilTreeInterface as ilXMLFileNodeInfoTreeInterface;
-use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
-use ILIAS\Export\ImportStatus\Exception\ilException as ilImportStatusException;
-use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusCollectionInterface;
-use ILIAS\Export\ImportStatus\I\ilFactoryInterface as ilImportStatusFactoryInterface;
-use ILIAS\Export\ImportHandler\I\Parser\ilFactoryInterface as ilParserFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\XSD\ilFactoryInterface as ilXSDFileFactoryInterface;
-use ILIAS\Export\ImportStatus\StatusType;
-use ILIAS\Export\ImportHandler\I\File\Path\ilFactoryInterface as ilFilePathFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilFilePathHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilFactoryInterface as ilXMlFileInfoNodeAttributeFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilHandlerInterface as ilXMLFileNodeInfoInterface;
 use ILIAS\Export\ImportHandler\I\File\Namespace\ilFactoryInterface as ilFileNamespaceHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\Path\ilFactoryInterface as ilFilePathFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilFactoryInterface as ilFileValidationSetFactoryInterface;
-use ILIAS\Export\Schema\ilXmlSchemaFactory;
-use ILIAS\Data\Version;
+use ILIAS\Export\ImportHandler\I\File\XML\Export\ilHandlerInterface as ilXMLExportFileHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilFactoryInterface as ilXMlFileInfoNodeAttributeFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilTreeInterface as ilXMLFileNodeInfoTreeInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilFactoryInterface as ilXMLFileSchemaFactory;
+use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
+use ILIAS\Export\ImportHandler\I\Parser\ilFactoryInterface as ilParserFactoryInterface;
+use ILIAS\Export\ImportStatus\Exception\ilException as ilImportStatusException;
+use ILIAS\Export\ImportStatus\I\ilFactoryInterface as ilImportStatusFactoryInterface;
+use ILIAS\Export\ImportStatus\I\ilHandlerInterface as ilImportStatusHandlerInterface;
+use ILIAS\Export\ImportStatus\StatusType;
+use ilLanguage;
+use ilLogger;
 use SplFileInfo;
 
 abstract class ilHandler extends ilXMLFileHandler implements ilXMLExportFileHandlerInterface
 {
-    protected ilXmlSchemaFactory $schema;
+    protected ilXMLFileSchemaFactory $schema;
     protected ilParserFactoryInterface $parser;
-    protected ilXSDFileFactoryInterface $xsd_file;
     protected ilFilePathFactoryInterface $path;
     protected ilXMlFileInfoNodeAttributeFactoryInterface $attribute;
     protected ilFileValidationSetFactoryInterface $set;
     protected ilLogger $logger;
+    protected ilLanguage $lng;
 
     public function __construct(
         ilFileNamespaceHandlerInterface $namespace,
         ilImportStatusFactoryInterface $status,
-        ilXmlSchemaFactory $schema,
+        ilXMLFileSchemaFactory $schema,
         ilParserFactoryInterface $parser,
-        ilXSDFileFactoryInterface $xsd_file,
         ilFilePathFactoryInterface $path,
         ilLogger $logger,
         ilXMlFileInfoNodeAttributeFactoryInterface $attribute,
-        ilFileValidationSetFactoryInterface $set
+        ilFileValidationSetFactoryInterface $set,
+        ilLanguage $lng
     ) {
         parent::__construct($namespace, $status);
         $this->schema = $schema;
         $this->parser = $parser;
-        $this->xsd_file = $xsd_file;
         $this->logger = $logger;
         $this->path = $path;
         $this->attribute = $attribute;
@@ -124,5 +120,24 @@ abstract class ilHandler extends ilXMLFileHandler implements ilXMLExportFileHand
             return false;
         }
         return count($nodes) > 0;
+    }
+
+    protected function getFailMsgNoMatchingVersionFound(
+        ilXMLFileHandlerInterface $xml_file_handler,
+        ilXSDFileHandlerInterface $xsd_file_handler,
+        string $version_str
+    ): ilImportStatusHandlerInterface {
+        $xml_str = "<br>XML-File: " . $xml_file_handler->getSubPathToDirBeginningAtPathEnd(ilFileValidationHandler::TMP_DIR_NAME)->getFilePath();
+        $xsd_str = "<br>XSD-File: " . $xsd_file_handler->getSubPathToDirBeginningAtPathEnd(ilFileValidationHandler::XML_DIR_NAME)->getFilePath();
+        $msg = "No valid schema file for version " . $version_str . " exists.";
+        $content = $this->status->content()->builder()->string()->withString(
+            "Validation FAILED"
+            . $xml_str
+            . $xsd_str
+            . "<br>ERROR Message: " . $msg
+        );
+        return $this->status->handler()
+            ->withType(StatusType::FAILED)
+            ->withContent($content);
     }
 }

--- a/Services/Export/classes/ImportHandler/File/XML/Manifest/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Manifest/class.ilFactory.php
@@ -20,43 +20,44 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Manifest;
 
-use ilLogger;
-use ILIAS\Export\ImportHandler\File\XML\Manifest\ilHandler as ilManifestXMLFileHandler;
-use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilFactoryInterface as ilManifestFileFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\ilFactoryInterface as ilFileFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerCollectionInterface as ilManifestXMLFileHandlerCollectionInterface;
-use ILIAS\Export\ImportHandler\File\XML\Manifest\ilHandlerCollection as ilManifestXMLFileHandlerCollection;
-use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerInterface as ilManifestXMLFileHandlerInterface;
-use ILIAS\Export\ImportHandler\I\Parser\ilFactoryInterface as ilParserFactoryInterface;
+use ILIAS\Export\ImportHandler\File\ilFactory as ilFileFactory;
 use ILIAS\Export\ImportHandler\File\Namespace\ilFactory as ilFileNamespaceFactory;
+use ILIAS\Export\ImportHandler\File\XML\Manifest\ilHandler as ilManifestXMLFileHandler;
+use ILIAS\Export\ImportHandler\File\XML\Manifest\ilHandlerCollection as ilManifestXMLFileHandlerCollection;
+use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilFactoryInterface as ilManifestFileFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerCollectionInterface as ilManifestXMLFileHandlerCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerInterface as ilManifestXMLFileHandlerInterface;
+use ILIAS\Export\ImportHandler\Parser\ilFactory as ilParserFactory;
 use ILIAS\Export\ImportStatus\ilFactory as ilImportStatusFactory;
 use ILIAS\Export\Schema\ilXmlSchemaFactory;
+use ilLanguage;
+use ilLogger;
 use SplFileInfo;
 
 class ilFactory implements ilManifestFileFactoryInterface
 {
     protected ilLogger $logger;
-    protected ilFileFactoryInterface $file;
-    protected ilParserFactoryInterface $parser;
+    protected ilLanguage $lng;
+    protected ilXmlSchemaFactory $schema_factory;
 
     public function __construct(
-        ilFileFactoryInterface $file,
-        ilParserFactoryInterface $parser,
-        ilLogger $logger
+        ilLogger $logger,
+        ilLanguage $lng,
+        ilXmlSchemaFactory $schema_factory
     ) {
         $this->logger = $logger;
-        $this->file = $file;
-        $this->parser = $parser;
+        $this->lng = $lng;
+        $this->schema_factory = $schema_factory;
     }
 
     public function handler(): ilManifestXMLFileHandlerInterface
     {
         return new ilManifestXMLFileHandler(
             new ilFileNamespaceFactory(),
-            new ilXmlSchemaFactory(),
+            $this->schema_factory,
             new ilImportStatusFactory(),
-            $this->file,
-            $this->parser,
+            new ilFileFactory($this->logger, $this->lng, $this->schema_factory),
+            new ilParserFactory($this->logger),
             $this->logger,
         );
     }
@@ -65,10 +66,10 @@ class ilFactory implements ilManifestFileFactoryInterface
     {
         return (new ilManifestXMLFileHandler(
             new ilFileNamespaceFactory(),
-            new ilXmlSchemaFactory(),
+            $this->schema_factory,
             new ilImportStatusFactory(),
-            $this->file,
-            $this->parser,
+            new ilFileFactory($this->logger, $this->lng, $this->schema_factory),
+            new ilParserFactory($this->logger),
             $this->logger,
         ))->withFileInfo($file_info);
     }

--- a/Services/Export/classes/ImportHandler/File/XML/Manifest/class.ilHandler.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Manifest/class.ilHandler.php
@@ -20,22 +20,20 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Manifest;
 
-use ilImportException;
-use ilLogger;
 use ILIAS\Export\ImportHandler\File\ilFactory as ilFileFactory;
 use ILIAS\Export\ImportHandler\File\XML\ilHandler as ilXMLFileHandler;
+use ILIAS\Export\ImportHandler\I\File\Namespace\ilFactoryInterface as ilFileNamespaceFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\ilCollectionInterface as ilXMLExportFileCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerCollectionInterface as ilManifestXMLFileHandlerCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerInterface as ilManifestHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
-use ILIAS\Export\ImportHandler\Parser\ilFactory as ilParserFactory;
 use ILIAS\Export\ImportHandler\I\Parser\ilHandlerInterface as ilParserHandler;
-use ILIAS\Export\ImportStatus\I\ilFactoryInterface as ilImportStatusFactoryInterface;
-use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusHandlerCollectionInterface;
+use ILIAS\Export\ImportHandler\Parser\ilFactory as ilParserFactory;
 use ILIAS\Export\ImportStatus\Exception\ilException as ilImportStatusException;
-use ILIAS\Export\ImportStatus\StatusType;
-use ILIAS\Export\ImportHandler\I\File\Namespace\ilFactoryInterface as ilFileNamespaceFactoryInterface;
+use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusHandlerCollectionInterface;
+use ILIAS\Export\ImportStatus\I\ilFactoryInterface as ilImportStatusFactoryInterface;
 use ILIAS\Export\Schema\ilXmlSchemaFactory;
+use ilLogger;
 use SplFileInfo;
 
 class ilHandler extends ilXMLFileHandler implements ilManifestHandlerInterface

--- a/Services/Export/classes/ImportHandler/File/XML/Manifest/class.ilHandlerCollection.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Manifest/class.ilHandlerCollection.php
@@ -20,8 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Manifest;
 
-use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerInterface as ilManifestXMLFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerCollectionInterface as ilManifestXMLFileHandlerCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerInterface as ilManifestXMLFileHandlerInterface;
 use ILIAS\Export\ImportStatus\Exception\ilException as ilImportStatusException;
 use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusHandlerCollectionInterface;
 use ILIAS\Export\ImportStatus\I\ilFactoryInterface as ilImportStatusFactoryInterface;

--- a/Services/Export/classes/ImportHandler/File/XML/Node/Info/Attribute/class.ilCollection.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Node/Info/Attribute/class.ilCollection.php
@@ -20,10 +20,10 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute;
 
-use ilLogger;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilCollectionInterface as ilXMLFileNodeInfoAttributeCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilPairInterface as ilXMLFileNodeInfoAttributePairInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilHandlerInterface as ilXMLFileNodeInfoInterface;
+use ilLogger;
 
 class ilCollection implements ilXMLFileNodeInfoAttributeCollectionInterface
 {

--- a/Services/Export/classes/ImportHandler/File/XML/Node/Info/Attribute/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Node/Info/Attribute/class.ilFactory.php
@@ -20,12 +20,12 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute;
 
-use ilLogger;
+use ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute\ilCollection as ilXMLFileNodeInfoAttribureCollection;
+use ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute\ilPair as ilXMLFileNodeInfoAttributePair;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilCollectionInterface as ilXMLFileNodeInfoAttributeCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilFactoryInterface as ilXMLFileNodeInfoAttributeFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilPairInterface as ilXMLFileNodeInfoAttributePairInterface;
-use ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute\ilPair as ilXMLFileNodeInfoAttributePair;
-use ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute\ilCollection as ilXMLFileNodeInfoAttribureCollection;
+use ilLogger;
 
 class ilFactory implements ilXMLFileNodeInfoAttributeFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/File/XML/Node/Info/DOM/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Node/Info/DOM/class.ilFactory.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
 namespace ILIAS\Export\ImportHandler\File\XML\Node\Info\DOM;
 
 use DOMNode;
+use ILIAS\Export\ImportHandler\File\XML\Node\Info\DOM\ilHandler as ilXMLFileDOMNodeInfoHandler;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\DOM\ilFactoryInterface as ilXMLFileDOMNodeInfoFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\DOM\ilHandlerInterface as ilXMLFileNodeInfoDOMNodeHandlerInterface;
-use ILIAS\Export\ImportHandler\File\XML\Node\Info\DOM\ilHandler as ilXMLFileDOMNodeInfoHandler;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilFactoryInterface as ilXMLFileNodeInfoFactoryInterface;
 
 class ilFactory implements ilXMLFileDOMNodeInfoFactoryInterface

--- a/Services/Export/classes/ImportHandler/File/XML/Node/Info/DOM/class.ilHandler.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Node/Info/DOM/class.ilHandler.php
@@ -22,10 +22,10 @@ namespace ILIAS\Export\ImportHandler\File\XML\Node\Info\DOM;
 
 use DOMAttr;
 use DOMNode;
-use ilImportException;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\DOM\ilHandlerInterface as ilXMLFileNodeInfoilDOMNodeHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilCollectionInterface as ilXMLFileNodeInfoCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilFactoryInterface as ilXMLFileNodeInfoFactoryInterface;
+use ilImportException;
 
 class ilHandler implements ilXMLFileNodeInfoilDOMNodeHandlerInterface
 {

--- a/Services/Export/classes/ImportHandler/File/XML/Node/Info/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Node/Info/class.ilFactory.php
@@ -20,9 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Node\Info;
 
-use DOMNode;
-use ilLogger;
 use ILIAS\Export\ImportHandler\File\XML\Node\Info\Attribute\ilFactory as ilXMLFileNodeInfoAttributeFactory;
+use ILIAS\Export\ImportHandler\File\XML\Node\Info\DOM\ilFactory as ilXMLFileDOMNodeInfoFactory;
 use ILIAS\Export\ImportHandler\File\XML\Node\Info\ilCollection as ilFileNodeInfoCollection;
 use ILIAS\Export\ImportHandler\File\XML\Node\Info\ilTree as ilXMLFileNodeInfoTree;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilFactoryInterface as ilXMLFileNodeInfoAttributeFactoryInterface;
@@ -31,7 +30,7 @@ use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilCollectionInterface as ilX
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilFactoryInterface as ilXMLFileNodeInfoFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilTreeInterface as ilXMLFileNodeInfoTreeInterface;
 use ILIAS\Export\ImportHandler\Parser\ilFactory as ilParserFactory;
-use ILIAS\Export\ImportHandler\File\XML\Node\Info\DOM\ilFactory as ilXMLFileDOMNodeInfoFactory;
+use ilLogger;
 
 class ilFactory implements ilXMLFileNodeInfoFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/File/XML/Node/Info/class.ilTree.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Node/Info/class.ilTree.php
@@ -20,17 +20,16 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Node\Info;
 
-use ilLogger;
 use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilXMLFilePathHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilPairInterface as ilXMLFileNodeInfoAttributePairInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilCollectionInterface as ilXMLFileNodeInfoAttributePairCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilCollectionInterface as ilXMLFileNodeInfoCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilFactoryInterface as ilXMLFileNodeInfoFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilHandlerInterface as ilXMLFileNodeInfoInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilTreeInterface as ilXMLFileNodeInfoTreeInterface;
 use ILIAS\Export\ImportHandler\I\Parser\ilFactoryInterface as ilParserFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilCollectionInterface as ilXMLFileNodeInfoAttributePairCollectionInterface;
 use ILIAS\Export\ImportStatus\Exception\ilException as ilImportStatusException;
+use ilLogger;
 
 class ilTree implements ilXMLFileNodeInfoTreeInterface
 {

--- a/Services/Export/classes/ImportHandler/File/XML/Node/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Node/class.ilFactory.php
@@ -20,10 +20,10 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML\Node;
 
-use ilLogger;
+use ILIAS\Export\ImportHandler\File\XML\Node\Info\ilFactory as ilXMLFileNodeInfo;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\ilFactoryInterface as ilXMLFileNodeFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilFactoryInterface as ilXMLFileNodeInfoInterface;
-use ILIAS\Export\ImportHandler\File\XML\Node\Info\ilFactory as ilXMLFileNodeInfo;
+use ilLogger;
 
 class ilFactory implements ilXMLFileNodeFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/File/XML/Schema/class.ilCollection.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Schema/class.ilCollection.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Export\ImportHandler\File\XML\Schema;
+
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilCollectionInterface as ilXMLFileSchemaCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilHandlerInterface as ilXMLFileSchemaHandlerInterface;
+
+class ilCollection implements ilXMLFileSchemaCollectionInterface
+{
+    /**
+     * @var ilXMLFileSchemaHandlerInterface[]
+     */
+    protected array $elements;
+    protected int $index;
+
+    public function __construct()
+    {
+        $this->elements = [];
+        $this->index = 0;
+    }
+
+    public function count(): int
+    {
+        return count($this->elements);
+    }
+
+    public function withElement(ilXMLFileSchemaHandlerInterface $element): ilXMLFileSchemaCollectionInterface
+    {
+        $clone = clone $this;
+        $clone->elements[] = $element;
+        return $clone;
+    }
+
+    public function withMerged(ilXMLFileSchemaCollectionInterface $other): ilXMLFileSchemaCollectionInterface
+    {
+        $clone = clone $this;
+        $clone->elements = array_merge($clone->elements, $other->toArray());
+        return $clone;
+    }
+
+    public function toArray(): array
+    {
+        return $this->elements;
+    }
+
+    public function current(): ilXMLFileSchemaHandlerInterface
+    {
+        return $this->elements[$this->index];
+    }
+
+    public function next(): void
+    {
+        $this->index++;
+    }
+
+    public function key(): int
+    {
+        return $this->index;
+    }
+
+    public function valid(): bool
+    {
+        return 0 <= $this->index && $this->index < count($this->elements);
+    }
+
+    public function rewind(): void
+    {
+        $this->index = 0;
+    }
+}

--- a/Services/Export/classes/ImportHandler/File/XML/Schema/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Schema/class.ilFactory.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Export\ImportHandler\File\XML\Schema;
+
+use ILIAS\Data\Version;
+use ILIAS\Export\ImportHandler\File\Path\ilFactory as ilFilePathFactory;
+use ILIAS\Export\ImportHandler\File\XML\Schema\ilCollection as ilXMLFileSchemaCollection;
+use ILIAS\Export\ImportHandler\File\XML\Schema\ilHandler as ilXMLFileSchemaHandler;
+use ILIAS\Export\ImportHandler\File\XSD\ilFactory as ilXSDFileFactory;
+use ILIAS\Export\ImportHandler\I\File\Path\ilFactoryInterface as ilFilePathFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilFilePathHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilXMLFilePathHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilHandlerInterface as ilXMLFileNodeInfoHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilCollectionInterface as ilXMLFileSchemaCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilFactoryInterface as ilXMLFileSchemaFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilHandlerInterface as ilXMLFileSchemaHandlerInterface;
+use ILIAS\Export\ImportHandler\Parser\ilFactory as ilParserFactory;
+use ILIAS\Export\Schema\ilXmlSchemaFactory;
+use ilLanguage;
+use ilLogger;
+
+class ilFactory implements ilXMLFileSchemaFactoryInterface
+{
+    protected ilLogger $logger;
+    protected ilLanguage $lng;
+    protected ilXmlSchemaFactory $schema_factory;
+
+    public function __construct(
+        ilLogger $logger,
+        ilLanguage $lng,
+        ilXmlSchemaFactory $schema_factory
+    ) {
+        $this->logger = $logger;
+        $this->lng = $lng;
+        $this->schema_factory = $schema_factory;
+    }
+
+    public function handler(): ilXMLFileSchemaHandlerInterface
+    {
+        return new ilXMLFileSchemaHandler(
+            new ilFilePathFactory($this->logger),
+            $this->schema_factory,
+            new ilParserFactory($this->logger),
+            new ilXSDFileFactory()
+        );
+    }
+
+    public function handlersFromXMLFileHandlerAtPath(
+        ilXMLFileHandlerInterface $xml_file_handler,
+        ilXMLFilePathHandlerInterface $path_to_entities
+    ): ilXMLFileSchemaCollectionInterface {
+        $parser = new ilParserFactory($this->logger);
+        $path = new ilFilePathFactory($this->logger);
+        $xml_file_node_info = $parser->DOM()->withFileHandler($xml_file_handler)
+            ->getNodeInfoAt($this->getPathToExportNode($path))
+            ->current();
+        $nodes = $parser->DOM()->withFileHandler($xml_file_handler)->getNodeInfoAt($path_to_entities);
+        $collection = new ilXMLFileSchemaCollection();
+        foreach ($nodes as $node) {
+            $collection = $collection->withElement($this->initSchemaFileFromXMLNodeInfoHandler($node));
+        }
+        return $collection;
+    }
+
+    protected function initSchemaFileFromXMLNodeInfoHandler(
+        ilXMLFileNodeInfoHandlerInterface $xml_file_node_info
+    ): ilXMLFileSchemaHandler {
+        $types = $this->getTypesArray($xml_file_node_info);
+        $version_str = $this->getVersionString($xml_file_node_info);
+        if ($version_str === '') {
+            return $this->handler()
+                ->withType($types[0])
+                ->withSubType($types[1]);
+        }
+        return $this->handler()
+            ->withType($types[0])
+            ->withSubType($types[1])
+            ->withVersion(new Version($version_str));
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getTypesArray(ilXMLFileNodeInfoHandlerInterface $xml_file_node_info): array
+    {
+        $type_str = $xml_file_node_info->getValueOfAttribute('Entity');
+        return str_contains($type_str, '_')
+            ? explode('_', $type_str)
+            : [$type_str, ''];
+    }
+
+    protected function getVersionString(ilXMLFileNodeInfoHandlerInterface $xml_file_node_info): string
+    {
+        return $xml_file_node_info->hasAttribute('SchemaVersion')
+            ? $xml_file_node_info->getValueOfAttribute('SchemaVersion')
+            : '';
+    }
+
+    protected function getPathToExportNode(ilFilePathFactoryInterface $path): ilFilePathHandlerInterface
+    {
+        return $path->handler()
+            ->withStartAtRoot(true)
+            ->withNode($path->node()->simple()->withName('exp:Export'));
+    }
+}

--- a/Services/Export/classes/ImportHandler/File/XML/Schema/class.ilHandler.php
+++ b/Services/Export/classes/ImportHandler/File/XML/Schema/class.ilHandler.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Export\ImportHandler\File\XML\Schema;
+
+use ILIAS\Data\Version;
+use ILIAS\Export\ImportHandler\I\File\Path\ilFactoryInterface as ilFilePathFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilHandlerInterface as ilXMLFileNodeInfoInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilHandlerInterface as ilXMLFileSchemaHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XSD\ilFactoryInterface as ilXSDFileFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
+use ILIAS\Export\ImportHandler\I\Parser\ilFactoryInterface as ilParserFactoryInterface;
+use ILIAS\Export\Schema\ilXmlSchemaFactory;
+
+class ilHandler implements ilXMLFileSchemaHandlerInterface
+{
+    protected ilXmlSchemaFactory $schema;
+    protected ilFilePathFactoryInterface $path;
+    protected ilParserFactoryInterface $parser;
+    protected ilXSDFileFactoryInterface $xsd;
+    protected null|string $type;
+    protected null|string $subtype;
+    protected null|Version $version;
+    protected null|ilXMLFileHandlerInterface $xml_file_handler;
+    protected null|ilXMLFileNodeInfoInterface $xml_file_node_info;
+
+    public function __construct(
+        ilFilePathFactoryInterface $path,
+        ilXmlSchemaFactory $schema,
+        ilParserFactoryInterface $parser,
+        ilXSDFileFactoryInterface $xsd
+    ) {
+        $this->path = $path;
+        $this->schema = $schema;
+        $this->parser = $parser;
+        $this->xsd = $xsd;
+        $this->type = null;
+        $this->subtype = null;
+        $this->version = null;
+        $this->xml_file_handler = null;
+        $this->xml_file_node_info = null;
+    }
+
+    public function getXSDFileHandlerByVersionOrLatest(): null|ilXSDFileHandlerInterface
+    {
+        if (
+            is_null($this->getVersion()) ||
+            is_null($this->getPrimaryType()) ||
+            is_null($this->getSecondaryType())
+        ) {
+            return null;
+        }
+        $latest_file_info = $this->schema->getByVersionOrLatest(
+            $this->getVersion(),
+            $this->getPrimaryType(),
+            $this->getSecondaryType()
+        );
+        return is_null($latest_file_info)
+            ? null
+            : $this->xsd->withFileInfo($latest_file_info);
+    }
+
+    public function getXSDFileHandlerLatest(): null|ilXSDFileHandlerInterface
+    {
+        if (
+            is_null($this->getPrimaryType()) ||
+            is_null($this->getSecondaryType())
+        ) {
+            return null;
+        }
+        $latest_file_info = $this->schema->getLatest(
+            $this->getPrimaryType(),
+            $this->getSecondaryType()
+        );
+        return is_null($latest_file_info)
+            ? null
+            : $this->xsd->withFileInfo($latest_file_info);
+    }
+
+    public function doesXSDFileWithMatchingVersionExist(): bool
+    {
+        if (
+            is_null($this->getVersion()) ||
+            is_null($this->getPrimaryType()) ||
+            is_null($this->getSecondaryType())
+        ) {
+            return false;
+        }
+        $file_info_with_version = $this->schema->getByVersion(
+            $this->getVersion(),
+            $this->getPrimaryType(),
+            $this->getSecondaryType()
+        );
+        return !is_null($file_info_with_version);
+    }
+
+    public function withType(string $type): ilXMLFileSchemaHandlerInterface
+    {
+        $clone = clone $this;
+        $clone->type = $type;
+        return $clone;
+    }
+
+    public function withSubType(string $subtype): ilXMLFileSchemaHandlerInterface
+    {
+        $clone = clone $this;
+        $clone->subtype = $subtype;
+        return $clone;
+    }
+
+    public function withVersion(Version $version): ilXMLFileSchemaHandlerInterface
+    {
+        $clone = clone $this;
+        $clone->version = $version;
+        return $clone;
+    }
+
+    public function getVersion(): null|Version
+    {
+        return $this->version;
+    }
+
+    public function getPrimaryType(): null|string
+    {
+        return $this->type;
+    }
+
+    public function getSecondaryType(): null|string
+    {
+        return $this->subtype;
+    }
+
+    public function getTypeString(): string
+    {
+        if (is_null($this->getPrimaryType())) {
+            return '';
+        }
+        if (is_null($this->getSecondaryType())) {
+            return $this->getPrimaryType();
+        }
+        return $this->getPrimaryType() . '_' . $this->getSecondaryType();
+    }
+}

--- a/Services/Export/classes/ImportHandler/File/XML/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XML/class.ilFactory.php
@@ -20,47 +20,41 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XML;
 
-use ilLogger;
-use ILIAS\Export\ImportHandler\File\XML\Manifest\ilFactory as ilManifestFileFactory;
-use ILIAS\Export\ImportHandler\I\File\XML\Export\ilFactoryInterface as ilXMLExportFileFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\ilFactoryInterface as ilXMLFileFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\ilCollectionInterface as ilXMLFileHanlderCollectionInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHanlderInterface;
-use ILIAS\Export\ImportHandler\File\XML\ilHandler as ilXMLFileHanlder;
-use ILIAS\Export\ImportHandler\File\XML\ilCollection as ilXMLFileHanlderCollection;
-use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilFactoryInterface as ilManifestFileFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\ilFactoryInterface as ilFileFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\ilFactoryInterface as ilXMLFileNodeFactoryInterface;
-use ILIAS\Export\ImportHandler\I\Parser\ilFactoryInterface as ilParserFactoryInterface;
-use ILIAS\Export\ImportStatus\ilFactory as ilStatusFactory;
-use ILIAS\Export\ImportHandler\File\XML\Node\ilFactory as ilXMLFileNodeFactory;
-use ILIAS\Export\ImportHandler\File\XML\Export\ilFactory as ilXMLExportFileFactory;
 use ILIAS\Export\ImportHandler\File\Namespace\ilFactory as ilFileNamespaceFactory;
+use ILIAS\Export\ImportHandler\File\XML\Export\ilFactory as ilXMLExportFileFactory;
+use ILIAS\Export\ImportHandler\File\XML\ilCollection as ilXMLFileHanlderCollection;
+use ILIAS\Export\ImportHandler\File\XML\ilHandler as ilXMLFileHanlder;
+use ILIAS\Export\ImportHandler\File\XML\Manifest\ilFactory as ilManifestFileFactory;
+use ILIAS\Export\ImportHandler\File\XML\Node\ilFactory as ilXMLFileNodeFactory;
+use ILIAS\Export\ImportHandler\File\XML\Schema\ilFactory as ilXMLFileSchemaFactory;
+use ILIAS\Export\ImportHandler\I\File\XML\Export\ilFactoryInterface as ilXMLExportFileFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\ilCollectionInterface as ilXMLFileHanlderCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\ilFactoryInterface as ilXMLFileFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHanlderInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilFactoryInterface as ilManifestFileFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\ilFactoryInterface as ilXMLFileNodeFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilFactoryInterface as ilXMLFileSchemaFactoryInterface;
+use ILIAS\Export\ImportStatus\ilFactory as ilStatusFactory;
+use ILIAS\Export\Schema\ilXmlSchemaFactory;
+use ilLanguage;
+use ilLogger;
 use SplFileInfo;
 
 class ilFactory implements ilXMLFileFactoryInterface
 {
     protected ilLogger $logger;
-    protected ilFileFactoryInterface $file;
-    protected ilParserFactoryInterface $parser;
+    protected ilLanguage $lng;
+    protected ilXmlSchemaFactory $schema_factory;
 
     public function __construct(
-        ilFileFactoryInterface $file,
-        ilParserFactoryInterface $parser,
-        ilLogger $logger
+        ilLogger $logger,
+        ilLanguage $lng,
+        ilXmlSchemaFactory $schema_factory
     ) {
         $this->logger = $logger;
-        $this->file = $file;
-        $this->parser = $parser;
+        $this->lng = $lng;
+        $this->schema_factory = $schema_factory;
     }
-
-    /*public function handler(): ilXMLFileHanlderInterface
-    {
-        return new ilXMLFileHanlder(
-            new ilFileNamespaceFactory(),
-            new ilStatusFactory()
-        );
-    }*/
 
     public function withFileInfo(SplFileInfo $file_info): ilXMLFileHanlderInterface
     {
@@ -78,9 +72,9 @@ class ilFactory implements ilXMLFileFactoryInterface
     public function manifest(): ilManifestFileFactoryInterface
     {
         return new ilManifestFileFactory(
-            $this->file,
-            $this->parser,
-            $this->logger
+            $this->logger,
+            $this->lng,
+            $this->schema_factory
         );
     }
 
@@ -91,6 +85,19 @@ class ilFactory implements ilXMLFileFactoryInterface
 
     public function export(): ilXMLExportFileFactoryInterface
     {
-        return new ilXMLExportFileFactory($this->logger);
+        return new ilXMLExportFileFactory(
+            $this->logger,
+            $this->lng,
+            $this->schema_factory
+        );
+    }
+
+    public function schema(): ilXMLFileSchemaFactoryInterface
+    {
+        return new ilXMLFileSchemaFactory(
+            $this->logger,
+            $this->lng,
+            $this->schema_factory
+        );
     }
 }

--- a/Services/Export/classes/ImportHandler/File/XML/class.ilHandler.php
+++ b/Services/Export/classes/ImportHandler/File/XML/class.ilHandler.php
@@ -21,20 +21,13 @@ declare(strict_types=1);
 namespace ILIAS\Export\ImportHandler\File\XML;
 
 use DOMDocument;
-use ILIAS\DI\Exceptions\Exception;
-use ilImportException;
 use ILIAS\Export\ImportHandler\File\ilHandler as ilFileHandler;
-use ILIAS\Export\ImportHandler\I\File\ilHandlerInterface as ilFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\Namespace\ilFactoryInterface as ilFileNamespaceFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\Namespace\ilHandlerInterface as ilFileNamespaceHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilCollectionInterface as ilFileValidationSetCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
 use ILIAS\Export\ImportStatus\Exception\ilException as ilImportStatusException;
 use ILIAS\Export\ImportStatus\I\ilFactoryInterface as ilImportStatusFactoryInterface;
-use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusCollectioninterface;
 use ILIAS\Export\ImportStatus\StatusType;
-use ILIAS\Export\Schema\ilXmlSchemaFactory;
 use SplFileInfo;
 
 class ilHandler extends ilFileHandler implements ilXMLFileHandlerInterface

--- a/Services/Export/classes/ImportHandler/File/XSD/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/XSD/class.ilFactory.php
@@ -20,10 +20,10 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File\XSD;
 
+use ILIAS\Export\ImportHandler\File\Namespace\ilFactory as ilFileNamespaceFactory;
+use ILIAS\Export\ImportHandler\File\XSD\ilHandler as ilXSDFileHandler;
 use ILIAS\Export\ImportHandler\I\File\XSD\ilFactoryInterface as ilXSDFileHandlerFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
-use ILIAS\Export\ImportHandler\File\XSD\ilHandler as ilXSDFileHandler;
-use ILIAS\Export\ImportHandler\File\Namespace\ilFactory as ilFileNamespaceFactory;
 use SplFileInfo;
 
 class ilFactory implements ilXSDFileHandlerFactoryInterface

--- a/Services/Export/classes/ImportHandler/File/XSD/class.ilHandler.php
+++ b/Services/Export/classes/ImportHandler/File/XSD/class.ilHandler.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 namespace ILIAS\Export\ImportHandler\File\XSD;
 
 use ILIAS\Export\ImportHandler\File\ilHandler as ilFileHandler;
-use ILIAS\Export\ImportHandler\I\File\ilHandlerInterface as ilFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
 use SplFileInfo;
 

--- a/Services/Export/classes/ImportHandler/File/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/File/class.ilFactory.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\File;
 
+use ilLanguage;
 use ilLogger;
 use ILIAS\Export\ImportHandler\File\Validation\ilFactory as ilFileValidationFactory;
 use ILIAS\Export\ImportHandler\File\XML\ilFactory as ilXMLFileFactory;
@@ -36,26 +37,30 @@ use ILIAS\Export\ImportHandler\I\File\XSD\ilFactoryInterface as ilXSDFileFactory
 use ILIAS\Export\ImportHandler\I\Parser\ilFactoryInterface as ilParserFactoryInterface;
 use ILIAS\Export\ImportHandler\File\Path\ilFactory as ilFilePathFactory;
 use ILIAS\Export\ImportHandler\File\Namespace\ilFactory as ilFileNamespaceFactory;
+use ILIAS\Export\Schema\ilXmlSchemaFactory;
 
 class ilFactory implements ilFileFactory
 {
     protected ilLogger $logger;
-    protected ilParserFactoryInterface $parser;
+    protected ilLanguage $lng;
+    protected ilXmlSchemaFactory $schema_factory;
 
     public function __construct(
-        ilParserFactoryInterface $parser,
-        ilLogger $logger
+        ilLogger $logger,
+        ilLanguage $lng,
+        ilXmlSchemaFactory $schema_factory
     ) {
         $this->logger = $logger;
-        $this->parser = $parser;
+        $this->lng = $lng;
+        $this->schema_factory = $schema_factory;
     }
 
     public function xml(): ilXMLFileFactoryInterface
     {
         return new ilXMLFileFactory(
-            $this,
-            $this->parser,
-            $this->logger
+            $this->logger,
+            $this->lng,
+            $this->schema_factory
         );
     }
 
@@ -66,11 +71,7 @@ class ilFactory implements ilFileFactory
 
     public function validation(): ilFileValidationFactoryInterface
     {
-        return new ilFileValidationFactory(
-            $this->logger,
-            $this->parser,
-            new ilFilePathFactory($this->logger)
-        );
+        return new ilFileValidationFactory($this->logger);
     }
 
     public function path(): ilFilePathFactoryInterface

--- a/Services/Export/classes/ImportHandler/I/File/Path/Node/interface.ilFactoryInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/Path/Node/interface.ilFactoryInterface.php
@@ -20,13 +20,13 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\Path\Node;
 
-use ILIAS\Export\ImportHandler\I\File\Path\Node\ilSimpleInterface as ilSimpleFilePathNodeInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilAnyElementInterface as ilAnyElementFilePathNodeInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilAnyNodeInterface as ilAnyNodeFilePathNodeInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilAttributeInterface as ilAttributeFilePathNodeInterface;
+use ILIAS\Export\ImportHandler\I\File\Path\Node\ilCloseRoundBrackedInterface as ilCloseRoundBrackedFilePathNodeInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilIndexInterface as ilIndexFilePathNodeInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\Node\ilOpenRoundBrackedInterface as ilOpenRoundBrackedFilePathNodeInterface;
-use ILIAS\Export\ImportHandler\I\File\Path\Node\ilCloseRoundBrackedInterface as ilCloseRoundBrackedFilePathNodeInterface;
+use ILIAS\Export\ImportHandler\I\File\Path\Node\ilSimpleInterface as ilSimpleFilePathNodeInterface;
 
 interface ilFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/I/File/Path/Node/interface.ilNodeInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/Path/Node/interface.ilNodeInterface.php
@@ -20,8 +20,6 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\Path\Node;
 
-use XMLReader;
-
 interface ilNodeInterface
 {
     public function toString(): string;

--- a/Services/Export/classes/ImportHandler/I/File/Validation/Set/interface.ilCollectionInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/Validation/Set/interface.ilCollectionInterface.php
@@ -20,9 +20,9 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\Validation\Set;
 
-use Iterator;
 use Countable;
 use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilHandlerInterface as ilFileValidationPairHandlerInterface;
+use Iterator;
 
 interface ilCollectionInterface extends Iterator, Countable
 {

--- a/Services/Export/classes/ImportHandler/I/File/Validation/Set/interface.ilFactoryInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/Validation/Set/interface.ilFactoryInterface.php
@@ -20,8 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\Validation\Set;
 
-use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilHandlerInterface as ilFileValidationSetInterface;
 use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilCollectionInterface as ilFileValidationSetCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilHandlerInterface as ilFileValidationSetInterface;
 
 interface ilFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/I/File/Validation/Set/interface.ilHandlerInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/Validation/Set/interface.ilHandlerInterface.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 namespace ILIAS\Export\ImportHandler\I\File\Validation\Set;
 
 use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilFilePathHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
 
 interface ilHandlerInterface
 {

--- a/Services/Export/classes/ImportHandler/I/File/Validation/interface.ilHandlerInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/Validation/interface.ilHandlerInterface.php
@@ -21,10 +21,10 @@ declare(strict_types=1);
 namespace ILIAS\Export\ImportHandler\I\File\Validation;
 
 use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilParserPathHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilCollectionInterface as ilFileValidationSetCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
 use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusHandlerCollectionInterface;
-use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilCollectionInterface as ilFileValidationSetCollectionInterface;
 
 interface ilHandlerInterface
 {

--- a/Services/Export/classes/ImportHandler/I/File/XML/Export/interface.ilCollectionInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Export/interface.ilCollectionInterface.php
@@ -20,9 +20,9 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\XML\Export;
 
+use Countable;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\ilHandlerInterface as ilXMLExportFileHandlerInterface;
 use Iterator;
-use Countable;
 
 interface ilCollectionInterface extends Iterator, Countable
 {

--- a/Services/Export/classes/ImportHandler/I/File/XML/Export/interface.ilFactoryInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Export/interface.ilFactoryInterface.php
@@ -20,10 +20,10 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\XML\Export;
 
-use ILIAS\Export\ImportHandler\I\File\XML\Export\ilHandlerInterface as ilXMLExportFileHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Export\ilCollectionInterface as ilXMLExportFileCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\Component\ilFactoryInterface as ilComponentXMLExportFileHandlerFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\DataSet\ilFactoryInterface as ilDataSetXMLExportFileHandlerFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Export\ilCollectionInterface as ilXMLExportFileCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Export\ilHandlerInterface as ilXMLExportFileHandlerInterface;
 use SplFileInfo;
 
 interface ilFactoryInterface

--- a/Services/Export/classes/ImportHandler/I/File/XML/Export/interface.ilHandlerInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Export/interface.ilHandlerInterface.php
@@ -20,13 +20,11 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\XML\Export;
 
-use ILIAS\Data\Version;
-use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilTreeInterface as ilXMLFileNodeInfoTreeInterface;
-use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilFilePathHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\Validation\Set\ilCollectionInterface as ilFileValidationSetCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilTreeInterface as ilXMLFileNodeInfoTreeInterface;
+use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusCollectionInterface;
 use SplFileInfo;
 
 interface ilHandlerInterface extends ilXMLFileHandlerInterface

--- a/Services/Export/classes/ImportHandler/I/File/XML/Manifest/interface.ilFactoryInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Manifest/interface.ilFactoryInterface.php
@@ -20,8 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\XML\Manifest;
 
-use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerInterface as ilManifestXMLFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerCollectionInterface as ilManifestXMLFileHandlerCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerInterface as ilManifestXMLFileHandlerInterface;
 use SplFileInfo;
 
 interface ilFactoryInterface

--- a/Services/Export/classes/ImportHandler/I/File/XML/Manifest/interface.ilHandlerCollectionInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Manifest/interface.ilHandlerCollectionInterface.php
@@ -20,12 +20,11 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\XML\Manifest;
 
+use Countable;
 use ILIAS\Export\ImportHandler\File\XML\Manifest\ilExportObjectType;
 use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerInterface as ilManifestXMLFileHandlerInterface;
 use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusHandlerCollectionInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\ilCollectionInterface as ilXMLFileHandlerCollectionInterface;
 use Iterator;
-use Countable;
 
 interface ilHandlerCollectionInterface extends Iterator, Countable
 {

--- a/Services/Export/classes/ImportHandler/I/File/XML/Manifest/interface.ilHandlerInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Manifest/interface.ilHandlerInterface.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 namespace ILIAS\Export\ImportHandler\I\File\XML\Manifest;
 
 use ILIAS\Export\ImportHandler\File\XML\Manifest\ilExportObjectType;
-use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Export\ilCollectionInterface as ilXMLExportFileCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilHandlerCollectionInterface as ilManifestXMLFileHandlerCollectionInterface;
 use ILIAS\Export\ImportStatus\I\ilCollectionInterface as ilImportStatusHandlerCollectionInterface;
 use SplFileInfo;

--- a/Services/Export/classes/ImportHandler/I/File/XML/Node/Info/Attribute/interface.ilCollectionInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Node/Info/Attribute/interface.ilCollectionInterface.php
@@ -20,10 +20,10 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute;
 
-use Iterator;
 use Countable;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilPairInterface as ilXMLFileNodeInfoAttributePairInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilHandlerInterface as ilXMLFileNodeInfoInterface;
+use Iterator;
 
 interface ilCollectionInterface extends Iterator, Countable
 {

--- a/Services/Export/classes/ImportHandler/I/File/XML/Node/Info/Attribute/interface.ilFactoryInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Node/Info/Attribute/interface.ilFactoryInterface.php
@@ -20,8 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute;
 
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilPairInterface as ilXMLFileNodeInfoAttributePairInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilCollectionInterface as ilXMLFileNodeInfoAttributeCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilPairInterface as ilXMLFileNodeInfoAttributePairInterface;
 
 interface ilFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/I/File/XML/Node/Info/interface.ilCollectionInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Node/Info/interface.ilCollectionInterface.php
@@ -20,9 +20,9 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\XML\Node\Info;
 
-use Iterator;
 use Countable;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilHandlerInterface as ilXMLFileNodeInfoInterface;
+use Iterator;
 
 interface ilCollectionInterface extends Iterator, Countable
 {

--- a/Services/Export/classes/ImportHandler/I/File/XML/Node/Info/interface.ilFactoryInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Node/Info/interface.ilFactoryInterface.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
 namespace ILIAS\Export\ImportHandler\I\File\XML\Node\Info;
 
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilFactoryInterface as ilXMLFileNodeInfoAttributeFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\DOM\ilFactoryInterface as ilXMLFileDOMNodeInfoFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilCollectionInterface as ilXMLFileNodeInfoCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilTreeInterface as ilXMLFileNodeInfoTreeInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\DOM\ilFactoryInterface as ilXMLFileDOMNodeInfoFactoryInterface;
 
 interface ilFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/I/File/XML/Node/Info/interface.ilTreeInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Node/Info/interface.ilTreeInterface.php
@@ -22,10 +22,9 @@ namespace ILIAS\Export\ImportHandler\I\File\XML\Node\Info;
 
 use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilXMLFilePathHandlerInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilPairInterface as ilXMLFileNodeInfoAttributePairInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilCollectionInterface as ilXMLFileNodeInfoAttributePairCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilCollectionInterface as ilXMLFileNodeInfoCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\ilHandlerInterface as ilXMLFileNodeInfoInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Node\Info\Attribute\ilCollectionInterface as ilXMLFileNodeInfoAttributePairCollectionInterface;
 
 interface ilTreeInterface
 {

--- a/Services/Export/classes/ImportHandler/I/File/XML/Schema/interface.ilCollectionInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Schema/interface.ilCollectionInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Export\ImportHandler\I\File\XML\Schema;
+
+use Countable;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilHandlerInterface as ilXMLFileSchemaHandlerInterface;
+use Iterator;
+
+interface ilCollectionInterface extends Iterator, Countable
+{
+    public function withElement(ilXMLFileSchemaHandlerInterface $element): ilCollectionInterface;
+
+    public function withMerged(ilCollectionInterface $other): ilCollectionInterface;
+
+    /**
+     * @return ilXMLFileSchemaHandlerInterface[]
+     */
+    public function toArray(): array;
+
+    public function current(): ilXMLFileSchemaHandlerInterface;
+
+    public function next(): void;
+
+    public function key(): int;
+
+    public function valid(): bool;
+
+    public function rewind(): void;
+}

--- a/Services/Export/classes/ImportHandler/I/File/XML/Schema/interface.ilFactoryInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Schema/interface.ilFactoryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Export\ImportHandler\I\File\XML\Schema;
+
+use ILIAS\Export\ImportHandler\I\File\Path\ilHandlerInterface as ilXMLFilePathHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilCollectionInterface as ilXMLFileSchemaCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilHandlerInterface as ilXMLFileSchemaHandler;
+
+interface ilFactoryInterface
+{
+    public function handler(): ilXMLFileSchemaHandler;
+
+    public function handlersFromXMLFileHandlerAtPath(
+        ilXMLFileHandlerInterface $xml_file_handler,
+        ilXMLFilePathHandlerInterface $path_to_entities
+    ): ilXMLFileSchemaCollectionInterface;
+}

--- a/Services/Export/classes/ImportHandler/I/File/XML/Schema/interface.ilHandlerInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/Schema/interface.ilHandlerInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Export\ImportHandler\I\File\XML\Schema;
+
+use ILIAS\Data\Version;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilHandlerInterface as ilXMLFileSchemaHandlerInterface;
+use ILIAS\Export\ImportHandler\I\File\XSD\ilHandlerInterface as ilXSDFileHandlerInterface;
+
+interface ilHandlerInterface
+{
+    public function getXSDFileHandlerByVersionOrLatest(): null|ilXSDFileHandlerInterface;
+
+    public function getXSDFileHandlerLatest(): null|ilXSDFileHandlerInterface;
+
+    public function doesXSDFileWithMatchingVersionExist(): bool;
+
+    public function withType(string $type): ilXMLFileSchemaHandlerInterface;
+
+    public function withSubType(string $subtype): ilXMLFileSchemaHandlerInterface;
+
+    public function withVersion(Version $version): ilXMLFileSchemaHandlerInterface;
+
+    public function getVersion(): null|Version;
+
+    public function getPrimaryType(): null|string;
+
+    public function getSecondaryType(): null|string;
+
+    public function getTypeString(): string;
+}

--- a/Services/Export/classes/ImportHandler/I/File/XML/interface.ilFactoryInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/interface.ilFactoryInterface.php
@@ -20,11 +20,12 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File\XML;
 
-use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHanlderInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Export\ilFactoryInterface as ilXMLExportFileFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\ilCollectionInterface as ilXMLFileHanlderCollectionInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHanlderInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Manifest\ilFactoryInterface as ilManifestFileFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\Node\ilFactoryInterface as ilXMLFileNodeFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\XML\Export\ilFactoryInterface as ilXMLExportFileFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\XML\Schema\ilFactoryInterface as ilXMLFileSchemaFactoryInterface;
 use SplFileInfo;
 
 interface ilFactoryInterface
@@ -38,4 +39,6 @@ interface ilFactoryInterface
     public function node(): ilXMLFileNodeFactoryInterface;
 
     public function export(): ilXMLExportFileFactoryInterface;
+
+    public function schema(): ilXMLFileSchemaFactoryInterface;
 }

--- a/Services/Export/classes/ImportHandler/I/File/XML/interface.ilHandlerInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/XML/interface.ilHandlerInterface.php
@@ -22,7 +22,6 @@ namespace ILIAS\Export\ImportHandler\I\File\XML;
 
 use DOMDocument;
 use ILIAS\Export\ImportHandler\I\File\ilHandlerInterface as ilFileHandlerInterface;
-use ILIAS\Export\ImportStatus\Exception\ilException as ilImportStatusException;
 use SplFileInfo;
 
 interface ilHandlerInterface extends ilFileHandlerInterface

--- a/Services/Export/classes/ImportHandler/I/File/interface.ilFactoryInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/interface.ilFactoryInterface.php
@@ -20,11 +20,11 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File;
 
+use ILIAS\Export\ImportHandler\I\File\Namespace\ilFactoryInterface as ilFileNamespaceFactoryInterface;
+use ILIAS\Export\ImportHandler\I\File\Path\ilFactoryInterface as ilFilePathFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\Validation\ilFactoryInterface as ilFileValidationFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XML\ilFactoryInterface as ilXMLFileFactoryInterface;
 use ILIAS\Export\ImportHandler\I\File\XSD\ilFactoryInterface as ilXSDFileFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\Path\ilFactoryInterface as ilFilePathFactoryInterface;
-use ILIAS\Export\ImportHandler\I\File\Namespace\ilFactoryInterface as ilFileNamespaceFactoryInterface;
 
 interface ilFactoryInterface
 {

--- a/Services/Export/classes/ImportHandler/I/File/interface.ilHandlerInterface.php
+++ b/Services/Export/classes/ImportHandler/I/File/interface.ilHandlerInterface.php
@@ -20,9 +20,9 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\File;
 
-use SplFileInfo;
 use ILIAS\Export\ImportHandler\I\File\Namespace\ilCollectionInterface as ilFileNamespaceCollectionInterface;
 use ILIAS\Export\ImportHandler\I\File\Namespace\ilHandlerInterface as ilFileNamespaceHandlerInterface;
+use SplFileInfo;
 
 interface ilHandlerInterface
 {

--- a/Services/Export/classes/ImportHandler/I/Parser/interface.ilFactoryInterface.php
+++ b/Services/Export/classes/ImportHandler/I/Parser/interface.ilFactoryInterface.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler\I\Parser;
 
-use ILIAS\Export\ImportHandler\I\File\XML\ilHandlerInterface as ilXMLFileHandlerInterface;
 use ILIAS\Export\ImportHandler\I\Parser\DOM\ilFactoryInterface as ilDOMParserFactoryInterface;
 
 interface ilFactoryInterface

--- a/Services/Export/classes/ImportHandler/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/class.ilFactory.php
@@ -20,21 +20,28 @@ declare(strict_types=1);
 
 namespace ILIAS\Export\ImportHandler;
 
+use ilLanguage;
 use ilLogger;
 use ILIAS\Export\ImportHandler\File\ilFactory as ilFileFactory;
 use ILIAS\Export\ImportHandler\I\File\ilFactoryInterface as ilFileFactoryInterface;
 use ILIAS\Export\ImportHandler\I\ilFactoryInterface as ilImportHandlerFactoryInterface;
 use ILIAS\Export\ImportHandler\I\Parser\ilFactoryInterface as ilParserFactoryInterface;
 use ILIAS\Export\ImportHandler\Parser\ilFactory as ilParserFactory;
+use ILIAS\Export\Schema\ilXmlSchemaFactory;
 
 class ilFactory implements ilImportHandlerFactoryInterface
 {
     protected ilLogger $logger;
+    protected ilLanguage $lng;
+    protected ilXmlSchemaFactory $schema_factory;
+
 
     public function __construct()
     {
         global $DIC;
         $this->logger = $DIC->logger()->root();
+        $this->lng = $DIC->language();
+        $this->schema_factory = new ilXmlSchemaFactory();
     }
 
     public function parser(): ilParserFactoryInterface
@@ -45,8 +52,9 @@ class ilFactory implements ilImportHandlerFactoryInterface
     public function file(): ilFileFactoryInterface
     {
         return new ilFileFactory(
-            new ilParserFactory($this->logger),
-            $this->logger
+            $this->logger,
+            $this->lng,
+            $this->schema_factory
         );
     }
 }

--- a/Services/Export/classes/ImportHandler/class.ilFactory.php
+++ b/Services/Export/classes/ImportHandler/class.ilFactory.php
@@ -41,6 +41,7 @@ class ilFactory implements ilImportHandlerFactoryInterface
         global $DIC;
         $this->logger = $DIC->logger()->root();
         $this->lng = $DIC->language();
+        $this->lng->loadLanguageModule("exp");
         $this->schema_factory = new ilXmlSchemaFactory();
     }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -9665,8 +9665,8 @@ exp#:#exp_error_too_many_objects#:#Der Export überschreitet die max. erlaubte Z
 exp#:#exp_export_files#:#Exportdateien
 exp#:#exp_file_created#:#Eine Exportdatei wurde erstellt.
 exp#:#exp_html#:#HTML
-exp#:#exp_print_pdf#:#Drucken/PDF
 exp#:#exp_import_validation_err_no_matching_xsd#:#Eine Schema Datei für Version %s existiert nicht.
+exp#:#exp_print_pdf#:#Drucken/PDF
 exp#:#exp_print_pdf_info#:#Um ein PDF zu erstellen, wählen Sie bitte anschließend in der Druckansicht "Als PDF speichern" als Ziel.
 exp#:#exp_really_delete#:#Möchten Sie diese Exportdateien wirklich löschen?
 exp#:#exp_scorm#:#SCORM

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -9666,6 +9666,7 @@ exp#:#exp_export_files#:#Exportdateien
 exp#:#exp_file_created#:#Eine Exportdatei wurde erstellt.
 exp#:#exp_html#:#HTML
 exp#:#exp_print_pdf#:#Drucken/PDF
+exp#:#exp_import_validation_err_no_matching_xsd#:#Eine Schema Datei für Version %s existiert nicht.
 exp#:#exp_print_pdf_info#:#Um ein PDF zu erstellen, wählen Sie bitte anschließend in der Druckansicht "Als PDF speichern" als Ziel.
 exp#:#exp_really_delete#:#Möchten Sie diese Exportdateien wirklich löschen?
 exp#:#exp_scorm#:#SCORM

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -9666,6 +9666,7 @@ exp#:#exp_error_too_many_objects#:#The export exceeds the maximum number of allo
 exp#:#exp_export_files#:#Export Files
 exp#:#exp_file_created#:#The export file has been created.
 exp#:#exp_html#:#HTML
+exp#:#exp_import_validation_err_no_matching_xsd#:#No valid schema file for version %s exists.
 exp#:#exp_print_pdf#:#Print/PDF
 exp#:#exp_print_pdf_info#:#To create a PDF please use the "Print to PDF" target as soon as the print view is presented.
 exp#:#exp_really_delete#:#Do you really want to delete these export files?

--- a/xml/SchemaValidation/ilias_crs_5_0.xsd
+++ b/xml/SchemaValidation/ilias_crs_5_0.xsd
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        elementFormDefault="qualified">
+    <xs:element name="Course">
+        <xs:complexType>
+            <xs:sequence>
+                <!-- Soap compatibility start -->
+                <xs:element minOccurs="0" maxOccurs="1" name="MetaData"/>
+                <xs:element minOccurs="0" maxOccurs="1" name="AdvancedMetaData"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" name="Admin" type="roleInfo"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" name="Tutor" type="roleInfo"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" name="Member" type="memberInfo"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" name="Subscriber" type="subscriberInfo"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" name="WaitingList" type="waitingListInfo"/>
+                <!-- Soap compatibility end -->
+                <xs:element minOccurs="1" maxOccurs="1" ref="Settings"/>
+                <xs:element minOccurs="1" maxOccurs="1" ref="Sort"/>
+                <xs:element minOccurs="1" maxOccurs="1" ref="ContainerSettings"/>
+            </xs:sequence>
+            <xs:attribute name="exportVersion" type="xs:string" use="required"/>
+            <xs:attribute name="id" type="xs:string" use="required"/>
+            <xs:attribute name="showMembers" type="binaryChoiceString" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- Soap compatibility start -->
+    <xs:complexType name="roleInfo">
+        <xs:attribute name="id" type="xs:string" use="required"/>
+        <xs:attribute name="notification" type="binaryChoiceString" use="required"/>
+        <xs:attribute name="passed" type="binaryChoiceString" use="required"/>
+        <xs:attribute name="contact" type="binaryChoiceString" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="memberInfo">
+        <xs:attribute name="id" type="xs:string" use="required"/>
+        <xs:attribute name="blocked" type="binaryChoiceString" use="required"/>
+        <xs:attribute name="passed" type="binaryChoiceString" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="subscriberInfo">
+        <xs:attribute name="id" type="xs:string" use="required"/>
+        <xs:attribute name="subscriptionTime" type="xs:integer" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="waitingListInfo">
+        <xs:attribute name="id" type="xs:string" use="required"/>
+        <xs:attribute name="position" type="xs:integer" use="required"/>
+        <xs:attribute name="subscriptionTime" type="xs:integer" use="required"/>
+    </xs:complexType>
+    <!-- Soap compatibility end -->
+
+    <xs:element name="Settings">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" name="Availability" type="AvailabilityStatus"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="Syllabus" type="xs:string"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="ImportantInformation" type="xs:string"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="TargetGroup" type="xs:string"/>
+                <xs:element minOccurs="1" maxOccurs="1" ref="Contact"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="Registration" type="RegistrationAvailabilityStatus"/>
+                <xs:element minOccurs="1" maxOccurs="1" ref="Period"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="WaitingListAutoFill" type="binaryChoiceInteger"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="CancellationEnd" type="NullOrInteger"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="MinMembers" type="xs:integer"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="ViewMode" type="xs:integer"/>
+                <xs:element minOccurs="0" maxOccurs="1" name="TimingMode" type="xs:integer"/>
+                <xs:element minOccurs="1" maxOccurs="1" ref="SessionLimit"/>
+                <xs:element minOccurs="1" maxOccurs="1" ref="WelcomeMail"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="StatusDetermination" type="xs:integer"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="MailToMembersType" type="xs:integer"/>
+                <xs:element minOccurs="1" maxOccurs="1" ref="CourseMap"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="Contact">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" name="Name" type="xs:string"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="Responsibility" type="xs:string"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="Phone" type="xs:string"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="Email" type="xs:string"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="Consultation" type="xs:string"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="binaryChoiceString">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="Yes"/>
+            <xs:enumeration value="No"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="binaryChoiceInteger">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="registrationTypes">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="Confirmation"/>
+            <xs:enumeration value="Direct"/>
+            <xs:enumeration value="Password"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:group name="AvailabilityBaseChoices">
+        <xs:choice>
+            <xs:element name="NotAvailable"/>
+            <xs:element name="Unlimited"/>
+            <xs:element name="TemporarilyAvailable">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="1" maxOccurs="1" name="Start" type="xs:integer"/>
+                        <xs:element minOccurs="1" maxOccurs="1" name="End" type="xs:integer"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:group>
+
+    <xs:complexType name="AvailabilityStatus">
+        <xs:choice>
+            <xs:group ref="AvailabilityBaseChoices"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="RegistrationAvailabilityStatus">
+        <xs:choice>
+            <xs:element minOccurs="0" maxOccurs="1" name="Disabled" type="xs:string"/>
+            <xs:element minOccurs="0" maxOccurs="1" name="Password" type="xs:string"/>
+            <xs:group ref="AvailabilityBaseChoices"/>
+        </xs:choice>
+        <xs:attribute name="registrationType" type="registrationTypes" use="required"/>
+        <xs:attribute name="notification" type="binaryChoiceString" use="required"/>
+        <xs:attribute name="waitingList" type="binaryChoiceString" use="required"/>
+        <xs:attribute name="maxMembers" type="NullOrInteger"/>
+    </xs:complexType>
+
+    <xs:simpleType name="NullOrInteger">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d*|\s{0}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="Period">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" name="Start" type="NullOrInteger"/>
+                <xs:element minOccurs="1" maxOccurs="1" name="End" type="NullOrInteger"/>
+            </xs:sequence>
+            <xs:attribute name="withTime" type="binaryChoiceInteger" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="SessionLimit">
+        <xs:complexType>
+            <xs:attribute name="active" type="binaryChoiceInteger" use="required"/>
+            <xs:attribute name="previous" type="xs:integer" use="required"/>
+            <xs:attribute name="next" type="xs:integer" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="WelcomeMail">
+        <xs:complexType>
+            <xs:attribute name="status" type="binaryChoiceInteger" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="CourseMap">
+        <xs:complexType>
+            <xs:attribute name="enabled" type="binaryChoiceInteger" use="required"/>
+            <xs:attribute name="latitude" type="xs:string" use="required"/>
+            <xs:attribute name="longitude" type="xs:string" use="required"/>
+            <xs:attribute name="location_zoom" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="Sort">
+        <xs:complexType>
+            <xs:attribute name="direction" type="sortDirection" use="optional"/>
+            <xs:attribute name="position" type="sortPosition" use="optional"/>
+            <xs:attribute name="order" type="sortOrder" use="optional"/>
+            <xs:attribute name="type" type="sortTypes" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="sortDirection">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="ASC"/>
+            <xs:enumeration value="DESC"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sortPosition">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="Bottom"/>
+            <xs:enumeration value="Top"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sortOrder">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="Activation"/>
+            <xs:enumeration value="Creation"/>
+            <xs:enumeration value="Title"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sortTypes">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="Manual"/>
+            <xs:enumeration value="Creation"/>
+            <xs:enumeration value="Title"/>
+            <xs:enumeration value="Activation"/>
+            <xs:enumeration value="Inherit"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="ContainerSettings">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" maxOccurs="unbounded" name="ContainerSetting" type="ContainerSetting"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="ContainerSetting">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="id" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_crsr_4_3.xsd
+++ b/xml/SchemaValidation/ilias_crsr_4_3.xsd
@@ -1,0 +1,49 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        elementFormDefault="qualified">
+
+    <!--################################################################################################################
+    ## + Container Reference ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ ##
+    #################################################################################################################-->
+
+    <xs:element name="ContainerReference">
+        <xs:complexType>
+            <xs:all>
+                <xs:element ref="Target"/>
+                <xs:element minOccurs="0" maxOccurs="1" name="Title" type="Title"/>
+                <xs:element ref="MemberUpdate"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="Target">
+        <xs:complexType>
+            <xs:attribute name="id" type="xs:nonNegativeInteger"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="Title">
+        <xs:simpleContent>
+            <xs:extension base="xs:token">
+                <xs:attribute name="type" default="1">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                            <xs:enumeration value="1"/>
+                            <xs:enumeration value="2"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+
+    <xs:element name="MemberUpdate">
+        <xs:simpleType>
+            <xs:restriction base="xs:int">
+                <xs:enumeration value="0"/>
+                <xs:enumeration value="1"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_exp_comp_4_0.xsd
+++ b/xml/SchemaValidation/ilias_exp_comp_4_0.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:exp="http://www.ilias.de/Services/Export/exp/4_1"
+        targetNamespace="http://www.ilias.de/Services/Export/exp/4_1"
+        elementFormDefault="unqualified">
+    <xs:element name="Export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" ref="exp:ExportItem"/>
+            </xs:sequence>
+            <xs:attribute name="InstallationId" type="xs:integer" use="required"/>
+            <xs:attribute name="InstallationUrl" type="xs:anyURI" use="required"/>
+            <xs:attribute name="Entity" type="xs:string" use="required"/>
+            <xs:attribute name="SchemaVersion" type="xs:string" use="required"/>
+            <xs:attribute name="TargetRelease" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ExportItem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:any minOccurs="1" maxOccurs='1' namespace="##any" processContents="skip"/>
+            </xs:sequence>
+            <xs:attribute name="Id" type="xs:integer" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_exp_comp_5_0.xsd
+++ b/xml/SchemaValidation/ilias_exp_comp_5_0.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:exp="http://www.ilias.de/Services/Export/exp/4_1"
+        targetNamespace="http://www.ilias.de/Services/Export/exp/4_1"
+        elementFormDefault="unqualified">
+    <xs:element name="Export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" ref="exp:ExportItem"/>
+            </xs:sequence>
+            <xs:attribute name="InstallationId" type="xs:integer" use="required"/>
+            <xs:attribute name="InstallationUrl" type="xs:anyURI" use="required"/>
+            <xs:attribute name="Entity" type="xs:string" use="required"/>
+            <xs:attribute name="SchemaVersion" type="xs:string" use="required"/>
+            <xs:attribute name="TargetRelease" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ExportItem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:any minOccurs="1" maxOccurs='1' namespace="##any" processContents="skip"/>
+            </xs:sequence>
+            <xs:attribute name="Id" type="xs:integer" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_exp_comp_6_0.xsd
+++ b/xml/SchemaValidation/ilias_exp_comp_6_0.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:exp="http://www.ilias.de/Services/Export/exp/4_1"
+        targetNamespace="http://www.ilias.de/Services/Export/exp/4_1"
+        elementFormDefault="unqualified">
+    <xs:element name="Export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" ref="exp:ExportItem"/>
+            </xs:sequence>
+            <xs:attribute name="InstallationId" type="xs:integer" use="required"/>
+            <xs:attribute name="InstallationUrl" type="xs:anyURI" use="required"/>
+            <xs:attribute name="Entity" type="xs:string" use="required"/>
+            <xs:attribute name="SchemaVersion" type="xs:string" use="required"/>
+            <xs:attribute name="TargetRelease" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ExportItem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:any minOccurs="1" maxOccurs='1' namespace="##any" processContents="skip"/>
+            </xs:sequence>
+            <xs:attribute name="Id" type="xs:integer" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_exp_comp_7_0.xsd
+++ b/xml/SchemaValidation/ilias_exp_comp_7_0.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:exp="http://www.ilias.de/Services/Export/exp/4_1"
+        targetNamespace="http://www.ilias.de/Services/Export/exp/4_1"
+        elementFormDefault="unqualified">
+    <xs:element name="Export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" ref="exp:ExportItem"/>
+            </xs:sequence>
+            <xs:attribute name="InstallationId" type="xs:integer" use="required"/>
+            <xs:attribute name="InstallationUrl" type="xs:anyURI" use="required"/>
+            <xs:attribute name="Entity" type="xs:string" use="required"/>
+            <xs:attribute name="SchemaVersion" type="xs:string" use="required"/>
+            <xs:attribute name="TargetRelease" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ExportItem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:any minOccurs="1" maxOccurs='1' namespace="##any" processContents="skip"/>
+            </xs:sequence>
+            <xs:attribute name="Id" type="xs:integer" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_exp_comp_8_0.xsd
+++ b/xml/SchemaValidation/ilias_exp_comp_8_0.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:exp="http://www.ilias.de/Services/Export/exp/4_1"
+        targetNamespace="http://www.ilias.de/Services/Export/exp/4_1"
+        elementFormDefault="unqualified">
+    <xs:element name="Export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" ref="exp:ExportItem"/>
+            </xs:sequence>
+            <xs:attribute name="InstallationId" type="xs:integer" use="required"/>
+            <xs:attribute name="InstallationUrl" type="xs:anyURI" use="required"/>
+            <xs:attribute name="Entity" type="xs:string" use="required"/>
+            <xs:attribute name="SchemaVersion" type="xs:string" use="required"/>
+            <xs:attribute name="TargetRelease" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ExportItem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:any minOccurs="1" maxOccurs='1' namespace="##any" processContents="skip"/>
+            </xs:sequence>
+            <xs:attribute name="Id" type="xs:integer" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_exp_dataset_4_0.xsd
+++ b/xml/SchemaValidation/ilias_exp_dataset_4_0.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.ilias.de/Services/DataSet/ds/4_3"
+        xmlns:exp="http://www.ilias.de/Services/Export/exp/4_1"
+        targetNamespace="http://www.ilias.de/Services/Export/exp/4_1"
+        elementFormDefault="unqualified">
+    <xs:import namespace="http://www.ilias.de/Services/DataSet/ds/4_3" schemaLocation="ilias_ds_4_3.xsd"/>
+    <xs:element name="Export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="unbounded" ref="exp:ExportItem"/>
+            </xs:sequence>
+            <xs:attribute name="InstallationId" type="xs:integer" use="required"/>
+            <xs:attribute name="InstallationUrl" type="xs:anyURI" use="required"/>
+            <xs:attribute name="Entity" type="xs:string" use="required"/>
+            <xs:attribute name="SchemaVersion" type="xs:string" use="required"/>
+            <xs:attribute name="TargetRelease" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ExportItem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" ref="ds:DataSet"/>
+            </xs:sequence>
+            <xs:attribute name="Id" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_exp_dataset_5_0.xsd
+++ b/xml/SchemaValidation/ilias_exp_dataset_5_0.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.ilias.de/Services/DataSet/ds/4_3"
+        xmlns:exp="http://www.ilias.de/Services/Export/exp/4_1"
+        targetNamespace="http://www.ilias.de/Services/Export/exp/4_1"
+        elementFormDefault="unqualified">
+    <xs:import namespace="http://www.ilias.de/Services/DataSet/ds/4_3" schemaLocation="ilias_ds_4_3.xsd"/>
+    <xs:element name="Export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="unbounded" ref="exp:ExportItem"/>
+            </xs:sequence>
+            <xs:attribute name="InstallationId" type="xs:integer" use="required"/>
+            <xs:attribute name="InstallationUrl" type="xs:anyURI" use="required"/>
+            <xs:attribute name="Entity" type="xs:string" use="required"/>
+            <xs:attribute name="SchemaVersion" type="xs:string" use="required"/>
+            <xs:attribute name="TargetRelease" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ExportItem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" ref="ds:DataSet"/>
+            </xs:sequence>
+            <xs:attribute name="Id" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_exp_dataset_6_0.xsd
+++ b/xml/SchemaValidation/ilias_exp_dataset_6_0.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.ilias.de/Services/DataSet/ds/4_3"
+        xmlns:exp="http://www.ilias.de/Services/Export/exp/4_1"
+        targetNamespace="http://www.ilias.de/Services/Export/exp/4_1"
+        elementFormDefault="unqualified">
+    <xs:import namespace="http://www.ilias.de/Services/DataSet/ds/4_3" schemaLocation="ilias_ds_4_3.xsd"/>
+    <xs:element name="Export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="unbounded" ref="exp:ExportItem"/>
+            </xs:sequence>
+            <xs:attribute name="InstallationId" type="xs:integer" use="required"/>
+            <xs:attribute name="InstallationUrl" type="xs:anyURI" use="required"/>
+            <xs:attribute name="Entity" type="xs:string" use="required"/>
+            <xs:attribute name="SchemaVersion" type="xs:string" use="required"/>
+            <xs:attribute name="TargetRelease" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ExportItem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" ref="ds:DataSet"/>
+            </xs:sequence>
+            <xs:attribute name="Id" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_exp_dataset_7_0.xsd
+++ b/xml/SchemaValidation/ilias_exp_dataset_7_0.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.ilias.de/Services/DataSet/ds/4_3"
+        xmlns:exp="http://www.ilias.de/Services/Export/exp/4_1"
+        targetNamespace="http://www.ilias.de/Services/Export/exp/4_1"
+        elementFormDefault="unqualified">
+    <xs:import namespace="http://www.ilias.de/Services/DataSet/ds/4_3" schemaLocation="ilias_ds_4_3.xsd"/>
+    <xs:element name="Export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="unbounded" ref="exp:ExportItem"/>
+            </xs:sequence>
+            <xs:attribute name="InstallationId" type="xs:integer" use="required"/>
+            <xs:attribute name="InstallationUrl" type="xs:anyURI" use="required"/>
+            <xs:attribute name="Entity" type="xs:string" use="required"/>
+            <xs:attribute name="SchemaVersion" type="xs:string" use="required"/>
+            <xs:attribute name="TargetRelease" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ExportItem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" ref="ds:DataSet"/>
+            </xs:sequence>
+            <xs:attribute name="Id" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_exp_dataset_8_0.xsd
+++ b/xml/SchemaValidation/ilias_exp_dataset_8_0.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.ilias.de/Services/DataSet/ds/4_3"
+        xmlns:exp="http://www.ilias.de/Services/Export/exp/4_1"
+        targetNamespace="http://www.ilias.de/Services/Export/exp/4_1"
+        elementFormDefault="unqualified">
+    <xs:import namespace="http://www.ilias.de/Services/DataSet/ds/4_3" schemaLocation="ilias_ds_4_3.xsd"/>
+    <xs:element name="Export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="unbounded" ref="exp:ExportItem"/>
+            </xs:sequence>
+            <xs:attribute name="InstallationId" type="xs:integer" use="required"/>
+            <xs:attribute name="InstallationUrl" type="xs:anyURI" use="required"/>
+            <xs:attribute name="Entity" type="xs:string" use="required"/>
+            <xs:attribute name="SchemaVersion" type="xs:string" use="required"/>
+            <xs:attribute name="TargetRelease" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ExportItem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="1" ref="ds:DataSet"/>
+            </xs:sequence>
+            <xs:attribute name="Id" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/SchemaValidation/ilias_sess_9.xsd
+++ b/xml/SchemaValidation/ilias_sess_9.xsd
@@ -29,6 +29,8 @@
 				<xs:element name='MailMembers' type="Data" minOccurs='1' maxOccurs='1'/>
 				<xs:element name='ShowMembers' type="Data" minOccurs='0' maxOccurs='1'/>
 				<xs:element name='ShowCannotPart' type="Data" minOccurs='1' maxOccurs='1'/>
+				<xs:element name='RegistrationNotificationEnabled' type="Data" minOccurs='0' maxOccurs='1'/>
+				<xs:element name='RegistrationNotificationOption' type="Data" minOccurs='0' maxOccurs='1'/>
 				<xs:element name='Type' type="Data" minOccurs='1' maxOccurs='1'/>
 			</xs:sequence>
 		</xs:complexType>


### PR DESCRIPTION
Adds a new error message that is shown if the available xsd files of a component do not match the schema version of the export xml.