### PR TITLE
Fix 41280: Modal::getCloseSignal not working

### DIFF
--- a/components/ILIAS/UI/resources/js/Modal/modal.js
+++ b/components/ILIAS/UI/resources/js/Modal/modal.js
@@ -40,7 +40,7 @@ il.UI = il.UI || {};
 		};
 
         var closeModal = function (id) {
-            $('#' + id).modal('close');
+            $('#' + id).modal('hide');
         };
 
         /**


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41280

This must be cherry-picked to all maintained versions. Until now, there are no usages of this method. I assume that is the reason it was never noticed.