### PR TITLE
Logging: remove Monolog

### DIFF
--- a/components/ILIAS/Logging/classes/NullLogger.php
+++ b/components/ILIAS/Logging/classes/NullLogger.php
@@ -22,7 +22,6 @@ namespace ILIAS\components\Logging;
 
 use ilLogger;
 use ilLogLevel;
-use Monolog\Logger;
 use Exception;
 
 class NullLogger extends ilLogger
@@ -74,12 +73,6 @@ class NullLogger extends ilLogger
 
     public function emergency(string $message, array $context = []): void
     {
-    }
-
-    /** @noinspection \PhpInconsistentReturnPointsInspection */
-    public function getLogger(): Logger
-    {
-        throw new Exception('Can not return monolog logger from a null logger.');
     }
 
     public function write(string $message, $level = ilLogLevel::INFO, array $context = []): void

--- a/components/ILIAS/Logging/classes/class.ilLogger.php
+++ b/components/ILIAS/Logging/classes/class.ilLogger.php
@@ -18,30 +18,22 @@
 
 declare(strict_types=1);
 
-use Monolog\Logger;
-use Monolog\Processor\MemoryPeakUsageProcessor;
-
 /**
  * Component logger with individual log levels by component id
  * @author Stefan Meyer
  */
 abstract class ilLogger
 {
-    public function __construct(private readonly Logger $logger)
-    {
-    }
-
     /**
      * Check whether current logger is handling a log level
      */
     public function isHandling(int $level): bool
     {
-        return $this->getLogger()->isHandling($level);
+        return false;
     }
 
     public function log(string $message, int $level = ilLogLevel::INFO, array $context = []): void
     {
-        $this->getLogger()->log($level, $message, $context);
     }
 
     public function dump($value, int $level = ilLogLevel::INFO): void
@@ -53,47 +45,34 @@ abstract class ilLogger
 
     public function debug(string $message, array $context = []): void
     {
-        $this->getLogger()->debug($message, $context);
     }
 
     public function info(string $message, array $context = []): void
     {
-        $this->getLogger()->info($message, $context);
     }
 
     public function notice(string $message, array $context = []): void
     {
-        $this->getLogger()->notice($message, $context);
     }
 
     public function warning(string $message, array $context = []): void
     {
-        $this->getLogger()->warning($message, $context);
     }
 
     public function error(string $message, array $context = []): void
     {
-        $this->getLogger()->error($message, $context);
     }
 
     public function critical(string $message, array $context = []): void
     {
-        $this->getLogger()->critical($message, $context);
     }
 
     public function alert(string $message, array $context = []): void
     {
-        $this->getLogger()->alert($message, $context);
     }
 
     public function emergency(string $message, array $context = []): void
     {
-        $this->getLogger()->emergency($message, $context);
-    }
-
-    public function getLogger(): Logger
-    {
-        return $this->logger;
     }
 
     /**
@@ -106,7 +85,6 @@ abstract class ilLogger
         if (!in_array($level, ilLogLevel::getLevels())) {
             $level = ilLogLevel::INFO;
         }
-        $this->getLogger()->log((int) $level, $message, $context);
     }
 
     /**
@@ -115,7 +93,6 @@ abstract class ilLogger
      */
     public function writeLanguageLog(string $topic, string $lang_key): void
     {
-        $this->getLogger()->debug("Language (" . $lang_key . "): topic -" . $topic . "- not present");
     }
 
     public function logStack(?int $level = null, string $message = '', array $context = []): void
@@ -132,7 +109,6 @@ abstract class ilLogger
         try {
             throw new Exception($message);
         } catch (Exception $ex) {
-            $this->getLogger()->log($level, $message . "\n" . $ex->getTraceAsString(), $context);
         }
     }
 
@@ -142,8 +118,5 @@ abstract class ilLogger
      */
     public function writeMemoryPeakUsage(int $level): void
     {
-        $this->getLogger()->pushProcessor(new MemoryPeakUsageProcessor());
-        $this->getLogger()->log($level, 'Memory usage: ');
-        $this->getLogger()->popProcessor();
     }
 }


### PR DESCRIPTION
Hi everyone,

we (mostly @kergomard and @lukastocker, I only a little bit) are currently working on [updating the dependencies to the versions that have been approved by the JF until now](https://github.com/ILIAS-eLearning/ILIAS/pull/7141).

Sadly, no one seems to feel responsible for Monolog and no PR for the inclusion of Monolog was opened and discussed so far. Various attempts to reach out to @smeyer-ilias have not resulted in a PR until now. Since the Monolog dependency is required on virtually every page of ILIAS (it plays a role in logging...) I hereby propose to remove the dependency from our code for the time being, so we can move on and run and develop the rest of the system with the updated dependencies, with broken logging, sadly.

If someone steps up for Monolog, this commit will be easy to revert. If no one steps up for Monolog, we will have to think about how we want to perform logging in the future. Either way, we should clear the way soon for everyone to work with the freshly approved dependencies.

Kind regards!