### PR TITLE
Fixed Type Error ContainerContentGUI

### DIFF
--- a/Services/Container/Content/class.ilContainerContentGUI.php
+++ b/Services/Container/Content/class.ilContainerContentGUI.php
@@ -673,10 +673,10 @@ abstract class ilContainerContentGUI
         ));
         $item_list_gui->initItem(
             $a_item_data['ref_id'],
-            $a_item_data['obj_id'],
-            $a_item_data['type'],
-            $a_item_data['title'],
-            $a_item_data['description']
+            (int) $a_item_data['obj_id'],
+            (string) $a_item_data['type'],
+            (string) $a_item_data['title'],
+            (string) $a_item_data['description']
         );
 
         // actions


### PR DESCRIPTION
TypeError thrown with message "Argument 4 passed to ilObjectListGUI::initItem() must be of the type string, null given, called in /var/www/html/Services/Container/Content/class.ilContainerContentGUI.php on line 679"

https://mantis.ilias.de/view.php?id=41098