### PR TITLE
[IMPROVEMENT] simplified stakeholder default owner

### DIFF
--- a/components/ILIAS/Bibliographic/classes/class.ilObjBibliographicStakeholder.php
+++ b/components/ILIAS/Bibliographic/classes/class.ilObjBibliographicStakeholder.php
@@ -27,10 +27,6 @@ class ilObjBibliographicStakeholder extends AbstractResourceStakeholder
 {
     protected ?ilDBInterface $database = null;
 
-    public function __construct()
-    {
-    }
-
     /**
      * @inheritDoc
      */
@@ -39,12 +35,9 @@ class ilObjBibliographicStakeholder extends AbstractResourceStakeholder
         return 'bibl';
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getOwnerOfNewResources(): int
     {
-        return 6;
+        return $this->default_owner;
     }
 
     public function getLocationURIForResourceUsage(ResourceIdentification $identification): ?string

--- a/components/ILIAS/DataCollection/classes/class.ilDataCollectionStakeholder.php
+++ b/components/ILIAS/DataCollection/classes/class.ilDataCollectionStakeholder.php
@@ -18,18 +18,10 @@
 
 declare(strict_types=1);
 
+use ILIAS\DI\Container;
+
 class ilDataCollectionStakeholder extends \ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder
 {
-    private int $owner;
-
-    public function __construct()
-    {
-        global $DIC;
-        $this->owner = $DIC->isDependencyAvailable('user')
-            ? $DIC->user()->getId()
-            : (defined('SYSTEM_USER_ID') ? (int) SYSTEM_USER_ID : 6);
-    }
-
     public function getId(): string
     {
         return "dcl_uploads";
@@ -37,6 +29,6 @@ class ilDataCollectionStakeholder extends \ILIAS\ResourceStorage\Stakeholder\Abs
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 }

--- a/components/ILIAS/Exercise/InstructionFile/class.ilExcInstructionFilesStakeholder.php
+++ b/components/ILIAS/Exercise/InstructionFile/class.ilExcInstructionFilesStakeholder.php
@@ -27,21 +27,8 @@ use ILIAS\ResourceStorage\Stakeholder\ResourceStakeholder;
  */
 class ilExcInstructionFilesStakeholder extends AbstractResourceStakeholder
 {
-    protected int $owner = 6;
-    private int $current_user;
     protected ?ilDBInterface $database = null;
 
-    /**
-     * ilObjFileStakeholder constructor.
-     */
-    public function __construct(int $owner = 6)
-    {
-        global $DIC;
-        $this->current_user = (int) ($DIC->isDependencyAvailable('user')
-            ? $DIC->user()->getId()
-            : (defined('ANONYMOUS_USER_ID') ? ANONYMOUS_USER_ID : 6));
-        $this->owner = $owner;
-    }
 
     public function getId(): string
     {
@@ -50,7 +37,7 @@ class ilExcInstructionFilesStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 
     public function canBeAccessedByCurrentUser(ResourceIdentification $identification): bool

--- a/components/ILIAS/Exercise/SampleSolution/class.ilExcSampleSolutionStakeholder.php
+++ b/components/ILIAS/Exercise/SampleSolution/class.ilExcSampleSolutionStakeholder.php
@@ -24,18 +24,8 @@ use ILIAS\ResourceStorage\Stakeholder\ResourceStakeholder;
 
 class ilExcSampleSolutionStakeholder extends AbstractResourceStakeholder
 {
-    protected int $owner = 6;
-    private int $current_user;
     protected ?ilDBInterface $database = null;
 
-    public function __construct(int $owner = 6)
-    {
-        global $DIC;
-        $this->current_user = (int) ($DIC->isDependencyAvailable('user')
-            ? $DIC->user()->getId()
-            : (defined('ANONYMOUS_USER_ID') ? ANONYMOUS_USER_ID : 6));
-        $this->owner = $owner;
-    }
 
     public function getId(): string
     {
@@ -44,7 +34,7 @@ class ilExcSampleSolutionStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 
     public function canBeAccessedByCurrentUser(ResourceIdentification $identification): bool

--- a/components/ILIAS/Exercise/TutorFeedbackFile/class.ilExcTutorFeedbackFileStakeholder.php
+++ b/components/ILIAS/Exercise/TutorFeedbackFile/class.ilExcTutorFeedbackFileStakeholder.php
@@ -26,18 +26,7 @@ use ILIAS\ResourceStorage\Stakeholder\ResourceStakeholder;
 
 class ilExcTutorFeedbackFileStakeholder extends AbstractResourceStakeholder
 {
-    protected int $owner = 6;
-    private int $current_user;
     protected ?ilDBInterface $database = null;
-
-    public function __construct(int $owner = 6)
-    {
-        global $DIC;
-        $this->current_user = (int) ($DIC->isDependencyAvailable('user')
-            ? $DIC->user()->getId()
-            : (defined('ANONYMOUS_USER_ID') ? ANONYMOUS_USER_ID : 6));
-        $this->owner = $owner;
-    }
 
     public function getId(): string
     {
@@ -46,7 +35,7 @@ class ilExcTutorFeedbackFileStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 
     public function canBeAccessedByCurrentUser(ResourceIdentification $identification): bool

--- a/components/ILIAS/Exercise/TutorFeedbackFile/class.ilExcTutorFeedbackZipStakeholder.php
+++ b/components/ILIAS/Exercise/TutorFeedbackFile/class.ilExcTutorFeedbackZipStakeholder.php
@@ -26,18 +26,7 @@ use ILIAS\ResourceStorage\Stakeholder\ResourceStakeholder;
 
 class ilExcTutorFeedbackZipStakeholder extends AbstractResourceStakeholder
 {
-    protected int $owner = 6;
-    private int $current_user;
     protected ?ilDBInterface $database = null;
-
-    public function __construct(int $owner = 6)
-    {
-        global $DIC;
-        $this->current_user = (int) ($DIC->isDependencyAvailable('user')
-            ? $DIC->user()->getId()
-            : (defined('ANONYMOUS_USER_ID') ? ANONYMOUS_USER_ID : 6));
-        $this->owner = $owner;
-    }
 
     public function getId(): string
     {
@@ -46,7 +35,7 @@ class ilExcTutorFeedbackZipStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 
     public function canBeAccessedByCurrentUser(ResourceIdentification $identification): bool

--- a/components/ILIAS/Exercise/TutorFeedbackFile/class.ilExcTutorTeamFeedbackFileStakeholder.php
+++ b/components/ILIAS/Exercise/TutorFeedbackFile/class.ilExcTutorTeamFeedbackFileStakeholder.php
@@ -26,18 +26,7 @@ use ILIAS\ResourceStorage\Stakeholder\ResourceStakeholder;
 
 class ilExcTutorTeamFeedbackFileStakeholder extends AbstractResourceStakeholder
 {
-    protected int $owner = 6;
-    private int $current_user;
     protected ?ilDBInterface $database = null;
-
-    public function __construct(int $owner = 6)
-    {
-        global $DIC;
-        $this->current_user = (int) ($DIC->isDependencyAvailable('user')
-            ? $DIC->user()->getId()
-            : (defined('ANONYMOUS_USER_ID') ? ANONYMOUS_USER_ID : 6));
-        $this->owner = $owner;
-    }
 
     public function getId(): string
     {
@@ -46,7 +35,7 @@ class ilExcTutorTeamFeedbackFileStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 
     public function canBeAccessedByCurrentUser(ResourceIdentification $identification): bool

--- a/components/ILIAS/File/classes/Icons/class.ilObjFileIconStakeholder.php
+++ b/components/ILIAS/File/classes/Icons/class.ilObjFileIconStakeholder.php
@@ -27,16 +27,6 @@ use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
  */
 class ilObjFileIconStakeholder extends AbstractResourceStakeholder
 {
-    /**
-     * ilObjFileIconStakeholder constructor.
-     */
-    public function __construct(protected int $owner = 6)
-    {
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function getId(): string
     {
         return 'file_icon';
@@ -47,6 +37,6 @@ class ilObjFileIconStakeholder extends AbstractResourceStakeholder
      */
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 }

--- a/components/ILIAS/File/classes/class.ilObjFileStakeholder.php
+++ b/components/ILIAS/File/classes/class.ilObjFileStakeholder.php
@@ -24,17 +24,7 @@ use ILIAS\ResourceStorage\Identification\ResourceIdentification;
  */
 class ilObjFileStakeholder extends AbstractResourceStakeholder
 {
-    private int $current_user;
     protected ?ilDBInterface $database = null;
-
-    /**
-     * ilObjFileStakeholder constructor.
-     */
-    public function __construct(protected int $owner = 6)
-    {
-        global $DIC;
-        $this->current_user = (int) ($DIC->isDependencyAvailable('user') ? $DIC->user()->getId() : ANONYMOUS_USER_ID);
-    }
 
     /**
      * @inheritDoc
@@ -46,7 +36,7 @@ class ilObjFileStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 
     public function canBeAccessedByCurrentUser(ResourceIdentification $identification): bool

--- a/components/ILIAS/FileServices/classes/UploadService/class.ilTemporaryStakeholder.php
+++ b/components/ILIAS/FileServices/classes/UploadService/class.ilTemporaryStakeholder.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 use ILIAS\ResourceStorage\Policy\FileNamePolicy;
 use ILIAS\ResourceStorage\Policy\FileNamePolicyException;
 use ILIAS\FileUpload\Processor\BlacklistExtensionPreProcessor;
@@ -16,15 +32,6 @@ use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
  */
 class ilTemporaryStakeholder extends AbstractResourceStakeholder
 {
-    protected int $owner_id;
-
-    public function __construct()
-    {
-        global $DIC;
-
-        $this->owner_id = $DIC->user()->getId();
-    }
-
     public function getId(): string
     {
         return 'irss_temp';
@@ -32,6 +39,6 @@ class ilTemporaryStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner_id;
+        return $this->default_owner;
     }
 }

--- a/components/ILIAS/Forum/classes/class.ilForumPostingFileStakeholder.php
+++ b/components/ILIAS/Forum/classes/class.ilForumPostingFileStakeholder.php
@@ -25,15 +25,6 @@ use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
  */
 class ilForumPostingFileStakeholder extends AbstractResourceStakeholder
 {
-    private int $default_owner;
-
-    public function __construct()
-    {
-        global $DIC;
-        $this->default_owner = $DIC->isDependencyAvailable('user') ? $DIC->user()->getId() : 6;
-    }
-
-
     public function getId(): string
     {
         return 'frm_post';

--- a/components/ILIAS/ILIASObject/classes/Properties/CoreProperties/TileImage/class.ilObjectTileImageStakeholder.php
+++ b/components/ILIAS/ILIASObject/classes/Properties/CoreProperties/TileImage/class.ilObjectTileImageStakeholder.php
@@ -21,27 +21,13 @@ declare(strict_types=1);
 namespace ILIAS\Object\Properties\CoreProperties\TileImage;
 
 use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
+use ILIAS\DI\Container;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
 class ilObjectTileImageStakeholder extends AbstractResourceStakeholder
 {
-    private int $default_owner;
-
-    public function __construct()
-    {
-        global $DIC;
-        $this->default_owner = $DIC->isDependencyAvailable('user')
-            ? $DIC->user()->getId()
-            : (defined('SYSTEM_USER_ID') ? (int) SYSTEM_USER_ID : 6);
-    }
-
-    public function setOwner(int $user_id_of_owner): void
-    {
-        $this->default_owner = $user_id_of_owner;
-    }
-
     public function getId(): string
     {
         return 'object_tile_image';

--- a/components/ILIAS/IndividualAssessment/classes/FileStorage/class.ilIndiviualAssessmentGradingStakeholder.php
+++ b/components/ILIAS/IndividualAssessment/classes/FileStorage/class.ilIndiviualAssessmentGradingStakeholder.php
@@ -24,10 +24,6 @@ class ilIndividualAssessmentGradingStakeholder extends AbstractResourceStakehold
 {
     private const ID = 'IASSGrading';
 
-    public function __construct(
-        protected int $owner = 6
-    ) {
-    }
 
     public function getId(): string
     {
@@ -36,6 +32,6 @@ class ilIndividualAssessmentGradingStakeholder extends AbstractResourceStakehold
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 }

--- a/components/ILIAS/MainMenu/classes/Administration/class.ilMMStorageStakeholder.php
+++ b/components/ILIAS/MainMenu/classes/Administration/class.ilMMStorageStakeholder.php
@@ -26,13 +26,6 @@ use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
  */
 class ilMMStorageStakeholder extends AbstractResourceStakeholder
 {
-    public function __construct()
-    {
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function getId(): string
     {
         return 'mme';
@@ -40,6 +33,6 @@ class ilMMStorageStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return 6;
+        return $this->default_owner;
     }
 }

--- a/components/ILIAS/MetaData/classes/Settings/Copyright/class.ilMDCopyrightImageStakeholder.php
+++ b/components/ILIAS/MetaData/classes/Settings/Copyright/class.ilMDCopyrightImageStakeholder.php
@@ -22,13 +22,6 @@ use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
 
 class ilMDCopyrightImageStakeholder extends AbstractResourceStakeholder
 {
-    protected int $owner = 6;
-
-    public function __construct(int $owner = 6)
-    {
-        $this->owner = $owner;
-    }
-
     public function getId(): string
     {
         return 'copyright_image';
@@ -36,6 +29,6 @@ class ilMDCopyrightImageStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 }

--- a/components/ILIAS/OrgUnit/classes/Types/ilOrgUnitTypeStakeholder.php
+++ b/components/ILIAS/OrgUnit/classes/Types/ilOrgUnitTypeStakeholder.php
@@ -25,10 +25,6 @@ class ilOrgUnitTypeStakeholder extends AbstractResourceStakeholder
 {
     private const ID = 'PRGType';
 
-    public function __construct(
-        protected int $owner = 6
-    ) {
-    }
 
     public function getId(): string
     {
@@ -37,7 +33,7 @@ class ilOrgUnitTypeStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 
     public function getPreprocessors(): array

--- a/components/ILIAS/ResourceStorage/src/Stakeholder/AbstractResourceStakeholder.php
+++ b/components/ILIAS/ResourceStorage/src/Stakeholder/AbstractResourceStakeholder.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\ResourceStorage\Stakeholder;
 
 use ILIAS\ResourceStorage\Identification\ResourceIdentification;
+use ILIAS\DI\Container;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions.ch>
@@ -28,6 +29,27 @@ use ILIAS\ResourceStorage\Identification\ResourceIdentification;
 abstract class AbstractResourceStakeholder implements ResourceStakeholder
 {
     private string $provider_name_cache = '';
+
+    protected int $default_owner;
+    protected int $current_user;
+
+    public function __construct(?int $user_id_of_owner = null)
+    {
+        global $DIC;
+
+        if ($user_id_of_owner === null) {
+            $user_id_of_owner = $DIC instanceof Container && $DIC->isDependencyAvailable('user')
+                ? $DIC->user()->getId()
+                : (defined('SYSTEM_USER_ID') ? (int) SYSTEM_USER_ID : 6);
+        }
+
+        $this->default_owner = $this->current_user = $user_id_of_owner;
+    }
+
+    public function setOwner(int $user_id_of_owner): void
+    {
+        $this->default_owner = $user_id_of_owner;
+    }
 
     public function getFullyQualifiedClassName(): string
     {

--- a/components/ILIAS/Skill/Profile/class.ilSkillProfileStorageStakeHolder.php
+++ b/components/ILIAS/Skill/Profile/class.ilSkillProfileStorageStakeHolder.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +14,9 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
 
@@ -28,26 +27,13 @@ use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
  */
 class ilSkillProfileStorageStakeHolder extends AbstractResourceStakeholder
 {
-    protected int $owner = 6;
-
-    public function __construct(int $owner = 6)
-    {
-        $this->owner = $owner;
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function getId(): string
     {
         return 'skl_prof';
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 }

--- a/components/ILIAS/StudyProgramme/classes/types/ilStudyProgrammeTypeStakeholder.php
+++ b/components/ILIAS/StudyProgramme/classes/types/ilStudyProgrammeTypeStakeholder.php
@@ -25,11 +25,6 @@ class ilStudyProgrammeTypeStakeholder extends AbstractResourceStakeholder
 {
     private const ID = 'PRGType';
 
-    public function __construct(
-        protected int $owner = 6
-    ) {
-    }
-
     public function getId(): string
     {
         return self::ID;
@@ -37,7 +32,7 @@ class ilStudyProgrammeTypeStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 
     public function getPreprocessors(): array

--- a/components/ILIAS/TestQuestionPool/classes/class.assFileUploadStakeholder.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFileUploadStakeholder.php
@@ -23,17 +23,6 @@ use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
  */
 class assFileUploadStakeholder extends AbstractResourceStakeholder
 {
-    private int $current_user;
-
-    public function __construct()
-    {
-        global $DIC;
-        $anonymous = defined(
-            'ANONYMOUS_USER_ID'
-        ) ? ANONYMOUS_USER_ID : 13;
-        $this->current_user = (int) ($DIC->isDependencyAvailable('user') ? $DIC->user()->getId() : $anonymous);
-    }
-
     public function getId(): string
     {
         return 'qpl_file_upload';
@@ -41,7 +30,7 @@ class assFileUploadStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->current_user;
+        return $this->default_owner;
     }
 
 }

--- a/components/ILIAS/User/classes/Avatar/class.ilUserProfilePictureStakeholder.php
+++ b/components/ILIAS/User/classes/Avatar/class.ilUserProfilePictureStakeholder.php
@@ -19,27 +19,13 @@
 declare(strict_types=1);
 
 use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
+use ILIAS\DI\Container;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
  */
 class ilUserProfilePictureStakeholder extends AbstractResourceStakeholder
 {
-    private int $default_owner;
-
-    public function __construct()
-    {
-        global $DIC;
-        $this->default_owner = $DIC->isDependencyAvailable('user')
-            ? $DIC->user()->getId()
-            : (defined('SYSTEM_USER_ID') ? (int) SYSTEM_USER_ID : 6);
-    }
-
-    public function setOwner(int $user_id_of_owner): void
-    {
-        $this->default_owner = $user_id_of_owner;
-    }
-
     public function getId(): string
     {
         return 'usr_picture';

--- a/components/ILIAS/WOPI/classes/Handler/WOPIStakeholderWrapper.php
+++ b/components/ILIAS/WOPI/classes/Handler/WOPIStakeholderWrapper.php
@@ -29,13 +29,11 @@ class WOPIStakeholderWrapper extends AbstractResourceStakeholder
     private ?int $user_id = null;
     private ?ResourceStakeholder $stakeholder = null;
 
-    public function __construct()
-    {
-    }
 
     public function init(ResourceStakeholder $stakeholder, int $user_id): void
     {
         $this->user_id = $user_id;
+        $this->setOwner($user_id);
         $this->stakeholder = $stakeholder;
     }
 

--- a/components/ILIAS/WOPI/classes/Handler/WOPIUnknownStakeholder.php
+++ b/components/ILIAS/WOPI/classes/Handler/WOPIUnknownStakeholder.php
@@ -24,10 +24,6 @@ use ILIAS\ResourceStorage\Stakeholder\AbstractResourceStakeholder;
 
 class WOPIUnknownStakeholder extends AbstractResourceStakeholder
 {
-    public function __construct(protected int $owner = 6)
-    {
-    }
-
     public function getId(): string
     {
         return 'wopi_unknown';
@@ -35,7 +31,7 @@ class WOPIUnknownStakeholder extends AbstractResourceStakeholder
 
     public function getOwnerOfNewResources(): int
     {
-        return $this->owner;
+        return $this->default_owner;
     }
 
 }


### PR DESCRIPTION
most of the existing stakeholders implement a mechanism to find out the current user and thus the owner of new resources. the methods for this differ slightly in some cases and, for example, this currently leads to problems in trunk during migrations.

With the PR, the methodology for this is moved to the `AbstractResourceStakeholder` and can therefore be improved centrally.

feedback welcome! if i do not receive any objections, i would merge the PR next week.