### PR TITLE
UIComponent: Render File Upload: Show Max nr of files and upload size

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -797,6 +797,8 @@ class Renderer extends AbstractComponentRenderer
             $file_preview_template
         );
 
+        $this->setHelpBlockForFileField($template, $input);
+
         $input = $this->initClientsideFileInput($input);
         $input = $this->initClientsideRenderer($input, $file_preview_template->get('block_file_preview'));
 
@@ -1117,5 +1119,22 @@ class Renderer extends AbstractComponentRenderer
 
 
         return $this->wrapInFormContext($component, $tpl->get(), $default_renderer);
+    }
+
+    private function setHelpBlockForFileField(Template $template, FI\File $input): void
+    {
+        $template->setCurrentBlock('HELP_BLOCK');
+
+        $template->setCurrentBlock('MAX_FILE_SIZE');
+        $template->setVariable('FILE_SIZE_LABEL', $this->txt('file_notice'));
+        $template->setVariable('FILE_SIZE_VALUE', new DataSize($input->getMaxFileSize(), DataSize::Byte));
+        $template->parseCurrentBlock();
+
+        $template->setCurrentBlock('MAX_FILES');
+        $template->setVariable('FILES_LABEL', $this->txt('ui_file_upload_max_nr'));
+        $template->setVariable('FILES_VALUE', $input->getMaxFiles());
+        $template->parseCurrentBlock();
+
+        $template->parseCurrentBlock();
     }
 }

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.file.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.file.html
@@ -26,4 +26,11 @@
         <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
     </div>
     <!-- END block_file_dropzone -->
+    <!-- BEGIN HELP_BLOCK -->
+    <div class="help-block">
+        <!-- BEGIN MAX_FILE_SIZE -->{FILE_SIZE_LABEL} {FILE_SIZE_VALUE}<!-- END MAX_FILE_SIZE -->
+        |
+        <!-- BEGIN MAX_FILES -->{FILES_LABEL} {FILES_VALUE}<!-- END MAX_FILES -->
+    </div>
+    <!-- END HELP_BLOCK -->
 </div>

--- a/components/ILIAS/UI/tests/Component/Input/Field/FileInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/FileInputTest.php
@@ -171,6 +171,7 @@ class FileInputTest extends ILIAS_UI_TestBase
                             <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
                         </div>
+                        <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1 </div>
                     </div>
                     <div class="help-block">byline</div>
                 </div>
@@ -200,6 +201,7 @@ class FileInputTest extends ILIAS_UI_TestBase
                         <div class="ui-input-file-input-dropzone">
                             <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
+                        <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1 </div>
                     </div>
                     <div class="help-block">byline</div>
                 </div>
@@ -226,6 +228,7 @@ class FileInputTest extends ILIAS_UI_TestBase
                         <div class="ui-input-file-input-dropzone">
                             <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
+                        <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1 </div>
                     </div>
                 </div>
             </div>
@@ -284,6 +287,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 				<button class="btn btn-link" data-action="#" id="id_3">select_files_from_computer</button>
 				<span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
 			</div>
+            <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1 </div>
 		</div>
 	</div>
 </div>
@@ -357,6 +361,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 				<button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button>
 				<span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
 			</div>
+            <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1 </div>
 		</div>
 	</div>
 </div>
@@ -439,6 +444,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 				<button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button>
 				<span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
 			</div>
+            <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1 </div>
 		</div>
 	</div>
 </div>
@@ -465,6 +471,7 @@ class FileInputTest extends ILIAS_UI_TestBase
                         <div class="ui-input-file-input-dropzone">
                             <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
+                    <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1 </div>
                     </div>
                 </div>
             </div>
@@ -490,6 +497,7 @@ class FileInputTest extends ILIAS_UI_TestBase
                         <div class="ui-input-file-input-dropzone">
                             <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
+                        <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1 </div>
                     </div>
                 </div>
             </div>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -17220,6 +17220,7 @@ ui#:#ui_file_input_general_error#:#Es ist ein Fehler aufgetreten. Sie können in
 ui#:#ui_file_input_invalid_amount#:#Sie dürfen nicht so viele Dateien auf einmal hochladen! Entfernen Sie einige Dateien, um fortzufahren.
 ui#:#ui_file_input_invalid_mime#:#Dateien vom Typ „%s“ sind nicht erlaubt.
 ui#:#ui_file_input_invalid_size#:#Datei überschreitet die maximale Dateigrösse von %s.
+ui#:#ui_file_upload_max_nr#:#Maximale Dateianzahl:
 ui#:#ui_invalid_url#:#Das Format der URL ist nicht korrekt.
 ui#:#ui_link_label#:#Label
 ui#:#ui_link_url#:#URL

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -17107,6 +17107,7 @@ ui#:#ui_file_input_general_error#:#An error occurred! You can check the JavaScri
 ui#:#ui_file_input_invalid_amount#:#You cannot upload this many files, please remove some in order to continue.
 ui#:#ui_file_input_invalid_mime#:#Files of type '%s' are not allowed
 ui#:#ui_file_input_invalid_size#:#File exceeds the maximum size of %s.
+ui#:#ui_file_upload_max_nr#:#Max Number of Files:
 ui#:#ui_invalid_url#:#Invalid URL-format
 ui#:#ui_link_label#:#Label
 ui#:#ui_link_url#:#URL


### PR DESCRIPTION
This PR addresses one part of Mantis Issue: https://mantis.ilias.de/view.php?id=39689

This PR displays the max nr of files and the max upload size below the file input field.

The info list may be extended to show the accepted file extensions in a future PR.