### PR TITLE
CI: Fix `php-cs-fixer` config

### DIFF
--- a/CI/PHP-CS-Fixer/code-format.php_cs
+++ b/CI/PHP-CS-Fixer/code-format.php_cs
@@ -23,7 +23,7 @@ return (new PhpCsFixer\Config())
         '@PSR12' => true,
         'strict_param' => false,
         'concat_space' => ['spacing' => 'one'],
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'function_declaration' => ['closure_fn_spacing' => 'none'],
         'binary_operator_spaces' => ['default' => 'single_space'],
         // 'types_spaces' => ['space' => 'single'],


### PR DESCRIPTION
Our custom configuration does not work within `PhpStorm` because of deprecation issue:

Detected deprecations in use:
- Rule "function_typehint_space" is deprecated. Use "type_declaration_spaces" instead.

See similar Issues:
- https://youtrack.jetbrains.com/issue/WI-70582
- https://youtrack.jetbrains.com/issue/WI-70838


If approved, this has to be picket to `trunk` and maybe also `release_8`.