### PR TITLE
[FEATURE] UI: simplify component renderers

### DIFF
--- a/components/ILIAS/UI/README.md
+++ b/components/ILIAS/UI/README.md
@@ -234,18 +234,17 @@ If you would like to implement a new component for the framework, you should per
         /**
          * @inheritdocs
          */
-        public function render(Component\Component $component, RendererInterface $default_renderer) {
-            $this->checkComponent($component);
+        public function render(Component\Component $component, RendererInterface $default_renderer): string 
+        {
+            // if this is not our component, call cannotHandleComponent($component)
+            // to throw a unified exception. 
+            if (!$component instanceof Component\Demo\Demo) {
+                $this->cannotHandleComponent($component);
+            }
+    
             $tpl = $this->getTemplate("tpl.demo.html", true, true);
             $tpl->setVariable("CONTENT",$component->getContent());
             return $tpl->get();
-        }
-
-        /**
-         * @inheritdocs
-         */
-        protected function getComponentInterfaceName() {
-            return array(Component\Demo\Demo::class);
         }
     }
     ```

--- a/components/ILIAS/UI/src/Implementation/Component/Breadcrumbs/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Breadcrumbs/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Breadcrumbs;
 
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
@@ -31,7 +31,9 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
+        if (!$component instanceof Component\Breadcrumbs\Breadcrumbs) {
+            $this->cannotHandleComponent($component);
+        }
 
         $tpl = $this->getTemplate("tpl.breadcrumbs.html", true, true);
 
@@ -43,13 +45,5 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Component\Breadcrumbs\Breadcrumbs::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Button/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Button/Renderer.php
@@ -34,8 +34,6 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Component\Button\Close) {
             return $this->renderClose($component);
         } elseif ($component instanceof Component\Button\Minimize) {
@@ -44,12 +42,10 @@ class Renderer extends AbstractComponentRenderer
             return $this->renderToggle($component);
         } elseif ($component instanceof Component\Button\Month) {
             return $this->renderMonth($component);
-        } else {
-            /**
-             * @var $component Component\Button\Button
-             */
+        } elseif ($component instanceof Component\Button\Button) {
             return $this->renderButton($component, $default_renderer);
         }
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderButton(Component\Button\Button $component, RendererInterface $default_renderer): string
@@ -356,22 +352,5 @@ class Renderer extends AbstractComponentRenderer
                 $tpl->parseCurrentBlock();
             }
         }
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Component\Button\Primary::class
-        , Component\Button\Standard::class
-        , Component\Button\Close::class
-        , Component\Button\Minimize::class
-        , Component\Button\Shy::class
-        , Component\Button\Month::class
-        , Component\Button\Tag::class
-        , Component\Button\Bulky::class
-        , Component\Button\Toggle::class
-        );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Card/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Card/Renderer.php
@@ -35,10 +35,10 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var Component\Card\Card $component
-         */
-        $this->checkComponent($component);
+        if (!$component instanceof Component\Card\Card) {
+            $this->cannotHandleComponent($component);
+        }
+
         $tpl = $this->getTemplate("tpl.card.html", true, true);
 
         $title = $component->getTitle();
@@ -79,7 +79,7 @@ class Renderer extends AbstractComponentRenderer
 
         if ($component->getImage()) {
             $tpl->setVariable("IMAGE", $default_renderer->render(
-                $component->getImage()->withAlt($this->txt("open")." ".strip_tags($image_alt))
+                $component->getImage()->withAlt($this->txt("open") . " " . strip_tags($image_alt))
             ));
         }
 
@@ -123,13 +123,5 @@ class Renderer extends AbstractComponentRenderer
         }
 
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdocs
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Component\Card\Card::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Chart/Bar/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Chart/Bar/Renderer.php
@@ -34,24 +34,13 @@ class Renderer extends AbstractComponentRenderer
 {
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var Bar\Bar $component
-         */
-        $this->checkComponent($component);
-
         if ($component instanceof Bar\Horizontal) {
-            /**
-             * @var Bar\Horizontal $component
-             */
             return $this->renderHorizontal($component, $default_renderer);
         } elseif ($component instanceof Bar\Vertical) {
-            /**
-             * @var Bar\Vertical $component
-             */
             return $this->renderVertical($component, $default_renderer);
         }
 
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderHorizontal(
@@ -418,10 +407,5 @@ class Renderer extends AbstractComponentRenderer
         parent::registerResources($registry);
         $registry->register('assets/js/chart.umd.js');
         $registry->register('assets/js/bar.js');
-    }
-
-    protected function getComponentInterfaceName(): array
-    {
-        return [Bar\Bar::class];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Chart/ProgressMeter/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Chart/ProgressMeter/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Chart\ProgressMeter;
 
@@ -36,27 +36,15 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var Component\Chart\ProgressMeter\ProgressMeter $component
-         */
-        $this->checkComponent($component);
-
         if ($component instanceof Component\Chart\ProgressMeter\FixedSize) {
-            /**
-             * @var Component\Chart\ProgressMeter\FixedSize $component
-             */
             return $this->renderFixedSize($component);
         } elseif ($component instanceof Mini) {
-            /**
-             * @var Mini $component
-             */
             return $this->renderMini($component);
-        } else {
-            /**
-             * @var Component\Chart\ProgressMeter\Standard $component
-             */
+        } elseif ($component instanceof Component\Chart\ProgressMeter\Standard) {
             return $this->renderStandard($component);
         }
+
+        $this->cannotHandleComponent($component);
     }
 
     /**
@@ -238,13 +226,5 @@ class Renderer extends AbstractComponentRenderer
     protected function getIsReached($a_val, $b_val): bool
     {
         return ($a_val >= $b_val);
-    }
-
-    /**
-     * @inheritdocs
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [Component\Chart\ProgressMeter\ProgressMeter::class];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Chart/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Chart/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Chart;
 
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
@@ -31,7 +31,9 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
+        if (!$component instanceof Component\Chart\ScaleBar) {
+            $this->cannotHandleComponent($component);
+        }
 
         $tpl = $this->getTemplate("tpl.scale_bar.html", true, true);
 
@@ -57,13 +59,5 @@ class Renderer extends AbstractComponentRenderer
         }
 
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdocs
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Component\Chart\ScaleBar::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Counter/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Counter/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Counter;
 
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
@@ -32,7 +32,9 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
+        if (!$component instanceof Component\Counter\Counter) {
+            $this->cannotHandleComponent($$component);
+        }
 
         $tpl = $this->getTemplate("tpl.counter.html", true, true);
         if ($component->getNumber() === 0) {
@@ -51,13 +53,5 @@ class Renderer extends AbstractComponentRenderer
     {
         parent::registerResources($registry);
         $registry->register('assets/js/counter.js');
-    }
-
-    /**
-     * @inheritdocs
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Component\Counter\Counter::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Deck/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Deck/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Deck;
 
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
@@ -32,6 +32,10 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
+        if (!$component instanceof Component\Deck\Deck) {
+            $this->cannotHandleComponent($component);
+        }
+
         $tpl_card = $this->getTemplate("tpl.deck_card.html", true, true);
         $tpl_row = $this->getTemplate("tpl.deck_row.html", true, true);
 
@@ -55,13 +59,5 @@ class Renderer extends AbstractComponentRenderer
         $tpl_row->setCurrentBlock("row");
         $tpl_row->setVariable("CARDS", $content);
         $tpl_row->parseCurrentBlock();
-    }
-
-    /**
-     * @inheritdocs
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Component\Deck\Deck::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Divider/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Divider/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Divider;
 
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
@@ -31,15 +31,13 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Component\Divider\Horizontal) {
             return $this->renderDividerHorizontal($component);
         }
         if ($component instanceof Component\Divider\Vertical) {
             return $this->renderDividerVertical();
         }
-        return "";
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderDividerHorizontal(Component\Divider\Horizontal $component): string
@@ -67,16 +65,5 @@ class Renderer extends AbstractComponentRenderer
         $tpl->touchBlock("divider");
 
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Divider\Horizontal::class,
-            Component\Divider\Vertical::class
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Dropdown/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Dropdown/Renderer.php
@@ -34,12 +34,11 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
+        if ($component instanceof Component\Dropdown\Dropdown) {
+            return $this->renderDropdown($component, $default_renderer);
+        }
 
-        /**
-         * @var $component Dropdown
-         */
-        return $this->renderDropdown($component, $default_renderer);
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderDropdown(Dropdown $component, RendererInterface $default_renderer): string
@@ -114,13 +113,5 @@ class Renderer extends AbstractComponentRenderer
     {
         parent::registerResources($registry);
         $registry->register('assets/js/dropdown.js');
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Component\Dropdown\Standard::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Dropzone/File/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Dropzone/File/Renderer.php
@@ -37,15 +37,13 @@ class Renderer extends AbstractComponentRenderer
 {
     public function render(Component $component, RenderInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof \ILIAS\UI\Component\Dropzone\File\Wrapper) {
             return $this->renderWrapper($component, $default_renderer);
         }
         if ($component instanceof \ILIAS\UI\Component\Dropzone\File\Standard) {
             return $this->renderStandard($component, $default_renderer);
         }
-        throw new LogicException("Cannot render '" . get_class($component) . "'");
+        $this->cannotHandleComponent($component);
     }
 
     public function registerResources(ResourceRegistry $registry): void
@@ -122,13 +120,5 @@ class Renderer extends AbstractComponentRenderer
     protected function bindAndApplyJavaScript(FileInterface $dropzone, Template $template): void
     {
         $template->setVariable('ID', $this->bindJavaScript($dropzone));
-    }
-
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            \ILIAS\UI\Component\Dropzone\File\Standard::class,
-            \ILIAS\UI\Component\Dropzone\File\Wrapper::class,
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Entity/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Entity/Renderer.php
@@ -34,8 +34,10 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-        return $this->renderEntity($component, $default_renderer);
+        if ($component instanceof Component\Entity\Entity) {
+            return $this->renderEntity($component, $default_renderer);
+        }
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderEntity(Entity $component, RendererInterface $default_renderer): string
@@ -90,15 +92,5 @@ class Renderer extends AbstractComponentRenderer
         }
 
         return $default_renderer->render($values);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Entity\Standard::class
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Image/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Image/Renderer.php
@@ -36,10 +36,10 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var Component\Image\Image $component
-         */
-        $this->checkComponent($component);
+        if (!$component instanceof Component\Image\Image) {
+            $this->cannotHandleComponent($component);
+        }
+
         $tpl = $this->getTemplate("tpl.image.html", true, true);
 
         if (($sources = $component->getAdditionalHighResSources()) !== []) {
@@ -91,14 +91,6 @@ class Renderer extends AbstractComponentRenderer
         }
 
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdocs
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [Component\Image\Image::class];
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Filter/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Filter/Renderer.php
@@ -36,13 +36,11 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Filter\Standard) {
             return $this->renderStandard($component, $default_renderer);
         }
 
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
     /**
@@ -242,13 +240,5 @@ class Renderer extends AbstractComponentRenderer
         $input_group = $input_group->withOnUpdate($component->getUpdateSignal());
 
         $tpl->setVariable("INPUTS", $default_renderer->render($input_group));
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Filter\Standard::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Renderer.php
@@ -34,8 +34,6 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Form\Standard) {
             return $this->renderStandard($component, $default_renderer);
         }
@@ -44,7 +42,7 @@ class Renderer extends AbstractComponentRenderer
             return $this->renderNoSubmit($component, $default_renderer);
         }
 
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderStandard(Form\Standard $component, RendererInterface $default_renderer): string
@@ -129,16 +127,5 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable("TXT_REQUIRED_TOP", $this->txt("required_field"));
             $tpl->setVariable("TXT_REQUIRED", $this->txt("required_field"));
         }
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Input\Container\Form\Standard::class,
-            FormWithoutSubmitButton::class,
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/ViewControl/Renderer.php
@@ -36,8 +36,6 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof ViewControl\Standard) {
             if (!$component->getRequest()) {
                 throw new LogicException("No request was passed to the container. Please call 'withRequest' on the Container.");
@@ -45,7 +43,7 @@ class Renderer extends AbstractComponentRenderer
             return $this->renderStandard($component, $default_renderer);
         }
 
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
 
@@ -112,15 +110,5 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable("INPUTS", $default_renderer->render($inputs));
         $tpl->setVariable('ID', $id);
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Input\Container\ViewControl\Standard::class
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FilterContextRenderer.php
@@ -38,14 +38,12 @@ use ILIAS\UI\Component\Input\Container\Form\FormInput;
  */
 class FilterContextRenderer extends Renderer
 {
+    /**
+     * @inheritdoc
+     */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var $component FilterInput
-         */
-        $this->checkComponent($component);
-
-        if (!$component instanceof F\Group || $component instanceof F\Duration) {
+        if ($component instanceof FilterInput) {
             $component = $this->setSignals($component);
         }
 
@@ -72,7 +70,7 @@ class FilterContextRenderer extends Renderer
                 return $this->renderDateTimeField($component, $default_renderer);
 
             default:
-                throw new LogicException("Cannot render '" . get_class($component) . "'");
+                $this->cannotHandleComponent($component);
         }
     }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -85,11 +85,6 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var $component Input
-         */
-        $this->checkComponent($component);
-
         $component = $this->setSignals($component);
 
         switch (true) {
@@ -158,7 +153,7 @@ class Renderer extends AbstractComponentRenderer
                 return $this->renderRatingField($component, $default_renderer);
 
             default:
-                throw new LogicException("Cannot render '" . get_class($component) . "'");
+                $this->cannotHandleComponent($component);
         }
     }
 
@@ -894,36 +889,6 @@ class Renderer extends AbstractComponentRenderer
             }
         }
         return $ret;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Input\Field\Text::class,
-            Component\Input\Field\Numeric::class,
-            Component\Input\Field\Group::class,
-            Component\Input\Field\OptionalGroup::class,
-            Component\Input\Field\SwitchableGroup::class,
-            Component\Input\Field\Section::class,
-            Component\Input\Field\Checkbox::class,
-            Component\Input\Field\Tag::class,
-            Component\Input\Field\Password::class,
-            Component\Input\Field\Select::class,
-            Component\Input\Field\Radio::class,
-            Component\Input\Field\Textarea::class,
-            Component\Input\Field\MultiSelect::class,
-            Component\Input\Field\DateTime::class,
-            Component\Input\Field\Duration::class,
-            Component\Input\Field\File::class,
-            Component\Input\Field\Url::class,
-            Component\Input\Field\Hidden::class,
-            Component\Input\Field\ColorPicker::class,
-            Component\Input\Field\Markdown::class,
-            Component\Input\Field\Rating::class,
-        ];
     }
 
     protected function renderFilePreview(

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
@@ -36,7 +36,6 @@ class Renderer extends AbstractComponentRenderer
 
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
         switch (true) {
             case ($component instanceof FieldSelection):
                 return $this->renderFieldSelection($component, $default_renderer);
@@ -50,19 +49,8 @@ class Renderer extends AbstractComponentRenderer
                 return '';
 
             default:
-                throw new LogicException("Cannot render '" . get_class($component) . "'");
+                $this->cannotHandleComponent($component);
         }
-    }
-
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Input\ViewControl\FieldSelection::class,
-            Component\Input\ViewControl\Sortation::class,
-            Component\Input\ViewControl\Pagination::class,
-            Component\Input\ViewControl\Group::class,
-            Component\Input\ViewControl\NullControl::class,
-        ];
     }
 
     protected function renderFieldSelection(FieldSelection $component, RendererInterface $default_renderer): string

--- a/components/ILIAS/UI/src/Implementation/Component/Item/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Item/Renderer.php
@@ -39,8 +39,6 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Notification) {
             return $this->renderNotification($component, $default_renderer);
         } elseif ($component instanceof Group) {
@@ -50,7 +48,7 @@ class Renderer extends AbstractComponentRenderer
         } elseif ($component instanceof Shy) {
             return $this->renderShy($component, $default_renderer);
         }
-        return "";
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderGroup(Group $component, RendererInterface $default_renderer): string
@@ -364,18 +362,5 @@ class Renderer extends AbstractComponentRenderer
     {
         parent::registerResources($registry);
         $registry->register('assets/js/notification.js');
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Standard::class,
-            Shy::class,
-            Group::class,
-            Notification::class
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Launcher/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Launcher/Renderer.php
@@ -28,11 +28,10 @@ class Renderer extends AbstractComponentRenderer
 {
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
         if ($component instanceof Inline) {
             return $this->renderInline($component, $default_renderer);
         }
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
     public function renderInline(Inline $component, RendererInterface $default_renderer): string
@@ -66,7 +65,7 @@ class Renderer extends AbstractComponentRenderer
         }
 
         if (!$launchable) {
-            $start_button =$start_button->withUnavailableAction();
+            $start_button = $start_button->withUnavailableAction();
         }
         if ($status_icon = $component->getStatusIcon()) {
             $tpl->setVariable("STATUS_ICON", $default_renderer->render($status_icon));
@@ -78,12 +77,5 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable("BUTTON", $default_renderer->render($start_button));
 
         return $tpl->get();
-    }
-
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Inline::class
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Layout/Alignment/Horizontal/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Layout/Alignment/Horizontal/Renderer.php
@@ -34,7 +34,6 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
         switch(true) {
             case ($component instanceof Component\Layout\Alignment\Horizontal\EvenlyDistributed):
                 return $this->renderAlignment($component, 'alignment_horizontal_evenly', $default_renderer);
@@ -42,7 +41,7 @@ class Renderer extends AbstractComponentRenderer
                 return $this->renderAlignment($component, 'alignment_horizontal_dynamic', $default_renderer);
 
             default:
-                throw new \LogicException("Cannot render: " . get_class($component));
+                $this->cannotHandleComponent($component);
         }
     }
 
@@ -59,16 +58,5 @@ class Renderer extends AbstractComponentRenderer
         }
         $tpl->touchBlock($alignment_type);
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Layout\Alignment\Horizontal\EvenlyDistributed::class,
-            Component\Layout\Alignment\Horizontal\DynamicallyDistributed::class
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Layout/Alignment/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Layout/Alignment/Renderer.php
@@ -34,13 +34,12 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
         switch(true) {
             case ($component instanceof Component\Layout\Alignment\Vertical):
                 return $this->renderAlignment($component, $default_renderer);
 
             default:
-                throw new \LogicException("Cannot render: " . get_class($component));
+                $this->cannotHandleComponent($component);
         }
     }
 
@@ -56,15 +55,5 @@ class Renderer extends AbstractComponentRenderer
         }
         $tpl->touchBlock('alignment_vertical');
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Layout\Alignment\Vertical::class,
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Layout/Page/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Layout/Page/Renderer.php
@@ -39,13 +39,11 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Component\Layout\Page\Standard) {
             return $this->renderStandardPage($component, $default_renderer);
         }
 
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderStandardPage(
@@ -205,15 +203,5 @@ class Renderer extends AbstractComponentRenderer
     {
         parent::registerResources($registry);
         $registry->register('assets/js/stdpage.js');
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(
-            Component\Layout\Page\Standard::class
-        );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Legacy/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Legacy/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Legacy;
 
@@ -35,22 +35,13 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var Legacy $component
-         */
-        $this->checkComponent($component);
+        if (!$component instanceof Component\Legacy\Legacy) {
+            $this->cannotHandleComponent($component);
+        }
 
         $component = $this->registerSignals($component);
         $this->bindJavaScript($component);
         return $component->getContent();
-    }
-
-    /**
-     * @inheritdocs
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [Component\Legacy\Legacy::class];
     }
 
     protected function registerSignals(Legacy $component): Component\JavaScriptBindable

--- a/components/ILIAS/UI/src/Implementation/Component/Link/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Link/Renderer.php
@@ -34,15 +34,13 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Component\Link\Standard) {
             return $this->renderStandard($component);
         }
         if ($component instanceof Component\Link\Bulky) {
             return $this->renderBulky($component, $default_renderer);
         }
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
     protected function setStandardVars(
@@ -120,16 +118,5 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
         return $this->maybeRenderWithTooltip($component, $tpl);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Link\Standard::class,
-            Component\Link\Bulky::class
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/CharacteristicValue/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/CharacteristicValue/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Listing\CharacteristicValue;
 
@@ -35,23 +35,13 @@ class Renderer extends AbstractComponentRenderer
     /**
      * @inheritdocs
      */
-    protected function getComponentInterfaceName(): array
-    {
-        return [Text::class];
-    }
-
-    /**
-     * @inheritdocs
-     */
     public function render(Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Text) {
             return $this->render_text($component);
         }
 
-        return '';
+        $this->cannotHandleComponent($component);
     }
 
     private function render_text(Text $component): string

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/Entity/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/Entity/Renderer.php
@@ -33,8 +33,10 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-        return $this->renderEntityListing($component, $default_renderer);
+        if ($component instanceof Component\Listing\Entity\EntityListing) {
+            return $this->renderEntityListing($component, $default_renderer);
+        }
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderEntityListing(EntityListing $component, RendererInterface $default_renderer): string
@@ -49,15 +51,5 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Listing\Entity\Standard::class
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/Renderer.php
@@ -35,11 +35,6 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var Component\Listing\Listing $component
-         */
-        $this->checkComponent($component);
-
         if ($component instanceof Component\Listing\Descriptive) {
             return $this->render_descriptive($component, $default_renderer);
         }
@@ -48,7 +43,11 @@ class Renderer extends AbstractComponentRenderer
             return $this->renderProperty($component, $default_renderer);
         }
 
-        return $this->render_simple($component, $default_renderer);
+        if ($component instanceof Component\Listing\Listing) {
+            return $this->render_simple($component, $default_renderer);
+        }
+
+        $this->cannotHandleComponent($component);
     }
 
     protected function render_descriptive(
@@ -121,13 +120,5 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdocs
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [Component\Listing\Listing::class];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Listing/Workflow/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Listing/Workflow/Renderer.php
@@ -33,12 +33,10 @@ class Renderer extends AbstractComponentRenderer
 {
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Linear) {
             return $this->render_linear($component, $default_renderer);
         }
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
     protected function render_linear(Linear $component, RendererInterface $default_renderer): string
@@ -104,12 +102,5 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
         return $tpl->get();
-    }
-
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Listing\Workflow\Workflow::class
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
@@ -48,8 +48,6 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof MainBar) {
             return $this->renderMainbar($component, $default_renderer);
         }
@@ -65,7 +63,7 @@ class Renderer extends AbstractComponentRenderer
         if ($component instanceof Component\MainControls\SystemInfo) {
             return $this->renderSystemInfo($component, $default_renderer);
         }
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
     protected function calculateMainBarTreePosition($pos, $slate)
@@ -460,19 +458,5 @@ class Renderer extends AbstractComponentRenderer
         $registry->register('assets/js/maincontrols.min.js');
         $registry->register('assets/js/GS.js');
         $registry->register('assets/js/system_info.js');
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(
-            MetaBar::class,
-            MainBar::class,
-            Footer::class,
-            ModeInfo::class,
-            Component\MainControls\SystemInfo::class
-        );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Renderer.php
@@ -30,7 +30,10 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
+        if (!$component instanceof ISlate\Slate) {
+            $this->cannotHandleComponent($component);
+        }
+
         switch (true) {
             case ($component instanceof ISlate\Notification):
                 return $this->renderNotificationSlate($component, $default_renderer);
@@ -175,18 +178,5 @@ class Renderer extends AbstractComponentRenderer
     {
         parent::registerResources($registry);
         $registry->register('assets/js/maincontrols.min.js');
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(
-            ISlate\Legacy::class,
-            ISlate\Combined::class,
-            ISlate\Notification::class,
-            ISlate\Drilldown::class
-        );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Menu/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Menu/Renderer.php
@@ -37,13 +37,14 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Menu\Drilldown) {
             return $this->renderDrilldownMenu($component, $default_renderer);
         }
+        if ($component instanceof Menu\Menu) {
+            return $this->renderStandardMenu($component, $default_renderer);
+        }
 
-        return $this->renderStandardMenu($component, $default_renderer);
+        $this->cannotHandleComponent($component);
     }
 
     /**
@@ -130,15 +131,5 @@ class Renderer extends AbstractComponentRenderer
     {
         parent::registerResources($registry);
         $registry->register('assets/js/drilldown.js');
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(
-            Menu\Menu::class
-        );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/MessageBox/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MessageBox/Renderer.php
@@ -35,12 +35,11 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $ui_fac = $this->getUIFactory();
+        if (!$component instanceof Component\MessageBox\MessageBox) {
+            $this->cannotHandleComponent($component);
+        }
 
-        /**
-         * @var Component\MessageBox\MessageBox $component
-         */
-        $this->checkComponent($component);
+        $ui_fac = $this->getUIFactory();
         $tpl = $this->getTemplate("tpl.messagebox.html", true, true);
 
         $buttons = $component->getButtons();
@@ -75,10 +74,5 @@ class Renderer extends AbstractComponentRenderer
         $tpl->parseCurrentBlock();
 
         return $tpl->get();
-    }
-
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Component\MessageBox\MessageBox::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Modal/InterruptiveItem/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Modal/InterruptiveItem/Renderer.php
@@ -31,15 +31,12 @@ class Renderer extends AbstractComponentRenderer
         Component $component,
         RendererInterface $default_renderer
     ): string {
-        $this->checkComponent($component);
-
         if ($component instanceof ItemInterface\Standard) {
             return $this->renderStandard($component, $default_renderer);
         } elseif ($component instanceof ItemInterface\KeyValue) {
             return $this->renderKeyValue($component, $default_renderer);
-        } else {
-            return '';
         }
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderStandard(
@@ -75,13 +72,5 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable('ITEM_VALUE', $component->getValue());
         $tpl->setVariable('ITEM_ID', $component->getId());
         return $tpl->get();
-    }
-
-    protected function getComponentInterfaceName(): array
-    {
-        return array(
-            ItemInterface\Standard::class,
-            ItemInterface\KeyValue::class
-        );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Modal/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Modal/Renderer.php
@@ -40,11 +40,12 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
+        if (!$component instanceof Component\Modal\Modal) {
+            $this->cannotHandleComponent($component);
+        }
 
         // If the modal is rendered async, we just create a fake container which will be
         // replaced by the modal upon successful ajax request
-        /** @var Modal $component */
         if ($component->getAsyncRenderUrl()) {
             return $this->renderAsync($component);
         }
@@ -56,7 +57,7 @@ class Renderer extends AbstractComponentRenderer
         } elseif ($component instanceof Component\Modal\Lightbox) {
             return $this->renderLightbox($component, $default_renderer);
         }
-        throw new \LogicException(self::class . " cannot render component '" . get_class($component) . "'.");
+        $this->cannotHandleComponent($component);
     }
 
     /**
@@ -258,18 +259,6 @@ class Renderer extends AbstractComponentRenderer
         }
         $tpl->setVariable('ID_CAROUSEL4', $id_carousel);
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(
-            Component\Modal\Interruptive::class,
-            Component\Modal\RoundTrip::class,
-            Component\Modal\Lightbox::class,
-        );
     }
 
     private function renderPage(LightboxPage $page, bool $first, Template $tpl, RendererInterface $default_renderer): void

--- a/components/ILIAS/UI/src/Implementation/Component/Panel/Listing/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Panel/Listing/Renderer.php
@@ -33,12 +33,10 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(C\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof C\Panel\Listing\Standard) {
             return $this->renderStandard($component, $default_renderer);
         }
-        return '';
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderStandard(C\Panel\Listing\Listing $component, RendererInterface $default_renderer): string
@@ -83,13 +81,5 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
         return $tpl;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(C\Panel\Listing\Standard::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Panel/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Panel/Renderer.php
@@ -35,26 +35,14 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var Component\Panel\Panel $component
-         */
-        $this->checkComponent($component);
-
         if ($component instanceof Component\Panel\Standard) {
-            /**
-             * @var Component\Panel\Standard $component
-             */
             return $this->renderStandard($component, $default_renderer);
         } elseif ($component instanceof Component\Panel\Sub) {
-            /**
-             * @var Component\Panel\Sub $component
-             */
             return $this->renderSub($component, $default_renderer);
+        } elseif ($component instanceof Component\Panel\Report) {
+            return $this->renderReport($component, $default_renderer);
         }
-        /**
-         * @var Component\Panel\Report $component
-         */
-        return $this->renderReport($component, $default_renderer);
+        $this->cannotHandleComponent($component);
     }
 
     protected function getContentAsString(Component\Component $component, RendererInterface $default_renderer): string
@@ -129,13 +117,5 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable("TITLE", $component->getTitle());
         $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdocs
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [Component\Panel\Panel::class];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Panel/Secondary/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Panel/Secondary/Renderer.php
@@ -33,14 +33,12 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(C\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof C\Panel\Secondary\Listing) {
             return $this->renderListing($component, $default_renderer);
         } elseif ($component instanceof C\Panel\Secondary\Legacy) {
             return $this->renderLegacy($component, $default_renderer);
         }
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderListing(C\Panel\Secondary\Listing $component, RendererInterface $default_renderer): string
@@ -117,13 +115,5 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
         return $tpl;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(C\Panel\Secondary\Listing::class, C\Panel\Secondary\Secondary::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Player/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Player/Renderer.php
@@ -32,18 +32,13 @@ class Renderer extends AbstractComponentRenderer
 {
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var Component\Player\Player $component
-         */
-        $this->checkComponent($component);
-
         if ($component instanceof Component\Player\Audio) {
             return $this->renderAudio($component, $default_renderer);
         }
         if ($component instanceof Component\Player\Video) {
             return $this->renderVideo($component, $default_renderer);
         }
-        return "";
+        $this->cannotHandleComponent($component);
     }
 
     public function renderAudio(Component\Component $component, RendererInterface $default_renderer): string
@@ -112,10 +107,5 @@ class Renderer extends AbstractComponentRenderer
         $registry->register('./assets/js/mediaelement-and-player.min.js');
         $registry->register('./assets/css/mediaelementplayer.min.css');
         $registry->register('./assets/js/vimeo.min.js');
-    }
-
-    protected function getComponentInterfaceName(): array
-    {
-        return [Component\Player\Player::class];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Avatar/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Avatar/Renderer.php
@@ -28,7 +28,10 @@ class Renderer extends AbstractComponentRenderer
 {
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
+        if (!$component instanceof Component\Symbol\Avatar\Avatar) {
+            $this->cannotHandleComponent($component);
+        }
+
         $tpl = null;
 
         $label = $this->convertSpecialCharacters($component->getLabel());
@@ -53,13 +56,5 @@ class Renderer extends AbstractComponentRenderer
         }
 
         return $tpl->get();
-    }
-
-    protected function getComponentInterfaceName(): array
-    {
-        return array(
-            Component\Symbol\Avatar\Letter::class,
-            Component\Symbol\Avatar\Picture::class,
-        );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Renderer.php
@@ -39,10 +39,9 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var $component Glyph
-         */
-        $this->checkComponent($component);
+        if (!$component instanceof Component\Symbol\Glyph\Glyph) {
+            $this->cannotHandleComponent($component);
+        }
 
         $tpl_file = $this->getTemplateFilename();
         $tpl = $this->getTemplate($tpl_file, true, true);
@@ -119,13 +118,5 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
         return $tpl->get();
-    }
-
-    /**
-     * @inheritdocs
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Component\Symbol\Glyph\Glyph::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Icon/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Icon/Renderer.php
@@ -35,10 +35,10 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        /**
-         * @var Component\Symbol\Icon\Icon $component
-         */
-        $this->checkComponent($component);
+        if (!$component instanceof Component\Symbol\Icon\Icon) {
+            $this->cannotHandleComponent($component);
+        }
+
         $tpl = $this->getTemplate("tpl.icon.html", true, true);
 
         $id = $this->bindJavaScript($component);
@@ -109,13 +109,5 @@ class Renderer extends AbstractComponentRenderer
         }
 
         return $this->getImagePathResolver()->resolveImagePath($icon_path_name);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(Component\Symbol\Icon\Icon::class);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -39,7 +39,6 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
         if ($component instanceof Component\Table\Presentation) {
             return $this->renderPresentationTable($component, $default_renderer);
         }
@@ -60,7 +59,7 @@ class Renderer extends AbstractComponentRenderer
         if ($component instanceof Component\Table\OrderingRow) {
             return $this->renderOrderingRow($component, $default_renderer);
         }
-        throw new \LogicException(self::class . " cannot render component '" . get_class($component) . "'.");
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderPresentationTable(
@@ -706,20 +705,5 @@ class Renderer extends AbstractComponentRenderer
             "$(document).on('$close', function() { il.UI.table.presentation.get('$table_id').collapseRow('$id'); return false; });" .
             "$(document).on('$toggle', function() { il.UI.table.presentation.get('$table_id').toggleRow('$id'); return false; });"
         );
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Table\PresentationRow::class,
-            Component\Table\Presentation::class,
-            Component\Table\Data::class,
-            Component\Table\DataRow::class,
-            Component\Table\Ordering::class,
-            Component\Table\OrderingRow::class,
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Toast/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Toast/Renderer.php
@@ -35,8 +35,6 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Component\Toast\Toast) {
             return $this->renderToast($component, $default_renderer);
         }
@@ -44,7 +42,7 @@ class Renderer extends AbstractComponentRenderer
             return $this->renderContainer($component, $default_renderer);
         }
 
-        throw new LogicException("Cannot render: " . get_class($component));
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderToast(Component\Toast\Toast $component, RendererInterface $default_renderer): string
@@ -105,16 +103,5 @@ class Renderer extends AbstractComponentRenderer
     {
         parent::registerResources($registry);
         $registry->register('assets/js/toast.js');
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Toast\Toast::class,
-            Component\Toast\Container::class
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Tree/Node/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Tree/Node/Renderer.php
@@ -34,7 +34,9 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
+        if (!$component instanceof Node\Node) {
+            $this->cannotHandleComponent($component);
+        }
 
         $tpl_name = "tpl.node.html";
         $tpl = $this->getTemplate($tpl_name, true, true);
@@ -155,17 +157,5 @@ class Renderer extends AbstractComponentRenderer
 
 				return false;
 			});");
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(
-            Node\Simple::class,
-            Node\Bylined::class,
-            Node\KeyValue::class
-        );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Tree/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Tree/Renderer.php
@@ -33,11 +33,9 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
-        /**
-         * @var $component Tree\Expandable
-         */
+        if (!$component instanceof Tree\Expandable) {
+            $this->cannotHandleComponent($component);
+        }
 
         $tpl_name = "tpl.tree.html";
         $tpl = $this->getTemplate($tpl_name, true, true);
@@ -104,15 +102,5 @@ class Renderer extends AbstractComponentRenderer
     {
         parent::registerResources($registry);
         $registry->register('assets/js/tree.js');
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(
-            Tree\Expandable::class
-        );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
@@ -38,8 +38,6 @@ class Renderer extends AbstractComponentRenderer
 
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        $this->checkComponent($component);
-
         if ($component instanceof Component\ViewControl\Mode) {
             return $this->renderMode($component, $default_renderer);
         }
@@ -52,7 +50,7 @@ class Renderer extends AbstractComponentRenderer
         if ($component instanceof Component\ViewControl\Pagination) {
             return $this->renderPagination($component, $default_renderer);
         }
-        throw new LogicException("Component '{$component->getCanonicalName()}' isn't supported by this renderer.");
+        $this->cannotHandleComponent($component);
     }
 
     protected function renderMode(Component\ViewControl\Mode $component, RendererInterface $default_renderer): string
@@ -389,18 +387,5 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setCurrentBlock($block);
         $tpl->setVariable($template_var, $id);
         $tpl->parseCurrentBlock();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return array(
-            Component\ViewControl\Mode::class,
-            Component\ViewControl\Section::class,
-            Component\ViewControl\Sortation::class,
-            Component\ViewControl\Pagination::class
-        );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Render/AbstractComponentRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Render/AbstractComponentRenderer.php
@@ -31,6 +31,7 @@ use ilLanguage;
 use InvalidArgumentException;
 use LogicException;
 use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
+use ILIAS\UI\Renderer;
 
 /**
  * Base class for all component renderers.
@@ -242,39 +243,19 @@ abstract class AbstractComponentRenderer implements ComponentRenderer, HelpTextR
     }
 
     /**
-     * Check if a given component fits this renderer and throw \LogicError if that is not
-     * the case.
-     *
-     * @throws	LogicException		if component does not fit.
+     * This method MUST be called by derived component renderers, if @see ComponentRenderer::render()
+     * cannot handle the provided component.
      */
-    final protected function checkComponent(Component $component): void
+    final protected function cannotHandleComponent(Component $component): never
     {
-        $interfaces = $this->getComponentInterfaceName();
-        if (!is_array($interfaces)) {
-            throw new LogicException(
-                "Expected array, found '" . (string) (null) . "' when rendering."
-            );
-        }
-
-        foreach ($interfaces as $interface) {
-            if ($component instanceof $interface) {
-                return;
-            }
-        }
-        $ifs = implode(", ", $interfaces);
         throw new LogicException(
-            "Expected $ifs, found '" . get_class($component) . "' when rendering."
+            sprintf(
+                "%s could not render component %s",
+                static::class,
+                get_class($component)
+            )
         );
     }
-
-    /**
-     * Get the name of the component-interface this renderer is supposed to render.
-     *
-     * ATTENTION: Fully qualified please!
-     *
-     * @return string[]
-     */
-    abstract protected function getComponentInterfaceName(): array;
 
     /**
      * @return mixed

--- a/components/ILIAS/UI/src/Implementation/Render/ComponentRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Render/ComponentRenderer.php
@@ -22,7 +22,6 @@ namespace ILIAS\UI\Implementation\Render;
 
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Renderer;
-use LogicException;
 
 /**
  * An entity that renders components to a string output.
@@ -35,7 +34,7 @@ interface ComponentRenderer
      * Render the component if possible and delegate additional rendering to the
      * default_renderer.
      *
-     * @throws LogicException if renderer is called with a component it can't render
+     * @throws \RuntimeException if renderer is called with a component it can't render
      */
     public function render(Component $component, Renderer $default_renderer): string;
 

--- a/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
+++ b/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
@@ -435,7 +435,7 @@ class GlyphTest extends ILIAS_UI_TestBase
 
     public function testDontRenderCounter(): void
     {
-        $this->expectException(LogicException::class);
+        $this->expectException(\LogicException::class);
         $r = new Renderer(
             $this->getUIFactory(),
             $this->getTemplateFactory(),

--- a/components/ILIAS/UI/tests/Renderer/AbstractRendererTest.php
+++ b/components/ILIAS/UI/tests/Renderer/AbstractRendererTest.php
@@ -36,11 +36,6 @@ namespace ILIAS\UI\Implementation\Component\Symbol\Glyph {
         {
             return $this->getTemplate($a, $b, $c);
         }
-
-        protected function getComponentInterfaceName(): array
-        {
-            return ["\\ILIAS\\UI\\Component\\Symbol\\Glyph\\Glyph"];
-        }
     }
 
     class GlyphNonAbstractRendererWithJS extends GlyphNonAbstractRenderer
@@ -70,11 +65,6 @@ namespace ILIAS\UI\Implementation\Component\Counter {
         public function _getTemplate(string $a, bool $b, bool $c): Template
         {
             return $this->getTemplate($a, $b, $c);
-        }
-
-        protected function getComponentInterfaceName(): array
-        {
-            return ["\\ILIAS\\UI\\Component\\Counter\\Counter"];
         }
     }
 }


### PR DESCRIPTION
Hi folks,

This is one part of the PR I created to introduce JavaScript hydration to the UI framework (#6948).

It centralises the `ComponentRenderer::render()` function inside our `AbstractComponentRenderer` by using a new abstract method called `renderComponent()` and gets rid of the `AbstractComponentRenderer::checkComponent()` calls. I also tried to streamline the `instanceof` checks a bit, and returned null in methods which threw a `LogicException` or returned an empty string if the component could not be handled.

Kind regards,
@thibsy 