### PR TITLE
COPage Bugfix #0040624: Use Ilias System Style for TOC Links

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -14510,15 +14510,15 @@ li.ilc_page_toc_PageTOCItem {
   white-space: nowrap;
 }
 a.ilc_page_toc_PageTOCLink {
-  color: #03a;
+  color: #4c6586;
   font-weight: normal;
   text-decoration: none;
 }
 a.ilc_page_toc_PageTOCLink:hover {
-  color: black;
+  color: #e2e8ef;
 }
 a.ilc_page_toc_PageTOCLink:visited {
-  color: blue;
+  color: #4c6586;
 }
 /* --- content styles (will move to content.css) --- */
 td.ilc_PageDisabled {

--- a/templates/default/less/Services/COPage/delos.less
+++ b/templates/default/less/Services/COPage/delos.less
@@ -429,17 +429,17 @@ li.ilc_page_toc_PageTOCItem {
 }
 
 a.ilc_page_toc_PageTOCLink {
-	color: #03a;
+	color: @il-main-color;
 	font-weight: normal;
 	text-decoration: none;
 }
 
 a.ilc_page_toc_PageTOCLink:hover {
-	color: black;
+	color: @il-highlight-bg;
 }
 
 a.ilc_page_toc_PageTOCLink:visited {
-	color: blue;
+	color: @il-main-color;
 }
 
 /* --- content styles (will move to content.css) --- */


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40624

TOC in ILIAS Content Pages has hard coded colors
As a first Bugfix we suggest using the ILIAS Main Color from System Styles.
For future Versions, adding a customizable Wiki Link for Content Styles could be considered
As this is not pickable for release_9 a additional PR will follow

Best, @fhelfer 