### PR TITLE
9/UI/listing restore previous design 40050

### DIFF
--- a/templates/default/070-components/legacy/Modules/_component_test.scss
+++ b/templates/default/070-components/legacy/Modules/_component_test.scss
@@ -121,28 +121,3 @@ $il-test-working-time-font-weight: $il-font-weight-bold;
 #tst_pass_details_overview tr {
     scroll-margin-top: 30px;
 }
-
-//
-// test result
-//
-
-.il-table-presentation-desclist.inline .il-listing-characteristic-value-row {
-    display: flex;
-    width: auto;
-    padding-right: $il-padding-xxxlarge-horizontal;
-}
-
-.il-table-presentation-desclist.inline  .il-listing-characteristic-value {
-    display: flex;
-    .il-listing-characteristic-value-item {
-        padding-left: $il-padding-small-horizontal;
-    }
-}
-
-.il-listing-characteristic-value-label, .il-listing-characteristic-value-item {
-    width: fit-content;
-}
-
-.il-listing-characteristic-value-row.clearfix {
-    border-top: none;
-}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -13328,27 +13328,6 @@ div.ilc_Page.readonly textarea[disabled] {
   scroll-margin-top: 30px;
 }
 
-.il-table-presentation-desclist.inline .il-listing-characteristic-value-row {
-  display: flex;
-  width: auto;
-  padding-right: 18px;
-}
-
-.il-table-presentation-desclist.inline .il-listing-characteristic-value {
-  display: flex;
-}
-.il-table-presentation-desclist.inline .il-listing-characteristic-value .il-listing-characteristic-value-item {
-  padding-left: 6px;
-}
-
-.il-listing-characteristic-value-label, .il-listing-characteristic-value-item {
-  width: fit-content;
-}
-
-.il-listing-characteristic-value-row.clearfix {
-  border-top: none;
-}
-
 /* Modules/Wiki */
 a.ilWikiPageMissing:link, a.ilWikiPageMissing:visited {
   color: #d00;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40050

# Issue

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/1e997e83-59cd-4db0-a144-928de1c8d073)

# Change

A custom design for the test result was conflicting with the listings default look. These lines of code (once written by me, I must confess, to polish the look of the test result) are now removed.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/62287710-e3b3-4ea0-8d6a-c4ff14bc692a)

@dsstrassner, as there is no way anymore to detect if the presentation table with the listing characteristics is rendered in the context of the test result, the look had to be set to the listing's default design everywhere. However, I am in contact with @yvseiler discussing improvements for the listing characteristics. Right now key and value are too far apart on desktop and we need to fix that globally not just for the test result.

This is how the test result looks now with the characteristics listing's default appearance:

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/20fa640a-421b-4242-a5d2-5298fd0e23e4)