### PR TITLE
9/UI/ta 40639 auto save msgbox

### DIFF
--- a/Modules/Test/ROADMAP.md
+++ b/Modules/Test/ROADMAP.md
@@ -34,6 +34,7 @@ Depending on development ressources, funding and approval, some new features are
 * UI Forms: Length of text fields not shorter than answer text. (see: [Mantis 35243](https://mantis.ilias.de/view.php?id=35243#c87241))
 * Grading: Use of Short Form / Offical Form. Conceptual changes only with the introduction of new UI forms. (see [Mantis](https://mantis.ilias.de/view.php?id=31209#c83984))
 * Streamlining of trimming and removal of white spaces in answer-options (see: [Mantis 35091](https://mantis.ilias.de/view.php?id=35091))
+* Auto-save messages should use UI components (e.g. toast), so a consistent UI/UX is used and easier to maintain throughout the entire system.
 
 ## Kiosk-Mode
 * current kiosk-mode enforces the header to be removed without it (the header) being a UI-Component.

--- a/Modules/Test/templates/default/tpl.il_as_tst_output.html
+++ b/Modules/Test/templates/default/tpl.il_as_tst_output.html
@@ -101,4 +101,4 @@
 	<!-- END finish_test_modal -->
 	</div>
 </div>
-<div id="autosavemessage" class="ilHighlighted tstAutosaveMsg"></div>
+<div id="autosavemessage" class="tstAutosaveMsg alert alert-info"></div>

--- a/templates/default/010-settings/_index.scss
+++ b/templates/default/010-settings/_index.scss
@@ -14,3 +14,4 @@
 @forward "./settings_header";
 @forward "./settings_layout";
 @forward "./settings_media";
+@forward "./settings_shadows";

--- a/templates/default/010-settings/_settings_shadows.scss
+++ b/templates/default/010-settings/_settings_shadows.scss
@@ -1,0 +1,1 @@
+$il-shadow--large: 20px 10px 30px rgba(0, 0, 0, .15);

--- a/templates/default/070-components/UI-framework/MainControls/_ui-component_mode_info.scss
+++ b/templates/default/070-components/UI-framework/MainControls/_ui-component_mode_info.scss
@@ -11,7 +11,7 @@ $il-mode-info-border: 3px solid $il-mode-info-color;
 $il-mode-info-height: 35px;
 $il-mode-info-text-color: white;
 $il-mode-info-zindex: 1010;
-$il-mode-info-shadow: 20px 10px 30px rgba(0, 0, 0, .15);
+$il-mode-info-shadow: $il-shadow--large;
 
 .c-mode-info {
   display: flex;

--- a/templates/default/070-components/legacy/Modules/_component_test_legacy.scss
+++ b/templates/default/070-components/legacy/Modules/_component_test_legacy.scss
@@ -1,5 +1,6 @@
 @use "../../../010-settings/" as *;
 @use "../../../050-layout/basics/_layout_spacing-variables"as *;
+@use "../../../070-components/legacy/component_alert" as alert;
 
 /* not yet refactored code from former ta.css */
 
@@ -575,13 +576,14 @@ div.ilc_Page.readonly textarea[disabled]
 
 .tstAutosaveMsg
 {
-	font-style: italic;
-	border: 1px #666 solid;
-	background-color: #ffffe0;
 	position:fixed;
 	z-index:99999999999;
-	top:0;
-	left:0;
+	top:$il-margin-xlarge-vertical;
+	right:$il-margin-xlarge-horizontal;
+	box-shadow: $il-shadow--large;
+	&:empty {
+		display: none;
+	}
 }
 
 .textarea {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -13192,13 +13192,14 @@ div.ilc_Page.readonly textarea[disabled] {
 }
 
 .tstAutosaveMsg {
-  font-style: italic;
-  border: 1px #666 solid;
-  background-color: #ffffe0;
   position: fixed;
   z-index: 99999999999;
-  top: 0;
-  left: 0;
+  top: 9px;
+  right: 15px;
+  box-shadow: 20px 10px 30px rgba(0, 0, 0, 0.15);
+}
+.tstAutosaveMsg:empty {
+  display: none;
 }
 
 .textarea {


### PR DESCRIPTION
# Issue

Empty auto-save message leaves border pixels on screen, when the message should be completely invisible.
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/07ba5b18-be86-4582-a392-82cce8669da7)

It's also not looking like the other alert and message boxes when it shows up:
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/db0cf0ce-2f83-4357-a702-e2aee66d89a3)

# Change

An :empty message box is now set to display: none; and should no longer show up. (If it shows up anyway it's because JavaScript or php leaves a whitespace " " string behind - this should be reported as a separate bug).

The design is now using uitility classes and shares new setting layer variables from the UI component message box and the UI mode info. Basically, we make a legacy div look like a UI component message box.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/c1429991-83af-4de3-845c-475dba73497f)


# Larger context

* We need to discuss in the css-squad: How do we make legacy components look like UI components if refactoring them properly is not feasible (at the moment)?
    * extending legacy components into UI components could be okay as an exception in this case
    * OR using UI component css classes as utility classes in html templates of legacy components