### PR TITLE
Course Refactor: Move external Course Code out of Certificate

### DIFF
--- a/components/ILIAS/Certificate/classes/Cron/class.ilCertificateTypeClassMap.php
+++ b/components/ILIAS/Certificate/classes/Cron/class.ilCertificateTypeClassMap.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\Course\Certificate\CoursePlaceholderValues;
 use ILIAS\StudyProgramme\Certificate\ilStudyProgrammePlaceholderValues;
 use ILIAS\Test\Certificate\TestPlaceholderValues;
 
@@ -30,7 +31,7 @@ class ilCertificateTypeClassMap
      * @var array<string, array{placeholder: string}>
      */
     private array $typeClassMap = [
-        'crs' => ['placeholder' => ilCoursePlaceholderValues::class],
+        'crs' => ['placeholder' => CoursePlaceholderValues::class],
         'tst' => ['placeholder' => TestPlaceholderValues::class],
         'exc' => ['placeholder' => ilExercisePlaceholderValues::class],
         'cmix' => ['placeholder' => ilCmiXapiPlaceholderValues::class],

--- a/components/ILIAS/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
+++ b/components/ILIAS/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
@@ -19,6 +19,9 @@
 declare(strict_types=1);
 
 use ILIAS\DI\Container;
+use ILIAS\Course\Certificate\CoursePlaceholderValues;
+use ILIAS\Course\Certificate\CoursePlaceholderDescription;
+use ILIAS\Course\Certificate\CertificateSettingsCourseFormRepository;
 use ILIAS\StudyProgramme\Certificate\ilStudyProgrammePlaceholderValues;
 use ILIAS\StudyProgramme\Certificate\ilStudyProgrammePlaceholderDescription;
 use ILIAS\StudyProgramme\Certificate\ilCertificateSettingsStudyProgrammeFormRepository;
@@ -83,10 +86,10 @@ class ilCertificateGUIFactory
 
                 break;
             case 'crs':
-                $placeholderDescriptionObject = new ilCoursePlaceholderDescription($objectId);
-                $placeholderValuesObject = new ilCoursePlaceholderValues();
+                $placeholderDescriptionObject = new CoursePlaceholderDescription($objectId);
+                $placeholderValuesObject = new CoursePlaceholderValues();
 
-                $formFactory = new ilCertificateSettingsCourseFormRepository(
+                $formFactory = new CertificateSettingsCourseFormRepository(
                     $object,
                     $certificatePath,
                     false,

--- a/components/ILIAS/Certificate/classes/Setup/MigrateCourseCertificateProviderDBUpdateSteps.php
+++ b/components/ILIAS/Certificate/classes/Setup/MigrateCourseCertificateProviderDBUpdateSteps.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Course\Certificate\CoursePlaceholderValues;
+
+class MigrateCourseCertificateProviderDBUpdateSteps implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->update(
+            'il_cert_cron_queue',
+            ['adapter_class' => [ilDBConstants::T_TEXT, CoursePlaceholderValues::class]],
+            ['adapter_class' => [ilDBConstants::T_TEXT, 'ilCoursePlaceholderValues']]
+        );
+    }
+}

--- a/components/ILIAS/Certificate/classes/Setup/class.ilCertificatSetupAgent.php
+++ b/components/ILIAS/Certificate/classes/Setup/class.ilCertificatSetupAgent.php
@@ -18,9 +18,10 @@
 
 declare(strict_types=1);
 
-use ILIAS\Certificate\Setup\Migration\CertificateIdMigration;
-use ILIAS\Refinery;
 use ILIAS\Setup;
+use ILIAS\Refinery;
+use ILIAS\Setup\ObjectiveCollection;
+use ILIAS\Certificate\Setup\Migration\CertificateIdMigration;
 
 class ilCertificatSetupAgent implements Setup\Agent
 {
@@ -43,8 +44,11 @@ class ilCertificatSetupAgent implements Setup\Agent
 
     public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
     {
-        return new ilDatabaseUpdateStepsExecutedObjective(
-            new ilCertificateDatabaseUpdateSteps()
+        return new ObjectiveCollection(
+            'Database is updated for component/ILIAS/Certificate',
+            true,
+            new ilDatabaseUpdateStepsExecutedObjective(new ilCertificateDatabaseUpdateSteps()),
+            new ilDatabaseUpdateStepsExecutedObjective(new MigrateCourseCertificateProviderDBUpdateSteps()),
         );
     }
 
@@ -55,7 +59,12 @@ class ilCertificatSetupAgent implements Setup\Agent
 
     public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
     {
-        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilCertificateDatabaseUpdateSteps());
+        return new ObjectiveCollection(
+            'Database is updated for component/ILIAS/Certificate',
+            true,
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilCertificateDatabaseUpdateSteps()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new MigrateCourseCertificateProviderDBUpdateSteps()),
+        );
     }
 
     public function getMigrations(): array

--- a/components/ILIAS/Certificate/classes/class.ilCertificateAppEventListener.php
+++ b/components/ILIAS/Certificate/classes/class.ilCertificateAppEventListener.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\Filesystem\Exception\IOException;
 use ILIAS\Certificate\API\UserCertificateApiInterface;
+use ILIAS\Course\Certificate\CertificateCourseLearningProgressEvaluation;
 
 class ilCertificateAppEventListener implements ilAppEventListener
 {
@@ -169,7 +170,7 @@ class ilCertificateAppEventListener implements ilAppEventListener
             'Triggering certificate evaluation of possible depending course objects ...'
         );
 
-        $progressEvaluation = new ilCertificateCourseLearningProgressEvaluation(
+        $progressEvaluation = new CertificateCourseLearningProgressEvaluation(
             new ilCachedCertificateTemplateRepository(
                 $this->templateRepository
             )

--- a/components/ILIAS/Certificate/tests/ilCertificateTypeClassMapTest.php
+++ b/components/ILIAS/Certificate/tests/ilCertificateTypeClassMapTest.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\Course\Certificate\CoursePlaceholderValues;
 use ILIAS\Test\Certificate\TestPlaceholderValues;
 
 /**
@@ -36,7 +37,7 @@ class ilCertificateTypeClassMapTest extends ilCertificateBaseTestCase
     {
         $class = $this->classMap->getPlaceHolderClassNameByType('crs');
 
-        $this->assertSame(ilCoursePlaceholderValues::class, $class);
+        $this->assertSame(CoursePlaceholderValues::class, $class);
     }
 
     public function testFetchTestPlaceHolderClass(): void

--- a/components/ILIAS/Course/classes/Certificate/CertificateCourseLearningProgressEvaluation.php
+++ b/components/ILIAS/Course/classes/Certificate/CertificateCourseLearningProgressEvaluation.php
@@ -18,10 +18,20 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Course\Certificate;
+
+use ilSetting;
+use ilLPStatus;
+use ilCertificateTemplate;
+use ilCertificateObjectHelper;
+use ilCertificateLPStatusHelper;
+use ilCertificateTemplateRepository;
+use ilCertificateObjUserTrackingHelper;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCertificateCourseLearningProgressEvaluation
+class CertificateCourseLearningProgressEvaluation
 {
     private readonly ilSetting $setting;
     private readonly ilCertificateObjectHelper $objectHelper;
@@ -93,6 +103,7 @@ class ilCertificateCourseLearningProgressEvaluation
 
                     if ($status !== ilLPStatus::LP_STATUS_COMPLETED_NUM) {
                         $completed = false;
+
                         break;
                     }
                 }

--- a/components/ILIAS/Course/classes/Certificate/CertificateParticipantsHelper.php
+++ b/components/ILIAS/Course/classes/Certificate/CertificateParticipantsHelper.php
@@ -18,10 +18,14 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Course\Certificate;
+
+use ilCourseParticipants;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCertificateParticipantsHelper
+class CertificateParticipantsHelper
 {
     public function getDateTimeOfPassed(int $objectId, int $userId): string
     {

--- a/components/ILIAS/Course/classes/Certificate/CertificateSettingsCourseFormRepository.php
+++ b/components/ILIAS/Course/classes/Certificate/CertificateSettingsCourseFormRepository.php
@@ -18,14 +18,38 @@
 
 declare(strict_types=1);
 
-use ILIAS\Filesystem\Exception\FileAlreadyExistsException;
-use ILIAS\Filesystem\Exception\FileNotFoundException;
+namespace ILIAS\Course\Certificate;
+
+use ilTree;
+use ilAccess;
+use ilObject;
+use ilSetting;
+use ilLanguage;
+use ilObjectLP;
+use ilException;
+use ilToolbarGUI;
+use ilWACException;
+use ilCtrlInterface;
+use ilLPObjSettings;
+use ilCertificateGUI;
+use ilPropertyFormGUI;
+use ilDatabaseException;
+use ilFormSectionHeaderGUI;
+use ilCertificateObjectHelper;
+use ilCertificateFormRepository;
+use ilCertificateObjectLPHelper;
+use ilRepositorySelector2InputGUI;
+use ilCertificateObjUserTrackingHelper;
+use ilCertificatePlaceholderDescription;
+use ilCertificateSettingsFormRepository;
 use ILIAS\Filesystem\Exception\IOException;
+use ILIAS\Filesystem\Exception\FileNotFoundException;
+use ILIAS\Filesystem\Exception\FileAlreadyExistsException;
 
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepository
+class CertificateSettingsCourseFormRepository implements ilCertificateFormRepository
 {
     private readonly ilCertificateSettingsFormRepository $settingsFormFactory;
     private readonly ilTree $tree;
@@ -106,6 +130,7 @@ class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepo
                 if (in_array($olp->getCurrentMode(), $invalid_modes, true)) {
                     $mode = '<strong>' . $mode . '</strong>';
                 }
+
                 return $objectHelper->lookupTitle($obj_id) . ' (' . $mode . ')';
             });
 
@@ -140,6 +165,7 @@ class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepo
                 $this->language->txt('certificate_learning_progress_must_be_active'),
                 implode(', ', $titlesOfObjectsWithInvalidModes)
             );
+
             throw new ilException($message);
         }
 
@@ -163,6 +189,7 @@ class ilCertificateSettingsCourseFormRepository implements ilCertificateFormRepo
         if ($formFields['subitems'] === 'null' || $formFields['subitems'] === null) {
             $formFields['subitems'] = [];
         }
+
         return $formFields;
     }
 

--- a/components/ILIAS/Course/classes/Certificate/CoursePlaceholderDescription.php
+++ b/components/ILIAS/Course/classes/Certificate/CoursePlaceholderDescription.php
@@ -18,10 +18,20 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Course\Certificate;
+
+use ilLanguage;
+use ilTemplate;
+use ilLegacyFormElementsUtil;
+use ilDefaultPlaceholderDescription;
+use ilCertificatePlaceholderDescription;
+use ilUserDefinedFieldsPlaceholderDescription;
+use ilObjectCustomUserFieldsPlaceholderDescription;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCoursePlaceholderDescription implements ilCertificatePlaceholderDescription
+class CoursePlaceholderDescription implements ilCertificatePlaceholderDescription
 {
     private readonly ilDefaultPlaceholderDescription $defaultPlaceHolderDescriptionObject;
     private readonly ilObjectCustomUserFieldsPlaceholderDescription $customUserFieldsPlaceholderDescriptionObject;
@@ -75,12 +85,12 @@ class ilCoursePlaceholderDescription implements ilCertificatePlaceholderDescript
             $template = new ilTemplate('tpl.default_description.html', true, true, 'components/ILIAS/Certificate');
         }
 
-        $template->setVariable("PLACEHOLDER_INTRODUCTION", $this->language->txt('certificate_ph_introduction'));
+        $template->setVariable('PLACEHOLDER_INTRODUCTION', $this->language->txt('certificate_ph_introduction'));
 
-        $template->setCurrentBlock("items");
+        $template->setCurrentBlock('items');
         foreach ($this->placeholder as $id => $caption) {
-            $template->setVariable("ID", $id);
-            $template->setVariable("TXT", $caption);
+            $template->setVariable('ID', $id);
+            $template->setVariable('TXT', $caption);
             $template->parseCurrentBlock();
         }
 
@@ -89,7 +99,7 @@ class ilCoursePlaceholderDescription implements ilCertificatePlaceholderDescript
 
     /**
      * This method MUST return an array containing an array with
-     * the the description as array value.
+     * the description as array value.
      * @return array - [PLACEHOLDER] => 'description'
      */
     public function getPlaceholderDescriptions(): array

--- a/components/ILIAS/Course/classes/Certificate/CoursePlaceholderValues.php
+++ b/components/ILIAS/Course/classes/Certificate/CoursePlaceholderValues.php
@@ -18,16 +18,33 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Course\Certificate;
+
+use ilObjUser;
+use ilLanguage;
+use ilException;
+use ilDatabaseException;
+use ilDateTimeException;
+use ilObjectTranslation;
+use ilCertificateDateHelper;
+use ilLegacyFormElementsUtil;
+use ilCertificateObjectHelper;
+use ilObjectNotFoundException;
+use ilDefaultPlaceholderValues;
+use ilCertificateLPStatusHelper;
+use ilInvalidCertificateException;
+use ilCertificatePlaceholderValues;
+use ilObjectCustomUserFieldsPlaceholderValues;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCoursePlaceholderValues implements ilCertificatePlaceholderValues
+class CoursePlaceholderValues implements ilCertificatePlaceholderValues
 {
     private readonly ilDefaultPlaceholderValues $defaultPlaceholderValuesObject;
     private readonly ilObjectCustomUserFieldsPlaceholderValues $customUserFieldsPlaceholderValuesObject;
     private readonly ilCertificateObjectHelper $objectHelper;
-    private readonly ilCertificateParticipantsHelper $participantsHelper;
-    private readonly ilCertificateUtilHelper $ilUtilHelper;
+    private readonly CertificateParticipantsHelper $participantsHelper;
     private readonly ilCertificateDateHelper $dateHelper;
     private readonly ilCertificateLPStatusHelper $lpStatusHelper;
 
@@ -36,8 +53,7 @@ class ilCoursePlaceholderValues implements ilCertificatePlaceholderValues
         ?ilDefaultPlaceholderValues $defaultPlaceholderValues = null,
         ?ilLanguage $language = null,
         ?ilCertificateObjectHelper $objectHelper = null,
-        ?ilCertificateParticipantsHelper $participantsHelper = null,
-        ?ilCertificateUtilHelper $ilUtilHelper = null,
+        ?CertificateParticipantsHelper $participantsHelper = null,
         ?ilCertificateDateHelper $dateHelper = null,
         ?ilCertificateLPStatusHelper $lpStatusHelper = null
     ) {
@@ -61,14 +77,9 @@ class ilCoursePlaceholderValues implements ilCertificatePlaceholderValues
         $this->objectHelper = $objectHelper;
 
         if (null === $participantsHelper) {
-            $participantsHelper = new ilCertificateParticipantsHelper();
+            $participantsHelper = new CertificateParticipantsHelper();
         }
         $this->participantsHelper = $participantsHelper;
-
-        if (null === $ilUtilHelper) {
-            $ilUtilHelper = new ilCertificateUtilHelper();
-        }
-        $this->ilUtilHelper = $ilUtilHelper;
 
         if (null === $dateHelper) {
             $dateHelper = new ilCertificateDateHelper();
@@ -89,11 +100,11 @@ class ilCoursePlaceholderValues implements ilCertificatePlaceholderValues
      */
     private function hasCompletionDate($possibleDate): bool
     {
-        return (
+        return
             $possibleDate !== false &&
             $possibleDate !== null &&
             $possibleDate !== ''
-        );
+        ;
     }
 
     /**
@@ -139,6 +150,7 @@ class ilCoursePlaceholderValues implements ilCertificatePlaceholderValues
             foreach ($languages as $trans) {
                 if ($trans->getLanguageCode() === $lng_code) {
                     $title = $trans->getTitle();
+
                     break;
                 }
             }

--- a/components/ILIAS/Course/classes/Objectives/Setup/ilCourseObjectiveSetupAgent.php
+++ b/components/ILIAS/Course/classes/Objectives/Setup/ilCourseObjectiveSetupAgent.php
@@ -18,39 +18,48 @@
 
 declare(strict_types=1);
 
-use ILIAS\Setup\Agent\NullAgent;
-use ILIAS\Setup\Objective;
-use ILIAS\Setup\Metrics;
-use ILIAS\Setup\Config;
 use ILIAS\Setup;
+use ILIAS\Setup\Config;
+use ILIAS\Setup\Metrics;
+use ILIAS\Setup\Objective;
+use ILIAS\Setup\Agent\NullAgent;
 use ILIAS\Refinery\Transformation;
+use ILIAS\Setup\ObjectiveCollection;
 
 class ilCourseObjectiveSetupAgent extends NullAgent
 {
     use Setup\Agent\HasNoNamedObjective;
 
-    public function getUpdateObjective(ILIAS\Setup\Config $config = null): Objective
+    public function getUpdateObjective(Config $config = null): Objective
     {
-        return new ilDatabaseUpdateStepsExecutedObjective(new ilCourseObjectiveDBUpdateSteps());
+        return new ObjectiveCollection(
+            'Database is updated for component/ILIAS/Course',
+            false,
+            new ilDatabaseUpdateStepsExecutedObjective(new ilCourseObjectiveDBUpdateSteps()),
+        );
     }
 
     public function getStatusObjective(Metrics\Storage $storage): Objective
     {
-        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilCourseObjectiveDBUpdateSteps());
+        return new ObjectiveCollection(
+            'Database is updated for component/ILIAS/Course',
+            true,
+            new ilDatabaseUpdateStepsExecutedObjective(new ilCourseObjectiveDBUpdateSteps()),
+        );
     }
 
     public function getArrayToConfigTransformation(): Transformation
     {
-        throw new \LogicException("Agent has no config.");
+        throw new LogicException('Agent has no config.');
     }
 
     public function getInstallObjective(Config $config = null): Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new Objective\NullObjective();
     }
 
     public function getBuildObjective(): Objective
     {
-        return new Setup\Objective\NullObjective();
+        return new Objective\NullObjective();
     }
 }

--- a/components/ILIAS/Course/tests/Certificate/ilCertificateCourseLearningProgressEvaluationTest.php
+++ b/components/ILIAS/Course/tests/Certificate/ilCertificateCourseLearningProgressEvaluationTest.php
@@ -18,10 +18,28 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Course\Certificate;
+
+use PDO;
+use ilLogger;
+use ilSetting;
+use ilLPStatus;
+use ilDBInterface;
+use ilDBStatement;
+use ilObjectDataCache;
+use ilCertificateTemplate;
+use ilCertificateObjectHelper;
+use PHPUnit\Framework\TestCase;
+use ilCertificateLPStatusHelper;
+use ilCertificateTemplateRepository;
+use ilCertificateObjUserTrackingHelper;
+use ilCachedCertificateTemplateRepository;
+use ilCertificateTemplateDatabaseRepository;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBaseTestCase
+class ilCertificateCourseLearningProgressEvaluationTest extends TestCase
 {
     public function testOnlyOneCourseIsCompletedOnLPChange(): void
     {
@@ -91,6 +109,7 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
                 function (int $id) use (&$consecutive_lookup): int {
                     $expected = array_shift($consecutive_lookup);
                     $this->assertEquals($expected, $id);
+
                     return $id * 10;
                 }
             );
@@ -110,6 +129,7 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
                 function (int $id) use (&$consecutive_status): int {
                     list($expected, $ret) = array_shift($consecutive_lookup);
                     $this->assertEquals($expected, $id);
+
                     return $ret;
                 }
             );
@@ -118,7 +138,7 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
             ->getMock();
         $trackingHelper->method('enabledLearningProgress')->willReturn(true);
 
-        $evaluation = new ilCertificateCourseLearningProgressEvaluation(
+        $evaluation = new CertificateCourseLearningProgressEvaluation(
             $templateRepository,
             $setting,
             $objectHelper,
@@ -208,6 +228,7 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
                 function (int $id) use (&$consecutive_lookup): int {
                     list($expected, $ret) = array_shift($consecutive_lookup);
                     $this->assertEquals($expected, $id);
+
                     return $ret;
                 }
             );
@@ -228,6 +249,7 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
                 function (int $id) use (&$consecutive_status): int {
                     list($expected, $ret) = array_shift($consecutive_lookup);
                     $this->assertEquals($expected, $id);
+
                     return $ret;
                 }
             );
@@ -236,7 +258,7 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
             ->getMock();
         $trackingHelper->method('enabledLearningProgress')->willReturn(false);
 
-        $evaluation = new ilCertificateCourseLearningProgressEvaluation(
+        $evaluation = new CertificateCourseLearningProgressEvaluation(
             $templateRepository,
             $setting,
             $objectHelper,
@@ -302,6 +324,7 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
                 function (string $k) use (&$consecutive_get) {
                     $expected = array_shift($consecutive_get);
                     $this->assertEquals($expected, $k);
+
                     return null;
                 }
             );
@@ -316,7 +339,7 @@ class ilCertificateCourseLearningProgressEvaluationTest extends ilCertificateBas
             ->getMock();
         $trackingHelper->method('enabledLearningProgress')->willReturn(false);
 
-        $evaluation = new ilCertificateCourseLearningProgressEvaluation(
+        $evaluation = new CertificateCourseLearningProgressEvaluation(
             $templateRepository,
             $setting,
             $objectHelper,

--- a/components/ILIAS/Course/tests/Certificate/ilCertificateSettingsCourseFormRepositoryTest.php
+++ b/components/ILIAS/Course/tests/Certificate/ilCertificateSettingsCourseFormRepositoryTest.php
@@ -18,10 +18,27 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Course\Certificate;
+
+use ilTree;
+use ilAccess;
+use ilSetting;
+use ilLanguage;
+use ilObjectLP;
+use ilObjCourse;
+use ilToolbarGUI;
+use ilCtrlInterface;
+use ilCertificateObjectHelper;
+use PHPUnit\Framework\TestCase;
+use ilCertificateObjectLPHelper;
+use ilCertificateObjUserTrackingHelper;
+use ilCertificatePlaceholderDescription;
+use ilCertificateSettingsFormRepository;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCertificateSettingsCourseFormRepositoryTest extends ilCertificateBaseTestCase
+class ilCertificateSettingsCourseFormRepositoryTest extends TestCase
 {
     public function testSaveSettings(): void
     {
@@ -91,7 +108,7 @@ class ilCertificateSettingsCourseFormRepositoryTest extends ilCertificateBaseTes
             ->expects($this->atLeastOnce())
             ->method('set');
 
-        $repository = new ilCertificateSettingsCourseFormRepository(
+        $repository = new CertificateSettingsCourseFormRepository(
             $object,
             '/some/where',
             false,
@@ -181,7 +198,7 @@ class ilCertificateSettingsCourseFormRepositoryTest extends ilCertificateBaseTes
             ->method('get')
             ->willReturn('[1, 2, 3]');
 
-        $repository = new ilCertificateSettingsCourseFormRepository(
+        $repository = new CertificateSettingsCourseFormRepository(
             $object,
             '/some/where',
             false,

--- a/components/ILIAS/Course/tests/Certificate/ilCoursePlaceholderDescriptionTest.php
+++ b/components/ILIAS/Course/tests/Certificate/ilCoursePlaceholderDescriptionTest.php
@@ -18,10 +18,19 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Course\Certificate;
+
+use ilLanguage;
+use ilTemplate;
+use PHPUnit\Framework\TestCase;
+use ilDefaultPlaceholderDescription;
+use ilUserDefinedFieldsPlaceholderDescription;
+use ilObjectCustomUserFieldsPlaceholderDescription;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCoursePlaceholderDescriptionTest extends ilCertificateBaseTestCase
+class ilCoursePlaceholderDescriptionTest extends TestCase
 {
     public function testPlaceholderGetHtmlDescription(): void
     {
@@ -48,19 +57,19 @@ class ilCoursePlaceholderDescriptionTest extends ilCertificateBaseTestCase
             ->willReturn([]);
 
         $customUserPlaceholderObject = $this->getMockBuilder(ilObjectCustomUserFieldsPlaceholderDescription::class)
-                                            ->disableOriginalConstructor()
-                                            ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $customUserPlaceholderObject->method("getPlaceholderDescriptions")
-                                    ->willReturn([
-                                        '+SOMETHING' => 'SOMEWHAT',
-                                        '+SOMETHING_ELSE' => 'ANYTHING'
-                                    ]);
+        $customUserPlaceholderObject->method('getPlaceholderDescriptions')
+            ->willReturn([
+                '+SOMETHING' => 'SOMEWHAT',
+                '+SOMETHING_ELSE' => 'ANYTHING'
+            ]);
 
         $customUserPlaceholderObject->method('createPlaceholderHtmlDescription')
-                                  ->willReturn('');
+            ->willReturn('');
 
-        $placeholderDescriptionObject = new ilCoursePlaceholderDescription(200, null, $languageMock, $userDefinePlaceholderMock, $customUserPlaceholderObject);
+        $placeholderDescriptionObject = new CoursePlaceholderDescription(200, null, $languageMock, $userDefinePlaceholderMock, $customUserPlaceholderObject);
 
         $html = $placeholderDescriptionObject->createPlaceholderHtmlDescription($templateMock);
 
@@ -75,8 +84,8 @@ class ilCoursePlaceholderDescriptionTest extends ilCertificateBaseTestCase
             ->getMock();
 
         $languageMock->expects($this->exactly(3))
-                     ->method('txt')
-                     ->willReturn('Something translated');
+            ->method('txt')
+            ->willReturn('Something translated');
 
         $defaultPlaceholder = $this->getMockBuilder(ilDefaultPlaceholderDescription::class)
             ->disableOriginalConstructor()
@@ -102,7 +111,7 @@ class ilCoursePlaceholderDescriptionTest extends ilCertificateBaseTestCase
                 ]
             );
 
-        $placeholderDescriptionObject = new ilCoursePlaceholderDescription(200, $defaultPlaceholder, $languageMock, null, $customUserPlaceholderObject);
+        $placeholderDescriptionObject = new CoursePlaceholderDescription(200, $defaultPlaceholder, $languageMock, null, $customUserPlaceholderObject);
 
         $placeHolders = $placeholderDescriptionObject->getPlaceholderDescriptions();
 

--- a/components/ILIAS/Course/tests/Certificate/ilCoursePlaceholderValuesTest.php
+++ b/components/ILIAS/Course/tests/Certificate/ilCoursePlaceholderValuesTest.php
@@ -18,11 +18,53 @@
 
 declare(strict_types=1);
 
+namespace ILIAS\Course\Certificate;
+
+use ilLanguage;
+use ilObjCourse;
+use ilDBInterface;
+use ILIAS\DI\Container;
+use ilObjectTranslation;
+use ilCertificateDateHelper;
+use ilCertificateUtilHelper;
+use ilCertificateObjectHelper;
+use ilDefaultPlaceholderValues;
+use PHPUnit\Framework\TestCase;
+use ilObjectTranslationLanguage;
+use ilObjectCustomUserFieldsPlaceholderValues;
+
 /**
  * @author  Niels Theen <ntheen@databay.de>
  */
-class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
+class ilCoursePlaceholderValuesTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (!defined('ANONYMOUS_USER_ID')) {
+            define('ANONYMOUS_USER_ID', 13);
+        }
+
+        global $DIC;
+
+        $this->dic = is_object($DIC) ? clone $DIC : $DIC;
+
+        $DIC = new Container();
+
+        parent::setUp();
+    }
+
+    protected function setGlobalVariable(string $name, $value): void
+    {
+        global $DIC;
+
+        $GLOBALS[$name] = $value;
+
+        unset($DIC[$name]);
+        $DIC[$name] = static function (Container $c) use ($name) {
+            return $GLOBALS[$name];
+        };
+    }
+
     public function testGetPlaceholderValues(): void
     {
         $customUserFieldsPlaceholderValues = $this->getMockBuilder(ilObjectCustomUserFieldsPlaceholderValues::class)
@@ -30,14 +72,14 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->getMock();
 
         $customUserFieldsPlaceholderValues->method('getPlaceholderValues')
-                                 ->willReturn([]);
+            ->willReturn([]);
 
         $defaultPlaceholderValues = $this->getMockBuilder(ilDefaultPlaceholderValues::class)
-             ->disableOriginalConstructor()
-             ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $defaultPlaceholderValues->method('getPlaceholderValues')
-             ->willReturn([]);
+            ->willReturn([]);
 
         $language = $this->getMockBuilder(ilLanguage::class)
             ->disableOriginalConstructor()
@@ -54,25 +96,25 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->willReturn('Some Title');
 
         $obj_translation = $this->getMockBuilder(ilObjectTranslation::class)
-                                ->disableOriginalConstructor()
-                                ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $german = $this->createMock(ilObjectTranslationLanguage::class);
         $german->method('getLanguageCode')
-               ->willReturn('de');
+            ->willReturn('de');
 
         $english = $this->createMock(ilObjectTranslationLanguage::class);
         $english->method('getLanguageCode')
-                ->willReturn('en');
+            ->willReturn('en');
 
         $obj_translation->method('getLanguages')
-                        ->willReturn([
-                            $german,
-                            $english
-                        ]);
+            ->willReturn([
+                $german,
+                $english
+            ]);
 
         $objectMock->method('getObjectTranslation')
-                   ->willReturn($obj_translation);
+            ->willReturn($obj_translation);
 
         $objectHelper = $this->getMockBuilder(ilCertificateObjectHelper::class)
             ->getMock();
@@ -80,7 +122,7 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
         $objectHelper->method('getInstanceByObjId')
             ->willReturn($objectMock);
 
-        $participantsHelper = $this->getMockBuilder(ilCertificateParticipantsHelper::class)
+        $participantsHelper = $this->getMockBuilder(CertificateParticipantsHelper::class)
             ->getMock();
 
         $participantsHelper->method('getDateTimeOfPassed')
@@ -103,18 +145,17 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->willReturn('2018-09-10 10:32:00');
 
         $database = $this->getMockBuilder(ilDBInterface::class)
-                         ->getMock();
+            ->getMock();
 
         $this->setGlobalVariable('ilDB', $database);
         $this->setGlobalVariable('lng', $language);
 
-        $valuesObject = new ilCoursePlaceholderValues(
+        $valuesObject = new CoursePlaceholderValues(
             $customUserFieldsPlaceholderValues,
             $defaultPlaceholderValues,
             $language,
             $objectHelper,
             $participantsHelper,
-            $ilUtilHelper,
             $ilDateHelper,
         );
 
@@ -133,16 +174,16 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
     public function testGetPreviewPlaceholderValues(): void
     {
         $customUserFieldsPlaceholderValues = $this->getMockBuilder(ilObjectCustomUserFieldsPlaceholderValues::class)
-              ->disableOriginalConstructor()
-              ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $customUserFieldsPlaceholderValues->method('getPlaceholderValuesForPreview')
-             ->willReturn(
-                 [
-                     'SOME_PLACEHOLDER' => 'ANYTHING',
-                     'SOME_OTHER_PLACEHOLDER' => '2018-09-10',
-                 ]
-             );
+            ->willReturn(
+                [
+                    'SOME_PLACEHOLDER' => 'ANYTHING',
+                    'SOME_OTHER_PLACEHOLDER' => '2018-09-10',
+                ]
+            );
 
         $defaultPlaceholderValues = $this->getMockBuilder(ilDefaultPlaceholderValues::class)
             ->disableOriginalConstructor()
@@ -197,7 +238,7 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
         $objectHelper->method('getInstanceByObjId')
             ->willReturn($objectMock);
 
-        $participantsHelper = $this->getMockBuilder(ilCertificateParticipantsHelper::class)
+        $participantsHelper = $this->getMockBuilder(CertificateParticipantsHelper::class)
             ->getMock();
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
@@ -215,13 +256,12 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
         $this->setGlobalVariable('ilDB', $database);
         $this->setGlobalVariable('lng', $language);
 
-        $valuesObject = new ilCoursePlaceholderValues(
+        $valuesObject = new CoursePlaceholderValues(
             $customUserFieldsPlaceholderValues,
             $defaultPlaceholderValues,
             $language,
             $objectHelper,
             $participantsHelper,
-            $utilHelper
         );
 
         $placeholderValues = $valuesObject->getPlaceholderValuesForPreview(100, 10);


### PR DESCRIPTION
Hi @smeyer-ilias,

With this PR we would like to move consumer specific classes from components/ILIAS/Certificate to the respective component, like it has been already done for CmiXapi and LTIConsumer.

All related unit tests were moved as well, they are added to the unit tests suites of the particular component.

There are still parts of tighter coupling to some object type strings in components/ILIAS/Certificate (e.g. to register a consumer), but this will hopefully be removed in future when the component revision has been finalized and all components are revised accordingly (funding might be necessary of course, for the certificate component as well as for the certificate providing components).

Feel free to organize the structure or rename the classes according to your component specific rules/patterns/guidelines.

Best, @fhelfer