### PR TITLE
Add "HTMLSpecialCharsAsEntities"-Refinery usage

### DIFF
--- a/components/ILIAS/Init/classes/Dependencies/InitUIFramework.php
+++ b/components/ILIAS/Init/classes/Dependencies/InitUIFramework.php
@@ -277,7 +277,8 @@ class InitUIFramework
                             $c["ui.pathresolver"],
                             $c["ui.data_factory"],
                             $c["help.text_retriever"],
-                            $c["ui.upload_limit_resolver"]
+                            $c["ui.upload_limit_resolver"],
+                            $c["refinery"]->encode()->htmlSpecialCharsAsEntities()
                         ),
                         new ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphRendererFactory(
                             $c["ui.factory"],
@@ -287,7 +288,8 @@ class InitUIFramework
                             $c["ui.pathresolver"],
                             $c["ui.data_factory"],
                             $c["help.text_retriever"],
-                            $c["ui.upload_limit_resolver"]
+                            $c["ui.upload_limit_resolver"],
+                            $c["refinery"]->encode()->htmlSpecialCharsAsEntities()
                         ),
                         new ILIAS\UI\Implementation\Component\Symbol\Icon\IconRendererFactory(
                             $c["ui.factory"],
@@ -297,7 +299,8 @@ class InitUIFramework
                             $c["ui.pathresolver"],
                             $c["ui.data_factory"],
                             $c["help.text_retriever"],
-                            $c["ui.upload_limit_resolver"]
+                            $c["ui.upload_limit_resolver"],
+                            $c["refinery"]->encode()->htmlSpecialCharsAsEntities()
                         ),
                         new ILIAS\UI\Implementation\Component\Input\Field\FieldRendererFactory(
                             $c["ui.factory"],
@@ -307,7 +310,8 @@ class InitUIFramework
                             $c["ui.pathresolver"],
                             $c["ui.data_factory"],
                             $c["help.text_retriever"],
-                            $c["ui.upload_limit_resolver"]
+                            $c["ui.upload_limit_resolver"],
+                            $c["refinery"]->encode()->htmlSpecialCharsAsEntities()
                         )
                     )
                 )

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FieldRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FieldRendererFactory.php
@@ -37,7 +37,8 @@ class FieldRendererFactory extends Render\DefaultRendererFactory
                 $this->image_path_resolver,
                 $this->data_factory,
                 $this->help_text_retriever,
-                $this->upload_limit_resolver
+                $this->upload_limit_resolver,
+                $this->escaper
             );
         }
         if (in_array('StandardFilterContainerInput', $contexts)) {
@@ -49,7 +50,8 @@ class FieldRendererFactory extends Render\DefaultRendererFactory
                 $this->image_path_resolver,
                 $this->data_factory,
                 $this->help_text_retriever,
-                $this->upload_limit_resolver
+                $this->upload_limit_resolver,
+                $this->escaper
             );
         }
         return new Renderer(
@@ -60,7 +62,8 @@ class FieldRendererFactory extends Render\DefaultRendererFactory
             $this->image_path_resolver,
             $this->data_factory,
             $this->help_text_retriever,
-            $this->upload_limit_resolver
+            $this->upload_limit_resolver,
+            $this->escaper
         );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/GlyphRendererFactory.php
@@ -42,7 +42,8 @@ class GlyphRendererFactory extends Render\DefaultRendererFactory
                 $this->image_path_resolver,
                 $this->data_factory,
                 $this->help_text_retriever,
-                $this->upload_limit_resolver
+                $this->upload_limit_resolver,
+                $this->escaper
             );
         }
         return new Renderer(
@@ -53,7 +54,8 @@ class GlyphRendererFactory extends Render\DefaultRendererFactory
             $this->image_path_resolver,
             $this->data_factory,
             $this->help_text_retriever,
-            $this->upload_limit_resolver
+            $this->upload_limit_resolver,
+            $this->escaper
         );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Icon/IconRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Icon/IconRendererFactory.php
@@ -42,7 +42,8 @@ class IconRendererFactory extends Render\DefaultRendererFactory
                 $this->image_path_resolver,
                 $this->data_factory,
                 $this->help_text_retriever,
-                $this->upload_limit_resolver
+                $this->upload_limit_resolver,
+                $this->escaper
             );
         }
         return new Renderer(
@@ -53,7 +54,8 @@ class IconRendererFactory extends Render\DefaultRendererFactory
             $this->image_path_resolver,
             $this->data_factory,
             $this->help_text_retriever,
-            $this->upload_limit_resolver
+            $this->upload_limit_resolver,
+            $this->escaper
         );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Render/AbstractComponentRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Render/AbstractComponentRenderer.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Render;
 
 use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Transformation;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\JavaScriptBindable;
 use ILIAS\UI\Component\Triggerer;
@@ -52,6 +53,7 @@ abstract class AbstractComponentRenderer implements ComponentRenderer, HelpTextR
         private DataFactory $data_factory,
         private HelpTextRetriever $help_text_retriever,
         private UploadLimitResolver $upload_limit_resolver,
+        private Transformation $escaper
     ) {
     }
 
@@ -325,6 +327,6 @@ abstract class AbstractComponentRenderer implements ComponentRenderer, HelpTextR
 
     protected function convertSpecialCharacters(string $value): string
     {
-        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8');
+        return $this->escaper->transform($value);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Render/DefaultRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Render/DefaultRendererFactory.php
@@ -22,6 +22,7 @@ namespace ILIAS\UI\Implementation\Render;
 
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Factory as RootFactory;
 use ILIAS\UI\HelpTextRetriever;
@@ -39,6 +40,7 @@ class DefaultRendererFactory implements RendererFactory
         protected DataFactory $data_factory,
         protected HelpTextRetriever $help_text_retriever,
         protected UploadLimitResolver $upload_limit_resolver,
+        protected Transformation $escaper,
     ) {
     }
 
@@ -57,6 +59,7 @@ class DefaultRendererFactory implements RendererFactory
             $this->data_factory,
             $this->help_text_retriever,
             $this->upload_limit_resolver,
+            $this->escaper,
         );
     }
 

--- a/components/ILIAS/UI/tests/Base.php
+++ b/components/ILIAS/UI/tests/Base.php
@@ -21,6 +21,7 @@ require_once(__DIR__ . '/../../../../vendor/composer/vendor/autoload.php');
 require_once(__DIR__ . '/Renderer/ilIndependentTemplate.php');
 require_once(__DIR__ . '/../../Language/classes/class.ilLanguage.php');
 
+use ILIAS\Refinery\Transformation;
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Component\Component as IComponent;
 use ILIAS\UI\Implementaiton\Component as I;
@@ -379,6 +380,11 @@ trait BaseUITestTrait
         return $this->createMock(UploadLimitResolver::class);
     }
 
+    public function getEscaper(): Transformation
+    {
+        return new ILIAS\Refinery\Encode\Transformation\HTMLSpecialCharsAsEntities();
+    }
+
     public function getDefaultRenderer(
         JavaScriptBinding $js_binding = null,
         array $with_stub_renderings = []
@@ -407,7 +413,8 @@ trait BaseUITestTrait
                         $image_path_resolver,
                         $data_factory,
                         $help_text_retriever,
-                        $this->getUploadLimitResolver()
+                        $this->getUploadLimitResolver(),
+                        $this->getEscaper()
                     ),
                     new GlyphRendererFactory(
                         $ui_factory,
@@ -417,7 +424,8 @@ trait BaseUITestTrait
                         $image_path_resolver,
                         $data_factory,
                         $help_text_retriever,
-                        $this->getUploadLimitResolver()
+                        $this->getUploadLimitResolver(),
+                        $this->getEscaper()
                     ),
                     new IconRendererFactory(
                         $ui_factory,
@@ -427,7 +435,8 @@ trait BaseUITestTrait
                         $image_path_resolver,
                         $data_factory,
                         $help_text_retriever,
-                        $this->getUploadLimitResolver()
+                        $this->getUploadLimitResolver(),
+                        $this->getEscaper()
                     ),
                     new FieldRendererFactory(
                         $ui_factory,
@@ -437,7 +446,8 @@ trait BaseUITestTrait
                         $image_path_resolver,
                         $data_factory,
                         $help_text_retriever,
-                        $this->getUploadLimitResolver()
+                        $this->getUploadLimitResolver(),
+                        $this->getEscaper()
                     )
                 )
             )

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlPaginationTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlPaginationTest.php
@@ -226,7 +226,8 @@ class ViewControlPaginationTest extends ViewControlTestBase
             $this->getImagePathResolver(),
             $this->getDataFactory(),
             $this->getHelpTextRetriever(),
-            $this->getUploadLimitResolver()
+            $this->getUploadLimitResolver(),
+            $this->getEscaper()
         );
     }
 

--- a/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
+++ b/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
@@ -444,7 +444,8 @@ class GlyphTest extends ILIAS_UI_TestBase
             new ilImagePathResolver(),
             $this->createMock(DataFactory::class),
             $this->createMock(HelpTextRetriever::class),
-            $this->getUploadLimitResolver()
+            $this->getUploadLimitResolver(),
+            $this->getEscaper()
         );
         $f = $this->getCounterFactory();
 

--- a/components/ILIAS/UI/tests/Component/Table/DataRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/DataRendererTest.php
@@ -90,7 +90,8 @@ class DataRendererTest extends TableTestBase
             new ilImagePathResolver(),
             new \ILIAS\Data\Factory(),
             new \ILIAS\UI\Help\TextRetriever\Echoing(),
-            $this->getUploadLimitResolver()
+            $this->getUploadLimitResolver(),
+            $this->getEscaper()
         );
     }
 

--- a/components/ILIAS/UI/tests/Renderer/AbstractRendererTest.php
+++ b/components/ILIAS/UI/tests/Renderer/AbstractRendererTest.php
@@ -208,7 +208,8 @@ namespace {
                 $this->image_path_resolver,
                 $this->getDataFactory(),
                 $this->help_text_retriever,
-                $this->getUploadLimitResolver()
+                $this->getUploadLimitResolver(),
+                $this->getEscaper()
             );
             $r->_getTemplate("tpl.glyph.html", true, false);
 
@@ -229,7 +230,8 @@ namespace {
                 $this->image_path_resolver,
                 $this->getDataFactory(),
                 $this->help_text_retriever,
-                $this->getUploadLimitResolver()
+                $this->getUploadLimitResolver(),
+                $this->getEscaper()
             );
 
             $this->expectException(TypeError::class);
@@ -251,7 +253,8 @@ namespace {
                 $this->image_path_resolver,
                 $this->getDataFactory(),
                 $this->help_text_retriever,
-                $this->getUploadLimitResolver()
+                $this->getUploadLimitResolver(),
+                $this->getEscaper()
             );
 
             $g = new Glyph(C\Symbol\Glyph\Glyph::SETTINGS, "aria_label");
@@ -278,7 +281,8 @@ namespace {
                 $this->image_path_resolver,
                 $this->getDataFactory(),
                 $this->help_text_retriever,
-                $this->getUploadLimitResolver()
+                $this->getUploadLimitResolver(),
+                $this->getEscaper()
             );
 
             $g = new Glyph(C\Symbol\Glyph\Glyph::SETTINGS, "aria_label");

--- a/components/ILIAS/UI/tests/Renderer/ComponentRendererFSLoaderTest.php
+++ b/components/ILIAS/UI/tests/Renderer/ComponentRendererFSLoaderTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 require_once(__DIR__ . "/TestComponent.php");
 
+use ILIAS\Refinery\Encode\Transformation\HTMLSpecialCharsAsEntities;
 use ILIAS\UI\Implementation as I;
 use PHPUnit\Framework\TestCase;
 use ILIAS\UI\Component\Component;
@@ -50,6 +51,7 @@ class ComponentRendererFSLoaderTest extends TestCase
         $data_factory = $this->getMockBuilder(ILIAS\Data\Factory::class)->getMock();
         $help_text_retriever = $this->createMock(ILIAS\UI\HelpTextRetriever::class);
         $upload_limit_resolver = $this->createMock(ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class);
+        $escaper = $this->createMock(HTMLSpecialCharsAsEntities::class);
 
         $default_renderer_factory = new I\Render\DefaultRendererFactory(
             $ui_factory,
@@ -60,6 +62,7 @@ class ComponentRendererFSLoaderTest extends TestCase
             $data_factory,
             $help_text_retriever,
             $upload_limit_resolver,
+            $escaper
         );
         $this->glyph_renderer = $this->createMock(I\Render\RendererFactory::class);
         $this->icon_renderer = $this->createMock(I\Render\RendererFactory::class);


### PR DESCRIPTION
As mentioned [here](https://github.com/ILIAS-eLearning/ILIAS/pull/7350) with the integration of the refinery, the function `convertSpecialCharacters` is obsolete and should be exchanged.