### PR TITLE
UI, Interruptive: 38085, allow for both form methods & provide individual parameters for items

### DIFF
--- a/src/Data/FormMethod.php
+++ b/src/Data/FormMethod.php
@@ -18,24 +18,10 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\UI\Component\Modal\InterruptiveItem;
+namespace ILIAS\Data;
 
-use ILIAS\UI\Component\Component;
-
-/**
- * Interface InterruptiveItem
- *
- * Represents an item to be displayed inside an interruptive modal
- */
-interface InterruptiveItem extends Component
+enum FormMethod: string
 {
-    /**
-     * Return an ID of the item
-     */
-    public function getId(): string;
-
-    /**
-     * Use this as a parameter name when submitting the interruptive modal
-     */
-    public function withParameterName(string $parameter_name): self;
+    case GET = 'GET';
+    case POST = 'POST';
 }

--- a/src/Data/FormMethod.php
+++ b/src/Data/FormMethod.php
@@ -24,4 +24,5 @@ enum FormMethod: string
 {
     case GET = 'GET';
     case POST = 'POST';
+    case DIALOG = 'DIALOG';
 }

--- a/src/UI/Component/Modal/InterruptiveItem/Factory.php
+++ b/src/UI/Component/Modal/InterruptiveItem/Factory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Modal\InterruptiveItem;
 
@@ -55,13 +55,15 @@ interface Factory
      * @param string $title
      * @param Image $icon
      * @param string $description
+     * @param string $parameter_name
      * @return \ILIAS\UI\Component\Modal\InterruptiveItem\Standard
      */
     public function standard(
         string $id,
         string $title,
         Image $icon = null,
-        string $description = ''
+        string $description = '',
+        string $parameter_name = InterruptiveItem::DEFAULT_PARAMETER_NAME
     ): Standard;
 
     /**
@@ -92,11 +94,13 @@ interface Factory
      * @param string $id
      * @param string $key
      * @param string $value
+     * @param string $parameter_name
      * @return \ILIAS\UI\Component\Modal\InterruptiveItem\KeyValue
      */
     public function keyValue(
         string $id,
         string $key,
-        string $value
+        string $value,
+        string $parameter_name = InterruptiveItem::DEFAULT_PARAMETER_NAME
     ): KeyValue;
 }

--- a/src/UI/Component/Modal/InterruptiveItem/InterruptiveItem.php
+++ b/src/UI/Component/Modal/InterruptiveItem/InterruptiveItem.php
@@ -30,12 +30,12 @@ use ILIAS\UI\Component\Component;
 interface InterruptiveItem extends Component
 {
     /**
+     * Use this as the default parameter name when submitting the interruptive modal
+     */
+    public const DEFAULT_PARAMETER_NAME = 'interruptive_items';
+
+    /**
      * Return an ID of the item
      */
     public function getId(): string;
-
-    /**
-     * Use this as a parameter name when submitting the interruptive modal
-     */
-    public function withParameterName(string $parameter_name): self;
 }

--- a/src/UI/Implementation/Component/Input/Container/ViewControl/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Container/ViewControl/Renderer.php
@@ -28,9 +28,12 @@ use LogicException;
 use ILIAS\UI\Implementation\Component\Input\ViewControl\HasInputGroup;
 use ILIAS\UI\Implementation\Component\ViewControl\Pagination;
 use ILIAS\UI\Implementation\Component\Input\ViewControl\Sortation;
+use ILIAS\UI\Implementation\Render\HiddenFieldsInjector;
 
 class Renderer extends AbstractComponentRenderer
 {
+    use HiddenFieldsInjector;
+
     /**
      * @inheritdoc
      */
@@ -88,21 +91,7 @@ class Renderer extends AbstractComponentRenderer
         // The remaining parameters for the view controls need to be stuffed into
         // hidden fields, so the browser passes them as query parameters once the
         // form is submitted.
-        foreach ($query_params as $k => $v) {
-            if (is_array($v)) {
-                foreach (array_values($v) as $arrv) {
-                    $tpl->setCurrentBlock('param');
-                    $tpl->setVariable("PARAM_NAME", $k . '[]');
-                    $tpl->setVariable("VALUE", $arrv);
-                    $tpl->parseCurrentBlock();
-                }
-            } else {
-                $tpl->setCurrentBlock('param');
-                $tpl->setVariable("PARAM_NAME", $k);
-                $tpl->setVariable("VALUE", $v);
-                $tpl->parseCurrentBlock();
-            }
-        }
+        $tpl->setVariable('QUERYPARAMS', $this->getHiddenFieldsHTML($query_params));
 
         $inputs = array_map(
             fn($input) => $input->withOnChange($submission_signal),

--- a/src/UI/Implementation/Component/Modal/Factory.php
+++ b/src/UI/Implementation/Component/Modal/Factory.php
@@ -27,6 +27,7 @@ use ILIAS\UI\Component\Modal\InterruptiveItem\Factory as ItemFactory;
 use ILIAS\UI\Implementation\Component\Input\FormInputNameSource;
 use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Component\Card\Card;
+use ILIAS\Data\FormMethod;
 
 /**
  * Implementation of factory for modals
@@ -43,9 +44,19 @@ class Factory implements M\Factory
     /**
      * @inheritdoc
      */
-    public function interruptive(string $title, string $message, string $form_action): M\Interruptive
-    {
-        return new Interruptive($title, $message, $form_action, $this->signal_generator);
+    public function interruptive(
+        string $title,
+        string $message,
+        string $form_action,
+        FormMethod $form_method = FormMethod::POST
+    ): M\Interruptive {
+        return new Interruptive(
+            $title,
+            $message,
+            $form_action,
+            $form_method,
+            $this->signal_generator
+        );
     }
 
     /**

--- a/src/UI/Implementation/Component/Modal/Factory.php
+++ b/src/UI/Implementation/Component/Modal/Factory.php
@@ -48,7 +48,7 @@ class Factory implements M\Factory
         string $title,
         string $message,
         string $form_action,
-        FormMethod $form_method = FormMethod::POST
+        FormMethod $form_method = FormMethod::POST,
     ): M\Interruptive {
         return new Interruptive(
             $title,

--- a/src/UI/Implementation/Component/Modal/Interruptive.php
+++ b/src/UI/Implementation/Component/Modal/Interruptive.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,10 +16,13 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Modal;
 
 use ILIAS\UI\Component\Modal as M;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
+use ILIAS\Data\FormMethod;
 
 class Interruptive extends Modal implements M\Interruptive
 {
@@ -29,25 +30,17 @@ class Interruptive extends Modal implements M\Interruptive
      * @var M\InterruptiveItem\InterruptiveItem[]
      */
     protected array $items = array();
-    protected string $title;
-    protected string $message;
     protected ?string $action_button_label = null;
     protected ?string $cancel_button_label = null;
-    protected string $form_action;
 
     public function __construct(
-        string $title,
-        string $message,
-        string $form_action,
+        protected string $title,
+        protected string $message,
+        protected string $form_action,
+        protected FormMethod $form_method,
         SignalGeneratorInterface $signal_generator
     ) {
         parent::__construct($signal_generator);
-        $this->checkStringArg('title', $title);
-        $this->checkStringArg('message', $message);
-        $this->checkStringArg('form_action', $form_action);
-        $this->title = $title;
-        $this->message = $message;
-        $this->form_action = $form_action;
     }
 
     /**
@@ -136,5 +129,10 @@ class Interruptive extends Modal implements M\Interruptive
     public function getFormAction(): string
     {
         return $this->form_action;
+    }
+
+    public function getFormMethod(): FormMethod
+    {
+        return $this->form_method;
     }
 }

--- a/src/UI/Implementation/Component/Modal/Interruptive.php
+++ b/src/UI/Implementation/Component/Modal/Interruptive.php
@@ -40,6 +40,9 @@ class Interruptive extends Modal implements M\Interruptive
         protected FormMethod $form_method,
         SignalGeneratorInterface $signal_generator
     ) {
+        if ($form_method === FormMethod::DIALOG) {
+            throw new \InvalidArgumentException("You may not use 'dialog'-method with Interruptives.");
+        }
         parent::__construct($signal_generator);
     }
 

--- a/src/UI/Implementation/Component/Modal/InterruptiveItem/Factory.php
+++ b/src/UI/Implementation/Component/Modal/InterruptiveItem/Factory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Modal\InterruptiveItem;
 
 use ILIAS\UI\Component\Modal\InterruptiveItem as ItemInterface;
@@ -29,16 +29,18 @@ class Factory implements ItemInterface\Factory
         string $id,
         string $title,
         Image $icon = null,
-        string $description = ''
+        string $description = '',
+        string $parameter_name = ItemInterface\InterruptiveItem::DEFAULT_PARAMETER_NAME
     ): ItemInterface\Standard {
-        return new Standard($id, $title, $icon, $description);
+        return new Standard($id, $parameter_name, $title, $icon, $description);
     }
 
     public function keyValue(
         string $id,
         string $key,
-        string $value
+        string $value,
+        string $parameter_name = ItemInterface\InterruptiveItem::DEFAULT_PARAMETER_NAME
     ): ItemInterface\KeyValue {
-        return new KeyValue($id, $key, $value);
+        return new KeyValue($id, $parameter_name, $key, $value);
     }
 }

--- a/src/UI/Implementation/Component/Modal/InterruptiveItem/InterruptiveItem.php
+++ b/src/UI/Implementation/Component/Modal/InterruptiveItem/InterruptiveItem.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Modal\InterruptiveItem;
 
 use ILIAS\UI\Implementation\Component\ComponentHelper;
@@ -28,6 +28,7 @@ abstract class InterruptiveItem implements ItemInterface
     use ComponentHelper;
 
     protected string $id;
+    protected string $parameter_name = 'interruptive_items';
 
     public function __construct(string $id)
     {
@@ -38,4 +39,17 @@ abstract class InterruptiveItem implements ItemInterface
     {
         return $this->id;
     }
+
+    public function withParameterName(string $parameter_name): static
+    {
+        $clone = clone $this;
+        $clone->parameter_name = $parameter_name;
+        return $clone;
+    }
+
+    public function getParameterName(): string
+    {
+        return $this->parameter_name;
+    }
+
 }

--- a/src/UI/Implementation/Component/Modal/InterruptiveItem/InterruptiveItem.php
+++ b/src/UI/Implementation/Component/Modal/InterruptiveItem/InterruptiveItem.php
@@ -27,24 +27,15 @@ abstract class InterruptiveItem implements ItemInterface
 {
     use ComponentHelper;
 
-    protected string $id;
-    protected string $parameter_name = 'interruptive_items';
-
-    public function __construct(string $id)
-    {
-        $this->id = $id;
+    public function __construct(
+        protected string $id,
+        protected string $parameter_name
+    ) {
     }
 
     public function getId(): string
     {
         return $this->id;
-    }
-
-    public function withParameterName(string $parameter_name): static
-    {
-        $clone = clone $this;
-        $clone->parameter_name = $parameter_name;
-        return $clone;
     }
 
     public function getParameterName(): string

--- a/src/UI/Implementation/Component/Modal/InterruptiveItem/KeyValue.php
+++ b/src/UI/Implementation/Component/Modal/InterruptiveItem/KeyValue.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,24 +16,21 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Modal\InterruptiveItem;
 
 use ILIAS\UI\Component\Modal\InterruptiveItem\KeyValue as KeyValueInterface;
 
 class KeyValue extends InterruptiveItem implements KeyValueInterface
 {
-    protected string $key;
-    protected string $value;
-
     public function __construct(
         string $id,
-        string $key,
-        string $value
+        string $parameter_name,
+        protected string $key,
+        protected string $value
     ) {
-        parent::__construct($id);
-
-        $this->key = $key;
-        $this->value = $value;
+        parent::__construct($id, $parameter_name);
     }
 
     public function getKey(): string

--- a/src/UI/Implementation/Component/Modal/InterruptiveItem/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/InterruptiveItem/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Modal\InterruptiveItem;
 
@@ -55,6 +55,7 @@ class Renderer extends AbstractComponentRenderer
             $default_renderer->render($component->getIcon()) : '';
         $tpl->setVariable('ITEM_ICON', $icon);
         $tpl->setVariable('ITEM_ID', $component->getId());
+        $tpl->setVariable('ITEM_PARAMETER', $component->getParameterName());
         $tpl->setVariable('ITEM_TITLE', $component->getTitle());
         if ($desc = $component->getDescription()) {
             $tpl->setVariable('ITEM_DESCRIPTION', $desc);
@@ -74,6 +75,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable('ITEM_KEY', $component->getKey());
         $tpl->setVariable('ITEM_VALUE', $component->getValue());
         $tpl->setVariable('ITEM_ID', $component->getId());
+        $tpl->setVariable('ITEM_PARAMETER', $component->getParameterName());
         return $tpl->get();
     }
 

--- a/src/UI/Implementation/Component/Modal/InterruptiveItem/Standard.php
+++ b/src/UI/Implementation/Component/Modal/InterruptiveItem/Standard.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Modal\InterruptiveItem;
 
 use ILIAS\UI\Component\Image\Image;
@@ -31,11 +31,12 @@ class Standard extends InterruptiveItem implements StandardInterface
 
     public function __construct(
         string $id,
+        string $parameter_name,
         string $title,
         Image $icon = null,
         string $description = ''
     ) {
-        parent::__construct($id);
+        parent::__construct($id, $parameter_name);
 
         $this->title = $title;
         $this->icon = $icon;

--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -30,12 +30,15 @@ use ILIAS\UI\Implementation\Component\Input\Container\Form\FormWithoutSubmitButt
 use ILIAS\UI\Component\Modal\LightboxPage;
 use ILIAS\UI\Implementation\Render\Template;
 use ILIAS\Data\FormMethod;
+use ILIAS\UI\Implementation\Render\HiddenFieldsInjector;
 
 /**
  * @author Stefan Wanzenried <sw@studer-raimann.ch>
  */
 class Renderer extends AbstractComponentRenderer
 {
+    use HiddenFieldsInjector;
+
     /**
      * @inheritdoc
      */
@@ -158,29 +161,16 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable('CLOSE_LABEL', $modal->getCancelButtonLabel() ?? $this->txt('cancel'));
 
         if($modal->getFormMethod() === FormMethod::GET) {
-            $params = $this->getDataFactory()->uri($url)->getParameters();
             $item_names = array_map(
                 fn($item) => $item->getParameterName(),
                 $modal->getAffectedItems()
             );
-            foreach($params as $key => $value) {
-                if(! in_array($key, $item_names)) {
-                    if(is_array($value)) {
-                        $key .= "[]";
-                        foreach($value as $entry) {
-                            $tpl->setCurrentBlock('query_params');
-                            $tpl->setVariable('QUERYPARAM_NAME', $key);
-                            $tpl->setVariable('QUERYPARAM_VALUE', $entry);
-                            $tpl->parseCurrentBlock();
-                        }
-                    } else {
-                        $tpl->setCurrentBlock('query_params');
-                        $tpl->setVariable('QUERYPARAM_NAME', $key);
-                        $tpl->setVariable('QUERYPARAM_VALUE', $value);
-                        $tpl->parseCurrentBlock();
-                    }
-                }
-            }
+            $params = array_filter(
+                $this->getDataFactory()->uri($url)->getParameters(),
+                fn($v, $k) => !in_array($k, $item_names),
+                ARRAY_FILTER_USE_BOTH
+            );
+            $tpl->setVariable('QUERYPARAMS', $this->getHiddenFieldsHTML($params));
         }
         return $tpl->get();
     }

--- a/src/UI/Implementation/Component/Modal/Renderer.php
+++ b/src/UI/Implementation/Component/Modal/Renderer.php
@@ -160,7 +160,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable('CANCEL_BUTTON_LABEL', $modal->getCancelButtonLabel() ?? $this->txt('cancel'));
         $tpl->setVariable('CLOSE_LABEL', $modal->getCancelButtonLabel() ?? $this->txt('cancel'));
 
-        if($modal->getFormMethod() === FormMethod::GET) {
+        if ($modal->getFormMethod() === FormMethod::GET) {
             $item_names = array_map(
                 fn($item) => $item->getParameterName(),
                 $modal->getAffectedItems()

--- a/src/UI/Implementation/Render/AbstractComponentRenderer.php
+++ b/src/UI/Implementation/Render/AbstractComponentRenderer.php
@@ -89,6 +89,11 @@ abstract class AbstractComponentRenderer implements ComponentRenderer, HelpTextR
         return $this->upload_limit_resolver;
     }
 
+    final protected function getTemplateFactory(): TemplateFactory
+    {
+        return $this->tpl_factory;
+    }
+
     /**
      * Get a text from the language file.
      */

--- a/src/UI/Implementation/Render/HiddenFieldsInjector.php
+++ b/src/UI/Implementation/Render/HiddenFieldsInjector.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\UI\Implementation\Render;
+
+trait HiddenFieldsInjector
+{
+    protected function getHiddenFieldsTemplate(): Template
+    {
+        $path = 'src/UI/templates/default/tpl.hiddenfields.html';
+        return $this->getTemplateFactory()->getTemplate($path, true, true);
+    }
+    protected function getHiddenFieldsHTML(array $parameters): string
+    {
+        $tpl = $this->getHiddenFieldsTemplate();
+        foreach($parameters as $key => $value) {
+            if(is_array($value)) {
+                $key .= "[]";
+                foreach($value as $entry) {
+                    $tpl->setCurrentBlock('params');
+                    $tpl->setVariable('PARAM_NAME', $key);
+                    $tpl->setVariable('PARAM_VALUE', $entry);
+                    $tpl->parseCurrentBlock();
+                }
+            } else {
+                $tpl->setCurrentBlock('params');
+                $tpl->setVariable('PARAM_NAME', $key);
+                $tpl->setVariable('PARAM_VALUE', $value);
+                $tpl->parseCurrentBlock();
+            }
+        }
+        return $tpl->get();
+    }
+}

--- a/src/UI/Implementation/Render/HiddenFieldsInjector.php
+++ b/src/UI/Implementation/Render/HiddenFieldsInjector.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Render;
 
 trait HiddenFieldsInjector
@@ -30,10 +30,10 @@ trait HiddenFieldsInjector
     protected function getHiddenFieldsHTML(array $parameters): string
     {
         $tpl = $this->getHiddenFieldsTemplate();
-        foreach($parameters as $key => $value) {
-            if(is_array($value)) {
+        foreach ($parameters as $key => $value) {
+            if (is_array($value)) {
                 $key .= "[]";
-                foreach($value as $entry) {
+                foreach ($value as $entry) {
                     $tpl->setCurrentBlock('params');
                     $tpl->setVariable('PARAM_NAME', $key);
                     $tpl->setVariable('PARAM_VALUE', $entry);

--- a/src/UI/examples/Modal/Interruptive/with_method_get.php
+++ b/src/UI/examples/Modal/Interruptive/with_method_get.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Modal\Interruptive;
+
+use ILIAS\Data\FormMethod;
+
+/**
+ * ---
+ * description: >
+ *   An example showing how you can change the form's method
+ *   and pass parameters in the query.
+ *
+ * expected output: >
+ *   ILIAS shows a button; on click, a Modal will open.
+ *   When submitting the modal, the query-results are shown
+ *   as characteristic value listing with two collections of values.
+ * ---
+ */
+function with_method_get()
+{
+    global $DIC;
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $query = $DIC->http()->wrapper()->query();
+    $refinery = $DIC->refinery();
+
+    $if = $factory->modal()->interruptiveItem();
+    $items = [
+        $if->keyValue('id-1', 'KEY 1', 'VALUE 1', 'imodal'),
+        $if->keyValue('id-2', 'KEY 2', 'VALUE 2', 'imodal'),
+        $if->keyValue('id-3', 'KEY 3', 'VALUE 3', 'other'),
+        $if->standard('id-4', 'KEY 4', null, 'description 4', 'other'),
+    ];
+    $modal = $factory->modal()->interruptive(
+        'Modal with GET-method',
+        'Am I interrupting you?',
+        $DIC->http()->request()->getUri()->__toString(),
+        FormMethod::GET
+    )
+    ->withAffectedItems($items);
+
+    $trigger = $factory->button()->standard('Show Modal', $modal->getShowSignal());
+
+    $out = $factory->legacy('');
+    $divider = $factory->divider()->horizontal();
+    if ($query->has('imodal')) {
+        $ids1 = $query->retrieve('imodal', $refinery->identity());
+        $ids2 = $query->retrieve('other', $refinery->identity());
+        $out = $factory->listing()->characteristicValue()->text([
+            'imodal' => print_r($ids1, true),
+            'other' => print_r($ids2, true),
+        ]);
+    }
+
+    return $renderer->render([$out, $divider, $modal, $trigger]);
+}

--- a/src/UI/examples/Table/Data/base.php
+++ b/src/UI/examples/Table/Data/base.php
@@ -256,8 +256,8 @@ function base()
         if ($action === 'delete') {
             $items = [];
             foreach ($ids as $id) {
-                $items[] = $f->modal()->interruptiveItem()->keyValue($id, $row_id_token->getName(), $id)
-                    ->withParameterName($row_id_token->getName());
+                $items[] = $f->modal()->interruptiveItem()
+                    ->keyValue($id, $row_id_token->getName(), $id, $row_id_token->getName());
             }
             echo($r->renderAsync([
                 $f->modal()->interruptive(

--- a/src/UI/examples/Table/Data/base.php
+++ b/src/UI/examples/Table/Data/base.php
@@ -8,6 +8,7 @@ use ILIAS\UI\Implementation\Component\Table as T;
 use ILIAS\UI\Component\Table as I;
 use ILIAS\Data\Range;
 use ILIAS\Data\Order;
+use ILIAS\Data\FormMethod;
 use ILIAS\UI\URLBuilder;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -255,18 +256,21 @@ function base()
         if ($action === 'delete') {
             $items = [];
             foreach ($ids as $id) {
-                $items[] = $f->modal()->interruptiveItem()->keyValue($id, $row_id_token->getName(), $id);
+                $items[] = $f->modal()->interruptiveItem()->keyValue($id, $row_id_token->getName(), $id)
+                    ->withParameterName($row_id_token->getName());
             }
             echo($r->renderAsync([
                 $f->modal()->interruptive(
                     'Deletion',
                     'You are about to delete items!',
-                    '#'
+                    $url_builder->withParameter($action_parameter_token, "delete_confirmed")->buildURI()->__toString(),
+                    FormMethod::GET
                 )->withAffectedItems($items)
                 ->withAdditionalOnLoadCode(static fn($id): string => "console.log('ASYNC JS');")
             ]));
             exit();
         }
+
         if ($action === 'info') {
             echo(
                 $r->render($f->messageBox()->info('an info message: <br><li>' . implode('<li>', $ids)))

--- a/src/UI/examples/Table/Data/base.php
+++ b/src/UI/examples/Table/Data/base.php
@@ -161,10 +161,10 @@ function base()
                     $this->ui_factory->symbol()->icon()->custom('templates/default/images/standard/icon_x.svg', '', 'small'),
                 ];
                 $icon = $icons[2];
-                if($record['achieve'] > 80) {
+                if ($record['achieve'] > 80) {
                     $icon = $icons[0];
                 }
-                if($record['achieve'] < 30) {
+                if ($record['achieve'] < 30) {
                     $icon = $icons[1];
                 }
                 $record['achieve'] = $icon;

--- a/src/UI/templates/default/Input/tpl.viewcontrol_container.html
+++ b/src/UI/templates/default/Input/tpl.viewcontrol_container.html
@@ -1,6 +1,4 @@
 <form role="form" class="il-viewcontrols-form l-bar__space-keeper" method="get" id="{ID}">
 	{INPUTS}
-	<!-- BEGIN param -->
-    <input  type="hidden" name="{PARAM_NAME}" value="{VALUE}" />
-    <!-- END param -->
+	{QUERYPARAMS}
 </form>

--- a/src/UI/templates/default/Modal/tpl.interruptive.html
+++ b/src/UI/templates/default/Modal/tpl.interruptive.html
@@ -32,9 +32,7 @@
 					</button>
 				</div>
 			</div>
-			<!-- BEGIN query_params -->
-				<input type="hidden" name="{QUERYPARAM_NAME}" value="{QUERYPARAM_VALUE}" />
-			<!-- END query_params -->
+			{QUERYPARAMS}
 		</form>
 	</div>
 </div>

--- a/src/UI/templates/default/Modal/tpl.interruptive.html
+++ b/src/UI/templates/default/Modal/tpl.interruptive.html
@@ -1,6 +1,6 @@
 <div class="modal fade c-modal--interruptive" tabindex="-1" role="dialog" id="{ID}">
 	<div class="modal-dialog" role="document">
-		<form action="{FORM_ACTION}" method="POST">
+		<form action="{FORM_ACTION}" method="{FORM_METHOD}">
 			<div class="modal-content">
 				<div class="modal-header">
 					<button type="button" class="close" data-dismiss="modal" aria-label="{CLOSE_LABEL}"><span aria-hidden="true">&times;</span></button>
@@ -32,6 +32,9 @@
 					</button>
 				</div>
 			</div>
+			<!-- BEGIN query_params -->
+				<input type="hidden" name="{QUERYPARAM_NAME}" value="{QUERYPARAM_VALUE}" />
+			<!-- END query_params -->
 		</form>
 	</div>
 </div>

--- a/src/UI/templates/default/Modal/tpl.keyValueInterruptiveItem.html
+++ b/src/UI/templates/default/Modal/tpl.keyValueInterruptiveItem.html
@@ -1,6 +1,6 @@
 <div class="c-modal--interruptive__items__key-value">
 	<dt class="c-modal--interruptive__items__key-value__key">
-		{ITEM_KEY} <input type="hidden" name="interruptive_items[]" value="{ITEM_ID}">
+		{ITEM_KEY} <input type="hidden" name="{ITEM_PARAMETER}[]" value="{ITEM_ID}">
 	</dt>
 	<dd class="c-modal--interruptive__items__key-value__value">
 		{ITEM_VALUE}

--- a/src/UI/templates/default/Modal/tpl.standardInterruptiveItem.html
+++ b/src/UI/templates/default/Modal/tpl.standardInterruptiveItem.html
@@ -9,6 +9,6 @@
 		<!-- END with_description -->
 	</td>
 	<td>
-		<input type="hidden" name="interruptive_items[]" value="{ITEM_ID}">
+		<input type="hidden" name="{ITEM_PARAMETER}[]" value="{ITEM_ID}">
 	</td>
 </tr>

--- a/src/UI/templates/default/tpl.hiddenfields.html
+++ b/src/UI/templates/default/tpl.hiddenfields.html
@@ -1,0 +1,3 @@
+<!-- BEGIN params -->
+<input type="hidden" name="{PARAM_NAME}" value="{PARAM_VALUE}" />
+<!-- END params -->

--- a/tests/UI/Component/Modal/InterruptiveItem/InterruptiveItemTest.php
+++ b/tests/UI/Component/Modal/InterruptiveItem/InterruptiveItemTest.php
@@ -34,30 +34,20 @@ class TestingItem extends Item
 
 class InterruptiveItemTest extends ILIAS_UI_TestBase
 {
-    public function testConstruction(): void
+    public function testInterruptiveItemConstruction(): void
     {
-        $item = new TestingItem('1');
+        $item = new TestingItem('1', 'interruptive_items');
         $this->assertInstanceOf(
             Item::class,
             $item
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
-    public function testGetId(): void
+    public function testInterruptiveItemConstructionParametersa(): void
     {
         $id = '1';
-        $item = new TestingItem($id);
+        $item = new TestingItem($id, 'param');
         $this->assertEquals($id, $item->getId());
+        $this->assertEquals('param', $item->getParameterName());
     }
-
-    public function testInterruptiveItemParameterName(): void
-    {
-        $item = new TestingItem('id');
-        $this->assertEquals('interruptive_items', $item->getParameterName());
-        $this->assertEquals('par', $item->withParameterName('par')->getParameterName());
-    }
-
 }

--- a/tests/UI/Component/Modal/InterruptiveItem/InterruptiveItemTest.php
+++ b/tests/UI/Component/Modal/InterruptiveItem/InterruptiveItemTest.php
@@ -52,4 +52,12 @@ class InterruptiveItemTest extends ILIAS_UI_TestBase
         $item = new TestingItem($id);
         $this->assertEquals($id, $item->getId());
     }
+
+    public function testInterruptiveItemParameterName(): void
+    {
+        $item = new TestingItem('id');
+        $this->assertEquals('interruptive_items', $item->getParameterName());
+        $this->assertEquals('par', $item->withParameterName('par')->getParameterName());
+    }
+
 }

--- a/tests/UI/Component/Modal/InterruptiveItem/KeyValueInterruptiveItemTest.php
+++ b/tests/UI/Component/Modal/InterruptiveItem/KeyValueInterruptiveItemTest.php
@@ -36,12 +36,14 @@ class KeyValueInterruptiveItemTest extends ILIAS_UI_TestBase
         $this->id = 'id';
         $this->key = 'key';
         $this->value = 'value';
+        $this->param = 'interruptive_items';
     }
 
     protected function getItem(): KeyValue
     {
         return new KeyValue(
             $this->id,
+            $this->param,
             $this->key,
             $this->value
         );

--- a/tests/UI/Component/Modal/InterruptiveItem/StandardInterruptiveItemTest.php
+++ b/tests/UI/Component/Modal/InterruptiveItem/StandardInterruptiveItemTest.php
@@ -38,12 +38,14 @@ class StandardInterruptiveItemTest extends ILIAS_UI_TestBase
         $this->title = 'title';
         $this->image = new I\Image\Image(C\Image\Image::STANDARD, 'path', 'alt');
         $this->description = 'description';
+        $this->param = 'interruptive_items';
     }
 
     protected function getItem(): Standard
     {
         return new Standard(
             $this->id,
+            $this->param,
             $this->title,
             $this->image,
             $this->description
@@ -54,6 +56,7 @@ class StandardInterruptiveItemTest extends ILIAS_UI_TestBase
     {
         return new Standard(
             $this->id,
+            $this->param,
             $this->title,
             $this->image
         );
@@ -63,6 +66,7 @@ class StandardInterruptiveItemTest extends ILIAS_UI_TestBase
     {
         return new Standard(
             $this->id,
+            $this->param,
             $this->title,
             null,
             $this->description

--- a/tests/UI/Component/Modal/InterruptiveTest.php
+++ b/tests/UI/Component/Modal/InterruptiveTest.php
@@ -23,6 +23,7 @@ require_once(__DIR__ . '/ModalBase.php');
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation as I;
 use ILIAS\Data\FormMethod;
+use ILIAS\Data\URI;
 
 /**
  * Tests on implementation for the interruptive modal
@@ -177,20 +178,25 @@ EOT;
 
     public function getDataFactory(): ILIAS\Data\Factory
     {
-        return new \ILIAS\Data\Factory();
+        $df = $this->createMock(\ILIAS\Data\Factory::class);
+        $df->method('uri')
+            ->willReturnCallback(
+                static fn(string $uri_string) => new URI($uri_string)
+            );
+        return $df;
     }
 
     public function testInterruptiveFormMethod(): void
     {
         $this->assertEquals(
-            \ILIAS\Data\FormMethod::POST,
+            FormMethod::POST,
             $this->getModalFactory()->interruptive('', '', '')->getFormMethod()
         );
 
         $this->assertEquals(
-            \ILIAS\Data\FormMethod::GET,
+            FormMethod::GET,
             $this->getModalFactory()
-                ->interruptive('', '', 'http://ilias.de', \ILIAS\Data\FormMethod::GET)
+                ->interruptive('', '', 'http://ilias.de', FormMethod::GET)
                 ->getFormMethod()
         );
     }
@@ -198,8 +204,8 @@ EOT;
     public function testInterruptiveFormQueryParams(): void
     {
         $par = urlencode('i[]');
-        $url = sprintf('http://ilias.de?some=thing&%s=1&%s=2',$par, $par);
-        $modal = $this->getModalFactory()->interruptive('', '', $url, \ILIAS\Data\FormMethod::GET);
+        $url = sprintf('http://ilias.de?some=thing&%s=1&%s=2', $par, $par);
+        $modal = $this->getModalFactory()->interruptive('', '', $url, FormMethod::GET);
         $renderer = $this->getDefaultRenderer();
         $html = $this->brutallyTrimHTML($renderer->render($modal));
         $this->assertStringNotContainsString('method="POST"', $html);
@@ -228,10 +234,6 @@ class InterruptiveItemMock implements C\Modal\InterruptiveItem\InterruptiveItem
     public function getCanonicalName(): string
     {
         return $this->canonical_name ?: 'InterruptiveItem';
-    }
-
-    public function withParameterName(string $parameter_name): static
-    {
     }
 
     public function getParameterName(): string


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38085

This lets you 
- construct an Interruptive Modal with GET-method 
- and  provide individual parameter names for its items

Comes in handy, e.g., when using delete-confirmations from a Data Table.