### PR TITLE
41413: Fix trying to assign string value to int|null property

### DIFF
--- a/Modules/File/classes/class.ilFileXMLParser.php
+++ b/Modules/File/classes/class.ilFileXMLParser.php
@@ -153,7 +153,7 @@ class ilFileXMLParser extends ilSaxParser
                     if ($this->date === null) {
                         // Version tag comes after Content tag. Take only first (= Should be latest)
                         $this->date = $a_attribs["date"];
-                        $this->usr_id = $a_attribs["usr_id"];
+                        $this->usr_id = (int) $a_attribs["usr_id"];
                         $this->versions[0]["date"] = $this->date;
                         $this->versions[0]["usr_id"] = $this->usr_id;
                     }


### PR DESCRIPTION
Fixes an error that occured when trying to import a Course that contained a File object.

The xml of the file object saves the attribute "usr_id" like this: 
```php
"il_" . IL_INST_ID . "_usr_" . $version["user_id"]
//Example: il_0_usr_6 => actual user-id "6"
```

the cast I added will always turn this string into **0**.

I'm uncertain if this is the correct solution, 
considering it's been done like this on other lines in the file, I would assume this is how it should be.
I could not find issues in the imported Objects with this cast added.

Mantis Issue: https://mantis.ilias.de/view.php?id=41413

If accepted this change should be picked into other branches >= release_8.