### PR TITLE
Draft: naive approach for managing markdown flavour (PoC).

### DIFF
--- a/components/ILIAS/UI/resources/js/Input/Field/dist/input.factory.min.js
+++ b/components/ILIAS/UI/resources/js/Input/Field/dist/input.factory.min.js
@@ -318,75 +318,75 @@ const CONTENT_WRAPPER_KEY_PREVIEW = 'preview';
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
 class Markdown extends Textarea {
-    /**
+  /**
      * @type {string[]}
      */
-    preview_history = [];
+  preview_history = [];
 
-    /**
+  /**
      * @type {PreviewRenderer}
      */
-    preview_renderer;
+  preview_renderer;
 
-    /**
+  /**
      * @type {Map}
      */
-    content_wrappers;
+  content_wrappers;
 
-    /**
+  /**
      * @type {HTMLButtonElement[]}
      */
-    view_controls;
+  view_controls;
 
-    /**
+  /**
      * @type {HTMLButtonElement[]}
      */
-    actions;
+  actions;
 
-    /**
+  /**
      * @param {PreviewRenderer} preview_renderer
      * @param {string} input_id
      * @throws {Error} if DOM elements are missing.
      */
-    constructor(preview_renderer, input_id) {
-        super(input_id);
+  constructor(preview_renderer, input_id) {
+    super(input_id);
 
-        let input_wrapper = this.textarea.closest('.c-input-markdown');
+    const input_wrapper = this.textarea.closest('.c-input-markdown');
 
-        if (null === input_wrapper) {
-            throw new Error(`Could not find input-wrapper for input-id '${input_id}'.`);
-        }
-
-        this.preview_renderer = preview_renderer;
-
-        this.content_wrappers = getContentWrappersOrAbort(input_wrapper);
-        this.view_controls = getViewControlsOrAbort(input_wrapper);
-        this.actions = getMarkdownActions(input_wrapper);
-
-        let has_newline_been_inserted = true;
-
-        this.textarea.addEventListener('keydown', (event) => {
-            has_newline_been_inserted = this.handleEnterKeyBeforeInsertionHook(event);
-        });
-
-        this.textarea.addEventListener('keyup', (event) => {
-            this.handleEnterKeyAfterInsertionHook(event, has_newline_been_inserted);
-        });
-
-        this.actions.forEach((action) => {
-            action.addEventListener('click', (event) => {
-                this.performMarkdownActionHook(event);
-            });
-        });
-
-        this.view_controls.forEach((control) => {
-            control.addEventListener('click', () => {
-                this.toggleViewingModeHook();
-            });
-        });
+    if (input_wrapper === null) {
+      throw new Error(`Could not find input-wrapper for input-id '${input_id}'.`);
     }
 
-    /**
+    this.preview_renderer = preview_renderer;
+
+    this.content_wrappers = getContentWrappersOrAbort(input_wrapper);
+    this.view_controls = getViewControlsOrAbort(input_wrapper);
+    this.actions = getMarkdownActions(input_wrapper);
+
+    let has_newline_been_inserted = true;
+
+    this.textarea.addEventListener('keydown', (event) => {
+      has_newline_been_inserted = this.handleEnterKeyBeforeInsertionHook(event);
+    });
+
+    this.textarea.addEventListener('keyup', (event) => {
+      this.handleEnterKeyAfterInsertionHook(event, has_newline_been_inserted);
+    });
+
+    this.actions.forEach((action) => {
+      action.addEventListener('click', (event) => {
+        this.performMarkdownActionHook(event);
+      });
+    });
+
+    this.view_controls.forEach((control) => {
+      control.addEventListener('click', () => {
+        this.toggleViewingModeHook();
+      });
+    });
+  }
+
+  /**
      * Automatically inserts a bullet-point or enumeration on the newly added line
      * according to the previous one.
      *
@@ -397,281 +397,290 @@ class Markdown extends Textarea {
      * @param {boolean} newline_inserted
      * @return {void}
      */
-    handleEnterKeyAfterInsertionHook(event, newline_inserted) {
-        // skip this hook if the previous one didn't insert a newline,
-        // otherwise this hook would undo the previous action.
-        if (!newline_inserted || !isEnterKeyPressed(event)) {
-            return;
-        }
-
-        let previous_line = this.getLinesBeforeSelection().pop();
-
-        if (undefined !== previous_line && isBulletPointed(previous_line)) {
-            this.applyTransformationToSelection(toggleBulletPoints);
-            return;
-        }
-
-        if (undefined !== previous_line && isEnumerated(previous_line)) {
-            this.insertSingleEnumeration();
-            return;
-        }
+  handleEnterKeyAfterInsertionHook(event, newline_inserted) {
+    // skip this hook if the previous one didn't insert a newline,
+    // otherwise this hook would undo the previous action.
+    if (!newline_inserted || !isEnterKeyPressed(event)) {
+      return;
     }
 
-    /**
+    const previous_line = this.getLinesBeforeSelection().pop();
+
+    if (undefined !== previous_line && isBulletPointed(previous_line)) {
+      this.applyTransformationToSelection(toggleBulletPoints);
+      return;
+    }
+
+    if (undefined !== previous_line && isEnumerated(previous_line)) {
+      this.insertSingleEnumeration();
+    }
+  }
+
+  /**
      * Removes the bullet-point or enumeration of the current line if there aren't
      * any other characters.
      *
      * @param {KeyboardEvent} event
      * @return {boolean}
      */
-    handleEnterKeyBeforeInsertionHook(event) {
-        if (!isEnterKeyPressed(event)) {
-            return false;
-        }
-
-        let current_line = this.getLinesOfSelection().shift();
-
-        // nothing to do if the current line is not an empty list entry.
-        if (undefined === current_line || !isEmptyListEntry(current_line)) {
-            return true;
-        }
-
-        let text_before_selection = this.getLinesBeforeSelection().join('\n');
-        let text_after_selection = this.getLinesAfterSelection().join('\n');
-
-        if (0 < text_before_selection.length) {
-            text_before_selection += '\n';
-        }
-
-        if (0 < text_after_selection.length) {
-            text_after_selection = '\n' + text_after_selection;
-        }
-
-        this.updateTextareaContent(
-            text_before_selection + text_after_selection,
-            this.getAbsoluteSelectionStart() - current_line.length,
-            this.getAbsoluteSelectionEnd() - current_line.length
-        );
-
-        // prevent newline from being added.
-        event.preventDefault();
-        return false;
+  handleEnterKeyBeforeInsertionHook(event) {
+    if (!isEnterKeyPressed(event)) {
+      return false;
     }
 
-    /**
+    const current_line = this.getLinesOfSelection().shift();
+
+    // nothing to do if the current line is not an empty list entry.
+    if (undefined === current_line || !isEmptyListEntry(current_line)) {
+      return true;
+    }
+
+    let text_before_selection = this.getLinesBeforeSelection().join('\n');
+    let text_after_selection = this.getLinesAfterSelection().join('\n');
+
+    if (text_before_selection.length > 0) {
+      text_before_selection += '\n';
+    }
+
+    if (text_after_selection.length > 0) {
+      text_after_selection = `\n${text_after_selection}`;
+    }
+
+    this.updateTextareaContent(
+      text_before_selection + text_after_selection,
+      this.getAbsoluteSelectionStart() - current_line.length,
+      this.getAbsoluteSelectionEnd() - current_line.length,
+    );
+
+    // prevent newline from being added.
+    event.preventDefault();
+    return false;
+  }
+
+  customHandlers = new Map();
+
+  /**
+     * @param {string} action
+     * @param {function(Markdown)} handler
+     */
+  registerAdditionalAction(action, handler) {
+    this.customHandlers.set(action, handler);
+  }
+
+  /**
      * @param {MouseEvent} event
      * @return {void}
      */
-    performMarkdownActionHook(event) {
-        let markdown_action = getMarkdownActionOfButton(event.target);
+  performMarkdownActionHook(event) {
+    const markdown_action = getMarkdownActionOfButton(event.target);
 
-        switch (markdown_action) {
-            case 'insert-heading':
-                this.insertCharactersAroundSelection('# ', '');
-                break;
-            case 'insert-link':
-                this.insertCharactersAroundSelection('[', '](url)');
-                break;
-            case 'insert-bold':
-                this.insertCharactersAroundSelection('**', '**');
-                break;
-            case 'insert-italic':
-                this.insertCharactersAroundSelection('_', '_');
-                break;
-            case 'insert-bullet-points':
-                this.applyTransformationToSelection(toggleBulletPoints);
-                break;
-            case 'insert-enumeration':
-                (this.isMultilineTextSelected()) ?
-                    this.applyTransformationToSelection(toggleEnumeration) :
-                    this.insertSingleEnumeration();
-                break;
-            default:
-                throw new Error(`Could not perform markdown-action '${markdown_action}'.`);
-        }
+    if (this.customHandlers.has(markdown_action)) {
+      const handler = this.customHandlers.get(markdown_action);
+      handler(this);
+      return;
     }
 
-    /**
+    switch (markdown_action) {
+      case 'insert-heading':
+        this.insertCharactersAroundSelection('# ', '');
+        break;
+      case 'insert-link':
+        this.insertCharactersAroundSelection('[', '](url)');
+        break;
+      case 'insert-bold':
+        this.insertCharactersAroundSelection('**', '**');
+        break;
+      case 'insert-italic':
+        this.insertCharactersAroundSelection('_', '_');
+        break;
+      case 'insert-bullet-points':
+        this.applyTransformationToSelection(toggleBulletPoints);
+        break;
+      case 'insert-enumeration':
+        (this.isMultilineTextSelected())
+          ? this.applyTransformationToSelection(toggleEnumeration)
+          : this.insertSingleEnumeration();
+        break;
+      default:
+        throw new Error(`Could not perform markdown-action '${markdown_action}'.`);
+    }
+  }
+
+  /**
      * @return {void}
      */
-    toggleViewingModeHook() {
-        this.content_wrappers.forEach(function (wrapper) {
-            toggleClassOfElement(wrapper, 'hidden');
-        });
+  toggleViewingModeHook() {
+    this.content_wrappers.forEach((wrapper) => {
+      toggleClassOfElement(wrapper, 'hidden');
+    });
 
-        this.view_controls.forEach(function (control) {
-            toggleClassOfElement(control, 'engaged');
-        });
+    this.view_controls.forEach((control) => {
+      toggleClassOfElement(control, 'engaged');
+    });
 
-        // only toggle actions if they weren't disabled initially.
-        if (!this.isDisabled()) {
-            this.actions.forEach(function (action) {
-                action.disabled = !action.disabled;
-                let glyph = action.querySelector('.glyph');
-                if (null !== glyph) {
-                    toggleClassOfElement(glyph, 'disabled');
-                }
-            });
+    // only toggle actions if they weren't disabled initially.
+    if (!this.isDisabled()) {
+      this.actions.forEach((action) => {
+        action.disabled = !action.disabled;
+        const glyph = action.querySelector('.glyph');
+        if (glyph !== null) {
+          toggleClassOfElement(glyph, 'disabled');
         }
-
-        this.maybeUpdatePreviewContent();
+      });
     }
 
-    /**
+    this.maybeUpdatePreviewContent();
+  }
+
+  /**
      * Insert a new enumeration on the current line if it's not already one.
      * All lines after that will be reindexed as long as they continue the
      * current enumeration.
      *
      * @return {void}
      */
-    insertSingleEnumeration() {
-        let lines_of_selection = this.getLinesOfSelection();
+  insertSingleEnumeration() {
+    const lines_of_selection = this.getLinesOfSelection();
 
-        // abort (refocus) if the current selection is not a single line or
-        // is already enumerated.
-        if (1 !== lines_of_selection.length) {
-            this.textarea.focus();
-            return;
-        }
-
-        let lines_before_selection = this.getLinesBeforeSelection();
-        let last_index = lines_before_selection.length - 1;
-        let previous_number = (0 <= last_index) ? getFirstNumber(lines_before_selection[last_index]) ?? 0 : 0;
-
-        let new_lines_of_selection = toggleEnumeration(lines_of_selection, ++previous_number);
-        let lines_after_selection = reindexContinuousLinesOfEnumeration(this.getLinesAfterSelection(), previous_number);
-
-        let text_before_selection = lines_before_selection.join('\n');
-        let text_after_selection = lines_after_selection.join('\n');
-        let text_of_selection = new_lines_of_selection.join('\n');
-
-        if (0 < text_before_selection.length && 0 < text_of_selection.length) {
-            text_before_selection += '\n';
-        }
-
-        if (0 < text_of_selection.length && 0 < text_after_selection.length) {
-            text_of_selection += '\n';
-        }
-
-        let new_content = text_before_selection + text_of_selection + text_after_selection;
-        let character_diff = new_content.length - this.textarea.value.length;
-
-        // the selection should be shifted by the amount of newly added/removed
-        // characters, so that the same text is still highlighted.
-        this.updateTextareaContent(
-            new_content,
-            this.getAbsoluteSelectionStart() + character_diff,
-            this.getAbsoluteSelectionEnd() + character_diff,
-        );
+    // abort (refocus) if the current selection is not a single line or
+    // is already enumerated.
+    if (lines_of_selection.length !== 1) {
+      this.textarea.focus();
+      return;
     }
 
-    /**
+    const lines_before_selection = this.getLinesBeforeSelection();
+    const last_index = lines_before_selection.length - 1;
+    let previous_number = (last_index >= 0) ? getFirstNumber(lines_before_selection[last_index]) ?? 0 : 0;
+
+    const new_lines_of_selection = toggleEnumeration(lines_of_selection, ++previous_number);
+    const lines_after_selection = reindexContinuousLinesOfEnumeration(this.getLinesAfterSelection(), previous_number);
+
+    let text_before_selection = lines_before_selection.join('\n');
+    const text_after_selection = lines_after_selection.join('\n');
+    let text_of_selection = new_lines_of_selection.join('\n');
+
+    if (text_before_selection.length > 0 && text_of_selection.length > 0) {
+      text_before_selection += '\n';
+    }
+
+    if (text_of_selection.length > 0 && text_after_selection.length > 0) {
+      text_of_selection += '\n';
+    }
+
+    const new_content = text_before_selection + text_of_selection + text_after_selection;
+    const character_diff = new_content.length - this.textarea.value.length;
+
+    // the selection should be shifted by the amount of newly added/removed
+    // characters, so that the same text is still highlighted.
+    this.updateTextareaContent(
+      new_content,
+      this.getAbsoluteSelectionStart() + character_diff,
+      this.getAbsoluteSelectionEnd() + character_diff,
+    );
+  }
+
+  /**
      * @param {function(string[]): string[]} transformation
      * @return {void}
      * @throws {Error} if the transformation does not return an array.
      *                 if the transformation is not a function.
      */
-    applyTransformationToSelection(transformation) {
-        if (!transformation instanceof Function) {
-            throw new Error(`Transformation must be an instance of Function, ${typeof transformation} given.`);
-        }
-
-        let transformed_selection = transformation(this.getLinesOfSelection());
-
-        if (!transformed_selection instanceof Array) {
-            throw new Error(`Transformation must return an instance of Array, ${typeof transformed_selection} returned.`);
-        }
-
-        let is_multiline = (1 < transformed_selection.length);
-
-        let text_before_selection = this.getLinesBeforeSelection().join('\n');
-        let text_after_selection = this.getLinesAfterSelection().join('\n');
-        let text_of_selection = transformed_selection.join('\n');
-
-        if (0 < text_before_selection.length && 0 < text_of_selection.length) {
-            text_before_selection += '\n';
-        }
-
-        if (0 < text_of_selection.length && 0 < text_after_selection.length) {
-            text_of_selection += '\n';
-        }
-
-        let new_content = text_before_selection + text_of_selection + text_after_selection;
-        let character_diff = new_content.length - this.textarea.value.length;
-
-        // the new selection should hold all transformed lines if they're a
-        // multiline selection. Otherwise, the selection should be shifted
-        // by the amount of newly added/removed characters, so that the same
-        // text is still highlighted.
-
-        let new_selection_start = (is_multiline) ?
-            text_before_selection.length :
-            this.getAbsoluteSelectionStart() + character_diff
-        ;
-
-        let new_selection_end = (is_multiline) ?
-            new_selection_start + text_of_selection.length - 1 :
-            this.getAbsoluteSelectionEnd() + character_diff
-        ;
-
-        this.updateTextareaContent(new_content, new_selection_start, new_selection_end);
+  applyTransformationToSelection(transformation) {
+    if (!transformation instanceof Function) {
+      throw new Error(`Transformation must be an instance of Function, ${typeof transformation} given.`);
     }
 
-    /**
+    const transformed_selection = transformation(this.getLinesOfSelection());
+
+    if (!transformed_selection instanceof Array) {
+      throw new Error(`Transformation must return an instance of Array, ${typeof transformed_selection} returned.`);
+    }
+
+    const is_multiline = (transformed_selection.length > 1);
+
+    let text_before_selection = this.getLinesBeforeSelection().join('\n');
+    const text_after_selection = this.getLinesAfterSelection().join('\n');
+    let text_of_selection = transformed_selection.join('\n');
+
+    if (text_before_selection.length > 0 && text_of_selection.length > 0) {
+      text_before_selection += '\n';
+    }
+
+    if (text_of_selection.length > 0 && text_after_selection.length > 0) {
+      text_of_selection += '\n';
+    }
+
+    const new_content = text_before_selection + text_of_selection + text_after_selection;
+    const character_diff = new_content.length - this.textarea.value.length;
+
+    // the new selection should hold all transformed lines if they're a
+    // multiline selection. Otherwise, the selection should be shifted
+    // by the amount of newly added/removed characters, so that the same
+    // text is still highlighted.
+
+    const new_selection_start = (is_multiline)
+      ? text_before_selection.length
+      : this.getAbsoluteSelectionStart() + character_diff;
+    const new_selection_end = (is_multiline)
+      ? new_selection_start + text_of_selection.length - 1
+      : this.getAbsoluteSelectionEnd() + character_diff;
+    this.updateTextareaContent(new_content, new_selection_start, new_selection_end);
+  }
+
+  /**
      * @param {string} chars_before_seletion
      * @param {string} chars_after_selection
      * @return {void}
      */
-    insertCharactersAroundSelection(chars_before_seletion, chars_after_selection) {
-        let new_content =
-            this.getTextBeforeSelection() +
-            chars_before_seletion +
-            this.getTextOfSelection() +
-            chars_after_selection +
-            this.getTextAfterSelection();
+  insertCharactersAroundSelection(chars_before_seletion, chars_after_selection) {
+    const new_content = this.getTextBeforeSelection()
+            + chars_before_seletion
+            + this.getTextOfSelection()
+            + chars_after_selection
+            + this.getTextAfterSelection();
 
-        // selection must be moved by the length of chars inserted before the selection
-        // in order to keep the same text highlighted.
-        let new_selection_start = this.getAbsoluteSelectionStart() + chars_before_seletion.length;
-        let new_selection_end = this.getAbsoluteSelectionEnd() + chars_before_seletion.length;
+    // selection must be moved by the length of chars inserted before the selection
+    // in order to keep the same text highlighted.
+    const new_selection_start = this.getAbsoluteSelectionStart() + chars_before_seletion.length;
+    const new_selection_end = this.getAbsoluteSelectionEnd() + chars_before_seletion.length;
 
-        this.updateTextareaContent(new_content, new_selection_start, new_selection_end);
-    }
+    this.updateTextareaContent(new_content, new_selection_start, new_selection_end);
+  }
 
-    /**
+  /**
      * Updates the current preview if the previously rendered content has changed.
      *
      * @return {void}
      */
-    maybeUpdatePreviewContent() {
-        let previous_content = this.preview_history[(this.preview_history.length - 1)] ?? '';
-        let current_content = this.textarea.value;
+  maybeUpdatePreviewContent() {
+    const previous_content = this.preview_history[(this.preview_history.length - 1)] ?? '';
+    const current_content = this.textarea.value;
 
-        if (current_content === previous_content) {
-            return;
-        }
-
-        this.preview_history.push(current_content);
-        this.preview_renderer
-            .getPreviewHtmlOf(current_content).then((html) => {
-                this.content_wrappers.get(CONTENT_WRAPPER_KEY_PREVIEW).innerHTML = html;
-            }
-        );
+    if (current_content === previous_content) {
+      return;
     }
 
-    /**
+    this.preview_history.push(current_content);
+    this.preview_renderer
+      .getPreviewHtmlOf(current_content).then((html) => {
+        this.content_wrappers.get(CONTENT_WRAPPER_KEY_PREVIEW).innerHTML = html;
+      });
+  }
+
+  /**
      * @return {function(string[]): string[]}
      */
-    getBulletPointTransformation() {
-        return toggleBulletPoints;
-    }
+  getBulletPointTransformation() {
+    return toggleBulletPoints;
+  }
 
-    /**
+  /**
      * @return {function(string[], number=1): string[]}
      */
-    getEnumerationTransformation() {
-        return toggleEnumeration;
-    }
+  getEnumerationTransformation() {
+    return toggleEnumeration;
+  }
 }
 
 /**
@@ -680,18 +689,18 @@ class Markdown extends Textarea {
  * @throws {Error}
  */
 function getContentWrappersOrAbort(input_wrapper) {
-    let content_wrappers = new Map();
+  const content_wrappers = new Map();
 
-    content_wrappers.set(CONTENT_WRAPPER_KEY_TEXTAREA, input_wrapper.querySelector('.ui-input-textarea'));
-    content_wrappers.set(CONTENT_WRAPPER_KEY_PREVIEW, input_wrapper.querySelector('.c-input-markdown__preview'));
+  content_wrappers.set(CONTENT_WRAPPER_KEY_TEXTAREA, input_wrapper.querySelector('.ui-input-textarea'));
+  content_wrappers.set(CONTENT_WRAPPER_KEY_PREVIEW, input_wrapper.querySelector('.c-input-markdown__preview'));
 
-    content_wrappers.forEach(function (wrapper) {
-        if (null === wrapper) {
-            throw new Error(`Could not find all content-wrappers for markdown-input.`);
-        }
-    });
+  content_wrappers.forEach((wrapper) => {
+    if (wrapper === null) {
+      throw new Error('Could not find all content-wrappers for markdown-input.');
+    }
+  });
 
-    return content_wrappers;
+  return content_wrappers;
 }
 
 /**
@@ -700,15 +709,15 @@ function getContentWrappersOrAbort(input_wrapper) {
  * @throws {Error}
  */
 function getViewControlsOrAbort(input_wrapper) {
-    let controls = input_wrapper
-        .querySelector('.il-viewcontrol-mode')
-        ?.getElementsByTagName('button');
+  const controls = input_wrapper
+    .querySelector('.il-viewcontrol-mode')
+    ?.getElementsByTagName('button');
 
-    if (!controls instanceof HTMLCollection || 2 !== controls.length) {
-        throw new Error(`Could not find exactly two view-controls.`);
-    }
+  if (!controls instanceof HTMLCollection || controls.length !== 2) {
+    throw new Error('Could not find exactly two view-controls.');
+  }
 
-    return [...controls];
+  return [...controls];
 }
 
 /**
@@ -717,15 +726,15 @@ function getViewControlsOrAbort(input_wrapper) {
  * @throws {Error}
  */
 function getMarkdownActions(input_wrapper) {
-    let actions = input_wrapper
-        .querySelector('.c-input-markdown__actions')
-        ?.getElementsByTagName('button');
+  const actions = input_wrapper
+    .querySelector('.c-input-markdown__actions')
+    ?.getElementsByTagName('button');
 
-    if (actions instanceof HTMLCollection) {
-        return [...actions];
-    }
+  if (actions instanceof HTMLCollection) {
+    return [...actions];
+  }
 
-    return [];
+  return [];
 }
 
 /**
@@ -733,16 +742,16 @@ function getMarkdownActions(input_wrapper) {
  * @return {string|null}
  */
 function getMarkdownActionOfButton(button) {
-    let action_wrapper = button.parentNode.closest('span');
-    if (!action_wrapper instanceof HTMLSpanElement) {
-        return null;
-    }
+  const action_wrapper = button.parentNode.closest('span');
+  if (!action_wrapper instanceof HTMLSpanElement) {
+    return null;
+  }
 
-    if (!action_wrapper.hasAttribute('data-action')) {
-        return null;
-    }
+  if (!action_wrapper.hasAttribute('data-action')) {
+    return null;
+  }
 
-    return action_wrapper.dataset.action;
+  return action_wrapper.dataset.action;
 }
 
 /**
@@ -751,27 +760,27 @@ function getMarkdownActionOfButton(button) {
  * @return {string[]}
  */
 function reindexContinuousLinesOfEnumeration(lines_after_selection, previous_number = 0) {
-    if (1 > lines_after_selection.length) {
-        return [];
+  if (lines_after_selection.length < 1) {
+    return [];
+  }
+
+  const reindexed_lines = [];
+  for (const line of lines_after_selection) {
+    if (!isEnumerated(line)) {
+      break;
     }
 
-    let reindexed_lines = [];
-    for (let line of lines_after_selection) {
-        if (!isEnumerated(line)) {
-            break;
-        }
+    reindexed_lines.push(line.replace(/([0-9]+)/, (++previous_number).toString()));
+  }
 
-        reindexed_lines.push(line.replace(/([0-9]+)/, (++previous_number).toString()));
-    }
+  // replace all reindexed lines in the actual array of lines if necessary.
+  if (reindexed_lines.length > 0) {
+    lines_after_selection = reindexed_lines.concat(
+      lines_after_selection.slice(reindexed_lines.length),
+    );
+  }
 
-    // replace all reindexed lines in the actual array of lines if necessary.
-    if (0 < reindexed_lines.length) {
-        lines_after_selection = reindexed_lines.concat(
-            lines_after_selection.slice(reindexed_lines.length)
-        );
-    }
-
-    return lines_after_selection;
+  return lines_after_selection;
 }
 
 /**
@@ -779,15 +788,15 @@ function reindexContinuousLinesOfEnumeration(lines_after_selection, previous_num
  * @return {string[]}
  */
 function toggleBulletPoints(lines_of_selection) {
-    let transformed_lines = [];
-    let to_list = !isBulletPointed(lines_of_selection[0] ?? '');
-    for (let line of lines_of_selection) {
-        transformed_lines.push(
-            (to_list) ? `- ${line}` : removeBulletPointOrEnummeration(line)
-        );
-    }
+  const transformed_lines = [];
+  const to_list = !isBulletPointed(lines_of_selection[0] ?? '');
+  for (const line of lines_of_selection) {
+    transformed_lines.push(
+      (to_list) ? `- ${line}` : removeBulletPointOrEnummeration(line),
+    );
+  }
 
-    return transformed_lines;
+  return transformed_lines;
 }
 
 /**
@@ -796,15 +805,15 @@ function toggleBulletPoints(lines_of_selection) {
  * @return {string[]}
  */
 function toggleEnumeration(lines_of_selection, next_number = 1) {
-    let transformed_lines = [];
-    let to_list = !isEnumerated(lines_of_selection[0] ?? '');
-    for (let line of lines_of_selection) {
-        transformed_lines.push(
-            (to_list) ? `${next_number++}. ${line}` : removeBulletPointOrEnummeration(line)
-        );
-    }
+  const transformed_lines = [];
+  const to_list = !isEnumerated(lines_of_selection[0] ?? '');
+  for (const line of lines_of_selection) {
+    transformed_lines.push(
+      (to_list) ? `${next_number++}. ${line}` : removeBulletPointOrEnummeration(line),
+    );
+  }
 
-    return transformed_lines;
+  return transformed_lines;
 }
 
 /**
@@ -812,12 +821,12 @@ function toggleEnumeration(lines_of_selection, next_number = 1) {
  * @return {number|null}
  */
 function getFirstNumber(line) {
-    let numbers = line.match(/([0-9]+)/);
-    if (null !== numbers) {
-        return parseInt(numbers[0]);
-    }
+  const numbers = line.match(/([0-9]+)/);
+  if (numbers !== null) {
+    return parseInt(numbers[0]);
+  }
 
-    return null;
+  return null;
 }
 
 /**
@@ -826,11 +835,11 @@ function getFirstNumber(line) {
  * @return {void}
  */
 function toggleClassOfElement(element, css_class) {
-    if (element.classList.contains(css_class)) {
-        element.classList.remove(css_class);
-    } else {
-        element.classList.add(css_class);
-    }
+  if (element.classList.contains(css_class)) {
+    element.classList.remove(css_class);
+  } else {
+    element.classList.add(css_class);
+  }
 }
 
 /**
@@ -838,11 +847,11 @@ function toggleClassOfElement(element, css_class) {
  * @return {boolean}
  */
 function isEnterKeyPressed(event) {
-    if (event instanceof KeyboardEvent) {
-        return ('Enter' === event.code);
-    }
+  if (event instanceof KeyboardEvent) {
+    return (event.code === 'Enter');
+  }
 
-    return false;
+  return false;
 }
 
 /**
@@ -850,7 +859,7 @@ function isEnterKeyPressed(event) {
  * @return {string}
  */
 function removeBulletPointOrEnummeration(line) {
-    return line.replace(/((^(\s*[-])|(^(\s*\d+\.)))\s*)/g, '');
+  return line.replace(/((^(\s*[-])|(^(\s*\d+\.)))\s*)/g, '');
 }
 
 /**
@@ -858,7 +867,7 @@ function removeBulletPointOrEnummeration(line) {
  * @return {boolean}
  */
 function isEmptyListEntry(line) {
-    return (0 < (line.match(/((^(\s*-)|(^(\s*\d+\.)))\s*)$/g) ?? []).length);
+  return ((line.match(/((^(\s*-)|(^(\s*\d+\.)))\s*)$/g) ?? []).length > 0);
 }
 
 /**
@@ -866,7 +875,7 @@ function isEmptyListEntry(line) {
  * @return {boolean}
  */
 function isBulletPointed(line) {
-    return (0 < (line.match(/^(\s*[-])/g) ?? []).length);
+  return ((line.match(/^(\s*[-])/g) ?? []).length > 0);
 }
 
 /**
@@ -874,7 +883,7 @@ function isBulletPointed(line) {
  * @return {boolean}
  */
 function isEnumerated(line) {
-    return (0 < (line.match(/^(\s*\d+\.)/g) ?? []).length);
+  return ((line.match(/^(\s*\d+\.)/g) ?? []).length > 0);
 }
 
 /**
@@ -923,7 +932,6 @@ class MarkdownFactory {
  * duplicate declarations if e.g. classes were to extend from each-
  * other and are bundled into separate files.
  */
-
 
 var il = il || {};
 il.UI = il.UI || {};

--- a/components/ILIAS/UI/resources/js/Input/Field/src/Markdown/markdown.class.js
+++ b/components/ILIAS/UI/resources/js/Input/Field/src/Markdown/markdown.class.js
@@ -1,4 +1,4 @@
-import Textarea from "../Textarea/textarea.class";
+import Textarea from '../Textarea/textarea.class';
 
 /**
  * @type {string}
@@ -14,75 +14,75 @@ const CONTENT_WRAPPER_KEY_PREVIEW = 'preview';
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
 export default class Markdown extends Textarea {
-    /**
+  /**
      * @type {string[]}
      */
-    preview_history = [];
+  preview_history = [];
 
-    /**
+  /**
      * @type {PreviewRenderer}
      */
-    preview_renderer;
+  preview_renderer;
 
-    /**
+  /**
      * @type {Map}
      */
-    content_wrappers;
+  content_wrappers;
 
-    /**
+  /**
      * @type {HTMLButtonElement[]}
      */
-    view_controls;
+  view_controls;
 
-    /**
+  /**
      * @type {HTMLButtonElement[]}
      */
-    actions;
+  actions;
 
-    /**
+  /**
      * @param {PreviewRenderer} preview_renderer
      * @param {string} input_id
      * @throws {Error} if DOM elements are missing.
      */
-    constructor(preview_renderer, input_id) {
-        super(input_id);
+  constructor(preview_renderer, input_id) {
+    super(input_id);
 
-        let input_wrapper = this.textarea.closest('.c-input-markdown');
+    const input_wrapper = this.textarea.closest('.c-input-markdown');
 
-        if (null === input_wrapper) {
-            throw new Error(`Could not find input-wrapper for input-id '${input_id}'.`);
-        }
-
-        this.preview_renderer = preview_renderer;
-
-        this.content_wrappers = getContentWrappersOrAbort(input_wrapper);
-        this.view_controls = getViewControlsOrAbort(input_wrapper);
-        this.actions = getMarkdownActions(input_wrapper);
-
-        let has_newline_been_inserted = true;
-
-        this.textarea.addEventListener('keydown', (event) => {
-            has_newline_been_inserted = this.handleEnterKeyBeforeInsertionHook(event);
-        });
-
-        this.textarea.addEventListener('keyup', (event) => {
-            this.handleEnterKeyAfterInsertionHook(event, has_newline_been_inserted);
-        });
-
-        this.actions.forEach((action) => {
-            action.addEventListener('click', (event) => {
-                this.performMarkdownActionHook(event);
-            });
-        });
-
-        this.view_controls.forEach((control) => {
-            control.addEventListener('click', () => {
-                this.toggleViewingModeHook();
-            });
-        });
+    if (input_wrapper === null) {
+      throw new Error(`Could not find input-wrapper for input-id '${input_id}'.`);
     }
 
-    /**
+    this.preview_renderer = preview_renderer;
+
+    this.content_wrappers = getContentWrappersOrAbort(input_wrapper);
+    this.view_controls = getViewControlsOrAbort(input_wrapper);
+    this.actions = getMarkdownActions(input_wrapper);
+
+    let has_newline_been_inserted = true;
+
+    this.textarea.addEventListener('keydown', (event) => {
+      has_newline_been_inserted = this.handleEnterKeyBeforeInsertionHook(event);
+    });
+
+    this.textarea.addEventListener('keyup', (event) => {
+      this.handleEnterKeyAfterInsertionHook(event, has_newline_been_inserted);
+    });
+
+    this.actions.forEach((action) => {
+      action.addEventListener('click', (event) => {
+        this.performMarkdownActionHook(event);
+      });
+    });
+
+    this.view_controls.forEach((control) => {
+      control.addEventListener('click', () => {
+        this.toggleViewingModeHook();
+      });
+    });
+  }
+
+  /**
      * Automatically inserts a bullet-point or enumeration on the newly added line
      * according to the previous one.
      *
@@ -93,281 +93,294 @@ export default class Markdown extends Textarea {
      * @param {boolean} newline_inserted
      * @return {void}
      */
-    handleEnterKeyAfterInsertionHook(event, newline_inserted) {
-        // skip this hook if the previous one didn't insert a newline,
-        // otherwise this hook would undo the previous action.
-        if (!newline_inserted || !isEnterKeyPressed(event)) {
-            return;
-        }
-
-        let previous_line = this.getLinesBeforeSelection().pop();
-
-        if (undefined !== previous_line && isBulletPointed(previous_line)) {
-            this.applyTransformationToSelection(toggleBulletPoints);
-            return;
-        }
-
-        if (undefined !== previous_line && isEnumerated(previous_line)) {
-            this.insertSingleEnumeration();
-            return;
-        }
+  handleEnterKeyAfterInsertionHook(event, newline_inserted) {
+    // skip this hook if the previous one didn't insert a newline,
+    // otherwise this hook would undo the previous action.
+    if (!newline_inserted || !isEnterKeyPressed(event)) {
+      return;
     }
 
-    /**
+    const previous_line = this.getLinesBeforeSelection().pop();
+
+    if (undefined !== previous_line && isBulletPointed(previous_line)) {
+      this.applyTransformationToSelection(toggleBulletPoints);
+      return;
+    }
+
+    if (undefined !== previous_line && isEnumerated(previous_line)) {
+      this.insertSingleEnumeration();
+    }
+  }
+
+  /**
      * Removes the bullet-point or enumeration of the current line if there aren't
      * any other characters.
      *
      * @param {KeyboardEvent} event
      * @return {boolean}
      */
-    handleEnterKeyBeforeInsertionHook(event) {
-        if (!isEnterKeyPressed(event)) {
-            return false;
-        }
-
-        let current_line = this.getLinesOfSelection().shift();
-
-        // nothing to do if the current line is not an empty list entry.
-        if (undefined === current_line || !isEmptyListEntry(current_line)) {
-            return true;
-        }
-
-        let text_before_selection = this.getLinesBeforeSelection().join('\n');
-        let text_after_selection = this.getLinesAfterSelection().join('\n');
-
-        if (0 < text_before_selection.length) {
-            text_before_selection += '\n';
-        }
-
-        if (0 < text_after_selection.length) {
-            text_after_selection = '\n' + text_after_selection;
-        }
-
-        this.updateTextareaContent(
-            text_before_selection + text_after_selection,
-            this.getAbsoluteSelectionStart() - current_line.length,
-            this.getAbsoluteSelectionEnd() - current_line.length
-        );
-
-        // prevent newline from being added.
-        event.preventDefault();
-        return false;
+  handleEnterKeyBeforeInsertionHook(event) {
+    if (!isEnterKeyPressed(event)) {
+      return false;
     }
 
-    /**
+    const current_line = this.getLinesOfSelection().shift();
+
+    // nothing to do if the current line is not an empty list entry.
+    if (undefined === current_line || !isEmptyListEntry(current_line)) {
+      return true;
+    }
+
+    let text_before_selection = this.getLinesBeforeSelection().join('\n');
+    let text_after_selection = this.getLinesAfterSelection().join('\n');
+
+    if (text_before_selection.length > 0) {
+      text_before_selection += '\n';
+    }
+
+    if (text_after_selection.length > 0) {
+      text_after_selection = `\n${text_after_selection}`;
+    }
+
+    this.updateTextareaContent(
+      text_before_selection + text_after_selection,
+      this.getAbsoluteSelectionStart() - current_line.length,
+      this.getAbsoluteSelectionEnd() - current_line.length,
+    );
+
+    // prevent newline from being added.
+    event.preventDefault();
+    return false;
+  }
+
+  /** @var {Map<string, function(Markdown)>} */
+  customHandlers = new Map();
+
+  /**
+   * @param {string} action
+   * @param {function(Markdown)} handler
+   */
+  registerAdditionalAction(action, handler) {
+    this.customHandlers.set(action, handler);
+  }
+
+  /**
      * @param {MouseEvent} event
      * @return {void}
      */
-    performMarkdownActionHook(event) {
-        let markdown_action = getMarkdownActionOfButton(event.target);
+  performMarkdownActionHook(event) {
+    const markdown_action = getMarkdownActionOfButton(event.target);
 
-        switch (markdown_action) {
-            case 'insert-heading':
-                this.insertCharactersAroundSelection('# ', '');
-                break;
-            case 'insert-link':
-                this.insertCharactersAroundSelection('[', '](url)');
-                break;
-            case 'insert-bold':
-                this.insertCharactersAroundSelection('**', '**');
-                break;
-            case 'insert-italic':
-                this.insertCharactersAroundSelection('_', '_');
-                break;
-            case 'insert-bullet-points':
-                this.applyTransformationToSelection(toggleBulletPoints);
-                break;
-            case 'insert-enumeration':
-                (this.isMultilineTextSelected()) ?
-                    this.applyTransformationToSelection(toggleEnumeration) :
-                    this.insertSingleEnumeration();
-                break;
-            default:
-                throw new Error(`Could not perform markdown-action '${markdown_action}'.`);
-        }
+    if (this.customHandlers.has(markdown_action)) {
+      const handler = this.customHandlers.get(markdown_action);
+      handler(this);
+      return;
     }
 
-    /**
+    switch (markdown_action) {
+      case 'insert-heading':
+        this.insertCharactersAroundSelection('# ', '');
+        break;
+      case 'insert-link':
+        this.insertCharactersAroundSelection('[', '](url)');
+        break;
+      case 'insert-bold':
+        this.insertCharactersAroundSelection('**', '**');
+        break;
+      case 'insert-italic':
+        this.insertCharactersAroundSelection('_', '_');
+        break;
+      case 'insert-bullet-points':
+        this.applyTransformationToSelection(toggleBulletPoints);
+        break;
+      case 'insert-enumeration':
+        (this.isMultilineTextSelected())
+          ? this.applyTransformationToSelection(toggleEnumeration)
+          : this.insertSingleEnumeration();
+        break;
+      default:
+        throw new Error(`Could not perform markdown-action '${markdown_action}'.`);
+    }
+  }
+
+  /**
      * @return {void}
      */
-    toggleViewingModeHook() {
-        this.content_wrappers.forEach(function (wrapper) {
-            toggleClassOfElement(wrapper, 'hidden');
-        });
+  toggleViewingModeHook() {
+    this.content_wrappers.forEach((wrapper) => {
+      toggleClassOfElement(wrapper, 'hidden');
+    });
 
-        this.view_controls.forEach(function (control) {
-            toggleClassOfElement(control, 'engaged');
-        });
+    this.view_controls.forEach((control) => {
+      toggleClassOfElement(control, 'engaged');
+    });
 
-        // only toggle actions if they weren't disabled initially.
-        if (!this.isDisabled()) {
-            this.actions.forEach(function (action) {
-                action.disabled = !action.disabled;
-                let glyph = action.querySelector('.glyph');
-                if (null !== glyph) {
-                    toggleClassOfElement(glyph, 'disabled');
-                }
-            });
+    // only toggle actions if they weren't disabled initially.
+    if (!this.isDisabled()) {
+      this.actions.forEach((action) => {
+        action.disabled = !action.disabled;
+        const glyph = action.querySelector('.glyph');
+        if (glyph !== null) {
+          toggleClassOfElement(glyph, 'disabled');
         }
-
-        this.maybeUpdatePreviewContent();
+      });
     }
 
-    /**
+    this.maybeUpdatePreviewContent();
+  }
+
+  /**
      * Insert a new enumeration on the current line if it's not already one.
      * All lines after that will be reindexed as long as they continue the
      * current enumeration.
      *
      * @return {void}
      */
-    insertSingleEnumeration() {
-        let lines_of_selection = this.getLinesOfSelection();
+  insertSingleEnumeration() {
+    const lines_of_selection = this.getLinesOfSelection();
 
-        // abort (refocus) if the current selection is not a single line or
-        // is already enumerated.
-        if (1 !== lines_of_selection.length) {
-            this.textarea.focus();
-            return;
-        }
-
-        let lines_before_selection = this.getLinesBeforeSelection();
-        let last_index = lines_before_selection.length - 1;
-        let previous_number = (0 <= last_index) ? getFirstNumber(lines_before_selection[last_index]) ?? 0 : 0;
-
-        let new_lines_of_selection = toggleEnumeration(lines_of_selection, ++previous_number);
-        let lines_after_selection = reindexContinuousLinesOfEnumeration(this.getLinesAfterSelection(), previous_number);
-
-        let text_before_selection = lines_before_selection.join('\n');
-        let text_after_selection = lines_after_selection.join('\n');
-        let text_of_selection = new_lines_of_selection.join('\n');
-
-        if (0 < text_before_selection.length && 0 < text_of_selection.length) {
-            text_before_selection += '\n';
-        }
-
-        if (0 < text_of_selection.length && 0 < text_after_selection.length) {
-            text_of_selection += '\n';
-        }
-
-        let new_content = text_before_selection + text_of_selection + text_after_selection;
-        let character_diff = new_content.length - this.textarea.value.length;
-
-        // the selection should be shifted by the amount of newly added/removed
-        // characters, so that the same text is still highlighted.
-        this.updateTextareaContent(
-            new_content,
-            this.getAbsoluteSelectionStart() + character_diff,
-            this.getAbsoluteSelectionEnd() + character_diff,
-        );
+    // abort (refocus) if the current selection is not a single line or
+    // is already enumerated.
+    if (lines_of_selection.length !== 1) {
+      this.textarea.focus();
+      return;
     }
 
-    /**
+    const lines_before_selection = this.getLinesBeforeSelection();
+    const last_index = lines_before_selection.length - 1;
+    let previous_number = (last_index >= 0) ? getFirstNumber(lines_before_selection[last_index]) ?? 0 : 0;
+
+    const new_lines_of_selection = toggleEnumeration(lines_of_selection, ++previous_number);
+    const lines_after_selection = reindexContinuousLinesOfEnumeration(
+      this.getLinesAfterSelection(),
+      previous_number,
+    );
+
+    let text_before_selection = lines_before_selection.join('\n');
+    const text_after_selection = lines_after_selection.join('\n');
+    let text_of_selection = new_lines_of_selection.join('\n');
+
+    if (text_before_selection.length > 0 && text_of_selection.length > 0) {
+      text_before_selection += '\n';
+    }
+
+    if (text_of_selection.length > 0 && text_after_selection.length > 0) {
+      text_of_selection += '\n';
+    }
+
+    const new_content = text_before_selection + text_of_selection + text_after_selection;
+    const character_diff = new_content.length - this.textarea.value.length;
+
+    // the selection should be shifted by the amount of newly added/removed
+    // characters, so that the same text is still highlighted.
+    this.updateTextareaContent(
+      new_content,
+      this.getAbsoluteSelectionStart() + character_diff,
+      this.getAbsoluteSelectionEnd() + character_diff,
+    );
+  }
+
+  /**
      * @param {function(string[]): string[]} transformation
      * @return {void}
      * @throws {Error} if the transformation does not return an array.
      *                 if the transformation is not a function.
      */
-    applyTransformationToSelection(transformation) {
-        if (!transformation instanceof Function) {
-            throw new Error(`Transformation must be an instance of Function, ${typeof transformation} given.`);
-        }
-
-        let transformed_selection = transformation(this.getLinesOfSelection());
-
-        if (!transformed_selection instanceof Array) {
-            throw new Error(`Transformation must return an instance of Array, ${typeof transformed_selection} returned.`);
-        }
-
-        let is_multiline = (1 < transformed_selection.length);
-
-        let text_before_selection = this.getLinesBeforeSelection().join('\n');
-        let text_after_selection = this.getLinesAfterSelection().join('\n');
-        let text_of_selection = transformed_selection.join('\n');
-
-        if (0 < text_before_selection.length && 0 < text_of_selection.length) {
-            text_before_selection += '\n';
-        }
-
-        if (0 < text_of_selection.length && 0 < text_after_selection.length) {
-            text_of_selection += '\n';
-        }
-
-        let new_content = text_before_selection + text_of_selection + text_after_selection;
-        let character_diff = new_content.length - this.textarea.value.length;
-
-        // the new selection should hold all transformed lines if they're a
-        // multiline selection. Otherwise, the selection should be shifted
-        // by the amount of newly added/removed characters, so that the same
-        // text is still highlighted.
-
-        let new_selection_start = (is_multiline) ?
-            text_before_selection.length :
-            this.getAbsoluteSelectionStart() + character_diff
-        ;
-
-        let new_selection_end = (is_multiline) ?
-            new_selection_start + text_of_selection.length - 1 :
-            this.getAbsoluteSelectionEnd() + character_diff
-        ;
-
-        this.updateTextareaContent(new_content, new_selection_start, new_selection_end);
+  applyTransformationToSelection(transformation) {
+    if (!transformation instanceof Function) {
+      throw new Error(`Transformation must be an instance of Function, ${typeof transformation} given.`);
     }
 
-    /**
+    const transformed_selection = transformation(this.getLinesOfSelection());
+
+    if (!transformed_selection instanceof Array) {
+      throw new Error(`Transformation must return an instance of Array, ${typeof transformed_selection} returned.`);
+    }
+
+    const is_multiline = (transformed_selection.length > 1);
+
+    let text_before_selection = this.getLinesBeforeSelection().join('\n');
+    const text_after_selection = this.getLinesAfterSelection().join('\n');
+    let text_of_selection = transformed_selection.join('\n');
+
+    if (text_before_selection.length > 0 && text_of_selection.length > 0) {
+      text_before_selection += '\n';
+    }
+
+    if (text_of_selection.length > 0 && text_after_selection.length > 0) {
+      text_of_selection += '\n';
+    }
+
+    const new_content = text_before_selection + text_of_selection + text_after_selection;
+    const character_diff = new_content.length - this.textarea.value.length;
+
+    // the new selection should hold all transformed lines if they're a
+    // multiline selection. Otherwise, the selection should be shifted
+    // by the amount of newly added/removed characters, so that the same
+    // text is still highlighted.
+
+    const new_selection_start = (is_multiline)
+      ? text_before_selection.length
+      : this.getAbsoluteSelectionStart() + character_diff;
+    const new_selection_end = (is_multiline)
+      ? new_selection_start + text_of_selection.length - 1
+      : this.getAbsoluteSelectionEnd() + character_diff;
+    this.updateTextareaContent(new_content, new_selection_start, new_selection_end);
+  }
+
+  /**
      * @param {string} chars_before_seletion
      * @param {string} chars_after_selection
      * @return {void}
      */
-    insertCharactersAroundSelection(chars_before_seletion, chars_after_selection) {
-        let new_content =
-            this.getTextBeforeSelection() +
-            chars_before_seletion +
-            this.getTextOfSelection() +
-            chars_after_selection +
-            this.getTextAfterSelection();
+  insertCharactersAroundSelection(chars_before_seletion, chars_after_selection) {
+    const new_content = this.getTextBeforeSelection()
+      + chars_before_seletion
+      + this.getTextOfSelection()
+      + chars_after_selection
+      + this.getTextAfterSelection();
 
-        // selection must be moved by the length of chars inserted before the selection
-        // in order to keep the same text highlighted.
-        let new_selection_start = this.getAbsoluteSelectionStart() + chars_before_seletion.length;
-        let new_selection_end = this.getAbsoluteSelectionEnd() + chars_before_seletion.length;
+    // selection must be moved by the length of chars inserted before the selection
+    // in order to keep the same text highlighted.
+    const new_selection_start = this.getAbsoluteSelectionStart() + chars_before_seletion.length;
+    const new_selection_end = this.getAbsoluteSelectionEnd() + chars_before_seletion.length;
 
-        this.updateTextareaContent(new_content, new_selection_start, new_selection_end);
-    }
+    this.updateTextareaContent(new_content, new_selection_start, new_selection_end);
+  }
 
-    /**
+  /**
      * Updates the current preview if the previously rendered content has changed.
      *
      * @return {void}
      */
-    maybeUpdatePreviewContent() {
-        let previous_content = this.preview_history[(this.preview_history.length - 1)] ?? '';
-        let current_content = this.textarea.value;
+  maybeUpdatePreviewContent() {
+    const previous_content = this.preview_history[(this.preview_history.length - 1)] ?? '';
+    const current_content = this.textarea.value;
 
-        if (current_content === previous_content) {
-            return;
-        }
-
-        this.preview_history.push(current_content);
-        this.preview_renderer
-            .getPreviewHtmlOf(current_content).then((html) => {
-                this.content_wrappers.get(CONTENT_WRAPPER_KEY_PREVIEW).innerHTML = html;
-            }
-        );
+    if (current_content === previous_content) {
+      return;
     }
 
-    /**
+    this.preview_history.push(current_content);
+    this.preview_renderer
+      .getPreviewHtmlOf(current_content).then((html) => {
+        this.content_wrappers.get(CONTENT_WRAPPER_KEY_PREVIEW).innerHTML = html;
+      });
+  }
+
+  /**
      * @return {function(string[]): string[]}
      */
-    getBulletPointTransformation() {
-        return toggleBulletPoints;
-    }
+  getBulletPointTransformation() {
+    return toggleBulletPoints;
+  }
 
-    /**
+  /**
      * @return {function(string[], number=1): string[]}
      */
-    getEnumerationTransformation() {
-        return toggleEnumeration;
-    }
+  getEnumerationTransformation() {
+    return toggleEnumeration;
+  }
 }
 
 /**
@@ -376,18 +389,24 @@ export default class Markdown extends Textarea {
  * @throws {Error}
  */
 function getContentWrappersOrAbort(input_wrapper) {
-    let content_wrappers = new Map();
+  const content_wrappers = new Map();
 
-    content_wrappers.set(CONTENT_WRAPPER_KEY_TEXTAREA, input_wrapper.querySelector('.ui-input-textarea'));
-    content_wrappers.set(CONTENT_WRAPPER_KEY_PREVIEW, input_wrapper.querySelector('.c-input-markdown__preview'));
+  content_wrappers.set(
+    CONTENT_WRAPPER_KEY_TEXTAREA,
+    input_wrapper.querySelector('.ui-input-textarea'),
+  );
+  content_wrappers.set(
+    CONTENT_WRAPPER_KEY_PREVIEW,
+    input_wrapper.querySelector('.c-input-markdown__preview'),
+  );
 
-    content_wrappers.forEach(function (wrapper) {
-        if (null === wrapper) {
-            throw new Error(`Could not find all content-wrappers for markdown-input.`);
-        }
-    });
+  content_wrappers.forEach((wrapper) => {
+    if (wrapper === null) {
+      throw new Error('Could not find all content-wrappers for markdown-input.');
+    }
+  });
 
-    return content_wrappers;
+  return content_wrappers;
 }
 
 /**
@@ -396,15 +415,15 @@ function getContentWrappersOrAbort(input_wrapper) {
  * @throws {Error}
  */
 function getViewControlsOrAbort(input_wrapper) {
-    let controls = input_wrapper
-        .querySelector('.il-viewcontrol-mode')
-        ?.getElementsByTagName('button');
+  const controls = input_wrapper
+    .querySelector('.il-viewcontrol-mode')
+    ?.getElementsByTagName('button');
 
-    if (!controls instanceof HTMLCollection || 2 !== controls.length) {
-        throw new Error(`Could not find exactly two view-controls.`);
-    }
+  if (!controls instanceof HTMLCollection || controls.length !== 2) {
+    throw new Error('Could not find exactly two view-controls.');
+  }
 
-    return [...controls];
+  return [...controls];
 }
 
 /**
@@ -413,15 +432,15 @@ function getViewControlsOrAbort(input_wrapper) {
  * @throws {Error}
  */
 function getMarkdownActions(input_wrapper) {
-    let actions = input_wrapper
-        .querySelector('.c-input-markdown__actions')
-        ?.getElementsByTagName('button');
+  const actions = input_wrapper
+    .querySelector('.c-input-markdown__actions')
+    ?.getElementsByTagName('button');
 
-    if (actions instanceof HTMLCollection) {
-        return [...actions];
-    }
+  if (actions instanceof HTMLCollection) {
+    return [...actions];
+  }
 
-    return [];
+  return [];
 }
 
 /**
@@ -429,16 +448,16 @@ function getMarkdownActions(input_wrapper) {
  * @return {string|null}
  */
 function getMarkdownActionOfButton(button) {
-    let action_wrapper = button.parentNode.closest('span');
-    if (!action_wrapper instanceof HTMLSpanElement) {
-        return null;
-    }
+  const action_wrapper = button.parentNode.closest('span');
+  if (!action_wrapper instanceof HTMLSpanElement) {
+    return null;
+  }
 
-    if (!action_wrapper.hasAttribute('data-action')) {
-        return null;
-    }
+  if (!action_wrapper.hasAttribute('data-action')) {
+    return null;
+  }
 
-    return action_wrapper.dataset.action;
+  return action_wrapper.dataset.action;
 }
 
 /**
@@ -447,27 +466,27 @@ function getMarkdownActionOfButton(button) {
  * @return {string[]}
  */
 function reindexContinuousLinesOfEnumeration(lines_after_selection, previous_number = 0) {
-    if (1 > lines_after_selection.length) {
-        return [];
+  if (lines_after_selection.length < 1) {
+    return [];
+  }
+
+  const reindexed_lines = [];
+  for (const line of lines_after_selection) {
+    if (!isEnumerated(line)) {
+      break;
     }
 
-    let reindexed_lines = [];
-    for (let line of lines_after_selection) {
-        if (!isEnumerated(line)) {
-            break;
-        }
+    reindexed_lines.push(line.replace(/([0-9]+)/, (++previous_number).toString()));
+  }
 
-        reindexed_lines.push(line.replace(/([0-9]+)/, (++previous_number).toString()));
-    }
+  // replace all reindexed lines in the actual array of lines if necessary.
+  if (reindexed_lines.length > 0) {
+    lines_after_selection = reindexed_lines.concat(
+      lines_after_selection.slice(reindexed_lines.length),
+    );
+  }
 
-    // replace all reindexed lines in the actual array of lines if necessary.
-    if (0 < reindexed_lines.length) {
-        lines_after_selection = reindexed_lines.concat(
-            lines_after_selection.slice(reindexed_lines.length)
-        );
-    }
-
-    return lines_after_selection;
+  return lines_after_selection;
 }
 
 /**
@@ -475,15 +494,15 @@ function reindexContinuousLinesOfEnumeration(lines_after_selection, previous_num
  * @return {string[]}
  */
 function toggleBulletPoints(lines_of_selection) {
-    let transformed_lines = [];
-    let to_list = !isBulletPointed(lines_of_selection[0] ?? '');
-    for (let line of lines_of_selection) {
-        transformed_lines.push(
-            (to_list) ? `- ${line}` : removeBulletPointOrEnummeration(line)
-        );
-    }
+  const transformed_lines = [];
+  const to_list = !isBulletPointed(lines_of_selection[0] ?? '');
+  for (const line of lines_of_selection) {
+    transformed_lines.push(
+      (to_list) ? `- ${line}` : removeBulletPointOrEnummeration(line),
+    );
+  }
 
-    return transformed_lines;
+  return transformed_lines;
 }
 
 /**
@@ -492,15 +511,15 @@ function toggleBulletPoints(lines_of_selection) {
  * @return {string[]}
  */
 function toggleEnumeration(lines_of_selection, next_number = 1) {
-    let transformed_lines = [];
-    let to_list = !isEnumerated(lines_of_selection[0] ?? '');
-    for (let line of lines_of_selection) {
-        transformed_lines.push(
-            (to_list) ? `${next_number++}. ${line}` : removeBulletPointOrEnummeration(line)
-        );
-    }
+  const transformed_lines = [];
+  const to_list = !isEnumerated(lines_of_selection[0] ?? '');
+  for (const line of lines_of_selection) {
+    transformed_lines.push(
+      (to_list) ? `${next_number++}. ${line}` : removeBulletPointOrEnummeration(line),
+    );
+  }
 
-    return transformed_lines;
+  return transformed_lines;
 }
 
 /**
@@ -508,12 +527,12 @@ function toggleEnumeration(lines_of_selection, next_number = 1) {
  * @return {number|null}
  */
 function getFirstNumber(line) {
-    let numbers = line.match(/([0-9]+)/);
-    if (null !== numbers) {
-        return parseInt(numbers[0]);
-    }
+  const numbers = line.match(/([0-9]+)/);
+  if (numbers !== null) {
+    return parseInt(numbers[0]);
+  }
 
-    return null;
+  return null;
 }
 
 /**
@@ -522,11 +541,11 @@ function getFirstNumber(line) {
  * @return {void}
  */
 function toggleClassOfElement(element, css_class) {
-    if (element.classList.contains(css_class)) {
-        element.classList.remove(css_class);
-    } else {
-        element.classList.add(css_class);
-    }
+  if (element.classList.contains(css_class)) {
+    element.classList.remove(css_class);
+  } else {
+    element.classList.add(css_class);
+  }
 }
 
 /**
@@ -534,11 +553,11 @@ function toggleClassOfElement(element, css_class) {
  * @return {boolean}
  */
 function isEnterKeyPressed(event) {
-    if (event instanceof KeyboardEvent) {
-        return ('Enter' === event.code);
-    }
+  if (event instanceof KeyboardEvent) {
+    return (event.code === 'Enter');
+  }
 
-    return false;
+  return false;
 }
 
 /**
@@ -546,7 +565,7 @@ function isEnterKeyPressed(event) {
  * @return {string}
  */
 function removeBulletPointOrEnummeration(line) {
-    return line.replace(/((^(\s*[-])|(^(\s*\d+\.)))\s*)/g, '');
+  return line.replace(/((^(\s*[-])|(^(\s*\d+\.)))\s*)/g, '');
 }
 
 /**
@@ -554,7 +573,7 @@ function removeBulletPointOrEnummeration(line) {
  * @return {boolean}
  */
 function isEmptyListEntry(line) {
-    return (0 < (line.match(/((^(\s*-)|(^(\s*\d+\.)))\s*)$/g) ?? []).length);
+  return ((line.match(/((^(\s*-)|(^(\s*\d+\.)))\s*)$/g) ?? []).length > 0);
 }
 
 /**
@@ -562,7 +581,7 @@ function isEmptyListEntry(line) {
  * @return {boolean}
  */
 function isBulletPointed(line) {
-    return (0 < (line.match(/^(\s*[-])/g) ?? []).length);
+  return ((line.match(/^(\s*[-])/g) ?? []).length > 0);
 }
 
 /**
@@ -570,5 +589,5 @@ function isBulletPointed(line) {
  * @return {boolean}
  */
 function isEnumerated(line) {
-    return (0 < (line.match(/^(\s*\d+\.)/g) ?? []).length);
+  return ((line.match(/^(\s*\d+\.)/g) ?? []).length > 0);
 }

--- a/components/ILIAS/UI/src/Component/Input/Field/Markdown.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Markdown.php
@@ -18,9 +18,22 @@
 
 namespace ILIAS\UI\Component\Input\Field;
 
+use ILIAS\UI\Component\Symbol\Glyph\Glyph;
+
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
 interface Markdown extends Textarea
 {
+    public const ACTION_HEADING = "ACTION_HEADING";
+    public const ACTION_LINK = "ACTION_LINK";
+    public const ACTION_BOLD = "ACTION_BOLD";
+    public const ACTION_ITALIC = "ACTION_ITALIC";
+    public const ACTION_ORDERED_LIST = "ACTION_ORDERED_LIST";
+    public const ACTION_UNORDERED_LIST = "ACTION_UNORDERED_LIST";
+
+    public function withAdditionalAction(Glyph $icon, string $action_name): static;
+
+    /** @param string[] $action_names */
+    public function withAllowedActions(array $action_names): static;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Markdown.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Markdown.php
@@ -24,12 +24,19 @@ use ILIAS\UI\Component\Input\Field\MarkdownRenderer;
 use ILIAS\UI\Component\Input\Field\Markdown as MarkdownInterface;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
+use ILIAS\UI\Component\Symbol\Glyph\Glyph;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
 class Markdown extends Textarea implements MarkdownInterface
 {
+    /** @var array<string, Glyph> */
+    protected array $additional_actions = [];
+
+    /** @var string[]|null */
+    protected ?array $allowed_actions = null;
+
     public function __construct(
         DataFactory $data_factory,
         Refinery $refinery,
@@ -38,6 +45,31 @@ class Markdown extends Textarea implements MarkdownInterface
         ?string $byline,
     ) {
         parent::__construct($data_factory, $refinery, $label, $byline);
+    }
+
+    public function withAdditionalAction(Glyph $icon, string $action_name): static
+    {
+        $clone = clone $this;
+        $clone->additional_actions[$action_name] = $icon;
+        return $clone;
+    }
+
+    public function getAdditionalActions(): array
+    {
+        return $this->additional_actions;
+    }
+
+    public function withAllowedActions(array $action_names): static
+    {
+        $clone = clone $this;
+        $clone->allowed_actions = $action_names;
+        return $clone;
+    }
+
+    /** @return string[]|null */
+    public function getAllowedActions(): ?array
+    {
+        return $this->allowed_actions;
     }
 
     public function getMarkdownRenderer(): MarkdownRenderer

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -516,15 +516,22 @@ class Renderer extends AbstractComponentRenderer
 
         /** @var $markdown_actions_glyphs Component\Symbol\Glyph\Glyph[] */
         $markdown_actions_glyphs = [
-            'ACTION_HEADING' => $this->getUIFactory()->symbol()->glyph()->header(),
-            'ACTION_LINK' => $this->getUIFactory()->symbol()->glyph()->link(),
-            'ACTION_BOLD' => $this->getUIFactory()->symbol()->glyph()->bold(),
-            'ACTION_ITALIC' => $this->getUIFactory()->symbol()->glyph()->italic(),
-            'ACTION_ORDERED_LIST' => $this->getUIFactory()->symbol()->glyph()->numberedlist(),
-            'ACTION_UNORDERED_LIST' => $this->getUIFactory()->symbol()->glyph()->bulletlist()
+            F\Markdown::ACTION_HEADING => $this->getUIFactory()->symbol()->glyph()->header(),
+            F\Markdown::ACTION_LINK => $this->getUIFactory()->symbol()->glyph()->link(),
+            F\Markdown::ACTION_BOLD => $this->getUIFactory()->symbol()->glyph()->bold(),
+            F\Markdown::ACTION_ITALIC => $this->getUIFactory()->symbol()->glyph()->italic(),
+            F\Markdown::ACTION_ORDERED_LIST => $this->getUIFactory()->symbol()->glyph()->numberedlist(),
+            F\Markdown::ACTION_UNORDERED_LIST => $this->getUIFactory()->symbol()->glyph()->bulletlist()
         ];
 
+        $allowed_actions = $component->getAllowedActions();
+
         foreach ($markdown_actions_glyphs as $tpl_variable => $glyph) {
+            // only render allowed actions
+            if (null !== $allowed_actions && !in_array($tpl_variable, $allowed_actions, true)) {
+                continue;
+            }
+
             if ($component->isDisabled()) {
                 $glyph = $glyph->withUnavailableAction();
             }
@@ -536,6 +543,23 @@ class Renderer extends AbstractComponentRenderer
             }
 
             $markdown_tpl->setVariable($tpl_variable, $default_renderer->render($action));
+        }
+
+        foreach ($component->getAdditionalActions() as $action_name => $glyph) {
+            if ($component->isDisabled()) {
+                $glyph = $glyph->withUnavailableAction();
+            }
+
+            $action = $this->getUIFactory()->button()->standard($default_renderer->render($glyph), '#');
+
+            if ($component->isDisabled()) {
+                $action = $action->withUnavailableAction();
+            }
+
+            $markdown_tpl->setCurrentBlock('with_additional_action');
+            $markdown_tpl->setVariable('ACTION_BUTTON', $default_renderer->render($action));
+            $markdown_tpl->setVariable('ACTION_NAME', $action_name);
+            $markdown_tpl->parseCurrentBlock();
         }
 
         // label must point to the wrapped textarea input, not the markdown input.

--- a/components/ILIAS/UI/src/Implementation/Component/JavaScriptBindable.php
+++ b/components/ILIAS/UI/src/Implementation/Component/JavaScriptBindable.php
@@ -54,7 +54,7 @@ trait JavaScriptBindable
         }
 
         $this->checkBinder($binder);
-        return $this->withOnLoadCode(fn ($id) => $current_binder($id) . "\n" . $binder($id));
+        return $this->withOnLoadCode(fn($id) => $binder($id) . "\n" . $current_binder($id));
     }
 
     /**

--- a/components/ILIAS/UI/src/examples/Input/Field/Markdown/with_additional_action.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Markdown/with_additional_action.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Markdown;
+
+/**
+ * Example show how to create and render a basic markdown field and attach it to a form.
+ */
+function with_additional_action(): string
+{
+    global $DIC;
+
+    // retrieve dependencies
+    $md_renderer = new \ilUIMarkdownPreviewGUI();
+    $query_wrapper = $DIC->http()->wrapper()->query();
+    $inputs = $DIC->ui()->factory()->input();
+    $glyphs = $DIC->ui()->factory()->symbol()->glyph();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    // declare form and input
+    $markdown_input = $inputs->field()->markdown($md_renderer, 'Markdown Input', 'Just a markdown input.');
+
+    // register custom action
+    $action_name = 'insert-quote';
+    $markdown_input = $markdown_input->withAdditionalAction($glyphs->comment(), $action_name);
+    $markdown_input = $markdown_input->withAdditionalOnLoadCode(
+        fn(string $id) => "
+            il.UI.Input.markdown.get('$id').registerAdditionalAction(
+                '$action_name',
+                function(markdown) {
+                    markdown.insertCharactersAroundSelection('> ', '');
+                }
+            );
+        "
+    );
+
+    $form = $inputs->container()->form()->standard('#', [$markdown_input]);
+
+    // please use ilCtrl to generate an appropriate link target
+    // and check it's command instead of this.
+    if ('POST' === $request->getMethod()) {
+        $form = $form->withRequest($request);
+        $data = $form->getData();
+    } else {
+        $data = 'no results yet.';
+    }
+
+    return
+        '<pre>' . print_r($data, true) . '</pre>' .
+        $renderer->render($form);
+}

--- a/components/ILIAS/UI/src/examples/Input/Field/Markdown/with_additional_syntax.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Markdown/with_additional_syntax.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Markdown;
+
+/**
+ * Example show how to create and render a basic markdown field and attach it to a form.
+ */
+function with_additional_syntax(): string
+{
+    global $DIC;
+
+    // retrieve dependencies
+    $md_renderer = new \ilUICustomMarkdownPreviewGUI();
+    $query_wrapper = $DIC->http()->wrapper()->query();
+    $inputs = $DIC->ui()->factory()->input();
+    $glyphs = $DIC->ui()->factory()->symbol()->glyph();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    // declare form and input
+    $markdown_input = $inputs->field()->markdown($md_renderer, 'Markdown Input', 'Just a markdown input.');
+
+    // register custom action
+    $action_name = 'insert-gap-question';
+    $markdown_input = $markdown_input->withAdditionalAction($glyphs->login(), $action_name);
+    $markdown_input = $markdown_input->withAdditionalOnLoadCode(
+        fn(string $id) => "
+            il.UI.Input.markdown.get('$id').registerAdditionalAction(
+                '$action_name',
+                function(markdown) {
+                    markdown.insertCharactersAroundSelection('==', '==');
+                }
+            );
+        "
+    );
+
+    $form = $inputs->container()->form()->standard('#', [$markdown_input]);
+
+    // please use ilCtrl to generate an appropriate link target
+    // and check it's command instead of this.
+    if ('POST' === $request->getMethod()) {
+        $form = $form->withRequest($request);
+        $data = $form->getData();
+    } else {
+        $data = 'no results yet.';
+    }
+
+    return
+        '<pre>' . print_r($data, true) . '</pre>' .
+        $renderer->render($form);
+}

--- a/components/ILIAS/UI/src/examples/Input/Field/Markdown/with_restricted_syntax.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Markdown/with_restricted_syntax.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Markdown;
+
+use ILIAS\UI\Component\Input\Field\Markdown;
+
+/**
+ * Example show how to create and render a basic markdown field and attach it to a form.
+ */
+function with_restricted_syntax(): string
+{
+    global $DIC;
+
+    // retrieve dependencies
+    $md_renderer = new \ilUIRestrictedMarkdownPreviewRendererGUI();
+    $query_wrapper = $DIC->http()->wrapper()->query();
+    $inputs = $DIC->ui()->factory()->input();
+    $glyphs = $DIC->ui()->factory()->symbol()->glyph();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    // declare form and input
+    $markdown_input = $inputs->field()->markdown($md_renderer, 'Markdown Input', 'Just a markdown input.');
+    $markdown_input = $markdown_input->withAllowedActions([
+        Markdown::ACTION_ITALIC,
+        Markdown::ACTION_BOLD,
+    ]);
+
+    $form = $inputs->container()->form()->standard('#', [$markdown_input]);
+
+    // please use ilCtrl to generate an appropriate link target
+    // and check it's command instead of this.
+    if ('POST' === $request->getMethod()) {
+        $form = $form->withRequest($request);
+        $data = $form->getData();
+    } else {
+        $data = 'no results yet.';
+    }
+
+    return
+        '<pre>' . print_r($data, true) . '</pre>' .
+        $renderer->render($form);
+}

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.markdown.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.markdown.html
@@ -8,6 +8,9 @@
             <span data-action="insert-italic">{ACTION_ITALIC}</span>
             <span data-action="insert-bullet-points">{ACTION_UNORDERED_LIST}</span>
             <span data-action="insert-enumeration">{ACTION_ORDERED_LIST}</span>
+            <!-- BEGIN with_additional_action -->
+            <span data-action="{ACTION_NAME}">{ACTION_BUTTON}</span>
+            <!-- END with_additional_action -->
         </div>
     </div>
     {TEXTAREA}

--- a/components/ILIAS/UI_/classes/class.ilUICustomMarkdownPreviewGUI.php
+++ b/components/ILIAS/UI_/classes/class.ilUICustomMarkdownPreviewGUI.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
+use League\CommonMark\Delimiter\DelimiterInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Node\Inline\AbstractStringContainer;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\MarkdownConverter;
+use League\CommonMark\Node\Inline\AbstractInline;
+use League\CommonMark\Node\Inline\DelimitedInterface;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Util\HtmlElement;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ilUICustomMarkdownPreviewGUI extends ilUIMarkdownPreviewGUI implements ilCtrlBaseClassInterface
+{
+    public function render(string $markdown_text): string
+    {
+        $environment = new Environment();
+
+        $processor = new class () implements DelimiterProcessorInterface {
+            public function getOpeningCharacter(): string
+            {
+                return '=';
+            }
+
+            public function getClosingCharacter(): string
+            {
+                return '=';
+            }
+
+            public function getMinLength(): int
+            {
+                return 1;
+            }
+
+            public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int
+            {
+                // don't allow =word== or ==word=.
+                if ($opener->getLength() !== $closer->getLength()) {
+                    return 0;
+                }
+
+                // only allow =word= and ==word==.
+                if ($opener->getLength() > 2 || $closer->getLength() > 2) {
+                    return 0;
+                }
+
+                return $opener->getLength();
+            }
+
+            public function process(
+                AbstractStringContainer $opener,
+                AbstractStringContainer $closer,
+                int $delimiterUse
+            ): void {
+                $gap = new GapNode(\str_repeat('=', $delimiterUse));
+
+                $tmp = $opener->next();
+                while ($tmp !== null && $tmp !== $closer) {
+                    $next = $tmp->next();
+                    $gap->appendChild($tmp);
+                    $tmp = $next;
+                }
+
+                $opener->insertAfter($gap);
+            }
+        };
+
+        $renderer = new class () implements NodeRendererInterface {
+            public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+            {
+                GapNode::assertInstanceOf($node);
+
+                $value = htmlspecialchars($childRenderer->renderNodes($node->children()));
+
+                return "<input type=\"text\" value=\"$value\" />";
+            }
+        };
+
+        $environment->addExtension(
+            new class ($renderer, $processor) implements ExtensionInterface {
+                public function __construct(
+                    protected NodeRendererInterface $renderer,
+                    protected DelimiterProcessorInterface $processor,
+                ) {
+                }
+
+                public function register(EnvironmentBuilderInterface $environment): void
+                {
+                    $environment->addDelimiterProcessor($this->processor);
+                    $environment->addRenderer(GapNode::class, $this->renderer);
+                }
+            }
+        );
+
+        $environment->addExtension(new CommonMarkCoreExtension());
+
+        $converter = new League\CommonMark\MarkdownConverter($environment);
+
+        return $converter->convert($markdown_text)->getContent();
+    }
+}
+
+class GapNode extends AbstractInline implements DelimitedInterface
+{
+    public function __construct(
+        protected string $delimiter,
+    ) {
+        parent::__construct();
+    }
+
+    public function getOpeningDelimiter(): string
+    {
+        return $this->delimiter;
+    }
+
+    public function getClosingDelimiter(): string
+    {
+        return $this->delimiter;
+    }
+}

--- a/components/ILIAS/UI_/classes/class.ilUIMarkdownPreviewGUI.php
+++ b/components/ILIAS/UI_/classes/class.ilUIMarkdownPreviewGUI.php
@@ -65,7 +65,7 @@ class ilUIMarkdownPreviewGUI implements MarkdownRenderer, ilCtrlBaseClassInterfa
     public function getAsyncUrl(): string
     {
         return $this->ctrl->getLinkTargetByClass(
-            self::class,
+            static::class,
             self::CMD_RENDER_ASYNC,
             null,
             true

--- a/components/ILIAS/UI_/classes/class.ilUIRestrictedMarkdownPreviewGUI.php
+++ b/components/ILIAS/UI_/classes/class.ilUIRestrictedMarkdownPreviewGUI.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+declare(strict_types=1);
+
+use League\CommonMark as Core;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Extension\CommonMark;
+use League\CommonMark\Extension\CommonMark\Delimiter\Processor\EmphasisDelimiterProcessor;
+use League\CommonMark\Extension\ConfigurableExtensionInterface;
+use League\CommonMark\Extension\InlinesOnly\ChildRenderer;
+use League\CommonMark\Environment\Environment;
+use League\Config\ConfigurationBuilderInterface;
+use Nette\Schema\Expect;
+
+/**
+ * @author       Thibeau Fuhrer <thibeau@sr.solutions>
+ * @noinspection AutoloadingIssuesInspection
+ */
+class ilUIRestrictedMarkdownPreviewRendererGUI extends ilUIMarkdownPreviewGUI implements ilCtrlBaseClassInterface
+{
+    public function render(string $markdown_text): string
+    {
+        $environment = new Environment();
+
+        // minimal inlines copied from commonmarks OnlyInlinesExtension.
+        $environment->addExtension(
+            new class () implements ConfigurableExtensionInterface {
+                public function configureSchema(ConfigurationBuilderInterface $builder): void
+                {
+                    $builder->addSchema('commonmark', Expect::structure([
+                        'use_asterisk' => Expect::bool(true),
+                        'use_underscore' => Expect::bool(true),
+                        'enable_strong' => Expect::bool(true),
+                        'enable_em' => Expect::bool(true),
+                    ]));
+                }
+
+                public function register(EnvironmentBuilderInterface $environment): void
+                {
+                    $childRenderer = new ChildRenderer();
+
+                    $environment
+                        ->addInlineParser(new Core\Parser\Inline\NewlineParser(), 200)
+                        ->addInlineParser(new CommonMark\Parser\Inline\EscapableParser(), 80)
+                        ->addInlineParser(new CommonMark\Parser\Inline\EntityParser(), 70)
+                        ->addDelimiterProcessor(new EmphasisDelimiterProcessor('*'))
+                        ->addDelimiterProcessor(new EmphasisDelimiterProcessor('_'))
+                        ->addRenderer(Core\Node\Block\Document::class, $childRenderer, 0)
+                        ->addRenderer(Core\Node\Block\Paragraph::class, $childRenderer, 0)
+                        ->addRenderer(CommonMark\Node\Inline\Emphasis::class, new CommonMark\Renderer\Inline\EmphasisRenderer(), 0)
+                        ->addRenderer(Core\Node\Inline\Newline::class, new Core\Renderer\Inline\NewlineRenderer(), 0)
+                        ->addRenderer(CommonMark\Node\Inline\Strong::class, new CommonMark\Renderer\Inline\StrongRenderer(), 0)
+                        ->addRenderer(Core\Node\Inline\Text::class, new Core\Renderer\Inline\TextRenderer(), 0);
+                }
+            }
+        );
+
+        $converter = new League\CommonMark\MarkdownConverter($environment);
+
+        return $converter->convert($markdown_text)->getContent();
+    }
+}


### PR DESCRIPTION
Hi folks,

This PR merely lays some groundwork for further discussion and analysis in regards to markdown flavours in ILIAS. The code changes provide a naive approach to demonstrate how markdown syntax can be restricted or extended by some higher order system with minimal changes to the UI framework itself. Please note this is not a proposal of any kind, these changes are only for demo purposes. The examples should be runnable, so feel free to checkout this branch and try it out yourselves.

Let me quickly summarise the current situation of ILIAS:

- we have introduced support for markdown with the `ILIAS\UI\Component\Input\Field\Markdown` input and the `ILIAS\Refinery\Transformation\MarkdownFormattingToHTML` transformation, for converting markdown syntax into HTML.
- we are using the `thephpleague\commonmark` php library for converting markdown syntax to HTML.
- the converter is currently wrapped by the `ILIAS\Refinery` transformation, which uses the default syntax and follows the [CommonMark specification](https://spec.commonmark.org/).
- the `ILIAS\UI\Component\Input\Field\Markdown` editor implements actions for inserting the according markdown syntax: unordered list, ordered list, heading, italic, bold and link.
- there is currently no concept or way for adding new functionality to the markdown editor, besides implementing new actions or mechanisms inside the UI framework itself. This couples the UI framework to  the refinery transformation implicitly, because submitted syntax needs to be supported by the transformation, or converter to be concrete.
- the `thephpleague\commonmark` library implements and supports an extension eco-system, which allows to add custom markdown flavours (dialects) in form of code-extensions which can be registered in the converter environment. There is also a broad set of existing extensions and a community around it.
- providing a `ILIAS\UI\Component\Input\Field\MarkdownRenderer` is the responsibility of the consumers of the markdown input. This could be a problem if we want to establish an ILIAS-wide markdown flavour, because consumers remain in control over which converter with what supported syntax they are using for their scenario.
- there is a [paper about text handling in ILIAS](docs/development/text-handling.md), which needs to be considered when working on the process and concept of maintaining a markdown flavour inside ILIAS. It e.g. talks about specific kinds of markdown string representations, which may prohibit certain syntax for specific locations.

During the investigation of how ILIAS could incorporate and maintain a markdown flavour, I have focused on the following aspects:

- is it possible to implement a custom mechanism for uploading and using images and other media inside the markdown editor? E.g. drag-and-dropping an image inside the editor will upload the image to the IRSS, which would store the image accordingly and return an URL for consumption of the image.
- is it possible to extend the markdown converter and editor, so tables can be written using a custom syntax? There already is an established convention for structuring tables using markdown syntax with `|` and `-` characters to divide columns and rows.
- is it possible to extend the markdown converter and editor, so further tailored functionality can be incorporated? E.g. using `==` as opening and closing characters for gap-questions in the ILIAS T&A service.
- is it possible to extend the markdown converter and editor, so latex markup can be embedded? ILIAS does so in other places using custom blocks (`[tex]...[/tex]`) to mark sections which should be compiled using a latex library on the client.
- how can we maintain such extensions or such a markdown flavour for ILIAS in the future? Should markdown flavours be maintained globally or locally (one flavour for all editors and converters, or one flavour for one editor and converter)?

During my investigation and while working on some sort of proof-of-concept for incorporating a markdown flavour, I have came to the following conclusions:

- inserting images is supported by default (syntax-wise), so implementing a custom approach for uploading and inserting images is not exactly related to the markdown flavour - the syntax doesn't care from what source the image is being loaded. This mechanism would need to be tightly coupled to the markdown input though, so it must be implemented in the UI framework directly.
- a mechanism for uploading images within the markdown editor could currently be implemented using a similar approach as for file inputs, using an upload handler for storing resources and providing URLs for consumption. This however will put the responsibility on the consumer again. A mechanism like this would also have the same problem as file inputs currently have: file deletions.
- tables have a well established markdown syntax and the converter already provides an according extension, so it can be easily incorporated. An action for inserting tables and/or table columns and rows would be more complex than other actions, and possibly requires separate actions.
- since the markdown converter allows to implement custom syntax, it would be possible to support syntax for any kind of transformations. However, we should keep in mind that markdown is designed for formatting text - I am not sure if supporting gap-questions really fits into this category. If we have established a process to incorporate additional syntax, it would be worth a discussion then.
- the PoC for implementing custom markdown syntax showed me, that markdown might not be the best tool for creating gap-questions in the T&A service. To actually implement this, two different kinds of converters need to be used: one for converting the syntax to inputs, so users can fill in the gaps, and one for collecting the actual values which serve as answers for these inputs.
- latex could technically be incorporated into markdown as well. There is a [FR for the centralisation of latex](https://docu.ilias.de/goto_docu_wiki_wpage_5614_1357.html), which IMO could be implemented inside the UI framework as well. The project certainly has some correlation with the outcome of this project, since the underlying issue could be addressed in a similar manner.
- a markdown syntax could be implemented similar to approaches currently used within ILIAS, using `[tex]...[/tex]` blocks to mark latex code for later processing. We could incorporate such syntax, but it should certainly be discussed when we have established a process as well.
- implementing markdown syntax like `[tex]...[/tex]` could potentially open doors for incorporating various other complex HTML structures like UI components, so e.g. `[ui_form]...[/ui_form]` blocks could feature `[ui_input ...]` inlines, which are converted to actual UI component forms. This may be something we want to avoid, since markdown is designed for text formatting, not creating entire page layouts. However, there are projects like WordPress out there, which are using similar text based approaches for [embedding complex HTML structures](https://codex.wordpress.org/Shortcode) inside their pages.
- syntax can also be suppressed by not registering certain core extensions in the converter environment. This could be necessary for scenarios in which e.g. only emphasised text should be allowed. The paper about text handling in ILIAS also talks about restricted markdown "shapes", which represent scenarios like this with according classes (e.g. `EmphasisedMarkdownShape`).
- for both, the restriction and the extension of syntax, we need to find ways to clearly communicate the supported syntax of the editor to the user, especially if we are maintaining local markdown flavours. It could otherwise be confusing for users, if certain syntax only works in certain places, and users could find themselves frustrated if the editor preview always seems to only convert an arbitrary set of syntax. For restriction, this could be permanently disabling the according action buttons or hiding them altogether, and for extensions this could simply be to provide an additional action button, or a dropdown menu featuring multiple additional actions.
- we will most likely need to support local markdown flavours, since we run into similar use-cases like we do with the file input regarding upload limits: certain restrictions or additions will be tailored to their scenario. E.g. object titles may only allow emphasised text, or the T&A service is required to implement additional syntax for structuring their questions in a unique way, which is not meant for global usage.
- the paper about text handling in ILIAS already suggests an approach for implementing data classes as a way to talk about text, and transforming text from one to another format using refinery transformations. This will ultimately be the determining factor when it comes to a markdown flavour. Following this approach we would need to think about a markdown flavour in a very modular way, since supported syntax needs to be tailored to the formats determined by such a text class.
- when incorporating markdown flavours into the UI framework, these text classes could be used to communicate the supported syntax. The transformation for both sync and async content could be delegated to the refinery, as long as the syntax is not custom. Custom syntax needs to be incorporated differently, since the UI framework will not be able to build the according editor actions or perform the desired transformations on its own.
- I am currently not sure how we would incorporate custom syntax (registering editor actions and injecting a converter) into the UI framework. The PoC implements a naive approach which primarily demands three things from the consumer:
	- the consumer must provide a glyph component to visually represent the client side action button.
	- the consumer must provide a JavaScript function (as string) which will be mapped to the client side action button.
	- the consumer must implement their own markdown converter which supports the additional syntax.

I am happy to discuss these findings and open to hear your feedback.

Kind regards,
@thibsy