### PR TITLE
Database/Setup: Add a hint to release "lock" state after failed datab…

### DIFF
--- a/Services/Database/classes/Setup/class.ilDatabaseUpdateStepsExecutedObjective.php
+++ b/Services/Database/classes/Setup/class.ilDatabaseUpdateStepsExecutedObjective.php
@@ -130,7 +130,8 @@ class ilDatabaseUpdateStepsExecutedObjective implements Objective
         throw new RuntimeException(
             "For update steps in $this->steps_class: step $started was started " .
             "last, but step $finished was finished last. Aborting because of that " .
-            "mismatch."
+            "mismatch." . PHP_EOL .
+            "Execute `DELETE FROM il_db_steps WHERE class = '$this->steps_class' AND step = $started;` and run the setup again to retry. "
         );
     }
 }


### PR DESCRIPTION
…ase update step

If a database update step fails, the ILIAS setup
(to be concrete: the database update objectives) are in a "locked" state, and administrators often do not know how to "release" this "lock" again after the issue has been fixed manually or within a new Git commit. As long as we have no option/mechanism to automatically clean up this state, I suggest providing an SQL statement which can be manually executed.

If approved, this should be merged to `release_9` and `trunk` as well.