### PR TITLE
NEWS: remove inline margin from news template breadcrump section. (#4…

### DIFF
--- a/Services/News/templates/default/tpl.show_news.html
+++ b/Services/News/templates/default/tpl.show_news.html
@@ -1,7 +1,7 @@
 <!-- BEGIN item -->
 <div class="{ITEM_ROW_CSS}">
 <!-- BEGIN context -->
-<div class="small" style="margin-left: -15px;">
+<div class="small">
 {CONTEXT_LOCATOR}
 </div>
 <h2><img class="ilIcon" style="vertical-align:middle" alt="{CONTEXT_TITLE}" border="0" src="{IMG_CONTEXT_TITLE}" />


### PR DESCRIPTION
…1037)

https://mantis.ilias.de/view.php?id=41037

I just removed the inline style in the news template as it was set to -15px and we do not want to use inline styling. There was no need to adjust the breadcrumb SCSS class.
As a result the breadcrumb is not glued directly to the panels border anymore - it's now aligned with the e.g media cast item as can be seen below:

![breadcrumbs_News_mediacast_after](https://github.com/ILIAS-eLearning/ILIAS/assets/67695434/3f98f25b-d6ec-4851-ad30-af116a8e97fd)
