### PR TITLE
Tracking: Fix null value passed to `ilTrQuery::executeQueries`

### DIFF
--- a/Services/Tracking/classes/class.ilTrQuery.php
+++ b/Services/Tracking/classes/class.ilTrQuery.php
@@ -327,7 +327,7 @@ class ilTrQuery
             $a_order_field = "login";
         } elseif (substr($a_order_field, 0, 4) == "udf_") {
             $udf_order = $a_order_field;
-            $a_order_field = null;
+            $a_order_field = '';
         }
         $result = self::executeQueries(
             $queries,


### PR DESCRIPTION
If approved, this has to be picked to `release_9` and `trunk` as well.

Mantis Issue: https://mantis.ilias.de/view.php?id=40974