### PR TITLE
UI, ViewControls/DataTable: 41310, group of nullcontrols to reserve both input names of pagination

### DIFF
--- a/src/UI/Implementation/Component/Input/ViewControl/Group.php
+++ b/src/UI/Implementation/Component/Input/ViewControl/Group.php
@@ -65,8 +65,12 @@ class Group extends ViewControlInput implements ViewControlGroupInterface, Group
      */
     public function getContent(): Result
     {
-        if (empty($this->getInputs())) {
-            return new Ok([]);
+        $inputs = array_filter(
+            $this->getInputs(),
+            fn($input) => ! ($input instanceof NullControl)
+        );
+        if (empty($inputs)) {
+            return new Ok(null);
         }
         return parent::getContent();
     }

--- a/src/UI/Implementation/Component/Input/ViewControl/Group.php
+++ b/src/UI/Implementation/Component/Input/ViewControl/Group.php
@@ -65,12 +65,8 @@ class Group extends ViewControlInput implements ViewControlGroupInterface, Group
      */
     public function getContent(): Result
     {
-        $inputs = array_filter(
-            $this->getInputs(),
-            fn($input) => ! ($input instanceof NullControl)
-        );
-        if (empty($inputs)) {
-            return new Ok(null);
+        if (empty($this->getInputs())) {
+            return new Ok([]);
         }
         return parent::getContent();
     }

--- a/src/UI/Implementation/Component/Input/ViewControl/NullControl.php
+++ b/src/UI/Implementation/Component/Input/ViewControl/NullControl.php
@@ -21,11 +21,20 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Input\ViewControl;
 
 use ILIAS\UI\Component\Input\ViewControl as VCInterface;
+use ILIAS\Data\Result;
 
 class NullControl extends ViewControlInput implements VCInterface\NullControl
 {
     public function isClientSideValueOk($value): bool
     {
         return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getContent(): Result
+    {
+        return new Result\Ok(null);
     }
 }

--- a/src/UI/Implementation/Component/Input/ViewControl/NullControl.php
+++ b/src/UI/Implementation/Component/Input/ViewControl/NullControl.php
@@ -29,12 +29,4 @@ class NullControl extends ViewControlInput implements VCInterface\NullControl
     {
         return true;
     }
-
-    /**
-     * @inheritdoc
-     */
-    public function getContent(): Result
-    {
-        return new Result\Ok(null);
-    }
 }

--- a/src/UI/Implementation/Component/Table/Data.php
+++ b/src/UI/Implementation/Component/Table/Data.php
@@ -403,6 +403,7 @@ class Data extends Table implements T\Data, JSBindable
         if ($request = $this->getRequest()) {
             $view_controls = $this->applyValuesToViewcontrols($view_controls, $request);
             $data = $view_controls->getData();
+
             $table = $table
                 ->withRange(($data[self::VIEWCONTROL_KEY_PAGINATION] ?? null)?->croppedTo($total_count ?? PHP_INT_MAX))
                 ->withOrder($data[self::VIEWCONTROL_KEY_ORDERING] ?? null)
@@ -428,7 +429,7 @@ class Data extends Table implements T\Data, JSBindable
         return $this->view_control_container_factory->standard($view_controls);
     }
 
-    protected function getViewControlPagination(?int $total_count = null): ViewControl\Pagination|ViewControl\NullControl
+    protected function getViewControlPagination(?int $total_count = null)//: ViewControl\Pagination|ViewControl\Group
     {
         $smallest_option = current(Pagination::DEFAULT_LIMITS);
         if (is_null($total_count) || $total_count >= $smallest_option) {
@@ -441,7 +442,10 @@ class Data extends Table implements T\Data, JSBindable
                         Pagination::FNAME_LIMIT => $range->getLength()
                     ]);
         }
-        return $this->view_control_factory->nullControl();
+        return $this->view_control_factory->group([
+            $this->view_control_factory->nullControl(),
+            $this->view_control_factory->nullControl()
+        ]);
     }
 
     protected function getViewControlOrdering(): ?ViewControl\Sortation

--- a/src/UI/Implementation/Component/Table/Data.php
+++ b/src/UI/Implementation/Component/Table/Data.php
@@ -404,8 +404,10 @@ class Data extends Table implements T\Data, JSBindable
             $view_controls = $this->applyValuesToViewcontrols($view_controls, $request);
             $data = $view_controls->getData();
 
+            $range = $data[self::VIEWCONTROL_KEY_PAGINATION];
+            $range = ($range instanceof Range) ? $range->croppedTo($total_count ?? PHP_INT_MAX) : null;
             $table = $table
-                ->withRange(($data[self::VIEWCONTROL_KEY_PAGINATION] ?? null)?->croppedTo($total_count ?? PHP_INT_MAX))
+                ->withRange($range)
                 ->withOrder($data[self::VIEWCONTROL_KEY_ORDERING] ?? null)
                 ->withSelectedOptionalColumns($data[self::VIEWCONTROL_KEY_FIELDSELECTION] ?? null);
         }
@@ -429,7 +431,7 @@ class Data extends Table implements T\Data, JSBindable
         return $this->view_control_container_factory->standard($view_controls);
     }
 
-    protected function getViewControlPagination(?int $total_count = null)//: ViewControl\Pagination|ViewControl\Group
+    protected function getViewControlPagination(?int $total_count = null): ViewControl\Pagination|ViewControl\Group
     {
         $smallest_option = current(Pagination::DEFAULT_LIMITS);
         if (is_null($total_count) || $total_count >= $smallest_option) {

--- a/src/UI/examples/Input/ViewControl/NullControl/base.php
+++ b/src/UI/examples/Input/ViewControl/NullControl/base.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Input\ViewControl\NullControl;
 
-use ILIAS\Data\Order;
-
 /**
  * ---
  * expected output: >

--- a/tests/UI/Component/Input/ViewControl/ViewControlGroupTest.php
+++ b/tests/UI/Component/Input/ViewControl/ViewControlGroupTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\UI\Implementation\Component\Input\ViewControl as Control;
+use ILIAS\UI\Implementation\Component\SignalGenerator;
+use ILIAS\Data\Order;
+use ILIAS\Data\Range;
+use ILIAS\Data\Result;
+use ILIAS\UI\Implementation\Component\Input\InputData;
+
+require_once('ViewControlBaseTest.php');
+
+class ViewControlGroupTest extends ViewControlBaseTest
+{
+    public function testViewControlGroupCreation(): void
+    {
+        $f = $this->buildVCFactory();
+        $vc1 = $f->nullControl();
+        $vc2 = $f->pagination();
+        $group = $f->group([$vc1, $vc2]);
+
+        $this->assertEquals([$vc1, $vc2], $group->getInputs());
+    }
+
+    public function testViewControlGroupGetContent(): void
+    {
+        $f = $this->buildVCFactory();
+        $input = $this->createMock(InputData::class);
+        $namesource = new DefNamesource();
+
+        $group = $f->group(
+            [
+                $f->nullControl(),
+                $f->pagination(),
+                $f->sortation(
+                    [
+                    'a' => new Order('field1', 'ASC'),
+                    'b' => new Order('field2', 'ASC')]
+                )
+            ]
+        )
+        ->withNameFrom($namesource)
+        ->withInput($input);
+
+        $this->assertInstanceOf(Result\Ok::class, $group->getContent());
+        $this->assertCount(3, $group->getContent()->value());
+        list($a, $b, $c) = $group->getContent()->value();
+        $this->assertNull($a);
+        $this->assertInstanceOf(Range::class, $b);
+        $this->assertInstanceOf(Order::class, $c);
+    }
+
+    public function testViewControlGroupRendering(): void
+    {
+        $f = $this->buildVCFactory();
+        $group = $f->group(
+            [
+                $f->nullControl(),
+                $f->pagination()
+                    ->withLimitOptions([2, 5, 10])
+                    ->withTotalCount(12)
+                    ->withOnChange((new SignalGenerator())->create()),
+                $f->sortation([
+                    'a' => new Order('field1', 'ASC'),
+                    'b' => new Order('field2', 'ASC')
+                ])
+                    ->withOnChange((new SignalGenerator())->create()),
+                $f->fieldSelection(['A', 'B'])
+                    ->withOnChange((new SignalGenerator())->create())
+            ]
+        );
+
+        $html = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($group));
+        $this->assertStringContainsString('il-viewcontrol il-viewcontrol-pagination', $html);
+        $this->assertStringContainsString('il-viewcontrol il-viewcontrol-sortation', $html);
+        $this->assertStringContainsString('il-viewcontrol il-viewcontrol-fieldselection', $html);
+    }
+}

--- a/tests/UI/Component/Input/ViewControl/ViewControlNullTest.php
+++ b/tests/UI/Component/Input/ViewControl/ViewControlNullTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\UI\Implementation\Component\Input\ViewControl as Control;
 use ILIAS\Data\Result;
+use ILIAS\UI\Implementation\Component\Input\InputData;
 
 require_once('ViewControlBaseTest.php');
 
@@ -30,15 +31,23 @@ class ViewControlNullTest extends ViewControlBaseTest
         $vc = $this->buildVCFactory()->nullControl();
         $this->assertEquals('', $this->getDefaultRenderer()->render($vc));
     }
+
     public function testViewControlFieldNullInGroup(): void
     {
         $f = $this->buildVCFactory();
-        $group = $f->group([
-            $f->nullControl(),
-            $f->nullControl()
-        ]);
-        $expected = new Result\Ok(null);
-        $this->assertEquals($expected, $group->getContent());
+        $input = $this->createMock(InputData::class);
+        $namesource = new DefNamesource();
 
+        $group = $f->group(
+            [
+                $f->nullControl(),
+                $f->nullControl()
+            ]
+        )
+        ->withNameFrom($namesource)
+        ->withInput($input);
+
+        $expected = new Result\Ok([null, null]);
+        $this->assertEquals($expected, $group->getContent());
     }
 }

--- a/tests/UI/Component/Input/ViewControl/ViewControlNullTest.php
+++ b/tests/UI/Component/Input/ViewControl/ViewControlNullTest.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\UI\Implementation\Component\Input\ViewControl as Control;
+use ILIAS\Data\Result;
 
 require_once('ViewControlBaseTest.php');
 
@@ -28,5 +29,16 @@ class ViewControlNullTest extends ViewControlBaseTest
     {
         $vc = $this->buildVCFactory()->nullControl();
         $this->assertEquals('', $this->getDefaultRenderer()->render($vc));
+    }
+    public function testViewControlFieldNullInGroup(): void
+    {
+        $f = $this->buildVCFactory();
+        $group = $f->group([
+            $f->nullControl(),
+            $f->nullControl()
+        ]);
+        $expected = new Result\Ok(null);
+        $this->assertEquals($expected, $group->getContent());
+
     }
 }

--- a/tests/UI/Component/Input/ViewControl/ViewControlNullTest.php
+++ b/tests/UI/Component/Input/ViewControl/ViewControlNullTest.php
@@ -31,23 +31,4 @@ class ViewControlNullTest extends ViewControlBaseTest
         $vc = $this->buildVCFactory()->nullControl();
         $this->assertEquals('', $this->getDefaultRenderer()->render($vc));
     }
-
-    public function testViewControlFieldNullInGroup(): void
-    {
-        $f = $this->buildVCFactory();
-        $input = $this->createMock(InputData::class);
-        $namesource = new DefNamesource();
-
-        $group = $f->group(
-            [
-                $f->nullControl(),
-                $f->nullControl()
-            ]
-        )
-        ->withNameFrom($namesource)
-        ->withInput($input);
-
-        $expected = new Result\Ok([null, null]);
-        $this->assertEquals($expected, $group->getContent());
-    }
 }

--- a/tests/UI/Component/Table/DataViewControlsTest.php
+++ b/tests/UI/Component/Table/DataViewControlsTest.php
@@ -110,8 +110,14 @@ class DataViewControlsTest extends TableTestBase
             array_keys($view_controls->getInputs())
         );
         $this->assertInstanceOf(
-            I\Input\ViewControl\NullControl::class,
-            $view_controls->getInputs()[ C\Table\Data::VIEWCONTROL_KEY_PAGINATION]
+            I\Input\ViewControl\Group::class,
+            $view_controls->getInputs()[C\Table\Data::VIEWCONTROL_KEY_PAGINATION]
+        );
+
+        $group_contents = $view_controls->getInputs()[C\Table\Data::VIEWCONTROL_KEY_PAGINATION]->getInputs();
+        array_walk(
+            $group_contents,
+            fn($vc) => $this->assertInstanceOf(I\Input\ViewControl\NullControl::class, $vc)
         );
     }
 


### PR DESCRIPTION
Addendum to https://github.com/ILIAS-eLearning/ILIAS/pull/7488;
The pagination actually has _two_ inputs, and the names are still shifted if only one nullControl is used.
