### PR TITLE
TA Lang_de Test ID

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -694,12 +694,12 @@ assessment#:#essay_scoring_mode_without_keywords_desc#:#Es werden keine Punkte a
 assessment#:#eval_all_users#:#Auswertung für alle Benutzer
 assessment#:#eval_legend_link#:#Für die Bedeutung der Spaltenüberschriften betrachten Sie bitte die Legende
 assessment#:#evaluated_users#:#Bewertete Benutzer
-assessment#:#exam_id#:#ILIAS-Prüfungsnummer:
-assessment#:#exam_id_label#:#ILIAS-Prüfungsnummer
-assessment#:#examid_in_test_pass#:#ILIAS-Prüfungsnummer anzeigen
-assessment#:#examid_in_test_pass_desc#:#Im Test wird eine ILIAS-Prüfungsnummer angezeigt. Für jeden Testdurchlauf wird eine eigene Nummer erzeugt.
-assessment#:#examid_in_test_res#:#ILIAS-Prüfungsnummer anzeigen
-assessment#:#examid_in_test_res_desc#:#In den Testergebnissen, der Statistik und dem Excel-Export wird die ILIAS-Prüfungsnummer dargestellt.
+assessment#:#exam_id#:#Test ID:
+assessment#:#exam_id_label#:#Test ID
+assessment#:#examid_in_test_pass#:#Test ID anzeigen
+assessment#:#examid_in_test_pass_desc#:#Im Test wird eine Test ID angezeigt. Für jeden Testdurchlauf wird eine eigene Nummer erzeugt.
+assessment#:#examid_in_test_res#:#ILIAS Test ID anzeigen
+assessment#:#examid_in_test_res_desc#:#In den Testergebnissen, der Statistik und dem Excel-Export wird die ILIAS Test ID dargestellt.
 assessment#:#exp_all_test_runs#:#Alle Durchläufe
 assessment#:#exp_eval_data#:#Daten exportieren
 assessment#:#exp_file_created#:#Exportdatei erzeugt.


### PR DESCRIPTION
hi @matthiaskunkel, I have adapted the German language variables (Prüfungsnummer) according to the English variable. (see [Mantis 38857](https://mantis.ilias.de/view.php?id=38857#c103280)).

Please merge to ILIAS 9 and Trunk. 

I have only self-assigned in this Pull Request because of statistic purposes.