### PR TITLE
MainBar/Performance: Optimize checks in `isCurrentUserAllowedToSeeCus…

### DIFF
--- a/Services/MainMenu/classes/class.ilObjMainMenuAccess.php
+++ b/Services/MainMenu/classes/class.ilObjMainMenuAccess.php
@@ -87,11 +87,11 @@ class ilObjMainMenuAccess extends ilObjectAccess implements ilMainMenuAccess
     public function isCurrentUserAllowedToSeeCustomItem(ilMMCustomItemStorage $item, Closure $current): Closure
     {
         return function () use ($item, $current): bool {
-            $roles_of_current_user = $this->rbacreview->assignedGlobalRoles($this->user->getId());
             if (!$item->hasRoleBasedVisibility()) {
                 return $current();
             }
             if (!empty($item->getGlobalRoleIDs())) {
+                $roles_of_current_user = $this->rbacreview->assignedGlobalRoles($this->user->getId());
                 foreach ($roles_of_current_user as $role_of_current_user) {
                     if (in_array((int) $role_of_current_user, $item->getGlobalRoleIDs(), true)) {
                         return $current();


### PR DESCRIPTION
…tomItem`

This PR changes the location of calling
`\ilRbacReview::assignedGlobalRoles`. Currently, it is called even if there is no role-based visibility configuration at all. What this PR does not address is the problem, that `\ilRbacReview::assignedGlobalRoles`
is called for every item, which results in redundant database requests (depending on the number of custom items).

If approved, this should be merged to `release_9` and `trunk` as well.