### PR TITLE
41202: Fix missing tableview_id option parameter in DataCollection

### DIFF
--- a/Modules/DataCollection/classes/DetailedView/class.ilDclDetailedViewGUI.php
+++ b/Modules/DataCollection/classes/DetailedView/class.ilDclDetailedViewGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -218,14 +219,14 @@ class ilDclDetailedViewGUI
 
             $html = str_ireplace(
                 "[" . $field->getTitle() . "]",
-                $this->record_obj->getRecordFieldSingleHTML($field->getId()),
+                $this->record_obj->getRecordFieldSingleHTML($field->getId(), ['tableview_id' => $this->tableview_id]),
                 $html
             );
         }
         foreach ($table->getStandardFields() as $field) {
             $html = str_ireplace(
                 "[" . $field->getId() . "]",
-                $this->record_obj->getRecordFieldSingleHTML($field->getId()),
+                $this->record_obj->getRecordFieldSingleHTML($field->getId(), ['tableview_id' => $this->tableview_id]),
                 $html
             );
         }

--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseRecordRepresentation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -99,7 +100,7 @@ class ilDclBaseRecordRepresentation
      */
     public function getSingleHTML(?array $options = null, bool $link = true): string
     {
-        return $this->getHTML($link);
+        return $this->getHTML($link, $options);
     }
 
     /**

--- a/Modules/DataCollection/classes/Fields/Rating/class.ilDclRatingRecordRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Rating/class.ilDclRatingRecordRepresentation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -35,7 +36,9 @@ class ilDclRatingRecordRepresentation extends ilDclBaseRecordRepresentation
 
         $this->ctrl->setParameterByClass(ilRatingGUI::class, "field_id", $this->getRecordField()->getField()->getId());
         $this->ctrl->setParameterByClass(ilRatingGUI::class, "record_id", $this->getRecordField()->getRecord()->getId());
-        $this->ctrl->setParameterByClass(ilObjDataCollectionGUI::class, 'tableview_id', $options['tableview_id']);
+        if (isset($options['tableview_id'])) {
+            $this->ctrl->setParameterByClass(ilObjDataCollectionGUI::class, 'tableview_id', $options['tableview_id']);
+        }
         return $rgui->getHTML();
 
     }


### PR DESCRIPTION
Fixes the missing tableview_id $options parameter.


This parameter is required for the single view of a **rating** column.

Will also fix https://mantis.ilias.de/view.php?id=41202

If accepted. This change should be picked into **release_9** & **trunk**