### PR TITLE
ComponentsRevision: fix WAC

### DIFF
--- a/components/ILIAS/Init/resources/.htaccess
+++ b/components/ILIAS/Init/resources/.htaccess
@@ -9,7 +9,7 @@
 	RewriteCond %{QUERY_STRING}  ^lang=([^=]*)$
 	RewriteRule ^goto_(.*)_([a-z]+_[0-9]+(.*)).html$ goto.php?client_id=$1&target=$2&lang=%1 [L]
 	RewriteRule ^goto_(.*)_([a-z]+_[0-9]+(.*)).html$ goto.php?client_id=$1&target=$2 [L]
-	RewriteRule ^data/.*/.*/.*$ components/ILIAS/WebAccessChecker/wac.php [L]
+	RewriteRule ^data/.*/.*/.*$ wac.php [L]
 	RewriteCond %{HTTP_USER_AGENT} ^(DavClnt)$
 	RewriteCond %{REQUEST_METHOD} ^(OPTIONS)$
 	RewriteRule .* "-" [R=401,L]

--- a/components/ILIAS/WebAccessChecker/classes/class.ilWACPath.php
+++ b/components/ILIAS/WebAccessChecker/classes/class.ilWACPath.php
@@ -24,7 +24,7 @@
  */
 class ilWACPath
 {
-    public const DIR_DATA = "public/data";
+    public const DIR_DATA = "data";
     public const DIR_SEC = "sec";
     /**
      * Copy this without to regex101.com and test with some URL of files
@@ -253,7 +253,8 @@ class ilWACPath
                 $real_data_dir,
                 '',
                 $realpath
-            ), '/'
+            ),
+            '/'
         );
 
         return "/" . self::DIR_DATA . '/' . $normalized_path . (!empty($query) ? '?' . $query : '');

--- a/components/ILIAS/WebAccessChecker/resources/wac.php
+++ b/components/ILIAS/WebAccessChecker/resources/wac.php
@@ -7,9 +7,8 @@
 
 use ILIAS\HTTP\Cookies\CookieFactoryImpl;
 
-//chdir('../../../../');
 /** @noRector */
-require_once(__DIR__ . '/../../../../vendor/composer/vendor/autoload.php');
+require_once(__DIR__ . '/../vendor/composer/vendor/autoload.php');
 
 $container = new \ILIAS\DI\Container();
 


### PR DESCRIPTION
while working on https://mantis.ilias.de/view.php?id=41201, I found the reason for content-styles not being loaded was the htacces and WebAccessChecker needed adjusting to the new public/data structure.
