### PR TITLE
T&A: 41125, Resvoled issue regarding failing unit test ilObjTestVerificationGUITest

### DIFF
--- a/components/ILIAS/Test/phpunit.xml
+++ b/components/ILIAS/Test/phpunit.xml
@@ -11,7 +11,7 @@
         </report>
     </coverage>
     <testsuite name="ilModulesTestSuite">
-        <file>./test/ilModulesTestSuite.php</file>
+        <file>./tests/ilModulesTestSuite.php</file>
     </testsuite>
     <logging>
         <testdoxHtml outputFile="build/dox.html"/>

--- a/components/ILIAS/Test/tests/ilObjTestVerificationGUITest.php
+++ b/components/ILIAS/Test/tests/ilObjTestVerificationGUITest.php
@@ -35,11 +35,11 @@ class ilObjTestVerificationGUITest extends ilTestBaseTestCase
         $this->addGlobal_rbacsystem();
         $this->addGlobal_rbacreview();
         $this->addGlobal_ilObjDataCache();
+        $this->addGlobal_ilSetting();
     }
 
     public function testConstruct(): void
     {
-        $this->markTestSkipped("See https://mantis.ilias.de/view.php?id=41125");
         $this->testObj = new ilObjTestVerificationGUI(
             0,
             1,
@@ -50,7 +50,6 @@ class ilObjTestVerificationGUITest extends ilTestBaseTestCase
 
     public function testGetType(): void
     {
-        $this->markTestSkipped("See https://mantis.ilias.de/view.php?id=41125");
         $this->testObj = new ilObjTestVerificationGUI(
             0,
             1,


### PR DESCRIPTION
Will be reviewed by @mbecker-databay & @thojou

A unit test was failing because of mandatory parameters that where not passed to a constructor.
I propose this as a fix.

[Mantis 41125](https://mantis.ilias.de/view.php?id=41125)