### PR TITLE
Transform all properties of symbols that are publicly accessible

### DIFF
--- a/src/UI/Implementation/Component/Symbol/Avatar/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Avatar/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Symbol\Avatar;
 
 use ILIAS\UI\Component;
@@ -31,7 +31,7 @@ class Renderer extends AbstractComponentRenderer
         $this->checkComponent($component);
         $tpl = null;
 
-        $label = $component->getLabel();
+        $label = $this->convertSpecialCharacters($component->getLabel());
         if ($label == "") {
             $label = $this->txt("user_avatar");
         }
@@ -49,7 +49,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl = $this->getTemplate('tpl.avatar_picture.html', true, true);
             $tpl->setVariable('ARIA_LABEL', $label);
             $tpl->setVariable('MODE', 'picture');
-            $tpl->setVariable('CUSTOMIMAGE', $component->getPicturePath());
+            $tpl->setVariable('CUSTOMIMAGE', $this->convertSpecialCharacters($component->getPicturePath()));
         }
 
         return $tpl->get();

--- a/src/UI/Implementation/Component/Symbol/Icon/Renderer.php
+++ b/src/UI/Implementation/Component/Symbol/Icon/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Symbol\Icon;
 
@@ -49,7 +49,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
 
-        $tpl->setVariable("NAME", $component->getName());
+        $tpl->setVariable("NAME", $this->convertSpecialCharacters($component->getName()));
         $tpl->setVariable("SIZE", $component->getSize());
 
         $tpl = $this->renderLabel($component, $tpl);
@@ -57,10 +57,10 @@ class Renderer extends AbstractComponentRenderer
         if ($component instanceof Component\Symbol\Icon\Standard) {
             $imagepath = $this->getStandardIconPath($component);
         } else {
-            $imagepath = $component->getIconPath();
+            $imagepath = $this->convertSpecialCharacters($component->getIconPath());
         }
 
-        $ab = $component->getAbbreviation();
+        $ab = $this->convertSpecialCharacters($component->getAbbreviation() ?? '');
         if ($ab) {
             $tpl->setVariable("ABBREVIATION", $ab);
 
@@ -86,7 +86,7 @@ class Renderer extends AbstractComponentRenderer
 
     protected function renderLabel(Component\Component $component, Template $tpl): Template
     {
-        $tpl->setVariable('LABEL', $component->getLabel());
+        $tpl->setVariable('LABEL', $this->convertSpecialCharacters($component->getLabel()));
         return $tpl;
     }
 

--- a/src/UI/Implementation/Render/AbstractComponentRenderer.php
+++ b/src/UI/Implementation/Render/AbstractComponentRenderer.php
@@ -328,4 +328,9 @@ abstract class AbstractComponentRenderer implements ComponentRenderer, HelpTextR
         }
         return $this->tooltip_renderer;
     }
+
+    protected function convertSpecialCharacters(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8');
+    }
 }

--- a/tests/UI/Component/Symbol/Avatar/AvatarTest.php
+++ b/tests/UI/Component/Symbol/Avatar/AvatarTest.php
@@ -224,4 +224,32 @@ class AvatarTest extends ILIAS_UI_TestBase
             }
         }
     }
+
+    public function testHTMLInLabel(): void
+    {
+        $f = $this->getAvatarFactory();
+        $r = $this->getDefaultRenderer();
+
+        $avatar = $f->letter('user')->withLabel('<h1>label</h1>');
+        $html = $this->brutallyTrimHTML($r->render($avatar));
+        $expected = $this->brutallyTrimHTML('
+<span class="il-avatar il-avatar-letter il-avatar-size-large il-avatar-letter-color-11" aria-label="&lt;h1&gt;label&lt;/h1&gt;" role="img">	
+    <span class="abbreviation">us</span>
+</span>');
+        $this->assertEquals($expected, $html);
+    }
+
+    public function testHTMLInCustomImage(): void
+    {
+        $f = $this->getAvatarFactory();
+        $r = $this->getDefaultRenderer();
+
+        $avatar = $f->picture('<h1>path</h1>', 'user');
+        $html = $this->brutallyTrimHTML($r->render($avatar));
+        $expected = $this->brutallyTrimHTML('
+<span class="il-avatar il-avatar-picture il-avatar-size-large">	
+    <img src="&lt;h1&gt;path&lt;/h1&gt;" alt="user_avatar"/>
+</span>');
+        $this->assertEquals($expected, $html);
+    }
 }

--- a/tests/UI/Component/Symbol/Icon/IconTest.php
+++ b/tests/UI/Component/Symbol/Icon/IconTest.php
@@ -203,4 +203,39 @@ imgtag;
 
         return $ico;
     }
+
+    public function testHTMLInName(): void
+    {
+        $ico = $this->getIconFactory()->standard('<h1>name</h1>', 'label');
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($ico));
+        $expected = '<img class="icon &lt;h1&gt;name&lt;/h1&gt; small" src="./templates/default/images/standard/icon_default.svg" alt="label"/>';
+        $this->assertEquals($expected, $html);
+    }
+
+    public function testHTMLInLabel(): void
+    {
+        $ico = $this->getIconFactory()->standard('name', '<h1>label</h1>');
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($ico));
+        $expected = '<img class="icon name small" src="./templates/default/images/standard/icon_default.svg" alt="&lt;h1&gt;label&lt;/h1&gt;"/>';
+        $this->assertEquals($expected, $html);
+    }
+
+    /**
+     * @depends testRenderingStandard
+     */
+    public function testHTMLInAbbreviation(): void
+    {
+        $ico = $this->getIconFactory()->standard('name', 'label')->withAbbreviation('<h1>abbreviation</h1>');
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($ico));
+        $expected = '<img class="icon name small" src="data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCINCgkgdmlld0JveD0iMCAwIDMyMCAzMjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyMCAzMjA7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+DQoJLnN0MHtjbGlwLXBhdGg6dXJsKCNTVkdJRF8wMDAwMDA0Nzc1MTgzNzAxNzcyMjkwMzQ5MDAwMDAwOTM5MjQyNjM5Mzc4Mzc4Mzg1N18pO2ZpbGw6IzRDNjU4Njt9DQo8L3N0eWxlPg0KPGc+DQoJPGc+DQoJCTxkZWZzPg0KCQkJPHJlY3QgaWQ9IlNWR0lEXzFfIiB3aWR0aD0iMzIwIiBoZWlnaHQ9IjMyMCIvPg0KCQk8L2RlZnM+DQoJCTxjbGlwUGF0aCBpZD0iU1ZHSURfMDAwMDAxNjU5Mjc3Njk0MzI5ODM0MDA2OTAwMDAwMTQyOTU5NjQxMjMxNjc4OTQ5MjBfIj4NCgkJCTx1c2UgeGxpbms6aHJlZj0iI1NWR0lEXzFfIiAgc3R5bGU9Im92ZXJmbG93OnZpc2libGU7Ii8+DQoJCTwvY2xpcFBhdGg+DQoJCTxwYXRoIHN0eWxlPSJjbGlwLXBhdGg6dXJsKCNTVkdJRF8wMDAwMDE2NTkyNzc2OTQzMjk4MzQwMDY5MDAwMDAxNDI5NTk2NDEyMzE2Nzg5NDkyMF8pO2ZpbGw6IzRDNjU4NjsiIGQ9Ik05MCw1MEg2MA0KCQkJYy01LjUsMC0xMCw0LjUtMTAsMTB2MjAwYzAsNS41LDQuNSwxMCwxMCwxMGgzMHYtMTVINjVWNjVoMjVWNTB6IE0yNzAsMjYwVjYwYzAtNS41LTQuNS0xMC0xMC0xMGgtMzB2MTVoMjV2MTkwaC0yNXYxNWgzMA0KCQkJQzI2NS41LDI3MCwyNzAsMjY1LjUsMjcwLDI2MCIvPg0KCTwvZz4NCjwvZz4NCjx0ZXh0CiAgIHN0eWxlPSIKICAgICAgZm9udC1zdHlsZTpub3JtYWw7CiAgICAgIGZvbnQtd2VpZ2h0Om5vcm1hbDsKICAgICAgZm9udC1zaXplOjhyZW07CiAgICAgIGZvbnQtZmFtaWx5OnNhbnMtc2VyaWY7CiAgICAgIGxldHRlci1zcGFjaW5nOjBweDsKICAgICAgZmlsbDojMDAwOwogICAgICBmaWxsLW9wYWNpdHk6MTsKICAgICIKICAgIHg9IjUwJSIKICAgIHk9IjU1JSIKICAgIGRvbWluYW50LWJhc2VsaW5lPSJtaWRkbGUiCiAgICB0ZXh0LWFuY2hvcj0ibWlkZGxlIgogID4mbHQ7aDEmZ3Q7YWJicmV2aWF0aW9uJmx0Oy9oMSZndDs8L3RleHQ+PC9zdmc+" alt="label" data-abbreviation="&lt;h1&gt;abbreviation&lt;/h1&gt;"/>';
+        $this->assertEquals($expected, $html);
+    }
+
+    public function testHTMLInCustomImage(): void
+    {
+        $ico = $this->getIconFactory()->custom('<h1>path</h1>', 'label');
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($ico));
+        $expected = '<img class="icon custom small" src="&lt;h1&gt;path&lt;/h1&gt;" alt="label"/>';
+        $this->assertEquals($expected, $html);
+    }
 }


### PR DESCRIPTION
This transforms all properties inside the Symbols that:
- can be changed by the consumer via the UI-Factory
- are raw part of the rendered HTML
- not restricted object wise (e.g. size)

This PR changes the following presentations:
- The Name/Title of Symbols
- The Label/Alt of Symbols


_This should use a refinery transformation, when #6314 is merged._