### PR TITLE
UIComponent: File Upload Input: Add visible file extension option

### DIFF
--- a/components/ILIAS/UI/src/Component/Input/Field/FileUpload.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/FileUpload.php
@@ -43,9 +43,15 @@ interface FileUpload
     public function getMaxFiles(): int;
 
     /**
+     * If $visible_extensions is null the file extensions shown to the user will be derived from $mime_types.
+     * If $visible_extensions is not null it will be shown to the user.
+     * The $visible_extensions do not change which files can be selected, they are only a visible indicator.
+     * $visible_extensions must be of the form: ['txt', 'html'].
+     *
      * @param string[] $mime_types
+     * @param null|string[] $visible_extensions
      */
-    public function withAcceptedMimeTypes(array $mime_types): FileUpload;
+    public function withAcceptedMimeTypes(array $mime_types, ?array $visible_extensions = null): FileUpload;
 
     /**
      * @return string[]

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
@@ -49,6 +49,9 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
     protected int $max_file_amount = 1;
     protected int $max_file_size_in_bytes;
 
+    /** @var null|string[] */
+    protected ?array $visible_extensions = null;
+
     public function __construct(
         ilLanguage $language,
         DataFactory $data_factory,
@@ -111,10 +114,11 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
         return $this->max_file_amount;
     }
 
-    public function withAcceptedMimeTypes(array $mime_types): FileUpload
+    public function withAcceptedMimeTypes(array $mime_types, ?array $visible_extensions = null): FileUpload
     {
         $clone = clone $this;
         $clone->accepted_mime_types = $mime_types;
+        $clone->visible_extensions = $visible_extensions;
 
         return $clone;
     }
@@ -122,6 +126,11 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
     public function getAcceptedMimeTypes(): array
     {
         return $this->accepted_mime_types;
+    }
+
+    public function getVisibleExtensions(): ?array
+    {
+        return $this->visible_extensions;
     }
 
     // ===============================================


### PR DESCRIPTION
Follow up to PR #7090.

This PR proposes to add an additional parameter to the `withAcceptedMimeTypes` to set the list of file extensions which should be shown to the user. If this is not set or set to `null` the file extensions are derived from the mime types. This only affects which file extensions are shown to the user, not which ones the user can select.