### PR TITLE
Remove HTML form card titles

### DIFF
--- a/Services/Container/js/Container.js
+++ b/Services/Container/js/Container.js
@@ -1,13 +1,10 @@
 il = il || {};
-il.Container = il.Container || {};
 (function($, il) {
 	il.Container = (function($) {
 		var initShowMore = function (id, block, url) {
 			$("#" + id).on("click", function(e) {
 				e.preventDefault();
-				var ids = $("#" + id).closest(".ilContainerItemsContainer").find("[data-list-item-id]")
-					.map(function() { return $(this).data("list-item-id"); }).get();
-				il.Util.sendAjaxPostRequestToUrl(url, {ids: ids}, function(o) {
+				il.Util.sendAjaxPostRequestToUrl(url, {ids: il.Container.ids}, function(o) {
 					$("#" + id).closest(".ilContainerShowMore").replaceWith($(o).find(".ilContainerItemsContainer").children());
 				})
 			});
@@ -17,6 +14,7 @@ il.Container = il.Container || {};
 			initShowMore: initShowMore
 		};
 	})($);
+	il.Container.ids = [];
 })($, il);
 
 (function($){

--- a/Services/Container/templates/default/tpl.container_list_item.html
+++ b/Services/Container/templates/default/tpl.container_list_item.html
@@ -94,6 +94,7 @@
 <div style="clear:both;"></div>
 </div>
 </div>
+<script>{ADD_IDS_SCRIPT}</script>
 <!-- BEGIN fileupload -->
 {FILE_UPLOAD}
 <!-- END fileupload -->

--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -2901,8 +2901,19 @@ class ilObjectListGUI
         $this->tpl->setVariable("DIV_CLASS", 'ilContainerListItemOuter');
         $this->tpl->setVariable(
             "DIV_ID",
-            'data-list-item-id="' . $this->getUniqueItemId(true) . '" id = "' . $this->getUniqueItemId(true) . '"'
+            'id = "' . $this->getUniqueItemId(true) . '"'
         );
+        if ($this->ctrl->getCmd() === "renderBlockAsynch") {
+            $this->tpl->setVariable(
+                "ADD_IDS_SCRIPT",
+                "il.Container.ids.push('{$this->getUniqueItemId(true)}');"
+            );
+        } else {
+            $this->tpl->setVariable(
+                "ADD_IDS_SCRIPT",
+                "window.addEventListener('DOMContentLoaded',() => {il.Container.ids.push('{$this->getUniqueItemId(true)}');});"
+            );
+        }
         $this->tpl->setVariable("ADDITIONAL", $this->getAdditionalInformation());
 
         if (is_object($this->getContainerObject())) {
@@ -3319,7 +3330,7 @@ class ilObjectListGUI
                                 $def_cmd_link
                             ) . "', '" . $def_cmd_frame . "');});";
                     });
-                $title = $ui->renderer()->render($button);
+                $title = $button;
             } else {
                 $image = $image->withAction($modified_link);
             }
@@ -3363,13 +3374,18 @@ class ilObjectListGUI
         }
 
         $card = $ui->factory()->card()->repositoryObject(
-            $title . '<span data-list-item-id="' . $this->getUniqueItemId(true) . '"></span>',
+            $title,
             $image
         )->withObjectIcon(
             $icon
         )->withActions(
             $dropdown
         );
+
+        $list_item_id = $this->getUniqueItemId(true);
+        $card = $card->withAdditionalOnLoadCode(function ($id) use ($list_item_id) {
+            return "il.Container.ids.push('$list_item_id');";
+        });
 
         if ($card_title_action != "") {
             $card = $card->withTitleAction($card_title_action);


### PR DESCRIPTION
This PR is a refactoring response to the [Bugfix of shy titles in cards](https://github.com/ILIAS-eLearning/ILIAS/pull/7571)

and a precondition for the [Secure transformation of the card title property](https://github.com/ILIAS-eLearning/ILIAS/pull/7567)

- Removes title button pre-rendering out of the construction process (Is now handled by the card renderer).
- Moves functional identification of "Show More" ids to the javascript from html.

