### PR TITLE
[FEATURE] UI: Introduce dedicated image upload field

### DIFF
--- a/components/ILIAS/Data/src/ImagePurpose.php
+++ b/components/ILIAS/Data/src/ImagePurpose.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\Data;
+
+/**
+ * This enum provides options to categorise the purpose of an image, which
+ * will be used to determine whether an alternate text is necessary or not,
+ * and possibly how it should be structured (in the future). More information
+ * about accessible images can be found here:
+ *
+ * @see https://www.w3.org/WAI/tutorials/images/
+ */
+enum ImagePurpose
+{
+    /**
+     * The image grahically conveys concepts and/or information to the context it
+     * is embedded in. An alternate text MUST be present.
+     */
+    case INFORMATIVE;
+
+    /**
+     * The image visually decorates the current page. It does not convey important
+     * information and an alternate text MUST NOT be present.
+     */
+    case DECORATIVE;
+
+    /**
+     * The image purpose is specified by the user and falls into one of the options
+     * of this enum. This option exists for cases where ILIAS does not know the
+     * image purpose, like e.g. in the page editor. An alternate text MAY be present.
+     */
+    case USER_DEFINED;
+}

--- a/components/ILIAS/File/classes/class.ilObjFileGUI.php
+++ b/components/ILIAS/File/classes/class.ilObjFileGUI.php
@@ -494,14 +494,14 @@ class ilObjFileGUI extends ilObject2GUI
 
         $errors = false;
         foreach ($files as $file_data) {
-            $rid = $this->storage->manage()->find($file_data[$this->upload_handler->getFileIdentifierParameterName()]);
+            $rid = $this->storage->manage()->find($file_data[0]);
             if (null !== $rid) {
                 try {
                     $processor->process(
                         $rid,
-                        $file_data[self::PARAM_TITLE] ?? null,
-                        $file_data[self::PARAM_DESCRIPTION] ?? null,
-                        $data[self::PARAM_COPYRIGHT_ID] ?? $data[1] ?? null
+                        $file_data[1][self::PARAM_TITLE] ?? null,
+                        $file_data[1][self::PARAM_DESCRIPTION] ?? null,
+                        $data[self::PARAM_COPYRIGHT_ID] ?? null
                     );
                 } catch (Throwable $t) {
                     $errors = true;

--- a/components/ILIAS/UI/resources/js/Input/Field/file.js
+++ b/components/ILIAS/UI/resources/js/Input/Field/file.js
@@ -34,7 +34,9 @@ il.UI.Input = il.UI.Input || {};
 		 * @type {{}}
 		 */
 		const SELECTOR = {
-			file_input: '[data-il-ui-component="file-field-input"]',
+			file_input: 'fieldset',
+			file_fieldset: '[data-il-ui-component="file-field-input"]',
+			image_fieldset: '[data-il-ui-component="image-field-input"]',
 			file_list: '.ui-input-file-input-list',
 			file_list_entry: '.ui-input-file-input',
 			file_entry_metadata: '.ui-input-file-metadata',
@@ -622,7 +624,7 @@ il.UI.Input = il.UI.Input || {};
 
 		let processCurrentFormDropzones = function (form, event) {
 			// retrieve all file inputs of the current form.
-			let file_inputs = $(form).find(SELECTOR.file_input);
+      		let file_inputs = $(form).find(`${SELECTOR.file_fieldset}, ${SELECTOR.image_fieldset}`);
 			current_dropzone_count = file_inputs.length;
 
             if (typeof file_inputs[Symbol.iterator] === 'function') {

--- a/components/ILIAS/UI/src/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Factory.php
@@ -22,7 +22,7 @@ namespace ILIAS\UI\Component\Input\Field;
 
 use ILIAS\UI\Component\Input\Container\Form\FormInput;
 use ILIAS\UI\Component\Input\Field\Node\NodeRetrieval;
-use ILIAS\UI\URLBuilderToken;
+use ILIAS\Data\ImagePurpose;
 
 /**
  * This is what a factory for input fields looks like.
@@ -580,27 +580,46 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *     A File Input is used to upload one or multiple files, using the native
-     *     filebrowser of a browser or Drag&Drop.
+     *     The File Field can be used to upload one or multiple files from the
+     *     user device storage.
      *   composition: >
-     *     A File Input is composed as a Dropzone and a list of files. The
-     *     Dropzone contains a Shy Button for file selection.
+     *     The File Field consists of a Dropzone and a Shy Button. Uploaded files
+     *     are listed in an EntityListing above the input, featuring the files
+     *     most important information like title, size and type. Optionally, each
+     *     entry may contain an epandable content area, featuring the provided
+     *     metadata input. Among each entry there are several Glyphs, to expand,
+     *     collapse or remove the corresponding entry.
      *   effect: >
-     *     According to configuration, the input will accept files of certain
-     *     types and sizes. Dragging files from a folder on the comuter to the
-     *     Page in ILIAS will highlight the Dropzone.
-     *     Clicking the Shy Button which starts the native browser file selection.
-     *     Droppping the file onto the Dropzone or selecting a file in native
-     *     browser will directly upload the file and add a info-line beneath
-     *     the dropzone with the title and the size of the file and a Remove
-     *     Glyph once the upload has finished.
-     *     Clicking the Remove Glyph will remove the file-info and calls the
-     *     upload-handler to delete the already uploaded file.
-     *     Invalid files will lead to a error message in the dropzone.
+     *     Clicking the Shy Button opens the browsers file dialog, letting the
+     *     user choose files from their device. Depending on the provided mime-
+     *     types, only certain files will be selectable in this dialog.
+     *     Dragging files from the device into the browser window, where ILIAS
+     *     is open, will highlight the Dropzone where they can be dropped.
+     *     Dropping files will create a new entry inside the PropertyListing.
+     *     Clicking the expand/collapse Glyphs will reveal or hide the file
+     *     entry's metadata input.
+     *     Clicking the removal Glyph will delete the file entry from the list.
+     *     The consumer is responsible to handle file deletions properly, if an
+     *     existing file has been removed this way.
+     *     Adding invalid files (e.g. wrong mime-type, too large) will show an
+     *     according message inside the file entry.
+     *     When the surrounding form is submitted, all files are uploaded first.
+     *     During this process every file entry will display a Progress Bar
+     *     representing the upload status.
+     *   rivals:
+     *     Image Field: >
+     *       if only images should be uploaded with this input, the Image Field
+     *       must be used instead.
      *
      * rules:
      *   usage:
-     *     1: The consuming component MUST handle uploads and deletions of files.
+     *     1: The consumer MUST handle uploads and deletions of files.
+     *     2: File entries should not be expandable, if there is no additional input.
+     *     3: >
+     *       The consumer MUST support chunked uploads if the max file size
+     *       exceeds the server limitation.
+     * accessibility:
+     *   1: The input MUST be operable using the keyboard only.
      *
      * context:
      *   - Upload icons for items in the MainBar (https://docu.ilias.de/goto_docu_wiki_wpage_3993_1357.html)
@@ -618,6 +637,79 @@ interface Factory
         ?string $byline = null,
         ?FormInput $metadata_input = null
     ): File;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     The Image Field can be used to upload one or multiple images from the
+     *     user device storage, encouraging them to provide an alternate text for
+     *     screen readers depending on the image purpose.
+     *   composition: >
+     *     The Image Field consists of a Dropzone and a Shy Button. Uploaded files
+     *     are listed in an EntityListing above the input, featuring an image
+     *     preview and the files most important information like title, size and type.
+     *     Optionally, each entry may contain an epandable content area, featuring
+     *     some additional inputs, depending on the image purpose and metadata input.
+     *     Among each entry there are several Glyphs, to expand, collapse or remove
+     *     the corresponding entry.
+     *   effect: >
+     *     Clicking the Shy Button opens the browsers file dialog, letting the
+     *     user choose files from their device. Depending on the provided mime-
+     *     types, only certain images will be selectable in this dialog.
+     *     Dragging files from the device into the browser window, where ILIAS
+     *     is open, will highlight the Dropzone where they can be dropped.
+     *     Dropping files will create a new entry inside the PropertyListing.
+     *     Clicking the expand/collapse Glyphs will reveal or hide the file
+     *     entrys additional inputs.
+     *     Clicking the removal Glyph will delete the file entry from the list.
+     *     The consumer is responsible to handle file deletions properly, if an
+     *     existing file has been removed this way.
+     *     Adding invalid files (e.g. wrong mime-type, too large) will show an
+     *     according message inside the file entry.
+     *     When the surrounding form is submitted, all files are uploaded first.
+     *     During this process every file entry will display a Progress Bar
+     *     representing the upload status.
+     *   rivals:
+     *     File Field: >
+     *       if other files than images should (also) be uploaded, the File Field
+     *       must be used instead.
+     *
+     * rules:
+     *   usage:
+     *     1: The consumer MUST handle uploads and deletions of files.
+     *     2: File entries should not be expandable, if there are no further inputs.
+     *     3: The consumer MUST only provide mime-types of images (image/*).
+     *     4: >
+     *       The consumer MUST support chunked uploads if the max file size
+     *       exceeds the server limitation.
+     *     5: >
+     *       Additional metadata inputs must be rendered BELOW the alt-text input, if
+     *       there is one.
+     *   accessibility:
+     *     1: The input MUST be operable using the keyboard only.
+     *
+     * context:
+     *   - Page editor: >
+     *       this input will be used inside the ILIAS page editor to encourage users
+     *       to provide alternate texts, depending on the image purpose.
+     *
+     * background: https://docu.ilias.de/goto_docu_wiki_wpage_5882_1357.html
+     * ---
+     * @param UploadHandler $upload_handler
+     * @param ImagePurpose $image_purpose
+     * @param string $label
+     * @param string|null $byline
+     * @param FormInput|null $metadata_input
+     * @return \ILIAS\UI\Component\Input\Field\Image
+     */
+    public function image(
+        UploadHandler $upload_handler,
+        ImagePurpose $image_purpose,
+        string $label,
+        ?string $byline = null,
+        FormInput $metadata_input = null,
+    ): Image;
 
     /**
      * ---

--- a/components/ILIAS/UI/src/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Factory.php
@@ -584,18 +584,17 @@ interface Factory
      *     user device storage.
      *   composition: >
      *     The File Field consists of a Dropzone and a Shy Button. Uploaded files
-     *     are listed in an EntityListing above the input, featuring the files
-     *     most important information like title, size and type. Optionally, each
-     *     entry may contain an epandable content area, featuring the provided
+     *     are listed in a file entry above the input, featuring the files most
+     *     important information like title, size and type. Optionally, each
+     *     entry may contain an expandable content area, featuring the provided
      *     metadata input. Among each entry there are several Glyphs, to expand,
      *     collapse or remove the corresponding entry.
      *   effect: >
      *     Clicking the Shy Button opens the browsers file dialog, letting the
      *     user choose files from their device. Depending on the provided mime-
      *     types, only certain files will be selectable in this dialog.
-     *     Dragging files from the device into the browser window, where ILIAS
-     *     is open, will highlight the Dropzone where they can be dropped.
-     *     Dropping files will create a new entry inside the PropertyListing.
+     *     Dragging files into the Dropzone and dropping them will create a new file
+     *     entry above the Shy Button.
      *     Clicking the expand/collapse Glyphs will reveal or hide the file
      *     entry's metadata input.
      *     Clicking the removal Glyph will delete the file entry from the list.
@@ -623,7 +622,6 @@ interface Factory
      *
      * context:
      *   - Upload icons for items in the MainBar (https://docu.ilias.de/goto_docu_wiki_wpage_3993_1357.html)
-     *
      * ---
      * @param UploadHandler $handler
      * @param string        $label
@@ -647,19 +645,17 @@ interface Factory
      *     screen readers depending on the image purpose.
      *   composition: >
      *     The Image Field consists of a Dropzone and a Shy Button. Uploaded files
-     *     are listed in an EntityListing above the input, featuring an image
-     *     preview and the files most important information like title, size and type.
-     *     Optionally, each entry may contain an epandable content area, featuring
+     *     are listed in a file entry above the input, featuring the most important
+     *     information like title, size and type.
+     *     Optionally, each entry may contain an expandable content area, featuring
      *     some additional inputs, depending on the image purpose and metadata input.
-     *     Among each entry there are several Glyphs, to expand, collapse or remove
-     *     the corresponding entry.
+     *     Among each entry there are Glyphs to expand, collapse or remove it.
      *   effect: >
      *     Clicking the Shy Button opens the browsers file dialog, letting the
      *     user choose files from their device. Depending on the provided mime-
      *     types, only certain images will be selectable in this dialog.
-     *     Dragging files from the device into the browser window, where ILIAS
-     *     is open, will highlight the Dropzone where they can be dropped.
-     *     Dropping files will create a new entry inside the PropertyListing.
+     *     Dragging files into the Dropzone and dropping them will create a new file
+     *     entry above the Shy Button.
      *     Clicking the expand/collapse Glyphs will reveal or hide the file
      *     entrys additional inputs.
      *     Clicking the removal Glyph will delete the file entry from the list.
@@ -690,9 +686,8 @@ interface Factory
      *     1: The input MUST be operable using the keyboard only.
      *
      * context:
-     *   - Page editor: >
-     *       this input will be used inside the ILIAS page editor to encourage users
-     *       to provide alternate texts, depending on the image purpose.
+     *   - this input will be used inside the ILIAS page editor to encourage users
+     *     to provide alternate texts, depending on the image purpose.
      *
      * background: https://docu.ilias.de/goto_docu_wiki_wpage_5882_1357.html
      * ---

--- a/components/ILIAS/UI/src/Component/Input/Field/Image.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Image.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Component\Input\Field;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+interface Image extends File
+{
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
@@ -129,6 +129,7 @@ class Factory implements I\Factory
             $this,
             $this->refinery,
             $this->upload_limit_resolver,
+            $this,
             $handler,
             $label,
             $metadata_input,

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
@@ -28,7 +28,6 @@ use ILIAS\UI\Component\Input\Field\UploadHandler;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 use ILIAS\Language\Language;
 use ILIAS\Data\ImagePurpose;
-use ILIAS\UI\Component\Input\Field\Image;
 
 class Factory implements I\Factory
 {
@@ -129,7 +128,6 @@ class Factory implements I\Factory
             $this,
             $this->refinery,
             $this->upload_limit_resolver,
-            $this,
             $handler,
             $label,
             $metadata_input,
@@ -144,7 +142,18 @@ class Factory implements I\Factory
         ?string $byline = null,
         FormInput $metadata_input = null
     ): Image {
-        throw new \ILIAS\UI\NotImplementedException();
+        return new Image(
+            $this->lng,
+            $this->data_factory,
+            $this,
+            $this->refinery,
+            $this->upload_limit_resolver,
+            $upload_handler,
+            $image_purpose,
+            $label,
+            $metadata_input,
+            $byline,
+        );
     }
 
     public function url(string $label, ?string $byline = null): Url

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
@@ -27,6 +27,8 @@ use ILIAS\UI\Component\Input\Field as I;
 use ILIAS\UI\Component\Input\Field\UploadHandler;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 use ILIAS\Language\Language;
+use ILIAS\Data\ImagePurpose;
+use ILIAS\UI\Component\Input\Field\Image;
 
 class Factory implements I\Factory
 {
@@ -132,6 +134,16 @@ class Factory implements I\Factory
             $metadata_input,
             $byline
         );
+    }
+
+    public function image(
+        UploadHandler $upload_handler,
+        ImagePurpose $image_purpose,
+        string $label,
+        ?string $byline = null,
+        FormInput $metadata_input = null
+    ): Image {
+        throw new \ILIAS\UI\NotImplementedException();
     }
 
     public function url(string $label, ?string $byline = null): Url

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
@@ -72,7 +72,7 @@ class File extends HasDynamicInputs implements C\Input\Field\File
             $refinery,
             $this->createDynamicInputsTemplate($field_factory, $metadata_input),
             $label,
-            $byline
+            $byline,
         );
     }
 
@@ -140,9 +140,8 @@ class File extends HasDynamicInputs implements C\Input\Field\File
         $this->checkArg("value", $this->isClientSideValueOk($value), "Display value does not match input type.");
 
         $clone = clone $this;
-        $identifier_key = $clone->upload_handler->getFileIdentifierParameterName();
         foreach ($value as $data) {
-            $file_id = ($clone->hasMetadataInputs()) ? $data[$identifier_key] : $data;
+            $file_id = ($clone->hasMetadataInputs()) ? $data[0] : $data;
 
             // that was not implicitly intended, but mapping dynamic inputs
             // to the file-id is also a duplicate protection.
@@ -208,19 +207,10 @@ class File extends HasDynamicInputs implements C\Input\Field\File
             if (!is_string($data) && !$this->hasMetadataInputs()) {
                 return false;
             }
-
-            if ($this->hasMetadataInputs()) {
-                // if a dynamic input template was provided, the values
-                // must all contain the file-id as an array entry.
-                if (!array_key_exists($this->upload_handler->getFileIdentifierParameterName(), $data)) {
-                    return false;
-                }
-
-                // if a dynamic input template was provided, the values
-                // must be valid for the template input.
-                if (!$this->getTemplateForDynamicInputs()->isClientSideValueOk($data)) {
-                    return false;
-                }
+            // if a dynamic input template was provided, the values
+            // must be valid for the template input.
+            if ($this->hasMetadataInputs() && !$this->dynamic_input_template->isClientSideValueOk($data)) {
+                return false;
             }
         }
 
@@ -229,23 +219,14 @@ class File extends HasDynamicInputs implements C\Input\Field\File
 
     protected function createDynamicInputsTemplate(Factory $field_factory, ?FormInput $metadata_input): FormInput
     {
-        $default_metadata_input = $field_factory->hidden();
+        $file_id_input = $field_factory->hidden();
 
         if (null === $metadata_input) {
-            return $default_metadata_input;
+            return $file_id_input;
         }
 
-        $inputs = ($metadata_input instanceof C\Input\Field\Group) ?
-            $metadata_input->getInputs() : [
-                $metadata_input,
-            ];
-
-        // map the file-id input to the UploadHandlers identifier key.
-        $inputs[$this->upload_handler->getFileIdentifierParameterName()] = $default_metadata_input;
-
-        // tell the input that it contains actual metadata inputs.
         $this->has_metadata_inputs = true;
 
-        return $field_factory->group($inputs, '');
+        return $field_factory->group([$file_id_input, $metadata_input]);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Image.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Image.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Input\Field;
+
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
+use ILIAS\UI\Component\Input\Container\Form\FormInput;
+use ILIAS\UI\Component as C;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Data\ImagePurpose;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Language\Language;
+
+/**
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+class Image extends File implements C\Input\Field\Image
+{
+    public function __construct(
+        Language $language,
+        DataFactory $data_factory,
+        Factory $field_factory,
+        Refinery $refinery,
+        UploadLimitResolver $upload_limit_resolver,
+        C\Input\Field\UploadHandler $handler,
+        protected ImagePurpose $image_purpose,
+        string $label,
+        ?FormInput $metadata_input,
+        ?string $byline
+    ) {
+        parent::__construct(
+            $language,
+            $data_factory,
+            $field_factory,
+            $refinery,
+            $upload_limit_resolver,
+            $handler,
+            $label,
+            $this->createMetaDataInput($language, $field_factory, $metadata_input),
+            $byline,
+        );
+
+        $this->accepted_mime_types = ['image/*'];
+    }
+
+    public function getImagePurpose(): ImagePurpose
+    {
+        return $this->image_purpose;
+    }
+
+    protected function createMetaDataInput(
+        Language $language,
+        Factory $field_factory,
+        ?FormInput $metadata_input
+    ): ?FormInput {
+        $image_purpose_input = match ($this->getImagePurpose()) {
+            ImagePurpose::USER_DEFINED => $this->createUserDefinedAltTextField($language, $field_factory),
+            ImagePurpose::INFORMATIVE => $this->createInformativeAltTextField($language, $field_factory),
+            default => null,
+        };
+        if (null === $image_purpose_input && null === $metadata_input) {
+            return null;
+        }
+        if (null === $image_purpose_input && null !== $metadata_input) {
+            return $metadata_input;
+        }
+        if (null !== $image_purpose_input && null === $metadata_input) {
+            return $field_factory->group([$image_purpose_input]);
+        }
+        return $field_factory->group([$image_purpose_input, $metadata_input]);
+    }
+
+    protected function createUserDefinedAltTextField(Language $language, Factory $field_factory): FormInput
+    {
+        return $field_factory->switchableGroup([
+            ImagePurpose::INFORMATIVE->name => $field_factory->group([$field_factory->textarea($language->txt('image_alt_text'))], $language->txt('image_purpose_informative')),
+            ImagePurpose::DECORATIVE->name => $field_factory->group([], $language->txt('image_purpose_decorative'))
+        ], $language->txt('image_purpose_user_defined'))->withRequired(true);
+    }
+
+    protected function createInformativeAltTextField(Language $language, Factory $field_factory): FormInput
+    {
+        return $field_factory->textarea($language->txt('image_alt_text'))->withRequired(true);
+    }
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -141,6 +141,9 @@ class Renderer extends AbstractComponentRenderer
             case ($component instanceof F\DateTime):
                 return $this->renderDateTimeField($component, $default_renderer);
 
+            case ($component instanceof F\Image):
+                return $this->renderImageField($component, $default_renderer);
+
             case ($component instanceof F\File):
                 return $this->renderFileField($component, $default_renderer);
 
@@ -774,6 +777,11 @@ class Renderer extends AbstractComponentRenderer
         $label_id = $this->createId();
         $tpl->setVariable('ID', $label_id);
         return $this->wrapInFormContext($component, $component->getLabel(), $tpl->get(), $label_id);
+    }
+
+    protected function renderImageField(F\Image $input, RendererInterface $default_renderer): string
+    {
+        return $this->renderFileField($input, $default_renderer);
     }
 
     protected function renderFileField(F\File $input, RendererInterface $default_renderer): string

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -782,8 +782,7 @@ class Renderer extends AbstractComponentRenderer
         foreach ($input->getGeneratedDynamicInputs() as $metadata_input) {
             $file_info = null;
             if (null !== ($data = $metadata_input->getValue())) {
-                $file_id = (!$input->hasMetadataInputs()) ?
-                    $data : $data[$input->getUploadHandler()->getFileIdentifierParameterName()] ?? null;
+                $file_id = (!$input->hasMetadataInputs()) ? $data : $data[0] ?? null;
 
                 if (null !== $file_id) {
                     $file_info = $input->getUploadHandler()->getInfoResult($file_id);

--- a/components/ILIAS/UI/src/examples/Input/Field/File/with_metadata.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/File/with_metadata.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\File;
+
+/**
+ * ---
+ * description: >
+ *   Example of how to create and render a File Field with ab additional metadata Field
+ *   and attach it to a form.
+ *
+ * expected output: >
+ *   ILIAS shows a Field titled "Upload File" next to a box surrounded by dashed lines.
+ *   You can choose a file by dragging the file to the box or by clicking "Select files".
+ *   Once you have choosen a file, a new entry above the box surrounded by dashed lines
+ *   will show up. Clicking the ">" next to the name of your file will expand the entry
+ *   further. Another Field becomes visible, which can be used to provide more information
+ *   about the file.
+ * ---
+ */
+function with_metadata(): string
+{
+    global $DIC;
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $file_input = $factory->input()->field()->file(
+        new \ilUIDemoFileUploadHandlerGUI(),
+        "Upload File",
+        "After choosing the file you can add additional metadata.",
+        $factory->input()->field()->switchableGroup([
+            $factory->input()->field()->group([$factory->input()->field()->text('New filename')], 'Yes'),
+            $factory->input()->field()->group([], 'No'),
+        ], 'Change filename?'),
+    );
+
+    $form = $factory->input()->container()->form()->standard("#", [$file_input]);
+
+    return $renderer->render($form);
+}

--- a/components/ILIAS/UI/src/examples/Input/Field/Image/base.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Image/base.php
@@ -20,12 +20,13 @@ declare(strict_types=1);
 namespace ILIAS\UI\examples\Input\Field\Image;
 
 use ILIAS\Data\ImagePurpose;
+use ILIAS\UI\URLBuilder;
 
 /**
  * ---
  * description: >
- *   The example shows how to create and render a Image Field for images where the purpose
- *   is user-defined and attach it to a Standard Form. The example does not show data processing.
+ *   The example shows how to create and render a Image Field and attach it to a Standard Form.
+ *   The example also shows data processing.
  *
  * expected output: >
  *   ILIAS shows the Image Field inside a Standard Form. Its label and byline are correctly
@@ -34,17 +35,25 @@ use ILIAS\Data\ImagePurpose;
  *   clicking Shy Button inside it, which opens a file browser window. Once you have choosen
  *   a file, a new file entry above the discernible box will show appear. Clicking the Glyph
  *   next to the name of your file will expand the entry further. Another Switchable Group Field
- *   becomes visible, which is required and must be used to define the image purpose. The option
- *   for informative images should show another Textarea Field which is required and the option
- *   for decorative images should not show any more Fields.
+ *   becomes visible, which can be used to provide more information about the image. Once
+ *   information has been filled out and the Form is submitted, the output should become
+ *   visible above the Standard Form.
  * ---
  */
-function user_defined(): string
+function base(): string
 {
     global $DIC;
 
+    $http = $DIC->http();
     $factory = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
+    $get_request = $http->wrapper()->query();
+    $data_factory = new \ILIAS\Data\Factory();
+    $refinery_factory = new \ILIAS\Refinery\Factory($data_factory, $DIC->language());
+
+    $example_uri = $data_factory->uri((string) $http->request()->getUri());
+    $url_builder = new URLBuilder($example_uri);
+    [$url_builder, $token] = $url_builder->acquireParameter(explode('\\', __NAMESPACE__), "process");
 
     $input = $factory->input()->field()->image(
         new \ilUIDemoFileUploadHandlerGUI(),
@@ -53,7 +62,18 @@ function user_defined(): string
         'Please provide an alternate text if necessary.',
     );
 
-    $form = $factory->input()->container()->form()->standard("#", [$input]);
+    $form = $factory->input()->container()->form()->standard(
+        (string) $url_builder->withParameter($token, '1')->buildURI(),
+        [$input]
+    );
 
-    return $renderer->render($form);
+    // simulates a form processing endpoint:
+    if ($get_request->has($token->getName())) {
+        $form = $form->withRequest($http->request());
+        $data = $form->getData();
+    } else {
+        $data = 'No submitted data yet.';
+    }
+
+    return '<pre>' . print_r($data, true) . '</pre>' . $renderer->render($form);
 }

--- a/components/ILIAS/UI/src/examples/Input/Field/Image/decorative.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Image/decorative.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Image;
+
+use ILIAS\Data\ImagePurpose;
+
+/**
+ * Example showing how the image field is used when the images' purpose
+ * is purely decorative.
+ */
+function decorative(): string
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $input = $factory->input()->field()->image(
+        new \ilUIDemoFileUploadHandlerGUI(),
+        ImagePurpose::DECORATIVE,
+        'Upload Image',
+        'This image will be purely decorative',
+    );
+
+    $form = $factory->input()->container()->form()->standard("#", [$input]);
+
+    return $renderer->render($form);
+}

--- a/components/ILIAS/UI/src/examples/Input/Field/Image/decorative.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Image/decorative.php
@@ -1,5 +1,20 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
 declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Input\Field\Image;
@@ -7,8 +22,19 @@ namespace ILIAS\UI\examples\Input\Field\Image;
 use ILIAS\Data\ImagePurpose;
 
 /**
- * Example showing how the image field is used when the images' purpose
- * is purely decorative.
+ * ---
+ * description: >
+ *   The example shows how to create and render a Image Field for decorative images and attach
+ *   it to a Standard Form. The example does not show data processing.
+ *
+ * expected output: >
+ *   ILIAS shows the Image Field inside a Standard Form. Its label and byline are correctly
+ *   rendered next to and underneath the actual input, which is displayed as a Shy Button
+ *   inside a discernible box. You can choose a file by dragging it onto this box, or by
+ *   clicking Shy Button inside it, which opens a file browser window. Once you have choosen
+ *   a file, a new file entry above the discernible box will show appear. There is no Glyph
+ *   next to the name of your file and the entry cannot be expanded any further.
+ * ---
  */
 function decorative(): string
 {

--- a/components/ILIAS/UI/src/examples/Input/Field/Image/informative.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Image/informative.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Image;
+
+use ILIAS\Data\ImagePurpose;
+
+/**
+ * Example showing how the image field is used when the image conveys important
+ * information to the context it will be used.
+ */
+function informative(): string
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $input = $factory->input()->field()->image(
+        new \ilUIDemoFileUploadHandlerGUI(),
+        ImagePurpose::INFORMATIVE,
+        'Upload Image',
+        'This image should convey important information.',
+    );
+
+    $form = $factory->input()->container()->form()->standard("#", [$input]);
+
+    return $renderer->render($form);
+}

--- a/components/ILIAS/UI/src/examples/Input/Field/Image/informative.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Image/informative.php
@@ -1,5 +1,20 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
 declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Input\Field\Image;
@@ -7,8 +22,21 @@ namespace ILIAS\UI\examples\Input\Field\Image;
 use ILIAS\Data\ImagePurpose;
 
 /**
- * Example showing how the image field is used when the image conveys important
- * information to the context it will be used.
+ * ---
+ * description: >
+ *   The example shows how to create and render a Image Field for informative images and attach
+ *   it to a Standard Form. The example does not show data processing.
+ *
+ * expected output: >
+ *   ILIAS shows the Image Field inside a Standard Form. Its label and byline are correctly
+ *   rendered next to and underneath the actual input, which is displayed as a Shy Button
+ *   inside a discernible box. You can choose a file by dragging it onto this box, or by
+ *   clicking Shy Button inside it, which opens a file browser window. Once you have choosen
+ *   a file, a new file entry above the discernible box will show appear. Clicking the Glyph
+ *   next to the name of your file will expand the entry further. Another Textarea Field
+ *   becomes visible, which is required and must be used to provide more information about
+ *   the image.
+ * ---
  */
 function informative(): string
 {

--- a/components/ILIAS/UI/src/examples/Input/Field/Image/user_defined.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Image/user_defined.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Image;
+
+use ILIAS\Data\ImagePurpose;
+
+/**
+ * Example showing how the image field is used when the image purpose cannot
+ * be determined by the consumer, leaving the decision up to the user.
+ */
+function user_defined(): string
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $input = $factory->input()->field()->image(
+        new \ilUIDemoFileUploadHandlerGUI(),
+        ImagePurpose::USER_DEFINED,
+        'Upload Image',
+        'Please provide an alternate text if necessary.',
+    );
+
+    $form = $factory->input()->container()->form()->standard("#", [$input]);
+
+    return $renderer->render($form);
+}

--- a/components/ILIAS/UI/src/examples/Input/Field/Image/with_metadata.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Image/with_metadata.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Image;
+
+use ILIAS\Data\ImagePurpose;
+
+/**
+ * Example showing how the image field is used with an additional metadata
+ * input.
+ */
+function with_metadata(): string
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $input = $factory->input()->field()->image(
+        new \ilUIDemoFileUploadHandlerGUI(),
+        ImagePurpose::USER_DEFINED,
+        'Upload Image',
+        'Please provide an alternate text if necessary.',
+        $factory->input()->field()->text('Additional information')
+    );
+
+    $form = $factory->input()->container()->form()->standard("#", [$input]);
+
+    return $renderer->render($form);
+}

--- a/components/ILIAS/UI/src/examples/Input/Field/Image/with_metadata.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Image/with_metadata.php
@@ -1,5 +1,20 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
 declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Input\Field\Image;
@@ -7,8 +22,22 @@ namespace ILIAS\UI\examples\Input\Field\Image;
 use ILIAS\Data\ImagePurpose;
 
 /**
- * Example showing how the image field is used with an additional metadata
- * input.
+ * ---
+ * description: >
+ *   The example shows how to create and render a Image Field with an additional metadata
+ *   input and attach it to a Standard Form. The example does not show data processing.
+ *
+ * expected output: >
+ *   ILIAS shows the Image Field inside a Standard Form. Its label and byline are correctly
+ *   rendered next to and underneath the actual input, which is displayed as a Shy Button
+ *   inside a discernible box. You can choose a file by dragging it onto this box, or by
+ *   clicking Shy Button inside it, which opens a file browser window. Once you have choosen
+ *   a file, a new file entry above the discernible box will show appear. Clicking the Glyph
+ *   next to the name of your file will expand the entry further. Another Switchable Group Field
+ *   becomes visible, which is required and must be used to provide more information about
+ *   the image. Beneath this an additional Text Field appears, which can be used to provide
+ *   even more information.
+ * ---
  */
 function with_metadata(): string
 {

--- a/components/ILIAS/UI/src/examples/Input/Field/Image/with_value.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Image/with_value.php
@@ -24,22 +24,19 @@ use ILIAS\Data\ImagePurpose;
 /**
  * ---
  * description: >
- *   The example shows how to create and render a Image Field for images where the purpose
- *   is user-defined and attach it to a Standard Form. The example does not show data processing.
+ *   The example shows how to create and render a Image Field with existing values and attach
+ *   it to a Standard Form. The example does not show data processing.
  *
  * expected output: >
  *   ILIAS shows the Image Field inside a Standard Form. Its label and byline are correctly
  *   rendered next to and underneath the actual input, which is displayed as a Shy Button
- *   inside a discernible box. You can choose a file by dragging it onto this box, or by
- *   clicking Shy Button inside it, which opens a file browser window. Once you have choosen
- *   a file, a new file entry above the discernible box will show appear. Clicking the Glyph
- *   next to the name of your file will expand the entry further. Another Switchable Group Field
- *   becomes visible, which is required and must be used to define the image purpose. The option
- *   for informative images should show another Textarea Field which is required and the option
- *   for decorative images should not show any more Fields.
+ *   inside a discernible box. Two file entries above the discernible box are visible. Clicking
+ *   the Glyph next to their names will expand the entry further. Both entries will show another
+ *   Switchable Group Field, which is required and is already provided with some information
+ *   about the corresnponding file.
  * ---
  */
-function user_defined(): string
+function with_value(): string
 {
     global $DIC;
 
@@ -51,7 +48,25 @@ function user_defined(): string
         ImagePurpose::USER_DEFINED,
         'Upload Image',
         'Please provide an alternate text if necessary.',
-    );
+        $factory->input()->field()->text('Additional information')
+    )->withMaxFiles(2);
+
+    $input = $input->withValue([
+        [
+            'file_id_1',
+            [
+                [ImagePurpose::INFORMATIVE->name, ['alternate text']],
+                'additional metadata',
+            ],
+        ],
+        [
+            'file_id_2',
+            [
+                ImagePurpose::DECORATIVE->name,
+                'additional metadata',
+            ],
+        ],
+    ]);
 
     $form = $factory->input()->container()->form()->standard("#", [$input]);
 

--- a/components/ILIAS/UI/src/examples/Input/Field/SwitchableGroup/with_value.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/SwitchableGroup/with_value.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\SwitchableGroup;
+
+/**
+ * ---
+ * description: >
+ *   Example showing two Switchable Group Fields provided with existing value(s).
+ *
+ * expected output: >
+ *   ILIAS shows two Switchable Group Fields. The first (above) one has the "Group 2" option
+ *   selected with the "Item 2" Field having NO value. The second (below) one has the "Group 2"
+ *   option selected with the "Item 2" Field having "some existing text value" as a value.
+ * ---
+ */
+function with_value(): string
+{
+    global $DIC;
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $group_one = $factory->input()->field()->group([$factory->input()->field()->text("Item 1", "Just some field")], "Group 1");
+    $group_two = $factory->input()->field()->group([$factory->input()->field()->text("Item 2", "Just some field")], "Group 2");
+
+    $switchable_group = $factory->input()->field()->switchableGroup(
+        [$group_one, $group_two],
+        "Switchable Group with existing value(s)",
+    );
+
+    // tells the input only which option is selected
+    $direct_value = $switchable_group->withValue(1);
+
+    // tells the input which option is selected and what value(s) it has
+    $nested_value = $switchable_group->withValue([1, ['some existing text value']]);
+
+    $form = $factory->input()->container()->form()->standard('#', [$direct_value, $nested_value]);
+
+    return $renderer->render($form);
+}

--- a/components/ILIAS/UI/src/examples/Input/Field/SwitchableGroup/with_value.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/SwitchableGroup/with_value.php
@@ -1,5 +1,20 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
 declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Input\Field\SwitchableGroup;

--- a/components/ILIAS/UI/tests/Component/Input/Field/FileInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/FileInputTest.php
@@ -279,7 +279,7 @@ class FileInputTest extends ILIAS_UI_TestBase
             $metadata_input
         )->withValue([
             [
-                $u->getFileIdentifierParameterName() => "file_id",
+                "file_id",
                 ""
             ]
         ])->withNameFrom($this->name_source);
@@ -291,40 +291,28 @@ class FileInputTest extends ILIAS_UI_TestBase
             <div class="ui-input-file">
                 <div class="ui-input-file-input-list">
                     <div class="ui-input-file-input">
-                        <div class="ui-input-file-info">
-                            <span data-action="expand">
-                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content">
-                                    <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-action="collapse">
-                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content">
-                                    <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-dz-name></span>
-                            <span data-dz-size></span>
-                            <span data-action="remove">
-                                <a tabindex="0" class="glyph" href="#" aria-label="close">
-                                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                        </div>
-                        <div class="ui-input-file-metadata" style="display: none;">
-                            <fieldset class="c-input" data-il-ui-component="text-field-input" data-il-ui-input-name="name_0[input_1][]">
-                                <label for="id_1">text_input</label>
-                                <div class="c-input__field">
-                                    <input id="id_1" type="text" name="name_0[input_1][]" class="c-field-text"/>
-                                </div>
+                        <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph" href="#"
+                                    aria-label="expand_content"><span class="glyphicon glyphicon-triangle-right"
+                                        aria-hidden="true"></span></a></span><span data-action="collapse"><a tabindex="0"
+                                    class="glyph" href="#" aria-label="collapse_content"><span
+                                        class="glyphicon glyphicon-triangle-bottom"
+                                        aria-hidden="true"></span></a></span><span data-dz-name></span><span
+                                data-dz-size></span><span data-action="remove"><a tabindex="0" class="glyph" href="#"
+                                    aria-label="close"><span class="glyphicon glyphicon-remove"
+                                        aria-hidden="true"></span></a></span><span class="ui-input-file-input-error-msg"
+                                data-dz-error-msg></span></div>
+                        <div class="ui-input-file-metadata" style="display: none;"><input id="id_1" type="hidden"
+                                name="name_0[input_1][]" value="file_id" />
+                            <fieldset class="c-input" data-il-ui-component="text-field-input"
+                                data-il-ui-input-name="name_0[input_2][]"><label for="id_2">text_input</label>
+                                <div class="c-input__field"><input id="id_2" type="text" name="name_0[input_2][]"
+                                        class="c-field-text" /></div>
                             </fieldset>
-                            <input id="id_2" type="hidden" name="name_0[input_2][]" value="file_id"/>
                         </div>
                         <div class="ui-input-file-input-progress-container">
                             <div class="ui-input-file-input-progress-indicator"></div>
                         </div>
-                    </div>
-                    <template>
+                    </div><template>
                         <div class="ui-input-file-input">
                             <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph"
                                         href="#" aria-label="expand_content"><span
@@ -337,12 +325,13 @@ class FileInputTest extends ILIAS_UI_TestBase
                                         aria-label="close"><span class="glyphicon glyphicon-remove"
                                             aria-hidden="true"></span></a></span><span class="ui-input-file-input-error-msg"
                                     data-dz-error-msg></span></div>
-                            <div class="ui-input-file-metadata" style="display: none;">
+                            <div class="ui-input-file-metadata" style="display: none;"><input id="id_3" type="hidden"
+                                    name="name_0[input_1][]" value="" />
                                 <fieldset class="c-input" data-il-ui-component="text-field-input"
-                                    data-il-ui-input-name="name_0[input_1][]"><label for="id_3">text_input</label>
-                                    <div class="c-input__field"><input id="id_3" type="text" name="name_0[input_1][]"
+                                    data-il-ui-input-name="name_0[input_2][]"><label for="id_4">text_input</label>
+                                    <div class="c-input__field"><input id="id_4" type="text" name="name_0[input_2][]"
                                             class="c-field-text" /></div>
-                                </fieldset><input id="id_4" type="hidden" name="name_0[input_2][]" value="" />
+                                </fieldset>
                             </div>
                             <div class="ui-input-file-input-progress-container">
                                 <div class="ui-input-file-input-progress-indicator"></div>
@@ -350,10 +339,9 @@ class FileInputTest extends ILIAS_UI_TestBase
                         </div>
                     </template>
                 </div>
-                <div class="ui-input-file-input-dropzone">
-                    <button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button>
-                    <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                </div>
+                <div class="ui-input-file-input-dropzone"><button class="btn btn-link" data-action="#"
+                        id="id_5">select_files_from_computer</button><span class="ui-input-file-input-error-msg"
+                        data-dz-error-msg></span></div>
                 <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1</div>
             </div>
             ',
@@ -385,7 +373,7 @@ class FileInputTest extends ILIAS_UI_TestBase
             $metadata_input
         )->withValue([
             [
-                $u->getFileIdentifierParameterName() => $test_file_id,
+                $test_file_id,
                 "test",
             ]
         ])->withNameFrom($this->name_source);
@@ -398,64 +386,47 @@ class FileInputTest extends ILIAS_UI_TestBase
             <div class="ui-input-file">
                 <div class="ui-input-file-input-list">
                     <div class="ui-input-file-input">
-                        <div class="ui-input-file-info">
-                            <span data-action="expand">
-                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content">
-                                    <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-action="collapse">
-                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content">
-                                    <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-dz-name>test file name 1</span>
-                            <span data-dz-size>1 MB</span>
-                            <span data-action="remove">
-                                <a tabindex="0" class="glyph" href="#" aria-label="close">
-                                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                        </div>
-                        <div class="ui-input-file-metadata" style="display: none;">
-                            <fieldset class="c-input" data-il-ui-component="text-field-input" data-il-ui-input-name="name_0[input_1][]">
-                                <label for="id_1">text_input</label>
-                                <div class="c-input__field">
-                                    <input id="id_1" type="text" value="test" name="name_0[input_1][]" class="c-field-text"/>
-                                </div>
+                        <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph" href="#"
+                                    aria-label="expand_content"><span class="glyphicon glyphicon-triangle-right"
+                                        aria-hidden="true"></span></a></span><span data-action="collapse"><a tabindex="0"
+                                    class="glyph" href="#" aria-label="collapse_content"><span
+                                        class="glyphicon glyphicon-triangle-bottom"
+                                        aria-hidden="true"></span></a></span><span data-dz-name>test file name 1</span><span
+                                data-dz-size>1 MB</span><span data-action="remove"><a tabindex="0" class="glyph" href="#"
+                                    aria-label="close"><span class="glyphicon glyphicon-remove"
+                                        aria-hidden="true"></span></a></span><span class="ui-input-file-input-error-msg"
+                                data-dz-error-msg></span></div>
+                        <div class="ui-input-file-metadata" style="display: none;"><input id="id_1" type="hidden"
+                                name="name_0[input_1][]" value="test_file_id_1" />
+                            <fieldset class="c-input" data-il-ui-component="text-field-input"
+                                data-il-ui-input-name="name_0[input_2][]"><label for="id_2">text_input</label>
+                                <div class="c-input__field"><input id="id_2" type="text" value="test"
+                                        name="name_0[input_2][]" class="c-field-text" /></div>
                             </fieldset>
-                            <input id="id_2" type="hidden" name="name_0[input_2][]" value="test_file_id_1"/>
                         </div>
                         <div class="ui-input-file-input-progress-container">
                             <div class="ui-input-file-input-progress-indicator"></div>
                         </div>
-                    </div>
-                    <template>
+                    </div><template>
                         <div class="ui-input-file-input">
-                            <div class="ui-input-file-info">
-                            <span data-action="expand">
-                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content">
-                                    <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-action="collapse">
-                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content">
-                                    <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-dz-name></span>
-                            <span data-dz-size></span>
-                            <span
-                                    data-action="remove"><a tabindex="0" class="glyph" href="#" aria-label="close"><span
-                                            class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></span><span
-                                    class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
-                            <div class="ui-input-file-metadata" style="display: none;">
+                            <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph"
+                                        href="#" aria-label="expand_content"><span
+                                            class="glyphicon glyphicon-triangle-right"
+                                            aria-hidden="true"></span></a></span><span data-action="collapse"><a
+                                        tabindex="0" class="glyph" href="#" aria-label="collapse_content"><span
+                                            class="glyphicon glyphicon-triangle-bottom"
+                                            aria-hidden="true"></span></a></span><span data-dz-name></span><span
+                                    data-dz-size></span><span data-action="remove"><a tabindex="0" class="glyph" href="#"
+                                        aria-label="close"><span class="glyphicon glyphicon-remove"
+                                            aria-hidden="true"></span></a></span><span class="ui-input-file-input-error-msg"
+                                    data-dz-error-msg></span></div>
+                            <div class="ui-input-file-metadata" style="display: none;"><input id="id_3" type="hidden"
+                                    name="name_0[input_1][]" value="" />
                                 <fieldset class="c-input" data-il-ui-component="text-field-input"
-                                data-il-ui-input-name="name_0[input_1][]"><label for="id_3">text_input</label>
-                                <div class="c-input__field"><input id="id_3" type="text" name="name_0[input_1][]"
-                                        class="c-field-text" /></div>
-                                </fieldset><input id="id_4" type="hidden" name="name_0[input_2][]" value="" />
+                                    data-il-ui-input-name="name_0[input_2][]"><label for="id_4">text_input</label>
+                                    <div class="c-input__field"><input id="id_4" type="text" name="name_0[input_2][]"
+                                            class="c-field-text" /></div>
+                                </fieldset>
                             </div>
                             <div class="ui-input-file-input-progress-container">
                                 <div class="ui-input-file-input-progress-indicator"></div>
@@ -463,10 +434,9 @@ class FileInputTest extends ILIAS_UI_TestBase
                         </div>
                     </template>
                 </div>
-                <div class="ui-input-file-input-dropzone">
-                    <button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button>
-                    <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                </div>
+                <div class="ui-input-file-input-dropzone"><button class="btn btn-link" data-action="#"
+                        id="id_5">select_files_from_computer</button><span class="ui-input-file-input-error-msg"
+                        data-dz-error-msg></span></div>
                 <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1</div>
             </div>
             ',

--- a/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
@@ -39,6 +39,10 @@ class Group1 extends Group
 
 class Group2 extends Group
 {
+    public function isClientSideValueOk($value): bool
+    {
+        return parent::isClientSideValueOk($value);
+    }
 }
 
 class SwitchableGroupInputTest extends ILIAS_UI_TestBase
@@ -186,12 +190,15 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
             ->expects($this->never())
             ->method("withValue");
         $this->child2
+            ->method('isClientSideValueOk')
+            ->willReturn(true);
+        $this->child2
             ->expects($this->once())
             ->method("withValue")
-            ->with(2)
+            ->with([2])
             ->willReturn($this->child2);
 
-        $new_group = $this->switchable_group->withValue(["child2", 2]);
+        $new_group = $this->switchable_group->withValue(["child2", [2]]);
 
         $this->assertEquals(["child1" => $this->child1, "child2" => $this->child2], $new_group->getInputs());
         $this->assertInstanceOf(SwitchableGroup::class, $new_group);

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -17236,6 +17236,10 @@ ui#:#footer_link_groups#:#Footer Link-Gruppen
 ui#:#footer_links#:#Footer Links
 ui#:#footer_permanent_link#:#Footer Permanent Link
 ui#:#footer_texts#:#Footer Texte
+ui#:#image_alt_text#:#Alternativtext
+ui#:#image_purpose_decorative#:#Dekoratives Bild
+ui#:#image_purpose_informative#:#Informatives Bild
+ui#:#image_purpose_user_defined#:#Verwendungszweck
 ui#:#label_fieldselection#:#Spaltenauswahl
 ui#:#label_fieldselection_refresh#:#Anwenden
 ui#:#label_modeviewcontrol#:#Anzeigemodus

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -17243,6 +17243,10 @@ ui#:#footer_link_groups#:#Footer Link-Groups
 ui#:#footer_links#:#Footer Links
 ui#:#footer_permanent_link#:#Footer Permanent Link
 ui#:#footer_texts#:#Footer Texts
+ui#:#image_alt_text#:#Alternate Text
+ui#:#image_purpose_decorative#:#Decorative Image
+ui#:#image_purpose_informative#:#Informative Image
+ui#:#image_purpose_user_defined#:#Image Purpose
 ui#:#label_fieldselection#:#Field Selection
 ui#:#label_fieldselection_refresh#:#Apply
 ui#:#label_modeviewcontrol#:#view mode


### PR DESCRIPTION
Hi folks,

I am happy to propose the public interface for a dedicated image upload field, which encourages users to provide alternate texts when necessary. The related FR can be found here: https://docu.ilias.de/goto_docu_wiki_wpage_5882_1357.html

As [discussed in the UI-Clinic](https://docu.ilias.de/goto_docu_dcl_8186_166_10629.html), we have decided to align this input with the existing file input, so we can reuse most of its functionality and reduce maintenance in the future. We also agreed, that the look-and-feel of the input needs some polishing. Therefore, I also updated the factory description of the file input, to match the new mockups more precisely.

I plan on using the `EntityListing` component to build the file-list internally. Maybe we could introduce some concrete `FileUploadEntity` in the future, to wrap up all of the components required to build this (progress bar, accordion, glyphs, ...). Let me know if this is a good idea.

Similar to the `Rating` input, I added an `ImagePurpose` enum to determine how the alternate text input should be handled. We currently know three different scenarios:

- the consumer knows that uploaded images will be informative, so an alt-text input is required.
- the consumer knows that uploaded images will be decorative, so an alt-text input is obsolete.
- the consumer doesn't know what the image purpose is, so an alt-text may be required. For this case a radio group must be used, letting the user make this choice.

I am looking forward to your review!

Kind regards,
@thibsy