### PR TITLE
Release 7: MediaCast - Support webm video files

### DIFF
--- a/Modules/MediaCast/classes/class.ilMediaCastSettings.php
+++ b/Modules/MediaCast/classes/class.ilMediaCastSettings.php
@@ -32,9 +32,10 @@
 */
 class ilMediaCastSettings
 {
-    private $supported_suffixes = ["mp4", "mp3", "jpg", "jpeg", "png", "gif", "svg"];
+    private $supported_suffixes = ["mp4", "mp3", "webm", "jpg", "jpeg", "png", "gif", "svg"];
     private $supported_mime_types = [
         "video/mp4" => "video/mp4",
+        "video/webm" => "video/webm",
         "audio/mpeg" => "audio/mpeg",
         "image/jpeg" => "image/jpeg",
         "image/png" => "image/png",


### PR DESCRIPTION
This Pr allows uploading of webm video files in a MediaCast object.

Changes should also be picked into newer ILIAS versions (8,9, trunk, ...)