### PR TITLE
[Docu] Install ILIAS: Removed language section

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -434,10 +434,6 @@ configuration might look like this afterwards:
 	"http" : {
 		"path" : "http://demo1.cat06.de"
 	},
-    "language" : {
-        "default_language" : "de",
-        "install_languages" : ["de"]
-    },
     "logging" : {
         "enable" : true,
         "path_to_logfile" : "/var/www/logs/ilias.log",


### PR DESCRIPTION
Referring to [Mantis issue 0041304](https://mantis.ilias.de/view.php?id=41304), I've removed the language section from the install script. The feature to install multiple languages during the installation process has been abandoned in June 2022.

When approved, please cherry-pick to respective branches. Thanks!