### PR TITLE
fix error in listView

### DIFF
--- a/Modules/Test/classes/class.ilTestQuestionRelatedObjectivesList.php
+++ b/Modules/Test/classes/class.ilTestQuestionRelatedObjectivesList.php
@@ -89,9 +89,14 @@ class ilTestQuestionRelatedObjectivesList
     public function getQuestionRelatedObjectiveTitles($questionId): string
     {
         $titles = array();
-
-        foreach ((array) $this->objectivesByQuestion[$questionId] as $objectiveId) {
-            $titles[] = $this->objectivesTitles[$objectiveId];
+        // avoid error if question is not assigned to any objective
+        if (isset((array) $this->objectivesByQuestion[$questionId])) {
+            foreach ((array) $this->objectivesByQuestion[$questionId] as $objectiveId) {
+                $titles[] = $this->objectivesTitles[$objectiveId];
+            }
+        } else {
+            // return an empty title if question is not assigned to any objective
+            $titles[]="";
         }
 
         return implode(', ', $titles);

--- a/Modules/Test/classes/class.ilTestQuestionRelatedObjectivesList.php
+++ b/Modules/Test/classes/class.ilTestQuestionRelatedObjectivesList.php
@@ -90,7 +90,7 @@ class ilTestQuestionRelatedObjectivesList
     {
         $titles = array();
         // avoid error if question is not assigned to any objective
-        if ($this->objectivesByQuestion[$questionId] != null) {
+        if (isset($this->objectivesByQuestion[$questionId])) {
             foreach ((array) $this->objectivesByQuestion[$questionId] as $objectiveId) {
                 $titles[] = $this->objectivesTitles[$objectiveId];
             }
@@ -136,7 +136,7 @@ class ilTestQuestionRelatedObjectivesList
 
     public function isQuestionRelatedToObjective($questionId, $objectiveId): bool
     {
-        if ($this->objectivesByQuestion[$questionId] == null {
+        if (!isset($this->objectivesByQuestion[$questionId])) {
                 return false;
             }
         foreach ($this->objectivesByQuestion[$questionId] as $relatedObjectiveId) {

--- a/Modules/Test/classes/class.ilTestQuestionRelatedObjectivesList.php
+++ b/Modules/Test/classes/class.ilTestQuestionRelatedObjectivesList.php
@@ -90,7 +90,7 @@ class ilTestQuestionRelatedObjectivesList
     {
         $titles = array();
         // avoid error if question is not assigned to any objective
-        if (isset((array) $this->objectivesByQuestion[$questionId])) {
+        if ($this->objectivesByQuestion[$questionId] != null) {
             foreach ((array) $this->objectivesByQuestion[$questionId] as $objectiveId) {
                 $titles[] = $this->objectivesTitles[$objectiveId];
             }
@@ -136,6 +136,9 @@ class ilTestQuestionRelatedObjectivesList
 
     public function isQuestionRelatedToObjective($questionId, $objectiveId): bool
     {
+        if ($this->objectivesByQuestion[$questionId] == null {
+                return false;
+            }
         foreach ($this->objectivesByQuestion[$questionId] as $relatedObjectiveId) {
             if ($relatedObjectiveId == $objectiveId) {
                 return true;


### PR DESCRIPTION
under some conditions invaltid objects are found when displaying object-lists. This results in an "array key not found" error. This PR shows a possible fix.