### PR TITLE
Notifications: Change authority assignments

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -1130,9 +1130,11 @@ of ILIAS. The file contains the following fields:
 
 * **Notifications**
     * Authority to Sign off Conceptual Changes: [mjansen](https://docu.ilias.de/goto_docu_usr_8784.html)
+        , [iszmais](https://docu.ilias.de/goto_docu_usr_65630.html)
     * Authority to Sign off Code Changes: [mjansen](https://docu.ilias.de/goto_docu_usr_8784.html)
-        , [mbecker](https://docu.ilias.de/goto_docu_usr_27266.html)
+        , [iszmais](https://docu.ilias.de/goto_docu_usr_65630.html)
     * Authority to Curate Test Cases: [mjansen](https://docu.ilias.de/goto_docu_usr_8784.html)
+        ,  [iszmais](https://docu.ilias.de/goto_docu_usr_65630.html)
     * Authority to (De-)Assign Authorities: [mjansen (Databay AG)](https://docu.ilias.de/goto_docu_usr_8784.html)
 	* Tester: [TESTER MISSING](https://docu.ilias.de/goto_docu_pg_64423_4793.html)
     * Assignee for Security Reports: [mjansen](https://docu.ilias.de/goto_docu_usr_8784.html)


### PR DESCRIPTION
With this PR I would like to add Ingmar Szmais (@iszmais) to the following authority sections of `components/ILIAS/Notifications`:

- `Authority to Sign off Conceptual Changes`
- `Authority to Sign off Code Change`
- `Authority to Curate Test Cases`

Ingmar provided most of the code changes for this
component in the last releases and already
did some conceptual work with/for interested parties for ILIAS 10.

@mbecker-databay will be removed from these sections, he inherited second maintainership after the initial author of this component left our company.