### PR TITLE
ilObjFile fix type issues

### DIFF
--- a/Modules/File/classes/class.ilObjFileAccess.php
+++ b/Modules/File/classes/class.ilObjFileAccess.php
@@ -128,8 +128,8 @@ class ilObjFileAccess extends ilObjectAccess implements ilWACCheckingClass
         if ($t_arr[0] != "file" || ((int) $t_arr[1]) <= 0) {
             return false;
         }
-        return $ilAccess->checkAccess("visible", "", $t_arr[1])
-            || $ilAccess->checkAccess("read", "", $t_arr[1]);
+        return $ilAccess->checkAccess("visible", "", (int)$t_arr[1])
+            || $ilAccess->checkAccess("read", "", (int)$t_arr[1]);
     }
 
     /**

--- a/Modules/File/classes/class.ilObjFileGUI.php
+++ b/Modules/File/classes/class.ilObjFileGUI.php
@@ -811,7 +811,7 @@ class ilObjFileGUI extends ilObject2GUI
 
         // added support for direct download goto links
         if ($a_additional && substr($a_additional, -8) == "download") {
-            ilObjectGUI::_gotoRepositoryNode($a_target, "sendfile");
+            ilObjectGUI::_gotoRepositoryNode((int)$a_target, "sendfile");
         }
 
         // static method, no workspace support yet


### PR DESCRIPTION
Some type issues, occured while testing some calendar workflows. See: https://mantis.ilias.de/view.php?id=41456 

Note, there could be more such issues in the affected classes.