### PR TITLE
Repository: Remove Creation of Column Separators

### DIFF
--- a/components/ILIAS/Repository/Administration/class.ilModulesTableGUI.php
+++ b/components/ILIAS/Repository/Administration/class.ilModulesTableGUI.php
@@ -86,11 +86,8 @@ class ilModulesTableGUI extends ilTable2GUI
         $pos_group_map[0] = "9999";
 
         foreach (ilObjRepositorySettings::getNewItemGroups() as $item) {
-            // #12807
-            if ((int) $item["type"] === ilObjRepositorySettings::NEW_ITEM_GROUP_TYPE_GROUP) {
-                $this->pos_group_options[$item["id"]] = $item["title"];
-                $pos_group_map[$item["id"]] = $item["pos"];
-            }
+            $this->pos_group_options[$item["id"]] = $item["title"];
+            $pos_group_map[$item["id"]] = $item["pos"];
         }
 
         $obj_types = [];

--- a/components/ILIAS/Repository/Administration/class.ilNewItemGroupTableGUI.php
+++ b/components/ILIAS/Repository/Administration/class.ilNewItemGroupTableGUI.php
@@ -95,7 +95,6 @@ class ilNewItemGroupTableGUI extends ilTable2GUI
                 "id" => $item["id"],
                 "pos" => $item["pos"],
                 "title" => $item["title"],
-                "type" => $item["type"],
                 "subitems" => is_array($subitems[$item["id"]] ?? null) ? count($subitems[$item["id"]]) : 0
             ];
         }
@@ -118,18 +117,15 @@ class ilNewItemGroupTableGUI extends ilTable2GUI
         $this->tpl->setVariable("VAR_POS", "grp_order[" . $a_set["id"] . "]");
         $this->tpl->setVariable("VAL_POS", $a_set["pos"]);
         $this->tpl->setVariable("TXT_TITLE", $a_set["title"]);
+        $this->tpl->setVariable("VAL_ITEMS", $a_set["subitems"]);
 
-        if ((int) $a_set["type"] === ilObjRepositorySettings::NEW_ITEM_GROUP_TYPE_GROUP) {
-            $this->tpl->setVariable("VAL_ITEMS", $a_set["subitems"]);
+        if ($this->has_write) {
+            $ilCtrl->setParameter($this->parent_obj, "grp_id", $a_set["id"]);
+            $url = $ilCtrl->getLinkTarget($this->parent_obj, "editNewItemGroup");
+            $ilCtrl->setParameter($this->parent_obj, "grp_id", "");
 
-            if ($this->has_write) {
-                $ilCtrl->setParameter($this->parent_obj, "grp_id", $a_set["id"]);
-                $url = $ilCtrl->getLinkTarget($this->parent_obj, "editNewItemGroup");
-                $ilCtrl->setParameter($this->parent_obj, "grp_id", "");
-
-                $this->tpl->setVariable("URL_EDIT", $url);
-                $this->tpl->setVariable("TXT_EDIT", $lng->txt("edit"));
-            }
+            $this->tpl->setVariable("URL_EDIT", $url);
+            $this->tpl->setVariable("TXT_EDIT", $lng->txt("edit"));
         }
     }
 }

--- a/components/ILIAS/Repository/Administration/class.ilObjRepositorySettingsGUI.php
+++ b/components/ILIAS/Repository/Administration/class.ilObjRepositorySettingsGUI.php
@@ -679,11 +679,6 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
                 $this->lng->txt("rep_new_item_group_add"),
                 $this->ctrl->getLinkTarget($this, "addNewItemGroup")
             );
-
-            $ilToolbar->addButton(
-                $this->lng->txt("rep_new_item_group_add_separator"),
-                $this->ctrl->getLinkTarget($this, "addNewItemGroupSeparator")
-            );
         }
 
         $grp_table = new ilNewItemGroupTableGUI($this, "listNewItemGroups", $has_write);
@@ -807,14 +802,6 @@ class ilObjRepositorySettingsGUI extends ilObjectGUI
 
         $form->setValuesByPost();
         $this->addNewItemGroup($form);
-    }
-
-    protected function addNewItemGroupSeparator(): void
-    {
-        if (ilObjRepositorySettings::addNewItemGroupSeparator()) {
-            $this->tpl->setOnScreenMessage('success', $this->lng->txt("settings_saved"), true);
-        }
-        $this->ctrl->redirect($this, "listNewItemGroups");
     }
 
     protected function saveNewItemGroupOrder(): void

--- a/components/ILIAS/Repository/Setup/class.RepositoryDBUpdateSteps.php
+++ b/components/ILIAS/Repository/Setup/class.RepositoryDBUpdateSteps.php
@@ -37,4 +37,10 @@ class RepositoryDBUpdateSteps implements \ilDatabaseUpdateSteps
         $this->db->manipulateF('DELETE FROM desktop_item WHERE item_id = %s', ['integer'], [1]);
         $this->db->manipulateF('DELETE FROM rep_rec_content_role WHERE ref_id = %s', ['integer'], [1]);
     }
+
+    public function step_2(): void
+    {
+        $this->db->manipulateF('DELETE FROM il_new_item_grp WHERE type = %s', ['integer'], [2]);
+        $this->db->dropTableColumn('il_new_item_grp', 'type');
+    }
 }

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -13875,12 +13875,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -13872,12 +13872,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Vyberte ty, které by měly být také smazány:
 rep#:#rep_multiple_reference_deletion_intro#:#Pro tento objekt existují další odkazy.
 rep#:#rep_new_item_group_add#:#Přidat skupinu
-rep#:#rep_new_item_group_add_separator#:#Přidat oddělovač sloupců
 rep#:#rep_new_item_group_delete_sure#:#Opravdu chcete odstranit následující skupiny?
 rep#:#rep_new_item_group_edit#:#Upravit skupinu
 rep#:#rep_new_item_group_nr_subitems#:#Počet přiřazených objektů
 rep#:#rep_new_item_group_other#:#Další
-rep#:#rep_new_item_group_separator#:#Oddělovač sloupců
 rep#:#rep_new_item_group_unassigned#:#Nepřiřazen
 rep#:#rep_new_item_group_unassigned_subitems#:#Počet objektů, u kterých bylo zrušeno přiřazení: %s
 rep#:#rep_new_item_groups#:#Nové skupiny položek

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -13875,12 +13875,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###16 09 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###16 09 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###16 09 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###16 09 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###16 09 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###16 09 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###16 09 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###16 09 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###16 09 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###16 09 2013 new variable

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -14810,12 +14810,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Wählen Sie diejenigen, die ebenfalls gelöscht werden sollen:
 rep#:#rep_multiple_reference_deletion_intro#:#Es existieren weitere Referenzen für dieses Objekt.
 rep#:#rep_new_item_group_add#:#Gruppierung hinzufügen
-rep#:#rep_new_item_group_add_separator#:#Spalten-Trenner hinzufügen
 rep#:#rep_new_item_group_delete_sure#:#Wollen Sie wirklich die folgenden Gruppierungen löschen?
 rep#:#rep_new_item_group_edit#:#Gruppierung bearbeiten
 rep#:#rep_new_item_group_nr_subitems#:#Anzahl zugeordnete Objekte
 rep#:#rep_new_item_group_other#:#Weitere
-rep#:#rep_new_item_group_separator#:#Spaltentrenner
 rep#:#rep_new_item_group_unassigned#:#Nicht zugeordnet
 rep#:#rep_new_item_group_unassigned_subitems#:#Anzahl nicht zugeordneter Objekte: %s
 rep#:#rep_new_item_groups#:#Gruppierungen

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -13876,12 +13876,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -14809,12 +14809,10 @@ rep#:#rep_mo_mem_dash#:#You are currently not yet a member of a course or group.
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.
 rep#:#rep_new_item_group_add#:#Add Grouping
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groupings?
 rep#:#rep_new_item_group_edit#:#Edit Grouping
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects
 rep#:#rep_new_item_group_other#:#Other
-rep#:#rep_new_item_group_separator#:#Column Separator
 rep#:#rep_new_item_group_unassigned#:#Not Assigned
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s
 rep#:#rep_new_item_groups#:#Grouping

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -13875,12 +13875,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Por favor selecciona cuales deben ser borradas:
 rep#:#rep_multiple_reference_deletion_intro#:#Existen referencias adicionales para este objeto.
 rep#:#rep_new_item_group_add#:#Añadiendo grupo
-rep#:#rep_new_item_group_add_separator#:#Añadir separador de columna
 rep#:#rep_new_item_group_delete_sure#:#¿Está seguro que desea eliminar los siguientes grupos?
 rep#:#rep_new_item_group_edit#:#Editar grupos
 rep#:#rep_new_item_group_nr_subitems#:#Número de la Asignación de elementos
 rep#:#rep_new_item_group_other#:#Otros
-rep#:#rep_new_item_group_separator#:#Separador de columna
 rep#:#rep_new_item_group_unassigned#:#No asignado
 rep#:#rep_new_item_group_unassigned_subitems#:#Número de elementos sin asignar: %s
 rep#:#rep_new_item_groups#:#Nuevos grupos de artículos

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.
 rep#:#rep_new_item_group_add#:#Add Group
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?
 rep#:#rep_new_item_group_edit#:#Edit Group
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects
 rep#:#rep_new_item_group_other#:#Other
-rep#:#rep_new_item_group_separator#:#Column Separator
 rep#:#rep_new_item_group_unassigned#:#Not Assigned
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s
 rep#:#rep_new_item_groups#:#New Item Groups

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -14613,12 +14613,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Veuillez sélectionner celles que vous souhaitez aussi supprimer :
 rep#:#rep_multiple_reference_deletion_intro#:#D'autres références existent pour cet objet.
 rep#:#rep_new_item_group_add#:#Ajouter Groupe
-rep#:#rep_new_item_group_add_separator#:#Ajouter Séparateur de Colonnes
 rep#:#rep_new_item_group_delete_sure#:#Etes-vous sûr de vouloir supprimer les groupes suivants ?
 rep#:#rep_new_item_group_edit#:#Editer Groupe
 rep#:#rep_new_item_group_nr_subitems#:#Nombre d'Objets Assignés
 rep#:#rep_new_item_group_other#:#Autre
-rep#:#rep_new_item_group_separator#:#Séparateur de Colonnes
 rep#:#rep_new_item_group_unassigned#:#Non Assigné
 rep#:#rep_new_item_group_unassigned_subitems#:#Nombre d'Objets Non Assignés : %s
 rep#:#rep_new_item_groups#:#Nouveau Groupe d'Objets

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#You are currently not yet a member of a course or group.
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.
 rep#:#rep_new_item_group_add#:#Add Grouping
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groupings?
 rep#:#rep_new_item_group_edit#:#Edit Grouping
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects
 rep#:#rep_new_item_group_other#:#Other
-rep#:#rep_new_item_group_separator#:#Column Separator
 rep#:#rep_new_item_group_unassigned#:#Not Assigned
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s
 rep#:#rep_new_item_groups#:#Grouping

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -13875,12 +13875,10 @@ rep#:#rep_mo_mem_dash#:#Jelenleg egy kurzusnak, illetve csoportnak sem tagja.
 rep#:#rep_multiple_reference_deletion_instruction#:#Válassza ki azokat, amelyeket szintén törölni szeretne:
 rep#:#rep_multiple_reference_deletion_intro#:#További hivatkozások vannak ehhez az objektumhoz.
 rep#:#rep_new_item_group_add#:#Csoportosítás hozzáadása
-rep#:#rep_new_item_group_add_separator#:#Oszlop elválasztó hozzáadása
 rep#:#rep_new_item_group_delete_sure#:#Biztos, hogy törli az alábbi csoportosításokat?
 rep#:#rep_new_item_group_edit#:#Csoportosítás módosítása
 rep#:#rep_new_item_group_nr_subitems#:#Hozzárendelt objektumok száma
 rep#:#rep_new_item_group_other#:#Egyebek
-rep#:#rep_new_item_group_separator#:#Oszlop elválasztó
 rep#:#rep_new_item_group_unassigned#:#Nincs hozzárendelve
 rep#:#rep_new_item_group_unassigned_subitems#:#Hozzá nem rendelt objektumok száma: %s
 rep#:#rep_new_item_groups#:#Csoportosítás

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Si prega di selezionare quello che dovrebbe essere eliminato:
 rep#:#rep_multiple_reference_deletion_intro#:#Per questo oggetto esistono ulteriori riferimenti.
 rep#:#rep_new_item_group_add#:#Add Group
-rep#:#rep_new_item_group_add_separator#:#Aggiungi separatore di colonna
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?
 rep#:#rep_new_item_group_edit#:#Edit Group
 rep#:#rep_new_item_group_nr_subitems#:#Numero degli oggetti assegnati
 rep#:#rep_new_item_group_other#:#Altro
-rep#:#rep_new_item_group_separator#:#Separatore di colonna
 rep#:#rep_new_item_group_unassigned#:#Non assegnato
 rep#:#rep_new_item_group_unassigned_subitems#:#Numero degli oggetti non assegnati: %s
 rep#:#rep_new_item_groups#:#New Item Groups

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -13967,12 +13967,10 @@ rep#:#rep_mo_mem_dash#:#現在コース、グループのどちらもメンバ�
 rep#:#rep_multiple_reference_deletion_instruction#:#どれを削除するのか選択してください：
 rep#:#rep_multiple_reference_deletion_intro#:#このオブジェクトには追加情報が存在します。
 rep#:#rep_new_item_group_add#:#グループ追加
-rep#:#rep_new_item_group_add_separator#:#列区切りを追加
 rep#:#rep_new_item_group_delete_sure#:#本当に次のグループ化を削除しますか?
 rep#:#rep_new_item_group_edit#:#グループ編集
 rep#:#rep_new_item_group_nr_subitems#:#割当て済みオブジェクト数
 rep#:#rep_new_item_group_other#:#その他
-rep#:#rep_new_item_group_separator#:#列区切り
 rep#:#rep_new_item_group_unassigned#:#割当てなし
 rep#:#rep_new_item_group_unassigned_subitems#:#未割当てオブジェクト数: %s
 rep#:#rep_new_item_groups#:#グループ化

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -13875,12 +13875,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.
 rep#:#rep_new_item_group_add#:#Toevoegen groep
-rep#:#rep_new_item_group_add_separator#:#Toevoegen kolom-scheidingsteken
 rep#:#rep_new_item_group_delete_sure#:#Weet je zeker dat je de volgende groepen wilt verwijderen?
 rep#:#rep_new_item_group_edit#:#Groep wijzigen
 rep#:#rep_new_item_group_nr_subitems#:#Aantal toegewezen objecten:
 rep#:#rep_new_item_group_other#:#Ander
-rep#:#rep_new_item_group_separator#:#Kolom-scheidingsteken
 rep#:#rep_new_item_group_unassigned#:#Niet toegewezen
 rep#:#rep_new_item_group_unassigned_subitems#:#Aantal niet toegewezen objecten: %s
 rep#:#rep_new_item_groups#:#Nieuwe itemgroepen

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Wybierz te, które również mają zostać usunięte:
 rep#:#rep_multiple_reference_deletion_intro#:#Dla tego obiektu istnieją dodatkowe rekomendacje.
 rep#:#rep_new_item_group_add#:#Dodaj grupę
-rep#:#rep_new_item_group_add_separator#:#Dodaj separator kolumny
 rep#:#rep_new_item_group_delete_sure#:#Czy naprawdę chcesz usunąć następujące grupy?
 rep#:#rep_new_item_group_edit#:#Edytuj grupę
 rep#:#rep_new_item_group_nr_subitems#:#Liczba przydzielonych obiektów
 rep#:#rep_new_item_group_other#:#Inne
-rep#:#rep_new_item_group_separator#:#Separatory kolumn
 rep#:#rep_new_item_group_unassigned#:#Nie przydzielono
 rep#:#rep_new_item_group_unassigned_subitems#:#Liczba nieprzydzielonych obiektów: %s
 rep#:#rep_new_item_groups#:#Grupy

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Selecione aqueles que também devem ser apagados:
 rep#:#rep_multiple_reference_deletion_intro#:#Há mais referências para este objeto.
 rep#:#rep_new_item_group_add#:#Add Group
-rep#:#rep_new_item_group_add_separator#:#Adicionar separador de coluna
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?
 rep#:#rep_new_item_group_edit#:#Edit Group
 rep#:#rep_new_item_group_nr_subitems#:#Número de objetos atribuídos
 rep#:#rep_new_item_group_other#:#Outros
-rep#:#rep_new_item_group_separator#:#Separador de coluna
 rep#:#rep_new_item_group_unassigned#:#Não atribuído
 rep#:#rep_new_item_group_unassigned_subitems#:#Número de objetos não atribuídos: %s
 rep#:#rep_new_item_groups#:#New Item Groups

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -13875,12 +13875,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -13874,12 +13874,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.
 rep#:#rep_new_item_group_add#:#Add Group
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?
 rep#:#rep_new_item_group_edit#:#Edit Group
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects
 rep#:#rep_new_item_group_other#:#Other
-rep#:#rep_new_item_group_separator#:#Column Separator
 rep#:#rep_new_item_group_unassigned#:#Not Assigned
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s
 rep#:#rep_new_item_groups#:#New Item Groups

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -13964,12 +13964,10 @@ rep#:#rep_mo_mem_dash#:#You are currently not yet a member of a course or group.
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.
 rep#:#rep_new_item_group_add#:#Add Grouping
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groupings?
 rep#:#rep_new_item_group_edit#:#Edit Grouping
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects
 rep#:#rep_new_item_group_other#:#Other
-rep#:#rep_new_item_group_separator#:#Column Separator
 rep#:#rep_new_item_group_unassigned#:#Not Assigned
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects
 rep#:#rep_new_item_groups#:#Grouping

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -13875,12 +13875,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -13875,12 +13875,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -14651,12 +14651,10 @@ rep#:#rep_mo_mem_dash#:#Du är för närvarande inte medlem i en kurs eller grup
 rep#:#rep_multiple_reference_deletion_instruction#:#Välj ut de som också bör raderas
 rep#:#rep_multiple_reference_deletion_intro#:#Det finns ytterligare referenser för detta objekt.
 rep#:#rep_new_item_group_add#:#Lägg till gruppering
-rep#:#rep_new_item_group_add_separator#:#Lägg till kolumnavgränsare
 rep#:#rep_new_item_group_delete_sure#:#Vill du verkligen ta bort följande grupperingar?
 rep#:#rep_new_item_group_edit#:#Redovisa gruppering
 rep#:#rep_new_item_group_nr_subitems#:#Antal tilldelade objekt
 rep#:#rep_new_item_group_other#:#Mer
-rep#:#rep_new_item_group_separator#:#Kolumnavgränsare
 rep#:#rep_new_item_group_unassigned#:#Inte tilldelad
 rep#:#rep_new_item_group_unassigned_subitems#:#Antal ej tilldelade objekt
 rep#:#rep_new_item_groups#:#Grupperingar

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -13873,12 +13873,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#da silinmesi gerektiğini olanları seçiniz:
 rep#:#rep_multiple_reference_deletion_intro#:#Ayrıntılı atıflar bu nesne için yapılmamış.
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -13875,12 +13875,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -13877,12 +13877,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#Please select the ones which should also be deleted:###28 08 2012 new variable
 rep#:#rep_multiple_reference_deletion_intro#:#Further references exist for this object.###28 08 2012 new variable
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -13872,12 +13872,10 @@ rep#:#rep_mo_mem_dash#:#Sie sind aktuell noch nicht Mitglied eines Kurses oder e
 rep#:#rep_multiple_reference_deletion_instruction#:#请选择应该也被删除的一项：
 rep#:#rep_multiple_reference_deletion_intro#:#这个对象的进一步参考已存在。
 rep#:#rep_new_item_group_add#:#Add Group###24 10 2013 new variable
-rep#:#rep_new_item_group_add_separator#:#Add Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_delete_sure#:#Are you sure you want to delete the following groups?###24 10 2013 new variable
 rep#:#rep_new_item_group_edit#:#Edit Group###24 10 2013 new variable
 rep#:#rep_new_item_group_nr_subitems#:#Number of Assigned Objects###24 10 2013 new variable
 rep#:#rep_new_item_group_other#:#Other###24 10 2013 new variable
-rep#:#rep_new_item_group_separator#:#Column Separator###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned#:#Not Assigned###24 10 2013 new variable
 rep#:#rep_new_item_group_unassigned_subitems#:#Number of Unassigned Objects: %s###24 10 2013 new variable
 rep#:#rep_new_item_groups#:#New Item Groups###24 10 2013 new variable


### PR DESCRIPTION
Hi @alex40724 

With the merge of the new "Add New Object" solution, we don't need the separators in the `NewItemsGroups` anymore. This removes  the corresponding code and drops the records from the table as well as removing the now unneeded `type`-column.

We do not loose much code, but at least a few lines are gone.

Best,
@kergomard 