### PR TITLE
ErrorHandling: Check for `tpl` existence

### DIFF
--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -322,7 +322,7 @@ class ilErrorHandling extends PEAR
                     $message .= ' ' . 'Please send a mail to <a href="mailto:' . $logger->mail() . '?subject=code: ' . $file_name . '">' . $logger->mail() . '</a>';
                 }
             }
-            if ($DIC->isDependencyAvailable('ui') && $DIC->isDependencyAvailable('tpl') && $DIC->isDependencyAvailable('ctrl')) {
+            if ($DIC->isDependencyAvailable('ui') && isset($DIC['tpl']) && $DIC->isDependencyAvailable('ctrl')) {
                 $DIC->ui()->mainTemplate()->setOnScreenMessage('failure', $message, true);
                 $DIC->ctrl()->redirectToURL("error.php");
             } else {


### PR DESCRIPTION
This PR fixes a wrong dependency check in the error handler. The current check of `tpl` causes an error, because there is no method `tpl` in the DI container.