### PR TITLE
[FEATURE] UI: improve context rendering

### DIFF
--- a/components/ILIAS/Init/classes/Dependencies/InitUIFramework.php
+++ b/components/ILIAS/Init/classes/Dependencies/InitUIFramework.php
@@ -261,7 +261,8 @@ class InitUIFramework
         };
         $c["ui.renderer"] = function ($c) {
             return new ILIAS\UI\Implementation\DefaultRenderer(
-                $c["ui.component_renderer_loader"]
+                $c["ui.component_renderer_loader"],
+                $c["ui.javascript_binding"],
             );
         };
         $c["ui.component_renderer_loader"] = function ($c) {

--- a/components/ILIAS/OrgUnit/classes/Positions/Authorities/class.ilOrgUnitGenericMultiInputGUI.php
+++ b/components/ILIAS/OrgUnit/classes/Positions/Authorities/class.ilOrgUnitGenericMultiInputGUI.php
@@ -456,10 +456,10 @@ class ilOrgUnitGenericMultiInputGUI extends ilFormPropertyGUI
          * do not render an a-tag around the glyph.
          * should be outdated and removed when Glyphs loose their Clickable
          */
-        $renderer = $this->ui_renderer->withAdditionalContext(
-            $this->ui_factory->button()->bulky($symbol, '', '')
-        );
+        // $renderer = $this->ui_renderer->withAdditionalContext(
+        //     $this->ui_factory->button()->bulky($symbol, '', '')
+        // );
 
-        return $renderer->render($symbol);
+        return $this->ui_renderer->render($symbol);
     }
 }

--- a/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeTreeExplorerGUI.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeTreeExplorerGUI.php
@@ -473,10 +473,10 @@ class ilObjStudyProgrammeTreeExplorerGUI extends ilExplorerBaseGUI
          * do not render an a-tag around the glyph.
          * should be outdated and removed when Glyphs loose their Clickable
          */
-        $renderer = $this->ui_renderer->withAdditionalContext(
-            $this->ui_factory->button()->bulky($symbol, '', '')
-        );
+        // $renderer = $this->ui_renderer->withAdditionalContext(
+        //     $this->ui_factory->button()->bulky($symbol, '', '')
+        // );
 
-        return $renderer->render($symbol);
+        return $this->ui_renderer->render($symbol);
     }
 }

--- a/components/ILIAS/UI/README.md
+++ b/components/ILIAS/UI/README.md
@@ -482,6 +482,30 @@ EOT;
 }
 ```
 
+### How can I make my component look different in some context?
+
+For some use cases you might get to the point where you want to know where your
+component is rendered to emit different HTML in your renderer. A general idea of
+the UI framework is that components have their unique look that is recognisable
+throughout the system, which is the exact reason you could not find a simple way
+to get to know where your component is being rendered.
+
+There still might be circumstances where a context dependent rendering is indeed
+required. A context can be understood as a collection or stack of all other surrounding
+UI components. This means, if e.g. a Page component is rendered which needs to render
+a Dropdown component somewhere that features some further Shy button compoennt, the 
+rendering stack or context when the button is rendered would be "Page -> Dropdown -> Shy".
+The [DefaultRenderer](./src/Implementation/DefaultRenderer.php) orchestrates this process
+and is responsible to remember this context at any time during the entire rendering
+process. Component renderers are able to react to this context using a `RendererFactory`,
+which receives the current context as an argument when loading the renderer of some
+component. The [FSLoader](./src/UI/Implementation/Render/FSLoader.php) contains directions
+on how to introduce new renderers for different contexts in your component.
+
+**Before using this mechanism, please consider if you really require a different look in a
+different context and, and if thats the case, whether you could achieve the same effect using
+CSS or not.**
+
 ### How to Change an Existing Component?
 
 1. Create a new branch based on the current trunk.
@@ -650,8 +674,6 @@ npm i -D "eslint" "eslint-config-airbnb-base" "eslint-plugin-import"
 
 ```
 
-
-
 ## FAQ
 
 ### There are so many rules, is that really necessary?
@@ -663,23 +685,6 @@ GUI of ILIAS is no option for several reasons and the current state (without rul
 is anarchy, rules seem to be the only sensible option to get some structure. All
 existing rules have a purpose, but there might be a more terse way to explain
 them. If you have found it, we'll be glad to accept your PR.
-
-### How do I know where my component is rendered?
-
-For some use cases you might get to the point where you want to know where your
-component is rendered to emit different HTML in your renderer. A general idea of
-the UI framework is that components have their unique look that is recognisable
-throughout the system, which is the exact reason you could not find a simple way
-to get to know where your component is rendered.
-
-There still might be circumstances where a context dependent rendering is indeed
-required. The [Renderer](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/src/UI/Renderer.php)
-offers a `withAdditionalContext` method for that purpose, which can be used to
-alter the selection of the renderer for your component. Before using it, consider
-if you really require a different look in a different context and, if that is indeed
-the case, whether you could achieve the same effect by using CSS. The class [FSLoader](src/UI/Implementation/Render/FSLoader.php)
-contains directions how to introduce new renderers for different contexts in your
-component.
 
 ### I don't understand that stuff, is there anyone who can explain it to me?
 

--- a/components/ILIAS/UI/src/Implementation/Component/Button/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Button/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Button;
 
@@ -330,8 +330,7 @@ class Renderer extends AbstractComponentRenderer
         RendererInterface $default_renderer,
         Template $tpl
     ): void {
-        $renderer = $default_renderer->withAdditionalContext($component);
-        $tpl->setVariable("ICON_OR_GLYPH", $renderer->render($component->getIconOrGlyph()));
+        $tpl->setVariable("ICON_OR_GLYPH", $default_renderer->render($component->getIconOrGlyph()));
         $label = $component->getLabel();
         if ($label !== null) {
             $tpl->setVariable("LABEL", $label);

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Filter/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Filter/Renderer.php
@@ -78,7 +78,7 @@ class Renderer extends AbstractComponentRenderer
     protected function registerSignals(Filter\Filter $filter): Filter\Filter
     {
         $update = $filter->getUpdateSignal();
-        return $filter->withAdditionalOnLoadCode(fn ($id) => "$(document).on('$update', function(event, signalData) {
+        return $filter->withAdditionalOnLoadCode(fn($id) => "$(document).on('$update', function(event, signalData) {
                 il.UI.filter.onInputUpdate(event, signalData, '$id'); return false; 
             });");
     }
@@ -103,7 +103,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl->parseCurrentBlock();
 
         $opener_expand = $f->button()->bulky($f->symbol()->glyph()->expand(), $this->txt("filter"), "")
-            ->withAdditionalOnLoadCode(fn ($id) => "$('#$id').on('click', function(event) {
+            ->withAdditionalOnLoadCode(fn($id) => "$('#$id').on('click', function(event) {
 					il.UI.filter.onAjaxCmd(event, '$id', 'expand');
 					event.preventDefault();
 			    });");
@@ -114,7 +114,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl->parseCurrentBlock();
 
         $opener_collapse = $f->button()->bulky($f->symbol()->glyph()->collapse(), $this->txt("filter"), "")
-            ->withAdditionalOnLoadCode(fn ($id) => "$('#$id').on('click', function(event) {
+            ->withAdditionalOnLoadCode(fn($id) => "$('#$id').on('click', function(event) {
 					il.UI.filter.onAjaxCmd(event, '$id', 'collapse');
 					event.preventDefault();
 			    });");
@@ -147,7 +147,7 @@ class Renderer extends AbstractComponentRenderer
 
         // render apply and reset buttons
         $apply = $f->button()->bulky($f->symbol()->glyph()->apply(), $this->txt("apply"), "")
-            ->withOnLoadCode(fn ($id) => "$('#$id').on('click', function(event) {
+            ->withOnLoadCode(fn($id) => "$('#$id').on('click', function(event) {
                         il.UI.filter.onCmd(event, '$id', 'apply');
                         return false; // stop event propagation
                 });
@@ -191,11 +191,11 @@ class Renderer extends AbstractComponentRenderer
          * @var $toggle Toggle
          */
         $toggle = $f->button()->toggle("", $toggle_on_signal, $toggle_off_signal, $component->isActivated());
-        $toggle = $toggle->withAdditionalOnLoadCode(fn ($id) => "$(document).on('$toggle_on_signal',function(event) {
+        $toggle = $toggle->withAdditionalOnLoadCode(fn($id) => "$(document).on('$toggle_on_signal',function(event) {
                         il.UI.filter.onCmd(event, '$id', 'toggleOn');
                         return false; // stop event propagation
             });");
-        $toggle = $toggle->withAdditionalOnLoadCode(fn ($id) => "$(document).on('$toggle_off_signal',function(event) {
+        $toggle = $toggle->withAdditionalOnLoadCode(fn($id) => "$(document).on('$toggle_off_signal',function(event) {
                         il.UI.filter.onCmd(event, '$id', 'toggleOff');
                         return false; // stop event propagation
             });");
@@ -241,8 +241,7 @@ class Renderer extends AbstractComponentRenderer
 
         $input_group = $input_group->withOnUpdate($component->getUpdateSignal());
 
-        $renderer = $default_renderer->withAdditionalContext($component);
-        $tpl->setVariable("INPUTS", $renderer->render($input_group));
+        $tpl->setVariable("INPUTS", $default_renderer->render($input_group));
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FieldRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FieldRendererFactory.php
@@ -27,7 +27,8 @@ class FieldRendererFactory extends Render\DefaultRendererFactory
 {
     public function getRendererInContext(Component\Component $component, array $contexts): Render\AbstractComponentRenderer
     {
-        if (in_array('DateTimeFieldInput', $contexts)
+        if (in_array('DurationFieldInput', $contexts)
+            && in_array('DateTimeFieldInput', $contexts)
             && in_array('StandardFilterContainerInput', $contexts)) {
             return new DateTimeFilterContextRenderer(
                 $this->ui_factory,

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
@@ -197,11 +197,11 @@ class FilterContextRenderer extends Renderer
         $input = array_shift($inputs); //from
         list($input, $tpl) = $this->internalRenderDateTimeField($input, $default_renderer);
         $first_input_id = $this->bindJSandApplyId($input, $tpl);
-        $input_html = $default_renderer->withAdditionalContext($input)->render($input);
+        $input_html = $default_renderer->render($input);
 
         $input = array_shift($inputs) //until
         ->withAdditionalPickerconfig(['useCurrent' => false]);
-        $input_html .= $default_renderer->withAdditionalContext($input)->render($input);
+        $input_html .= $default_renderer->render($input);
 
         $tpl = $this->getTemplate("tpl.duration.html", true, true);
         $id = $this->bindJSandApplyId($component, $tpl);

--- a/components/ILIAS/UI/src/Implementation/Component/Link/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Link/Renderer.php
@@ -111,8 +111,7 @@ class Renderer extends AbstractComponentRenderer
     ): string {
         $tpl_name = "tpl.bulky.html";
         $tpl = $this->setStandardVars($tpl_name, $component);
-        $renderer = $default_renderer->withAdditionalContext($component);
-        $tpl->setVariable("SYMBOL", $renderer->render($component->getSymbol()));
+        $tpl->setVariable("SYMBOL", $default_renderer->render($component->getSymbol()));
 
         $aria_role = $component->getAriaRole();
         if ($aria_role != null) {

--- a/components/ILIAS/UI/src/Implementation/Render/DecoratedRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Render/DecoratedRenderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Render;
 
 use ILIAS\UI\Renderer;
@@ -30,16 +30,6 @@ abstract class DecoratedRenderer implements Renderer
     public function __construct(Renderer $default)
     {
         $this->default = $default;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function withAdditionalContext(Component $context): DecoratedRenderer
-    {
-        $clone = clone $this;
-        $clone->default = $clone->default->withAdditionalContext($context);
-        return $clone;
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Render/DefaultRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Render/DefaultRendererFactory.php
@@ -70,12 +70,4 @@ class DefaultRendererFactory implements RendererFactory
         $parts[count($parts) - 1] = "Renderer";
         return implode("\\", $parts);
     }
-
-    /**
-     * @inheritdocs
-     */
-    public function getJSBinding(): JavaScriptBinding
-    {
-        return $this->js_binding;
-    }
 }

--- a/components/ILIAS/UI/src/Implementation/Render/RendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Render/RendererFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Render;
 
@@ -36,14 +36,4 @@ interface RendererFactory
      * @param string[] $contexts
      */
     public function getRendererInContext(Component $component, array $contexts): ComponentRenderer;
-
-    // TODO: This is missing some method to enumerate contexts and the different
-    // renderers. This would be needed to show different renderings in the Kitchen
-    // Sink.
-
-    /**
-     * Todo: This was implemented to fix 21830. Do we really want this on the renderer
-     * factory interfaces?
-     */
-    public function getJSBinding(): JavaScriptBinding;
 }

--- a/components/ILIAS/UI/src/Renderer.php
+++ b/components/ILIAS/UI/src/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI;
 
@@ -51,20 +51,4 @@ interface Renderer
      * @return string
      */
     public function renderAsync($component, ?Renderer $root = null);
-
-    /**
-     * Get a new renderer with an additional context.
-     *
-     * A context makes it possible to use another renderer for (some) components when
-     * they are renderer as subcomponents of a certain components. The use case that
-     * spawned this functionality is the observation, that e.g. items representing
-     * repository objects are renderer in different lists, where the individual items
-     * look different every time but are morally the same item. Another use case could
-     * be a special rendering of input fields in filters over tables.
-     *
-     * If a component wants to render itself differently in different contexts, it must
-     * implement a RendererFactory. The class \ILIAS\UI\Implementation\Render\FSLoader
-     * contains directions how to do that.
-     */
-    public function withAdditionalContext(Component $context): Renderer;
 }

--- a/components/ILIAS/UI/tests/Base.php
+++ b/components/ILIAS/UI/tests/Base.php
@@ -219,12 +219,19 @@ class TestDefaultRenderer extends DefaultRenderer
 {
     protected array $with_stub_renderings = [];
 
-    public function __construct(Render\Loader $component_renderer_loader, array $with_stub_renderings = [])
-    {
+    public function __construct(
+        Render\Loader $component_renderer_loader,
+        JavaScriptBinding $java_script_binding,
+        array $with_stub_renderings = [],
+        protected array $with_additional_contexts = [],
+    ) {
         $this->with_stub_renderings = array_map(function ($component) {
             return get_class($component);
         }, $with_stub_renderings);
-        parent::__construct($component_renderer_loader);
+
+        array_walk($this->with_additional_contexts, fn(Component $c) => $this->pushContext($c));
+
+        parent::__construct($component_renderer_loader, $java_script_binding);
     }
 
     public function _getRendererFor(IComponent $component): Render\ComponentRenderer
@@ -379,9 +386,14 @@ trait BaseUITestTrait
         return $this->createMock(UploadLimitResolver::class);
     }
 
+    /**
+     * @param Component[] $with_stub_renderings
+     * @param Component[] $with_additional_contexts
+     */
     public function getDefaultRenderer(
         JavaScriptBinding $js_binding = null,
-        array $with_stub_renderings = []
+        array $with_stub_renderings = [],
+        array $with_additional_contexts = [],
     ): TestDefaultRenderer {
         $ui_factory = $this->getUIFactory();
         $tpl_factory = $this->getTemplateFactory();
@@ -442,7 +454,7 @@ trait BaseUITestTrait
                 )
             )
         );
-        return new TestDefaultRenderer($component_renderer_loader, $with_stub_renderings);
+        return new TestDefaultRenderer($component_renderer_loader, $js_binding, $with_stub_renderings, $with_additional_contexts);
     }
 
     public function getDecoratedRenderer(Renderer $default)

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
@@ -118,8 +118,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         $if = $this->buildInputFactory();
         $text = $if->text('label', 'byline'); // byline will not be rendered in this context
         $filter = $f->standard("#", "#", "#", "#", "#", "#", [], [], false, false);
-        $r = $this->getDefaultRenderer();
-        $fr = $r->withAdditionalContext($filter);
+        $fr = $this->getDefaultRenderer(null, [], [$filter]);
         $html = $this->brutallyTrimHTML($fr->render($text));
 
         $expected = $this->brutallyTrimHTML('
@@ -144,8 +143,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         $if = $this->buildInputFactory();
         $numeric = $if->numeric('label', 'byline'); // byline will not be rendered in this context
         $filter = $f->standard("#", "#", "#", "#", "#", "#", [], [], false, false);
-        $r = $this->getDefaultRenderer();
-        $fr = $r->withAdditionalContext($filter);
+        $fr = $this->getDefaultRenderer(null, [], [$filter]);
         $html = $this->brutallyTrimHTML($fr->render($numeric));
 
         $expected = $this->brutallyTrimHTML('
@@ -171,8 +169,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         $options = ["one" => "One", "two" => "Two", "three" => "Three"];
         $select = $if->select('label', $options, 'byline'); // byline will not be rendered in this context
         $filter = $f->standard("#", "#", "#", "#", "#", "#", [], [], false, false);
-        $r = $this->getDefaultRenderer();
-        $fr = $r->withAdditionalContext($filter);
+        $fr = $this->getDefaultRenderer(null, [], [$filter]);
         $html = $this->brutallyTrimHTML($fr->render($select));
 
         $expected = $this->brutallyTrimHTML('
@@ -201,8 +198,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         $options = ["one" => "One", "two" => "Two", "three" => "Three"];
         $multi = $if->multiSelect('label', $options, 'byline'); // byline will not be rendered in this context
         $filter = $f->standard("#", "#", "#", "#", "#", "#", [], [], false, false);
-        $r = $this->getDefaultRenderer();
-        $fr = $r->withAdditionalContext($filter);
+        $fr = $this->getDefaultRenderer(null, [], [$filter]);
         $html = $this->brutallyTrimHTML($fr->render($multi));
 
         $expected = $this->brutallyTrimHTML('
@@ -229,8 +225,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         $if = $this->buildInputFactory();
         $datetime = $if->dateTime('label', 'byline'); // byline will not be rendered in this context
         $filter = $f->standard("#", "#", "#", "#", "#", "#", [], [], false, false);
-        $r = $this->getDefaultRenderer();
-        $fr = $r->withAdditionalContext($filter);
+        $fr = $this->getDefaultRenderer(null, [], [$filter]);
         $html = $this->brutallyTrimHTML($fr->render($datetime));
 
         $expected = $this->brutallyTrimHTML('
@@ -255,11 +250,10 @@ class FilterInputTest extends ILIAS_UI_TestBase
     {
         $f = $this->buildFactory();
         $if = $this->buildInputFactory();
+        $duration = $if->duration('label', 'byline');
         $datetime = $if->dateTime('label', 'byline'); // byline will not be rendered in this context
         $filter = $f->standard("#", "#", "#", "#", "#", "#", [], [], false, false);
-        $r = $this->getDefaultRenderer();
-        $fr = $r->withAdditionalContext($filter);
-        $dr = $fr->withAdditionalContext($datetime);
+        $dr = $this->getDefaultRenderer(null, [], [$filter, $duration, $datetime]);
         $html = $this->brutallyTrimHTML($dr->render($datetime));
 
         $expected = $this->brutallyTrimHTML('
@@ -281,8 +275,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         $if = $this->buildInputFactory();
         $datetime = $if->duration('label', 'byline'); // byline will not be rendered in this context
         $filter = $f->standard("#", "#", "#", "#", "#", "#", [], [], false, false);
-        $r = $this->getDefaultRenderer();
-        $fr = $r->withAdditionalContext($filter);
+        $fr = $this->getDefaultRenderer(null, [], [$filter]);
         $html = $this->brutallyTrimHTML($fr->render($datetime));
         $label_start = 'duration_default_label_start';
         $label_end = 'duration_default_label_end';

--- a/components/ILIAS/UI/tests/Component/MainControls/SystemInfoTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/SystemInfoTest.php
@@ -209,7 +209,8 @@ EOT;
 
     public function getDefaultRenderer(
         JavaScriptBinding $js_binding = null,
-        array $with_stub_renderings = []
+        array $with_stub_renderings = [],
+        array $with_additional_contexts = [],
     ): TestDefaultRenderer {
         return parent::getDefaultRenderer(new class () implements JavaScriptBinding {
             public function createId(): string

--- a/components/ILIAS/UI/tests/Renderer/AbstractRendererTest.php
+++ b/components/ILIAS/UI/tests/Renderer/AbstractRendererTest.php
@@ -167,11 +167,6 @@ namespace {
         {
             return '';
         }
-
-        public function withAdditionalContext(C\Component $context): Renderer
-        {
-            return $this;
-        }
     }
 
     class AbstractRendererTest extends ILIAS_UI_TestBase


### PR DESCRIPTION
Hi folks,

I have removed some unnecessary complexity from the UI framework:

- `Renderer::withAdditionalContext()`: this method has been invoked in order to provide a context to the current rendering chain. However, due to the recursive nature of our rendering process, we can always know the current context because all rendering calls will eventually invoke our `DefaultRenderer` again. I have discussed with @klees to replace usages of this method by creating a new instance of the concrete context renderer already. However, I have decided not to do so until we have a proper mechanism to gather assets and inject them into our page component.
- `RendererFactory::getJSBinding()`: since instances are passed by reference, we can simply inject the `JavaScriptBinding` directly into our `DefaultRenderer`. No need to retrieve the `RendererFactory` and/or `ComponentRenderer` again.

Kind regards,
@thibsy 