### PR TITLE
Test: Don't pass null when adding mark steps from db

### DIFF
--- a/Modules/Test/classes/class.assMarkSchema.php
+++ b/Modules/Test/classes/class.assMarkSchema.php
@@ -204,7 +204,12 @@ class ASS_MarkSchema
         if ($result->numRows() > 0) {
             /** @noinspection PhpAssignmentInConditionInspection */
             while ($data = $ilDB->fetchAssoc($result)) {
-                $this->addMarkStep($data["short_name"], $data["official_name"], (float) $data["minimum_level"], (int) $data["passed"]);
+                $this->addMarkStep(
+                    $data["short_name"] ?? '',
+                    $data["official_name"] ?? '',
+                    (float) $data["minimum_level"],
+                    (int) $data["passed"]
+                );
             }
         }
     }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=40966

If approved, please check if this fix needs to be picked to `release_9` and `trunk` as well.