### PR TITLE
UI: fix backwards compatibility for Data/Table backport

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Checkbox.php
+++ b/src/UI/Implementation/Component/Input/Field/Checkbox.php
@@ -51,7 +51,7 @@ class Checkbox extends FormInput implements C\Input\Field\Checkbox, C\Changeable
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         if ($value == "checked" || $value === "" || is_bool($value)) {
             return true;

--- a/src/UI/Implementation/Component/Input/Field/DateTime.php
+++ b/src/UI/Implementation/Component/Input/Field/DateTime.php
@@ -174,7 +174,7 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
         return $this->with_time_only;
     }
 
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return is_string($value);
     }

--- a/src/UI/Implementation/Component/Input/Field/Duration.php
+++ b/src/UI/Implementation/Component/Input/Field/Duration.php
@@ -276,7 +276,7 @@ class Duration extends Group implements C\Input\Field\Duration
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return true;
     }

--- a/src/UI/Implementation/Component/Input/Field/File.php
+++ b/src/UI/Implementation/Component/Input/Field/File.php
@@ -195,7 +195,7 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
         );
     }
 
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         if (!is_array($value)) {
             return false;

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -154,4 +154,10 @@ class Group extends FormInput implements C\Input\Field\Group, GroupInternal
     {
         return $this->data_factory;
     }
+
+    /** ATTENTION: @see GroupInternals::_isClientSideValueOk() */
+    protected function isClientSideValueOk($value): bool
+    {
+        return $this->_isClientSideValueOk($value);
+    }
 }

--- a/src/UI/Implementation/Component/Input/Field/Hidden.php
+++ b/src/UI/Implementation/Component/Input/Field/Hidden.php
@@ -46,7 +46,7 @@ class Hidden extends FormInput implements \ILIAS\UI\Component\Input\Field\Hidden
         return null;
     }
 
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return true;
     }

--- a/src/UI/Implementation/Component/Input/Field/Link.php
+++ b/src/UI/Implementation/Component/Input/Field/Link.php
@@ -85,7 +85,7 @@ class Link extends Group implements C\Input\Field\Link
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return true;
     }

--- a/src/UI/Implementation/Component/Input/Field/MultiSelect.php
+++ b/src/UI/Implementation/Component/Input/Field/MultiSelect.php
@@ -61,7 +61,7 @@ class MultiSelect extends FormInput implements C\Input\Field\MultiSelect
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         if (is_null($value)) {
             return true;

--- a/src/UI/Implementation/Component/Input/Field/Numeric.php
+++ b/src/UI/Implementation/Component/Input/Field/Numeric.php
@@ -57,7 +57,7 @@ class Numeric extends FormInput implements C\Input\Field\Numeric
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return is_numeric($value) || $value === "" || $value === null;
     }

--- a/src/UI/Implementation/Component/Input/Field/OptionalGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/OptionalGroup.php
@@ -51,7 +51,7 @@ class OptionalGroup extends Group implements I\OptionalGroup
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         if ($value === null) {
             return true;

--- a/src/UI/Implementation/Component/Input/Field/Password.php
+++ b/src/UI/Implementation/Component/Input/Field/Password.php
@@ -61,7 +61,7 @@ class Password extends FormInput implements C\Input\Field\Password, Triggerable
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return is_string($value);
     }

--- a/src/UI/Implementation/Component/Input/Field/Radio.php
+++ b/src/UI/Implementation/Component/Input/Field/Radio.php
@@ -49,7 +49,7 @@ class Radio extends FormInput implements C\Input\Field\Radio
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return ($value === '' || array_key_exists($value, $this->getOptions()));
     }

--- a/src/UI/Implementation/Component/Input/Field/Select.php
+++ b/src/UI/Implementation/Component/Input/Field/Select.php
@@ -61,7 +61,7 @@ class Select extends FormInput implements C\Input\Field\Select
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return in_array($value, array_keys($this->options)) || $value == "";
     }

--- a/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -68,7 +68,7 @@ class SwitchableGroup extends Group implements I\SwitchableGroup
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         if (!is_string($value) && !is_int($value)) {
             return false;

--- a/src/UI/Implementation/Component/Input/Field/Tag.php
+++ b/src/UI/Implementation/Component/Input/Field/Tag.php
@@ -132,7 +132,7 @@ class Tag extends FormInput implements C\Input\Field\Tag
     /**
      * @inheritDoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         if ($this->getMaxTags() > 0) {
             $max_tags = $this->getMaxTags();

--- a/src/UI/Implementation/Component/Input/Field/Text.php
+++ b/src/UI/Implementation/Component/Input/Field/Text.php
@@ -70,7 +70,7 @@ class Text extends FormInput implements C\Input\Field\Text
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         if (!is_string($value)) {
             return false;

--- a/src/UI/Implementation/Component/Input/Field/Textarea.php
+++ b/src/UI/Implementation/Component/Input/Field/Textarea.php
@@ -103,7 +103,7 @@ class Textarea extends FormInput implements C\Input\Field\Textarea
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return is_string($value);
     }

--- a/src/UI/Implementation/Component/Input/Field/Url.php
+++ b/src/UI/Implementation/Component/Input/Field/Url.php
@@ -97,7 +97,7 @@ class Url extends FormInput implements C\Input\Field\Url
     /**
      * @inheritdoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         if (is_string($value) && trim($value) === "") {
             return true;

--- a/src/UI/Implementation/Component/Input/Group.php
+++ b/src/UI/Implementation/Component/Input/Group.php
@@ -121,9 +121,11 @@ trait Group
     }
 
     /**
-     * @inheritdoc
+     * ATTENTION: This is not the same as @see Input::isClientSideValueOk(),
+     * even if it had the same name. These are different symbols, as this trait
+     * is not in the hierarchy that defines the original isClientSideValueOk.
      */
-    public function isClientSideValueOk($value): bool
+    protected function _isClientSideValueOk($value): bool
     {
         if (!is_array($value)) {
             return false;

--- a/src/UI/Implementation/Component/Input/Input.php
+++ b/src/UI/Implementation/Component/Input/Input.php
@@ -116,7 +116,7 @@ abstract class Input implements InputInternal
      *
      * @param mixed $value
      */
-    abstract public function isClientSideValueOk($value): bool;
+    abstract protected function isClientSideValueOk($value): bool;
 
     /**
      * The error of the input as used in HTML.

--- a/src/UI/Implementation/Component/Input/ViewControl/FieldSelection.php
+++ b/src/UI/Implementation/Component/Input/ViewControl/FieldSelection.php
@@ -45,7 +45,7 @@ class FieldSelection extends ViewControlInput implements VCInterface\FieldSelect
         $this->internal_selection_signal = $signal_generator->create();
     }
 
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return is_null($value) || is_array($value);
     }

--- a/src/UI/Implementation/Component/Input/ViewControl/Group.php
+++ b/src/UI/Implementation/Component/Input/ViewControl/Group.php
@@ -98,4 +98,10 @@ class Group extends ViewControlInput implements ViewControlGroupInterface, Group
     {
         return $this->data_factory;
     }
+
+    /** ATTENTION: @see GroupInternals::_isClientSideValueOk() */
+    protected function isClientSideValueOk($value): bool
+    {
+        return $this->_isClientSideValueOk($value);
+    }
 }

--- a/src/UI/Implementation/Component/Input/ViewControl/GroupDecorator.php
+++ b/src/UI/Implementation/Component/Input/ViewControl/GroupDecorator.php
@@ -92,7 +92,7 @@ trait GroupDecorator
     /**
      * @inheritDoc
      */
-    public function isClientSideValueOk($value): bool
+    protected function isClientSideValueOk($value): bool
     {
         return $this->input_group->isClientSideValueOk($value);
     }


### PR DESCRIPTION
Hi everyone,

the method `isClientSideValueOk` changing from protected to public made plugins break that implemented their own inputs. When switching back the method to `public` unit tests fail, indicating that we cross class hierarchies when calling the method. This was due to the fact that we indeed had two different methods `isClientSideValueOk`, one from the original input hierarchy, one from a trait for groups. These are reconciled now and thus the method can be protected again.

Kind regards!