### PR TITLE
T&A: Mantisticket 41383, Release 9

### DIFF
--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -2805,21 +2805,6 @@ class ilObjCourseGUI extends ilContainerGUI
     }
 
     /**
-     * @inheritDoc
-     */
-    public function prepareOutput(bool $show_subobjects = true): bool
-    {
-        if (!$this->getCreationMode()) {
-            $settings = ilMemberViewSettings::getInstance();
-            if ($settings->isActive() && $settings->getContainer() != $this->object->getRefId()) {
-                $settings->setContainer($this->object->getRefId());
-                $this->rbac_system->initMemberView();
-            }
-        }
-        return parent::prepareOutput($show_subobjects);
-    }
-
-    /**
      * Create a course mail signature
      * @return string
      */

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1049,18 +1049,6 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
         $this->ctrl->redirectByClass('ilObjTestGUI', 'questions');
     }
 
-    public function prepareOutput(bool $show_subobjects = true): bool
-    {
-        if (!$this->getCreationMode()) {
-            $settings = ilMemberViewSettings::getInstance();
-            if ($settings->isActive() && $settings->getContainer() != $this->object->getRefId()) {
-                $settings->setContainer($this->object->getRefId());
-                $this->rbac_system->initMemberView();
-            }
-        }
-        return parent::prepareOutput($show_subobjects);
-    }
-
     private function userResultsGatewayObject()
     {
         $this->ctrl->setCmdClass('ilTestEvaluationGUI');


### PR DESCRIPTION
@thojou and @mbecker-databay will take care of this

https://mantis.ilias.de/view.php?id=41383

The problem was caused by the method prepareOutput in class.ilObjTestGUI. Within the method, a refID of an ilObjTest was used as a refID of an ilContainer, which caused the exception. 

In consultation with @fhelfer who added this method with https://github.com/ILIAS-eLearning/ILIAS/pull/6333 to fix https://mantis.ilias.de/view.php?id=37993 we noticed that the code now seems unnecessary. 

The same method was also implemented in ilObjCourseGUI and it seems as if it no longer provides any functionality. Instead, the functionality was outsourced into ilMemberViewSettings.

We removed both methods which solved the problem.