### PR TITLE
[FIX] UI: revert breaking change in `tpl.standardpage.html`

### DIFF
--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -15,10 +15,6 @@
 	<title>{VIEW_TITLE}: {SHORT_TITLE}</title>
 	<link rel="icon" href="{FAVICON_PATH}" type="image/x-icon">
 
-	<!-- This is the safest place for now to initialize our global namespace which is -->
-	<!-- used by several scripts included on the way to expose their business logic.  -->
-	<script type="application/javascript">var il = il ||{}; window.il = il;</script>
-
 	<style>
 		{CSS_INLINE}
 	</style>

--- a/src/UI/templates/js/Core/dist/core.js
+++ b/src/UI/templates/js/Core/dist/core.js
@@ -12,6 +12,8 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  */
+
+var il = il || {};
 (function (il, $) {
     'use strict';
 

--- a/src/UI/templates/js/Core/src/core.js
+++ b/src/UI/templates/js/Core/src/core.js
@@ -21,6 +21,7 @@ import replaceContent from './core.replaceContent';
 import URLBuilder from './core.URLBuilder';
 import URLBuilderToken from './core.URLBuilderToken';
 
+il = il || {};
 il.UI = il.UI || {};
 il.UI.core = il.UI.core || {};
 

--- a/tests/UI/Component/Layout/Page/StandardPageTest.php
+++ b/tests/UI/Component/Layout/Page/StandardPageTest.php
@@ -257,7 +257,6 @@ class StandardPageTest extends ILIAS_UI_TestBase
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>View Title: Short Title</title>
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <script type="application/javascript">var il = il ||{}; window.il = il;</script>
     <style></style>
 </head>
 
@@ -298,7 +297,6 @@ class StandardPageTest extends ILIAS_UI_TestBase
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>:</title>
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <script type="application/javascript">var il = il ||{}; window.il = il;</script>
     <style></style>
 </head>
 
@@ -340,7 +338,6 @@ class StandardPageTest extends ILIAS_UI_TestBase
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>:</title>
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <script type="application/javascript">var il = il ||{}; window.il = il;</script>
     <style></style>
     <meta name="meta_datum_key_1" content="meta_datum_value_1" />
     <meta name="meta_datum_key_2" content="meta_datum_value_2" />
@@ -415,7 +412,6 @@ class StandardPageTest extends ILIAS_UI_TestBase
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>:</title>
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <script type="application/javascript">var il = il ||{}; window.il = il;</script>
     <style></style>
 </head>
 


### PR DESCRIPTION
Hi folks,

@iszmais has brought another [breaking change](https://github.com/ILIAS-eLearning/ILIAS/commit/25139f0fe323e1ea237b9ea6d2216531a7427ce3) to my attention, which has been caused by the data table backport. This makes skins cause JavaScript errors if they are manipulating the `tpl.standardpage.tpl` file of the page component.

I reverted this commit and cherry-picked @nhaagen solution which he proposed in #7458 already.

Kind regards,
@thibsy 