### PR TITLE
Fix #41163 Fix name of file for file record presentation in dcl

### DIFF
--- a/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordFieldModel.php
@@ -46,7 +46,7 @@ class ilDclFileRecordFieldModel extends ilDclBaseRecordFieldModel
 
     public function getRecordRepresentation(): ?ilDclBaseRecordRepresentation
     {
-        return new ilDclFileRecordPresentation($this);
+        return new ilDclFileRecordRepresentation($this);
     }
 
     public function parseValue($value)

--- a/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/File/class.ilDclFileRecordRepresentation.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 /**
  * @noinspection AutoloadingIssuesInspection
  */
-class ilDclFileRecordPresentation extends ilDclBaseRecordRepresentation
+class ilDclFileRecordRepresentation extends ilDclBaseRecordRepresentation
 {
     use ilDclFileFieldHelper;
 


### PR DESCRIPTION
The filename needs to match the format defined at https://github.com/ILIAS-eLearning/ILIAS/blob/acfdea63ba7a1dbd7f61211a679ad2d2c12113f1/Modules/DataCollection/classes/Fields/class.ilDclFieldFactory.php#L27 otherwise loading will fall back to base case at https://github.com/ILIAS-eLearning/ILIAS/blob/acfdea63ba7a1dbd7f61211a679ad2d2c12113f1/Modules/DataCollection/classes/Fields/class.ilDclFieldFactory.php#L134-L139