### PR TITLE
Tracking/ObjectStatistics: Migrate primary key to UUID

### DIFF
--- a/Services/Tracking/classes/Setup/Migration/MigrateObjectStatisticsPrimaryKey.php
+++ b/Services/Tracking/classes/Setup/Migration/MigrateObjectStatisticsPrimaryKey.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tracking\Setup\Migration;
+
+use ilDatabaseUpdateSteps;
+use ilDBInterface;
+
+class MigrateObjectStatisticsPrimaryKey implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->modifyTableColumn(
+            'obj_stat_log',
+            'log_id',
+            [
+                'type' => 'text',
+                'length' => 64,
+                'notnull' => true,
+            ]
+        );
+
+        $this->db->modifyTableColumn(
+            'obj_stat_tmp',
+            'log_id',
+            [
+                'type' => 'text',
+                'length' => 64,
+                'notnull' => true,
+            ]
+        );
+
+        if ($this->db->sequenceExists('obj_stat_log')) {
+            $this->db->dropSequence('obj_stat_log');
+        }
+    }
+}

--- a/Services/Tracking/classes/Setup/TrackingSetupAgent.php
+++ b/Services/Tracking/classes/Setup/TrackingSetupAgent.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Tracking\Setup;
+
+use ILIAS\Tracking\Setup\Migration\MigrateObjectStatisticsPrimaryKey;
+use ILIAS\Setup;
+use ILIAS\Refinery;
+use ilDatabaseUpdateStepsExecutedObjective;
+use LogicException;
+
+class TrackingSetupAgent implements Setup\Agent
+{
+    use Setup\Agent\HasNoNamedObjective;
+
+    public function hasConfig(): bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation(): Refinery\Transformation
+    {
+        throw new LogicException('Agent has no config.');
+    }
+
+    public function getInstallObjective(Setup\Config $config = null): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
+    {
+        return new ilDatabaseUpdateStepsExecutedObjective(
+            new MigrateObjectStatisticsPrimaryKey()
+        );
+    }
+
+    public function getBuildArtifactObjective(): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getMigrations(): array
+    {
+        return [];
+    }
+}

--- a/Services/Tracking/classes/class.ilChangeEvent.php
+++ b/Services/Tracking/classes/class.ilChangeEvent.php
@@ -1,7 +1,22 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=0);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**
  * Class ilChangeEvent tracks change events on repository objects.
@@ -325,7 +340,9 @@ class ilChangeEvent
         $now = time();
 
         $fields = array();
-        $fields['log_id'] = array("integer", $ilDB->nextId('obj_stat_log'));
+
+        $data = new \ILIAS\Data\UUID\Factory();
+        $fields['log_id'] = array("text", $data->uuid4()->toString());
         $fields["obj_id"] = array("integer", $a_obj_id);
         $fields["obj_type"] = array("text", ilObject::_lookupType($a_obj_id));
         $fields["tstamp"] = array("timestamp", $now);


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=41330

It is not necessary to migrate existing records in `obj_stat_log`. All records (with `int` values) are just temporary and will be deleted as soon as the synchronization process (to `obj_stat_tmp`) is triggered.

If approved, this should be merged to `release_9` and `trunk` as well.