### PR TITLE
[FIX] 0041147: missing dropzones for files in list-view

### DIFF
--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -2913,7 +2913,7 @@ class ilObjectListGUI
         $content = $this->tpl->get();
         $file_upload_dropzone = new ilObjFileUploadDropzone($this->ref_id, $content);
         if ($this->context === self::CONTEXT_REPOSITORY
-            && $this->requested_cmd === "view"
+            && ($this->requested_cmd === "view" || $this->requested_cmd === "" || $this->requested_cmd === "render")
             && $file_upload_dropzone->isUploadAllowed($this->type)
         ) {
             return $file_upload_dropzone->getDropzoneHtml();


### PR DESCRIPTION
@kergomard I don't know exactly what the $this->requested_cmd is, but in any case the dropzone must be rendered at "", "view" and "render" :-)

fixes https://mantis.ilias.de/view.php?id=41147