### PR TITLE
SETUP: adjust installation and update process with 'register_nic' set…

### DIFF
--- a/setup/classes/class.ilNICKeyRegisteredObjective.php
+++ b/setup/classes/class.ilNICKeyRegisteredObjective.php
@@ -57,12 +57,6 @@ class ilNICKeyRegisteredObjective extends ilSetupObjective
         $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
         $settings = $factory->settingsFor("common");
 
-        if (!$this->config->getRegisterNIC()) {
-            throw new Setup\UnachievableException(
-                "It is not allowed to deactivate an registered NIC."
-            );
-        }
-
         $systemfolder_config = $environment->getConfigFor("systemfolder");
         $http_config = $environment->getConfigFor("http");
 
@@ -120,7 +114,7 @@ class ilNICKeyRegisteredObjective extends ilSetupObjective
     {
         $factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
         $settings = $factory->settingsFor("common");
-        return $settings->get("inst_id") === '0';
+        return ($settings->get("inst_id") === '0') && $this->config->getRegisterNIC();
     }
 
     protected function getRegistrationProblem(array $nic_response_parts): string

--- a/setup/classes/class.ilSetupAgent.php
+++ b/setup/classes/class.ilSetupAgent.php
@@ -88,9 +88,7 @@ class ilSetupAgent implements Setup\Agent
                 new Setup\Condition\PHPExtensionLoadedCondition("gd"),
                 $this->getPHPMemoryLimitCondition(),
                 new ilSetupConfigStoredObjective($config),
-                $config->getRegisterNIC()
-                    ? new ilNICKeyRegisteredObjective($config)
-                    : new ilNICKeyStoredObjective($config)
+                new ilNICKeyRegisteredObjective($config)
             )
         );
     }


### PR DESCRIPTION
…tings (#40140).

https://mantis.ilias.de/view.php?id=40140

As the installation process failed with the previous changes in ilNICKeyRegisteredObjective the update and installation process was adjusted as following:

- remove the error message regarding setting 'register_nic' to false after it was already set to 'true'
- extend 'isApplicable' by checking if 'getRegisterNic' is true
- adjust the list of objectives in the installation step of the 'SetupAgent'