### PR TITLE
Authentication: Use PHP core randomizer

### DIFF
--- a/components/ILIAS/Authentication/classes/class.ilSession.php
+++ b/components/ILIAS/Authentication/classes/class.ilSession.php
@@ -217,9 +217,8 @@ class ilSession
         }
 
         if (!$DIC->cron()->manager()->isJobActive('auth_destroy_expired_sessions')) {
-            // finally delete deprecated sessions
-            $random = new ilRandom();
-            if ($random->int(0, 50) === 2) {
+            $r = new \Random\Randomizer();
+            if ($r->getInt(0, 50) === 2) {
                 // get time _before_ destroying expired sessions
                 self::_destroyExpiredSessions();
                 ilSessionStatistics::aggretateRaw($now);


### PR DESCRIPTION
The `Random` component is not maintained. With this PR I suggest to use the PHP core randomizer to retrieve a random `int` value.