### PR TITLE
Composer: Add `dflydev/fig-cookies` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -44,6 +44,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"dflydev/fig-cookies": "^3.1",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `dflydev/fig-cookies` as composer package.

Usage:
* `CookieFactory` in HTTP Service

Wrapped By:
* `\ILIAS\HTTP\Cookies\CookieFactoryImpl` and `\ILIAS\HTTP\Cookies\CookieWrapper`

Reasoning:
* The library implements the management of cookies in PSR-7 requests and responses as we use them in the HTTP service. The library rarely receives new releases, on average about once a year, but is probably actively developed further by 13 contributors. should the library no longer be maintained, a separate implementation would be manageably large.

Maintenance:
* the package is maintained, but only with rare new versions https://github.com/dflydev/dflydev-fig-cookies/releases

Links:
* Packagist: https://packagist.org/packages/dflydev/fig-cookies
* GitHub: https://github.com/dflydev/dflydev-fig-cookies
* Documentation: https://github.com/dflydev/dflydev-fig-cookies/blob/main/README.md