### PR TITLE
UI Core: 40906 use ampersand and question mark in preg_replace

### DIFF
--- a/Services/UICore/classes/class.ilCtrl.php
+++ b/Services/UICore/classes/class.ilCtrl.php
@@ -1169,7 +1169,7 @@ class ilCtrl implements ilCtrlInterface
             if (preg_match("/($ampersand|\?)$parameter_name(=|$)/", $url)) {
                 // replace the value appended to the given parameter
                 // name by the provided one.
-                $url = preg_replace("/(?<=($parameter_name=))([^&]*|$)/", (string) $value, $url);
+                $url = preg_replace("/(?<=(($ampersand|\?)$parameter_name=))([^&]*|$)/", (string) $value, $url);
             } else {
                 // append the parameter key => value pair and prepend
                 // a question mark or ampersand, determined by whether


### PR DESCRIPTION
[Mantis Ticket](https://mantis.ilias.de/view.php?id=40906)

Ampersand and question mark should be used in preg_replace to prevent false replaces.