### PR TITLE
Transform the title property of cards.

### DIFF
--- a/src/UI/Implementation/Component/Card/Renderer.php
+++ b/src/UI/Implementation/Component/Card/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Card;
 
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
@@ -27,6 +27,7 @@ use ILIAS\UI\Implementation\Component\Symbol\Icon\Standard as StandardIcon;
 use ILIAS\UI\Component\Button\Shy;
 use ILIAS\UI\Implementation\Component\Button\Button;
 use ILIAS\UI\Component\Link\Link;
+use ilObjectGUI;
 
 class Renderer extends AbstractComponentRenderer
 {
@@ -43,6 +44,9 @@ class Renderer extends AbstractComponentRenderer
 
         $title = $component->getTitle();
         $image_alt = $title;
+        if (is_string($title)) {
+            $title = strip_tags($title, ilObjectGUI::ALLOWED_TAGS_IN_TITLE_AND_DESCRIPTION);
+        }
 
         if ($title instanceof Button || $title instanceof Link) {
             $image_alt = $title->getLabel();
@@ -78,7 +82,7 @@ class Renderer extends AbstractComponentRenderer
 
         if ($component->getImage()) {
             $tpl->setVariable("IMAGE", $default_renderer->render(
-                $component->getImage()->withAlt($this->txt("open")." ".strip_tags($image_alt))
+                $component->getImage()->withAlt($this->txt("open") . " " . $image_alt)
             ));
         }
 

--- a/tests/UI/Component/Card/CardTest.php
+++ b/tests/UI/Component/Card/CardTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 require_once(__DIR__ . "/../../../../libs/composer/vendor/autoload.php");
 require_once(__DIR__ . "/../../Base.php");
@@ -181,5 +181,37 @@ class CardTest extends ILIAS_UI_TestBase
             "</div>";
 
         $this->assertHTMLEquals($this->brutallyTrimHTML($expected_html), $html);
+    }
+
+    public function test_render_content_with_allowed_tag_in_title(): void
+    {
+        $r = $this->getDefaultRenderer();
+        $c = $this->getBaseCard();
+        $c = $c->withTitle('<b>name</b>');
+
+        $expected_html =
+            "<div class=\"il-card thumbnail\">" .
+            "   <div class=\"il-card-image-container\"><img src=\"src\" class=\"img-standard\" alt=\"open &lt;b&gt;name&lt;/b&gt;\" /></div>" .
+            "   <div class=\"card-no-highlight\"></div>" .
+            "   <div class=\"caption card-title\"><b>name</b></div>" .
+            "</div>";
+
+        $this->assertHTMLEquals($this->brutallyTrimHTML($expected_html), $this->brutallyTrimHTML($r->render($c)));
+    }
+
+    public function test_render_content_with_prohibited_tag_in_title(): void
+    {
+        $r = $this->getDefaultRenderer();
+        $c = $this->getBaseCard();
+        $c = $c->withTitle('<h1>name</h1>');
+
+        $expected_html =
+            "<div class=\"il-card thumbnail\">" .
+            "   <div class=\"il-card-image-container\"><img src=\"src\" class=\"img-standard\" alt=\"open &lt;h1&gt;name&lt;/h1&gt;\" /></div>" .
+            "   <div class=\"card-no-highlight\"></div>" .
+            "   <div class=\"caption card-title\">name</div>" .
+            "</div>";
+
+        $this->assertHTMLEquals($this->brutallyTrimHTML($expected_html), $this->brutallyTrimHTML($r->render($c)));
     }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41459

**DEPENDS ON https://github.com/ILIAS-eLearning/ILIAS/pull/7572**

This transforms the title property of cards

This PR changes the following presentations:
- The Title of Objects within a tile view.

_This should use a refinery transformation, when #6314 is merged._