### PR TITLE
LegacyForm/FileWizard: Use UI/KS glyphs

### DIFF
--- a/components/ILIAS/Form/classes/class.ilFileWizardInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilFileWizardInputGUI.php
@@ -28,6 +28,8 @@ use ILIAS\Filesystem\Util;
 class ilFileWizardInputGUI extends ilFileInputGUI
 {
     protected ilGlobalTemplateInterface $tpl;
+    protected \ILIAS\UI\Factory $ui_factory;
+    protected \ILIAS\UI\Renderer $ui_renderer;
     protected array $filenames = array();
     protected bool $allowMove = false;
     protected string $imagepath_web = "";
@@ -41,6 +43,8 @@ class ilFileWizardInputGUI extends ilFileInputGUI
         $this->lng = $DIC->language();
         $this->lng->loadLanguageModule("form");
         $this->tpl = $DIC["tpl"];
+        $this->ui_factory = $DIC->ui()->factory();
+        $this->ui_renderer = $DIC->ui()->renderer();
         parent::__construct($a_title, $a_postvar);
     }
 
@@ -195,8 +199,18 @@ class ilFileWizardInputGUI extends ilFileInputGUI
                 $tpl->setVariable("CMD_UP", "cmd[up" . $this->getFieldId() . "][$i]");
                 $tpl->setVariable("CMD_DOWN", "cmd[down" . $this->getFieldId() . "][$i]");
                 $tpl->setVariable("ID", $this->getFieldId() . "[$i]");
-                $tpl->setVariable("UP_BUTTON", ilGlyphGUI::get(ilGlyphGUI::UP));
-                $tpl->setVariable("DOWN_BUTTON", ilGlyphGUI::get(ilGlyphGUI::DOWN));
+                $tpl->setVariable(
+                    "UP_BUTTON",
+                    $this->ui_renderer->render(
+                        $this->ui_factory->symbol()->glyph()->up()
+                    )
+                );
+                $tpl->setVariable(
+                    "DOWN_BUTTON",
+                    $this->ui_renderer->render(
+                        $this->ui_factory->symbol()->glyph()->down()
+                    )
+                );
                 $tpl->parseCurrentBlock();
             }
 
@@ -216,8 +230,18 @@ class ilFileWizardInputGUI extends ilFileInputGUI
                 );
             }
 
-            $tpl->setVariable("ADD_BUTTON", ilGlyphGUI::get(ilGlyphGUI::ADD));
-            $tpl->setVariable("REMOVE_BUTTON", ilGlyphGUI::get(ilGlyphGUI::REMOVE));
+            $tpl->setVariable(
+                "ADD_BUTTON",
+                $this->ui_renderer->render(
+                    $this->ui_factory->symbol()->glyph()->add()
+                )
+            );
+            $tpl->setVariable(
+                "REMOVE_BUTTON",
+                $this->ui_renderer->render(
+                    $this->ui_factory->symbol()->glyph()->remove()
+                )
+            );
             $tpl->setVariable("TXT_MAX_SIZE", $lng->txt("file_notice") . " " . $this->getMaxFileSizeString());
             $tpl->setVariable("MAX_UPLOAD_VALUE", $this->getMaxFileUploads());
             $tpl->setVariable("TXT_MAX_UPLOADS", $lng->txt("form_msg_max_upload") . " " . $this->getMaxFileUploads());

--- a/components/ILIAS/Form/resources/filewizard.js
+++ b/components/ILIAS/Form/resources/filewizard.js
@@ -1,54 +1,69 @@
 var ilFileWizardInputTemplate = {
-		
+
 	tag_container: 'div.wzdcnt',
 	tag_row: 'div.wzdrow',
 	tag_button: 'imagewizard',
-	
-	getRowFromEvent: function(e) {
-		return $(e.target).parent(this.tag_row);
+
+	initEvents: function (rootel) {
+		let that = this;
+		$(rootel).find('span.' + this.tag_button + '_add a').click(function (e) {
+			that.addRow(e);
+		});
+		$(rootel).find('span.' + this.tag_button + '_remove a').click(function (e) {
+			that.removeRow(e);
+		});
+		$(rootel).find('span.' + this.tag_button + '_up a').click(function (e) {
+			that.moveRowUp(e);
+		});
+		$(rootel).find('span.' + this.tag_button + '_down a').click(function (e) {
+			that.moveRowDown(e);
+		});
 	},
-	
-	getContainerFromEvent: function(e) {
-		return $(e.target).parents(this.tag_container);
+
+	getRowFromEvent: function (e) {
+		return $(e.target).closest(this.tag_row);
 	},
-			
-	cleanRow: function(row) {
-            
-            $(row).find('input:file').val('');
-            $(row).find('input[type=hidden]').remove();
-            $(row).find('img').remove();
+
+	getContainerFromEvent: function (e) {
+		return $(e.target).closest(this.tag_container);
 	},
-		
-	reindexRows: function(rootel) {					
+
+	cleanRow: function (row) {
+		$(row).find('input:file').val('');
+		$(row).find('input[type=hidden]').remove();
+		$(row).find('img').remove();
+	},
+
+	reindexRows: function (rootel) {
 		var that = this;
 		var rowindex = 0;
-	
+
 		// process all rows
-		$(rootel).find(this.tag_row).each(function() {
-			
+		$(rootel).find(this.tag_row).each(function () {
+
 			// file
-			$(this).find('input:file').each(function() {					
+			$(this).find('input:file').each(function () {
 				that.handleId(this, 'id', rowindex);
-				that.handleId(this, 'name', rowindex);							
+				that.handleId(this, 'name', rowindex);
 			});
-			
+
 			// hidden
-			$(this).find('input:hidden').each(function() {		
-				that.handleId(this, 'name', rowindex);													
+			$(this).find('input:hidden').each(function () {
+				that.handleId(this, 'name', rowindex);
 			});
-			
-			// button
-			$(this).find('button').each(function() {	
+
+			// span with glyph
+			$(this).find('> span').each(function () {
 				that.handleId(this, 'id', rowindex);
-				that.handleId(this, 'name', rowindex);											
+				that.handleId(this, 'data-name', rowindex);
 			});
-								
+
 			rowindex++;
-		});					
+		});
 	}
 };
 
-$(document).ready(function() {
-	var ilFileWizardInput = $.extend({}, ilFileWizardInputTemplate, ilWizardInput);
+$(document).ready(function () {
+	var ilFileWizardInput = $.extend({}, ilWizardInput, ilFileWizardInputTemplate);
 	ilFileWizardInput.init();
 });

--- a/components/ILIAS/Form/templates/default/tpl.prop_filewizardinput.html
+++ b/components/ILIAS/Form/templates/default/tpl.prop_filewizardinput.html
@@ -3,11 +3,11 @@
 	<div class="wzdrow form-inline">
 	<!-- BEGIN image -->	<img style="margin: 5px 0px 5px 0px;" src="{SRC_IMAGE}" alt="{ALT_IMAGE}" {WIDTH} {HEIGHT}  /><input type="hidden" name="picture_{ID}" value="{PICTURE_FILE}" /><br /><!-- END image -->
 		<input type="file" class="form-control" id="{ID}" name="{POST_VAR}" size="30" />
-		<button type="button" name="{CMD_ADD}" class="imagewizard_add btn btn-link" id="add_{ID}" data-val="{MAX_UPLOAD_VALUE}" onclick="javascript: return false;" >{ADD_BUTTON}</button>
-		<button type="button" name="{CMD_REMOVE}" class="imagewizard_remove btn btn-link" id="remove_{ID}" data-val="{MAX_UPLOAD_VALUE}" onclick="javascript: return false;">{REMOVE_BUTTON}</button>
+		<span id="add_{ID}" class="imagewizard_add btn btn-link" data-name="{CMD_ADD}" data-val="{MAX_UPLOAD_VALUE}">{ADD_BUTTON}</span>
+		<span id="remove_{ID}" class="imagewizard_remove btn btn-link" data-name="{CMD_REMOVE}" data-val="{MAX_UPLOAD_VALUE}">{REMOVE_BUTTON}</span>
 	<!-- BEGIN move -->
-		<button type="button" name="{CMD_UP}" class="imagewizard_up btn btn-link" id="up_{ID}" onclick="javascript: return false;" >{UP_BUTTON}</button>
-		<button type="button" name="{CMD_DOWN}" class="imagewizard_down btn btn-link" id="down_{ID}" onclick="javascript: return false;">{DOWN_BUTTON}</button>	
+		<span id="up_{ID}" class="imagewizard_up btn btn-link" data-name="{CMD_UP}">{UP_BUTTON}</span>
+		<span id="down_{ID}" class="imagewizard_down btn btn-link" data-name="{CMD_DOWN}">{DOWN_BUTTON}</span>
 	<!-- END move -->
 		<div class="help-block">{TXT_MAX_SIZE}</div>
 		<div class="help-block">{TXT_MAX_UPLOADS}</div>


### PR DESCRIPTION
This PR removes the legacy UI glyph usages from `ilFileWizardInputGUI`.

I had to rewrite the JS code, because glyphs inside `a` elements inside `button` elements are **not** valid in `HTML`. `button` elements were used before as trigger element for the different actions like `add`, `remove`, `move up` and `move down`.

> The element a must not appear as a descendant of the button element.