### PR TITLE
TermsOfService: Fix updating documents

### DIFF
--- a/Services/TermsOfService/classes/Document/class.ilTermsOfServiceDocumentFormGUI.php
+++ b/Services/TermsOfService/classes/Document/class.ilTermsOfServiceDocumentFormGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Filesystem\Filesystem;
 use ILIAS\FileUpload\DTO\UploadResult;
@@ -152,9 +152,11 @@ class ilTermsOfServiceDocumentFormGUI extends ilPropertyFormGUI
         }
 
         if ($this->fileUpload->hasUploads() && !$this->fileUpload->hasBeenProcessed()) {
-            try {
-                $this->fileUpload->process();
+            $this->fileUpload->process();
+        }
 
+        if ($this->fileUpload->hasUploads()) {
+            try {
                 /** @var UploadResult|null $uploadResult */
                 $uploadResult = array_values($this->fileUpload->getResults())[0];
                 if (!($uploadResult instanceof UploadResult)) {

--- a/Services/TermsOfService/test/gui/ilTermsOfServiceDocumentFormGUITest.php
+++ b/Services/TermsOfService/test/gui/ilTermsOfServiceDocumentFormGUITest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Filesystem\Filesystem;
 use ILIAS\FileUpload\Collection\ImmutableStringMap;
@@ -522,12 +522,12 @@ class ilTermsOfServiceDocumentFormGUITest extends ilTermsOfServiceBaseTest
             ->getMock();
 
         $fu
-            ->expects($this->exactly(3))
+            ->expects($this->atLeast(3))
             ->method('hasUploads')
             ->willReturn(true);
 
         $fu
-            ->expects($this->exactly(3))
+            ->expects($this->atLeast(3))
             ->method('hasBeenProcessed')
             ->willReturn(false);
 


### PR DESCRIPTION
Updating existing documents seems to be broken, if the upload request has been already "processed".

I guess this fix is not necessary for ILIAS >= 9.x.

Caused by: https://github.com/ILIAS-eLearning/ILIAS/commit/7e77741e0abf0f9a9cfaa882ea5bddb73b3f7d88

Mantis Issue: https://mantis.ilias.de/view.php?id=41288