### PR TITLE
ILIAS 10: Add Unique Certificate ID for Certificate Editor

### DIFF
--- a/components/ILIAS/Certificate/Overview/CertificateOverviewTable.php
+++ b/components/ILIAS/Certificate/Overview/CertificateOverviewTable.php
@@ -244,7 +244,7 @@ class CertificateOverviewTable implements DataRetrieval
 
             $table_rows[] = [
                 'id' => $certificate->getId(),
-                'certificate_id' => $certificate->getCertificateId()->get(),
+                'certificate_id' => $certificate->getCertificateId()->asString(),
                 'issue_date' => $certificate->getAcquiredTimestamp(),
                 'object' => $objectTitle,
                 'obj_id' => (string) $certificate->getObjId(),

--- a/components/ILIAS/Certificate/Overview/CertificateOverviewTable.php
+++ b/components/ILIAS/Certificate/Overview/CertificateOverviewTable.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Certificate\Overview;
+
+use DateTime;
+use DateTimeImmutable;
+use Exception;
+use Generator;
+use ilAccessHandler;
+use ilCtrl;
+use ilCtrlInterface;
+use ILIAS\Data\Order;
+use ILIAS\Data\Range;
+use ILIAS\UI\Component\Table\DataRetrieval;
+use ILIAS\UI\Component\Table\DataRowBuilder;
+use ILIAS\UI\Factory;
+use ILIAS\UI\Implementation\Component\Input\Container\Filter\Standard;
+use ILIAS\UI\Implementation\Component\Table\Table;
+use ILIAS\UI\Renderer;
+use ILIAS\UI\URLBuilder;
+use ILIAS\UI\URLBuilderToken;
+use ilLanguage;
+use ilLink;
+use ilObjCertificateSettingsGUI;
+use ilObject;
+use ilObjUser;
+use ilUIService;
+use ilUserCertificate;
+use ilUserCertificateRepository;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CertificateOverviewTable implements DataRetrieval
+{
+    private ilUserCertificateRepository $repo;
+    private ilUIService $ui_service;
+    private Factory $ui_factory;
+    private ilLanguage $lng;
+    private ServerRequestInterface|RequestInterface $request;
+    private \ILIAS\Data\Factory $data_factory;
+    private ilCtrl|ilCtrlInterface $ctrl;
+    private Standard $filter;
+    private Table $table;
+    private Renderer $ui_renderer;
+    private ilAccessHandler $access;
+    private ilObjUser $user;
+
+    public function __construct(
+        ?Factory $ui_factory = null,
+        ?ilUserCertificateRepository $repo = null,
+        ?ilUIService $ui_service = null,
+        ?ilLanguage $lng = null,
+        ServerRequestInterface|RequestInterface|null $request = null,
+        ?\ILIAS\Data\Factory $data_factory = null,
+        ?ilCtrl $ctrl = null,
+        ?Renderer $ui_renderer = null,
+        ?ilAccessHandler $access = null,
+        ?ilObjUser $user = null
+    ) {
+        global $DIC;
+        $this->ui_factory = $ui_factory ?: $DIC->ui()->factory();
+        $this->repo = $repo ?: new ilUserCertificateRepository();
+        $this->ui_service = $ui_service ?: $DIC->uiService();
+        $this->lng = $lng ?: $DIC->language();
+        $this->request = $request ?: $DIC->http()->request();
+        $this->data_factory = $data_factory ?: new \ILIAS\Data\Factory();
+        $this->ctrl = $ctrl ?: $DIC->ctrl();
+        $this->ui_renderer = $ui_renderer ?: $DIC->ui()->renderer();
+        $this->access = $access ?: $DIC->access();
+        $this->user = $user ?: $DIC->user();
+
+        $this->filter = $this->buildFilter();
+        $this->table = $this->buildTable();
+    }
+
+    public function getRows(
+        DataRowBuilder $row_builder,
+        array $visible_column_ids,
+        Range $range,
+        Order $order,
+        ?array $filter_data,
+        ?array $additional_parameters
+    ): Generator {
+        /**
+         * @var array{certificate_id: null|string, issue_date: null|DateTime, object: null|string, owner: null|string} $filter_data
+         */
+        $filter_data = $this->ui_service->filter()->getData($this->filter);
+        [$order_field, $order_direction] = $order->join([], fn($ret, $key, $value) => [$key, $value]);
+
+        if (isset($filter_data['issue_date']) && $filter_data['issue_date'] !== '') {
+            try {
+                $filter_data['issue_date'] = new DateTime($filter_data['issue_date']);
+            } catch (Exception $e) {
+                $filter_data['issue_date'] = null;
+            }
+        } else {
+            $filter_data['issue_date'] = null;
+        }
+
+        $table_rows = $this->buildTableRows($this->repo->fetchCertificatesForOverview($this->user->getLanguage(), $filter_data, $range));
+        $colum_to_order = array_column($table_rows, $order_field);
+        array_multisort($colum_to_order, $order_direction === 'ASC' ? SORT_ASC : SORT_DESC, $table_rows);
+
+        foreach ($table_rows as $row) {
+            $row['issue_date'] = DateTimeImmutable::createFromMutable((new DateTime())->setTimestamp($row['issue_date']));
+            yield $row_builder->buildDataRow((string) $row['id'], $row);
+        }
+    }
+
+    public function getTotalRowCount(?array $filter_data, ?array $additional_parameters): ?int
+    {
+        /**
+         * @var array{certificate_id: null|string, issue_date: null|DateTime, object: null|string, owner: null|string} $filter_data
+         */
+        $filter_data = $this->ui_service->filter()->getData($this->filter);
+
+        if (isset($filter_data['issue_date']) && $filter_data['issue_date'] !== '') {
+            try {
+                $filter_data['issue_date'] = new DateTime($filter_data['issue_date']);
+            } catch (Exception $e) {
+                $filter_data['issue_date'] = null;
+            }
+        } else {
+            $filter_data['issue_date'] = null;
+        }
+
+        return $this->repo->fetchCertificatesForOverviewCount($filter_data);
+    }
+
+
+    private function buildFilter(): Standard
+    {
+        return $this->ui_service->filter()->standard(
+            'certificates_overview_filter',
+            $this->ctrl->getLinkTargetByClass(
+                ilObjCertificateSettingsGUI::class,
+                ilObjCertificateSettingsGUI::CMD_CERTIFICATES_OVERVIEW
+            ),
+            [
+                'certificate_id' => $this->ui_factory->input()->field()->text($this->lng->txt('certificate_id')),
+                'issue_date' => $this->ui_factory->input()->field()->text($this->lng->txt('certificate_issue_date')),
+                'object' => $this->ui_factory->input()->field()->text($this->lng->txt('obj')),
+                'obj_id' => $this->ui_factory->input()->field()->text($this->lng->txt('object_id')),
+                'owner' => $this->ui_factory->input()->field()->text($this->lng->txt('owner')),
+            ],
+            [true, true, true, true, true],
+            true,
+            true
+        );
+    }
+
+    private function buildTable(): Table
+    {
+        $uiTable = $this->ui_factory->table();
+        return $uiTable->data(
+            $this->lng->txt('certificates'),
+            [
+                'certificate_id' => $uiTable->column()->text($this->lng->txt('certificate_id')),
+                'issue_date' => $uiTable->column()->date(
+                    $this->lng->txt('certificate_issue_date'),
+                    $this->data_factory->dateFormat()->withTime24($this->data_factory->dateFormat()->standard())
+                ),
+                'object' => $uiTable->column()->text($this->lng->txt('obj')),
+                'obj_id' => $uiTable->column()->text($this->lng->txt('object_id')),
+                'owner' => $uiTable->column()->text($this->lng->txt('owner')),
+            ],
+            $this
+        )
+            ->withId('certificateOverviewTable')
+            ->withRequest($this->request)
+            ->withActions($this->buildTableActions());
+    }
+
+    private function buildTableActions(): array
+    {
+        $uri_download = $this->data_factory->uri(
+            ILIAS_HTTP_PATH . '/' . $this->ctrl->getLinkTargetByClass(
+                ilObjCertificateSettingsGUI::class,
+                ilObjCertificateSettingsGUI::CMD_DOWNLOAD_CERTIFICATE
+            )
+        );
+
+        /**
+         * @var URLBuilder $url_builder_download
+         * @var URLBuilderToken $action_parameter_token_download ,
+         * @var URLBuilderToken $row_id_token_download
+         */
+        [
+            $url_builder_download,
+            $action_parameter_token_download,
+            $row_id_token_download
+        ] =
+            (new URLBuilder($uri_download))->acquireParameters(
+                ['cert_overview'],
+                'action',
+                'id'
+            );
+
+        return [
+            'download' => $this->ui_factory->table()->action()->single(
+                $this->lng->txt('download'),
+                $url_builder_download->withParameter($action_parameter_token_download, 'download'),
+                $row_id_token_download
+            )
+        ];
+    }
+
+    /**
+     * @param ilUserCertificate[] $certificates
+     */
+    private function buildTableRows(array $certificates): array
+    {
+        $table_rows = [];
+
+        foreach ($certificates as $certificate) {
+            $refIds = ilObject::_getAllReferences($certificate->getObjId());
+            $objectTitle = ilObject::_lookupTitle($certificate->getObjId());
+            foreach ($refIds as $refId) {
+                if ($this->access->checkAccess('read', '', $refId)) {
+                    $objectTitle = $this->ui_renderer->render(
+                        $this->ui_factory->link()->standard($objectTitle, ilLink::_getLink($refId))
+                    );
+                    break;
+                }
+            }
+
+            $table_rows[] = [
+                'id' => $certificate->getId(),
+                'certificate_id' => $certificate->getCertificateId()->get(),
+                'issue_date' => $certificate->getAcquiredTimestamp(),
+                'object' => $objectTitle,
+                'obj_id' => (string) $certificate->getObjId(),
+                'owner' => ilObjUser::_lookupLogin($certificate->getUserId()),
+            ];
+        }
+        return $table_rows;
+    }
+
+    public function render(): string
+    {
+        return $this->ui_renderer->render([$this->filter, $this->table]);
+    }
+}

--- a/components/ILIAS/Certificate/Overview/CertificateOverviewTable.php
+++ b/components/ILIAS/Certificate/Overview/CertificateOverviewTable.php
@@ -184,6 +184,7 @@ class CertificateOverviewTable implements DataRetrieval
             ],
             $this
         )
+            ->withOrder(new Order('issue_date', Order::DESC))
             ->withId('certificateOverviewTable')
             ->withRequest($this->request)
             ->withActions($this->buildTableActions());

--- a/components/ILIAS/Certificate/Overview/CertificateOverviewTable.php
+++ b/components/ILIAS/Certificate/Overview/CertificateOverviewTable.php
@@ -29,11 +29,11 @@ use ilCtrl;
 use ilCtrlInterface;
 use ILIAS\Data\Order;
 use ILIAS\Data\Range;
+use ILIAS\UI\Component\Table\Data;
 use ILIAS\UI\Component\Table\DataRetrieval;
 use ILIAS\UI\Component\Table\DataRowBuilder;
 use ILIAS\UI\Factory;
 use ILIAS\UI\Implementation\Component\Input\Container\Filter\Standard;
-use ILIAS\UI\Implementation\Component\Table\Table;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\URLBuilder;
 use ILIAS\UI\URLBuilderToken;
@@ -58,7 +58,7 @@ class CertificateOverviewTable implements DataRetrieval
     private \ILIAS\Data\Factory $data_factory;
     private ilCtrl|ilCtrlInterface $ctrl;
     private Standard $filter;
-    private Table $table;
+    private Data $table;
     private Renderer $ui_renderer;
     private ilAccessHandler $access;
     private ilObjUser $user;
@@ -167,7 +167,7 @@ class CertificateOverviewTable implements DataRetrieval
         );
     }
 
-    private function buildTable(): Table
+    private function buildTable(): Data
     {
         $uiTable = $this->ui_factory->table();
         return $uiTable->data(

--- a/components/ILIAS/Certificate/PRIVACY.md
+++ b/components/ILIAS/Certificate/PRIVACY.md
@@ -37,6 +37,7 @@ For each issued persisting user certificate, the ID of the user account is store
 
     Stored Data (if used as a placeholder in a certificate template):
 
+      - Certificate ID (globally unique id)
       - Username
       - Fullname Presentation
       - Firstname
@@ -62,14 +63,17 @@ For each issued persisting user certificate, the ID of the user account is store
   "PRIVACY.md" of those object types to see presentation of certificate data in that very object type.
   For example the course object presents certificate download links in the "Member" tab to user accounts with
   "Manage Member" permission.
+- Furthermore, certificates are presented to users in "Administration > Achievements > Certificates" in the **Certificates** tab   
+  if the user has **read** permission on the certificate settings.
 
 ## Data being deleted
 
 - If a user account is deleted, all it's certificates will be completely deleted from the database.
   There is no trash for users.
 
-## Data being exported 
+## Data being exported
 
 - Certificate owners can export PDF documents of their certificates at "Achievements > Certificates".
   No other exports of user related data is provided by the "Certificate Service" itself. Exports may be possible
   in the object types listed above. Please refer to the respective "PRIVACY.md" files.
+- Users with **read** permission on the certificate settings can export PDF documents of certificates at "Administration > Achievements > Certificates" in the **Certificates** tab.

--- a/components/ILIAS/Certificate/README.md
+++ b/components/ILIAS/Certificate/README.md
@@ -259,7 +259,7 @@ Example:
 
 ```php
 // Refers to already used certificate template
-$patternCertificateId = 10;
+use ILIAS\Certificate\ValueObject\CertificateId;$patternCertificateId = 10;
 
 // Object ID of the Module/Service (e.g. Course, Test)
 $objId                = 200;
@@ -294,6 +294,9 @@ $iliasVersion         = 'v5.4.0';
 // Determines if the current certifcate is the newest and visible certificate
 $currentlyActive      = true;
 
+// Unique UUID for the certificate
+$cert_id = new CertificateId('unique-uuid');
+
 $certificate = new ilUserCertificate(
 	$patternCertificateId,
 	$objId,
@@ -307,6 +310,7 @@ $certificate = new ilUserCertificate(
 	$version,
 	$iliasVersion,
 	$currentlyActive,
+	$cert_id
 );
 
 $repository = new ilUserCertificateRepository($database, $logger);

--- a/components/ILIAS/Certificate/classes/Placeholder/Description/class.ilDefaultPlaceholderDescription.php
+++ b/components/ILIAS/Certificate/classes/Placeholder/Description/class.ilDefaultPlaceholderDescription.php
@@ -40,6 +40,7 @@ class ilDefaultPlaceholderDescription implements ilCertificatePlaceholderDescrip
         $this->language = $language;
 
         $this->placeholder = [
+            'CERTIFICATE_ID' => $language->txt('certificate_ph_cert_id'),
             'USER_LOGIN' => $language->txt('certificate_ph_login'),
             'USER_FULLNAME' => $language->txt('certificate_ph_fullname'),
             'USER_FIRSTNAME' => $language->txt('certificate_ph_firstname'),

--- a/components/ILIAS/Certificate/classes/Placeholder/Values/class.ilDefaultPlaceholderValues.php
+++ b/components/ILIAS/Certificate/classes/Placeholder/Values/class.ilDefaultPlaceholderValues.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Data\UUID\Factory;
+
 require_once 'components/ILIAS/Calendar/classes/class.ilDateTime.php'; // Required because of global contant IL_CAL_DATE
 
 /**
@@ -33,7 +35,9 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
     private readonly ilLanguage $language;
     private readonly ilCertificateUtilHelper $utilHelper;
     private readonly ilUserDefinedFieldsPlaceholderValues $userDefinedFieldsPlaceholderValues;
+    private readonly Factory $uuid_factory;
     private readonly ilLanguage $user_language;
+
 
     public function __construct(
         ?ilCertificateObjectHelper $objectHelper = null,
@@ -42,7 +46,8 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
         ?ilLanguage $language = null,
         ?ilCertificateUtilHelper $utilHelper = null,
         ?ilUserDefinedFieldsPlaceholderValues $userDefinedFieldsPlaceholderValues = null,
-        private readonly int $birthdayDateFormat = IL_CAL_DATE
+        ?ILIAS\Data\UUID\Factory $uuid_factory = null,
+        private readonly int $birthdayDateFormat = IL_CAL_DATE,
     ) {
         if (null === $objectHelper) {
             $objectHelper = new ilCertificateObjectHelper();
@@ -76,7 +81,13 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
         }
         $this->userDefinedFieldsPlaceholderValues = $userDefinedFieldsPlaceholderValues;
 
+        if (!$uuid_factory) {
+            $uuid_factory = new ILIAS\Data\UUID\Factory();
+        }
+        $this->uuid_factory = $uuid_factory;
+
         $this->placeholder = [
+            'CERTIFICATE_ID' => '',
             'USER_LOGIN' => '',
             'USER_FULLNAME' => '',
             'USER_FIRSTNAME' => '',
@@ -170,6 +181,7 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
     public function getPlaceholderValuesForPreview(int $userId, int $objId): array
     {
         $previewPlacholderValues = [
+            'CERTIFICATE_ID' => $this->utilHelper->prepareFormOutput($this->uuid_factory->uuid4AsString()),
             "USER_LOGIN" => $this->utilHelper->prepareFormOutput($this->language->txt("certificate_var_user_login")),
             "USER_FULLNAME" => $this->utilHelper->prepareFormOutput($this->language->txt("certificate_var_user_fullname")),
             "USER_FIRSTNAME" => $this->utilHelper->prepareFormOutput($this->language->txt("certificate_var_user_firstname")),

--- a/components/ILIAS/Certificate/classes/Setup/Migration/CertificateIdMigration.php
+++ b/components/ILIAS/Certificate/classes/Setup/Migration/CertificateIdMigration.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+
+namespace ILIAS\Certificate\Setup\Migration;
+
+use ilDatabaseException;
+use ilDatabaseUpdatedObjective;
+use ilDBConstants;
+use ilDBPdoInterface;
+use ilDBStatement;
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Migration;
+use JsonException;
+use ReflectionClass;
+use ILIAS\Data\UUID\Factory;
+
+
+class CertificateIdMigration implements Migration
+{
+    public const NUMBER_OF_STEPS = 10000;
+    public const NUMBER_OF_CERTS_PER_STEP = 100000;
+
+    private ilDBPdoInterface $db;
+    private Factory $uuid_factory;
+    private ilDBStatement $prepared_statement;
+
+    public function getLabel(): string
+    {
+        return (new ReflectionClass($this))->getShortName();
+    }
+    public function getDefaultAmountOfStepsPerRun(): int
+    {
+        return self::NUMBER_OF_STEPS;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return [
+            new ilDatabaseUpdatedObjective()
+        ];
+    }
+
+    public function prepare(Environment $environment): void
+    {
+        $this->db = $environment->getResource(Environment::RESOURCE_DATABASE);
+        $this->prepared_statement = $this->db->prepareManip(
+            'UPDATE il_cert_user_cert SET certificate_id = ?, template_values = ? WHERE id = ?',
+            [
+                ilDBConstants::T_TEXT,
+                ilDBConstants::T_CLOB,
+                ilDBConstants::T_INTEGER
+            ]
+        );
+
+        $this->uuid_factory = new Factory();
+    }
+
+    /**
+     * @throws JsonException
+     * @throws ilDatabaseException
+     */
+    public function step(Environment $environment): void
+    {
+        $result = $this->db->query(
+            'SELECT id, template_values FROM il_cert_user_cert WHERE certificate_id IS NULL LIMIT ' . self::NUMBER_OF_CERTS_PER_STEP
+        );
+
+        while($row = $this->db->fetchAssoc($result)) {
+            $template_values = json_decode($row['template_values'], true, 512, JSON_THROW_ON_ERROR);
+            $certificate_id = $this->uuid_factory->uuid4AsString();
+
+            $template_values['CERTIFICATE_ID'] = $certificate_id;
+
+            $this->db->execute($this->prepared_statement, [
+                $certificate_id,
+                json_encode($template_values, JSON_THROW_ON_ERROR),
+                (int) $row['id']
+            ]);
+        }
+
+        if ($this->getRemainingAmountOfSteps() === 0) {
+            $this->db->modifyTableColumn(
+                'il_cert_user_cert',
+                'certificate_id',
+                [
+                    'type' => 'text',
+                    'length' => 64,
+                    'notnull' => true,
+                ]
+            );
+            $this->db->addUniqueConstraint('il_cert_user_cert', ['id', 'certificate_id'], 'c1');
+        }
+    }
+
+    public function getRemainingAmountOfSteps(): int
+    {
+        $result = $this->db->query(
+            'SELECT COUNT(id) AS missing_cert_id FROM il_cert_user_cert WHERE certificate_id IS NULL'
+        );
+        $row = $this->db->fetchAssoc($result);
+
+        $remaining_certs = (int) $row['missing_cert_id'];
+
+        return (int) ceil($remaining_certs / self::NUMBER_OF_CERTS_PER_STEP);
+    }
+}

--- a/components/ILIAS/Certificate/classes/Setup/Migration/CertificateIdMigration.php
+++ b/components/ILIAS/Certificate/classes/Setup/Migration/CertificateIdMigration.php
@@ -79,8 +79,9 @@ class CertificateIdMigration implements Migration
      */
     public function step(Environment $environment): void
     {
+        $this->db->setLimit(self::NUMBER_OF_CERTS_PER_STEP);
         $result = $this->db->query(
-            'SELECT id, template_values FROM il_cert_user_cert WHERE certificate_id IS NULL LIMIT ' . self::NUMBER_OF_CERTS_PER_STEP
+            'SELECT id, template_values FROM il_cert_user_cert WHERE certificate_id IS NULL'
         );
 
         while($row = $this->db->fetchAssoc($result)) {

--- a/components/ILIAS/Certificate/classes/Setup/Migration/CertificateIdMigration.php
+++ b/components/ILIAS/Certificate/classes/Setup/Migration/CertificateIdMigration.php
@@ -35,7 +35,7 @@ use ILIAS\Data\UUID\Factory;
 
 class CertificateIdMigration implements Migration
 {
-    public const NUMBER_OF_STEPS = 10000;
+    public const NUMBER_OF_STEPS = 5;
     public const NUMBER_OF_CERTS_PER_STEP = 100000;
 
     private ilDBPdoInterface $db;

--- a/components/ILIAS/Certificate/classes/Setup/class.ilCertificatSetupAgent.php
+++ b/components/ILIAS/Certificate/classes/Setup/class.ilCertificatSetupAgent.php
@@ -18,8 +18,9 @@
 
 declare(strict_types=1);
 
-use ILIAS\Setup;
+use ILIAS\Certificate\Setup\Migration\CertificateIdMigration;
 use ILIAS\Refinery;
+use ILIAS\Setup;
 
 class ilCertificatSetupAgent implements Setup\Agent
 {
@@ -59,6 +60,8 @@ class ilCertificatSetupAgent implements Setup\Agent
 
     public function getMigrations(): array
     {
-        return [];
+        return [
+            new CertificateIdMigration()
+        ];
     }
 }

--- a/components/ILIAS/Certificate/classes/Setup/class.ilCertificateDatabaseUpdateSteps.php
+++ b/components/ILIAS/Certificate/classes/Setup/class.ilCertificateDatabaseUpdateSteps.php
@@ -77,4 +77,18 @@ class ilCertificateDatabaseUpdateSteps implements ilDatabaseUpdateSteps
             $this->db->addIndex('il_cert_user_cert', ['background_image_path', 'currently_active'], 'i7');
         }
     }
+
+    public function step_6(): void
+    {
+        if (
+            $this->db->tableExists('il_cert_user_cert')
+            && !$this->db->tableColumnExists('il_cert_user_cert', 'certificate_id')
+        ) {
+            $this->db->addTableColumn('il_cert_user_cert', 'certificate_id', [
+                'type' => 'text',
+                'length' => 64,
+                'notnull' => false,
+            ]);
+        }
+    }
 }

--- a/components/ILIAS/Certificate/classes/User/class.ilUserCertificate.php
+++ b/components/ILIAS/Certificate/classes/User/class.ilUserCertificate.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Certificate\ValueObject\CertificateId;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
@@ -40,6 +42,7 @@ class ilUserCertificate
         private int $version,
         private readonly string $iliasVersion,
         private readonly bool $currentlyActive,
+        private readonly CertificateId $certificate_id,
         ?string $backgroundImagePath = null,
         ?string $thumbnailImagePath = null,
         private ?int $id = null
@@ -138,5 +141,10 @@ class ilUserCertificate
     public function getThumbnailImagePath(): string
     {
         return $this->thumbnailImagePath;
+    }
+
+    public function getCertificateId(): CertificateId
+    {
+        return $this->certificate_id;
     }
 }

--- a/components/ILIAS/Certificate/classes/User/class.ilUserCertificateRepository.php
+++ b/components/ILIAS/Certificate/classes/User/class.ilUserCertificateRepository.php
@@ -763,7 +763,7 @@ AND  usr_id = ' . $this->database->quote($userId, 'integer');
         return (int) $this->database->fetchAssoc($result)['count'];
     }
 
-    public function requestNewCertificateId(): CertificateId
+    public function requestIdentity(): CertificateId
     {
         return new CertificateId($this->uuid_factory->uuid4AsString());
     }

--- a/components/ILIAS/Certificate/classes/User/class.ilUserCertificateRepository.php
+++ b/components/ILIAS/Certificate/classes/User/class.ilUserCertificateRepository.php
@@ -97,7 +97,7 @@ class ilUserCertificateRepository
             'currently_active' => ['integer', (int) $userCertificate->isCurrentlyActive()],
             'background_image_path' => ['text', $userCertificate->getBackgroundImagePath()],
             'thumbnail_image_path' => ['text', $userCertificate->getThumbnailImagePath()],
-            'certificate_id' => ['text', $userCertificate->getCertificateId()->get()]
+            'certificate_id' => ['text', $userCertificate->getCertificateId()->asString()]
         ];
 
         $this->logger->debug(sprintf(

--- a/components/ILIAS/Certificate/classes/User/class.ilUserCertificateRepository.php
+++ b/components/ILIAS/Certificate/classes/User/class.ilUserCertificateRepository.php
@@ -18,6 +18,10 @@
 
 declare(strict_types=1);
 
+use ILIAS\Certificate\ValueObject\CertificateId;
+use ILIAS\Data\Range;
+use ILIAS\Data\UUID\Factory;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
@@ -26,11 +30,13 @@ class ilUserCertificateRepository
     private readonly ilDBInterface $database;
     private readonly ilLogger $logger;
     private readonly string $defaultTitle;
+    private ?Factory $uuid_factory;
 
     public function __construct(
         ?ilDBInterface $database = null,
         ?ilLogger $logger = null,
-        ?string $defaultTitle = null
+        ?string $defaultTitle = null,
+        ?Factory $uuid_factory = null,
     ) {
         if (null === $database) {
             global $DIC;
@@ -48,7 +54,14 @@ class ilUserCertificateRepository
             global $DIC;
             $defaultTitle = $DIC->language()->txt('certificate_no_object_title');
         }
+
         $this->defaultTitle = $defaultTitle;
+
+        if (!$uuid_factory) {
+            $uuid_factory = new ILIAS\Data\UUID\Factory();
+        }
+        $this->uuid_factory = $uuid_factory;
+
     }
 
     /**
@@ -83,7 +96,8 @@ class ilUserCertificateRepository
             'ilias_version' => ['text', $userCertificate->getIliasVersion()],
             'currently_active' => ['integer', (int) $userCertificate->isCurrentlyActive()],
             'background_image_path' => ['text', $userCertificate->getBackgroundImagePath()],
-            'thumbnail_image_path' => ['text', $userCertificate->getThumbnailImagePath()]
+            'thumbnail_image_path' => ['text', $userCertificate->getThumbnailImagePath()],
+            'certificate_id' => ['text', $userCertificate->getCertificateId()->get()]
         ];
 
         $this->logger->debug(sprintf(
@@ -120,6 +134,7 @@ SELECT
   il_cert_user_cert.background_image_path,
   il_cert_user_cert.id,
   il_cert_user_cert.thumbnail_image_path,
+  il_cert_user_cert.certificate_id,
   COALESCE(object_data.title, object_data_del.title, ' . $this->database->quote($this->defaultTitle, 'text') . ') AS title
 FROM il_cert_user_cert
 LEFT JOIN object_data ON object_data.obj_id = il_cert_user_cert.obj_id
@@ -180,6 +195,7 @@ SELECT
   il_cert_user_cert.background_image_path,
   il_cert_user_cert.id,
   il_cert_user_cert.thumbnail_image_path,
+  il_cert_user_cert.certificate_id,
   COALESCE(object_data.title, object_data_del.title, ' . $this->database->quote($this->defaultTitle, 'text') . ') AS title
 FROM il_cert_user_cert
 LEFT JOIN object_data ON object_data.obj_id = il_cert_user_cert.obj_id
@@ -280,6 +296,7 @@ AND currently_active = 1';
   il_cert_user_cert.background_image_path,
   il_cert_user_cert.id,
   il_cert_user_cert.thumbnail_image_path,
+  il_cert_user_cert.certificate_id,
   usr_data.lastname,
   COALESCE(object_data.title, object_data_del.title, ' . $this->database->quote($this->defaultTitle, 'text') . ') AS title
 FROM il_cert_user_cert
@@ -346,6 +363,7 @@ AND il_cert_user_cert.currently_active = 1';
   il_cert_user_cert.background_image_path,
   il_cert_user_cert.id,
   il_cert_user_cert.thumbnail_image_path,
+  il_cert_user_cert.certificate_id,
   COALESCE(object_data.title, object_data_del.title, ' . $this->database->quote($this->defaultTitle, 'text') . ') AS title
 FROM il_cert_user_cert
 LEFT JOIN object_data ON object_data.obj_id = il_cert_user_cert.obj_id
@@ -604,6 +622,7 @@ AND  usr_id = ' . $this->database->quote($userId, 'integer');
             (int) $row['version'],
             $row['ilias_version'],
             (bool) $row['currently_active'],
+            new CertificateId($row['certificate_id']),
             (string) $row['background_image_path'],
             (string) $row['thumbnail_image_path'],
             isset($row['id']) ? (int) $row['id'] : null
@@ -621,5 +640,131 @@ AND  usr_id = ' . $this->database->quote($userId, 'integer');
         $this->database->manipulate($sql);
 
         $this->logger->debug(sprintf('END - Successfully deleted certificate for user("%s") in object (obj_id: %s)"', $userId, $obj_id));
+    }
+
+    /**
+     * @return ilUserCertificate[]
+     * @var array{certificate_id: null|string, issue_date: null|DateTime, object: null|string, owner: null|string} $filter
+     */
+    public function fetchCertificatesForOverview(string $user_language, array $filter, ?Range $range = null): array
+    {
+        $sql_filters = [];
+        foreach ($filter as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            $column_name = $key;
+            switch ($key) {
+                case 'issue_date':
+                    $column_name = 'acquired_timestamp';
+                    break;
+                case 'object':
+                    $column_name = 'object_data.title';
+                    break;
+                case 'owner':
+                    $column_name = 'usr_data.login';
+                    break;
+                case 'obj_id':
+                    $column_name = 'cert.obj_id';
+                    break;
+            }
+
+            if ($key === 'issue_date') {
+                /** @var null|DateTime $value */
+                $sql_filters[] = $this->database->equals(
+                    $column_name,
+                    (string) $value->getTimestamp(),
+                    ilDBConstants::T_INTEGER
+                );
+            } else {
+                $sql_filters[] = $this->database->like($column_name, ilDBConstants::T_TEXT, "%$value%");
+            }
+        }
+
+        if ($range) {
+            $this->database->setLimit($range->getLength(), $range->getStart());
+        }
+
+        $result = $this->database->query(
+            'SELECT cert.*, ' .
+            '(CASE
+               WHEN (trans.title IS NOT NULL AND LENGTH(trans.title) > 0) THEN trans.title
+               WHEN (object_data.title IS NOT NULL AND LENGTH(object_data.title) > 0) THEN object_data.title 
+               WHEN (object_data_del.title IS NOT NULL AND LENGTH(object_data_del.title) > 0) THEN object_data_del.title 
+               ELSE ' . $this->database->quote($this->defaultTitle, ilDBConstants::T_TEXT) . '
+               END
+             ) as object, '
+            . 'usr_data.login AS owner FROM il_cert_user_cert AS cert '
+            . 'LEFT JOIN object_data ON object_data.obj_id = cert.obj_id '
+            . 'INNER JOIN usr_data ON usr_data.usr_id = cert.usr_id '
+            . 'LEFT JOIN object_data_del ON object_data_del.obj_id = cert.obj_id '
+            . 'LEFT JOIN object_translation trans ON trans.obj_id = object_data.obj_id AND trans.lang_code = ' . $this->database->quote($user_language, 'text')
+            . ($sql_filters !== [] ? " WHERE " . implode(" AND ", $sql_filters) : "")
+        );
+
+        $certificates = [];
+        while ($row = $this->database->fetchAssoc($result)) {
+            $certificates[] = $this->createUserCertificate($row);
+        }
+        return $certificates;
+    }
+
+    /**
+     * @var array{certificate_id: null|string, issue_date: null|DateTime, object: null|string, owner: null|string} $filter
+     */
+    public function fetchCertificatesForOverviewCount(array $filter, ?Range $range = null): int
+    {
+        $sql_filters = [];
+        foreach ($filter as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            $column_name = $key;
+            switch ($key) {
+                case 'issue_date':
+                    $column_name = 'acquired_timestamp';
+                    break;
+                case 'object':
+                    $column_name = 'object_data.title';
+                    break;
+                case 'owner':
+                    $column_name = 'usr_data.login';
+                    break;
+                case 'obj_id':
+                    $column_name = 'cert.obj_id';
+                    break;
+            }
+
+            if ($key === 'issue_date') {
+                /** @var null|DateTime $value */
+                $sql_filters[] = $this->database->equals(
+                    $column_name,
+                    (string) $value->getTimestamp(),
+                    ilDBConstants::T_INTEGER
+                );
+            } else {
+                $sql_filters[] = $this->database->like($column_name, ilDBConstants::T_TEXT, "%$value%");
+            }
+        }
+
+        if ($range) {
+            $this->database->setLimit($range->getLength(), $range->getStart());
+        }
+
+        $result = $this->database->query(
+            'SELECT COUNT(id) as count FROM il_cert_user_cert AS cert '
+            . 'LEFT JOIN object_data ON object_data.obj_id = cert.obj_id '
+            . 'INNER JOIN usr_data ON usr_data.usr_id = cert.usr_id'
+            . ($sql_filters !== [] ? ' AND ' . implode(' AND ', $sql_filters) : '')
+        );
+
+        return (int) $this->database->fetchAssoc($result)['count'];
+    }
+
+    public function requestNewCertificateId(): CertificateId
+    {
+        return new CertificateId($this->uuid_factory->uuid4AsString());
     }
 }

--- a/components/ILIAS/Certificate/classes/ValueObject/CertificateId.php
+++ b/components/ILIAS/Certificate/classes/ValueObject/CertificateId.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Certificate\ValueObject;
+
+use InvalidArgumentException;
+
+class CertificateId
+{
+    private const UUID_LENGTH = 36;
+    private const UUID_SEPARATOR_COUNT = 4;
+
+    private readonly string $certificate_id;
+
+    public function __construct(string $certificate_id)
+    {
+        if ($certificate_id === '') {
+            throw new InvalidArgumentException('certificate_id cannot be empty.');
+        }
+
+        if (strlen($certificate_id) !== self::UUID_LENGTH) {
+            throw new InvalidArgumentException(sprintf(
+                'certificate_id must be a valid UUID. UUID must be %s characters long.',
+                self::UUID_LENGTH
+            ));
+        }
+
+        if (substr_count($certificate_id, '-') !== 4) {
+            throw new InvalidArgumentException(sprintf(
+                'certificate_id must be a valid UUID. UUID must contain %s "-" characters.',
+                self::UUID_SEPARATOR_COUNT
+            ));
+        }
+        $this->certificate_id = $certificate_id;
+    }
+
+    public function get(): string
+    {
+        return $this->certificate_id;
+    }
+}

--- a/components/ILIAS/Certificate/classes/ValueObject/CertificateId.php
+++ b/components/ILIAS/Certificate/classes/ValueObject/CertificateId.php
@@ -51,7 +51,7 @@ class CertificateId
         $this->certificate_id = $certificate_id;
     }
 
-    public function get(): string
+    public function asString(): string
     {
         return $this->certificate_id;
     }

--- a/components/ILIAS/Certificate/classes/class.ilCertificateCron.php
+++ b/components/ILIAS/Certificate/classes/class.ilCertificateCron.php
@@ -257,7 +257,7 @@ class ilCertificateCron extends ilCronJob
             $type
         ));
 
-        $cert_id = $this->userRepository->requestNewCertificateId();
+        $cert_id = $this->userRepository->requestIdentity();
         $certificateContent = $template->getCertificateContent();
 
         $placeholderValues = $placeholderValueObject->getPlaceholderValues($userId, $objId);

--- a/components/ILIAS/Certificate/classes/class.ilCertificateCron.php
+++ b/components/ILIAS/Certificate/classes/class.ilCertificateCron.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Certificate\ValueObject\CertificateId;
+use ILIAS\Data\UUID\Factory;
 use ILIAS\DI\Container;
 use ILIAS\Cron\Schedule\CronJobScheduleType;
 
@@ -39,7 +41,7 @@ class ilCertificateCron extends ilCronJob
         ?ilLanguage $language = null,
         private ?ilCertificateObjectHelper $objectHelper = null,
         private ?ilSetting $settings = null,
-        private ?ilCronManager $cronManager = null
+        private ?ilCronManager $cronManager = null,
     ) {
         if (null === $dic) {
             global $DIC;
@@ -255,9 +257,11 @@ class ilCertificateCron extends ilCronJob
             $type
         ));
 
+        $cert_id = $this->userRepository->requestNewCertificateId();
         $certificateContent = $template->getCertificateContent();
 
         $placeholderValues = $placeholderValueObject->getPlaceholderValues($userId, $objId);
+        $placeholderValues['CERTIFICATE_ID'] = $cert_id->get();
 
         $this->logger->debug(sprintf(
             'Values for placeholders: "%s"',
@@ -266,7 +270,7 @@ class ilCertificateCron extends ilCronJob
 
         $certificateContent = $this->valueReplacement->replace(
             $placeholderValues,
-            $certificateContent
+            $certificateContent,
         );
 
         $thumbnailImagePath = $template->getThumbnailImagePath();
@@ -283,8 +287,10 @@ class ilCertificateCron extends ilCronJob
             $template->getVersion(),
             ILIAS_VERSION_NUMERIC,
             true,
+            $cert_id,
             $template->getBackgroundImagePath(),
-            $thumbnailImagePath
+            $thumbnailImagePath,
+            null,
         );
 
         $persistedUserCertificate = $this->userRepository->save($userCertificate);

--- a/components/ILIAS/Certificate/classes/class.ilCertificateCron.php
+++ b/components/ILIAS/Certificate/classes/class.ilCertificateCron.php
@@ -261,7 +261,7 @@ class ilCertificateCron extends ilCronJob
         $certificateContent = $template->getCertificateContent();
 
         $placeholderValues = $placeholderValueObject->getPlaceholderValues($userId, $objId);
-        $placeholderValues['CERTIFICATE_ID'] = $cert_id->get();
+        $placeholderValues['CERTIFICATE_ID'] = $cert_id->asString();
 
         $this->logger->debug(sprintf(
             'Values for placeholders: "%s"',

--- a/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
+++ b/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
@@ -97,7 +97,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
         if ($this->certificate_active_validator->validate() && $this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 self::TAB_CERTIFICATES,
-                $this->lng->txt('certificates'),
+                $this->lng->txt('overview'),
                 $this->ctrl->getLinkTarget($this, self::CMD_CERTIFICATES_OVERVIEW)
             );
         }

--- a/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
+++ b/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
@@ -102,7 +102,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
             );
         }
 
-        if ($this->certificate_active_validator->validate() && $this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+        if ($this->certificate_active_validator->validate() && $this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 self::TAB_CERTIFICATES,
                 $this->lng->txt('certificates'),
@@ -237,7 +237,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
     {
         if (
             !$this->certificate_active_validator->validate()
-            || !$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())
+            || !$this->rbac_system->checkAccess('read', $this->object->getRefId())
         ) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->WARNING);
         }
@@ -253,7 +253,7 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
     {
         if (
             !$this->certificate_active_validator->validate()
-            || !$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())
+            || !$this->rbac_system->checkAccess('read', $this->object->getRefId())
         ) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->WARNING);
         }

--- a/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
+++ b/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
@@ -94,19 +94,19 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
 
     public function getAdminTabs(): void
     {
-        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
-            $this->tabs_gui->addTarget(
-                'settings',
-                $this->ctrl->getLinkTarget($this, 'settings'),
-                ['settings', 'view']
-            );
-        }
-
         if ($this->certificate_active_validator->validate() && $this->rbac_system->checkAccess('read', $this->object->getRefId())) {
             $this->tabs_gui->addTab(
                 self::TAB_CERTIFICATES,
                 $this->lng->txt('certificates'),
                 $this->ctrl->getLinkTarget($this, self::CMD_CERTIFICATES_OVERVIEW)
+            );
+        }
+
+        if ($this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+            $this->tabs_gui->addTarget(
+                'settings',
+                $this->ctrl->getLinkTarget($this, 'settings'),
+                ['settings', 'view']
             );
         }
 

--- a/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
+++ b/components/ILIAS/Certificate/classes/class.ilObjCertificateSettingsGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Certificate\Overview\CertificateOverviewTable;
+
 /**
  * Certificate Settings.
  * @author            Helmut Schottmüller <ilias@aurealis.de>
@@ -28,20 +30,38 @@ declare(strict_types=1);
  */
 class ilObjCertificateSettingsGUI extends ilObjectGUI
 {
+    public const TAB_CERTIFICATES = 'certificates';
+    public const CMD_CERTIFICATES_OVERVIEW = 'certificatesOverview';
+    public const CMD_DOWNLOAD_CERTIFICATE = 'downloadCertificate';
+
     protected \ILIAS\HTTP\GlobalHttpState $httpState;
     protected \ILIAS\FileUpload\FileUpload $upload;
+    private ilLogger $logger;
+    private ilUserCertificateRepository $user_certificate_repo;
+    private ilCertificateActiveValidator $certificate_active_validator;
 
-    public function __construct($data, int $id = 0, bool $call_by_reference = true, bool $prepare_output = true)
-    {
+    public function __construct(
+        $data,
+        int $id = 0,
+        bool $call_by_reference = true,
+        bool $prepare_output = true,
+        ?ilUserCertificateRepository $user_certificate_repo = null,
+        ?ilCertificateActiveValidator $certificate_active_validator = null,
+    ) {
         global $DIC;
 
         parent::__construct($data, $id, $call_by_reference, $prepare_output);
 
         $this->httpState = $DIC->http();
         $this->upload = $DIC->upload();
+        $this->logger = $DIC->logger()->root();
         $this->type = 'cert';
         $this->lng->loadLanguageModule('certificate');
+        $this->lng->loadLanguageModule('cert');
         $this->lng->loadLanguageModule('trac');
+
+        $this->user_certificate_repo = $user_certificate_repo ?: new ilUserCertificateRepository();
+        $this->certificate_active_validator = $certificate_active_validator ?: new ilCertificateActiveValidator();
     }
 
     public function executeCommand(): void
@@ -79,6 +99,14 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
                 'settings',
                 $this->ctrl->getLinkTarget($this, 'settings'),
                 ['settings', 'view']
+            );
+        }
+
+        if ($this->certificate_active_validator->validate() && $this->rbac_system->checkAccess('visible,read', $this->object->getRefId())) {
+            $this->tabs_gui->addTab(
+                self::TAB_CERTIFICATES,
+                $this->lng->txt('certificates'),
+                $this->ctrl->getLinkTarget($this, self::CMD_CERTIFICATES_OVERVIEW)
             );
         }
 
@@ -204,6 +232,68 @@ class ilObjCertificateSettingsGUI extends ilObjectGUI
         $form->addItem($persistentCertificateMode);
 
         $this->tpl->setContent($form->getHTML());
+    }
+    public function certificatesOverview(): void
+    {
+        if (
+            !$this->certificate_active_validator->validate()
+            || !$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())
+        ) {
+            $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->WARNING);
+        }
+
+        $this->tabs_gui->activateTab(self::TAB_CERTIFICATES);
+
+        $table = new CertificateOverviewTable();
+
+        $this->tpl->setContent($table->render());
+    }
+
+    public function downloadCertificate(): void
+    {
+        if (
+            !$this->certificate_active_validator->validate()
+            || !$this->rbac_system->checkAccess('visible,read', $this->object->getRefId())
+        ) {
+            $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->WARNING);
+        }
+
+        $certificate_id = $this->httpState->wrapper()->query()->retrieve(
+            'cert_overview_id',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->always([]),
+            ])
+        );
+
+        if ($certificate_id === []) {
+            $this->ctrl->redirect($this, self::CMD_CERTIFICATES_OVERVIEW);
+        }
+
+        //Only one download at a time is possible
+        $certificate_id = $certificate_id[array_key_first($certificate_id)];
+
+        try {
+            $user_certificate = $this->user_certificate_repo->fetchCertificate($certificate_id);
+            if (!$user_certificate->isCurrentlyActive()) {
+                throw new Exception('Certificate is not active');
+            }
+        } catch (Exception $ex) {
+            $this->logger->error('Fetching user certificate for download failed. Ex.: ' . $ex->getMessage());
+            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('error_creating_certificate_pdf'), true);
+            $this->ctrl->redirect($this, self::CMD_CERTIFICATES_OVERVIEW);
+        }
+
+        $pdf_generator = new ilPdfGenerator($this->user_certificate_repo);
+
+        $pdf_action = new ilCertificatePdfAction(
+            $pdf_generator,
+            new ilCertificateUtilHelper(),
+            $this->lng->txt('error_creating_certificate_pdf')
+        );
+
+        $pdf_action->downloadPdf($user_certificate->getUserId(), $user_certificate->getObjId());
+        $this->ctrl->redirect($this, self::CMD_CERTIFICATES_OVERVIEW);
     }
 
     public function save(): void

--- a/components/ILIAS/Certificate/tests/ilCertificateLearningHistoryProviderTest.php
+++ b/components/ILIAS/Certificate/tests/ilCertificateLearningHistoryProviderTest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Certificate\ValueObject\CertificateId;
+
 class ilCertificateLearningHistoryProviderTest extends ilCertificateBaseTestCase
 {
     public function testIsActive(): void
@@ -134,6 +136,7 @@ class ilCertificateLearningHistoryProviderTest extends ilCertificateBaseTestCase
                             1,
                             'v5.4.0',
                             true,
+                            new CertificateId('11111111-2222-3333-4444-555555555555'),
                             '/some/where/background_1.jpg',
                             '/some/where/else/thumbnail_1.jpg',
                             40
@@ -157,6 +160,7 @@ class ilCertificateLearningHistoryProviderTest extends ilCertificateBaseTestCase
                             1,
                             'v5.4.0',
                             true,
+                            new CertificateId('11111111-2222-3333-4444-555555555555'),
                             '/some/where/background_1.jpg',
                             '/some/where/else/thumbnail_1.jpg',
                             50

--- a/components/ILIAS/Certificate/tests/ilCertificateTemplatePreviewActionTest.php
+++ b/components/ILIAS/Certificate/tests/ilCertificateTemplatePreviewActionTest.php
@@ -33,6 +33,7 @@ class ilCertificateTemplatePreviewActionTest extends ilCertificateBaseTestCase
 
         $placeholderValuesObject->method('getPlaceholderValuesForPreview')
             ->willReturn([
+                'CERTIFICATE_ID' => 'randomUniqueString',
                 'USER_LOGIN' => 'SomeLogin',
                 'USER_FULLNAME' => 'SomeFullName',
                 'USER_FIRSTNAME' => 'SomeFirstName'

--- a/components/ILIAS/Certificate/tests/ilDefaultPlaceholderDescriptionTest.php
+++ b/components/ILIAS/Certificate/tests/ilDefaultPlaceholderDescriptionTest.php
@@ -61,7 +61,7 @@ class ilDefaultPlaceholderDescriptionTest extends ilCertificateBaseTestCase
             ->onlyMethods(['txt', 'loadLanguageModule'])
             ->getMock();
 
-        $languageMock->expects($this->exactly(16))
+        $languageMock->expects($this->exactly(17))
             ->method('txt')
             ->willReturn('Something translated');
 
@@ -81,6 +81,7 @@ class ilDefaultPlaceholderDescriptionTest extends ilCertificateBaseTestCase
 
         $this->assertSame(
             [
+                'CERTIFICATE_ID' => 'Something translated',
                 'USER_LOGIN' => 'Something translated',
                 'USER_FULLNAME' => 'Something translated',
                 'USER_FIRSTNAME' => 'Something translated',

--- a/components/ILIAS/Certificate/tests/ilDefaultPlaceholderValuesTest.php
+++ b/components/ILIAS/Certificate/tests/ilDefaultPlaceholderValuesTest.php
@@ -148,6 +148,10 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
         $userDefinePlaceholderMock->method('getPlaceholderValuesForPreview')
             ->willReturn([]);
 
+        $uuid_factory_mock = $this->getMockBuilder(ILIAS\Data\UUID\Factory::class)
+            ->getMock();
+        $uuid_factory_mock->method('uuid4AsString')->willReturn('randomUniqueString');
+
         $placeHolderObject = new ilDefaultPlaceholderValues(
             $objectHelper,
             $dateHelper,
@@ -155,6 +159,7 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
             $language,
             $utilHelper,
             $userDefinePlaceholderMock,
+            $uuid_factory_mock,
             1
         );
         $placeHolderObject->setUserLanguage($language);
@@ -163,6 +168,7 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
 
         $this->assertEquals(
             [
+                'CERTIFICATE_ID' => '',
                 'USER_LOGIN' => 'a_login',
                 'USER_FULLNAME' => 'Niels Theen',
                 'USER_FIRSTNAME' => 'Niels',
@@ -226,6 +232,10 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
         $userDefinePlaceholderMock->method('getPlaceholderValuesForPreview')
             ->willReturn([]);
 
+        $uuid_factory_mock = $this->getMockBuilder(ILIAS\Data\UUID\Factory::class)
+            ->getMock();
+        $uuid_factory_mock->method('uuid4AsString')->willReturn('randomUniqueString');
+
         $placeHolderObject = new ilDefaultPlaceholderValues(
             $objectHelper,
             $dateHelper,
@@ -233,6 +243,7 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
             $language,
             $utilHelper,
             $userDefinePlaceholderMock,
+            $uuid_factory_mock,
             1
         );
 
@@ -243,6 +254,7 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
 
         $this->assertSame(
             [
+                'CERTIFICATE_ID' => 'randomUniqueString',
                 'USER_LOGIN' => 'Something',
                 'USER_FULLNAME' => 'Something',
                 'USER_FIRSTNAME' => 'Something',

--- a/components/ILIAS/Certificate/tests/ilExercisePlaceholderDescriptionTest.php
+++ b/components/ILIAS/Certificate/tests/ilExercisePlaceholderDescriptionTest.php
@@ -61,7 +61,7 @@ class ilExercisePlaceholderDescriptionTest extends ilCertificateBaseTestCase
             ->onlyMethods(['txt', 'loadLanguageModule'])
             ->getMock();
 
-        $languageMock->expects($this->exactly(21))
+        $languageMock->expects($this->exactly(22))
             ->method('txt')
             ->willReturn('Something translated');
 
@@ -81,6 +81,7 @@ class ilExercisePlaceholderDescriptionTest extends ilCertificateBaseTestCase
 
         $this->assertSame(
             [
+                'CERTIFICATE_ID' => 'Something translated',
                 'USER_LOGIN' => 'Something translated',
                 'USER_FULLNAME' => 'Something translated',
                 'USER_FIRSTNAME' => 'Something translated',

--- a/components/ILIAS/Certificate/tests/ilPdfGeneratorTest.php
+++ b/components/ILIAS/Certificate/tests/ilPdfGeneratorTest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Certificate\ValueObject\CertificateId;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
@@ -44,6 +46,7 @@ class ilPdfGeneratorTest extends ilCertificateBaseTestCase
             3,
             'v5.4.0',
             true,
+            new CertificateId('11111111-2222-3333-4444-555555555555'),
             '/some/where/background.jpg',
             '/some/where/thumbnail.jpg',
             300
@@ -110,6 +113,7 @@ class ilPdfGeneratorTest extends ilCertificateBaseTestCase
             3,
             'v5.4.0',
             true,
+            new CertificateId('11111111-2222-3333-4444-555555555555'),
             '/some/where/background.jpg',
             '/some/where/thumbnail.jpg',
             300

--- a/components/ILIAS/Certificate/tests/ilTestPlaceholderDescriptionTest.php
+++ b/components/ILIAS/Certificate/tests/ilTestPlaceholderDescriptionTest.php
@@ -61,7 +61,7 @@ class ilTestPlaceholderDescriptionTest extends ilCertificateBaseTestCase
             ->onlyMethods(['txt', 'loadLanguageModule'])
             ->getMock();
 
-        $languageMock->expects($this->exactly(25))
+        $languageMock->expects($this->exactly(26))
             ->method('txt')
             ->willReturn('Something translated');
 
@@ -81,6 +81,7 @@ class ilTestPlaceholderDescriptionTest extends ilCertificateBaseTestCase
 
         $this->assertSame(
             [
+                'CERTIFICATE_ID' => 'Something translated',
                 'USER_LOGIN' => 'Something translated',
                 'USER_FULLNAME' => 'Something translated',
                 'USER_FIRSTNAME' => 'Something translated',

--- a/components/ILIAS/Certificate/tests/ilUserCertificateRepositoryTest.php
+++ b/components/ILIAS/Certificate/tests/ilUserCertificateRepositoryTest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Certificate\ValueObject\CertificateId;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
@@ -48,6 +50,7 @@ class ilUserCertificateRepositoryTest extends ilCertificateBaseTestCase
                 'currently_active' => ['integer', true],
                 'background_image_path' => ['text', '/some/where/background.jpg'],
                 'thumbnail_image_path' => ['text', '/some/where/thumbnail.svg'],
+                'certificate_id' => ['text', '11111111-2222-3333-4444-555555555555'],
             ]
         );
 
@@ -77,8 +80,10 @@ class ilUserCertificateRepositoryTest extends ilCertificateBaseTestCase
             1,
             'v5.4.0',
             true,
+            new CertificateId('11111111-2222-3333-4444-555555555555'),
             '/some/where/background.jpg',
-            '/some/where/thumbnail.svg'
+            '/some/where/thumbnail.svg',
+            null
         );
 
         $repository->save($userCertificate);
@@ -108,7 +113,8 @@ class ilUserCertificateRepositoryTest extends ilCertificateBaseTestCase
                 'currently_active' => true,
                 'background_image_path' => '/some/where/background.jpg',
                 'thumbnail_image_path' => '/some/where/thumbnail.svg',
-                'title' => 'Some Title'
+                'title' => 'Some Title',
+                'certificate_id' => '11111111-2222-3333-4444-555555555555'
             ],
             [
                 'id' => 142,
@@ -126,7 +132,8 @@ class ilUserCertificateRepositoryTest extends ilCertificateBaseTestCase
                 'currently_active' => true,
                 'background_image_path' => '/some/where/else/background.jpg',
                 'thumbnail_image_path' => '/some/where/thumbnail.svg',
-                'title' => 'Someother Title'
+                'title' => 'Someother Title',
+                'certificate_id' => '11111111-2222-3333-4444-555555555555'
             ]
         );
 
@@ -173,6 +180,7 @@ class ilUserCertificateRepositoryTest extends ilCertificateBaseTestCase
                 'currently_active' => true,
                 'background_image_path' => '/some/where/background.jpg',
                 'thumbnail_image_path' => '/some/where/thumbnail.svg',
+                'certificate_id' => '11111111-2222-3333-4444-555555555555'
             ],
             [
                 'id' => 142,
@@ -190,6 +198,7 @@ class ilUserCertificateRepositoryTest extends ilCertificateBaseTestCase
                 'currently_active' => true,
                 'background_image_path' => '/some/where/else/background.jpg',
                 'thumbnail_image_path' => '/some/where/thumbnail.svg',
+                'certificate_id' => '11111111-2222-3333-4444-555555555555'
             ]
         );
 
@@ -264,7 +273,8 @@ class ilUserCertificateRepositoryTest extends ilCertificateBaseTestCase
                 'background_image_path' => '/some/where/background.jpg',
                 'thumbnail_image_path' => '/some/where/else/thumbnail.svg',
                 'title' => 'SomeTitle',
-                'someDescription' => 'SomeDescription'
+                'someDescription' => 'SomeDescription',
+                'certificate_id' => '11111111-2222-3333-4444-555555555555'
             ],
             [
                 'id' => 142,
@@ -283,7 +293,8 @@ class ilUserCertificateRepositoryTest extends ilCertificateBaseTestCase
                 'background_image_path' => '/some/where/else/background.jpg',
                 'thumbnail_image_path' => '/some/where/else/thumbnail.svg',
                 'title' => 'SomeTitle',
-                'someDescription' => 'SomeDescription'
+                'someDescription' => 'SomeDescription',
+                'certificate_id' => '11111111-2222-3333-4444-555555555555'
             ]
         );
 
@@ -327,7 +338,8 @@ class ilUserCertificateRepositoryTest extends ilCertificateBaseTestCase
                 'background_image_path' => '/some/where/background.jpg',
                 'thumbnail_image_path' => '/some/where/else/thumbnail.svg',
                 'title' => 'SomeTitle',
-                'someDescription' => 'SomeDescription'
+                'someDescription' => 'SomeDescription',
+                'certificate_id' => '11111111-2222-3333-4444-555555555555'
             ]
         );
 

--- a/components/ILIAS/Certificate/tests/ilUserCertificateTest.php
+++ b/components/ILIAS/Certificate/tests/ilUserCertificateTest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Certificate\ValueObject\CertificateId;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
@@ -38,9 +40,10 @@ class ilUserCertificateTest extends ilCertificateBaseTestCase
             1,
             'v5.4.0',
             true,
+            new CertificateId('11111111-2222-3333-4444-555555555555'),
             '/some/where/background.jpg',
             '/some/where/thumbnail.svg',
-            140
+            140,
         );
 
         $this->assertSame(1, $userCertificate->getPatternCertificateId());
@@ -57,5 +60,6 @@ class ilUserCertificateTest extends ilCertificateBaseTestCase
         $this->assertTrue($userCertificate->isCurrentlyActive());
         $this->assertSame('/some/where/background.jpg', $userCertificate->getBackgroundImagePath());
         $this->assertSame(140, $userCertificate->getId());
+        $this->assertSame('11111111-2222-3333-4444-555555555555', $userCertificate->getCertificateId()->get());
     }
 }

--- a/components/ILIAS/Certificate/tests/ilUserCertificateTest.php
+++ b/components/ILIAS/Certificate/tests/ilUserCertificateTest.php
@@ -60,6 +60,6 @@ class ilUserCertificateTest extends ilCertificateBaseTestCase
         $this->assertTrue($userCertificate->isCurrentlyActive());
         $this->assertSame('/some/where/background.jpg', $userCertificate->getBackgroundImagePath());
         $this->assertSame(140, $userCertificate->getId());
-        $this->assertSame('11111111-2222-3333-4444-555555555555', $userCertificate->getCertificateId()->get());
+        $this->assertSame('11111111-2222-3333-4444-555555555555', $userCertificate->getCertificateId()->asString());
     }
 }

--- a/components/ILIAS/ScormAicc/tests/ilScormPlaceholderDescriptionTest.php
+++ b/components/ILIAS/ScormAicc/tests/ilScormPlaceholderDescriptionTest.php
@@ -91,7 +91,7 @@ class ilScormPlaceholderDescriptionTest extends TestCase
             ->onlyMethods(['txt', 'loadLanguageModule'])
             ->getMock();
 
-        $languageMock->expects($this->exactly(21))
+        $languageMock->expects($this->exactly(22))
             ->method('txt')
             ->willReturn('Something translated');
 
@@ -122,6 +122,7 @@ class ilScormPlaceholderDescriptionTest extends TestCase
 
         $this->assertSame(
             [
+                'CERTIFICATE_ID' => 'Something translated',
                 'USER_LOGIN' => 'Something translated',
                 'USER_FULLNAME' => 'Something translated',
                 'USER_FIRSTNAME' => 'Something translated',

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2752,6 +2752,8 @@ certificate#:#certificate_error_upload_bgimage#:#Beim Hochladen des Hintergrundb
 certificate#:#certificate_export#:#Exportieren
 certificate#:#certificate_failed#:#nicht bestanden
 certificate#:#certificate_file_basename#:#Zertifikat
+certificate#:#certificate_id#:#Zertifikat ID
+certificate#:#certificate_issue_date#:#Ausstellungsdatum
 certificate#:#certificate_learning_progress_must_be_active#:#Nur Objekte mit aktivem Lernfortschritt dürfen ausgewählt werden. Bei folgenden Objekten ist der Lernfortschritt nicht aktiv: %s
 certificate#:#certificate_letter#:#US Brief (11 inch x 8.5 inch)
 certificate#:#certificate_letter_landscape#:#US Brief Quer (8,5 inch x 11 inch)
@@ -2763,6 +2765,7 @@ certificate#:#certificate_pageheight#:#Seitenhöhe
 certificate#:#certificate_pagewidth#:#Seitenbreite
 certificate#:#certificate_passed#:#bestanden
 certificate#:#certificate_ph_birthday#:#Geburtstag des Teilnehmers oder der Teilnehmerin
+certificate#:#certificate_ph_cert_id#:#Eindeutige Zertifikats-ID
 certificate#:#certificate_ph_city#:#Stadt der Adresse des Teilnehmers oder der Teilnehmerin
 certificate#:#certificate_ph_country#:#Land der Adresse des Teilnehmers oder der Teilnehmerin
 certificate#:#certificate_ph_date#:#Aktuelles Datum

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2754,6 +2754,8 @@ certificate#:#certificate_error_upload_bgimage#:#An error occurred during the up
 certificate#:#certificate_export#:#Export
 certificate#:#certificate_failed#:#failed
 certificate#:#certificate_file_basename#:#Certificate
+certificate#:#certificate_id#:#Certificate ID
+certificate#:#certificate_issue_date#:#Issue Date
 certificate#:#certificate_learning_progress_must_be_active#:#Only objects with an active Learning Progress can be selected. The Learning Progress is deactivated on the following objects: %s
 certificate#:#certificate_letter#:#Letter (11 inch x 8.5 inch)
 certificate#:#certificate_letter_landscape#:#Letter Landscape (8.5 inch x 11 inch)
@@ -2765,6 +2767,7 @@ certificate#:#certificate_pageheight#:#Page Height
 certificate#:#certificate_pagewidth#:#Page Width
 certificate#:#certificate_passed#:#passed
 certificate#:#certificate_ph_birthday#:#Birthday of the user
+certificate#:#certificate_ph_cert_id#:#Unique Certificate ID
 certificate#:#certificate_ph_city#:#City of the user's address
 certificate#:#certificate_ph_country#:#Country of the user's address
 certificate#:#certificate_ph_date#:#Actual date


### PR DESCRIPTION
Implements the global unique certificate-id feature based on: 
https://docu.ilias.de/goto.php?target=wiki_wpage_7780_1357&client_id=docu