### PR TITLE
9/UI/TA kiosk header infos

### DIFF
--- a/Modules/Test/classes/class.ilTestOutputGUI.php
+++ b/Modules/Test/classes/class.ilTestOutputGUI.php
@@ -960,26 +960,33 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
 
     protected function getTestPlayerTitle(): string
     {
-        $test_title = $this->object->getShowKioskModeTitle() ? $this->object->getTitle() : '';
-        $user_name = $this->object->getShowKioskModeParticipant() ? $this->user->getFullname() : '';
-        $exam_id = '';
+        $titleContent = $this->ui_factory->listing()->property();
+
+        if ($this->object->getShowKioskModeParticipant()) {
+            $testParticipantNameLabel = $this->lng->txt("conf_user_name");
+            // this is a placeholder solution with inline html tags to differentiate the different elements
+            // should be removed when a title component with grouping and visual weighting is available
+            // see:  https://github.com/ILIAS-eLearning/ILIAS/pull/7311
+            $testParticipantNameValue = "<span class='il-test-kiosk-head__participant-name'>" . $this->user->getFullname() . "</span>";
+            $titleContent = $titleContent->withProperty($testParticipantNameLabel, $testParticipantNameValue, false);
+        }
+
         if ($this->object->isShowExamIdInTestPassEnabled()) {
-            $exam_id = $this->lng->txt("exam_id")
-            . ' '
-            . ilObjTest::buildExamId(
+            $testExamIdLabel = $this->lng->txt("exam_id_label");
+            $testExamIdValue = ilObjTest::buildExamId(
                 $this->test_session->getActiveId(),
                 $this->test_session->getPass(),
                 $this->object->getId()
             );
+            $titleContent = $titleContent->withProperty($testExamIdLabel, $testExamIdValue);
         }
 
-        $layout = $this->ui_factory->layout()->alignment()->vertical(
-            $this->ui_factory->legacy($test_title),
-            $this->ui_factory->layout()->alignment()->horizontal()->dynamicallyDistributed(
-                $this->ui_factory->legacy($user_name),
-                $this->ui_factory->legacy($exam_id)
-            )
-        );
-        return $this->ui_renderer->render($layout);
+        if ($this->object->getShowKioskModeTitle()) {
+            $testNameLabel = $this->lng->txt("test");
+            $testNameValue = $this->object->getTitle();
+            $titleContent = $titleContent->withProperty($testNameLabel, $testNameValue, false);
+        }
+
+        return $this->ui_renderer->render($titleContent);
     }
 }

--- a/src/UI/ROADMAP.md
+++ b/src/UI/ROADMAP.md
@@ -27,7 +27,9 @@ when to provide an Icon, restrictions of the Title (lengths, nouns vs verbs etc.
 subjects: [Feature Wiki](https://docu.ilias.de/goto_docu_wiki_wpage_6080_1357.html). 
 However, this has not been decided yet and is thus most certainly up for discussion.
 
-Note; One important aspect here, will be to clarify at some point the relation to the [Global Screen](../GlobalScreen). 
+Note; One important aspect here, will be to clarify at some point the relation to the [Global Screen](../GlobalScreen).
+
+The need for a title section component was also discovered while discussing [this PR for the Test & Assessment kiosk mode header](https://github.com/ILIAS-eLearning/ILIAS/pull/7311). This shows that there are use cases beyond the content page title and actions that should be taken into account. Maybe the UI Entity could serve as inspiration for how properties and actions in a title sections could be arranged with effective visual weighting by relevance and semantic grouping.
 
 ### Tabs and Sub Tabs (advanced, variable)
 Note that a major part of the work for this Components will be to setup a comprehensive set of rules on the naming of 

--- a/templates/default/050-layout/_layout_element-bar.scss
+++ b/templates/default/050-layout/_layout_element-bar.scss
@@ -1,6 +1,15 @@
 @use "../050-layout/basics/" as *;
 
+$l-bar__gap--elements: $il-margin-small-horizontal;
+$l-bar__gap--groups: $il-margin-xlarge-horizontal;
 $l-bar__element__margin-bottom: $il-margin-xlarge-vertical; // this margin separates stacking elements on small screens
+
+// bridge into CSS variables, so there is something to override locally without counter-styling
+:root {
+    --l-bar__gap--elements: #{$l-bar__gap--elements};
+    --l-bar__gap--groups: #{$l-bar__gap--groups};
+    --l-bar__element__margin-bottom: #{$l-bar__element__margin-bottom};
+}
 
 .l-bar__container {
     // MAY be used to wrap the element-bar and can be styled with padding, margin, background-color as desired
@@ -16,7 +25,7 @@ $l-bar__element__margin-bottom: $il-margin-xlarge-vertical; // this margin separ
 }
 
 .l-bar__space-keeper:not(:empty) {
-    margin-bottom: -($l-bar__element__margin-bottom); // counteract element margin-bottom, so outer edge doesn't have a visible margin-bottom
+    margin-bottom: calc(-1 * var(--l-bar__element__margin-bottom)); // counteract element margin-bottom, so outer edge doesn't have a visible margin-bottom
     &.l-bar__space-keeper--space-between {
         justify-content: space-between;
     }
@@ -24,7 +33,7 @@ $l-bar__element__margin-bottom: $il-margin-xlarge-vertical; // this margin separ
 
 .l-bar__space-keeper > .l-bar__element,
 .l-bar__group > .l-bar__element {
-    margin-bottom: $l-bar__element__margin-bottom;
+    margin-bottom: var(--l-bar__element__margin-bottom);
     &:last-child {
         margin-right: 0;
     }
@@ -32,12 +41,12 @@ $l-bar__element__margin-bottom: $il-margin-xlarge-vertical; // this margin separ
 
 .l-bar__group > .l-bar__element,
 .l-bar__space-keeper > .l-bar__element {
-    margin-right: $il-margin-small-horizontal;
+    margin-right: var(--l-bar__gap--elements);
 }
 
 .l-bar__space-keeper > .l-bar__group,
 .l-bar__group > .l-bar__group {
-    margin-right: $il-margin-xlarge-horizontal;
+    margin-right: var(--l-bar__gap--groups);
     &:last-child {
         margin-right: 0;
     }

--- a/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
+++ b/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
@@ -112,8 +112,8 @@ div.il-system-infos {
 
 // logo-container
 .il-logo {
-	width: 50%; // needs further attention because of added pagetitle
 	height: $il-standard-page-logo-height;
+	overflow: hidden;
 	justify-self: start;
 	display: flex;
   	align-items: center;
@@ -126,7 +126,8 @@ div.il-system-infos {
 	font-weight: $il-font-weight-bold;
 	display: flex;
 	font-size: $il-font-size-large;
-	align-items: flex-end;
+	align-items: center;
+	min-height: 100%;
 	padding-left: 35px; // dynamic value desirable
 	color: $il-standard-page-header-page-title-color;
 }

--- a/templates/default/070-components/legacy/Modules/_component_test_legacy.scss
+++ b/templates/default/070-components/legacy/Modules/_component_test_legacy.scss
@@ -4,11 +4,6 @@
 
 /* not yet refactored code from former ta.css */
 
-.kiosk {
-	padding: 2em;
-	background-color: #fafafa;
-}
-
 .fullwidth_invisible {
 	background-color: transparent !important;
 }
@@ -26,6 +21,18 @@
 	margin-right: auto;
 	font-weight: bold;
 	font-size: 150%;
+}
+
+.il-pagetitle {
+	.l-bar__space-keeper {
+		--l-bar__element__margin-bottom: #{$il-margin-xs-vertical};
+		font-size: $il-font-size-base;
+		font-weight: $il-font-weight-base;
+	}
+	.il-test-kiosk-head__participant-name {
+		font-size: $il-font-size-xlarge;
+		font-weight: $il-font-weight-bold;
+	}
 }
 
 .col2 {
@@ -61,27 +68,6 @@
 	padding: 5px;
 	background: #E2FFC7; /* Fallback IE 6-8 */
 	background: rgba(226, 255, 199, .4);
-}
-
-#kioskOptions {
-	clear: both;
-	overflow: hidden;
-	width: 100%;
-	border-top: 1px #aaa solid;
-	border-bottom: 1px #aaa solid;
-	margin-bottom: 1em;
-	padding: 1em 0;
-}
-
-#kioskTestTitle {
-	float: left;
-	width: 50%;
-}
-
-#kioskParticipant {
-	float: right;
-	text-align: right;
-	width: 50%;
 }
 
 .print {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -1729,6 +1729,12 @@ th {
 }
 
 /* Responsive container system from Bootstrap 5 has been removed */
+:root {
+  --l-bar__gap--elements: 6px;
+  --l-bar__gap--groups: 15px;
+  --l-bar__element__margin-bottom: 9px;
+}
+
 .l-bar__space-keeper,
 .l-bar__group {
   display: flex;
@@ -1738,7 +1744,7 @@ th {
 }
 
 .l-bar__space-keeper:not(:empty) {
-  margin-bottom: -9px;
+  margin-bottom: calc(-1 * var(--l-bar__element__margin-bottom));
 }
 .l-bar__space-keeper:not(:empty).l-bar__space-keeper--space-between {
   justify-content: space-between;
@@ -1746,7 +1752,7 @@ th {
 
 .l-bar__space-keeper > .l-bar__element,
 .l-bar__group > .l-bar__element {
-  margin-bottom: 9px;
+  margin-bottom: var(--l-bar__element__margin-bottom);
 }
 .l-bar__space-keeper > .l-bar__element:last-child,
 .l-bar__group > .l-bar__element:last-child {
@@ -1755,12 +1761,12 @@ th {
 
 .l-bar__group > .l-bar__element,
 .l-bar__space-keeper > .l-bar__element {
-  margin-right: 6px;
+  margin-right: var(--l-bar__gap--elements);
 }
 
 .l-bar__space-keeper > .l-bar__group,
 .l-bar__group > .l-bar__group {
-  margin-right: 15px;
+  margin-right: var(--l-bar__gap--groups);
 }
 .l-bar__space-keeper > .l-bar__group:last-child,
 .l-bar__group > .l-bar__group:last-child {
@@ -5103,8 +5109,8 @@ div.il-system-infos {
 }
 
 .il-logo {
-  width: 50%;
   height: 45px;
+  overflow: hidden;
   justify-self: start;
   display: flex;
   align-items: center;
@@ -5117,7 +5123,8 @@ div.il-system-infos {
   font-weight: 600;
   display: flex;
   font-size: 1rem;
-  align-items: flex-end;
+  align-items: center;
+  min-height: 100%;
   padding-left: 35px;
   color: #161616;
 }
@@ -12655,11 +12662,6 @@ div.ilSurveyPageEditActionMenu {
 }
 
 /* not yet refactored code from former ta.css */
-.kiosk {
-  padding: 2em;
-  background-color: #fafafa;
-}
-
 .fullwidth_invisible {
   background-color: transparent !important;
 }
@@ -12677,6 +12679,16 @@ div.ilSurveyPageEditActionMenu {
   margin-right: auto;
   font-weight: bold;
   font-size: 150%;
+}
+
+.il-pagetitle .l-bar__space-keeper {
+  --l-bar__element__margin-bottom: 1px;
+  font-size: 0.875rem;
+  font-weight: 400;
+}
+.il-pagetitle .il-test-kiosk-head__participant-name {
+  font-size: 1.115rem;
+  font-weight: 600;
 }
 
 .col2 {
@@ -12711,27 +12723,6 @@ div.ilSurveyPageEditActionMenu {
   padding: 5px;
   background: #E2FFC7; /* Fallback IE 6-8 */
   background: rgba(226, 255, 199, 0.4);
-}
-
-#kioskOptions {
-  clear: both;
-  overflow: hidden;
-  width: 100%;
-  border-top: 1px #aaa solid;
-  border-bottom: 1px #aaa solid;
-  margin-bottom: 1em;
-  padding: 1em 0;
-}
-
-#kioskTestTitle {
-  float: left;
-  width: 50%;
-}
-
-#kioskParticipant {
-  float: right;
-  text-align: right;
-  width: 50%;
 }
 
 .print {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38857

# Issue

In the kiosk mode of the Test & Assessment, long titles and names can lead to a broken header layout:
![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/75747119-34c1-46cd-838a-25fe2d8414d0)

# Changes

* SCSS tool Elementbar now exposes root CSS variables that can be overridden locally. In this case elementbars in the ILIAS standardpage header get more narrow spacings to make the most of the limited space. This is a proof of concept. We need to discuss in the CSS Squad if and under which conditions we allow SCSS to CSS variable exposure.
* Switched from the Alignment Layout component to a Property Listing UI component in php to follow the Key-Value nature of the information being rendered.
* The following is a temporary solution and should be changed in ILIAS 10 (see outlook): The participant's name was supposed to appear highlighted as during in person exams a supervisor might want to glance over people's shoulders to quickly check the name. The Property Listing doesn't know such a highlighted property, so html tags had to be sneaked into that string in php. A general css class allows overriding through system styles. Not sure if a one line html template might be the better emergency solution.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/c67bca55-d8c7-4c56-b3e7-13c248be53d9)

# Outlook

I would suggest the creation of a header component for ILIAS 10 that can handle properties with various priorities and icons similar to the UI entity component. Such a header component could be used to generate not only this system header, but also potentially the header for content pages (this is legacy atm) or even panels and form sections.