### PR TITLE
T&A 41186: Fix missing solutionhint points after test import

### DIFF
--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -534,6 +534,9 @@ class ilQTIParser extends ilSaxParser
             case "resprocessing":
                 $this->resprocessingBeginTag($a_attribs);
                 break;
+            case assQuestionExport::ITEM_SOLUTIONHINT:
+                $this->solutionhint['points'] = (float)$a_attribs['points'];
+                break;
         }
     }
 


### PR DESCRIPTION
This pull request addresses the problem mentioned in the mantis ticket https://mantis.ilias.de/view.php?id=41186. The issue occurred because the XML parsing ignored the solutionhint points.