### PR TITLE
[FIX] #40890 Component: streamline plugin environment.

### DIFF
--- a/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentActivatePluginsObjective.php
@@ -179,7 +179,6 @@ class ilComponentActivatePluginsObjective implements Setup\Objective
         };
         $GLOBALS["DIC"]["ilAppEventHandler"] = null;
         $GLOBALS["DIC"]["ilSetting"] = new ilSetting();
-        $GLOBALS["DIC"]["objDefinition"] = new ilObjectDefinition();
         $GLOBALS["DIC"]["ilUser"] = new class () extends ilObjUser {
             public array $prefs = [];
 
@@ -197,6 +196,10 @@ class ilComponentActivatePluginsObjective implements Setup\Objective
             define('SYSTEM_ROLE_ID', '2');
         }
 
+        if (!defined("ILIAS_ABSOLUTE_PATH")) {
+            define("ILIAS_ABSOLUTE_PATH", dirname(__FILE__, 5));
+        }
+
         if (!defined("CLIENT_ID")) {
             define('CLIENT_ID', $client_ini->readVariable('client', 'name'));
         }
@@ -204,6 +207,11 @@ class ilComponentActivatePluginsObjective implements Setup\Objective
         if (!defined("ILIAS_WEB_DIR")) {
             define('ILIAS_WEB_DIR', dirname(__DIR__, 4) . "/data/");
         }
+
+        // initialise this last to make sure the environment defined here
+        // will be available for plugins, ilObjectDefinition will create
+        // plugin instances, see https://mantis.ilias.de/view.php?id=40890
+        $GLOBALS["DIC"]["objDefinition"] = new ilObjectDefinition();
 
         return $DIC;
     }

--- a/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentInstallPluginObjective.php
@@ -182,7 +182,6 @@ class ilComponentInstallPluginObjective implements Setup\Objective
         $GLOBALS["DIC"]["ilSetting"] = new ilSetting();
         $GLOBALS["DIC"]["component.repository"] = $component_repository;
         $GLOBALS["DIC"]["component.factory"] = $component_factory;
-        $GLOBALS["DIC"]["objDefinition"] = new ilObjectDefinition();
         $GLOBALS["DIC"]["ilUser"] = new class () extends ilObjUser {
             public array $prefs = [];
 
@@ -197,8 +196,16 @@ class ilComponentInstallPluginObjective implements Setup\Objective
             }
         };
 
+        if (!defined('DEBUG')) {
+            define('DEBUG', false);
+        }
+
         if (!defined('SYSTEM_ROLE_ID')) {
             define('SYSTEM_ROLE_ID', '2');
+        }
+
+        if (!defined("ILIAS_ABSOLUTE_PATH")) {
+            define("ILIAS_ABSOLUTE_PATH", dirname(__FILE__, 5));
         }
 
         if (!defined("CLIENT_ID")) {
@@ -208,6 +215,11 @@ class ilComponentInstallPluginObjective implements Setup\Objective
         if (!defined("ILIAS_WEB_DIR")) {
             define('ILIAS_WEB_DIR', dirname(__DIR__, 4) . "/data/");
         }
+
+        // initialise this last to make sure the environment defined here
+        // will be available for plugins, ilObjectDefinition will create
+        // plugin instances, see https://mantis.ilias.de/view.php?id=40890
+        $GLOBALS["DIC"]["objDefinition"] = new ilObjectDefinition();
 
         return $DIC;
     }

--- a/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
+++ b/Services/Component/classes/Setup/class.ilComponentUpdatePluginObjective.php
@@ -247,7 +247,6 @@ class ilComponentUpdatePluginObjective implements Setup\Objective
         };
         $GLOBALS["DIC"]["ilObjDataCache"] = new ilObjectDataCache();
         $GLOBALS["DIC"]["ilSetting"] = new ilSetting();
-        $GLOBALS["DIC"]["objDefinition"] = new ilObjectDefinition();
         $GLOBALS["DIC"]["rbacadmin"] = new class () extends ilRbacAdmin {
             public function __construct()
             {
@@ -271,12 +270,12 @@ class ilComponentUpdatePluginObjective implements Setup\Objective
             define('DEBUG', false);
         }
 
-        if (!defined("ILIAS_ABSOLUTE_PATH")) {
-            define("ILIAS_ABSOLUTE_PATH", dirname(__FILE__, 5));
-        }
-
         if (!defined('SYSTEM_ROLE_ID')) {
             define('SYSTEM_ROLE_ID', '2');
+        }
+
+        if (!defined("ILIAS_ABSOLUTE_PATH")) {
+            define("ILIAS_ABSOLUTE_PATH", dirname(__FILE__, 5));
         }
 
         if (!defined("CLIENT_ID")) {
@@ -286,6 +285,11 @@ class ilComponentUpdatePluginObjective implements Setup\Objective
         if (!defined("ILIAS_WEB_DIR")) {
             define('ILIAS_WEB_DIR', dirname(__DIR__, 4) . "/data/");
         }
+
+        // initialise this last to make sure the environment defined here
+        // will be available for plugins, ilObjectDefinition will create
+        // plugin instances, see https://mantis.ilias.de/view.php?id=40890
+        $GLOBALS["DIC"]["objDefinition"] = new ilObjectDefinition();
 
         return [$ORIG_DIC, $ORIG_ilDB];
     }


### PR DESCRIPTION
Hi @klees,

I have opened this PR to address the following mantis issue: https://mantis.ilias.de/view.php?id=40890.

As described, there are some inconsistencies between the different plugin objectives when it comes to global constants. Since the problem occurs depending on what objectives are actually performed first, I considered this an ILIAS bug. In this PR I solved the issue by moving the initialisation of `ilObjectDefinition` to the bottom. While at it, I also made sure the same constants are defined in each objective.

Let me know if you think otherwise, or want to address this issue differently - or not at all.

Kind regards,
@thibsy 