### PR TITLE
Bugfix table action for detaching forum moderators

### DIFF
--- a/components/ILIAS/Forum/classes/Moderation/ForumModeratorsTable.php
+++ b/components/ILIAS/Forum/classes/Moderation/ForumModeratorsTable.php
@@ -118,7 +118,7 @@ class ForumModeratorsTable implements UI\Component\Table\DataRetrieval
         );
 
         return [
-            'detachModeratorRole' => $this->ui_factory->table()->action()->multi(
+            'detachModeratorRole' => $this->ui_factory->table()->action()->single(
                 $this->lng->txt('remove'),
                 $url_builder_detach->withParameter($action_parameter_token_copy, 'detachModeratorRole'),
                 $row_id_token_detach


### PR DESCRIPTION
Bugfix table action for detaching forum moderators. "ALL_OBJECTS"-Feature is not suitable here.