### PR TITLE
StudyProgramme Refactor: Move external StudyProgramme Code out of Certificate

### DIFF
--- a/components/ILIAS/Certificate/classes/Cron/class.ilCertificateTypeClassMap.php
+++ b/components/ILIAS/Certificate/classes/Cron/class.ilCertificateTypeClassMap.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\StudyProgramme\Certificate\ilStudyProgrammePlaceholderValues;
 use ILIAS\Test\Certificate\TestPlaceholderValues;
 
 /**

--- a/components/ILIAS/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
+++ b/components/ILIAS/Certificate/classes/Gui/class.ilCertificateGUIFactory.php
@@ -19,6 +19,9 @@
 declare(strict_types=1);
 
 use ILIAS\DI\Container;
+use ILIAS\StudyProgramme\Certificate\ilStudyProgrammePlaceholderValues;
+use ILIAS\StudyProgramme\Certificate\ilStudyProgrammePlaceholderDescription;
+use ILIAS\StudyProgramme\Certificate\ilCertificateSettingsStudyProgrammeFormRepository;
 use ILIAS\Test\Certificate\TestPlaceholderValues;
 use ILIAS\Test\Certificate\TestPlaceholderDescription;
 use ILIAS\Course\Certificate\CertificateTestTemplateDeleteAction;

--- a/components/ILIAS/StudyProgramme/StudyProgramme.php
+++ b/components/ILIAS/StudyProgramme/StudyProgramme.php
@@ -32,5 +32,9 @@ class StudyProgramme implements Component\Component
         array | \ArrayAccess &$pull,
         array | \ArrayAccess &$internal,
     ): void {
+        $contribute[\ILIAS\Setup\Agent::class] = fn() =>
+        new \ilStudyProgrammeSetupAgent(
+            $pull[\ILIAS\Refinery\Factory::class]
+        );
     }
 }

--- a/components/ILIAS/StudyProgramme/classes/Certificate/class.ilCertificateSettingsStudyProgrammeFormRepository.php
+++ b/components/ILIAS/StudyProgramme/classes/Certificate/class.ilCertificateSettingsStudyProgrammeFormRepository.php
@@ -18,28 +18,30 @@
 
 declare(strict_types=1);
 
-use ILIAS\Filesystem\Exception\IOException;
-use ILIAS\Filesystem\Exception\FileAlreadyExistsException;
-use ILIAS\Filesystem\Exception\FileNotFoundException;
+namespace ILIAS\StudyProgramme\Certificate;
 
-class ilCertificateSettingsStudyProgrammeFormRepository implements ilCertificateFormRepository
+use ILIAS\Filesystem\Exception\IOException;
+use ILIAS\Filesystem\Exception\FileNotFoundException;
+use ILIAS\Filesystem\Exception\FileAlreadyExistsException;
+
+class ilCertificateSettingsStudyProgrammeFormRepository implements \ilCertificateFormRepository
 {
-    private readonly ilCertificateSettingsFormRepository $settingsFormRepository;
+    private readonly \ilCertificateSettingsFormRepository $settingsFormRepository;
 
     public function __construct(
-        ilObject $object,
+        \ilObject $object,
         string $certificatePath,
         bool $hasAdditionalElements,
-        ilLanguage $language,
-        ilCtrlInterface $ctrl,
-        ilAccess $access,
-        ilToolbarGUI $toolbar,
-        ilCertificatePlaceholderDescription $placeholderDescriptionObject,
-        ?ilCertificateSettingsFormRepository $settingsFormRepository = null
+        \ilLanguage $language,
+        \ilCtrlInterface $ctrl,
+        \ilAccess $access,
+        \ilToolbarGUI $toolbar,
+        \ilCertificatePlaceholderDescription $placeholderDescriptionObject,
+        ?\ilCertificateSettingsFormRepository $settingsFormRepository = null
     ) {
         global $DIC;
 
-        $this->settingsFormRepository = $settingsFormRepository ?? new ilCertificateSettingsFormRepository(
+        $this->settingsFormRepository = $settingsFormRepository ?? new \ilCertificateSettingsFormRepository(
             $object->getId(),
             $certificatePath,
             $hasAdditionalElements,
@@ -57,11 +59,11 @@ class ilCertificateSettingsStudyProgrammeFormRepository implements ilCertificate
      * @throws FileAlreadyExistsException
      * @throws FileNotFoundException
      * @throws IOException
-     * @throws ilDatabaseException
-     * @throws ilException
-     * @throws ilWACException
+     * @throws \ilDatabaseException
+     * @throws \ilException
+     * @throws \ilWACException
      */
-    public function createForm(ilCertificateGUI $certificateGUI): ilPropertyFormGUI
+    public function createForm(\ilCertificateGUI $certificateGUI): \ilPropertyFormGUI
     {
         return $this->settingsFormRepository->createForm($certificateGUI);
     }

--- a/components/ILIAS/StudyProgramme/classes/Certificate/class.ilStudyProgrammePlaceholderDescription.php
+++ b/components/ILIAS/StudyProgramme/classes/Certificate/class.ilStudyProgrammePlaceholderDescription.php
@@ -18,16 +18,18 @@
 
 declare(strict_types=1);
 
-class ilStudyProgrammePlaceholderDescription implements ilCertificatePlaceholderDescription
+namespace ILIAS\StudyProgramme\Certificate;
+
+class ilStudyProgrammePlaceholderDescription implements \ilCertificatePlaceholderDescription
 {
-    private readonly ilDefaultPlaceholderDescription $defaultPlaceHolderDescriptionObject;
-    private readonly ilLanguage $language;
+    private readonly \ilDefaultPlaceholderDescription $defaultPlaceHolderDescriptionObject;
+    private readonly \ilLanguage $language;
     private array $placeholder;
 
     public function __construct(
-        ?ilDefaultPlaceholderDescription $defaultPlaceholderDescriptionObject = null,
-        ?ilLanguage $language = null,
-        ?ilUserDefinedFieldsPlaceholderDescription $userDefinedFieldPlaceHolderDescriptionObject = null
+        ?\ilDefaultPlaceholderDescription $defaultPlaceholderDescriptionObject = null,
+        ?\ilLanguage $language = null,
+        ?\ilUserDefinedFieldsPlaceholderDescription $userDefinedFieldPlaceHolderDescriptionObject = null
     ) {
         global $DIC;
 
@@ -38,7 +40,7 @@ class ilStudyProgrammePlaceholderDescription implements ilCertificatePlaceholder
         $this->language = $language;
 
         if (null === $defaultPlaceholderDescriptionObject) {
-            $defaultPlaceholderDescriptionObject = new ilDefaultPlaceholderDescription(
+            $defaultPlaceholderDescriptionObject = new \ilDefaultPlaceholderDescription(
                 $language,
                 $userDefinedFieldPlaceHolderDescriptionObject
             );
@@ -58,10 +60,10 @@ class ilStudyProgrammePlaceholderDescription implements ilCertificatePlaceholder
      * This methods MUST return an array containing an array with
      * the the description as array value.
      */
-    public function createPlaceholderHtmlDescription(?ilTemplate $template = null): string
+    public function createPlaceholderHtmlDescription(?\ilTemplate $template = null): string
     {
         if (null === $template) {
-            $template = new ilTemplate('tpl.default_description.html', true, true, 'components/ILIAS/Certificate');
+            $template = new \ilTemplate('tpl.default_description.html', true, true, 'components/ILIAS/Certificate');
         }
 
         $template->setVariable("PLACEHOLDER_INTRODUCTION", $this->language->txt('certificate_ph_introduction'));

--- a/components/ILIAS/StudyProgramme/classes/Certificate/class.ilStudyProgrammePlaceholderValues.php
+++ b/components/ILIAS/StudyProgramme/classes/Certificate/class.ilStudyProgrammePlaceholderValues.php
@@ -18,15 +18,17 @@
 
 declare(strict_types=1);
 
-class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValues
+namespace ILIAS\StudyProgramme\Certificate;
+
+class ilStudyProgrammePlaceholderValues implements \ilCertificatePlaceholderValues
 {
-    private readonly ilDefaultPlaceholderValues $defaultPlaceholderValuesObject;
-    private readonly ilCertificateObjectHelper $objectHelper;
+    private readonly \ilDefaultPlaceholderValues $defaultPlaceholderValuesObject;
+    private readonly \ilCertificateObjectHelper $objectHelper;
 
     public function __construct(
-        ?ilDefaultPlaceholderValues $defaultPlaceholderValues = null,
-        ?ilLanguage $language = null,
-        ?ilCertificateObjectHelper $objectHelper = null
+        ?\ilDefaultPlaceholderValues $defaultPlaceholderValues = null,
+        ?\ilLanguage $language = null,
+        ?\ilCertificateObjectHelper $objectHelper = null
     ) {
         if (null === $language) {
             global $DIC;
@@ -35,11 +37,11 @@ class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValue
         }
 
         if (null === $defaultPlaceholderValues) {
-            $defaultPlaceholderValues = new ilDefaultPlaceholderValues();
+            $defaultPlaceholderValues = new \ilDefaultPlaceholderValues();
         }
 
         if (null === $objectHelper) {
-            $objectHelper = new ilCertificateObjectHelper();
+            $objectHelper = new \ilCertificateObjectHelper();
         }
         $this->objectHelper = $objectHelper;
 
@@ -52,9 +54,9 @@ class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValue
      * ilInvalidCertificateException MUST be thrown if the
      * data could not be determined or the user did NOT
      * achieve the certificate.
-     * @throws ilDatabaseException
-     * @throws ilException
-     * @throws ilObjectNotFoundException
+     * @throws \ilDatabaseException
+     * @throws \ilException
+     * @throws \ilObjectNotFoundException
      */
     public function getPlaceholderValues(int $userId, int $objId): array
     {
@@ -64,19 +66,19 @@ class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValue
         $latest_progress = $this->getRelevantProgressFromAssignments($assignments);
         $type = $object->getSubType();
 
-        $placeholders['PRG_TITLE'] = ilLegacyFormElementsUtil::prepareFormOutput($object->getTitle());
-        $placeholders['PRG_DESCRIPTION'] = ilLegacyFormElementsUtil::prepareFormOutput($object->getDescription());
-        $placeholders['PRG_TYPE'] = ilLegacyFormElementsUtil::prepareFormOutput($type ? $type->getTitle() : '');
-        $placeholders['PRG_POINTS'] = ilLegacyFormElementsUtil::prepareFormOutput(
+        $placeholders['PRG_TITLE'] = \ilLegacyFormElementsUtil::prepareFormOutput($object->getTitle());
+        $placeholders['PRG_DESCRIPTION'] = \ilLegacyFormElementsUtil::prepareFormOutput($object->getDescription());
+        $placeholders['PRG_TYPE'] = \ilLegacyFormElementsUtil::prepareFormOutput($type ? $type->getTitle() : '');
+        $placeholders['PRG_POINTS'] = \ilLegacyFormElementsUtil::prepareFormOutput(
             $latest_progress ? (string) $latest_progress->getCurrentAmountOfPoints() : ''
         );
-        $placeholders['PRG_COMPLETION_DATE'] = ilLegacyFormElementsUtil::prepareFormOutput(
-            $latest_progress && $latest_progress->getCompletionDate() instanceof DateTimeImmutable ? $latest_progress->getCompletionDate(
+        $placeholders['PRG_COMPLETION_DATE'] = \ilLegacyFormElementsUtil::prepareFormOutput(
+            $latest_progress && $latest_progress->getCompletionDate() instanceof \DateTimeImmutable ? $latest_progress->getCompletionDate(
             )->format('d.m.Y') : ''
         );
-        $placeholders['PRG_EXPIRES_AT'] = ilLegacyFormElementsUtil::prepareFormOutput(
+        $placeholders['PRG_EXPIRES_AT'] = \ilLegacyFormElementsUtil::prepareFormOutput(
             $latest_progress && $latest_progress->getValidityOfQualification(
-            ) instanceof DateTimeImmutable ? $latest_progress->getValidityOfQualification()->format('d.m.Y') : ''
+            ) instanceof \DateTimeImmutable ? $latest_progress->getValidityOfQualification()->format('d.m.Y') : ''
         );
         return $placeholders;
     }
@@ -92,17 +94,17 @@ class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValue
 
         $object = $this->objectHelper->getInstanceByObjId($objId);
         $type = $object->getSubType();
-        $today = ilLegacyFormElementsUtil::prepareFormOutput((new DateTime())->format('d.m.Y'));
-        $placeholders['PRG_TITLE'] = ilLegacyFormElementsUtil::prepareFormOutput($object->getTitle());
-        $placeholders['PRG_DESCRIPTION'] = ilLegacyFormElementsUtil::prepareFormOutput($object->getDescription());
-        $placeholders['PRG_TYPE'] = ilLegacyFormElementsUtil::prepareFormOutput($type ? $type->getTitle() : '');
-        $placeholders['PRG_POINTS'] = ilLegacyFormElementsUtil::prepareFormOutput((string) $object->getPoints());
+        $today = \ilLegacyFormElementsUtil::prepareFormOutput((new \DateTime())->format('d.m.Y'));
+        $placeholders['PRG_TITLE'] = \ilLegacyFormElementsUtil::prepareFormOutput($object->getTitle());
+        $placeholders['PRG_DESCRIPTION'] = \ilLegacyFormElementsUtil::prepareFormOutput($object->getDescription());
+        $placeholders['PRG_TYPE'] = \ilLegacyFormElementsUtil::prepareFormOutput($type ? $type->getTitle() : '');
+        $placeholders['PRG_POINTS'] = \ilLegacyFormElementsUtil::prepareFormOutput((string) $object->getPoints());
         $placeholders['PRG_COMPLETION_DATE'] = $today;
         $placeholders['PRG_EXPIRES_AT'] = $today;
         return $placeholders;
     }
 
-    protected function getRelevantProgressFromAssignments(array $assignments): ?ilPRGProgress
+    protected function getRelevantProgressFromAssignments(array $assignments): ?\ilPRGProgress
     {
         if (count($assignments) === 0) {
             return null;
@@ -115,7 +117,7 @@ class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValue
         return $latest_progress;
     }
 
-    protected function getLatestSuccessfulAssignment(array $assignments): ?ilPRGAssignment
+    protected function getLatestSuccessfulAssignment(array $assignments): ?\ilPRGAssignment
     {
         $successful = array_filter(
             $assignments,
@@ -132,7 +134,7 @@ class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValue
         );
         if (count($unlimited) > 0) {
             $successful = $unlimited;
-            usort($successful, static function (ilPRGAssignment $a, ilPRGAssignment $b): int {
+            usort($successful, static function (\ilPRGAssignment $a, \ilPRGAssignment $b): int {
                 $a_dat = $a->getProgressTree()->getCompletionDate();
                 $b_dat = $b->getProgressTree()->getCompletionDate();
                 if ($a_dat > $b_dat) {
@@ -150,7 +152,7 @@ class ilStudyProgrammePlaceholderValues implements ilCertificatePlaceholderValue
                 fn($ass) => !is_null($ass->getProgressTree()->getValidityOfQualification())
             );
             $successful = $limited;
-            usort($successful, static function (ilPRGAssignment $a, ilPRGAssignment $b): int {
+            usort($successful, static function (\ilPRGAssignment $a, \ilPRGAssignment $b): int {
                 $a_dat = $a->getProgressTree()->getValidityOfQualification();
                 $b_dat = $b->getProgressTree()->getValidityOfQualification();
                 if ($a_dat > $b_dat) {

--- a/components/ILIAS/StudyProgramme/classes/Setup/class.ilMigrateStudyProgrammeCertificateProviderDBUpdateSteps.php
+++ b/components/ILIAS/StudyProgramme/classes/Setup/class.ilMigrateStudyProgrammeCertificateProviderDBUpdateSteps.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\StudyProgramme\Certificate\ilStudyProgrammePlaceholderValues;
+
+class ilMigrateStudyProgrammeCertificateProviderDBUpdateSteps implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->update(
+            'il_cert_cron_queue',
+            ['adapter_class' => [ilDBConstants::T_TEXT, ilStudyProgrammePlaceholderValues::class]],
+            ['adapter_class' => [ilDBConstants::T_TEXT, 'ilStudyProgrammePlaceholderValues']]
+        );
+    }
+}

--- a/components/ILIAS/StudyProgramme/classes/Setup/class.ilStudyProgrammeSetupAgent.php
+++ b/components/ILIAS/StudyProgramme/classes/Setup/class.ilStudyProgrammeSetupAgent.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Setup\Config;
+use ILIAS\Setup\Metrics;
+use ILIAS\Setup\Objective;
+use ILIAS\Setup\Agent\NullAgent;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Setup\ObjectiveCollection;
+use ILIAS\Setup\Objective\NullObjective;
+use ILIAS\Setup\Agent\HasNoNamedObjective;
+
+class ilStudyProgrammeSetupAgent extends NullAgent
+{
+    use HasNoNamedObjective;
+
+    public function getUpdateObjective(Config $config = null): Objective
+    {
+        return new ObjectiveCollection(
+            'Database is updated for component/ILIAS/StudyProgramme',
+            false,
+            new ilDatabaseUpdateStepsExecutedObjective(
+                new ilMigrateStudyProgrammeCertificateProviderDBUpdateSteps()
+            ),
+        );
+    }
+
+    public function getStatusObjective(Metrics\Storage $storage): Objective
+    {
+        return new ObjectiveCollection(
+            'Database is updated for component/ILIAS/StudyProgramme',
+            true,
+            new ilDatabaseUpdateStepsMetricsCollectedObjective(
+                $storage,
+                new ilMigrateStudyProgrammeCertificateProviderDBUpdateSteps()
+            ),
+        );
+    }
+
+    public function hasConfig(): bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation(): Transformation
+    {
+        throw new LogicException('Agent has no config.');
+    }
+
+    public function getInstallObjective(Config $config = null): Objective
+    {
+        return new NullObjective();
+    }
+
+    public function getBuildObjective(): Objective
+    {
+        return new NullObjective();
+    }
+
+    public function getMigrations(): array
+    {
+        return [];
+    }
+}

--- a/components/ILIAS/StudyProgramme/tests/ilObjStudyProgrammeCertificateTest.php
+++ b/components/ILIAS/StudyProgramme/tests/ilObjStudyProgrammeCertificateTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\StudyProgramme\Certificate\ilStudyProgrammePlaceholderValues;
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.


### PR DESCRIPTION
Hi @klees,

With this PR we would like to move consumer specific classes from components/ILIAS/Certificate to the respective component, like it has been already done for CmiXapi and LTIConsumer.

All related unit tests were moved as well, they are added to the unit tests suites of the particular component.

There are still parts of tighter coupling to some object type strings in components/ILIAS/Certificate (e.g. to register a consumer), but this will hopefully be removed in future when the component revision has been finalized and all components are revised accordingly (funding might be necessary of course, for the certificate component as well as for the certificate providing components).

Feel free to organize the structure or rename the classes according to your component specific rules/patterns/guidelines.

Best, @fhelfer