### PR TITLE
LP: 40895, key error for failed_users_num

### DIFF
--- a/Services/Tracking/classes/status/class.ilLPStatusCollection.php
+++ b/Services/Tracking/classes/status/class.ilLPStatusCollection.php
@@ -195,7 +195,8 @@ class ilLPStatusCollection extends ilLPStatus
 
                     if ($isGrouping) {
                         foreach ($tmp_users as $tmp_user_id) {
-                            ++$gr_failed_users_num[$tmp_user_id];
+                            $gr_failed_users_num[$tmp_user_id] =
+                                ($gr_failed_users_num[$tmp_user_id] ?? 0) + 1;
                         }
                     } else {
                         // One item failed is sufficient for status failed.


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40895

Issue is in 8, but occurs in 9, too.