### PR TITLE
CI: Fixed copyright checker throwing error if file has "declare(strict_types=1);" in line 3

### DIFF
--- a/CI/Copyright-Checker/copyright-checker.sh
+++ b/CI/Copyright-Checker/copyright-checker.sh
@@ -68,6 +68,10 @@ function is_copyright_valid() {
     offset=3
   fi
 
+  if [[ "$(cat $file)" == *"declare(strict_types=1);"* ]]; then
+    offset=$((2 + ${offset}))
+  fi
+
   for copyright_line in "${COPYRIGHT_LINES[@]}"; do
     local line_to_check="$(sed "${offset}q;d" "${file}")"
     if ! [ "${copyright_line}" = "${line_to_check}" ]; then


### PR DESCRIPTION
Will be reviewed by @mjansenDatabay  & @thojou

I encountered a issue where the copy right checker failes in the pipeline when a file contains declare(strict_types=1); in line 3.

Example: https://github.com/ILIAS-eLearning/ILIAS/pull/7321

The checker is executed only on newly changed files. This means that if the file already contained the keyword and the checker was not executed it slipped past it.

Since there are quit many files that have this structure this could be a neat fix.