### PR TITLE
WAC/Init: Provide a possible fix for Mantis 39817

### DIFF
--- a/Modules/CmiXapi/classes/XapiProxy/DataService.php
+++ b/Modules/CmiXapi/classes/XapiProxy/DataService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace XapiProxy;
 
@@ -67,14 +67,15 @@ class ilInitialisation extends \ilInitialisation
     /**
      * Function; initGlobal($a_name, $a_class, $a_source_file)
      *  Derive from protected to public...
-     * @param string      $a_class
-     * @param string|null $a_source_file
-     * @see \ilInitialisation::initGlobal($a_name, $a_class, $a_source_file)
+     * @see \ilInitialisation::initGlobal()
      */
-    //    public static function initGlobal(string $a_name, string $a_class, ?string $a_source_file = null) : void
-    public static function initGlobal($a_name, $a_class, $a_source_file = null): void
-    {
-        parent::initGlobal($a_name, $a_class, $a_source_file);
+    public static function initGlobal(
+        string $a_name,
+        $a_class,
+        ?string $a_source_file = null,
+        ?bool $destroy_existing = false
+    ): void {
+        parent::initGlobal($a_name, $a_class, $a_source_file, $destroy_existing);
     }
 
     /**

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1046,24 +1046,27 @@ class ilInitialisation
     protected static function initAccessHandling(): void
     {
         self::initGlobal(
-            "rbacreview",
-            "ilRbacReview",
-            "./Services/AccessControl/classes/class.ilRbacReview.php"
+            'rbacreview',
+            'ilRbacReview',
+            './Services/AccessControl/classes/class.ilRbacReview.php',
+            true
         );
 
         $rbacsystem = ilRbacSystem::getInstance();
-        self::initGlobal("rbacsystem", $rbacsystem);
+        self::initGlobal('rbacsystem', $rbacsystem, null, true);
 
         self::initGlobal(
-            "rbacadmin",
-            "ilRbacAdmin",
-            "./Services/AccessControl/classes/class.ilRbacAdmin.php"
+            'rbacadmin',
+            'ilRbacAdmin',
+            './Services/AccessControl/classes/class.ilRbacAdmin.php',
+            true
         );
 
         self::initGlobal(
-            "ilAccess",
-            "ilAccess",
-            "./Services/AccessControl/classes/class.ilAccess.php"
+            'ilAccess',
+            'ilAccess',
+            './Services/AccessControl/classes/class.ilAccess.php',
+            true
         );
     }
 
@@ -1080,18 +1083,28 @@ class ilInitialisation
     }
 
     /**
-     * Initialize global instance
-     * @param string $a_name
-     * @param string|object $a_class
-     * @param ?string $a_source_file
+     * @param object|string $a_class
      */
-    protected static function initGlobal($a_name, $a_class, $a_source_file = null): void
-    {
+    protected static function initGlobal(
+        string $a_name,
+        $a_class,
+        ?string $a_source_file = null,
+        ?bool $destroy_existing = false
+    ): void {
         global $DIC;
+
+        if ($destroy_existing) {
+            if (isset($GLOBALS[$a_name])) {
+                unset($GLOBALS[$a_name]);
+            }
+            if (isset($DIC[$a_name])) {
+                unset($DIC[$a_name]);
+            }
+        }
 
         $GLOBALS[$a_name] = is_object($a_class) ? $a_class : new $a_class();
 
-        $DIC[$a_name] = function ($c) use ($a_name) {
+        $DIC[$a_name] = static function (Container $c) use ($a_name) {
             return $GLOBALS[$a_name];
         };
     }
@@ -1193,7 +1206,11 @@ class ilInitialisation
      */
     protected static function initSession(): void
     {
-        $GLOBALS["DIC"]["ilAuthSession"] = function ($c) {
+        if (isset($GLOBALS['DIC']['ilAuthSession'])) {
+            unset($GLOBALS['DIC']['ilAuthSession']);
+        }
+
+        $GLOBALS['DIC']['ilAuthSession'] = static function (Container $c): ilAuthSession {
             $auth_session = ilAuthSession::getInstance(
                 $c['ilLoggerFactory']->getLogger('auth')
             );
@@ -1366,7 +1383,8 @@ class ilInitialisation
         self::initGlobal(
             "ilUser",
             "ilObjUser",
-            "./Services/User/classes/class.ilObjUser.php"
+            "./Services/User/classes/class.ilObjUser.php",
+            true
         );
         $ilias->account = $ilUser;
 

--- a/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
+++ b/Services/WebAccessChecker/classes/class.ilWebAccessChecker.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -15,7 +16,6 @@
  *
  *********************************************************************/
 
-// declare(strict_types=1);
 use ILIAS\HTTP\Cookies\CookieFactory;
 use ILIAS\HTTP\Cookies\CookieWrapper;
 use ILIAS\HTTP\Services;
@@ -343,12 +343,11 @@ class ilWebAccessChecker
         global $DIC;
         session_destroy();
         ilContext::init(ilContext::CONTEXT_WAC);
-        ilInitialisation::reinitILIAS();
+        ilInitialisation::reInitUser();
         /**
-         * @var $ilAuthSession \ilAuthSession
+         * @var ilAuthSession $ilAuthSession
          */
         $ilAuthSession = $DIC['ilAuthSession'];
-        $ilAuthSession->init();
         $ilAuthSession->regenerateId();
         $ilAuthSession->setUserId(ANONYMOUS_USER_ID);
         $ilAuthSession->setAuthenticated(false, ANONYMOUS_USER_ID);


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=39817

This PR provides a workaround for WAC issues where the initialisation is executed twice (see: `\ilWebAccessChecker::initAnonymousSession`) and the super global variables (GPRC) are already replaced with `ArrayAccess` implementations.

Instead of booting the system twice, only the session- and user-based initialisation parts are called again for the case, where the WAC has to initialise an anonymous session.

@Uwe-Kohnle I had to change one method signature of your `ilInitialisation` derivative in the `CmiXapi` component.