### PR TITLE
Calendar: set correct category mode when ref id is set (26706)

### DIFF
--- a/Services/Calendar/classes/class.ilCalendarPresentationGUI.php
+++ b/Services/Calendar/classes/class.ilCalendarPresentationGUI.php
@@ -99,7 +99,7 @@ class ilCalendarPresentationGUI
         $this->initCalendarView();
         $cats = ilCalendarCategories::_getInstance($this->user->getId());
 
-        if ($this->category_id > 0) {        // single calendar view
+        if ($this->category_id > 0 && $this->ref_id <= 0) {        // single calendar view
             // ensure activation of this category
             $vis = ilCalendarVisibility::_getInstanceByUserId($this->user->getId(), $a_ref_id);
             $vis->forceVisibility($this->category_id);


### PR DESCRIPTION
This PR re-fixes [26706](https://mantis.ilias.de/view.php?id=26706). It seems like it got broken again by #7226.

I'm not sure whether this re-fix breaks anything else, please check this PR for side effects. For what its worth, the error fixed by #7226 doesn't reappear.