### PR TITLE
Recalculating only single users test results on Manual Scoring by Participant.

### DIFF
--- a/Modules/Test/classes/class.ilTestScoringGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringGUI.php
@@ -365,7 +365,7 @@ class ilTestScoringGUI extends ilTestServiceGUI
         require_once './Modules/Test/classes/class.ilTestScoring.php';
         $scorer = new ilTestScoring($this->object);
         $scorer->setPreserveManualScores(true);
-        $scorer->recalculateSolutions();
+        $scorer->recalculateSolution($activeId, $pass);
 
         if ($this->object->getAnonymity() == 0) {
             $user_name = ilObjUser::_lookupName(ilObjTestAccess::_getParticipantId($activeId));


### PR DESCRIPTION
Currently when you are manually scoring by user in a test currently the system goes through every other user's tests (and all of their passes of the test) and also manually re-scores them even though nothing has changed.

This normally isn't an issue, however we've noticed huge performance issues on larger tests with lots of participants (150 questions, 80 participants)

This change will only recalculate the solutions for the user you are modifying, this brings down processing time significantly.