### PR TITLE
[Forum] Remove ilObjForum::_deleteUser call from ilObjUser

### DIFF
--- a/Modules/Forum/classes/class.ilForumAppEventListener.php
+++ b/Modules/Forum/classes/class.ilForumAppEventListener.php
@@ -479,7 +479,8 @@ class ilForumAppEventListener implements ilAppEventListener
             case 'Services/User':
                 switch ($a_event) {
                     case 'deleteUser':
-                        ilForumPostDraft::deleteDraftsByUserId($a_parameter['usr_id']);
+                        ilForumPostDraft::deleteDraftsByUserId((int) $a_parameter['usr_id']);
+                        ilObjForum::_deleteUser((int) $a_parameter['usr_id']);
                         break;
                 }
                 break;

--- a/Services/User/classes/class.ilObjUser.php
+++ b/Services/User/classes/class.ilObjUser.php
@@ -1108,9 +1108,6 @@ class ilObjUser extends ilObject
             $ilDB->quote($this->getId(), "integer");
         $ilDB->manipulate($q);
 
-        // DELETE FORUM ENTRIES (not complete in the moment)
-        ilObjForum::_deleteUser($this->getId());
-
         // Delete crs entries
         ilObjCourse::_deleteUser($this->getId());
 


### PR DESCRIPTION
The forum component already has an event listener for deleted user accounts. The call of this function is moved there.
This allows a further internal refactoring in the forum component and reduces the dependencies in ilObjUser.