### PR TITLE
[FIX] #41133 UI: file input clear queue

### DIFF
--- a/src/UI/templates/js/Input/Field/file.js
+++ b/src/UI/templates/js/Input/Field/file.js
@@ -551,6 +551,7 @@ il.UI.Input = il.UI.Input || {};
 			}
 
 			for (let i = 0; i < dropzones[input_id].files.length; ++i) {
+				dropzones[input_id].options.current_file_count -= 1;
 				let file = dropzones[input_id].files[i];
 				let file_id_input = $(`#${file.input_id}`);
 				let file_preview = file_id_input.closest(SELECTOR.file_list_entry);
@@ -558,6 +559,7 @@ il.UI.Input = il.UI.Input || {};
 			}
 
 			dropzones[input_id].removeAllFiles();
+			maybeToggleActionButtonAndErrorMessage(input_id);
 		}
 
 		/**


### PR DESCRIPTION
Hi folks,

This PR addresses the following mantis issue: https://mantis.ilias.de/view.php?id=41133

Its a small adjustment to the `file.js`, which did not decrease the file amount properly and forgot to toggle the shy button and error message of the input.

Kind regards,
@thibsy 