### PR TITLE
fix errors if password field is null

### DIFF
--- a/Services/Form/classes/class.ilPasswordInputGUI.php
+++ b/Services/Form/classes/class.ilPasswordInputGUI.php
@@ -173,7 +173,9 @@ class ilPasswordInputGUI extends ilSubEnabledFormPropertyGUI
         $retype_value = ($this->getUseStripSlashes())
             ? $this->str($this->getPostVar() . "_retype")
             : $this->raw($this->getPostVar() . "_retype");
-
+        if ($pass_value === null) {
+            $pass_value = '';
+        }
         if ($this->getRequired() && trim($pass_value) == "") {
             $this->setAlert($lng->txt("msg_input_is_required"));
             return false;
@@ -214,7 +216,7 @@ class ilPasswordInputGUI extends ilSubEnabledFormPropertyGUI
         return $this->checkSubItemsInput();
     }
 
-    public function getInput(): string
+    public function getInput(): ?string
     {
         if ($this->getUseStripSlashes()) {
             return $this->str($this->getPostVar());


### PR DESCRIPTION
If users without global Admin, but full access to UserAdministration try to save datafields of accounts with admin-role, errors appear because the password field is null (instead of ""). This Commit fixes this issue.  Since the checks in the function  "check input" all test if the password is "",  I chose to set a null password field to "" instead of adding a null-check to each if clause.

This fix may be usable for release_9 and trunk, too