### PR TITLE
IASS: adjust access to members and learning progress tab. (#40930)

### DIFF
--- a/Modules/IndividualAssessment/classes/AccessControl/class.ilIndividualAssessmentAccessHandler.php
+++ b/Modules/IndividualAssessment/classes/AccessControl/class.ilIndividualAssessmentAccessHandler.php
@@ -177,8 +177,7 @@ class ilIndividualAssessmentAccessHandler implements IndividualAssessmentAccessH
     public function mayViewAnyUser(): bool
     {
         return $this->mayViewAllUsers()
-            || $this->checkRBACOrPositionAccessToObj('read_learning_progress')
-            || $this->checkRBACOrPositionAccessToObj('edit_learning_progress');
+            || $this->checkRBACOrPositionAccessToObj('read_learning_progress');
     }
 
     public function mayViewAllUsers(): bool
@@ -188,12 +187,12 @@ class ilIndividualAssessmentAccessHandler implements IndividualAssessmentAccessH
 
     public function mayGradeAnyUser(): bool
     {
-        return $this->mayGradeAllUsers() || $this->checkRBACOrPositionAccessToObj('edit_learning_progress');
+        return $this->mayGradeAllUsers() || $this->checkRBACOrPositionAccessToObj('read_learning_progress');
     }
 
     public function mayGradeAllUsers(): bool
     {
-        return $this->checkRBACAccessToObj('edit_learning_progress');
+        return $this->checkRBACAccessToObj('read_learning_progress');
     }
 
     public function mayGradeUser(int $user_id): bool
@@ -232,5 +231,10 @@ class ilIndividualAssessmentAccessHandler implements IndividualAssessmentAccessH
     public function isSystemAdmin(): bool
     {
         return $this->review->isAssigned($this->usr->getId(), SYSTEM_ROLE_ID);
+    }
+
+    public function mayEditLearningProgressSettings(): bool
+    {
+        return $this->checkRBACAccessToObj('edit_learning_progress');
     }
 }

--- a/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentGUI.php
@@ -325,7 +325,7 @@ class ilObjIndividualAssessmentGUI extends ilObjectGUI
         }
 
         if (($this->object->accessHandler()->mayViewAllUsers()
-            || $this->object->accessHandler()->mayGradeAllUsers()
+            || $this->object->accessHandler()->mayEditLearningProgressSettings()
             || ($this->object->loadMembers()->userAllreadyMember($this->usr)
             && $this->object->isActiveLP()))
             && ilObjUserTracking::_enabledLearningProgress()) {

--- a/Modules/IndividualAssessment/interfaces/AccessControl/interface.IndividualAssessmentAccessHandler.php
+++ b/Modules/IndividualAssessment/interfaces/AccessControl/interface.IndividualAssessmentAccessHandler.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Mechanic regarding the access control and roles of an objet goes here.
@@ -51,4 +51,5 @@ interface IndividualAssessmentAccessHandler
     public function mayViewUser(int $user_id): bool;
     public function mayAmendAllUsers(): bool;
     public function isSystemAdmin(): bool;
+    public function mayEditLearningProgressSettings(): bool;
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40930

The members tab should only be visible if the user has reading rights. "edit_learning_progress" has nothing to do with this tab as it should be read as "edit_learning_progress_settings".
As result a new function, which will check if the user had permission to edit the learning progress settings, had to be added for the learning progress tab.