### PR TITLE
SCORM: Fix argument type for `number_format` in certificate values / Move SCORM related `Certificate` files to `SCORM`

### DIFF
--- a/Modules/ScormAicc/classes/Certificate/class.ilCertificateScormPdfFilename.php
+++ b/Modules/ScormAicc/classes/Certificate/class.ilCertificateScormPdfFilename.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,9 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
+declare(strict_types=1);
+
 class ilCertificateScormPdfFilename implements ilCertificateFilename
 {
     private ilSetting $scormSetting;

--- a/Modules/ScormAicc/classes/Certificate/class.ilCertificateScormTemplateDeleteAction.php
+++ b/Modules/ScormAicc/classes/Certificate/class.ilCertificateScormTemplateDeleteAction.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,9 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
+declare(strict_types=1);
+
 class ilCertificateScormTemplateDeleteAction implements ilCertificateDeleteAction
 {
     private ilCertificateTemplateDeleteAction $deleteAction;

--- a/Modules/ScormAicc/classes/Certificate/class.ilCertificateSettingsScormFormRepository.php
+++ b/Modules/ScormAicc/classes/Certificate/class.ilCertificateSettingsScormFormRepository.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,13 +16,12 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\Filesystem\Exception\FileNotFoundException;
 use ILIAS\Filesystem\Exception\FileAlreadyExistsException;
 use ILIAS\Filesystem\Exception\IOException;
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
 class ilCertificateSettingsScormFormRepository implements ilCertificateFormRepository
 {
     private ilObject $object;

--- a/Modules/ScormAicc/classes/Certificate/class.ilScormPlaceholderDescription.php
+++ b/Modules/ScormAicc/classes/Certificate/class.ilScormPlaceholderDescription.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,9 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
+declare(strict_types=1);
+
 class ilScormPlaceholderDescription implements ilCertificatePlaceholderDescription
 {
     private ilDefaultPlaceholderDescription $defaultPlaceHolderDescriptionObject;

--- a/Modules/ScormAicc/classes/Certificate/class.ilScormPlaceholderValues.php
+++ b/Modules/ScormAicc/classes/Certificate/class.ilScormPlaceholderValues.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,9 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
+declare(strict_types=1);
+
 class ilScormPlaceholderValues implements ilCertificatePlaceholderValues
 {
     private ilLanguage $language;
@@ -151,7 +148,7 @@ class ilScormPlaceholderValues implements ilCertificatePlaceholderValues
                     $placeHolders['SCO_P_' . $counter] = $this->language->txt('certificate_points_notavailable');
                     if ($a_scores['raw'] !== null) {
                         $placeHolders['SCO_P_' . $counter] = number_format(
-                            $a_scores['raw'],
+                            (float) $a_scores['raw'],
                             1,
                             $this->language->txt('lang_sep_decimal'),
                             $this->language->txt('lang_sep_thousand')
@@ -161,7 +158,7 @@ class ilScormPlaceholderValues implements ilCertificatePlaceholderValues
                     $placeHolders['SCO_PM_' . $counter] = $this->language->txt('certificate_points_notavailable');
                     if ($a_scores['max'] !== null) {
                         $placeHolders['SCO_PM_' . $counter] = number_format(
-                            $a_scores['max'],
+                            (float) $a_scores['max'],
                             1,
                             $this->language->txt('lang_sep_decimal'),
                             $this->language->txt('lang_sep_thousand')
@@ -171,7 +168,7 @@ class ilScormPlaceholderValues implements ilCertificatePlaceholderValues
                     $placeHolders['SCO_PP_' . $counter] = $this->language->txt('certificate_points_notavailable');
                     if ($a_scores['scaled'] !== null) {
                         $placeHolders['SCO_PP_' . $counter] = number_format(
-                            ($a_scores['scaled'] * 100),
+                            (float) ($a_scores['scaled'] * 100),
                             1,
                             $this->language->txt('lang_sep_decimal'),
                             $this->language->txt('lang_sep_thousand')

--- a/Modules/ScormAicc/test/ilCertificateScormTemplateDeleteActionTest.php
+++ b/Modules/ScormAicc/test/ilCertificateScormTemplateDeleteActionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,10 +16,11 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-class ilCertificateScormTemplateDeleteActionTest extends ilCertificateBaseTestCase
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class ilCertificateScormTemplateDeleteActionTest extends TestCase
 {
     public function testDeleteScormTemplateAndSettings(): void
     {

--- a/Modules/ScormAicc/test/ilCertificateSettingsScormFormRepositoryTest.php
+++ b/Modules/ScormAicc/test/ilCertificateSettingsScormFormRepositoryTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,10 +16,11 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-class ilCertificateSettingsScormFormRepositoryTest extends ilCertificateBaseTestCase
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class ilCertificateSettingsScormFormRepositoryTest extends TestCase
 {
     public function testSave(): void
     {

--- a/Modules/ScormAicc/test/ilScormPlaceholderDescriptionTest.php
+++ b/Modules/ScormAicc/test/ilScormPlaceholderDescriptionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,10 +16,11 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
-class ilScormPlaceholderDescriptionTest extends ilCertificateBaseTestCase
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class ilScormPlaceholderDescriptionTest extends TestCase
 {
     public function testPlaceholderGetHtmlDescription(): void
     {

--- a/Modules/ScormAicc/test/ilScormPlaceholderValuesTest.php
+++ b/Modules/ScormAicc/test/ilScormPlaceholderValuesTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,9 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
-/**
- * @author  Niels Theen <ntheen@databay.de>
- */
+declare(strict_types=1);
+
 class ilScormPlaceholderValuesTest extends ilCertificateBaseTestCase
 {
     public function testGetPlaceholderValues(): void


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=39850

The actual fix can be found here: https://github.com/ILIAS-eLearning/ILIAS/pull/7423/files#diff-d16df26049e855853f421fe21a33e5f92e79da3c91fd5499a6b11cb52950d11bR151

---

With this PR I would also like to move consumer specific classes from `Sevices/Certificate` to the respective component (here: Scorm), like it has been already done for `CmiXapi` and `LITConsumer`.

All related unit tests were moved as well.

There are still parts of tighter coupling to some object type strings in `Services/Certificate` (e.g. to register a consumer), but this will hopefully be removed in future.

---

If approved, please pick this to `release_9` and `trunk` as well.