### PR TITLE
Remove withConsecutive calls from various components

### DIFF
--- a/components/ILIAS/Badge/tests/BadgeParentTest.php
+++ b/components/ILIAS/Badge/tests/BadgeParentTest.php
@@ -131,7 +131,13 @@ class BadgeParentTest extends TestCase
         ])->willReturn($descriptive);
 
         $factory->method('listing')->willReturn($listing);
-        $factory->method('legacy')->withConsecutive(['Lorem'], [$rendered])->willReturnOnConsecutiveCalls($parent_link, $legacy);
+        $consecutive = ['Lorem', $rendered];
+        $factory->method('legacy')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
+        )->willReturnOnConsecutiveCalls($parent_link, $legacy);
 
         $renderer->expects(self::once())->method('render')->willReturn($rendered);
 

--- a/components/ILIAS/Badge/tests/TileTest.php
+++ b/components/ILIAS/Badge/tests/TileTest.php
@@ -129,10 +129,15 @@ class TileTest extends TestCase
 
         $ui->method('factory')->willReturn($factory);
 
+        $consecutive = [$badge_id, ''];
         $ctrl->expects(self::once())->method('getLinkTargetByClass')->with($gui_class_name, 'deactivateInCard')->willReturn($url);
-        $ctrl->expects(self::exactly(2))->method('setParameterByClass')->withConsecutive(
-            [$gui_class_name, 'badge_id', (string) $badge_id],
-            [$gui_class_name, 'badge_id', '']
+        $ctrl->expects(self::exactly(2))->method('setParameterByClass')->with(
+            $this->identicalTo($gui_class_name),
+            $this->identicalTo('badge_id'),
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
         );
 
         $language->method('txt')->willReturnCallback(

--- a/components/ILIAS/Certificate/tests/ilCertificateCourseLearningProgressEvaluationTest.php
+++ b/components/ILIAS/Certificate/tests/ilCertificateCourseLearningProgressEvaluationTest.php
@@ -65,11 +65,14 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
             ->disableOriginalConstructor()
             ->getMock();
 
+        $consecutive_get = ['cert_subitems_5', 'cert_subitems_6'];
         $setting
             ->method('get')
-            ->withConsecutive(
-                ['cert_subitems_5'],
-                ['cert_subitems_6']
+            ->with(
+                $this->callback(function ($value) use (&$consecutive_get) {
+                    $this->assertSame(array_shift($consecutive_get), $value);
+                    return true;
+                })
             )
             ->willReturnOnConsecutiveCalls(
                 '[10,20]',
@@ -79,24 +82,26 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
         $objectHelper = $this->getMockBuilder(ilCertificateObjectHelper::class)
             ->getMock();
 
+        $consecutive_id = [10, 20, 10, 50];
         $objectHelper->method('lookupObjId')
-            ->withConsecutive(
-                [10],
-                [20],
-                [10],
-                [50]
+            ->with(
+                $this->callback(function ($value) use (&$consecutive_id) {
+                    $this->assertSame(array_shift($consecutive_id), $value);
+                    return true;
+                })
             )
             ->willReturnOnConsecutiveCalls(100, 200, 100, 500);
 
         $statusHelper = $this->getMockBuilder(ilCertificateLPStatusHelper::class)
             ->getMock();
 
+        $consecutive_status = [100, 200, 100, 500];
         $statusHelper->method('lookUpStatus')
-            ->withConsecutive(
-                [100],
-                [200],
-                [100],
-                [500]
+            ->with(
+                $this->callback(function ($value) use (&$consecutive_status) {
+                    $this->assertSame(array_shift($consecutive_status), $value);
+                    return true;
+                })
             )
             ->willReturnOnConsecutiveCalls(
                 ilLPStatus::LP_STATUS_COMPLETED_NUM,
@@ -164,11 +169,14 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
             ->disableOriginalConstructor()
             ->getMock();
 
+        $consecutive_get = ['cert_subitems_5', 'cert_subitems_6'];
         $setting
             ->method('get')
-            ->withConsecutive(
-                ['cert_subitems_5'],
-                ['cert_subitems_6']
+            ->with(
+                $this->callback(function ($value) use (&$consecutive_get) {
+                    $this->assertSame(array_shift($consecutive_get), $value);
+                    return true;
+                })
             )
             ->willReturnOnConsecutiveCalls(
                 '[10,20]',
@@ -178,31 +186,28 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
         $objectHelper = $this->getMockBuilder(ilCertificateObjectHelper::class)
             ->getMock();
 
+        $consecutive_id = [10, 20, 10, 500];
         $objectHelper->method('lookupObjId')
-            ->withConsecutive(
-                [10],
-                [20],
-                [10],
-                [500]
+            ->with(
+                $this->callback(function ($value) use (&$consecutive_id) {
+                    $this->assertSame(array_shift($consecutive_id), $value);
+                    return true;
+                })
             )
             ->willReturnOnConsecutiveCalls(100, 200, 100, 500);
 
         $statusHelper = $this->getMockBuilder(ilCertificateLPStatusHelper::class)
             ->getMock();
 
+        $consecutive_status = [100, 200, 100, 500];
         $statusHelper->method('lookUpStatus')
-            ->withConsecutive(
-                [100],
-                [200],
-                [100],
-                [500]
+            ->with(
+                $this->callback(function ($value) use (&$consecutive_status) {
+                    $this->assertSame(array_shift($consecutive_status), $value);
+                    return true;
+                })
             )
-            ->willReturnOnConsecutiveCalls(
-                ilLPStatus::LP_STATUS_COMPLETED_NUM,
-                ilLPStatus::LP_STATUS_COMPLETED_NUM,
-                ilLPStatus::LP_STATUS_COMPLETED_NUM,
-                ilLPStatus::LP_STATUS_COMPLETED_NUM
-            );
+            ->willReturn(ilLPStatus::LP_STATUS_COMPLETED_NUM);
 
         $trackingHelper = $this->getMockBuilder(ilCertificateObjUserTrackingHelper::class)
             ->getMock();
@@ -264,16 +269,16 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
             ->disableOriginalConstructor()
             ->getMock();
 
+        $consecutive = ['cert_subitems_5', 'cert_subitems_6'];
         $setting
             ->method('get')
-            ->withConsecutive(
-                ['cert_subitems_5'],
-                ['cert_subitems_6']
+            ->with(
+                $this->callback(function ($value) use (&$consecutive) {
+                    $this->assertSame(array_shift($consecutive), $value);
+                    return true;
+                })
             )
-            ->willReturnOnConsecutiveCalls(
-                null,
-                null
-            );
+            ->willReturn(null);
 
         $objectHelper = $this->getMockBuilder(ilCertificateObjectHelper::class)
             ->getMock();

--- a/components/ILIAS/Certificate/tests/ilCertificateLearningHistoryProviderTest.php
+++ b/components/ILIAS/Certificate/tests/ilCertificateLearningHistoryProviderTest.php
@@ -203,10 +203,14 @@ class ilCertificateLearningHistoryProviderTest extends ilCertificateBaseTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $consecutive = ['Course Title', 'Test Title'];
         $link->method('standard')
-            ->withConsecutive(
-                ['Course Title', '<a href> </a>'],
-                ['Test Title', '<a href> </a>']
+            ->with(
+                $this->callback(function ($value) use (&$consecutive) {
+                    $this->assertSame(array_shift($consecutive), $value);
+                    return true;
+                }),
+                $this->identicalTo('<a href> </a>')
             )
             ->willReturn($std_link);
 

--- a/components/ILIAS/Certificate/tests/ilCertificateTemplateRepositoryTest.php
+++ b/components/ILIAS/Certificate/tests/ilCertificateTemplateRepositoryTest.php
@@ -244,9 +244,6 @@ class ilCertificateTemplateRepositoryTest extends ilCertificateBaseTestCase
         $this->assertSame(30, $template->getId());
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testDeleteTemplateFromDatabase(): void
     {
         $database = $this->createMock(ilDBInterface::class);
@@ -255,8 +252,15 @@ class ilCertificateTemplateRepositoryTest extends ilCertificateBaseTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $consecutive = [10, 200];
         $database->method('quote')
-            ->withConsecutive([10, 'integer'], [200, 'integer'])
+            ->with(
+                $this->callback(function ($value) use (&$consecutive) {
+                    $this->assertSame(array_shift($consecutive), $value);
+                    return true;
+                }),
+                $this->identicalTo('integer')
+            )
             ->willReturnOnConsecutiveCalls('10', '200');
 
         $database->method('query')
@@ -284,8 +288,15 @@ AND obj_id = 200');
             ->disableOriginalConstructor()
             ->getMock();
 
+        $consecutive = [10, 30];
         $database->method('quote')
-            ->withConsecutive([10, 'integer'], [30, 'integer'])
+            ->with(
+                $this->callback(function ($value) use (&$consecutive) {
+                    $this->assertSame(array_shift($consecutive), $value);
+                    return true;
+                }),
+                $this->identicalTo('integer')
+            )
             ->willReturnOnConsecutiveCalls('10', '30');
 
         $database->method('fetchAssoc')->willReturnOnConsecutiveCalls(
@@ -319,15 +330,7 @@ AND obj_id = 200');
             ]
         );
 
-        $database->method('query')
-            ->withConsecutive(
-                [$this->anything()],
-                [
-                    'UPDATE il_cert_template
-SET currently_active = 1
-WHERE id = 30'
-                ]
-            );
+        $database->method('query');
 
         $objectDataCache = $this->getMockBuilder(ilObjectDataCache::class)
             ->disableOriginalConstructor()

--- a/components/ILIAS/Certificate/tests/ilPageFormatsTest.php
+++ b/components/ILIAS/Certificate/tests/ilPageFormatsTest.php
@@ -30,15 +30,21 @@ class ilPageFormatsTest extends ilCertificateBaseTestCase
             ->onlyMethods(['txt'])
             ->getMock();
 
+        $consecutive = [
+            'certificate_a4',
+            'certificate_a4_landscape',
+            'certificate_a5',
+            'certificate_a5_landscape',
+            'certificate_letter',
+            'certificate_letter_landscape',
+            'certificate_custom'
+        ];
         $languageMock->method('txt')
-            ->withConsecutive(
-                ['certificate_a4'],
-                ['certificate_a4_landscape'],
-                ['certificate_a5'],
-                ['certificate_a5_landscape'],
-                ['certificate_letter'],
-                ['certificate_letter_landscape'],
-                ['certificate_custom']
+            ->with(
+                $this->callback(function ($value) use (&$consecutive) {
+                    $this->assertSame(array_shift($consecutive), $value);
+                    return true;
+                })
             )
             ->willReturn('Some Translation');
 

--- a/components/ILIAS/Cron/tests/CronJobManagerTest.php
+++ b/components/ILIAS/Cron/tests/CronJobManagerTest.php
@@ -117,9 +117,15 @@ class CronJobManagerTest extends TestCase
             $clock_factory
         );
 
-        $repository->expects($this->exactly(2))->method('activateJob')->withConsecutive(
-            [$job, $clock_factory->system()->now(), $user, true],
-            [$job, $clock_factory->system()->now(), $user, false]
+        $consecutive = [true, false];
+        $repository->expects($this->exactly(2))->method('activateJob')->with(
+            $this->identicalTo($job),
+            $this->identicalTo($clock_factory->system()->now()),
+            $this->identicalTo($user),
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
         );
 
         $job->expects($this->exactly(2))->method('activationWasToggled')->with(
@@ -154,9 +160,15 @@ class CronJobManagerTest extends TestCase
             $clock_factory
         );
 
-        $repository->expects($this->exactly(2))->method('deactivateJob')->withConsecutive(
-            [$job, $clock_factory->system()->now(), $user, true],
-            [$job, $clock_factory->system()->now(), $user, false]
+        $consecutive = [true, false];
+        $repository->expects($this->exactly(2))->method('deactivateJob')->with(
+            $this->identicalTo($job),
+            $this->identicalTo($clock_factory->system()->now()),
+            $this->identicalTo($user),
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
         );
 
         $job->expects($this->exactly(2))->method('activationWasToggled')->with(

--- a/components/ILIAS/DataProtection/tests/ConsumerTest.php
+++ b/components/ILIAS/DataProtection/tests/ConsumerTest.php
@@ -71,7 +71,14 @@ class ConsumerTest extends TestCase
     {
         $by_trying = $this->mockTree(ByTrying::class, ['transform' => true]);
         $settings = $this->mock(ilSetting::class);
-        $settings->method('get')->withConsecutive(['dpro_enabled', ''], ['dpro_no_acceptance', ''])->willReturn('true');
+        $consecutive = ['dpro_enabled', 'dpro_no_acceptance'];
+        $settings->method('get')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            }),
+            $this->identicalTo('')
+        )->willReturn('true');
 
         $container = $this->mockTree(Container::class, [
             'settings' => $settings,
@@ -98,7 +105,14 @@ class ConsumerTest extends TestCase
         $by_trying->method('transform')->willReturnOnConsecutiveCalls(true, false);
 
         $settings = $this->mock(ilSetting::class);
-        $settings->method('get')->withConsecutive(['dpro_enabled', ''], ['dpro_no_acceptance', ''])->willReturnOnConsecutiveCalls('true', 'false');
+        $consecutive = ['dpro_enabled', 'dpro_no_acceptance'];
+        $settings->method('get')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            }),
+            $this->identicalTo('')
+        )->willReturnOnConsecutiveCalls('true', 'false');
 
         $container = $this->mockTree(Container::class, [
             'settings' => $settings,

--- a/components/ILIAS/LegalDocuments/tests/AdministrationTest.php
+++ b/components/ILIAS/LegalDocuments/tests/AdministrationTest.php
@@ -91,7 +91,14 @@ class AdministrationTest extends TestCase
         ];
 
         $repository = $this->getMockBuilder(DocumentRepository::class)->getMock();
-        $repository->expects(self::exactly(count($documents)))->method('deleteDocument')->withConsecutive(...array_map(fn($d) => [$d], $documents));
+
+        $consecutive = $documents;
+        $repository->expects(self::exactly(count($documents)))->method('deleteDocument')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
+        );
 
         $config = $this->mockMethod(Config::class, 'legalDocuments', [], $this->mockMethod(
             Provide::class,

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/BlocksTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/BlocksTest.php
@@ -161,7 +161,13 @@ class BlocksTest extends TestCase
         ]);
 
         $language = $this->mock(ilLanguage::class);
-        $language->expects(self::exactly(2))->method('loadLanguageModule')->withConsecutive(['dummy lang'], ['ldoc']);
+        $consecutive = ['dummy lang', 'ldoc'];
+        $language->expects(self::exactly(2))->method('loadLanguageModule')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
+        );
 
         $instance = new Blocks(
             'foo',

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/ShowOnLoginPageTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/ShowOnLoginPageTest.php
@@ -57,7 +57,18 @@ class ShowOnLoginPageTest extends TestCase
         $legacy = $this->mock(Legacy::class);
 
         $template = $this->mock(ilTemplate::class);
-        $template->expects(self::exactly(2))->method('setVariable')->withConsecutive(['LABEL', htmlentities($translated)], ['HREF', $url]);
+        $consecutive_key = ['LABEL', 'HREF'];
+        $consecutive_value = [htmlentities($translated), $url];
+        $template->expects(self::exactly(2))->method('setVariable')->with(
+            $this->callback(function ($value) use (&$consecutive_key) {
+                $this->assertSame(array_shift($consecutive_key), $value);
+                return true;
+            }),
+            $this->callback(function ($value) use (&$consecutive_value) {
+                $this->assertSame(array_shift($consecutive_value), $value);
+                return true;
+            })
+        );
         $template->expects(self::once())->method('get')->willReturn('Rendered');
 
         $instance = new ShowOnLoginPage($this->mockTree(Provide::class, [

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/MarshalTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/MarshalTest.php
@@ -95,9 +95,12 @@ class MarshalTest extends TestCase
             'always' => $always,
             'null' => $null,
         ]);
-        $refinery->expects(self::exactly(2))->method('byTrying')->withConsecutive(
-            [[$nice_null, $decorate->fromString()]],
-            [[$series, $decorate->toString()]]
+        $consecutive = [[$nice_null, $decorate->fromString()], [$series, $decorate->toString()]];
+        $refinery->expects(self::exactly(2))->method('byTrying')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
         )->willReturn($by_trying);
 
         $convert = (new Marshal($refinery))->nullable($decorate);

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/UITest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/UITest.php
@@ -53,7 +53,13 @@ class UITest extends TestCase
     public function testTxt(): void
     {
         $language = $this->mockMethod(ilLanguage::class, 'txt', ['ldoc_foo'], 'baz');
-        $language->expects(self::exactly(2))->method('exists')->withConsecutive(['bar_foo'], ['ldoc_foo'])->willReturnOnConsecutiveCalls(false, true);
+        $consecutive = ['bar_foo', 'ldoc_foo'];
+        $language->expects(self::exactly(2))->method('exists')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
+        )->willReturnOnConsecutiveCalls(false, true);
 
         $instance = new UI('bar', $this->mock(UIFactory::class), $this->mock(ilGlobalTemplateInterface::class), $language);
         $this->assertSame('baz', $instance->txt('foo'));
@@ -62,7 +68,13 @@ class UITest extends TestCase
     public function testTxtFallback(): void
     {
         $language = $this->mockMethod(ilLanguage::class, 'txt', ['foo'], 'baz');
-        $language->expects(self::exactly(2))->method('exists')->withConsecutive(['bar_foo'], ['ldoc_foo'])->willReturn(false);
+        $consecutive = ['bar_foo', 'ldoc_foo'];
+        $language->expects(self::exactly(2))->method('exists')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
+        )->willReturn(false);
 
         $instance = new UI('bar', $this->mock(UIFactory::class), $this->mock(ilGlobalTemplateInterface::class), $language);
         $this->assertSame('baz', $instance->txt('foo'));

--- a/components/ILIAS/LegalDocuments/tests/Provide/ProvideDocumentTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Provide/ProvideDocumentTest.php
@@ -221,7 +221,13 @@ class ProvideDocumentTest extends TestCase
         $condition->expects(self::exactly(2))->method('knownToNeverMatchWith')->with($condition)->willReturn(false);
 
         $definition = $this->mock(ConditionDefinition::class);
-        $definition->expects(self::exactly(3))->method('withCriterion')->withConsecutive([$content], [$other_existing_content], [$content])->willReturn($condition);
+        $consecutive = [$content, $other_existing_content, $content];
+        $definition->expects(self::exactly(3))->method('withCriterion')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
+        )->willReturn($condition);
 
         $instance = new ProvideDocument('foo', $this->mock(DocumentRepository::class), new SelectionMap([
             'hoo' => $this->mockMethod(ConditionDefinition::class, 'withCriterion', [$existing_content], $condition),

--- a/components/ILIAS/LegalDocuments/tests/Provide/ProvidePublicPageTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Provide/ProvidePublicPageTest.php
@@ -40,7 +40,15 @@ class ProvidePublicPageTest extends TestCase
     public function testUrl(): void
     {
         $ctrl = $this->mock(ilCtrl::class);
-        $ctrl->expects(self::exactly(2))->method('setParameterByClass')->withConsecutive([ilStartUpGUI::class, 'id', 'foo'], [ilStartUpGUI::class, 'id', '']);
+        $consecutive = ['foo', ''];
+        $ctrl->expects(self::exactly(2))->method('setParameterByClass')->with(
+            $this->identicalTo(ilStartUpGUI::class),
+            $this->identicalTo('id'),
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
+        );
         $ctrl->expects(self::once())->method('getLinkTargetByClass')->with(ilStartUpGUI::class, 'showLegalDocuments')->willReturn('url');
 
         $instance = new ProvidePublicPage('foo', $ctrl);

--- a/components/ILIAS/LegalDocuments/tests/ProvideTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ProvideTest.php
@@ -88,7 +88,14 @@ class ProvideTest extends TestCase
         $document = $this->mock(ProvideDocument::class);
 
         $internal = $this->mock(Internal::class);
-        $internal->expects(self::exactly(2))->method('get')->withConsecutive(['document', 'foo'], ['writable-document', 'foo'])->willReturn($document);
+        $consecutive = ['document', 'writable-document'];
+        $internal->expects(self::exactly(2))->method('get')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            }),
+            $this->identicalTo('foo')
+        )->willReturn($document);
 
         $instance = new Provide('foo', $internal, $this->mock(Container::class));
         $instance->document();

--- a/components/ILIAS/OnScreenChat/tests/SubscriberRepositoryTest.php
+++ b/components/ILIAS/OnScreenChat/tests/SubscriberRepositoryTest.php
@@ -29,11 +29,16 @@ class SubscriberRepositoryTest extends ilOnScreenChatBaseTest
         $db = $this->createMock(ilDBInterface::class);
         $resultMock = $this->createMock(ilDBStatement::class);
 
+        $consecutive = ['FROM osc_activity', 'FROM osc_messages'];
         $db->expects($this->exactly(2))
             ->method('queryF')
-            ->withConsecutive(
-                [$this->stringContains('FROM osc_activity'), $this->isType('array'), $this->isType('array')],
-                [$this->stringContains('FROM osc_messages'), $this->isType('array'), $this->isType('array')]
+            ->with(
+                $this->callback(function ($value) use (&$consecutive) {
+                    $this->assertStringContainsString(array_shift($consecutive), $value);
+                    return true;
+                }),
+                $this->isType('array'),
+                $this->isType('array')
             )
             ->willReturn($resultMock);
 

--- a/components/ILIAS/TermsOfService/tests/UserSettingsTest.php
+++ b/components/ILIAS/TermsOfService/tests/UserSettingsTest.php
@@ -76,7 +76,13 @@ class UserSettingsTest extends TestCase
         $return_date = new DateTimeImmutable();
 
         $by_trying = $this->mock(ByTrying::class);
-        $by_trying->expects(self::exactly(2))->method('transform')->withConsecutive(['agree date'], [$date])->willReturnOnConsecutiveCalls($return_date, 'another date');
+        $consecutive = [$date, 'agree date'];
+        $by_trying->expects(self::exactly(2))->method('transform')->with(
+            $this->callback(function ($value) use (&$consecutive) {
+                $this->assertSame(array_shift($consecutive), $value);
+                return true;
+            })
+        )->willReturnOnConsecutiveCalls($return_date, 'another date');
 
         $user = $this->mock(ilObjUser::class);
         $user->expects(self::once())->method('getAgreeDate')->willReturn('agree date');


### PR DESCRIPTION
This removes the usage of the outdated function `withConsecutive` from the following components:
- components/ILIAS/Authentication/tests
- components/ILIAS/Badge/tests
- components/ILIAS/Certificate/tests
- components/ILIAS/Cron/tests
- components/ILIAS/DataProtection/tests
- components/ILIAS/Forum/tests
- components/ILIAS/LegalDocuments/tests
- components/ILIAS/Mail/tests
- components/ILIAS/OnScreenChat/tests
- components/ILIAS/TermsOfService/tests

Further this resolves the following Issues:
- https://mantis.ilias.de/view.php?id=41314 by removing the call limit at all.
- https://mantis.ilias.de/view.php?id=41316 by changing the expected value withing the mock.