### PR TITLE
UI: adjust rendering of main action button and dropdown button. (#41033)

### DIFF
--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -857,15 +857,14 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
         if ($found_threads === false) {
             $vc_container = $this->factory->panel()->listing()->standard(
                 $this->lng->txt('thread_overview'),
-                [$this->factory->item()->group($this->lng->txt('frm_no_threads'), [])]);
+                [$this->factory->item()->group($this->lng->txt('frm_no_threads'), [])]
+            );
         } else {
             $vc_container = $this->factory->panel()->listing()->standard(
                 $this->lng->txt('thread_overview'),
                 [$top_threads, $normal_threads]
             )->withViewControls($view_control);
         }
-
-
 
         $default_html = $this->renderer->render($vc_container);
         $modals = $this->renderer->render($this->modal_collection);
@@ -5912,8 +5911,9 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
 
                 $items[] = $this->uiFactory->button()->shy($this->lng->txt($lng_id), $url);
             }
-            $action_menu = $this->uiFactory->dropdown()->standard($items);
-            $render_content = [$action_menu];
+
+            $dropdown = $this->uiFactory->dropdown()->standard($items);
+            $render_action_buttons = [$dropdown];
             if (isset($primary_action, $primary_action_language_id)) {
                 if ($primary_action_language_id === 'activate_post') {
                     $action_button = $this->addActivationFormModal($node);
@@ -5923,9 +5923,9 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
                         $primary_action
                     );
                 }
-                array_unshift($render_content, $action_button);
+                $tpl->setVariable('MAIN_ACTION', $this->uiRenderer->render($action_button));
             }
-            $tpl->setVariable('COMMANDS', $this->uiRenderer->render($render_content));
+            $tpl->setVariable('DROPDOWN_ACTIONS', $this->uiRenderer->render($render_action_buttons));
         }
     }
 

--- a/Modules/Forum/templates/default/tpl.forums_threads_view.html
+++ b/Modules/Forum/templates/default/tpl.forums_threads_view.html
@@ -39,8 +39,16 @@
 				<!-- END attachments -->
 			</div>
 		</div>
-		<div class="ilFrmPostClear"></div><!-- BEGIN commands_block -->
-		<div class="ilFrmPostCommands ilForumInlineCommandContainer">{COMMANDS}</div><!-- END commands_block -->
+		<div class="ilFrmPostClear"></div>
+		<!-- BEGIN action_bar -->
+		<div class="il-item-actions l-bar__space-keeper">
+			<!-- BEGIN main_action --><div class="l-bar__element">{MAIN_ACTION}</div><!-- END main_action -->
+			<!-- BEGIN dropdown_actions --><div class="l-bar__element">{DROPDOWN_ACTIONS}</div><!-- END dropdown_actions -->
+		</div>
+		<!-- END action_bar -->
+
+		<!-- BEGIN commands_block
+		<div class="ilFrmPostCommands ilForumInlineCommandContainer">{COMMANDS}</div>--><!-- END commands_block -->
 		<div class="ilFrmPostClear"></div>
 		<!-- BEGIN edit_draft_anchor --><a id="{EDIT_DRAFT_ANCHOR}"></a><!-- END edit_draft_anchor -->
 		{DRAFT_FORM}

--- a/templates/default/070-components/legacy/Modules/_component_forum.scss
+++ b/templates/default/070-components/legacy/Modules/_component_forum.scss
@@ -260,6 +260,6 @@ li.ilPostingNeedsActivation {
 	display: flex;
 }
 
-.ilForumInlineCommandContainer > div {
-	margin-left: 10px;
+.il-item-actions {
+	float: right;
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -12039,8 +12039,8 @@ li.ilPostingNeedsActivation {
   display: flex;
 }
 
-.ilForumInlineCommandContainer > div {
-  margin-left: 10px;
+.il-item-actions {
+  float: right;
 }
 
 /* Modules/LearningModule */


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41033

This includes following changes:

- remove 'ilForumInlineCommandContainer > div' with margin-left value from legacy SCSS file _component_forum.scss as it's not needed anymore
- add 'il-item-actions' class for alignment purposes to legacy SCSS file _component_forum.scss
- adjust the 'forum_threads_view' HTML template
- adjust the rendering of the main action button and the dropdown button in the 'ilObjForumGUI' file.

... instead of just changing the margin value in the specific SCSS file. With these changes the template will - at least partly - be build like an UI Framework standard item template. 