### PR TITLE
[FIX] #38079 UI: update Field\Image description

### DIFF
--- a/src/UI/Component/Input/Field/Factory.php
+++ b/src/UI/Component/Input/Field/Factory.php
@@ -571,7 +571,7 @@ interface Factory
      * ---
      * description:
      *   purpose: >
-     *     A File Input is used to upload a single file using the native
+     *     A File Input is used to upload one or multiple files, using the native
      *     filebrowser of a browser or Drag&Drop.
      *   composition: >
      *     A File Input is composed as a Dropzone and a list of files. The


### PR DESCRIPTION
Hi folks,

This PR addresses the following mantis issue: https://mantis.ilias.de/view.php?id=38079

It merely updates the factory description of the `Field\File` input, so it states that `one or multiple files` can be uploaded instead of just `a single file`.

Kind regards,
@thibsy 