### PR TITLE
PRG: 41216, do not throw if ref_id is not found

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserTable.php
+++ b/Modules/StudyProgramme/classes/class.ilStudyProgrammeUserTable.php
@@ -346,11 +346,10 @@ class ilStudyProgrammeUserTable
                 return $title;
             case 'crsr':
                 $title = ilContainerReference::_lookupTitle($obj_id);
-                if(ilObject::_isInTrash(
-                    ilObjStudyProgramme::getRefIdFor(
-                        ilContainerReference::_lookupTargetId($obj_id)
-                    )
-                )) {
+                $target_obj_id = ilContainerReference::_lookupTargetId($obj_id);
+                $refs = ilObject::_getAllReferences($target_obj_id);
+                $target_ref_id = array_shift($refs) ?? null;
+                if($target_ref_id === null || ilObject::_isInTrash($target_ref_id)) {
                     return sprintf('(%s)', $title);
                 }
                 return $title;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41216
PRG throws, if there is no ref_id for an ob_id; this is not wanted in the context of looking up a title / deletion status for user table.