### PR TITLE
Fix blank error page and wrong header status

### DIFF
--- a/error.php
+++ b/error.php
@@ -21,11 +21,14 @@ try {
     $tpl->setContent($local_tpl->get());
     $tpl->printToStdout();
 } catch (Exception $e) {
+    header("HTTP/1.1 500 Internal Server Error");
     if (defined('DEVMODE') && DEVMODE) {
         throw $e;
     }
 
     if (!($e instanceof \PDOException)) {
         die($e->getMessage());
+    } else {
+        die('Database Connection Failed.');
     }
 }


### PR DESCRIPTION
Outputs an error message if the database could not be connected and adds the header status 500. 