### PR TITLE
Abandon Session Mode «Load-Dependent Session Settings»

### DIFF
--- a/components/ILIAS/Authentication/classes/Setup/AbandonLoadDependantSessionDatabaseUpdateObjective.php
+++ b/components/ILIAS/Authentication/classes/Setup/AbandonLoadDependantSessionDatabaseUpdateObjective.php
@@ -34,7 +34,8 @@ class AbandonLoadDependantSessionDatabaseUpdateObjective implements ilDatabaseUp
 
     public function step_1(): void
     {
-        $this->db->manipulate('DELETE FROM settings WHERE ' . $this->db->in(
+        $this->db->manipulate(
+            'DELETE FROM settings WHERE ' . $this->db->in(
                 'keyword',
                 [
                     'session_handling_type',

--- a/components/ILIAS/Authentication/classes/Setup/AbandonLoadDependantSessionDatabaseUpdateObjective.php
+++ b/components/ILIAS/Authentication/classes/Setup/AbandonLoadDependantSessionDatabaseUpdateObjective.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Authentication\Setup;
+
+use ilDatabaseUpdateSteps;
+use ilDBInterface;
+
+class AbandonLoadDependantSessionDatabaseUpdateObjective implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->manipulate('DELETE FROM settings WHERE ' . $this->db->in(
+                'keyword',
+                [
+                    'session_handling_type',
+                    'session_max_count',
+                    'session_min_idle',
+                    'session_max_idle',
+                    'session_max_idle_after_first_request'
+                ]
+            )
+        );
+
+        if ($this->db->tableExists('usr_session_log')) {
+            $this->db->dropTable('usr_session_log', false);
+        }
+
+        if ($this->db->tableColumnExists('usr_session_stats', 'max_sessions')) {
+            $this->db->dropTableColumn('usr_session_stats', 'max_sessions');
+        }
+
+        if ($this->db->tableColumnExists('usr_session_stats', 'closed_limit')) {
+            $this->db->dropTableColumn('usr_session_stats', 'closed_limit');
+        }
+
+        if ($this->db->tableColumnExists('usr_session_stats', 'closed_idle')) {
+            $this->db->dropTableColumn('usr_session_stats', 'closed_idle');
+        }
+
+        if ($this->db->tableColumnExists('usr_session_stats', 'closed_idle_first')) {
+            $this->db->dropTableColumn('usr_session_stats', 'closed_idle_first');
+        }
+    }
+}

--- a/components/ILIAS/Authentication/classes/class.ilSession.php
+++ b/components/ILIAS/Authentication/classes/class.ilSession.php
@@ -355,12 +355,7 @@ class ilSession
     }
 
     /**
-     *
      * Returns the expiration timestamp in seconds
-     *
-     * @return	integer	The expiration timestamp in seconds
-     * @static
-     *
      */
     public static function getExpireValue(): int
     {
@@ -368,10 +363,7 @@ class ilSession
     }
 
     /**
-     *
      * Returns the idle time in seconds
-     *
-     * @return	integer	The idle time in seconds
      */
     public static function getIdleValue(): int
     {
@@ -383,11 +375,7 @@ class ilSession
     }
 
     /**
-     *
      * Returns the session expiration value
-     *
-     * @return integer	The expiration value in seconds
-     *
      */
     public static function getSessionExpireValue(): int
     {

--- a/components/ILIAS/Authentication/classes/class.ilSession.php
+++ b/components/ILIAS/Authentication/classes/class.ilSession.php
@@ -26,33 +26,12 @@ declare(strict_types=1);
 class ilSession
 {
     /**
-     *
-     * Constant for fixed dession handling
-     *
-     * @var integer
-     *
-     */
-    public const SESSION_HANDLING_FIXED = 0;
-
-    /**
-     *
-     * Constant for load dependend session handling
-     *
-     * @var integer
-     *
-     */
-    public const SESSION_HANDLING_LOAD_DEPENDENT = 1;
-
-    /**
      * Constant for reason of session destroy
      *
      * @var integer
      */
     public const SESSION_CLOSE_USER = 1;  // manual logout
     public const SESSION_CLOSE_EXPIRE = 2;  // has expired
-    public const SESSION_CLOSE_FIRST = 3;  // kicked by session control (first abidencer)
-    public const SESSION_CLOSE_IDLE = 4;  // kickey by session control (ilde time)
-    public const SESSION_CLOSE_LIMIT = 5;  // kicked by session control (limit reached)
     public const SESSION_CLOSE_LOGIN = 6;  // anonymous => login
     public const SESSION_CLOSE_PUBLIC = 7;  // => anonymous
     public const SESSION_CLOSE_TIME = 8;  // account time limit reached
@@ -379,58 +358,28 @@ class ilSession
      *
      * Returns the expiration timestamp in seconds
      *
-     * @param	boolean	If passed, the value for fixed session is returned
      * @return	integer	The expiration timestamp in seconds
      * @static
      *
      */
-    public static function getExpireValue(bool $fixedMode = false): int
+    public static function getExpireValue(): int
     {
-        global $DIC;
-
-        if ($fixedMode) {
-            // fixed session
-            return time() + self::getIdleValue($fixedMode);
-        }
-
-        /** @var ilSetting $ilSetting */
-        $ilSetting = $DIC['ilSetting'];
-        if ($ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_FIXED) {
-            return time() + self::getIdleValue($fixedMode);
-        }
-
-        if ($ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_LOAD_DEPENDENT) {
-            // load dependent session settings
-            $max_idle = (int) ($ilSetting->get('session_max_idle') ?? ilSessionControl::DEFAULT_MAX_IDLE);
-            return time() + $max_idle * 60;
-        }
-        return time() + ilSessionControl::DEFAULT_MAX_IDLE * 60;
+            return time() + self::getIdleValue();
     }
 
     /**
      *
      * Returns the idle time in seconds
      *
-     * @param	boolean	If passed, the value for fixed session is returned
      * @return	integer	The idle time in seconds
      */
-    public static function getIdleValue(bool $fixedMode = false): int
+    public static function getIdleValue(): int
     {
         global $DIC;
 
-        $ilSetting = $DIC['ilSetting'];
         $ilClientIniFile = $DIC['ilClientIniFile'];
 
-        if ($fixedMode || $ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_FIXED) {
-            // fixed session
-            return (int) $ilClientIniFile->readVariable('session', 'expire');
-        }
-
-        if ($ilSetting->get('session_handling_type', (string) self::SESSION_HANDLING_FIXED) === (string) self::SESSION_HANDLING_LOAD_DEPENDENT) {
-            // load dependent session settings
-            return ((int) $ilSetting->get('session_max_idle', (string) (ilSessionControl::DEFAULT_MAX_IDLE))) * 60;
-        }
-        return ilSessionControl::DEFAULT_MAX_IDLE * 60;
+        return (int) $ilClientIniFile->readVariable('session', 'expire');
     }
 
     /**
@@ -442,7 +391,7 @@ class ilSession
      */
     public static function getSessionExpireValue(): int
     {
-        return self::getIdleValue(true);
+        return self::getIdleValue();
     }
 
     /**

--- a/components/ILIAS/Authentication/classes/class.ilSession.php
+++ b/components/ILIAS/Authentication/classes/class.ilSession.php
@@ -359,7 +359,7 @@ class ilSession
      */
     public static function getExpireValue(): int
     {
-            return time() + self::getIdleValue();
+        return time() + self::getIdleValue();
     }
 
     /**

--- a/components/ILIAS/Authentication/classes/class.ilSessionReminder.php
+++ b/components/ILIAS/Authentication/classes/class.ilSessionReminder.php
@@ -60,16 +60,7 @@ class ilSessionReminder
 
         $ilSetting = $DIC['ilSetting'];
 
-        $isSessionReminderEnabled = (bool) $ilSetting->get('session_reminder_enabled', null);
-        $sessionHandlingMode = (int) $ilSetting->get(
-            'session_handling_type',
-            (string) ilSession::SESSION_HANDLING_FIXED
-        );
-
-        return (
-            $isSessionReminderEnabled &&
-            $sessionHandlingMode === ilSession::SESSION_HANDLING_FIXED
-        );
+        return (bool) $ilSetting->get('session_reminder_enabled');
     }
 
     public function __construct(ilObjUser $user, ClockInterface $clock)
@@ -89,7 +80,7 @@ class ilSessionReminder
             )) * 60
         );
 
-        $this->setExpirationTime(ilSession::getIdleValue(true) + $this->clock->now()->getTimestamp());
+        $this->setExpirationTime(ilSession::getIdleValue() + $this->clock->now()->getTimestamp());
         $this->setCurrentTime($this->clock->now()->getTimestamp());
 
         $this->calculateSecondsUntilExpiration();

--- a/components/ILIAS/Authentication/classes/class.ilSessionStatisticsGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilSessionStatisticsGUI.php
@@ -469,15 +469,6 @@ class ilSessionStatisticsGUI
 
         $active = ilSessionControl::getExistingSessionCount(ilSessionControl::$session_types_controlled);
 
-        $control_active = ((int) $this->settings->get('session_handling_type', "0") === 1);
-        if ($control_active) {
-            $control_max_sessions = (int) $this->settings->get('session_max_count', (string) ilSessionControl::DEFAULT_MAX_COUNT);
-            $control_min_idle = (int) $this->settings->get('session_min_idle', (string) ilSessionControl::DEFAULT_MIN_IDLE);
-            $control_max_idle = (int) $this->settings->get('session_max_idle', (string) ilSessionControl::DEFAULT_MAX_IDLE);
-            $control_max_idle_first = (int) $this->settings->get('session_max_idle_after_first_request', (string) ilSessionControl::DEFAULT_MAX_IDLE_AFTER_FIRST_REQUEST);
-        }
-
-        $last_maxed_out = new ilDateTime(ilSessionStatistics::getLastMaxedOut(), IL_CAL_UNIX);
         $last_aggr = new ilDateTime(ilSessionStatistics::getLastAggregation(), IL_CAL_UNIX);
 
 
@@ -490,32 +481,6 @@ class ilSessionStatisticsGUI
 
         $left->setVariable("CAPTION_LAST_AGGR", $this->lng->txt("trac_last_aggregation"));
         $left->setVariable("VALUE_LAST_AGGR", ilDatePresentation::formatDate($last_aggr));
-
-        $left->setVariable("CAPTION_LAST_MAX", $this->lng->txt("trac_last_maxed_out_sessions"));
-        $left->setVariable("VALUE_LAST_MAX", ilDatePresentation::formatDate($last_maxed_out));
-
-        $left->setVariable("CAPTION_SESSION_CONTROL", $this->lng->txt("sess_load_dependent_session_handling"));
-        if (!$control_active) {
-            $left->setVariable("VALUE_SESSION_CONTROL", $this->lng->txt("no"));
-        } else {
-            $left->setVariable("VALUE_SESSION_CONTROL", $this->lng->txt("yes"));
-
-            $left->setCurrentBlock("control_details");
-
-            $left->setVariable("CAPTION_SESSION_CONTROL_LIMIT", $this->lng->txt("session_max_count"));
-            $left->setVariable("VALUE_SESSION_CONTROL_LIMIT", $control_max_sessions);
-
-            $left->setVariable("CAPTION_SESSION_CONTROL_IDLE_MIN", $this->lng->txt("session_min_idle"));
-            $left->setVariable("VALUE_SESSION_CONTROL_IDLE_MIN", $control_min_idle);
-
-            $left->setVariable("CAPTION_SESSION_CONTROL_IDLE_MAX", $this->lng->txt("session_max_idle"));
-            $left->setVariable("VALUE_SESSION_CONTROL_IDLE_MAX", $control_max_idle);
-
-            $left->setVariable("CAPTION_SESSION_CONTROL_IDLE_FIRST", $this->lng->txt("session_max_idle_after_first_request"));
-            $left->setVariable("VALUE_SESSION_CONTROL_IDLE_FIRST", $control_max_idle_first);
-
-            $left->parseCurrentBlock();
-        }
 
         // sync button
         if ($this->access->checkAccess("write", "", $this->ref_id)) {
@@ -531,11 +496,9 @@ class ilSessionStatisticsGUI
     {
         // basic data - time related
 
-        $maxed_out_duration = round(ilSessionStatistics::getMaxedOutDuration($a_time_from, $a_time_to) / 60);
         $counters = ilSessionStatistics::getNumberOfSessionsByType($a_time_from, $a_time_to);
         $opened = (int) $counters["opened"];
-        $closed_limit = (int) $counters["closed_limit"];
-        unset($counters["opened"], $counters["closed_limit"]);
+        unset($counters["opened"]);
 
 
         // build center column
@@ -549,8 +512,6 @@ class ilSessionStatisticsGUI
                 new ilDateTime($a_time_to, IL_CAL_UNIX)
             ) . ")";
 
-        $data["maxed_out_time"] = array($this->lng->txt("trac_maxed_out_time"), $maxed_out_duration);
-        $data["maxed_out_counter"] = array($this->lng->txt("trac_maxed_out_counter"), $closed_limit);
         $data["opened"] = array($this->lng->txt("trac_sessions_opened"), $opened);
         $data["closed"] = array($this->lng->txt("trac_sessions_closed"), array_sum($counters));
         foreach ($counters as $type => $counter) {
@@ -629,12 +590,6 @@ class ilSessionStatisticsGUI
             $colors[] = $colors_map[$measure];
         }
 
-        if ($a_scale === self::SCALE_DAY || $a_scale === self::SCALE_WEEK) {
-            $max_line = $chart->getDataInstance(ilChartGrid::DATA_LINES);
-            $max_line->setLabel($this->lng->txt("session_max_count"));
-            $colors[] = "#cc0000";
-        }
-
         $chart->setColors($colors);
 
         $chart_data = $this->adaptDataToScale($a_scale, $a_data);
@@ -689,17 +644,10 @@ class ilSessionStatisticsGUI
                 $value = (int) $item["active_" . $measure];
                 $act_line[$measure]->addPoint($date, $value);
             }
-
-            if (isset($max_line)) {
-                $max_line->addPoint($date, (int) $item["max_sessions"]);
-            }
         }
 
         foreach ($act_line as $line) {
             $chart->addData($line);
-        }
-        if (isset($max_line)) {
-            $chart->addData($max_line);
         }
 
         $chart->setTicks($labels, null, true);

--- a/components/ILIAS/Authentication/service.xml
+++ b/components/ILIAS/Authentication/service.xml
@@ -14,7 +14,6 @@
 		<event type="raise" id="beforeLogout" />
 		<event type="raise" id="afterLogout" />
 		<event type="raise" id="expiredSessionDetected" />
-		<event type="raise" id="reachedSessionPoolLimit" />
 	</events>
 	<copage>
 		<pageobject parent_type="auth" class_name="ilLoginPage" directory="classes"/>

--- a/components/ILIAS/Authentication/templates/default/tpl.session_statistics_center.html
+++ b/components/ILIAS/Authentication/templates/default/tpl.session_statistics_center.html
@@ -12,6 +12,4 @@
 			<li>{CAPTION_CLOSED_DETAILS}: {VALUE_CLOSED_DETAILS}</li>
 			<!-- END closed_details -->
 		</ul>		
-		<p>{CAPTION_MAXED_OUT_COUNTER}: {VALUE_MAXED_OUT_COUNTER}</p>
-		<p>{CAPTION_MAXED_OUT_TIME}: {VALUE_MAXED_OUT_TIME}</p>
 </div>

--- a/components/ILIAS/Authentication/templates/default/tpl.session_statistics_left.html
+++ b/components/ILIAS/Authentication/templates/default/tpl.session_statistics_left.html
@@ -2,16 +2,6 @@
 	<div class="panel-body">
 		<p>{CAPTION_CURRENT}: {VALUE_CURRENT}</p>
 		<p>{CAPTION_LAST_AGGR}: {VALUE_LAST_AGGR}</p>
-		<p>{CAPTION_LAST_MAX}: {VALUE_LAST_MAX}</p>
-		<p>{CAPTION_SESSION_CONTROL}: {VALUE_SESSION_CONTROL}</p>
-		<!-- BEGIN control_details -->
-		<ul style="margin:0px; margin-bottom: 10px;">
-			<li>{CAPTION_SESSION_CONTROL_LIMIT}: {VALUE_SESSION_CONTROL_LIMIT}</li>
-			<li>{CAPTION_SESSION_CONTROL_IDLE_MIN}: {VALUE_SESSION_CONTROL_IDLE_MIN}</li>
-			<li>{CAPTION_SESSION_CONTROL_IDLE_MAX}: {VALUE_SESSION_CONTROL_IDLE_MAX}</li>
-			<li>{CAPTION_SESSION_CONTROL_IDLE_FIRST}: {VALUE_SESSION_CONTROL_IDLE_FIRST}</li>
-		</ul>
-		<!-- END control_details -->
 	</div>
 	<!-- BEGIN sync -->
 	<div class="panel-footer">

--- a/components/ILIAS/Authentication/tests/ilSessionTest.php
+++ b/components/ILIAS/Authentication/tests/ilSessionTest.php
@@ -81,10 +81,6 @@ class ilSessionTest extends TestCase
         $settings = $this->getMockBuilder(ilSetting::class)->getMock();
         $settings->method('get')->willReturnCallback(
             function ($arg) {
-                if ($arg === 'session_handling_type') {
-                    return (string) ilSession::SESSION_HANDLING_FIXED;
-                }
-
                 if ($arg === 'session_statistics') {
                     return '0';
                 }

--- a/components/ILIAS/LDAP/tests/ilLDAPServerTest.php
+++ b/components/ILIAS/LDAP/tests/ilLDAPServerTest.php
@@ -92,9 +92,6 @@ class ilLDAPServerTest extends TestCase
         $setting = $DIC['ilSetting'];
         $setting->method("get")->willReturnCallback(
             function ($arg) {
-                if ($arg === 'session_handling_type') {
-                    return (string) ilSession::SESSION_HANDLING_FIXED;
-                }
                 if ($arg === 'session_statistics') {
                     return "0";
                 }
@@ -120,9 +117,6 @@ class ilLDAPServerTest extends TestCase
         $setting = $DIC['ilSetting'];
         $setting->method("get")->willReturnCallback(
             function ($arg) {
-                if ($arg === 'session_handling_type') {
-                    return (string) ilSession::SESSION_HANDLING_FIXED;
-                }
                 if ($arg === 'session_statistics') {
                     return "0";
                 }

--- a/components/ILIAS/Scorm2004/classes/class.ilSCORM13PlayerGUI.php
+++ b/components/ILIAS/Scorm2004/classes/class.ilSCORM13PlayerGUI.php
@@ -379,7 +379,7 @@ class ilSCORM13PlayerGUI
             if ($session_timeout > $max_idle) {
                 $session_timeout = $max_idle;
             }
-            $min_idle = (int) $ilSetting->get('session_min_idle', (string) ilSessionControl::DEFAULT_MIN_IDLE) * 60;
+            $min_idle = ilSessionControl::DEFAULT_MIN_IDLE * 60;
             if ($session_timeout > $min_idle) {
                 $session_timeout = $min_idle;
             }

--- a/components/ILIAS/ScormAicc/classes/SCORM/class.ilObjSCORMInitData.php
+++ b/components/ILIAS/ScormAicc/classes/SCORM/class.ilObjSCORMInitData.php
@@ -82,7 +82,7 @@ class ilObjSCORMInitData
             if ($session_timeout > $max_idle) {
                 $session_timeout = $max_idle;
             }
-            $min_idle = (int) $ilSetting->get('session_min_idle', (string) ilSessionControl::DEFAULT_MIN_IDLE) * 60;
+            $min_idle = ilSessionControl::DEFAULT_MIN_IDLE * 60;
             if ($session_timeout > $min_idle) {
                 $session_timeout = $min_idle;
             }

--- a/components/ILIAS/User/classes/class.ilObjUserFolderGUI.php
+++ b/components/ILIAS/User/classes/class.ilObjUserFolderGUI.php
@@ -1730,27 +1730,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
             'dpro_withdrawal_usr_deletion' => (bool) $this->settings->get('dpro_withdrawal_usr_deletion'),
             'tos_withdrawal_usr_deletion' => (bool) $this->settings->get('tos_withdrawal_usr_deletion'),
 
-            'session_handling_type' => $this->settings->get(
-                'session_handling_type',
-                (string) ilSession::SESSION_HANDLING_FIXED
-            ),
             'session_reminder_enabled' => $this->settings->get('session_reminder_enabled'),
-            'session_max_count' => $this->settings->get(
-                'session_max_count',
-                (string) ilSessionControl::DEFAULT_MAX_COUNT
-            ),
-            'session_min_idle' => $this->settings->get(
-                'session_min_idle',
-                (string) ilSessionControl::DEFAULT_MIN_IDLE
-            ),
-            'session_max_idle' => $this->settings->get(
-                'session_max_idle',
-                (string) ilSessionControl::DEFAULT_MAX_IDLE
-            ),
-            'session_max_idle_after_first_request' => $this->settings->get(
-                'session_max_idle_after_first_request',
-                (string) ilSessionControl::DEFAULT_MAX_IDLE_AFTER_FIRST_REQUEST
-            ),
 
             'login_max_attempts' => $security->getLoginMaxAttempts(),
             'ps_prevent_simultaneous_logins' => (int) $security->isPreventionOfSimultaneousLoginsEnabled(),
@@ -1901,46 +1881,12 @@ class ilObjUserFolderGUI extends ilObjectGUI
                 );
 
                 // BEGIN SESSION SETTINGS
+
                 $this->settings->set(
-                    'session_handling_type',
-                    $this->form->getInput('session_handling_type')
+                    'session_reminder_enabled',
+                    $this->form->getInput('session_reminder_enabled')
                 );
 
-                if ($this->form->getInput('session_handling_type') == ilSession::SESSION_HANDLING_FIXED) {
-                    $this->settings->set(
-                        'session_reminder_enabled',
-                        $this->form->getInput('session_reminder_enabled')
-                    );
-                } elseif ($this->form->getInput(
-                    'session_handling_type'
-                ) == ilSession::SESSION_HANDLING_LOAD_DEPENDENT) {
-                    if (
-                        $this->settings->get(
-                            'session_allow_client_maintenance',
-                            (string) ilSessionControl::DEFAULT_ALLOW_CLIENT_MAINTENANCE
-                        )
-                    ) {
-                        // has to be done BEFORE updating the setting!
-                        ilSessionStatistics::updateLimitLog((int) $this->form->getInput('session_max_count'));
-
-                        $this->settings->set(
-                            'session_max_count',
-                            $this->form->getInput('session_max_count')
-                        );
-                        $this->settings->set(
-                            'session_min_idle',
-                            $this->form->getInput('session_min_idle')
-                        );
-                        $this->settings->set(
-                            'session_max_idle',
-                            $this->form->getInput('session_max_idle')
-                        );
-                        $this->settings->set(
-                            'session_max_idle_after_first_request',
-                            $this->form->getInput('session_max_idle_after_first_request')
-                        );
-                    }
-                }
                 // END SESSION SETTINGS
                 $this->settings->set(
                     'letter_avatars',
@@ -2073,16 +2019,6 @@ class ilObjUserFolderGUI extends ilObjectGUI
             (string) ilSessionControl::DEFAULT_ALLOW_CLIENT_MAINTENANCE
         );
 
-        $ssettings = new ilRadioGroupInputGUI(
-            $this->lng->txt('sess_mode'),
-            'session_handling_type'
-        );
-
-        // first option, fixed session duration
-        $fixed = new ilRadioOption(
-            $this->lng->txt('sess_fixed_duration'),
-            (string) ilSession::SESSION_HANDLING_FIXED
-        );
 
         // create session reminder subform
         $cb = new ilCheckboxInputGUI(
@@ -2101,85 +2037,12 @@ class ilObjUserFolderGUI extends ilObjectGUI
                 $time
             )
         );
-        $fixed->addSubItem($cb);
-
-        // add session handling to radio group
-        $ssettings->addOption($fixed);
-
-        // second option, session control
-        $ldsh = new ilRadioOption(
-            $this->lng->txt('sess_load_dependent_session_handling'),
-            (string) ilSession::SESSION_HANDLING_LOAD_DEPENDENT
-        );
-
-        // add session control subform
-
-        // this is the max count of active sessions
-        // that are getting started simlutanously
-        $sub_ti = new ilTextInputGUI(
-            $this->lng->txt('session_max_count'),
-            'session_max_count'
-        );
-        $sub_ti->setMaxLength(5);
-        $sub_ti->setSize(5);
-        $sub_ti->setInfo($this->lng->txt('session_max_count_info'));
-        if (!$allow_client_maintenance) {
-            $sub_ti->setDisabled(true);
-        }
-        $ldsh->addSubItem($sub_ti);
-
-        // after this (min) idle time the session can be deleted,
-        // if there are further requests for new sessions,
-        // but max session count is reached yet
-        $sub_ti = new ilTextInputGUI(
-            $this->lng->txt('session_min_idle'),
-            'session_min_idle'
-        );
-        $sub_ti->setMaxLength(5);
-        $sub_ti->setSize(5);
-        $sub_ti->setInfo($this->lng->txt('session_min_idle_info'));
-        if (!$allow_client_maintenance) {
-            $sub_ti->setDisabled(true);
-        }
-        $ldsh->addSubItem($sub_ti);
-
-        // after this (max) idle timeout the session expires
-        // and become invalid, so it is not considered anymore
-        // when calculating current count of active sessions
-        $sub_ti = new ilTextInputGUI(
-            $this->lng->txt('session_max_idle'),
-            'session_max_idle'
-        );
-        $sub_ti->setMaxLength(5);
-        $sub_ti->setSize(5);
-        $sub_ti->setInfo($this->lng->txt('session_max_idle_info'));
-        if (!$allow_client_maintenance) {
-            $sub_ti->setDisabled(true);
-        }
-        $ldsh->addSubItem($sub_ti);
-
-        // this is the max duration that can elapse between the first and the secnd
-        // request to the system before the session is immidietly deleted
-        $sub_ti = new ilTextInputGUI(
-            $this->lng->txt('session_max_idle_after_first_request'),
-            'session_max_idle_after_first_request'
-        );
-        $sub_ti->setMaxLength(5);
-        $sub_ti->setSize(5);
-        $sub_ti->setInfo($this->lng->txt('session_max_idle_after_first_request_info'));
-        if (!$allow_client_maintenance) {
-            $sub_ti->setDisabled(true);
-        }
-        $ldsh->addSubItem($sub_ti);
-
-        // add session control to radio group
-        $ssettings->addOption($ldsh);
 
         // add radio group to form
         if ($allow_client_maintenance) {
             // just shows the status wether the session
             //setting maintenance is allowed by setup
-            $this->form->addItem($ssettings);
+            $this->form->addItem($cb);
         } else {
             // just shows the status wether the session
             //setting maintenance is allowed by setup
@@ -2188,8 +2051,8 @@ class ilObjUserFolderGUI extends ilObjectGUI
                 'session_config'
             );
             $ti->setValue($this->lng->txt('session_config_maintenance_disabled'));
-            $ssettings->setDisabled(true);
-            $ti->addSubItem($ssettings);
+            $cb->setDisabled(true);
+            $ti->addSubItem($cb);
             $this->form->addItem($ti);
         }
 

--- a/components/ILIAS/User/classes/class.ilObjUserFolderGUI.php
+++ b/components/ILIAS/User/classes/class.ilObjUserFolderGUI.php
@@ -2021,7 +2021,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
 
 
         // create session reminder subform
-        $cb = new ilCheckboxInputGUI(
+        $session_reminder = new ilCheckboxInputGUI(
             $this->lng->txt('session_reminder'),
             'session_reminder_enabled'
         );
@@ -2030,7 +2030,7 @@ class ilObjUserFolderGUI extends ilObjectGUI
             $expires,
             true
         );
-        $cb->setInfo(
+        $session_reminder->setInfo(
             $this->lng->txt('session_reminder_info') . '<br />' .
             sprintf(
                 $this->lng->txt('session_reminder_session_duration'),
@@ -2042,18 +2042,18 @@ class ilObjUserFolderGUI extends ilObjectGUI
         if ($allow_client_maintenance) {
             // just shows the status wether the session
             //setting maintenance is allowed by setup
-            $this->form->addItem($cb);
+            $this->form->addItem($session_reminder);
         } else {
             // just shows the status wether the session
             //setting maintenance is allowed by setup
-            $ti = new ilNonEditableValueGUI(
+            $session_config = new ilNonEditableValueGUI(
                 $this->lng->txt('session_config'),
                 'session_config'
             );
-            $ti->setValue($this->lng->txt('session_config_maintenance_disabled'));
-            $cb->setDisabled(true);
-            $ti->addSubItem($cb);
-            $this->form->addItem($ti);
+            $session_config->setValue($this->lng->txt('session_config_maintenance_disabled'));
+            $session_reminder->setDisabled(true);
+            $session_config->addSubItem($session_reminder);
+            $this->form->addItem($session_config);
         }
 
         // END SESSION SETTINGS

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2498,7 +2498,7 @@ blog#:#blog_permanent_link#:#Permalink
 blog#:#blog_posting#:#Beitrag
 blog#:#blog_posting_deleted#:#Der Beitrag wurde gelöscht.
 blog#:#blog_posting_deletion_confirmation#:#Wollen Sie diesen Beitrag wirklich löschen?
-blog#:#blog_posting_edit_approval_info#:#Der Beitrag muss durch die Blog-Redaktion freigeschaltet werden, bevor er sichtbar wird. Die Freischaltung kann nur stattfinden, wenn der Beitrag schon veröffentlicht wurde. 
+blog#:#blog_posting_edit_approval_info#:#Der Beitrag muss durch die Blog-Redaktion freigeschaltet werden, bevor er sichtbar wird. Die Freischaltung kann nur stattfinden, wenn der Beitrag schon veröffentlicht wurde.
 blog#:#blog_posting_not_found#:#Der Beitrag ist nicht verfügbar.
 blog#:#blog_postings#:#Beiträge
 blog#:#blog_presentation_frame#:#Darstellung
@@ -5384,7 +5384,6 @@ common#:#question#:#Frage
 common#:#question_message#:#Frage
 common#:#quit#:#Logout
 common#:#quote#:#Zitat
-common#:#reached_session_limit#:#Die maximale Anzahl von Benutzern, die online sind, ist erreicht. Bitte versuchen Sie es später noch einmal.
 common#:#read#:#Lesezugriff
 common#:#readcount_anonymous_users#:#Lesezugriffe anonymer Benutzer
 common#:#readcount_users#:#Lesezugriffe registrierter Benutzer
@@ -5568,22 +5567,11 @@ common#:#server_disabled#:#Der Chat ist deaktiviert
 common#:#server_software#:#Server-Software
 common#:#sess#:#Sitzung
 common#:#sess_fixed_duration#:#Fixe Session-Dauer
-common#:#sess_load_dependent_session_handling#:#Lastabhängige Session-Einstellungen
-common#:#sess_mode#:#Session-Modus
-common#:#sess_new#:#Neue Sitzung anlegen
 common#:#session_config#:#Session-Einstellungen
 common#:#session_config_maintenance_disabled#:#Änderungen im Mandanten nicht zugelassen
 common#:#session_mail_subject_deletion#:#Abmeldung von Benutzer/in „%s“ von der Sitzung „%s“
 common#:#session_mail_subject_entered#:#Beitritt von Benutzer/in „%s“ zur Sitzung „%s“
 common#:#session_mail_subject_registered#:#Registrierung von Benutzer/in „%s“ für die Sitzung „%s“
-common#:#session_max_count#:#Maximale Anzahl aktiver Sessions
-common#:#session_max_count_info#:#Definiert die maximale Anzahl an Sessions, die gleichzeitig existieren können. Wenn dieser Wert auf "0" gesetzt wird, ist die Funktion deaktiviert.
-common#:#session_max_idle#:#Maximale Leerlaufzeit einer Session (in Minuten)
-common#:#session_max_idle_after_first_request#:#Minimale Leerlaufzeit einer Session nach der ersten Anfrage (in Minuten)
-common#:#session_max_idle_after_first_request_info#:#Wenn ein Benutzer nach seiner ersten Anfrage für diesen Zeitraum inaktiv ist kann seine Session gelöscht werden, sofern eine andere Session für einen anderen Benutzer erstellt werden soll und das maximale Session-Limit erreicht wurde.
-common#:#session_max_idle_info#:#Wenn ein Benutzer für diesen Zeitraum inaktiv ist, ist seine Session ausgelaufen.
-common#:#session_min_idle#:#Minimale Leerlaufzeit einer Session (in Minuten)
-common#:#session_min_idle_info#:#Wenn ein Benutzer für mindestens diesen Zeitraum inaktiv ist, kann seine Session gelöscht werden, sofern eine andere Session für einen anderen Benutzer erstellt werden soll und das maximale Session Limit erreicht wurde.
 common#:#session_reminder#:#Session-Reminder
 common#:#session_reminder_alert#:#Ihre Sitzung läuft in %1$s um %2$s ab!  Klicken Sie auf OK, um Ihre Sitzung zu verlängern! Wollen Sie dagegen in der aktuellen Browser-Sitzung nicht mehr erinnert werden, wählen Sie bitte Abbrechen.  Betroffene Installation: %3$s.
 common#:#session_reminder_info#:#Wenn aktiviert, erhalten Sie eine Erinnerung, bevor Ihre Sitzung abläuft.
@@ -16958,8 +16946,6 @@ trac#:#trac_assigned#:#Ausgewählt
 trac#:#trac_average#:#Durchschnitt
 trac#:#trac_begin_at#:#Startdatum
 trac#:#trac_closed_expire#:#Timeout
-trac#:#trac_closed_idle#:#Leerlaufzeit
-trac#:#trac_closed_idle_first#:#Leerlaufzeit (1. Anfrage)
 trac#:#trac_closed_login#:#Anonym zu Login
 trac#:#trac_closed_manual#:#Logout
 trac#:#trac_closed_misc#:#Sonstige
@@ -17003,7 +16989,6 @@ trac#:#trac_in_progress#:#In Bearbeitung
 trac#:#trac_info_edited#:#Wenn Sie der Meinung sind, dass Sie alle Inhalte bearbeitet haben, können Sie hier den Status Ihres Lernfortschrittes ändern.
 trac#:#trac_last_access#:#Letzter Zugriff
 trac#:#trac_last_aggregation#:#Stand
-trac#:#trac_last_maxed_out_sessions#:#Letzte Volllast
 trac#:#trac_learning_progress#:#Lernfortschritt
 trac#:#trac_learning_progress_of#:#Lernfortschritt von %s
 trac#:#trac_learning_progress_settings_info#:#Erweiterte Daten aktivieren
@@ -17030,8 +17015,6 @@ trac#:#trac_manual_is_displayed#:#Bestimmt Lernfortschritt
 trac#:#trac_manual_no_display#:#Im Lernfortschritt nicht anzeigen
 trac#:#trac_mark#:#Note
 trac#:#trac_matrix#:#Matrixansicht
-trac#:#trac_maxed_out_counter#:#Abgewiesene Benutzer
-trac#:#trac_maxed_out_time#:#Vollauslastung [min]
 trac#:#trac_measure#:#Kennzahl
 trac#:#trac_members_short#:#Teil.
 trac#:#trac_min_passed#:#Minimalanzahl zu bestehender Materialien:

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5361,7 +5361,6 @@ common#:#question#:#Question
 common#:#question_message#:#Question
 common#:#quit#:#Quit
 common#:#quote#:#Quote
-common#:#reached_session_limit#:#The limit of online users is reached. Please try again later.
 common#:#read#:#Read
 common#:#readcount_anonymous_users#:#Number of anonymous read accesses
 common#:#readcount_users#:#Number of non-anonymous read accesses
@@ -5545,22 +5544,11 @@ common#:#server_disabled#:#The Chat is Disabled
 common#:#server_software#:#Server Software
 common#:#sess#:#Session
 common#:#sess_fixed_duration#:#Fixed Session Duration
-common#:#sess_load_dependent_session_handling#:#Load-Dependent Session Settings
-common#:#sess_mode#:#Session Mode
-common#:#sess_new#:#New Session
 common#:#session_config#:#Session Settings
 common#:#session_config_maintenance_disabled#:#Maintenance by client not allowed
 common#:#session_mail_subject_deletion#:#Deregistration of user "%s" from session "%s"
 common#:#session_mail_subject_entered#:#Joining of user "%s" in session "%s"
 common#:#session_mail_subject_registered#:#Registration of user "%s" for session "%s"
-common#:#session_max_count#:#Max Number of Active Sessions
-common#:#session_max_count_info#:#Defines the maximum number of sessions that can be created simultaneously. Set the value to ‘0’ to disable the feature.
-common#:#session_max_idle#:#Maximum Session Idle (in minutes)
-common#:#session_max_idle_after_first_request#:#Max session idle after first request (in minutes)
-common#:#session_max_idle_after_first_request_info#:#All sessions that idles for at least this period of time after first request will be destroyed if another session should be opened for another user and the maximum number of existing sessions is reached.
-common#:#session_max_idle_info#:#Defines the maximum period of idle time a user can idle before his session expires.
-common#:#session_min_idle#:#Max Session Idle (in Minutes) When Max Number of Active Sessions Reached
-common#:#session_min_idle_info#:#If a user has been idle for at least this period of time and the maximum number of active sessions allowed has been reached, then their session will be automatically ended when a different user starts a new session.
 common#:#session_reminder#:#Session Reminder
 common#:#session_reminder_alert#:#Your session expires in %1$s at %2$s!  Choose OK to continue your session. If you click Cancel you will not be reminded during the current browser session anymore.  Installation: %3$s.
 common#:#session_reminder_info#:#Receive a reminder before your online-session expires.
@@ -16845,8 +16833,6 @@ trac#:#trac_assigned#:#Assigned
 trac#:#trac_average#:#Average
 trac#:#trac_begin_at#:#Start date
 trac#:#trac_closed_expire#:#Timeout
-trac#:#trac_closed_idle#:#Idle Time
-trac#:#trac_closed_idle_first#:#Idle Time (1st Request)
 trac#:#trac_closed_login#:#Anonymous To Login
 trac#:#trac_closed_manual#:#Logout
 trac#:#trac_closed_misc#:#Misc.
@@ -16890,7 +16876,6 @@ trac#:#trac_in_progress#:#In Progress
 trac#:#trac_info_edited#:#Set the status to ‘Completed’ if you think you have processed all content.
 trac#:#trac_last_access#:#Last Access
 trac#:#trac_last_aggregation#:#Last Aggregation
-trac#:#trac_last_maxed_out_sessions#:#Last Full Load
 trac#:#trac_learning_progress#:#Learning Progress
 trac#:#trac_learning_progress_of#:#Learning Progress of %s
 trac#:#trac_learning_progress_settings_info#:#Activate extended data
@@ -16917,8 +16902,6 @@ trac#:#trac_manual_is_displayed#:#Is Displayed
 trac#:#trac_manual_no_display#:#Do not display in Learning Progress
 trac#:#trac_mark#:#Mark
 trac#:#trac_matrix#:#Matrix View
-trac#:#trac_maxed_out_counter#:#Rejected Users
-trac#:#trac_maxed_out_time#:#Full Load [min]
 trac#:#trac_measure#:#Figure
 trac#:#trac_members_short#:#Members
 trac#:#trac_min_passed#:#Minimum Number of Passed Materials:


### PR DESCRIPTION
Removes everything related to the load-dependent session settings

Feature Wiki Page: https://docu.ilias.de/goto_docu_wiki_wpage_8263_1357.html

* @Uwe-Kohnle: We had to change one line in the SCORM components
* @kergomard: We removed the "Session Mode" setting from the user component

A quick review is highly appreciated.