### PR TITLE
T&A: 41152, Fix call to undefined method getTestId in ilTestAccess

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestAccess.php
+++ b/components/ILIAS/Test/classes/class.ilTestAccess.php
@@ -149,7 +149,7 @@ class ilTestAccess
         $participantData = new ilTestParticipantData($this->db, $this->lng);
         $participantData->setActiveIdsFilter(array($active_id));
         $participantData->setParticipantAccessFilter($access_filter);
-        $participantData->load($this->getTestId());
+        $participantData->load($test_id);
 
         return in_array($active_id, $participantData->getActiveIds());
     }


### PR DESCRIPTION
When trying to access the detailed overview of a test pass you get an error "Call to undefined method ilTestAccess::getTestId()".

The method `getTestId` was removed some time ago but was not properly replaced. The method in which `getTestId` is called has got an additional parameter `$test_id` which was unused but implemented probably to replace the `getTestId` method call.

Just by simply replacing the `getTestId` call with the `$test_id` parameter we get the expected behaviour.

This issue is only occurs in ILIAS 10.