### PR TITLE
xapi auth token encoding bugfix

### DIFF
--- a/Modules/CmiXapi/classes/class.ilCmiXapiLaunchGUI.php
+++ b/Modules/CmiXapi/classes/class.ilCmiXapiLaunchGUI.php
@@ -112,7 +112,7 @@ class ilCmiXapiLaunchGUI
             if ($this->object->isBypassProxyEnabled()) {
                 $params['auth'] = urlencode($this->object->getLrsType()->getBasicAuth());
             } else {
-                $params['auth'] = urlencode('Basic ' . base64_encode(
+                $params['auth'] = rawurlencode('Basic ' . base64_encode(
                     CLIENT_ID . ':' . $token
                 ));
             }


### PR DESCRIPTION
Basic auth token has to be encoded and start like 'Basic%20', not like 'Basic+' rawurlencode function encodes space as '%20' but urlencode encodes space char as '+'. With +, authentication to xapiproxy or LRS fails.