### PR TITLE
Fix mock order of calls

### DIFF
--- a/components/ILIAS/TermsOfService/tests/UserSettingsTest.php
+++ b/components/ILIAS/TermsOfService/tests/UserSettingsTest.php
@@ -76,7 +76,7 @@ class UserSettingsTest extends TestCase
         $return_date = new DateTimeImmutable();
 
         $by_trying = $this->mock(ByTrying::class);
-        $consecutive = [$date, 'agree date'];
+        $consecutive = ['agree date', $date];
         $by_trying->expects(self::exactly(2))->method('transform')->with(
             $this->callback(function ($value) use (&$consecutive) {
                 $this->assertSame(array_shift($consecutive), $value);


### PR DESCRIPTION
Fixing a bug withing the order caused in the restoration of tests: https://github.com/ILIAS-eLearning/ILIAS/pull/7465