### PR TITLE
CSS, Templates Authority Change

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -429,9 +429,12 @@ of ILIAS. The file contains the following fields:
 [//]: # (BEGIN CSSAndTemplates)
 
 * **CSS / Templates**
-    * Authority to Sign off Conceptual Changes: [amstutz](https://docu.ilias.de/goto_docu_usr_26468.html)
+    * Authority to Sign off Conceptual Changes: [yvseiler](https://docu.ilias.de/goto_docu_usr_17694.html)
+      , [catenglaender](https://docu.ilias.de/goto_docu_usr_79291.html)
     * Authority to Sign off Code Changes: [amstutz](https://docu.ilias.de/goto_docu_usr_26468.html)
+      , [catenglaender](https://docu.ilias.de/goto_docu_usr_79291.html)
     * Authority to Curate Test Cases: [amstutz](https://docu.ilias.de/goto_docu_usr_26468.html)
+      , [yvseiler](https://docu.ilias.de/goto_docu_usr_17694.html)
     * Authority to (De-)Assign Authorities: [amstutz](https://docu.ilias.de/goto_docu_usr_26468.html)
 	* Tester: [fschmid](https://docu.ilias.de/goto_docu_usr_21087.html)
     * Assignee for Security Reports: [amstutz](https://docu.ilias.de/goto_docu_usr_26468.html)


### PR DESCRIPTION
Wir sind sehr froh, dass die Authorities endlich Teil von unserem Entwicklungsprozess sind. Dies erlaubt uns, etwas transparenter zu kommunizieren und zu definieren, wer im Bereich CSS welche Authority übernimmt. Die aktuelle Beschreibung entspricht nicht der optimalen Verteilung bezüglich der vorhandenen Skills in der Community.

Neu würden wir gerne die Authority to „Sign off Conceptual Changes“ @yvseiler und @catenglaender übergeben und @Amstutz dort hinausnehmen. Die beiden verfügen über ein tiefes Verständnis von Design und UI Konzepten. Wir sind uns sicher, dass diese Authority bei den beiden in sehr kompetenten Händen liegen wird.

Weiter würde, soll @catenglaender "Autority to Sign off Code Changes" gegeben werden. @catenglaender verfügt über herausragende CSS Expertise, welche hier dringend benötigt wird.

@yvseiler soll weiter die "Curate Test Cases" kriegen, um @Amstutz hierbei unterstützen und vertreten zu können.