### PR TITLE
UI: Introduce Is Nullable to Certain Column Types

### DIFF
--- a/components/ILIAS/UI/src/Component/Table/Column/Date.php
+++ b/components/ILIAS/UI/src/Component/Table/Column/Date.php
@@ -25,4 +25,5 @@ use ILIAS\Data\DateFormat\DateFormat;
 interface Date extends Column
 {
     public function getFormat(): DateFormat;
+    public function withIsNullable(bool $nullable): void;
 }

--- a/components/ILIAS/UI/src/Component/Table/Column/Link.php
+++ b/components/ILIAS/UI/src/Component/Table/Column/Link.php
@@ -22,4 +22,5 @@ namespace ILIAS\UI\Component\Table\Column;
 
 interface Link extends Column
 {
+    public function withIsNullable(bool $nullable): void;
 }

--- a/components/ILIAS/UI/src/Component/Table/Column/LinkListing.php
+++ b/components/ILIAS/UI/src/Component/Table/Column/LinkListing.php
@@ -22,4 +22,5 @@ namespace ILIAS\UI\Component\Table\Column;
 
 interface LinkListing extends Column
 {
+    public function withIsNullable(bool $nullable): void;
 }

--- a/components/ILIAS/UI/src/Component/Table/Column/Number.php
+++ b/components/ILIAS/UI/src/Component/Table/Column/Number.php
@@ -27,4 +27,5 @@ interface Number extends Column
 
     public function withDecimals(int $number_of_decimals): self;
     public function withUnit(string $unit, string $unit_position = self::UNIT_POSITION_AFT): self;
+    public function withIsNullable(bool $nullable): void;
 }

--- a/components/ILIAS/UI/src/Component/Table/Column/TimeSpan.php
+++ b/components/ILIAS/UI/src/Component/Table/Column/TimeSpan.php
@@ -25,4 +25,5 @@ use ILIAS\Data\DateFormat\DateFormat;
 interface TimeSpan extends Column
 {
     public function getFormat(): DateFormat;
+    public function withIsNullable(bool $nullable): void;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Date.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Date.php
@@ -54,4 +54,9 @@ class Date extends Column implements C\Date
             $this->desc_label ?? $this->getTitle() . self::SEPERATOR . $this->lng->txt('order_option_chronological_descending')
         ];
     }
+
+    public function withIsNullable(bool $nullable): void
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Link.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Link.php
@@ -41,4 +41,9 @@ class Link extends Column implements C\Link
             $this->desc_label ?? $this->getTitle() . self::SEPERATOR . $this->lng->txt('order_option_alphabetical_descending')
         ];
     }
+
+    public function withIsNullable(bool $nullable): void
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/LinkListing.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/LinkListing.php
@@ -44,4 +44,9 @@ class LinkListing extends Column implements C\LinkListing
             $this->desc_label ?? $this->getTitle() . self::SEPERATOR . $this->lng->txt('order_option_alphabetical_descending')
         ];
     }
+
+    public function withIsNullable(bool $nullable): void
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Number.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Number.php
@@ -95,4 +95,9 @@ class Number extends Column implements C\Number
             $this->desc_label ?? $this->getTitle() . self::SEPERATOR . $this->lng->txt('order_option_numerical_descending')
         ];
     }
+
+    public function withIsNullable(bool $nullable): void
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/TimeSpan.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/TimeSpan.php
@@ -57,4 +57,9 @@ class TimeSpan extends Column implements C\TimeSpan
             $this->desc_label ?? $this->getTitle() . self::SEPERATOR . $this->lng->txt('order_option_chronological_descending')
         ];
     }
+
+    public function withIsNullable(bool $nullable): void
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
 }


### PR DESCRIPTION
Hi everybody

This PR is first to start a discussion. I would also implement this afterwards, if we think some implementation is needed, but I would then ask you to be a little bit patient with me (this is outside any contract).

While working on the table to show logs in the test I had the requirement to add a column with optional content (in my case a link). This is currently not possible. Right now it is possible to render the link and then insert it as a text column, but I don't believe this to be the right solution either.

This PR thus proposes to add a function `Column::withIsNullable(bool $nullable): void` to certain column types, but not all.

Open questions and explanations:
* I did not add `withIsNullable` to all column-types, because I believe that certain types, e.g. `Status` or `Boolean` profit from being clear: In these cases the options are clear and should always be defined. Other types contain primarily text (`Text`and `EMail`) and here I think it is better to force the use of empty strings for empty values instead of offering two different options to achieve the same thing, although this argument is a little controversial, as there still is a difference between the empty value and a non-existent value. `Number` in my eyes is different and a clear case of the latter, as we have a clear and visual difference between the neutral value, ie. `0`, and a non-existent value, ie. `null`.
* I think the TimeSpan is another interesting case, where my current thinking is that `nullable` should mean that either the left or the right or both values can be `null`. I would argue that this avoids the need to introduce more of these "configuration functions" as all this scenarios are very well possible (and I would argue will come up).
* Finally sorting: I would suggest to add empty values to the end of the list, as I this feels more logical to me (fuzzy argument, I know). The argument for putting it first: Our main database sorts them in first by default (I know: changeable). I have no clear-cut opinion on this.

If I get it right the functions on the interfaces of the table come with little in the way of doc-blocks and I think this should be self explanatory, too, but I could add some information to the `Column\Factory` if desired.

Thank you very much and best,
@kergomard 