### PR TITLE
CI: Check the code style of files in PRs, don't try to fix it

### DIFF
--- a/CI/PHP-CS-Fixer/run_check.sh
+++ b/CI/PHP-CS-Fixer/run_check.sh
@@ -19,7 +19,7 @@ else
   	if [ -f ${FILE} ]
   	then
 	  	echo "Check file: ${FILE}"
-	  	RUNCSFIXER=$(libs/composer/vendor/bin/php-cs-fixer fix --using-cache=no --diff --config=./CI/PHP-CS-Fixer/code-format.php_cs ${FILE})
+	  	RUNCSFIXER=$(libs/composer/vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --config=./CI/PHP-CS-Fixer/code-format.php_cs ${FILE})
 	  	RESULT=$?
 	  	if [[ ${RESULT} -ne 0 ]]
 	  	then


### PR DESCRIPTION
This PR changes the `php-cs-fixer` when running in a "GitHub Actions" context. Instead of fixing files, this PR suggests to only check them.

I stumbled upon the issue because no code style violations have been detected in PR https://github.com/ILIAS-eLearning/ILIAS/pull/7160 .

If the `php-cs-fixer` actually fixes files, the exit code is `0`, which does not lead to a failing CI pipeline.

If approved, this has to be picked to `release_9` and `trunk`.