### PR TITLE
Fix wrong permission check on mail lists

### DIFF
--- a/Services/Contact/classes/class.ilMailingListsGUI.php
+++ b/Services/Contact/classes/class.ilMailingListsGUI.php
@@ -77,7 +77,7 @@ class ilMailingListsGUI
             !ilBuddySystem::getInstance()->isEnabled() ||
             (
                 0 === count(ilBuddyList::getInstanceByGlobalUser()->getLinkedRelations()) &&
-                $this->mlists->hasAny()
+                !$this->mlists->hasAny()
             )
         ) {
             $this->error->raiseError($this->lng->txt('msg_no_perm_read'), $this->error->MESSAGE);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41278

- Allows users to access their mailing lists when they have at least 1, even when they have no contacts.