### PR TITLE
Component: Avoid redundant event handling on plugin update

### DIFF
--- a/Services/Component/classes/class.ilPlugin.php
+++ b/Services/Component/classes/class.ilPlugin.php
@@ -284,8 +284,6 @@ abstract class ilPlugin
 
         $this->readEventListening();
 
-        $this->readEventListening();
-
         // set last update version to current version
         $this->component_repository->setCurrentPluginVersion(
             $this->getPluginInfo()->getId(),


### PR DESCRIPTION
This PR fixes a redundant call of `\ilPlugin::readEventListening` when updating a plugin in `\ilPlugin::update`.

Mantis Issue: https://mantis.ilias.de/view.php?id=41085