### PR TITLE
Group/Course: Fix Saving of Object Properties

### DIFF
--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -845,11 +845,7 @@ class ilObjCourseGUI extends ilContainerGUI
         }
         $this->object->handleAutoFill();
 
-        $obj_service->commonSettings()->legacyForm($form, $this->object)->saveTitleIconVisibility();
-        $obj_service->commonSettings()->legacyForm($form, $this->object)->saveTopActionsVisibility();
         ilContainer::_writeContainerSetting($this->object->getId(), "rep_breacrumb", $form->getInput('rep_breacrumb'));
-        $obj_service->commonSettings()->legacyForm($form, $this->object)->saveIcon();
-        $obj_service->commonSettings()->legacyForm($form, $this->object)->saveTileImage();
         $this->saveListPresentation($form);
 
         $this->object->setViewMode((int) $form->getInput('view_mode'));
@@ -900,6 +896,11 @@ class ilObjCourseGUI extends ilContainerGUI
             $this->object->handleAutoFill();
         }
         $this->object->update();
+
+        $obj_service->commonSettings()->legacyForm($form, $this->object)->saveTitleIconVisibility();
+        $obj_service->commonSettings()->legacyForm($form, $this->object)->saveTopActionsVisibility();
+        $obj_service->commonSettings()->legacyForm($form, $this->object)->saveIcon();
+        $obj_service->commonSettings()->legacyForm($form, $this->object)->saveTileImage();
 
         ilObjectServiceSettingsGUI::updateServiceSettingsForm(
             $this->object->getId(),

--- a/Modules/Group/classes/class.ilObjGroupGUI.php
+++ b/Modules/Group/classes/class.ilObjGroupGUI.php
@@ -665,6 +665,9 @@ class ilObjGroupGUI extends ilContainerGUI
                     break;
             }
 
+            // update object settings
+            $this->object->update();
+
             // title icon visibility
             $obj_service->commonSettings()->legacyForm($form, $this->object)->saveTitleIconVisibility();
 
@@ -679,9 +682,6 @@ class ilObjGroupGUI extends ilContainerGUI
 
             // list presentation
             $this->saveListPresentation($form);
-
-            // update object settings
-            $this->object->update();
 
 
             ilObjectServiceSettingsGUI::updateServiceSettingsForm(


### PR DESCRIPTION
This is not an easy fix as it comes from the interplay of Legacy-Forms and UI-KS-Forms.

See: https://mantis.ilias.de/view.php?id=40928