### PR TITLE
T&A 41171 Fix Whoops in detailed Test Results if no user is selected

### DIFF
--- a/Modules/Test/classes/class.ilParticipantsTestResultsGUI.php
+++ b/Modules/Test/classes/class.ilParticipantsTestResultsGUI.php
@@ -334,9 +334,12 @@ class ilParticipantsTestResultsGUI
     private function showDetailedResultsCmd(): void
     {
         $usr_ids = $this->getUserIdsFromPost();
-        if ($usr_ids !== []) {
-            ilSession::set('show_user_results', $usr_ids);
+        if (empty($usr_ids)) {
+            $this->main_tpl->setOnScreenMessage('info', $this->lng->txt("select_one_user"), true);
+            $this->ctrl->redirect($this);
         }
+
+        ilSession::set('show_user_results', $usr_ids);
         $results_href = $this->ctrl->getLinkTargetByClass(
             [ilTestResultsGUI::class, ilParticipantsTestResultsGUI::class, ilTestEvaluationGUI::class],
             'multiParticipantsPassDetails'


### PR DESCRIPTION
This PR aims to address the problem reported in Mantis issue https://mantis.ilias.de/view.php?id=41171.

If no user is selected for the problematic multi-command action, a compliant info message is shown. This replicates the behavior of the other multi-commands in the same table.

These changes may also be cherry-picked into trunk. In release_8 the error does not occur.

Kind regards.