### PR TITLE
[FIX] #40739 Style: fix custom goto-link targets

### DIFF
--- a/Services/Style/System/classes/class.ilStyleDefinition.php
+++ b/Services/Style/System/classes/class.ilStyleDefinition.php
@@ -283,7 +283,7 @@ class ilStyleDefinition
                             $DIC->refinery()->kindlyTo()->string()
                         );
                         $target_arr = explode('_', $target);
-                        $ref_id = $target_arr[1];
+                        $ref_id = $target_arr[1] ?? '';
                     }
 
                     // check whether any ref id assigns a new style


### PR DESCRIPTION
Hi folks,

This PR addresses the following mantis issue: https://mantis.ilias.de/view.php?id=40739

I honestly did not try this, as I am totally unfamiliar with custom skins. However, the change is rather trivial and solved the reported issue for one of our customers, so IMO this should be good to merge. Please note that `$ref_id` is already initialised as an empty string by default, in case you were wondering why I choose this value.

Kind regards,
@thibsy 