### PR TITLE
Fix missing cast_spaces php-cs-fixer config

### DIFF
--- a/CI/PHP-CS-Fixer/code-format.php_cs
+++ b/CI/PHP-CS-Fixer/code-format.php_cs
@@ -22,6 +22,7 @@ return (new PhpCsFixer\Config())
 	->setRules([
         '@PSR12' => true,
         'strict_param' => false,
+        'cast_spaces' => true,
         'concat_space' => ['spacing' => 'one'],
         'function_typehint_space' => true,
         'function_declaration' => ['closure_fn_spacing' => 'none'],


### PR DESCRIPTION
The PR https://github.com/ILIAS-eLearning/ILIAS/pull/4960 removed the php-cs-fixer configuration **cast_spaces**.

This leads to no space being added after a cast:

* cast_spaces = **false**
  ```
    $value = (int)$value;
  ```
* cast_spaces = **true**
  ```
    $value = (int) $value;
  ```

- This space is still enabled in the phpstorm config template (CI/PHP-CS-Fixer/code-format.php_cs).
``<option name="SPACE_AFTER_TYPE_CAST" value="true" />``

- Until ILIAS 8 (until the rules were set to PSR 12) spaces were still used.
- Many projects use a space between the cast and the variable, so I'd expect this to be the widely accepted way to use/style casts. Even the example in the PSR 12 specification use a space https://www.php-fig.org/psr/psr-12/#61-unary-operators .

If accepted, this change should also be picked into `trunk` and `release_8` as well.