### PR TITLE
[FIX] UI: revert input type hints for backwards compatibility.

### DIFF
--- a/src/UI/Component/Input/Container/Form/FormInput.php
+++ b/src/UI/Component/Input/Container/Form/FormInput.php
@@ -66,7 +66,7 @@ interface FormInput extends Input, JavaScriptBindable, OnUpdateable
      * (see getConstraintForRequirement() on Input/Field implementations).
      * A custom constraint SHOULD be explained in the byline of the input.
      */
-    public function withRequired(bool $is_required, ?Constraint $requirement_constraint = null): self;
+    public function withRequired(bool $is_required, ?Constraint $requirement_constraint = null);
 
     /**
      * Is this input disabled?

--- a/src/UI/Component/Input/Field/DateTime.php
+++ b/src/UI/Component/Input/Field/DateTime.php
@@ -33,7 +33,7 @@ interface DateTime extends FormInput
     /**
      * Get an input like this using the given format.
      */
-    public function withFormat(DateFormat $format): self;
+    public function withFormat(DateFormat $format): DateTime;
 
     /**
      * Get the date-format of this input.
@@ -43,7 +43,7 @@ interface DateTime extends FormInput
     /**
      * Get an input like this using the given timezone.
      */
-    public function withTimezone(string $tz): self;
+    public function withTimezone(string $tz): DateTime;
 
     /**
      * Get the timezone of this input.
@@ -53,7 +53,7 @@ interface DateTime extends FormInput
     /**
      * Limit accepted values to datetime past (and including) the given $datetime.
      */
-    public function withMinValue(DateTimeImmutable $datetime): self;
+    public function withMinValue(DateTimeImmutable $datetime): DateTime;
 
     /**
      * Return the lowest value the input accepts.
@@ -63,7 +63,7 @@ interface DateTime extends FormInput
     /**
      * Limit accepted values to datetime before (and including) the given value.
      */
-    public function withMaxValue(DateTimeImmutable $datetime): self;
+    public function withMaxValue(DateTimeImmutable $datetime): DateTime;
 
     /**
      * Return the maximum date the input accepts.
@@ -73,7 +73,7 @@ interface DateTime extends FormInput
     /**
      * Input both date and time.
      */
-    public function withUseTime(bool $with_time): self;
+    public function withUseTime(bool $with_time): DateTime;
 
     /**
      * Should the input be used to get both date and time?
@@ -83,7 +83,7 @@ interface DateTime extends FormInput
     /**
      * Use this Input for a time-value rather than a date.
      */
-    public function withTimeOnly(bool $time_only): self;
+    public function withTimeOnly(bool $time_only): DateTime;
 
     /**
      * Should the input be used to get a time only?

--- a/src/UI/Component/Input/Field/HasDynamicInputs.php
+++ b/src/UI/Component/Input/Field/HasDynamicInputs.php
@@ -31,7 +31,7 @@ interface HasDynamicInputs extends FormInput
      * Returns the instance of Input which should be used to generate
      * dynamic inputs on clientside.
      */
-    public function getTemplateForDynamicInputs(): FormInput;
+    public function getTemplateForDynamicInputs(): Input;
 
     /**
      * Returns serverside generated dynamic Inputs, which happens when

--- a/src/UI/Implementation/Component/Input/Field/Checkbox.php
+++ b/src/UI/Implementation/Component/Input/Field/Checkbox.php
@@ -64,7 +64,7 @@ class Checkbox extends FormInput implements C\Input\Field\Checkbox, C\Changeable
     /**
      * @inheritdoc
      */
-    public function withValue($value): self
+    public function withValue($value): C\Input\Field\Input
     {
         $value = $value ?? false;
 
@@ -81,7 +81,7 @@ class Checkbox extends FormInput implements C\Input\Field\Checkbox, C\Changeable
     /**
      * @inheritdoc
      */
-    public function withInput(InputData $input): self
+    public function withInput(InputData $input): C\Input\Field\Input
     {
         if ($this->getName() === null) {
             throw new LogicException("Can only collect if input has a name.");

--- a/src/UI/Implementation/Component/Input/Field/DateTime.php
+++ b/src/UI/Implementation/Component/Input/Field/DateTime.php
@@ -84,7 +84,7 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
      *
      * Allows to pass a \DateTimeImmutable for consistencies sake.
      */
-    public function withValue($value): self
+    public function withValue($value)
     {
         // TODO: It would be a lot nicer if the value would be held as DateTimeImmutable
         // internally, but currently this is just to much. Added to the roadmap.
@@ -97,7 +97,7 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
         return $clone;
     }
 
-    public function withFormat(DateFormat $format): self
+    public function withFormat(DateFormat $format): C\Input\Field\DateTime
     {
         $clone = clone $this;
         $clone->format = $format;
@@ -110,7 +110,7 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
     }
 
 
-    public function withTimezone(string $tz): self
+    public function withTimezone(string $tz): C\Input\Field\DateTime
     {
         $timezone_trafo = $this->refinery->dateTime()->changeTimezone($tz);
         $clone = clone $this;
@@ -126,7 +126,7 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
         return $this->timezone;
     }
 
-    public function withMinValue(DateTimeImmutable $datetime): self
+    public function withMinValue(DateTimeImmutable $datetime): C\Input\Field\DateTime
     {
         $clone = clone $this;
         $clone->min_date = $datetime;
@@ -138,7 +138,7 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
         return $this->min_date;
     }
 
-    public function withMaxValue(DateTimeImmutable $datetime): self
+    public function withMaxValue(DateTimeImmutable $datetime): C\Input\Field\DateTime
     {
         $clone = clone $this;
         $clone->max_date = $datetime;
@@ -150,7 +150,7 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
         return $this->max_date;
     }
 
-    public function withUseTime(bool $with_time): self
+    public function withUseTime(bool $with_time): C\Input\Field\DateTime
     {
         $clone = clone $this;
         $clone->with_time = $with_time;
@@ -162,7 +162,7 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
         return $this->with_time;
     }
 
-    public function withTimeOnly(bool $time_only): self
+    public function withTimeOnly(bool $time_only): C\Input\Field\DateTime
     {
         $clone = clone $this;
         $clone->with_time_only = $time_only;
@@ -202,7 +202,7 @@ class DateTime extends FormInput implements C\Input\Field\DateTime
      * The bootstrap picker can be configured, e.g. with a minimum date.
      * @param array <string => mixed> $config
      */
-    public function withAdditionalPickerconfig(array $config): self
+    public function withAdditionalPickerconfig(array $config): C\Input\Field\DateTime
     {
         $clone = clone $this;
         $clone->additional_picker_config = array_merge($clone->additional_picker_config, $config);

--- a/src/UI/Implementation/Component/Input/Field/FormInput.php
+++ b/src/UI/Implementation/Component/Input/Field/FormInput.php
@@ -56,7 +56,7 @@ abstract class FormInput extends Input implements FormInputInternal
     /**
      * @inheritDoc
      */
-    public function withInput(InputData $input): Input
+    public function withInput(InputData $input)
     {
         if (!$this->isDisabled()) {
             return parent::withInput($input);
@@ -85,7 +85,7 @@ abstract class FormInput extends Input implements FormInputInternal
     /**
      * @inheritdoc
      */
-    public function withLabel(string $label): self
+    public function withLabel(string $label)
     {
         $clone = clone $this;
         $clone->label = $label;
@@ -103,7 +103,7 @@ abstract class FormInput extends Input implements FormInputInternal
     /**
      * @inheritdoc
      */
-    public function withByline(string $byline): self
+    public function withByline(string $byline)
     {
         $clone = clone $this;
         $clone->byline = $byline;
@@ -121,7 +121,7 @@ abstract class FormInput extends Input implements FormInputInternal
     /**
      * @inheritdoc
      */
-    public function withRequired(bool $is_required, ?Constraint $requirement_constraint = null): self
+    public function withRequired(bool $is_required, ?Constraint $requirement_constraint = null)
     {
         $clone = clone $this;
         $clone->is_required = $is_required;
@@ -140,7 +140,7 @@ abstract class FormInput extends Input implements FormInputInternal
     /**
      * @inheritdoc
      */
-    public function withDisabled(bool $is_disabled): self
+    public function withDisabled(bool $is_disabled)
     {
         $clone = clone $this;
         $clone->is_disabled = $is_disabled;
@@ -150,7 +150,7 @@ abstract class FormInput extends Input implements FormInputInternal
     /**
      * @inheritdoc
      */
-    public function withOnUpdate(Signal $signal): self
+    public function withOnUpdate(Signal $signal)
     {
         return $this->withTriggeredSignal($signal, 'update');
     }

--- a/src/UI/Implementation/Component/Input/Field/Group.php
+++ b/src/UI/Implementation/Component/Input/Field/Group.php
@@ -34,6 +34,7 @@ use ILIAS\Data\Result\Ok;
 use Generator;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
 use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\Field\Input as LegacyInputInterface;
 
 /**
  * This implements the group input.
@@ -60,14 +61,14 @@ class Group extends FormInput implements C\Input\Field\Group, GroupInternal
         $this->lng = $lng;
     }
 
-    public function withDisabled(bool $is_disabled): self
+    public function withDisabled(bool $is_disabled): LegacyInputInterface
     {
         $clone = parent::withDisabled($is_disabled);
         $clone->setInputs(array_map(fn ($i) => $i->withDisabled($is_disabled), $this->getInputs()));
         return $clone;
     }
 
-    public function withRequired(bool $is_required, ?Constraint $requirement_constraint = null): self
+    public function withRequired(bool $is_required, ?Constraint $requirement_constraint = null): LegacyInputInterface
     {
         $clone = parent::withRequired($is_required, $requirement_constraint);
         $clone->setInputs(array_map(fn ($i) => $i->withRequired($is_required, $requirement_constraint), $this->getInputs()));
@@ -87,7 +88,7 @@ class Group extends FormInput implements C\Input\Field\Group, GroupInternal
         return false;
     }
 
-    public function withOnUpdate(Signal $signal): self
+    public function withOnUpdate(Signal $signal)
     {
         $clone = parent::withOnUpdate($signal);
         $clone->setInputs(array_map(fn ($i) => $i->withOnUpdate($signal), $this->getInputs()));
@@ -118,7 +119,7 @@ class Group extends FormInput implements C\Input\Field\Group, GroupInternal
     /**
      * @inheritdoc
      */
-    public function withNameFrom(NameSource $source, ?string $parent_name = null): self
+    public function withNameFrom(NameSource $source, ?string $parent_name = null): LegacyInputInterface
     {
         /** @var $clone self */
         $clone = parent::withNameFrom($source, $parent_name);

--- a/src/UI/Implementation/Component/Input/Field/HasDynamicInputsBase.php
+++ b/src/UI/Implementation/Component/Input/Field/HasDynamicInputsBase.php
@@ -26,6 +26,7 @@ use ILIAS\UI\Implementation\Component\Input\NameSource;
 use ILIAS\UI\Implementation\Component\Input\InputData;
 use ILIAS\UI\Component\Input\Container\Form\FormInput as FormInputInterface;
 use ILIAS\UI\Component\Input\Field\HasDynamicInputs;
+use ILIAS\UI\Component\Input\Field\Input as LegacyInputInterface;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
 use InvalidArgumentException;
@@ -65,7 +66,7 @@ abstract class HasDynamicInputsBase extends FormInput implements HasDynamicInput
      * Returns the instance of Field which should be used to generate
      * dynamic inputs on clientside.
      */
-    public function getTemplateForDynamicInputs(): FormInputInterface
+    public function getTemplateForDynamicInputs(): LegacyInputInterface
     {
         return $this->dynamic_input_template;
     }

--- a/src/UI/Implementation/Component/Input/Field/Input.php
+++ b/src/UI/Implementation/Component/Input/Field/Input.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Input\Field;
+
+/**
+ * This is a legacy support of Implementation\Component\Input\Field\Input
+ * that has been moved to Implementation\Component\Input\Input.
+ *
+ * Please always extend from \ILIAS\UI\Implementation\Component\Input\Input
+ * or \ILIAS\UI\Implementation\Component\Input\Field\FormInput.
+ *
+ * @deprecated removed in 9
+ */
+abstract class Input extends FormInput
+{
+}

--- a/src/UI/Implementation/Component/Input/Field/OptionalGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/OptionalGroup.php
@@ -59,7 +59,7 @@ class OptionalGroup extends Group implements I\OptionalGroup
         return parent::isClientSideValueOk($value);
     }
 
-    public function withRequired($is_required, ?Constraint $requirement_constraint = null): self
+    public function withRequired($is_required, ?Constraint $requirement_constraint = null): I\Input
     {
         /** @noinspection PhpIncompatibleReturnTypeInspection */
         return FormInput::withRequired($is_required, $requirement_constraint);
@@ -73,7 +73,7 @@ class OptionalGroup extends Group implements I\OptionalGroup
     /**
      * @inheritdoc
      */
-    public function withValue($value): self
+    public function withValue($value): I\Input
     {
         if ($value === null) {
             $clone = clone $this;
@@ -102,7 +102,7 @@ class OptionalGroup extends Group implements I\OptionalGroup
     /**
      * @inheritdoc
      */
-    public function withInput(InputData $input): self
+    public function withInput(InputData $input): I\Input
     {
         if ($this->getName() === null) {
             throw new LogicException("Can only collect if input has a name.");

--- a/src/UI/Implementation/Component/Input/Field/Password.php
+++ b/src/UI/Implementation/Component/Input/Field/Password.php
@@ -87,7 +87,7 @@ class Password extends FormInput implements C\Input\Field\Password, Triggerable
         bool $upper = true,
         bool $numbers = true,
         bool $special = true
-    ): self {
+    ): C\Input\Field\Input {
         $pw_validation = $this->refinery->password();
         $constraints = [
             $this->refinery->string()->hasMinLength($min_length),

--- a/src/UI/Implementation/Component/Input/Field/Radio.php
+++ b/src/UI/Implementation/Component/Input/Field/Radio.php
@@ -99,7 +99,7 @@ class Radio extends FormInput implements C\Input\Field\Radio
     /**
      * @inheritdoc
      */
-    public function withInput(InputData $input): self
+    public function withInput(InputData $input): C\Input\Field\Input
     {
         if ($this->getName() === null) {
             throw new LogicException("Can only collect if input has a name.");

--- a/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/src/UI/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -76,7 +76,7 @@ class SwitchableGroup extends Group implements I\SwitchableGroup
         return array_key_exists($value, $this->getInputs());
     }
 
-    public function withRequired($is_required, ?Constraint $requirement_constraint = null): self
+    public function withRequired($is_required, ?Constraint $requirement_constraint = null): I\Input
     {
         /** @noinspection PhpIncompatibleReturnTypeInspection */
         return FormInput::withRequired($is_required, $requirement_constraint);
@@ -85,7 +85,7 @@ class SwitchableGroup extends Group implements I\SwitchableGroup
     /**
      * @inheritdoc
      */
-    public function withValue($value): self
+    public function withValue($value): I\Input
     {
         if (is_string($value) || is_int($value)) {
             /** @noinspection PhpIncompatibleReturnTypeInspection */
@@ -126,7 +126,7 @@ class SwitchableGroup extends Group implements I\SwitchableGroup
     /**
      * @inheritdoc
      */
-    public function withInput(InputData $input): self
+    public function withInput(InputData $input): I\Input
     {
         if ($this->getName() === null) {
             throw new LogicException("Can only collect if input has a name.");

--- a/src/UI/Implementation/Component/Input/Field/Tag.php
+++ b/src/UI/Implementation/Component/Input/Field/Tag.php
@@ -229,7 +229,7 @@ class Tag extends FormInput implements C\Input\Field\Tag
     /**
      * @inheritDoc
      */
-    public function withTagMaxLength(int $max_length): self
+    public function withTagMaxLength(int $max_length): C\Input\Field\Tag
     {
         $clone = clone $this;
         $clone->tag_max_length = $max_length;
@@ -248,7 +248,7 @@ class Tag extends FormInput implements C\Input\Field\Tag
     /**
      * @inheritDoc
      */
-    public function withMaxTags(int $max_tags): self
+    public function withMaxTags(int $max_tags): C\Input\Field\Tag
     {
         $clone = clone $this;
         $clone->max_tags = $max_tags;
@@ -267,7 +267,7 @@ class Tag extends FormInput implements C\Input\Field\Tag
     /**
      * @inheritDoc
      */
-    public function withInput(InputData $input): self
+    public function withInput(InputData $input): C\Input\Field\Input
     {
         // ATTENTION: This is a slightly modified copy of parent::withInput, which
         // fixes #27909 but makes the Tag Input unusable in Filter Containers.
@@ -291,12 +291,12 @@ class Tag extends FormInput implements C\Input\Field\Tag
     }
 
     // Events
-    public function withAdditionalOnTagAdded(Signal $signal): self
+    public function withAdditionalOnTagAdded(Signal $signal): C\Input\Field\Tag
     {
         return $this->appendTriggeredSignal($signal, self::EVENT_ITEM_ADDED);
     }
 
-    public function withAdditionalOnTagRemoved(Signal $signal): self
+    public function withAdditionalOnTagRemoved(Signal $signal): C\Input\Field\Tag
     {
         return $this->appendTriggeredSignal($signal, self::EVENT_ITEM_REMOVED);
     }

--- a/src/UI/Implementation/Component/Input/Group.php
+++ b/src/UI/Implementation/Component/Input/Group.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Input;
 
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Component\Input\Field\Input as LegacyInputInterface;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Refinery\Constraint;
 use ILIAS\Data\Factory as DataFactory;
@@ -55,7 +56,7 @@ trait Group
      * @param mixed $value
      * @throws  \InvalidArgumentException    if value does not fit client side input
      */
-    public function withValue($value): \ILIAS\UI\Implementation\Component\Input\Input
+    public function withValue($value): LegacyInputInterface
     {
         $this->checkArg("value", $this->isClientSideValueOk($value), "Display value does not match input type.");
         $clone = clone $this;
@@ -71,7 +72,7 @@ trait Group
      *
      * @inheritdoc
      */
-    public function withInput(InputData $input): \ILIAS\UI\Implementation\Component\Input\Input
+    public function withInput(InputData $input): LegacyInputInterface
     {
         if (empty($this->getInputs())) {
             return $this;

--- a/src/UI/Implementation/Component/Input/Input.php
+++ b/src/UI/Implementation/Component/Input/Input.php
@@ -103,7 +103,7 @@ abstract class Input implements InputInternal
      * @param   mixed $value
      * @throws  InvalidArgumentException    if value does not fit client side input
      */
-    public function withValue($value): self
+    public function withValue($value)
     {
         $this->checkArg("value", $this->isClientSideValueOk($value), "Display value does not match input type.");
         $clone = clone $this;
@@ -129,7 +129,7 @@ abstract class Input implements InputInternal
     /**
      * Get an input like this one, with a different error.
      */
-    public function withError(string $error): self
+    public function withError(string $error)
     {
         $clone = clone $this;
         $clone->setError($error);
@@ -147,7 +147,7 @@ abstract class Input implements InputInternal
     /**
      * Apply a transformation to the current or future content.
      */
-    public function withAdditionalTransformation(Transformation $trafo): self
+    public function withAdditionalTransformation(Transformation $trafo)
     {
         $clone = clone $this;
         $clone->setAdditionalTransformation($trafo);
@@ -202,7 +202,7 @@ abstract class Input implements InputInternal
     /**
      * @inheritdoc
      */
-    public function withNameFrom(NameSource $source, ?string $parent_name = null): self
+    public function withNameFrom(NameSource $source, ?string $parent_name = null)
     {
         $clone = clone $this;
         if ($source instanceof DynamicInputsNameSource) {
@@ -222,7 +222,7 @@ abstract class Input implements InputInternal
      *
      * @inheritdoc
      */
-    public function withInput(InputData $input): self
+    public function withInput(InputData $input)
     {
         if ($this->getName() === null) {
             throw new LogicException("Can only collect if input has a name.");

--- a/src/UI/Implementation/Component/Input/InputInternal.php
+++ b/src/UI/Implementation/Component/Input/InputInternal.php
@@ -58,7 +58,7 @@ interface InputInternal extends Input
     /**
      * Get an input like this one, with a different error.
      */
-    public function withError(string $error): self;
+    public function withError(string $error);
 
     /**
      * The error of the input as used in HTML.


### PR DESCRIPTION
Hi folks,

The data table backport has introduced several breaking changes in form of type hints which could lead to compile- or fatal errors when plugins implement custom inputs extending from concrete inputs of the UI framework. This commit reverts these changes back to the previous state as good as possible, but there is still one breaking change in `Input::withRequired()`, which gained an additional parameter that cannot not be reverted. However, this should be less problematic because additional optional parameters are possible, so adding this parameter to the custom implementation would still allow it to be compatible for versions above and below 8.11 - nonetheless, it requires action. Maybe we should communicate this to our dev-lists as well.

You can perform a `git diff v8.10 -- src/UI/Component/Input/Field src/UI/Implementation/Component/Input/Field` to check that actually none of the type-hints change in a manner that would break now.

Kind regards,
@thibsy 