### PR TITLE
Language: Add NullLanguage class

### DIFF
--- a/components/ILIAS/Language/src/NullLanguage.php
+++ b/components/ILIAS/Language/src/NullLanguage.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Language;
+
+class NullLanguage implements Language
+{
+    public function txt(string $a_topic, string $a_default_lang_fallback_mod = ""): string
+    {
+        return $a_topic;
+    }
+
+    public function loadLanguageModule(string $a_module): void
+    {
+    }
+}


### PR DESCRIPTION
I'm currently fixing missing properties in the Refinery.
Among others the `ILIAS\Refinery\To\Transformation\StringTransformation` and `ILIAS\Refinery\To\Transformation\ListTransformation`  are missing a `$lng` property (which is used in the `ILIAS\Refinery\ProblemBuilder::getLngClosure()`).

The problem is that these two transformations are used in the templating class `IT` and there it is not always guaranteed (AFAIK) that `$DIC->language()` is available, so I cannot require the `ILIAS\Language\Language` interface in the constructor of those transformations.
Therefore I would like to add a `NullLanguage` which can be used instead.
