### PR TITLE
UI: Translate 'unlimited' for the Input ViewControl Pagination

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -17152,6 +17152,7 @@ ui#:#ui_link_label#:#Label
 ui#:#ui_link_url#:#URL
 ui#:#ui_md_input_edit#:#Bearbeiten
 ui#:#ui_md_input_view#:#Vorschau
+ui#:#ui_pagination_unlimited#:#Unbegrenzt
 ui#:#ui_select_dropdown_label#:#Bitte auswählen
 ui#:#ui_table_no_records#:#Keine Einträge
 ui#:#ui_transcription#:#Abschrift

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -17153,6 +17153,7 @@ ui#:#ui_link_label#:#Label
 ui#:#ui_link_url#:#URL
 ui#:#ui_md_input_edit#:#Edit
 ui#:#ui_md_input_view#:#View
+ui#:#ui_pagination_unlimited#:#Unlimited
 ui#:#ui_select_dropdown_label#:#Please select
 ui#:#ui_table_no_records#:#No records
 ui#:#ui_transcription#:#Transcript

--- a/src/UI/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/src/UI/Implementation/Component/Input/ViewControl/Renderer.php
@@ -322,7 +322,7 @@ class Renderer extends AbstractComponentRenderer
             $signal = clone $internal_signal;
             $signal->addOption('offset', $offset);
             $signal->addOption('limit', (string)$option);
-            $option_label = $option === \PHP_INT_MAX ? 'unlimited' : (string)$option;
+            $option_label = $option === \PHP_INT_MAX ? $this->txt('ui_pagination_unlimited') : (string)$option;
 
             $item = $ui_factory->button()->shy($option_label, '#')
                 ->withOnClick($signal);


### PR DESCRIPTION
Fix Mantis Bug: https://mantis.ilias.de/view.php?id=39821

This PR adds a new language variable to translate _unlimited_ for the Pagination ViewControl.