### PR TITLE
User: Add goto link for the login page (ILIAS 10)

### DIFF
--- a/components/ILIAS/Authentication/classes/StaticUrlHandler.php
+++ b/components/ILIAS/Authentication/classes/StaticUrlHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Authentication;
+
+use ILIAS\StaticURL\Handler\Handler;
+use ILIAS\StaticURL\Handler\BaseHandler;
+use ILIAS\StaticURL\Request\Request;
+use ILIAS\StaticURL\Context;
+use ILIAS\StaticURL\Response\Factory;
+use ILIAS\StaticURL\Response\Response;
+use ilCtrlInterface;
+use ilLanguage;
+
+class StaticUrlHandler extends BaseHandler implements Handler
+{
+    private readonly ilCtrlInterface $ctrl;
+    private readonly ilLanguage $language;
+
+    public function __construct()
+    {
+        global $DIC;
+        $this->ctrl = $DIC->ctrl();
+        $this->language = $DIC->language();
+    }
+
+    public function getNamespace(): string
+    {
+        return 'auth';
+    }
+
+    public function handle(Request $request, Context $context, Factory $response_factory): Response
+    {
+        $additional_params = join('/', $request->getAdditionalParameters() ?? []);
+
+        return match ($additional_params) {
+            'login' => $response_factory->can(rtrim(ILIAS_HTTP_PATH, '/') . '/login.php?' . http_build_query([
+                'cmd' => 'force_login',
+                'lang' => $this->language->getLangKey(),
+            ])),
+        };
+    }
+}

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -293,6 +293,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             $tpl->setVariable('LPE', $page_editor_html);
         }
 
+        $this->mainTemplate->setPermanentLink('auth', null, 'login');
         self::printToGlobalTemplate($tpl);
     }
 


### PR DESCRIPTION
Add goto link (`/go/auth/login` & `goto.php/auth/login`) which redirects to the login page.

Feature Request: https://docu.ilias.de/goto_docu_wiki_wpage_8233_1357.html