### PR TITLE
UI: add tabindex to context form template. (#32111)

### DIFF
--- a/Modules/Test/test/ScoreSettingsTest.php
+++ b/Modules/Test/test/ScoreSettingsTest.php
@@ -154,7 +154,7 @@ class ScoreSettingsTest extends ILIAS_UI_TestBase
     <div class="il-section-input-header"><h2>test_scoring</h2></div>
 
     <div class="form-group row">
-        <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_text_count_system</label>
+        <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">tst_text_count_system</label>
         <div class="col-sm-8 col-md-9 col-lg-10">
             <div id="id_1" class="il-input-radio">
 
@@ -174,7 +174,7 @@ class ScoreSettingsTest extends ILIAS_UI_TestBase
     </div>
 
     <div class="form-group row">
-        <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_score_cutting</label>
+        <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">tst_score_cutting</label>
         <div class="col-sm-8 col-md-9 col-lg-10">
             <div id="id_2" class="il-input-radio">
 
@@ -194,7 +194,7 @@ class ScoreSettingsTest extends ILIAS_UI_TestBase
     </div>
 
     <div class="form-group row">
-        <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_pass_scoring</label>
+        <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">tst_pass_scoring</label>
         <div class="col-sm-8 col-md-9 col-lg-10">
             <div id="id_3" class="il-input-radio">
                 <div class="form-control form-control-sm il-input-radiooption">
@@ -263,12 +263,12 @@ EOT;
 <div class="il-section-input">
     <div class="il-section-input-header"><h2>test_results</h2></div>
         <div class="form-group row">
-            <label for="id_8" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_access_enabled</label>
+            <label tabindex="0" for="id_8" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_access_enabled</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <input type="checkbox" id="id_8" value="checked" class="form-control form-control-sm" />
                 <div class="help-block">tst_results_access_enabled_desc</div>
                 <div class="form-group row">
-                    <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_access_setting<span class="asterisk">*</span></label>
+                    <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_access_setting<span class="asterisk">*</span></label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <div id="id_2" class="il-input-radio">
                             <div class="form-control form-control-sm il-input-radiooption">
@@ -291,7 +291,7 @@ EOT;
                                 <input type="radio" id="id_2_3_opt" value="3" />
                                 <label for="id_2_3_opt">tst_results_access_date</label>
                                 <div class="form-group row">
-                                    <label for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">tst_reporting_date<span class="asterisk">*</span></label>
+                                    <label tabindex="0" for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">tst_reporting_date<span class="asterisk">*</span></label>
                                     <div class="col-sm-8 col-md-9 col-lg-10">
                                         <div class="input-group date il-input-datetime">
                                             <input id="id_3" type="datetime-local" class="form-control form-control-sm" />
@@ -305,28 +305,28 @@ EOT;
             </div>
 
             <div class="form-group row">
-                <label for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_grading_opt_show_status</label>
+                <label tabindex="0" for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_grading_opt_show_status</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input type="checkbox" id="id_4" value="checked" class="form-control form-control-sm" />
                     <div class="help-block">tst_results_grading_opt_show_status_desc</div>
                 </div>
             </div>
             <div class="form-group row">
-                <label for="id_5" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_grading_opt_show_mark</label>
+                <label tabindex="0" for="id_5" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_grading_opt_show_mark</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input type="checkbox" id="id_5" value="checked" class="form-control form-control-sm" />
                     <div class="help-block">tst_results_grading_opt_show_mark_desc</div>
                 </div>
             </div>
             <div class="form-group row">
-                <label for="id_6" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_grading_opt_show_details</label>
+                <label tabindex="0" for="id_6" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_grading_opt_show_details</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input type="checkbox" id="id_6" value="checked" class="form-control form-control-sm" />
                     <div class="help-block">tst_results_grading_opt_show_details_desc</div>
                 </div>
             </div>
             <div class="form-group row">
-                <label for="id_7" class="control-label col-sm-4 col-md-3 col-lg-2">tst_pass_deletion</label>
+                <label tabindex="0" for="id_7" class="control-label col-sm-4 col-md-3 col-lg-2">tst_pass_deletion</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input type="checkbox" id="id_7" value="checked" class="form-control form-control-sm" />
                     <div class="help-block">tst_pass_deletion_allowed</div>
@@ -364,45 +364,45 @@ EOT;
     <div class="il-section-input-header"><h2>tst_results_details_options</h2></div>
 
     <div class="form-group row">
-        <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_print_best_solution</label>
+        <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">tst_results_print_best_solution</label>
         <div class="col-sm-8 col-md-9 col-lg-10">
             <input type="checkbox" id="id_1" value="checked" class="form-control form-control-sm" /><div class="help-block">tst_results_print_best_solution_info</div>
         </div>
     </div>
 
     <div class="form-group row">
-        <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_feedback</label>
+        <label tabindex="0" for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_feedback</label>
         <div class="col-sm-8 col-md-9 col-lg-10">
             <input type="checkbox" id="id_2" value="checked" class="form-control form-control-sm" /><div class="help-block">tst_show_solution_feedback_desc</div>
         </div>
     </div>
 
     <div class="form-group row">
-        <label for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_suggested</label><div class="col-sm-8 col-md-9 col-lg-10">
+        <label tabindex="0" for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_suggested</label><div class="col-sm-8 col-md-9 col-lg-10">
             <input type="checkbox" id="id_3" value="checked" class="form-control form-control-sm" /><div class="help-block">tst_show_solution_suggested_desc</div>
         </div>
     </div>
 
     <div class="form-group row">
-        <label for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_printview</label><div class="col-sm-8 col-md-9 col-lg-10">
+        <label tabindex="0" for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_printview</label><div class="col-sm-8 col-md-9 col-lg-10">
             <input type="checkbox" id="id_4" value="checked" class="form-control form-control-sm" /><div class="help-block">tst_show_solution_printview_desc</div>
         </div>
     </div>
 
     <div class="form-group row">
-        <label for="id_5" class="control-label col-sm-4 col-md-3 col-lg-2">tst_hide_pagecontents</label><div class="col-sm-8 col-md-9 col-lg-10">
+        <label tabindex="0" for="id_5" class="control-label col-sm-4 col-md-3 col-lg-2">tst_hide_pagecontents</label><div class="col-sm-8 col-md-9 col-lg-10">
             <input type="checkbox" id="id_5" value="checked" class="form-control form-control-sm" /><div class="help-block">tst_hide_pagecontents_desc</div>
         </div>
     </div>
 
     <div class="form-group row">
-        <label for="id_6" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_signature</label><div class="col-sm-8 col-md-9 col-lg-10">
+        <label tabindex="0" for="id_6" class="control-label col-sm-4 col-md-3 col-lg-2">tst_show_solution_signature</label><div class="col-sm-8 col-md-9 col-lg-10">
             <input type="checkbox" id="id_6" value="checked" class="form-control form-control-sm" /><div class="help-block">tst_show_solution_signature_desc</div>
         </div>
     </div>
 
     <div class="form-group row">
-        <label for="id_7" class="control-label col-sm-4 col-md-3 col-lg-2">examid_in_test_res</label><div class="col-sm-8 col-md-9 col-lg-10">
+        <label tabindex="0" for="id_7" class="control-label col-sm-4 col-md-3 col-lg-2">examid_in_test_res</label><div class="col-sm-8 col-md-9 col-lg-10">
             <input type="checkbox" id="id_7" value="checked" checked="checked" class="form-control form-control-sm" /><div class="help-block">examid_in_test_res_desc</div>
         </div>
     </div>
@@ -430,13 +430,13 @@ EOT;
     <div class="il-section-input-header"><h2>tst_results_gamification</h2></div>
 
     <div class="form-group row">
-        <label for="id_10" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_enabled</label>
+        <label tabindex="0" for="id_10" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_enabled</label>
         <div class="col-sm-8 col-md-9 col-lg-10">
             <input type="checkbox" id="id_10" value="checked" class="form-control form-control-sm" />
             <div class="help-block">tst_highscore_description</div>
 
             <div class="form-group row">
-                <label class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_mode<span class="asterisk">*</span></label>
+                <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_mode<span class="asterisk">*</span></label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div id="id_2" class="il-input-radio">
                         <div class="form-control form-control-sm il-input-radiooption">
@@ -461,7 +461,7 @@ EOT;
             </div>
 
             <div class="form-group row">
-                <label for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_top_num<span class="asterisk">*</span></label>
+                <label tabindex="0" for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_top_num<span class="asterisk">*</span></label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input id="id_3" type="number" value="10" class="form-control form-control-sm" />
                     <div class="help-block">tst_highscore_top_num_description</div>
@@ -469,42 +469,42 @@ EOT;
             </div>
 
             <div class="form-group row">
-                <label for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_anon</label>
+                <label tabindex="0" for="id_4" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_anon</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input type="checkbox" id="id_4" value="checked" checked="checked" class="form-control form-control-sm" />
                     <div class="help-block">tst_highscore_anon_description</div>
                 </div>
             </div>
             <div class="form-group row">
-                <label for="id_5" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_achieved_ts</label>
+                <label tabindex="0" for="id_5" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_achieved_ts</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input type="checkbox" id="id_5" value="checked" checked="checked" class="form-control form-control-sm" />
                     <div class="help-block">tst_highscore_achieved_ts_description</div>
                 </div>
             </div>
             <div class="form-group row">
-                <label for="id_6" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_score</label>
+                <label tabindex="0" for="id_6" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_score</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input type="checkbox" id="id_6" value="checked" checked="checked" class="form-control form-control-sm" />
                     <div class="help-block">tst_highscore_score_description</div>
                 </div>
             </div>
             <div class="form-group row">
-                <label for="id_7" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_percentage</label>
+                <label tabindex="0" for="id_7" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_percentage</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input type="checkbox" id="id_7" value="checked" checked="checked" class="form-control form-control-sm" />
                     <div class="help-block">tst_highscore_percentage_description</div>
                 </div>
             </div>
             <div class="form-group row">
-                <label for="id_8" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_hints</label>
+                <label tabindex="0" for="id_8" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_hints</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input type="checkbox" id="id_8" value="checked" checked="checked" class="form-control form-control-sm" />
                     <div class="help-block">tst_highscore_hints_description</div>
                 </div>
             </div>
             <div class="form-group row">
-                <label for="id_9" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_wtime</label>
+                <label tabindex="0" for="id_9" class="control-label col-sm-4 col-md-3 col-lg-2">tst_highscore_wtime</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input type="checkbox" id="id_9" value="checked" checked="checked" class="form-control form-control-sm" />
                     <div class="help-block">tst_highscore_wtime_description</div>

--- a/src/UI/templates/default/Input/tpl.context_form.html
+++ b/src/UI/templates/default/Input/tpl.context_form.html
@@ -1,5 +1,5 @@
 <div class="form-group row">
-	<label <!-- BEGIN for -->for="{ID}" <!-- END for -->class="control-label col-sm-4 col-md-3 col-lg-2">{LABEL}<!-- BEGIN required --><span class="asterisk">*</span><!-- END required --></label>
+	<label tabindex="0" <!-- BEGIN for -->for="{ID}" <!-- END for -->class="control-label col-sm-4 col-md-3 col-lg-2">{LABEL}<!-- BEGIN required --><span class="asterisk">*</span><!-- END required --></label>
 	<div class="col-sm-8 col-md-9 col-lg-10">
 		<!-- BEGIN error --><div class="help-block alert alert-danger" aria-describedby="{ERROR_FOR_ID}" role="alert">{ERROR}</div><!-- END error -->
 		{INPUT}

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -127,7 +127,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
       <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
    </div>
    <div class="form-group row">
-      <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+      <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
       <div class="col-sm-8 col-md-9 col-lg-10">
          <input id="id_1" type="text" name="form/input_0" class="form-control form-control-sm"/>
          <div class="help-block">byline</div>
@@ -178,7 +178,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
       <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">create</button></div>
    </div>
    <div class="form-group row">
-      <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+      <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
       <div class="col-sm-8 col-md-9 col-lg-10">
          <input id="id_1" type="text" name="form/input_0" class="form-control form-control-sm"/>
          <div class="help-block">byline</div>
@@ -211,7 +211,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
       <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
    </div>
    <div class="form-group row">
-      <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+      <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
       <div class="col-sm-8 col-md-9 col-lg-10">
          <input id="id_1" type="text" name="form/input_0" class="form-control form-control-sm"/>
          <div class="help-block">byline</div>
@@ -276,7 +276,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
                 <div class="help-block alert alert-danger" role="alert">testing error message</div>
 
                 <div class="form-group row">
-                    <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+                    <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <div class="help-block alert alert-danger" aria-describedby="id_1" role="alert">This is invalid...</div>
                         <input id="id_1" type="text" name="form_0/input_1" class="form-control form-control-sm" />
@@ -336,7 +336,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
                 <div class="help-block alert alert-danger" role="alert">This is a fail on form.</div>
 
                 <div class="form-group row">
-                    <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+                    <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <input id="id_1" type="text" name="form_0/input_1" class="form-control form-control-sm" />
                         <div class="help-block">byline</div>
@@ -370,7 +370,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         </div>
     </div>
     <div class="form-group row">
-        <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>
+        <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>
         <div class="col-sm-8 col-md-9 col-lg-10">
             <input id="id_1" type="text" name="form/input_0" class="form-control form-control-sm"/>
              <div class="help-block">byline</div>

--- a/tests/UI/Component/Input/Field/CheckboxInputTest.php
+++ b/tests/UI/Component/Input/Field/CheckboxInputTest.php
@@ -75,7 +75,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
-           <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+           <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
            <div class="col-sm-8 col-md-9 col-lg-10">
               <input type="checkbox" id="id_1" value="checked" name="name_0" class="form-control form-control-sm"/>
               <div class="help-block">byline</div>
@@ -97,7 +97,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($checkbox));
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
-           <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+           <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
            <div class="col-sm-8 col-md-9 col-lg-10">
               <div class="help-block alert alert-danger" aria-describedby="id_1" role="alert">an_error</div>
               <input type="checkbox" id="id_1" value="checked" name="name_0" class="form-control form-control-sm"/>
@@ -120,7 +120,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
-           <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+           <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
            <div class="col-sm-8 col-md-9 col-lg-10">
               <input type="checkbox" id="id_1" value="checked" name="name_0" class="form-control form-control-sm" />
            </div>
@@ -140,7 +140,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($checkbox));
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row">
-               <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+               <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                <div class="col-sm-8 col-md-9 col-lg-10">
                   <input type="checkbox" id="id_1" value="checked" checked="checked" name="name_0" class="form-control form-control-sm" />
                </div>
@@ -173,7 +173,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
-           <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>
+           <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>
            <div class="col-sm-8 col-md-9 col-lg-10"><input type="checkbox" id="id_1" value="checked" name="name_0" class="form-control form-control-sm"/></div>
         </div>
         ');
@@ -192,7 +192,7 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row">
-               <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+               <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                <div class="col-sm-8 col-md-9 col-lg-10"><input type="checkbox" id="id_1" value="checked" name="name_0" disabled="disabled" class="form-control form-control-sm"/></div>
             </div>
         ');

--- a/tests/UI/Component/Input/Field/ColorPickerInputTest.php
+++ b/tests/UI/Component/Input/Field/ColorPickerInputTest.php
@@ -72,7 +72,7 @@ class ColorPickerInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row">
-            <label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
             <input id="id_1" type="color" name="name_0" value=""/>
             <div class="help-block">byline</div>
@@ -97,7 +97,7 @@ class ColorPickerInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row">
-            <label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
             <input id="id_1" type="color" name="name_0" value=""/>
             <div class="help-block">byline</div>
@@ -122,7 +122,7 @@ class ColorPickerInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row">
-            <label class="control-label col-sm-4 col-md-3 col-lg-2">label
+            <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label
             <span class="asterisk">*</span></label>
             <div class="col-sm-8 col-md-9 col-lg-10">
             <input id="id_1" type="color" name="name_0" value=""/>
@@ -148,7 +148,7 @@ class ColorPickerInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row">
-            <label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
             <input id="id_1" type="color" name="name_0" value="value_0"/>
             <div class="help-block">byline</div>

--- a/tests/UI/Component/Input/Field/DurationInputTest.php
+++ b/tests/UI/Component/Input/Field/DurationInputTest.php
@@ -167,17 +167,17 @@ class DurationInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
-           <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+           <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
            <div class="col-sm-8 col-md-9 col-lg-10">
               <div class="il-input-duration" id="id_3">
                  <div class="form-group row">
-                    <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label_start . '</label>
+                    <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label_start . '</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                        <div class="input-group date il-input-datetime"><input id="id_1" type="date" class="form-control form-control-sm" /></div>
                     </div>
                  </div>
                  <div class="form-group row">
-                    <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label_end . '</label>
+                    <label tabindex="0" for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label_end . '</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                        <div class="input-group date il-input-datetime"><input id="id_2" type="date" class="form-control form-control-sm" /></div>
                     </div>
@@ -206,17 +206,17 @@ class DurationInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row">
-               <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+               <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                <div class="col-sm-8 col-md-9 col-lg-10">
                   <div class="il-input-duration" id="id_3">
                      <div class="form-group row">
-                        <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $other_start_label . '</label>
+                        <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $other_start_label . '</label>
                         <div class="col-sm-8 col-md-9 col-lg-10">
                            <div class="input-group date il-input-datetime"><input id="id_1" type="date" class="form-control form-control-sm" /></div>
                         </div>
                      </div>
                      <div class="form-group row">
-                        <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">' . $other_end_label . '</label>
+                        <label tabindex="0" for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">' . $other_end_label . '</label>
                         <div class="col-sm-8 col-md-9 col-lg-10">
                            <div class="input-group date il-input-datetime"><input id="id_2" type="date" class="form-control form-control-sm" /></div>
                         </div>

--- a/tests/UI/Component/Input/Field/FileInputTest.php
+++ b/tests/UI/Component/Input/Field/FileInputTest.php
@@ -163,7 +163,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
             <div class="form-group row">
-                <label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+                <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div id="id_3" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
@@ -192,7 +192,7 @@ class FileInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($text));
 
         $expected = $this->brutallyTrimHTML('
-            <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <div class="form-group row"><label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div class="help-block alert alert-danger" aria-describedby="id_3" role="alert">an_error</div>
                     <div id="id_3" class="ui-input-file">
@@ -219,7 +219,7 @@ class FileInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($text));
 
         $expected = $this->brutallyTrimHTML('
-            <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <div class="form-group row"><label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div id="id_3" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
@@ -255,7 +255,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-	<label class="control-label col-sm-4 col-md-3 col-lg-2"></label>
+	<label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2"></label>
 	<div class="col-sm-8 col-md-9 col-lg-10">
 		<div id="id_4" class="ui-input-file">
 			<div class="ui-input-file-input-list ui-input-dynamic-inputs-list">
@@ -314,7 +314,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-	<label class="control-label col-sm-4 col-md-3 col-lg-2">file_input</label>
+	<label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">file_input</label>
 	<div class="col-sm-8 col-md-9 col-lg-10">
 		<div id="id_6" class="ui-input-file">
 			<div class="ui-input-file-input-list ui-input-dynamic-inputs-list">
@@ -341,7 +341,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 					</div>
 					<div class="ui-input-file-metadata" style="display: none;">
 						<div class="form-group row">
-							<label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">text_input</label>
+							<label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">text_input</label>
 							<div class="col-sm-8 col-md-9 col-lg-10">
 								<input id="id_1" type="text" name="name_0[input_1][]" class="form-control form-control-sm"/>
 							</div>
@@ -396,7 +396,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-	<label class="control-label col-sm-4 col-md-3 col-lg-2">file_input</label>
+	<label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">file_input</label>
 	<div class="col-sm-8 col-md-9 col-lg-10">
 		<div id="id_6" class="ui-input-file">
 			<div class="ui-input-file-input-list ui-input-dynamic-inputs-list">
@@ -423,7 +423,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 					</div>
 					<div class="ui-input-file-metadata" style="display: none;">
 						<div class="form-group row">
-							<label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">text_input</label>
+							<label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">text_input</label>
 							<div class="col-sm-8 col-md-9 col-lg-10">
 								<input id="id_1" type="text" value="test" name="name_0[input_1][]" class="form-control form-control-sm"/>
 							</div>
@@ -458,7 +458,7 @@ class FileInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($text));
 
         $expected = $this->brutallyTrimHTML('
-            <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>
+            <div class="form-group row"><label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div id="id_3" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
@@ -483,7 +483,7 @@ class FileInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($text));
 
         $expected = $this->brutallyTrimHTML('
-            <div class="form-group row"><label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <div class="form-group row"><label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div id="id_3" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>

--- a/tests/UI/Component/Input/Field/GroupInputTest.php
+++ b/tests/UI/Component/Input/Field/GroupInputTest.php
@@ -389,14 +389,14 @@ class GroupInputTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
         <div class="form-group row">
-            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">input1</label>
+            <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">input1</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <input id="id_1" type="text" class="form-control form-control-sm" />
                 <div class="help-block">in 1</div>
             </div>
         </div>
         <div class="form-group row">
-            <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">input2</label>
+            <label tabindex="0" for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">input2</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <input id="id_2" type="text" class="form-control form-control-sm" />
                 <div class="help-block">in 2</div>

--- a/tests/UI/Component/Input/Field/LinkInputTest.php
+++ b/tests/UI/Component/Input/Field/LinkInputTest.php
@@ -73,13 +73,13 @@ class LinkInputTest extends ILIAS_UI_TestBase
 
         $expected = '
             <div class="form-group row">
-                <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">ui_link_label</label>
+                <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">ui_link_label</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input id="id_1" type="text" name="name_0/label_1" class="form-control form-control-sm" />
                 </div>
             </div>
             <div class="form-group row">
-                <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">ui_link_url</label>
+                <label tabindex="0" for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">ui_link_url</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <input id="id_2" type="url" name="name_0/url_2" class="form-control form-control-sm" />
                 </div>

--- a/tests/UI/Component/Input/Field/MarkdownTest.php
+++ b/tests/UI/Component/Input/Field/MarkdownTest.php
@@ -130,7 +130,7 @@ class MarkdownTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML(
             "
                 <div class=\"form-group row\">
-                    <label for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                    <label tabindex=\"0\" for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                     <div class=\"col-sm-8 col-md-9 col-lg-10\">
                         <div class=\"c-input-markdown\">
                             <div class=\"c-input-markdown__controls\">
@@ -186,7 +186,7 @@ class MarkdownTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML(
             "
                 <div class=\"form-group row\">
-                    <label for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                    <label tabindex=\"0\" for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                     <div class=\"col-sm-8 col-md-9 col-lg-10\">
                         <div class=\"c-input-markdown\">
                             <div class=\"c-input-markdown__controls\">
@@ -245,7 +245,7 @@ class MarkdownTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML(
             "
                 <div class=\"form-group row\">
-                    <label for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                    <label tabindex=\"0\" for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                     <div class=\"col-sm-8 col-md-9 col-lg-10\">
                         <div class=\"c-input-markdown\">
                             <div class=\"c-input-markdown__controls\">
@@ -303,7 +303,7 @@ class MarkdownTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML(
             "
                 <div class=\"form-group row\">
-                    <label for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                    <label tabindex=\"0\" for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                     <div class=\"col-sm-8 col-md-9 col-lg-10\">
                         <div class=\"c-input-markdown\">
                             <div class=\"c-input-markdown__controls\">
@@ -360,7 +360,7 @@ class MarkdownTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML(
             "
                 <div class=\"form-group row\">
-                    <label for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label<span class=\"asterisk\">*</span></label>
+                    <label tabindex=\"0\" for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label<span class=\"asterisk\">*</span></label>
                     <div class=\"col-sm-8 col-md-9 col-lg-10\">
                         <div class=\"c-input-markdown\">
                             <div class=\"c-input-markdown__controls\">
@@ -418,7 +418,7 @@ class MarkdownTest extends ILIAS_UI_TestBase
         $expected = $this->brutallyTrimHTML(
             "
                 <div class=\"form-group row\">
-                    <label for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                    <label tabindex=\"0\" for=\"id_1\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                     <div class=\"col-sm-8 col-md-9 col-lg-10\">
                     <div class=\"help-block alert alert-danger\" aria-describedby=\"id_1\" role=\"alert\">$error</div>
                         <div class=\"c-input-markdown\">

--- a/tests/UI/Component/Input/Field/MultiSelectInputTest.php
+++ b/tests/UI/Component/Input/Field/MultiSelectInputTest.php
@@ -123,7 +123,7 @@ class MultiSelectInputTest extends ILIAS_UI_TestBase
         $byline = $ms->getByline();
         $expected = ""
             . "<div class=\"form-group row\">"
-                . "<label class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
+                . "<label tabindex=\"0\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
                 . "<div class=\"col-sm-8 col-md-9 col-lg-10\">"
                     . "<ul class=\"il-input-multiselect\" id=\"id_1\">";
 
@@ -161,7 +161,7 @@ class MultiSelectInputTest extends ILIAS_UI_TestBase
         $byline = $ms->getByline();
         $expected = ""
             . "<div class=\"form-group row\">"
-                . "<label class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
+                . "<label tabindex=\"0\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
                 . "<div class=\"col-sm-8 col-md-9 col-lg-10\">"
                     . "<ul class=\"il-input-multiselect\" id=\"id_1\">";
 
@@ -205,7 +205,7 @@ class MultiSelectInputTest extends ILIAS_UI_TestBase
         $byline = $ms->getByline();
         $expected = ""
             . "<div class=\"form-group row\">"
-            . "<label class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
+            . "<label tabindex=\"0\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
             . "<div class=\"col-sm-8 col-md-9 col-lg-10\">"
             . "<ul class=\"il-input-multiselect\" id=\"id_1\">";
 
@@ -238,7 +238,7 @@ class MultiSelectInputTest extends ILIAS_UI_TestBase
         $byline = $ms->getByline();
         $expected = ""
             . "<div class=\"form-group row\">"
-            . "<label class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
+            . "<label tabindex=\"0\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
             . "<div class=\"col-sm-8 col-md-9 col-lg-10\">"
             . "<ul class=\"il-input-multiselect\" id=\"id_1\">"
             . "<li>-</li>"

--- a/tests/UI/Component/Input/Field/NumericInputTest.php
+++ b/tests/UI/Component/Input/Field/NumericInputTest.php
@@ -73,7 +73,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
    <div class="col-sm-8 col-md-9 col-lg-10">
       <input id="id_1" type="number" name="name_0" class="form-control form-control-sm" />
       <div class="help-block">byline</div>
@@ -96,7 +96,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
    <div class="col-sm-8 col-md-9 col-lg-10">
       <div class="help-block alert alert-danger" aria-describedby="id_1" role="alert">an_error</div>
       <input id="id_1" type="number" name="name_0" class="form-control form-control-sm" />		
@@ -117,7 +117,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
    <div class="col-sm-8 col-md-9 col-lg-10">		<input id="id_1" type="number" name="name_0" class="form-control form-control-sm" />					</div>
 </div>
 ');
@@ -136,7 +136,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
    <div class="col-sm-8 col-md-9 col-lg-10">		<input id="id_1" type="number" value="10" name="name_0" class="form-control form-control-sm" />					</div>
 </div>
 ');
@@ -154,7 +154,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
    <div class="col-sm-8 col-md-9 col-lg-10">		<input id="id_1" type="number" name="name_0" disabled="disabled" class="form-control form-control-sm" />					</div>
 </div>');
         $this->assertEquals($expected, $html);

--- a/tests/UI/Component/Input/Field/PasswordInputTest.php
+++ b/tests/UI/Component/Input/Field/PasswordInputTest.php
@@ -98,7 +98,7 @@ class PasswordInputTest extends ILIAS_UI_TestBase
         $r = $this->getDefaultRenderer();
         $expected = '
             <div class="form-group row">
-                <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
+                <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div class="il-input-password" id="id_1_container">
                         <input id="id_1" type="password" name="' . $name . '" class="form-control form-control-sm" autocomplete="off" />
@@ -121,7 +121,7 @@ class PasswordInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($pwd));
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
    <div class="col-sm-8 col-md-9 col-lg-10">
       <div class="help-block alert alert-danger" aria-describedby="id_1" role="alert">an_error</div>
       <div class="il-input-password" id="id_1_container"><input id="id_1" type="password" name="name_0" class="form-control form-control-sm" autocomplete="off" /></div>
@@ -142,7 +142,7 @@ class PasswordInputTest extends ILIAS_UI_TestBase
         $r = $this->getDefaultRenderer();
         $expected = '
             <div class="form-group row">
-                <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
+                <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div class="il-input-password" id="id_1_container">
                         <input id="id_1" type="password" name="' . $name . '" class="form-control form-control-sm" autocomplete="off" />
@@ -163,7 +163,7 @@ class PasswordInputTest extends ILIAS_UI_TestBase
         $r = $this->getDefaultRenderer();
         $expected = '
             <div class="form-group row">
-                <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
+                <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
                 <div class="col-sm-8 col-md-9 col-lg-10">
                     <div class="il-input-password" id="id_1_container">
                         <input id="id_1" type="password" name="' . $name . '" value="' . $value . '" class="form-control form-control-sm" autocomplete="off" />
@@ -185,7 +185,7 @@ class PasswordInputTest extends ILIAS_UI_TestBase
 
         $expected = '
         <div class="form-group row">
-            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '<span class="asterisk">*</span></label>
+            <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '<span class="asterisk">*</span></label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <div class="il-input-password" id="id_1_container">
                     <input id="id_1" type="password" name="' . $name . '" class="form-control form-control-sm" autocomplete="off" />
@@ -207,7 +207,7 @@ class PasswordInputTest extends ILIAS_UI_TestBase
 
         $expected = '
         <div class="form-group row">
-            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
+            <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">' . $label . '</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <div class="il-input-password" id="id_1_container">
                     <input id="id_1" type="password" name="' . $name . '" disabled="disabled" class="form-control form-control-sm" autocomplete="off" />

--- a/tests/UI/Component/Input/Field/RadioInputTest.php
+++ b/tests/UI/Component/Input/Field/RadioInputTest.php
@@ -80,7 +80,7 @@ class RadioInputTest extends ILIAS_UI_TestBase
 
         $expected = ""
             . "<div class=\"form-group row\">"
-                . "<label class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
+                . "<label tabindex=\"0\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
                 . "<div class=\"col-sm-8 col-md-9 col-lg-10\">"
                     . "<div id=\"id_1\" class=\"il-input-radio\">";
 
@@ -113,7 +113,7 @@ class RadioInputTest extends ILIAS_UI_TestBase
         $radio = $radio->withValue($value);
         $expected = ""
             . "<div class=\"form-group row\">"
-                . "<label class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
+                . "<label tabindex=\"0\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
                 . "<div class=\"col-sm-8 col-md-9 col-lg-10\">"
                     . "<div id=\"id_1\" class=\"il-input-radio\">";
 
@@ -150,7 +150,7 @@ class RadioInputTest extends ILIAS_UI_TestBase
 
         $expected = ""
             . "<div class=\"form-group row\">"
-            . "<label class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
+            . "<label tabindex=\"0\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>"
             . "<div class=\"col-sm-8 col-md-9 col-lg-10\">"
             . "<div id=\"id_1\" class=\"il-input-radio\">";
 

--- a/tests/UI/Component/Input/Field/SectionInputTest.php
+++ b/tests/UI/Component/Input/Field/SectionInputTest.php
@@ -57,14 +57,14 @@ class SectionInputTest extends ILIAS_UI_TestBase
                     <div class="il-section-input-header-byline">section byline</div>
                 </div>
                 <div class="form-group row">
-                    <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">input1</label>
+                    <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">input1</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <input id="id_1" type="text" class="form-control form-control-sm" />
                         <div class="help-block">in 1</div>
                     </div>
                 </div>
                 <div class="form-group row">
-                    <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">input2</label>
+                    <label tabindex="0" for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">input2</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <input id="id_2" type="text" class="form-control form-control-sm" />
                         <div class="help-block">in 2</div>
@@ -95,7 +95,7 @@ EOT;
                 </div>
                 <div class="help-block alert alert-danger" role="alert"> Some Error </div>
                 <div class="form-group row">
-                    <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">input1</label>
+                    <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">input1</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <input id="id_1" type="text" class="form-control form-control-sm" />
                         <div class="help-block">in 1</div>

--- a/tests/UI/Component/Input/Field/SelectTest.php
+++ b/tests/UI/Component/Input/Field/SelectTest.php
@@ -136,7 +136,7 @@ class SelectInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-    <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+    <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
     <div class="col-sm-8 col-md-9 col-lg-10">
         <select id="id_1" name="name_0">
             <option selected="selected" value="">-</option>
@@ -165,7 +165,7 @@ class SelectInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-    <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+    <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
     <div class="col-sm-8 col-md-9 col-lg-10">
         <select id="id_1" name="name_0">
             <option value="">-</option>
@@ -193,7 +193,7 @@ class SelectInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-    <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+    <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
     <div class="col-sm-8 col-md-9 col-lg-10">
         <select id="id_1" name="name_0" disabled="disabled">
             <option selected="selected" value="">-</option>

--- a/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/tests/UI/Component/Input/Field/SwitchableGroupInputTest.php
@@ -428,13 +428,13 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
         $html = $r->render($sg);
         $expected = <<<EOT
 <div class="form-group row">
-    <label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+    <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
     <div class="col-sm-8 col-md-9 col-lg-10">
         <div id="id_1" class="il-input-radio">
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_g1_opt" value="g1" /><label for="id_1_g1_opt"></label>
                 <div class="form-group row">
-                    <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">f</label>
+                    <label tabindex="0" for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">f</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <input id="id_2" type="text" class="form-control form-control-sm" />
                         <div class="help-block">some field</div>
@@ -444,7 +444,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_g2_opt" value="g2" /><label for="id_1_g2_opt"></label>
                 <div class="form-group row">
-                    <label for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">f2</label>
+                    <label tabindex="0" for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">f2</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <input id="id_3" type="text" class="form-control form-control-sm" />
                         <div class="help-block">some other field</div>
@@ -473,13 +473,13 @@ EOT;
         $html = $r->render($sg->withValue('g2'));
         $expected = <<<EOT
 <div class="form-group row">
-    <label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+    <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
     <div class="col-sm-8 col-md-9 col-lg-10">
         <div id="id_1" class="il-input-radio">
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_g1_opt" value="g1" /><label for="id_1_g1_opt"></label>
                 <div class="form-group row">
-                    <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">f</label>
+                    <label tabindex="0" for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">f</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <input id="id_2" type="text" class="form-control form-control-sm" />
                         <div class="help-block">some field</div>
@@ -489,7 +489,7 @@ EOT;
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_g2_opt" value="g2" checked="checked" /><label for="id_1_g2_opt"></label>
                 <div class="form-group row">
-                    <label for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">f2</label>
+                    <label tabindex="0" for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">f2</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <input id="id_3" type="text" class="form-control form-control-sm" />
                         <div class="help-block">some other field</div>
@@ -530,13 +530,13 @@ EOT;
 
         $expected = <<<EOT
 <div class="form-group row">
-    <label class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+    <label tabindex="0" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
     <div class="col-sm-8 col-md-9 col-lg-10">
         <div id="id_1" class="il-input-radio">
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_0_opt" value="0" /><label for="id_1_0_opt"></label>
                 <div class="form-group row">
-                    <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">f</label>
+                    <label tabindex="0" for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">f</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <input id="id_2" type="text" class="form-control form-control-sm" />
                         <div class="help-block">some field</div>
@@ -546,7 +546,7 @@ EOT;
             <div class="form-control form-control-sm il-input-radiooption">
                 <input type="radio" id="id_1_1_opt" value="1" checked="checked" /><label for="id_1_1_opt"></label>
                 <div class="form-group row">
-                    <label for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">f2</label>
+                    <label tabindex="0" for="id_3" class="control-label col-sm-4 col-md-3 col-lg-2">f2</label>
                     <div class="col-sm-8 col-md-9 col-lg-10">
                         <input id="id_3" type="text" class="form-control form-control-sm" />
                         <div class="help-block">some other field</div>

--- a/tests/UI/Component/Input/Field/TagInputTest.php
+++ b/tests/UI/Component/Input/Field/TagInputTest.php
@@ -80,7 +80,7 @@ class TagInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($text));
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
-            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <div id="container-id_1" class="form-control form-control-sm il-input-tag-container">
                     <input id="id_1" name="name_0" class="form-control form-control-sm il-input-tag" value=""/> 
@@ -105,7 +105,7 @@ class TagInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($text));
         $expected = $this->brutallyTrimHTML('
            <div class="form-group row">
-            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <div class="help-block alert alert-danger" aria-describedby="id_1" role="alert">an_error</div>
                 <div id="container-id_1" class="form-control form-control-sm il-input-tag-container">
@@ -129,7 +129,7 @@ class TagInputTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($text));
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
-            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <div id="container-id_1" class="form-control form-control-sm il-input-tag-container">
                     <input id="id_1" name="name_0" class="form-control form-control-sm il-input-tag" value=""/> 
@@ -152,7 +152,7 @@ class TagInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
-            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>
+            <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <div id="container-id_1" class="form-control form-control-sm il-input-tag-container">
                     <input id="id_1" name="name_0" class="form-control form-control-sm il-input-tag" value=""/> 
@@ -176,7 +176,7 @@ class TagInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
         <div class="form-group row">
-            <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+            <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
             <div class="col-sm-8 col-md-9 col-lg-10">
                 <div id="container-id_1" class="form-control form-control-sm il-input-tag-container disabled">
                     <input id="id_1" name="name_0" class="form-control form-control-sm il-input-tag" readonly value=""/> 

--- a/tests/UI/Component/Input/Field/TextInputTest.php
+++ b/tests/UI/Component/Input/Field/TextInputTest.php
@@ -72,7 +72,7 @@ class TextInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
    <div class="col-sm-8 col-md-9 col-lg-10">
       <input id="id_1" type="text" name="name_0" class="form-control form-control-sm" />		
       <div class="help-block">byline</div>
@@ -95,7 +95,7 @@ class TextInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>
    <div class="col-sm-8 col-md-9 col-lg-10">
       <div class="help-block alert alert-danger" aria-describedby="id_1" role="alert">an_error</div>
       <input id="id_1" type="text" name="name_0" class="form-control form-control-sm" />
@@ -117,7 +117,7 @@ class TextInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
    <div class="col-sm-8 col-md-9 col-lg-10"><input id="id_1" type="text" name="name_0" class="form-control form-control-sm" /></div>
 </div>
 ');
@@ -136,7 +136,7 @@ class TextInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
    <div class="col-sm-8 col-md-9 col-lg-10"><input id="id_1" type="text" value="value" name="name_0" class="form-control form-control-sm" /></div>
 </div>
 ');
@@ -155,7 +155,7 @@ class TextInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
    <div class="col-sm-8 col-md-9 col-lg-10"><input id="id_1" type="text" value="0" name="name_0" class="form-control form-control-sm" /></div>
 </div>
 ');
@@ -173,7 +173,7 @@ class TextInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label<span class="asterisk">*</span></label>	
    <div class="col-sm-8 col-md-9 col-lg-10"><input id="id_1" type="text" name="name_0" class="form-control form-control-sm" /></div>
 </div>
 ');
@@ -191,7 +191,7 @@ class TextInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
    <div class="col-sm-8 col-md-9 col-lg-10"><input id="id_1" type="text" name="name_0" disabled="disabled" class="form-control form-control-sm" /></div>
 </div>
 ');
@@ -226,7 +226,7 @@ class TextInputTest extends ILIAS_UI_TestBase
 
         $expected = $this->brutallyTrimHTML('
 <div class="form-group row">
-   <label for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
+   <label tabindex="0" for="id_1" class="control-label col-sm-4 col-md-3 col-lg-2">label</label>	
    <div class="col-sm-8 col-md-9 col-lg-10">				<input id="id_1" type="text" name="name_0" maxlength="8"  class="form-control form-control-sm" />					</div>
 </div>
 ');

--- a/tests/UI/Component/Input/Field/TextareaTest.php
+++ b/tests/UI/Component/Input/Field/TextareaTest.php
@@ -136,7 +136,7 @@ class TextareaTest extends ILIAS_UI_TestBase
 
         $expected = "
             <div class=\"form-group row\">
-                <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                 <div class=\"col-sm-8 col-md-9 col-lg-10\">
                     <div class=\"ui-input-textarea\">
                         <textarea id=\"$id\" class=\"form-control form-control-sm\" name=\"$name\"></textarea>
@@ -164,7 +164,7 @@ class TextareaTest extends ILIAS_UI_TestBase
 
         $expected = "
             <div class=\"form-group row\">
-                <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                 <div class=\"col-sm-8 col-md-9 col-lg-10\">
                     <div class=\"ui-input-textarea\">
                         <textarea id=\"$id\" class=\"form-control form-control-sm\" name=\"$name\" minlength=\"$min\"></textarea>
@@ -191,7 +191,7 @@ class TextareaTest extends ILIAS_UI_TestBase
 
         $expected = "
             <div class=\"form-group row\">
-                <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                <label tabindex= \"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                 <div class=\"col-sm-8 col-md-9 col-lg-10\">
                     <div class=\"ui-input-textarea\">
                         <textarea id=\"$id\" class=\"form-control form-control-sm\" name=\"$name\" maxlength=\"$max\"></textarea>
@@ -222,7 +222,7 @@ class TextareaTest extends ILIAS_UI_TestBase
 
         $expected = "
             <div class=\"form-group row\">
-                <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                 <div class=\"col-sm-8 col-md-9 col-lg-10\">
                     <div class=\"ui-input-textarea\">
                         <textarea id=\"$id\" class=\"form-control form-control-sm\" name=\"$name\" minlength=\"5\" maxlength=\"20\"></textarea>
@@ -250,7 +250,7 @@ class TextareaTest extends ILIAS_UI_TestBase
 
         $expected = "
             <div class=\"form-group row\">
-                <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                 <div class=\"col-sm-8 col-md-9 col-lg-10\">
                     <div class=\"ui-input-textarea\">
                         <textarea id=\"$id\" class=\"form-control form-control-sm\" name=\"$name\">$value</textarea>
@@ -278,7 +278,7 @@ class TextareaTest extends ILIAS_UI_TestBase
 
         $expected = "
             <div class=\"form-group row\">
-                <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                 <div class=\"col-sm-8 col-md-9 col-lg-10\">
                     <div class=\"help-block alert alert-danger\" aria-describedby=\"$id\" role=\"alert\">an_error</div>
                     <div class=\"ui-input-textarea\">
@@ -305,7 +305,7 @@ class TextareaTest extends ILIAS_UI_TestBase
 
         $expected = "
             <div class=\"form-group row\">
-                <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                 <div class=\"col-sm-8 col-md-9 col-lg-10\">
                     <div class=\"ui-input-textarea\">
                         <textarea id=\"$id\" class=\"form-control form-control-sm\" name=\"$name\" disabled=\"disabled\"></textarea>

--- a/tests/UI/Component/Input/Field/UrlInputTest.php
+++ b/tests/UI/Component/Input/Field/UrlInputTest.php
@@ -71,7 +71,7 @@ class UrlInputTest extends ILIAS_UI_TestBase
         $html = $this->normalizeHTML($renderer->render($url));
 
         $expected = "<div class=\"form-group row\">
-                        <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                        <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                         <div class=\"col-sm-8 col-md-9 col-lg-10\">
                             <input id=\"$id\" type=\"url\" name=\"$name\" class=\"form-control form-control-sm\" />
                             <div class=\"help-block\">$byline</div>
@@ -97,7 +97,7 @@ class UrlInputTest extends ILIAS_UI_TestBase
         $html = $this->normalizeHTML($renderer->render($url));
 
         $expected = "<div class=\"form-group row\">
-                        <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                        <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                         <div class=\"col-sm-8 col-md-9 col-lg-10\">
                             <div class=\"help-block alert alert-danger\" aria-describedby=\"id_1\" role=\"alert\">$error</div>
                             <input id=\"$id\" type=\"url\" name=\"$name\" class=\"form-control form-control-sm\" />
@@ -122,7 +122,7 @@ class UrlInputTest extends ILIAS_UI_TestBase
         $html = $this->normalizeHTML($renderer->render($url));
 
         $expected = "<div class=\"form-group row\">
-                        <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                        <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                         <div class=\"col-sm-8 col-md-9 col-lg-10\">
                             <input id=\"$id\" type=\"url\" name=\"$name\" class=\"form-control form-control-sm\" />
                         </div>
@@ -146,7 +146,7 @@ class UrlInputTest extends ILIAS_UI_TestBase
         $html = $this->normalizeHTML($renderer->render($url));
 
         $expected = "<div class=\"form-group row\">
-                        <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                        <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                         <div class=\"col-sm-8 col-md-9 col-lg-10\">
                            <input id=\"$id\" type=\"url\" value=\"$value\" name=\"$name\" class=\"form-control form-control-sm\" />
                         </div>
@@ -169,7 +169,7 @@ class UrlInputTest extends ILIAS_UI_TestBase
         $html = $this->normalizeHTML($renderer->render($url));
 
         $expected = "<div class=\"form-group row\">
-                        <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label<span class=\"asterisk\">*</span></label>
+                        <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label<span class=\"asterisk\">*</span></label>
                         <div class=\"col-sm-8 col-md-9 col-lg-10\">
                             <input id=\"$id\" type=\"url\" name=\"$name\" class=\"form-control form-control-sm\" />
                         </div>
@@ -192,7 +192,7 @@ class UrlInputTest extends ILIAS_UI_TestBase
         $html = $this->normalizeHTML($renderer->render($url));
 
         $expected = "<div class=\"form-group row\">
-                        <label for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
+                        <label tabindex=\"0\" for=\"$id\" class=\"control-label col-sm-4 col-md-3 col-lg-2\">$label</label>
                         <div class=\"col-sm-8 col-md-9 col-lg-10\">
                             <input id=\"$id\" type=\"url\" name=\"$name\" disabled=\"disabled\" class=\"form-control form-control-sm\" />
                         </div>

--- a/tests/UI/Component/Launcher/LauncherInlineTest.php
+++ b/tests/UI/Component/Launcher/LauncherInlineTest.php
@@ -231,7 +231,7 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
                     <div class="modal-body">$msg_html
                         <form id="id_3" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="http://localhost/ilias.php" method="post" novalidate="novalidate">
                             <div class="form-group row">
-                                <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">Understood</label>
+                                <label tabindex="0" for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">Understood</label>
                                 <div class="col-sm-8 col-md-9 col-lg-10">
                                     <input type="checkbox" id="id_2" value="checked" name="form/input_0" class="form-control form-control-sm" />
                                     <div class="help-block">ok</div>


### PR DESCRIPTION
And adjust test cases accordingly.

https://mantis.ilias.de/view.php?id=32111

This PR provides the possibility to tab to a label (like the first label in a SwitchableGroupInput) through an set tabindex. As a result screenreaders can detect the label and read them out loud to users before jumping to linked input fields like "Text Input", "Radio Input" etc. and their labels.

The changes apply to multiple UI Framework Input Fields.