### PR TITLE
Chatroom: Drop upload table. Remove deleted user from ban table

### DIFF
--- a/components/ILIAS/Chatroom/classes/CleanUpBans.php
+++ b/components/ILIAS/Chatroom/classes/CleanUpBans.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Chatroom;
+
+use ilDBConstants;
+use Closure;
+
+class CleanUpBans
+{
+    /**
+     * @param Closure(string, string[]): Closure(array): void
+     */
+    public function __construct(private readonly Closure $prepare)
+    {
+    }
+
+    public function removeEntriesOfDeletedUser(int $id): void
+    {
+        $execute = ($this->prepare)('DELETE FROM chatroom_bans WHERE user_id = ?', [ilDBConstants::T_INTEGER]);
+        $execute([$id]);
+    }
+}

--- a/components/ILIAS/Chatroom/classes/Setup/UpdateSteps.php
+++ b/components/ILIAS/Chatroom/classes/Setup/UpdateSteps.php
@@ -49,20 +49,6 @@ class UpdateSteps implements ilDatabaseUpdateSteps
         $this->dropTableWhenExists('chatroom_smilies');
     }
 
-    private function dropColumnWhenExists(string $table, string $column): void
-    {
-        if ($this->db->tableColumnExists($table, $column)) {
-            $this->db->dropTableColumn($table, $column);
-        }
-    }
-
-    private function dropTableWhenExists(string $table): void
-    {
-        if ($this->db->tableExists($table)) {
-            $this->db->dropTable($table);
-        }
-    }
-
     public function step_3(): void
     {
         $this->dropColumnWhenExists('chatroom_settings', 'restrict_history');
@@ -82,5 +68,25 @@ class UpdateSteps implements ilDatabaseUpdateSteps
             [ilDBConstants::T_TEXT],
             ['chtr']
         );
+    }
+
+    public function step_5(): void
+    {
+        $this->dropTableWhenExists('chatroom_uploads');
+        $this->db->manipulate('DELETE FROM chatroom_bans WHERE user_id NOT IN (SELECT usr_id FROM usr_data)');
+    }
+
+    private function dropColumnWhenExists(string $table, string $column): void
+    {
+        if ($this->db->tableColumnExists($table, $column)) {
+            $this->db->dropTableColumn($table, $column);
+        }
+    }
+
+    private function dropTableWhenExists(string $table): void
+    {
+        if ($this->db->tableExists($table)) {
+            $this->db->dropTable($table);
+        }
     }
 }

--- a/components/ILIAS/Chatroom/classes/class.ilChatroom.php
+++ b/components/ILIAS/Chatroom/classes/class.ilChatroom.php
@@ -38,7 +38,6 @@ class ilChatroom
     private static string $userTable = 'chatroom_users';
     private static string $sessionTable = 'chatroom_sessions';
     private static string $banTable = 'chatroom_bans';
-    private static string $uploadTable = 'chatroom_uploads';
     private array $settings = [];
     /**
      * Each value of this array describes a setting with the internal type.
@@ -469,24 +468,6 @@ class ilChatroom
     public function getRoomId(): int
     {
         return $this->roomId;
-    }
-
-    public function saveFileUploadToDb(int $user_id, string $filename, string $type): void
-    {
-        global $DIC;
-
-        $upload_id = $DIC->database()->nextId(self::$uploadTable);
-        $DIC->database()->insert(
-            self::$uploadTable,
-            [
-                'upload_id' => [ilDBConstants::T_INTEGER, $upload_id],
-                'room_id' => [ilDBConstants::T_INTEGER, $this->roomId],
-                'user_id' => [ilDBConstants::T_INTEGER, $user_id],
-                'filename' => [ilDBConstants::T_TEXT, $filename],
-                'filetype' => [ilDBConstants::T_TEXT, $type],
-                'timestamp' => [ilDBConstants::T_INTEGER, time()]
-            ]
-        );
     }
 
     public function banUser(int $user_id, int $actor_id, string $comment = ''): void

--- a/components/ILIAS/Chatroom/classes/class.ilChatroomAppEventListener.php
+++ b/components/ILIAS/Chatroom/classes/class.ilChatroomAppEventListener.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Chatroom\CleanUpBans;
+
+class ilChatroomAppEventListener implements ilAppEventListener
+{
+    private static ?ilChatroomAppEventListener $instance = null;
+
+    private readonly CleanUpBans $clean_up;
+
+    /**
+     * @param array<string, mixed>  $a_parameter
+     */
+    public static function handleEvent(string $component, string $event, array $parameter): void
+    {
+        global $DIC;
+        self::$instance ??= new self($DIC->database());
+        self::$instance->handle($component, $event, $parameter);
+    }
+
+    private function __construct(ilDBInterface $database)
+    {
+        $this->clean_up = new CleanUpBans($this->dbCachePrepare($database));
+    }
+
+    private function handle(string $component, string $event, array $parameter): void
+    {
+        if ($event === 'deleteUser') {
+            $this->clean_up->removeEntriesOfDeletedUser($parameter['usr_id']);
+        }
+    }
+
+    /**
+     * @return Closure(string, array): Closure(array): void
+     */
+    private function dbCachePrepare(ilDBInterface $db): Closure
+    {
+        return $this->cache(function (...$args) use ($db): Closure {
+            $statement = $db->prepare(...$args);
+            return fn(array $values = []) => $db->execute($statement, $values);
+        });
+    }
+
+    /**
+     * @template A
+     * @template B
+     *
+     * @param Closure(...A): B
+     * @return Closure(...A): B
+     */
+    private function cache(Closure $proc): Closure
+    {
+        $cache = [];
+        return function (...$args) use (&$cache, $proc) {
+            $key = json_encode($args);
+            if (!isset($cache[$key])) {
+                $cache[$key] = $proc(...$args);
+            }
+            return $cache[$key];
+        };
+    }
+}

--- a/components/ILIAS/Chatroom/module.xml
+++ b/components/ILIAS/Chatroom/module.xml
@@ -21,6 +21,7 @@
 	</objects>
 	<events>
 		<event type="raise" id="chatSettingsChanged" />
+		<event type="listen" id="components/ILIAS/User" />
 	</events>
 	<logging />
 	<web_access_checker>


### PR DESCRIPTION
Drop `chatroom_uploads` table.
Delete the corresponding entry from then `chatroom_ban` table when a user is deleted (add listener).