### PR TITLE
Composer: Add `league/flysystem as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"league/flysystem": "^3.0",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `league/flysystem` as composer dependency (which I simply forgot, mea culpa).

Usage:
* `Filesystem` Service

Wrapped By:
* `Filesystem` Service

Reasoning:
`league/flysystem` is the quasi-standard for file system operations. the library is actively developed and continuously maintained. With 116 contributors, many people are working on flysystem

Maintenance:
* `league/flysystem` is actively maintained by multiple contributors. There is recent activity way yesterday: https://github.com/thephpleague/flysystem/commit/072735c56cc0da00e10716dd90d5a7f7b40b36be

Links:
* Packagist: https://packagist.org/packages/league/flysystem
* GitHub: https://github.com/thephpleague/flysystem/
* Documentation: https://flysystem.thephpleague.com/docs/