### PR TITLE
SOAP: Avoid `client.ini.php` change to make SOAP plugins work

### DIFF
--- a/Services/WebServices/SOAP/classes/class.ilAbstractSoapMethod.php
+++ b/Services/WebServices/SOAP/classes/class.ilAbstractSoapMethod.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 /**
@@ -44,7 +60,7 @@ abstract class ilAbstractSoapMethod extends ilSoapAdministration implements ilSo
      */
     protected function initIliasAndCheckSession(string $session_id): void
     {
-        $this->initAuth($session_id, true);
+        $this->initAuth($session_id);
         $this->reInitUser();
         if (!$this->checkSession($session_id)) {
             throw new ilSoapPluginException($this->getMessage());

--- a/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
+++ b/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
@@ -48,12 +48,16 @@ class AsyncTaskManager extends BasicTaskManager
         $soap_client->enableWSDL(true);
         $soap_client->init();
         $session_id = session_id();
-        $client_id = $DIC->http()->wrapper()->cookie()->has('ilClientId')
-            ? $DIC->http()->wrapper()->cookie()->retrieve(
-                'ilClientId',
-                $DIC->refinery()->kindlyTo()->string()
-            )
-            : '';
+        $client_id = $DIC->http()->wrapper()->cookie()->retrieve(
+            'ilClientId',
+            $DIC->refinery()->byTrying([
+                $DIC->refinery()->kindlyTo()->string(),
+                $DIC->refinery()->always(
+                    defined('CLIENT_ID') ? CLIENT_ID : null
+                )
+            ])
+        );
+
         try {
             $soap_client->call(self::CMD_START_WORKER, array(
                 $session_id . '::' . $client_id,

--- a/webservice/soap/classes/class.ilSoapAdministration.php
+++ b/webservice/soap/classes/class.ilSoapAdministration.php
@@ -1,27 +1,22 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
-/*
- +-----------------------------------------------------------------------------+
- | ILIAS open source                                                           |
- +-----------------------------------------------------------------------------+
- | Copyright (c) 1998-2009 ILIAS open source, University of Cologne            |
- |                                                                             |
- | This program is free software; you can redistribute it and/or               |
- | modify it under the terms of the GNU General Public License                 |
- | as published by the Free Software Foundation; either version 2              |
- | of the License, or (at your option) any later version.                      |
- |                                                                             |
- | This program is distributed in the hope that it will be useful,             |
- | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
- | GNU General Public License for more details.                                |
- |                                                                             |
- | You should have received a copy of the GNU General Public License           |
- | along with this program; if not, write to the Free Software                 |
- | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
- +-----------------------------------------------------------------------------+
-*/
 
 /**
  * soap server
@@ -135,18 +130,21 @@ class ilSoapAdministration
         return $this->message_code;
     }
 
-    protected function initAuth(string $sid, bool $mutate_super_global_cookies = false): void
+    protected function initAuth(string $sid): void
     {
         global $DIC;
 
         [$sid, $client] = $this->explodeSid($sid);
 
-        if ($mutate_super_global_cookies || !isset($DIC)) {
-            $_COOKIE['ilClientId'] = $client;
-            $_COOKIE[session_name()] = $sid;
-        } else {
-            ilUtil::setCookie(session_name(), $sid);
+        if (session_status() === PHP_SESSION_ACTIVE && $sid === session_id()) {
+            return;
         }
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+
+        session_id($sid);
     }
 
     protected function initIlias(): void


### PR DESCRIPTION
This is a follow-up PR for https://github.com/ILIAS-eLearning/ILIAS/pull/7116 . Instead of setting cookies based on the `sid` passed in the SOAP request, `session_id` is used to set the current session id to load the user session when `session_start` is called.

Please test this thoroughly before merging.

If approved, this MUST be picked to `release_9` and `trunk` as well.