### PR TITLE
UI: adjust rendering of header in property forms. (#41142)

### DIFF
--- a/components/ILIAS/Form/classes/class.ilPropertyFormGUI.php
+++ b/components/ILIAS/Form/classes/class.ilPropertyFormGUI.php
@@ -536,8 +536,8 @@ class ilPropertyFormGUI extends ilFormGUI
             }
 
             // required top
-            if ($this->required_text) {
-                $this->tpl->setCurrentBlock("header");
+            $this->tpl->setCurrentBlock("header");
+            if ($this->checkForRequiredField()) {
                 $this->tpl->setCurrentBlock("required_text_top");
                 $this->tpl->setVariable("TXT_REQUIRED_TOP", $lng->txt("required_field"));
                 $this->tpl->parseCurrentBlock();
@@ -1062,5 +1062,26 @@ class ilPropertyFormGUI extends ilFormGUI
                 }
             }
         }
+    }
+
+    protected function checkForRequiredField(): bool
+    {
+        foreach ($this->items as $item) {
+            if ($item->getType() != "hidden") {
+                if ($this->getMode() == "subform") {
+                    if (!$this->hideRequired($item->getType())) {
+                        if ($item->getRequired()) {
+                            return true;
+                        }
+                    }
+                } elseif (!$this->hideRequired($item->getType())) {
+                    if ($item->getRequired()) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/components/ILIAS/Form/templates/default/tpl.property_form.html
+++ b/components/ILIAS/Form/templates/default/tpl.property_form.html
@@ -11,11 +11,11 @@
 <!-- BEGIN header -->
 <!-- BEGIN title_icon --><!-- <img src="{IMG_ICON}" alt="{IMG_ALT}" border="0"/> --><!-- END title_icon -->
 		<div class="ilFormHeader clearfix">
+			<!-- BEGIN required_text_top -->
 			<div class="col-sm-6 ilFormRequired--top">
-				<!-- BEGIN required_text_top -->
 				<span class="asterisk">*</span><span class="small"> {TXT_REQUIRED_TOP}</span>
-				<!-- END required_text_top -->
-				&nbsp;</div>
+			&nbsp;</div>
+			<!-- END required_text_top -->
 			<h2 class="ilHeader">{TXT_TITLE}</h2>
 		<div class="ilFormCmds">
 				<!-- BEGIN commands2 -->


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41142

As changes before this commit resulted to missing header content like settings (e.g. learning progress) the rendering of the header in property forms had to be adjusted.

If no required fields are set the header part for required text output won't get rendered (before it rendered an empty ).

If at least one required field is set in a formular a required text will get rendered in the header of the formular.