### PR TITLE
IASS: fix displaying specific tabs if orgu positions are set. (#40684)

### DIFF
--- a/Modules/IndividualAssessment/classes/AccessControl/class.ilIndividualAssessmentAccessHandler.php
+++ b/Modules/IndividualAssessment/classes/AccessControl/class.ilIndividualAssessmentAccessHandler.php
@@ -72,9 +72,12 @@ class ilIndividualAssessmentAccessHandler implements IndividualAssessmentAccessH
             );
         }
 
-        if ($operation == "edit_learning_progress") {
+        if ($operation == "write_learning_progress") {
             return $this->handler->checkRbacOrPositionPermissionAccess(
-                "edit_learning_progress",
+                // This feels super odd, but this is actually ok because we do not have
+                // a dedicated RBAC permission to write_learning_progress.
+                // See: https://mantis.ilias.de/view.php?id=36056#c89865
+                "read_learning_progress",
                 "write_learning_progress",
                 $this->iass->getRefId()
             );
@@ -176,8 +179,7 @@ class ilIndividualAssessmentAccessHandler implements IndividualAssessmentAccessH
 
     public function mayViewAnyUser(): bool
     {
-        return $this->mayViewAllUsers()
-            || $this->checkRBACOrPositionAccessToObj('read_learning_progress');
+        return $this->checkRBACOrPositionAccessToObj('read_learning_progress');
     }
 
     public function mayViewAllUsers(): bool
@@ -187,21 +189,18 @@ class ilIndividualAssessmentAccessHandler implements IndividualAssessmentAccessH
 
     public function mayGradeAnyUser(): bool
     {
-        return $this->mayGradeAllUsers() || $this->checkRBACOrPositionAccessToObj('read_learning_progress');
-    }
-
-    public function mayGradeAllUsers(): bool
-    {
-        return $this->checkRBACAccessToObj('read_learning_progress');
+        return $this->checkRBACOrPositionAccessToObj('write_learning_progress');
     }
 
     public function mayGradeUser(int $user_id): bool
     {
         return
-            $this->mayGradeAllUsers() ||
             (count(
                 $this->handler->filterUserIdsByRbacOrPositionOfCurrentUser(
-                    "edit_learning_progress",
+                    // This feels super odd, but this is actually ok because we do not have
+                    // a dedicated RBAC permission to write_learning_progress.
+                    // See: https://mantis.ilias.de/view.php?id=36056#c89865
+                    "read_learning_progress",
                     "write_learning_progress",
                     $this->iass->getRefId(),
                     [$user_id]

--- a/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilObjIndividualAssessmentGUI.php
@@ -326,6 +326,7 @@ class ilObjIndividualAssessmentGUI extends ilObjectGUI
 
         if (($this->object->accessHandler()->mayViewAllUsers()
             || $this->object->accessHandler()->mayEditLearningProgressSettings()
+            || $this->object->accessHandler()->mayReadLearningProgress()
             || ($this->object->loadMembers()->userAllreadyMember($this->usr)
             && $this->object->isActiveLP()))
             && ilObjUserTracking::_enabledLearningProgress()) {

--- a/Modules/IndividualAssessment/interfaces/AccessControl/interface.IndividualAssessmentAccessHandler.php
+++ b/Modules/IndividualAssessment/interfaces/AccessControl/interface.IndividualAssessmentAccessHandler.php
@@ -46,7 +46,6 @@ interface IndividualAssessmentAccessHandler
     public function mayViewAnyUser(): bool;
     public function mayViewAllUsers(): bool;
     public function mayGradeAnyUser(): bool;
-    public function mayGradeAllUsers(): bool;
     public function mayGradeUser(int $user_id): bool;
     public function mayViewUser(int $user_id): bool;
     public function mayAmendAllUsers(): bool;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40684

According to the test case  (linked in the mantis ticket) following should now be possible:

A. Org Unit position permissions "Set learning progress of other users" and "View learning progress of other users" are set:
- display all employees
- display employee's data and enable the possibility to change those data
- display learning progress tab with the data of your employees
- disable the possibility to change learning progress data/settings
- do not display other users and their data. You also can't change their data.

Change A to B. Org Unit position permission "View learning progress of other users" is disabled:
- enable the possibility to assess participants (only your employees - not other users)
- do not display the learning progress tab
- only display your own assessments

Change A to C. Org Unit position permission "Set learning progress of other users" is disabled:
- display data of your employees
- disable the possibility to change data and assessments
- display learning progress data but disable the possibility to change the learning progress data/settings