### PR TITLE
Exercise Refactor: Move external Exercise Code out of Certificate

### DIFF
--- a/components/ILIAS/Certificate/classes/Cron/class.ilCertificateTypeClassMap.php
+++ b/components/ILIAS/Certificate/classes/Cron/class.ilCertificateTypeClassMap.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\Exercise\Certificate\ExercisePlaceholderValues;
 use ILIAS\Course\Certificate\CoursePlaceholderValues;
 use ILIAS\StudyProgramme\Certificate\ilStudyProgrammePlaceholderValues;
 use ILIAS\Test\Certificate\TestPlaceholderValues;
@@ -33,7 +34,7 @@ class ilCertificateTypeClassMap
     private array $typeClassMap = [
         'crs' => ['placeholder' => CoursePlaceholderValues::class],
         'tst' => ['placeholder' => TestPlaceholderValues::class],
-        'exc' => ['placeholder' => ilExercisePlaceholderValues::class],
+        'exc' => ['placeholder' => ExercisePlaceholderValues::class],
         'cmix' => ['placeholder' => ilCmiXapiPlaceholderValues::class],
         'lti' => ['placeholder' => ilLTIConsumerPlaceholderValues::class],
         'sahs' => ['placeholder' => ilScormPlaceholderValues::class],

--- a/components/ILIAS/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
+++ b/components/ILIAS/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
@@ -19,6 +19,9 @@
 declare(strict_types=1);
 
 use ILIAS\DI\Container;
+use ILIAS\Exercise\Certificate\ExercisePlaceholderValues;
+use ILIAS\Exercise\Certificate\ExercisePlaceholderDescription;
+use ILIAS\Exercise\Certificate\CertificateSettingsExerciseRepository;
 use ILIAS\Course\Certificate\CoursePlaceholderValues;
 use ILIAS\Course\Certificate\CoursePlaceholderDescription;
 use ILIAS\Course\Certificate\CertificateSettingsCourseFormRepository;
@@ -102,10 +105,10 @@ class ilCertificateGUIFactory
 
                 break;
             case 'exc':
-                $placeholderDescriptionObject = new ilExercisePlaceholderDescription();
-                $placeholderValuesObject = new ilExercisePlaceholderValues();
+                $placeholderDescriptionObject = new ExercisePlaceholderDescription();
+                $placeholderValuesObject = new ExercisePlaceholderValues();
 
-                $formFactory = new ilCertificateSettingsExerciseRepository(
+                $formFactory = new CertificateSettingsExerciseRepository(
                     $object,
                     $certificatePath,
                     false,

--- a/components/ILIAS/Certificate/classes/Setup/MigrateExerciseCertificateProviderDBUpdateSteps.php
+++ b/components/ILIAS/Certificate/classes/Setup/MigrateExerciseCertificateProviderDBUpdateSteps.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Exercise\Certificate\ExercisePlaceholderValues;
+
+class MigrateExerciseCertificateProviderDBUpdateSteps implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->update(
+            'il_cert_cron_queue',
+            ['adapter_class' => [ilDBConstants::T_TEXT, ExercisePlaceholderValues::class]],
+            ['adapter_class' => [ilDBConstants::T_TEXT, 'ilExercisePlaceholderValues']]
+        );
+    }
+}

--- a/components/ILIAS/Certificate/classes/Setup/class.ilCertificatSetupAgent.php
+++ b/components/ILIAS/Certificate/classes/Setup/class.ilCertificatSetupAgent.php
@@ -49,6 +49,7 @@ class ilCertificatSetupAgent implements Setup\Agent
             true,
             new ilDatabaseUpdateStepsExecutedObjective(new ilCertificateDatabaseUpdateSteps()),
             new ilDatabaseUpdateStepsExecutedObjective(new MigrateCourseCertificateProviderDBUpdateSteps()),
+            new ilDatabaseUpdateStepsExecutedObjective(new MigrateExerciseCertificateProviderDBUpdateSteps()),
         );
     }
 
@@ -64,6 +65,7 @@ class ilCertificatSetupAgent implements Setup\Agent
             true,
             new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilCertificateDatabaseUpdateSteps()),
             new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new MigrateCourseCertificateProviderDBUpdateSteps()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new MigrateExerciseCertificateProviderDBUpdateSteps()),
         );
     }
 

--- a/components/ILIAS/Certificate/tests/ilCertificateTypeClassMapTest.php
+++ b/components/ILIAS/Certificate/tests/ilCertificateTypeClassMapTest.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\Exercise\Certificate\ExercisePlaceholderValues;
 use ILIAS\Course\Certificate\CoursePlaceholderValues;
 use ILIAS\Test\Certificate\TestPlaceholderValues;
 
@@ -51,7 +52,7 @@ class ilCertificateTypeClassMapTest extends ilCertificateBaseTestCase
     {
         $class = $this->classMap->getPlaceHolderClassNameByType('exc');
 
-        $this->assertSame(ilExercisePlaceholderValues::class, $class);
+        $this->assertSame(ExercisePlaceholderValues::class, $class);
     }
 
     public function testFetchScormPlaceHolderClass(): void

--- a/components/ILIAS/Exercise/Certificate/CertificateExerciseMembersHelper.php
+++ b/components/ILIAS/Exercise/Certificate/CertificateExerciseMembersHelper.php
@@ -18,10 +18,14 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Exercise\Certificate;
+
+use ilExerciseMembers;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCertificateExerciseMembersHelper
+class CertificateExerciseMembersHelper
 {
     public function lookUpStatus(int $objectId, int $userId): ?string
     {

--- a/components/ILIAS/Exercise/Certificate/CertificateSettingsExerciseRepository.php
+++ b/components/ILIAS/Exercise/Certificate/CertificateSettingsExerciseRepository.php
@@ -18,14 +18,29 @@
 
 declare(strict_types=1);
 
-use ILIAS\Filesystem\Exception\FileAlreadyExistsException;
-use ILIAS\Filesystem\Exception\FileNotFoundException;
+namespace ILIAS\Exercise\Certificate;
+
+use ilObject;
+use ilLanguage;
+use ilException;
+use ilToolbarGUI;
+use ilWACException;
+use ilAccessHandler;
+use ilCtrlInterface;
+use ilCertificateGUI;
+use ilPropertyFormGUI;
+use ilDatabaseException;
+use ilCertificateFormRepository;
+use ilCertificatePlaceholderDescription;
+use ilCertificateSettingsFormRepository;
 use ILIAS\Filesystem\Exception\IOException;
+use ILIAS\Filesystem\Exception\FileNotFoundException;
+use ILIAS\Filesystem\Exception\FileAlreadyExistsException;
 
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCertificateSettingsExerciseRepository implements ilCertificateFormRepository
+class CertificateSettingsExerciseRepository implements ilCertificateFormRepository
 {
     private readonly ilCertificateSettingsFormRepository $settingsFormFactory;
 

--- a/components/ILIAS/Exercise/Certificate/ExercisePlaceholderDescription.php
+++ b/components/ILIAS/Exercise/Certificate/ExercisePlaceholderDescription.php
@@ -18,10 +18,19 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Exercise\Certificate;
+
+use ilLanguage;
+use ilTemplate;
+use ilLegacyFormElementsUtil;
+use ilDefaultPlaceholderDescription;
+use ilCertificatePlaceholderDescription;
+use ilUserDefinedFieldsPlaceholderDescription;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilExercisePlaceholderDescription implements ilCertificatePlaceholderDescription
+class ExercisePlaceholderDescription implements ilCertificatePlaceholderDescription
 {
     private readonly ilDefaultPlaceholderDescription $defaultPlaceHolderDescriptionObject;
     private readonly ilLanguage $language;
@@ -46,9 +55,7 @@ class ilExercisePlaceholderDescription implements ilCertificatePlaceholderDescri
                 $userDefinedFieldPlaceHolderDescriptionObject
             );
         }
-        $this->defaultPlaceHolderDescriptionObject = $defaultPlaceholderDescriptionObject;
-
-        $this->placeholder = $this->defaultPlaceHolderDescriptionObject->getPlaceholderDescriptions();
+        $this->placeholder = $defaultPlaceholderDescriptionObject->getPlaceholderDescriptions();
 
         $this->placeholder['RESULT_PASSED'] = ilLegacyFormElementsUtil::prepareFormOutput(
             $language->txt('certificate_var_result_passed')
@@ -92,7 +99,7 @@ class ilExercisePlaceholderDescription implements ilCertificatePlaceholderDescri
 
     /**
      * This method MUST return an array containing an array with
-     * the the description as array value.
+     * the description as array value.
      * @return array - [PLACEHOLDER] => 'description'
      */
     public function getPlaceholderDescriptions(): array

--- a/components/ILIAS/Exercise/Certificate/ExercisePlaceholderValues.php
+++ b/components/ILIAS/Exercise/Certificate/ExercisePlaceholderValues.php
@@ -18,16 +18,31 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Exercise\Certificate;
+
+use ilLanguage;
+use ilException;
+use ilDatabaseException;
+use ilDateTimeException;
+use ilCertificateDateHelper;
+use ilCertificateUtilHelper;
+use ilCertificateObjectHelper;
+use ilObjectNotFoundException;
+use ilCertificateLPMarksHelper;
+use ilDefaultPlaceholderValues;
+use ilCertificateLPStatusHelper;
+use ilCertificatePlaceholderValues;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilExercisePlaceholderValues implements ilCertificatePlaceholderValues
+class ExercisePlaceholderValues implements ilCertificatePlaceholderValues
 {
     private readonly ilLanguage $language;
     private readonly ilDefaultPlaceholderValues $defaultPlaceholderValuesObject;
     private readonly ilCertificateLPMarksHelper $lpMarksHelper;
     private readonly ilCertificateObjectHelper $objectHelper;
-    private readonly ilCertificateExerciseMembersHelper $exerciseMembersHelper;
+    private readonly CertificateExerciseMembersHelper $exerciseMembersHelper;
     private readonly ilCertificateLPStatusHelper $lpStatusHelper;
     private readonly ilCertificateUtilHelper $utilHelper;
     private readonly ilCertificateDateHelper $dateHelper;
@@ -37,7 +52,7 @@ class ilExercisePlaceholderValues implements ilCertificatePlaceholderValues
         ?ilLanguage $language = null,
         ?ilCertificateObjectHelper $objectHelper = null,
         ?ilCertificateLPMarksHelper $lpMarksHelper = null,
-        ?ilCertificateExerciseMembersHelper $exerciseMembersHelper = null,
+        ?CertificateExerciseMembersHelper $exerciseMembersHelper = null,
         ?ilCertificateLPStatusHelper $lpStatusHelper = null,
         ?ilCertificateUtilHelper $utilHelper = null,
         ?ilCertificateDateHelper $dateHelper = null
@@ -68,7 +83,7 @@ class ilExercisePlaceholderValues implements ilCertificatePlaceholderValues
         $this->lpMarksHelper = $lpMarksHelper;
 
         if (null === $exerciseMembersHelper) {
-            $exerciseMembersHelper = new ilCertificateExerciseMembersHelper();
+            $exerciseMembersHelper = new CertificateExerciseMembersHelper();
         }
         $this->exerciseMembersHelper = $exerciseMembersHelper;
 
@@ -111,7 +126,9 @@ class ilExercisePlaceholderValues implements ilCertificatePlaceholderValues
         $placeHolders = $this->defaultPlaceholderValuesObject->getPlaceholderValues($userId, $objId);
 
         if ($status !== null) {
-            $placeHolders['RESULT_PASSED'] = $this->utilHelper->prepareFormOutput($this->language->txt('exc_' . $status));
+            $placeHolders['RESULT_PASSED'] = $this->utilHelper->prepareFormOutput(
+                $this->language->txt('exc_' . $status)
+            );
         }
 
         $placeHolders['RESULT_MARK'] = $this->utilHelper->prepareFormOutput($mark);
@@ -138,8 +155,12 @@ class ilExercisePlaceholderValues implements ilCertificatePlaceholderValues
 
         $object = $this->objectHelper->getInstanceByObjId($objId);
 
-        $placeholders['RESULT_PASSED'] = $this->utilHelper->prepareFormOutput($this->language->txt('certificate_var_result_passed'));
-        $placeholders['RESULT_MARK'] = $this->utilHelper->prepareFormOutput($this->language->txt('certificate_var_result_mark_short'));
+        $placeholders['RESULT_PASSED'] = $this->utilHelper->prepareFormOutput(
+            $this->language->txt('certificate_var_result_passed')
+        );
+        $placeholders['RESULT_MARK'] = $this->utilHelper->prepareFormOutput(
+            $this->language->txt('certificate_var_result_mark_short')
+        );
         $placeholders['EXERCISE_TITLE'] = $this->utilHelper->prepareFormOutput($object->getTitle());
 
         return $placeholders;

--- a/components/ILIAS/Exercise/classes/Setup/class.ilExerciseSetupAgent.php
+++ b/components/ILIAS/Exercise/classes/Setup/class.ilExerciseSetupAgent.php
@@ -32,7 +32,7 @@ class ilExerciseSetupAgent extends Setup\Agent\NullAgent
     public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
     {
         return new ObjectiveCollection(
-            'Database is updated for component/ILIAS/Course',
+            'Database is updated for component/ILIAS/Exercise',
             false,
             new ilDatabaseUpdateStepsExecutedObjective(new ilExerciseDBUpdateSteps()),
         );

--- a/components/ILIAS/Exercise/classes/Setup/class.ilExerciseSetupAgent.php
+++ b/components/ILIAS/Exercise/classes/Setup/class.ilExerciseSetupAgent.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 //namespace ILIAS\Exercise\Setup;
 
 use ILIAS\Setup;
+use ILIAS\Exercise\Setup\ilExerciseDBUpdateSteps;
+use ILIAS\Setup\ObjectiveCollection;
 
 /**
  * @author Alexander Killing <killing@leifos.de>
@@ -29,7 +31,11 @@ class ilExerciseSetupAgent extends Setup\Agent\NullAgent
 {
     public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
     {
-        return new \ilDatabaseUpdateStepsExecutedObjective(new \ILIAS\Exercise\Setup\ilExerciseDBUpdateSteps());
+        return new ObjectiveCollection(
+            'Database is updated for component/ILIAS/Course',
+            false,
+            new ilDatabaseUpdateStepsExecutedObjective(new ilExerciseDBUpdateSteps()),
+        );
     }
 
     public function getMigrations(): array

--- a/components/ILIAS/Exercise/tests/Certificate/ilCertificateSettingsExerciseRepositoryTest.php
+++ b/components/ILIAS/Exercise/tests/Certificate/ilCertificateSettingsExerciseRepositoryTest.php
@@ -18,10 +18,23 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Exercise\Certificate;
+
+use ilAccess;
+use ilObject;
+use ilLanguage;
+use ilToolbarGUI;
+use ilCtrlInterface;
+use ilCertificateGUI;
+use ilPropertyFormGUI;
+use PHPUnit\Framework\TestCase;
+use ilCertificatePlaceholderDescription;
+use ilCertificateSettingsFormRepository;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCertificateSettingsExerciseRepositoryTest extends ilCertificateBaseTestCase
+class ilCertificateSettingsExerciseRepositoryTest extends TestCase
 {
     public function testCreate(): void
     {
@@ -62,7 +75,7 @@ class ilCertificateSettingsExerciseRepositoryTest extends ilCertificateBaseTestC
             ->method('createForm')
             ->willReturn($formMock);
 
-        $repository = new ilCertificateSettingsExerciseRepository(
+        $repository = new CertificateSettingsExerciseRepository(
             $object,
             '/some/where/',
             false,
@@ -120,7 +133,7 @@ class ilCertificateSettingsExerciseRepositoryTest extends ilCertificateBaseTestC
             ->disableOriginalConstructor()
             ->getMock();
 
-        new ilCertificateSettingsExerciseRepository(
+        new CertificateSettingsExerciseRepository(
             $object,
             '/some/where/',
             false,
@@ -172,7 +185,7 @@ class ilCertificateSettingsExerciseRepositoryTest extends ilCertificateBaseTestC
             ->method('fetchFormFieldData')
             ->willReturn(['something' => 'value']);
 
-        $repository = new ilCertificateSettingsExerciseRepository(
+        $repository = new CertificateSettingsExerciseRepository(
             $object,
             '/some/where/',
             false,

--- a/components/ILIAS/Exercise/tests/Certificate/ilExercisePlaceHolderValuesTest.php
+++ b/components/ILIAS/Exercise/tests/Certificate/ilExercisePlaceHolderValuesTest.php
@@ -18,10 +18,22 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Exercise\Certificate;
+
+use ilObject;
+use ilLanguage;
+use ilCertificateDateHelper;
+use ilCertificateUtilHelper;
+use ilCertificateObjectHelper;
+use ilCertificateLPMarksHelper;
+use ilDefaultPlaceholderValues;
+use PHPUnit\Framework\TestCase;
+use ilCertificateLPStatusHelper;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilExercisePlaceholderValuesTest extends ilCertificateBaseTestCase
+class ilExercisePlaceholderValuesTest extends TestCase
 {
     public function testGetPlaceholderValues(): void
     {
@@ -59,7 +71,7 @@ class ilExercisePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->method('lookUpMark')
             ->willReturn('400');
 
-        $exerciseMemberHelper = $this->getMockBuilder(ilCertificateExerciseMembersHelper::class)
+        $exerciseMemberHelper = $this->getMockBuilder(CertificateExerciseMembersHelper::class)
             ->getMock();
 
         $lpStatusHelper = $this->getMockBuilder(ilCertificateLPStatusHelper::class)
@@ -87,8 +99,7 @@ class ilExercisePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->method('formatDateTime')
             ->willReturn('2018-09-10 12:01:33');
 
-
-        $placeHolderObject = new ilExercisePlaceholderValues(
+        $placeHolderObject = new ExercisePlaceholderValues(
             $defaultPlaceholders,
             $language,
             $objectHelper,
@@ -141,7 +152,7 @@ class ilExercisePlaceholderValuesTest extends ilCertificateBaseTestCase
         $lpMarksHelper = $this->getMockBuilder(ilCertificateLPMarksHelper::class)
             ->getMock();
 
-        $exerciseMemberHelper = $this->getMockBuilder(ilCertificateExerciseMembersHelper::class)
+        $exerciseMemberHelper = $this->getMockBuilder(CertificateExerciseMembersHelper::class)
             ->getMock();
 
         $lpStatusHelper = $this->getMockBuilder(ilCertificateLPStatusHelper::class)
@@ -164,7 +175,7 @@ class ilExercisePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->method('getPlaceholderValuesForPreview')
             ->willReturn(['SOME_PLACEHOLDER' => 'something']);
 
-        $placeHolderObject = new ilExercisePlaceholderValues(
+        $placeHolderObject = new ExercisePlaceholderValues(
             $defaultPlaceholders,
             $language,
             $objectHelper,

--- a/components/ILIAS/Exercise/tests/Certificate/ilExercisePlaceholderDescriptionTest.php
+++ b/components/ILIAS/Exercise/tests/Certificate/ilExercisePlaceholderDescriptionTest.php
@@ -18,10 +18,17 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Exercise\Certificate;
+
+use ilLanguage;
+use ilTemplate;
+use PHPUnit\Framework\TestCase;
+use ilUserDefinedFieldsPlaceholderDescription;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilExercisePlaceholderDescriptionTest extends ilCertificateBaseTestCase
+class ilExercisePlaceholderDescriptionTest extends TestCase
 {
     public function testPlaceholderGetHtmlDescription(): void
     {
@@ -47,7 +54,7 @@ class ilExercisePlaceholderDescriptionTest extends ilCertificateBaseTestCase
         $templateMock->method('get')
             ->willReturn('');
 
-        $placeholderDescriptionObject = new ilExercisePlaceholderDescription(null, $languageMock, $userDefinePlaceholderMock);
+        $placeholderDescriptionObject = new ExercisePlaceholderDescription(null, $languageMock, $userDefinePlaceholderMock);
 
         $html = $placeholderDescriptionObject->createPlaceholderHtmlDescription($templateMock);
 
@@ -75,7 +82,7 @@ class ilExercisePlaceholderDescriptionTest extends ilCertificateBaseTestCase
         $userDefinePlaceholderMock->method('getPlaceholderDescriptions')
             ->willReturn([]);
 
-        $placeholderDescriptionObject = new ilExercisePlaceholderDescription(null, $languageMock, $userDefinePlaceholderMock);
+        $placeholderDescriptionObject = new ExercisePlaceholderDescription(null, $languageMock, $userDefinePlaceholderMock);
 
         $placeHolders = $placeholderDescriptionObject->getPlaceholderDescriptions();
 


### PR DESCRIPTION
Hi @alex40724,

With this PR we would like to move consumer specific classes from `components/ILIAS/Certificate` to the respective component, like it has been already done for `CmiXapi` and `LTIConsumer`.

All related unit tests were moved as well, they are added to the unit tests suites of the particular component.

There are still parts of tighter coupling to some object type strings in `components/ILIAS/Certificate` (e.g. to register a consumer), but this will hopefully be removed in future when the component revision has been finalized and all components are revised accordingly (funding might be necessary of course, for the certificate component as well as for the certificate providing components).

Feel free to organize the structure or rename the classes according to your component specific rules/patterns/guidelines.

Best, @fhelfer 