### PR TITLE
TestQuestionPool: Ensure proper use of `unserialize`

### DIFF
--- a/Modules/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assErrorTextImport.php
@@ -64,7 +64,7 @@ class assErrorTextImport extends assQuestionImport
         $this->object->setErrorText($item->getMetadataEntry("errortext"));
         $parsed_error_text = $item->getMetadataEntry("parsederrortext");
         if ($parsed_error_text !== null) {
-            $this->object->setParsedErrorText(unserialize($parsed_error_text));
+            $this->object->setParsedErrorText(unserialize($parsed_error_text, ['allowed_classes' => false]));
         }
         $this->object->setTextSize($item->getMetadataEntry("textsize"));
         $errordata = unserialize($item->getMetadataEntry("errordata"), ["allowed_classes" => false]);

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assTextQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assTextQuestionImport.php
@@ -247,14 +247,14 @@ class assTextQuestionImport extends assQuestionImport
             return array();
         }
 
-        $termScoring = @unserialize($termScoringString);
+        $termScoring = @unserialize($termScoringString, ['allowed_classes' => false]);
 
         if (is_array($termScoring)) {
             return $termScoring;
         }
 
         $termScoringString = base64_decode($termScoringString);
-        $termScoring = unserialize($termScoringString);
+        $termScoring = unserialize($termScoringString, ['allowed_classes' => false]);
 
         if (is_array($termScoring)) {
             return $termScoring;


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=41368

If approved, this should be picked to `release_9` and `trunk` as well.