### PR TITLE
[FIX] #39474 UI: remove duplicate ids from message boxes

### DIFF
--- a/src/UI/templates/default/MessageBox/tpl.messagebox.html
+++ b/src/UI/templates/default/MessageBox/tpl.messagebox.html
@@ -1,4 +1,4 @@
 <!-- BEGIN message_box -->
 <div class="alert <!-- BEGIN failure_class -->alert-danger<!-- END failure_class --><!-- BEGIN success_class -->alert-success<!-- END success_class --><!-- BEGIN info_class -->alert-info<!-- END info_class --><!-- BEGIN confirmation_class -->alert-warning<!-- END confirmation_class -->" role="{ROLE}">
-	<div class="ilAccHeadingHidden"><a id="il_message_focus" name="il_message_focus">{ACC_TEXT}</a></div>{MESSAGE_TEXT}<!-- BEGIN buttons --><div>{BUTTONS}</div><!-- END buttons -->{LINK_LIST}</div>
+	<div class="ilAccHeadingHidden"><a name="il_message_focus">{ACC_TEXT}</a></div>{MESSAGE_TEXT}<!-- BEGIN buttons --><div>{BUTTONS}</div><!-- END buttons -->{LINK_LIST}</div>
 <!-- END message_box -->

--- a/tests/UI/Component/MessageBox/MessageBoxTest.php
+++ b/tests/UI/Component/MessageBox/MessageBoxTest.php
@@ -177,7 +177,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><a id=\"il_message_focus\" name=\"il_message_focus\">" .
+                    "<div class=\"ilAccHeadingHidden\"><a name=\"il_message_focus\">" .
                     $g->getType() . "_message</a></div>Lorem ipsum dolor sit amet.</div>";
         $this->assertHTMLEquals($expected, $html);
     }
@@ -199,7 +199,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><a id=\"il_message_focus\" name=\"il_message_focus\">" .
+                    "<div class=\"ilAccHeadingHidden\"><a name=\"il_message_focus\">" .
                     $g->getType() . "_message</a></div>Lorem ipsum dolor sit amet." .
                     "<div><button class=\"btn btn-default\"   data-action=\"#\" id=\"id_1\">Confirm</button>" .
                     "<button class=\"btn btn-default\"   data-action=\"#\" id=\"id_2\">Cancel</button></div></div>";
@@ -226,7 +226,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><a id=\"il_message_focus\" name=\"il_message_focus\">" .
+                    "<div class=\"ilAccHeadingHidden\"><a name=\"il_message_focus\">" .
                     $g->getType() . "_message</a></div>Lorem ipsum dolor sit amet." .
                     "<ul><li><a href=\"#\" >Open Exercise Assignment</a></li>" .
                     "<li><a href=\"#\" >Open other screen</a></li></ul></div>";
@@ -255,7 +255,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
 
         $html = $this->normalizeHTML($r->render($g));
         $expected = "<div class=\"alert $css_classes\" role=\"$role_type\">" .
-                    "<div class=\"ilAccHeadingHidden\"><a id=\"il_message_focus\" name=\"il_message_focus\">" .
+                    "<div class=\"ilAccHeadingHidden\"><a name=\"il_message_focus\">" .
                     $g->getType() . "_message</a></div>Lorem ipsum dolor sit amet." .
                     "<div><button class=\"btn btn-default\"   data-action=\"#\" id=\"id_1\">Confirm</button>" .
                     "<button class=\"btn btn-default\"   data-action=\"#\" id=\"id_2\">Cancel</button></div>" .


### PR DESCRIPTION
Hi folks,

This PR addresses the following mantis issue: https://mantis.ilias.de/view.php?id=39474

The problem was not exactly related to the `Dropzone\Wrapper` component like the ticket suggests, but rather the `Component\MessageBox` components which were wrapped by them. I noticed there is an `id="il_message_focus"` in the `tpl.messagebox.html` template, which leads to duplicate ids when rendering more than one of them. To fix this issue I simply removed this attribute from the template. I couldn't find any usages of this ID, so I think we're fine.

Since I had to adjust the rendering unit-tests, I also decoupled the `Launcher\Inline` rendering test while at it.

Kind regards,
@thibsy