### PR TITLE
T&A 41114: Fix "method on null" error during test import with skills.

### DIFF
--- a/Modules/Test/classes/class.ilTestImporter.php
+++ b/Modules/Test/classes/class.ilTestImporter.php
@@ -349,6 +349,7 @@ class ilTestImporter extends ilXmlImporter
     protected function importSkillLevelThresholds(ilImportMapping $mapping, ilAssQuestionSkillAssignmentList $assignmentList, ilObjTest $test_obj, $xmlFile)
     {
         $parser = new ilTestSkillLevelThresholdXmlParser($xmlFile);
+        $parser->initSkillLevelThresholdImportList();
         $parser->startParsing();
 
         $importer = new ilTestSkillLevelThresholdImporter($this->db);


### PR DESCRIPTION
This PR aims to address the problem reported in Mantis issue https://mantis.ilias.de/view.php?id=41114.

Unfortunately, I couldn't replicate the issue locally because it demands a more complicated setup with multiple ILIAS installations. However, I traced the execution path during the test import routine and discovered that the necessary reference wasn't initialized when needed. By initializing this missing reference before passing it into the importer class, the issue should be resolved.

After a discussion with @mbecker-databay, it seems that this change is appropriate.

@mbecker-databay & @kergomard could you please review and merge this change?