### PR TITLE
41398: Fix mail template loaded from wrong directory

### DIFF
--- a/Services/Mail/README.md
+++ b/Services/Mail/README.md
@@ -95,7 +95,7 @@ when no template can be determined.
 Per Skin, one HTML template can be defined and has to be
 stored in the following location:
 
-    ./Customizing/global/skin/<NAME>/Services/Mail/tpl.html_mail_template.html.
+    ./Customizing/global/skin/<SKIN-NAME>/<STYLE-NAME>/Services/Mail/tpl.html_mail_template.html.
 
 The HTML frame template concept consists of the HTML
 markup file itself and some optional attachments.

--- a/Services/Mail/classes/class.ilMimeMail.php
+++ b/Services/Mail/classes/class.ilMimeMail.php
@@ -236,9 +236,10 @@ class ilMimeMail
 
         if ($DIC->settings()->get('mail_send_html', '0')) {
             $skin = $DIC['ilClientIniFile']->readVariable('layout', 'skin');
+            $style = $DIC['ilClientIniFile']->readVariable('layout', 'style');
 
-            $this->buildBodyMultiParts($skin);
-            $this->buildHtmlInlineImages($skin);
+            $this->buildBodyMultiParts($skin, $style);
+            $this->buildHtmlInlineImages($skin, $style);
         } else {
             $this->finalBody = $this->removeHTMLTags($this->body);
         }
@@ -251,7 +252,7 @@ class ilMimeMail
         return strip_tags($maybeHTML);
     }
 
-    protected function buildBodyMultiParts(string $skin): void
+    protected function buildBodyMultiParts(string $skin, string $style): void
     {
         if ($this->body === '') {
             $this->body = ' ';
@@ -268,30 +269,30 @@ class ilMimeMail
             $this->finalBodyAlt = strip_tags(str_ireplace(["<br />", "<br>", "<br/>"], "\n", $this->body));
         }
 
-        $this->finalBody = str_replace('{PLACEHOLDER}', $this->body, $this->getHtmlEnvelope($skin));
+        $this->finalBody = str_replace('{PLACEHOLDER}', $this->body, $this->getHtmlEnvelope($skin, $style));
     }
 
-    protected function getHtmlEnvelope(string $skin): string
+    protected function getHtmlEnvelope(string $skin, string $style): string
     {
         $bracket_path = './Services/Mail/templates/default/tpl.html_mail_template.html';
 
         if ($skin !== 'default') {
-            $tplpath = './Customizing/global/skin/' . $skin . '/Services/Mail/tpl.html_mail_template.html';
+            $tplpath = './Customizing/global/skin/' . $skin . '/' . $style . '/Services/Mail/tpl.html_mail_template.html';
 
             if (is_file($tplpath)) {
-                $bracket_path = './Customizing/global/skin/' . $skin . '/Services/Mail/tpl.html_mail_template.html';
+                $bracket_path = './Customizing/global/skin/' . $skin . '/' . $style . '/Services/Mail/tpl.html_mail_template.html';
             }
         }
 
         return file_get_contents($bracket_path);
     }
 
-    protected function buildHtmlInlineImages(string $skin): void
+    protected function buildHtmlInlineImages(string $skin, string $style): void
     {
         $this->gatherImagesFromDirectory('./Services/Mail/templates/default/img');
 
         if ($skin !== 'default') {
-            $skinDirectory = './Customizing/global/skin/' . $skin . '/Services/Mail/img';
+            $skinDirectory = './Customizing/global/skin/' . $skin . '/' . $style . '/Services/Mail/img';
             if (is_dir($skinDirectory) && is_readable($skinDirectory)) {
                 $this->gatherImagesFromDirectory($skinDirectory, true);
             }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11464,7 +11464,7 @@ mail#:#mail_select_grp#:#Bitte mindestens eine Gruppe auswählen.
 mail#:#mail_select_one_entry#:#Sie müssen mindestens einen Eintrag auswählen
 mail#:#mail_select_one_file#:#Sie müssen mindestens eine Datei auswählen
 mail#:#mail_send_html#:#HTML-Rahmen
-mail#:#mail_send_html_info#:#Falls aktiviert, wird der Nachrichtentext von externen E-Mails in einen HTML-Rahmen gesetzt. Dieser kann über ein Skin-Template unter './Customizing/global/skin/[SKIN]/Services/Mail/tpl.html_mail_template.html' (als Kopie von './Services/Mail/templates/default/tpl.html_mail_template.html') angepasst werden.
+mail#:#mail_send_html_info#:#Falls aktiviert, wird der Nachrichtentext von externen E-Mails in einen HTML-Rahmen gesetzt. Dieser kann über ein Skin-Template unter './Customizing/global/skin/[SKIN]/[STYLE]/Services/Mail/tpl.html_mail_template.html' (als Kopie von './Services/Mail/templates/default/tpl.html_mail_template.html') angepasst werden.
 mail#:#mail_serial_letter_placeholders#:#Platzhalter für Serienbrief
 mail#:#mail_settings_external_frm_head#:#Externe E-Mails
 mail#:#mail_settings_external_tab#:#Extern

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11464,7 +11464,7 @@ mail#:#mail_select_grp#:#Please select at least one group.
 mail#:#mail_select_one_entry#:#You must select at least one entry.
 mail#:#mail_select_one_file#:#You must select at least one file.
 mail#:#mail_send_html#:#HTML Frame
-mail#:#mail_send_html_info#:#Embed the body of external e-mails in an HTML frame. The corresponding template can be customised by creating a copy of './Services/Mail/templates/default/tpl.html_mail_template.html' at './Customizing/global/skin/[SKIN]/Services/Mail/tpl.html_mail_template.html'.
+mail#:#mail_send_html_info#:#Embed the body of external e-mails in an HTML frame. The corresponding template can be customised by creating a copy of './Services/Mail/templates/default/tpl.html_mail_template.html' at './Customizing/global/skin/[SKIN]/[STYLE]/Services/Mail/tpl.html_mail_template.html'.
 mail#:#mail_serial_letter_placeholders#:#Mail Merge Placeholders
 mail#:#mail_settings_external_frm_head#:#External E-Mails
 mail#:#mail_settings_external_tab#:#External


### PR DESCRIPTION
Fixes mail template loaded from wrong (old) path


Mantis Ticket: https://mantis.ilias.de/view.php?id=41398

if accepted these changes should be picked into branches >= release_9