### PR TITLE
Logging: Fix PHP type error when rendering tables during error handling

### DIFF
--- a/Services/Logging/classes/error/class.ilLoggingErrorFileStorage.php
+++ b/Services/Logging/classes/error/class.ilLoggingErrorFileStorage.php
@@ -111,7 +111,7 @@ class ilLoggingErrorFileStorage
             $ret .= "\n\n-- $title --\n\n";
             if (count($content) > 0) {
                 foreach ($content as $key => $value) {
-                    $key = str_pad($key, self::KEY_SPACE);
+                    $key = str_pad((string) $key, self::KEY_SPACE);
 
                     // indent multiline values, first print_r, split in lines,
                     // indent all but first line, then implode again.


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=41348

If approved, this has to be picked to `trunk` as well (but I guess the type issue could be also valid for `release_8`).