### PR TITLE
Oblige maintainers to demand changes in form of PRs

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -43,7 +43,8 @@ Responsibilities of a component maintainer:
   by the [Issue-Tracker](https://mantis.ilias.de).
 - Component maintainers are responsible for Pull Requests to their component and get assigned related Pull Requests
   by the Technical Board according to the [Rules for Maintainers and Coordinators assigned to PRs[(Rules for Maintainers and Coordinators assigned to PRs)
-
+- Component maintainer are obliged to demand any contribution to their component in form of a PR and to provide
+  their own contributions in form of PRs, too. Fixes regarding the security of ILIAS are excluded from that rule.
 
 ## Becoming a Maintainer
 


### PR DESCRIPTION
This PRs propose to enable Maintainers (Coordinators/Authorities) to demand, and self-control, any contribution to their component to be in form of a Pull Request, except security related issues.

This explicitly does **not** create a requirement for contribution via PRs itsself (since that is already the case via the "Rules for Contributors", wich requires PRs, and the "Who is a contributor?" wich includes all individuals involved in the developement process, including Maintainers (Coordinators/Authorities) them self), but strengthens the authority of Maintainers (Coordinators/Authorities) to fulfill their responsibility.