### PR TITLE
9/UI/modal remove close button border 40881

### DIFF
--- a/templates/default/070-components/UI-framework/Modal/_ui-component_modal.scss
+++ b/templates/default/070-components/UI-framework/Modal/_ui-component_modal.scss
@@ -99,7 +99,6 @@ $il-modal-dark-carousel-color: $il-main-bg !default;
 			color: $il-modal-light-color;
 			background-color: $il-modal-dark-color;
 			opacity: 1;
-			border: 1px solid $il-main-border-color;
 		}
 	}
   }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6974,7 +6974,6 @@ div.alert ul > li:before {
   color: white;
   background-color: #2c2c2c;
   opacity: 1;
-  border: 1px solid #dddddd;
 }
 
 .modal-open .modal {


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=40881

# Issue

Most modals had the border around the close button X already removed. The UI component lightbox and lightbox image still showed a border.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/f2bb998c-c017-4c08-b405-7cda4315cb54)

# Changes

Border has been removed.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/04a7d2fb-7247-49d7-a386-46eb037978f6)
