### PR TITLE
GroupReference: Fix PHP error in `\ilObjGroupReferenceAccess::_checkAccess`

### DIFF
--- a/Modules/GroupReference/classes/class.ilObjGroupReferenceAccess.php
+++ b/Modules/GroupReference/classes/class.ilObjGroupReferenceAccess.php
@@ -1,6 +1,20 @@
 <?php
 
-/* Copyright (c) 1998-2016 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 include_once("./Services/ContainerReference/classes/class.ilContainerReferenceAccess.php");
 
@@ -30,7 +44,7 @@ class ilObjGroupReferenceAccess extends ilContainerReferenceAccess
             case 'visible':
             case 'read':
                 include_once './Modules/GroupReference/classes/class.ilObjGroupReference.php';
-                $target_ref_id = ilObjGroupReference::_lookupTargetRefId($obj_id);
+                $target_ref_id = (int) ilObjGroupReference::_lookupTargetRefId($obj_id);
 
                 if (!$ilAccess->checkAccessOfUser($user_id, $permission, $cmd, $target_ref_id)) {
                     return false;


### PR DESCRIPTION
(cherry picked from commit 664c8de07e75497b06ea16a7c4e341b792545cc5)

Mantis Issue: https://mantis.ilias.de/view.php?id=40733