### PR TITLE
T&A: 41152, Fixed division by zero exception in assFormulaQuestionResult::convertDecimalToCoprimeFraction()

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionResult.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionResult.php
@@ -846,6 +846,10 @@ class assFormulaQuestionResult
 
     public static function convertDecimalToCoprimeFraction($decimal_value, $tolerance = 1.e-9)
     {
+        if (empty($decimal_value)) {
+            return '';
+        }
+
         $to_string = (string) $decimal_value;
         $is_negative = strpos($to_string, '-') === 0;
         if ($is_negative) {


### PR DESCRIPTION
Will be reviewed by @thojou & @mbecker-databay

Upon calling the aformentioned method with an empty string or value that could not be cast into a numeric value or that would be cast to 0 the method would throw an exception because at some point it would try to divide by 0.

This is not a perfect solution but it is a possible work around. The issue is also present in ILIAS 7. The actual issue goes much deeper than just the Method that is causing the Exception. The value given to the Method is sometimes invalid and thus the issue is the value beeing wrongly put together before.

Because the code has a very high cyclomatic complexity it is hard to debug. If the core issue shall be fully resolved, a general overhaul of the code is needed first to clear up the complexity.