### PR TITLE
Changes implementation of getCurrentMode in class ilPluginLP

### DIFF
--- a/Services/Component/classes/class.ilPluginLP.php
+++ b/Services/Component/classes/class.ilPluginLP.php
@@ -74,8 +74,8 @@ class ilPluginLP extends ilObjectLP
     public function getCurrentMode(): int
     {
         $mode = ilLPObjSettings::_lookupDBMode($this->obj_id);
-        if (!is_null($mode)) {
-            return $mode;
+        if ($mode === ilLPObjSettings::LP_MODE_UNDEFINED) {
+            return ilLPObjSettings::LP_MODE_UNDEFINED;
         }
 
         if ($this->status !== null) {

--- a/Services/Component/classes/class.ilPluginLP.php
+++ b/Services/Component/classes/class.ilPluginLP.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -13,8 +14,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 include_once "Services/Object/classes/class.ilObjectLP.php";
 

--- a/Services/Component/classes/class.ilPluginLP.php
+++ b/Services/Component/classes/class.ilPluginLP.php
@@ -73,15 +73,14 @@ class ilPluginLP extends ilObjectLP
 
     public function getCurrentMode(): int
     {
-        $mode = ilLPObjSettings::_lookupDBMode($this->obj_id);
-        if ($mode === ilLPObjSettings::LP_MODE_UNDEFINED) {
+        if (is_null($this->status)) {
             return ilLPObjSettings::LP_MODE_UNDEFINED;
         }
-
-        if ($this->status !== null) {
-            return ilLPObjSettings::LP_MODE_PLUGIN;
+        $mode = ilLPObjSettings::_lookupDBMode($this->obj_id);
+        if ($mode === ilLPObjSettings::LP_MODE_DEACTIVATED) {
+            return ilLPObjSettings::LP_MODE_DEACTIVATED;
         }
-        return ilLPObjSettings::LP_MODE_UNDEFINED;
+        return ilLPObjSettings::LP_MODE_PLUGIN;
     }
 
     protected static function isLPMember(array &$res, int $usr_id, array $obj_ids): bool

--- a/Services/Component/classes/class.ilPluginLP.php
+++ b/Services/Component/classes/class.ilPluginLP.php
@@ -73,6 +73,11 @@ class ilPluginLP extends ilObjectLP
 
     public function getCurrentMode(): int
     {
+        $mode = ilLPObjSettings::_lookupDBMode($this->obj_id);
+        if (!is_null($mode)) {
+            return $mode;
+        }
+
         if ($this->status !== null) {
             return ilLPObjSettings::LP_MODE_PLUGIN;
         }


### PR DESCRIPTION
If a u_mode entry exists in ut_lp_settings it is used instead of LP_MODE_PLUGIN.

This allows plugins to set their own u_mode.