### PR TITLE
T&A 41349 Fix TypeError when trying to access question pool skills tab

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -410,6 +410,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 $gui = new ilQuestionPoolSkillAdministrationGUI(
                     $ilias,
                     $ilCtrl,
+                    $this->refinery,
                     $ilAccess,
                     $ilTabs,
                     $tpl,


### PR DESCRIPTION
This PR aims to address the problem reported in Mantis issue https://mantis.ilias.de/view.php?id=41349.

Attempting to access the problematic skills tab of the question pool will now result in the normal expected behavior.

The error does not occur in Release_9.

Kind regards.