### PR TITLE
Add ext-pdo as required extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
 	},
 	"require": {
 		"php": ">=8.1 <8.3",
+		"ext-pdo": "*",
 		"ext-gd": "*",
 		"ext-dom": "*",
 		"ext-xsl": "*",


### PR DESCRIPTION
Just a small addition because i skipped over this extension and wondered about the random error messages way toooo long :(