### PR TITLE
#40960 fixing check for ilAccordionsInits to use the correct variable name.

### DIFF
--- a/Services/COPage/xsl/page.xsl
+++ b/Services/COPage/xsl/page.xsl
@@ -3631,7 +3631,7 @@
 					</xsl:choose>
 				</xsl:variable>
 				<script type="text/javascript">
-					if (typeof variable === 'undefined') {
+					if (typeof ilAccordionsInits === 'undefined') {
 						var ilAccordionsInits = [];
 					}
 					ilAccordionsInits.push({
@@ -3652,7 +3652,7 @@
 			</xsl:if>
 			<xsl:if test="@Type = 'Carousel' and $mode != 'print' and $compare_mode = 'n'">
 				<script type="text/javascript">
-					if (typeof variable === 'undefined') {
+					if (typeof ilAccordionsInits === 'undefined') {
 						var ilAccordionsInits = [];
 					}
 					ilAccordionsInits.push({


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=40960