### PR TITLE
[FIX] #39532,#39260 UI: distinguish example post urls.

### DIFF
--- a/src/UI/examples/Dropzone/File/Standard/base.php
+++ b/src/UI/examples/Dropzone/File/Standard/base.php
@@ -11,12 +11,16 @@ function base()
     $factory = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
     $request = $DIC->http()->request();
+    $wrapper = $DIC->http()->wrapper()->query();
+
+    $submit_flag = 'dropzone_standard_base';
+    $post_url = "{$request->getUri()}&$submit_flag";
 
     $dropzone = $factory
         ->dropzone()->file()->standard(
             'Upload your files here',
             'Drag files in here to upload them!',
-            '#',
+            $post_url,
             $factory->input()->field()->file(
                 new \ilUIAsyncDemoFileUploadHandlerGUI(),
                 'your files'
@@ -27,7 +31,7 @@ function base()
 
     // please use ilCtrl to generate an appropriate link target
     // and check it's command instead of this.
-    if ('POST' === $request->getMethod()) {
+    if ($wrapper->has($submit_flag)) {
         $dropzone = $dropzone->withRequest($request);
         $data = $dropzone->getData();
     } else {

--- a/src/UI/examples/Dropzone/File/Standard/bulky.php
+++ b/src/UI/examples/Dropzone/File/Standard/bulky.php
@@ -11,12 +11,16 @@ function bulky()
     $factory = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
     $request = $DIC->http()->request();
+    $wrapper = $DIC->http()->wrapper()->query();
+
+    $submit_flag = 'dropzone_standard_bulky';
+    $post_url = "{$request->getUri()}&$submit_flag";
 
     $dropzone = $factory
         ->dropzone()->file()->standard(
             'Upload your files here',
             'Drag files in here to upload them!',
-            '#',
+            $post_url,
             $factory->input()->field()->file(
                 new \ilUIAsyncDemoFileUploadHandlerGUI(),
                 'your files'
@@ -29,7 +33,7 @@ function bulky()
 
     // please use ilCtrl to generate an appropriate link target
     // and check it's command instead of this.
-    if ('POST' === $request->getMethod()) {
+    if ($wrapper->has($submit_flag)) {
         $dropzone = $dropzone->withRequest($request);
         $data = $dropzone->getData();
     } else {

--- a/src/UI/examples/Dropzone/File/Standard/with_additional_input.php
+++ b/src/UI/examples/Dropzone/File/Standard/with_additional_input.php
@@ -11,12 +11,16 @@ function with_additional_input()
     $factory = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
     $request = $DIC->http()->request();
+    $wrapper = $DIC->http()->wrapper()->query();
+
+    $submit_flag = 'dropzone_standard_with_additional_input';
+    $post_url = "{$request->getUri()}&$submit_flag";
 
     $dropzone = $factory
         ->dropzone()->file()->standard(
             'Upload your files here',
             'Drag files in here to upload them!',
-            '#',
+            $post_url,
             $factory->input()->field()->file(
                 new \ilUIAsyncDemoFileUploadHandlerGUI(),
                 'your files'
@@ -31,7 +35,7 @@ function with_additional_input()
 
     // please use ilCtrl to generate an appropriate link target
     // and check it's command instead of this.
-    if ('POST' === $request->getMethod()) {
+    if ($wrapper->has($submit_flag)) {
         $dropzone = $dropzone->withRequest($request);
         $data = $dropzone->getData();
     } else {

--- a/src/UI/examples/Dropzone/File/Wrapper/base.php
+++ b/src/UI/examples/Dropzone/File/Wrapper/base.php
@@ -11,11 +11,15 @@ function base()
     $factory = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
     $request = $DIC->http()->request();
+    $wrapper = $DIC->http()->wrapper()->query();
+
+    $submit_flag = 'dropzone_wrapper_base';
+    $post_url = "{$request->getUri()}&$submit_flag";
 
     $dropzone = $factory
         ->dropzone()->file()->wrapper(
             'Upload your files here',
-            '#',
+            $post_url,
             $factory->messageBox()->info('Drag and drop files onto me!'),
             $factory->input()->field()->file(
                 new \ilUIAsyncDemoFileUploadHandlerGUI(),
@@ -25,7 +29,7 @@ function base()
 
     // please use ilCtrl to generate an appropriate link target
     // and check it's command instead of this.
-    if ('POST' === $request->getMethod()) {
+    if ($wrapper->has($submit_flag)) {
         $dropzone = $dropzone->withRequest($request);
         $data = $dropzone->getData();
     } else {

--- a/src/UI/examples/Dropzone/File/Wrapper/with_additional_input.php
+++ b/src/UI/examples/Dropzone/File/Wrapper/with_additional_input.php
@@ -11,11 +11,15 @@ function with_additional_input()
     $factory = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
     $request = $DIC->http()->request();
+    $wrapper = $DIC->http()->wrapper()->query();
+
+    $submit_flag = 'dropzone_wrapper_with_additional_input';
+    $post_url = "{$request->getUri()}&$submit_flag";
 
     $dropzone = $factory
         ->dropzone()->file()->wrapper(
             'Upload your files here',
-            '#',
+            $post_url,
             $factory->messageBox()->info('Drag and drop files onto me!'),
             $factory->input()->field()->file(
                 new \ilUIAsyncDemoFileUploadHandlerGUI(),
@@ -29,7 +33,7 @@ function with_additional_input()
 
     // please use ilCtrl to generate an appropriate link target
     // and check it's command instead of this.
-    if ('POST' === $request->getMethod()) {
+    if ($wrapper->has($submit_flag)) {
         $dropzone = $dropzone->withRequest($request);
         $data = $dropzone->getData();
     } else {

--- a/src/UI/examples/Dropzone/File/Wrapper/with_clear_button.php
+++ b/src/UI/examples/Dropzone/File/Wrapper/with_clear_button.php
@@ -10,11 +10,15 @@ function with_clear_button()
 
     $factory = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    $submit_flag = 'dropzone_wrapper_with_clear_button';
+    $post_url = "{$request->getUri()}&$submit_flag";
 
     $dropzone = $factory
         ->dropzone()->file()->wrapper(
             'Upload your files here',
-            '#',
+            $post_url,
             $factory->messageBox()->info('Drag and drop files onto me!'),
             $factory->input()->field()->file(
                 new \ilUIAsyncDemoFileUploadHandlerGUI(),


### PR DESCRIPTION
Hi folks,

This PR fixes the following mantis issues:

- https://mantis.ilias.de/view.php?id=39532
- https://mantis.ilias.de/view.php?id=39260

The issues are caused by the same problem: the examples don't use proper post URLs and merely check if the current request method is post. Therefore `withRequest()` is called for every example, even though only one of them was actually submitted. This leads to the problem because the `with_additional_input()` example of both dropzones expects another input to be present.

This fix is merely a bandaid, because the root problem is that examples should have access to information like post-URLs via arguments. If you like, I'll add this to the roadmap.

Kind regards,
@thibsy
