### PR TITLE
Fix thread Id typo in forum post delete

### DIFF
--- a/Modules/Forum/classes/class.ilForum.php
+++ b/Modules/Forum/classes/class.ilForum.php
@@ -616,7 +616,7 @@ class ilForum
                 }
             }
 
-            $this->db->manipulateF('DELETE FROM frm_posts WHERE pos_thr_fk = %s', ['integer'], [$post->getTreeId()]);
+            $this->db->manipulateF('DELETE FROM frm_posts WHERE pos_thr_fk = %s', ['integer'], [$post->getThreadId()]);
         } else {
             for ($i = 0; $i < $dead_pos; $i++) {
                 $this->db->manipulateF('DELETE FROM frm_posts WHERE pos_pk = %s', ['integer'], [$deleted_post_ids[$i]]);


### PR DESCRIPTION
Fixes the deletion of subordinate posts by thread id through the tree id.

(This worked in ILIAS 8 since both ids are the same there, but since ILIAS 9 they are different)