### PR TITLE
Database: Revert behaviour of ilDBPdo::executeMultiple() to documented functionality

### DIFF
--- a/Services/Database/classes/PDO/class.ilDBPdo.php
+++ b/Services/Database/classes/PDO/class.ilDBPdo.php
@@ -1426,10 +1426,10 @@ abstract class ilDBPdo implements ilDBInterface, ilDBPdoInterface
         return $this->manager->dropConstraint($table_name, "PRIMARY", true);
     }
 
-    public function executeMultiple(array $stmt, array $data): array
+    public function executeMultiple(ilDBStatement $stmt, array $data): array
     {
-        foreach ($stmt as $k => $s) {
-            $s->execute($data[$k]);
+        foreach ($data as $set) {
+            $this->execute($stmt, $set);
         }
         return [];
     }

--- a/Services/Database/interfaces/interface.ilDBPdoInterface.php
+++ b/Services/Database/interfaces/interface.ilDBPdoInterface.php
@@ -71,7 +71,7 @@ interface ilDBPdoInterface extends ilDBInterface
      * @param ilDBStatement[] $stmt
      * @return string[]
      */
-    public function executeMultiple(array $stmt, array $data): array;
+    public function executeMultiple(ilDBStatement $stmt, array $data): array;
 
     public function fromUnixtime(string $expr, bool $to_text = true): string;
 


### PR DESCRIPTION
The behaviour of `ilDBPdo::executeMultiple()` has changed during the update to PHP8 in https://github.com/ILIAS-eLearning/ILIAS/commit/26f7a22ad87a24539abc4a24506e9f3094584c00 . In the current version, you can use **multiple** statements, but only **one** data entry is executed per statement. Previously, **all** data entries were executed with **one** statement, which seems more useful and is also the way the method is documented in https://github.com/ILIAS-eLearning/ILIAS/tree/release_8/Services/Database#multiple-similar-data-manipulation.

This PR reverts the behaviour to the one used in ILIAS 7 and adjusts the interface accordingly. The method itself doesn't seem to be used in any core components, but the current state might probably break things in plugins (as it did in our case).