### PR TITLE
fix some functoins if optional parameters are omitted

### DIFF
--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -159,7 +159,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
     /**
      * @return soap_fault|SoapFault|string|null
      */
-    public function getObjectByReference(string $sid, int $a_ref_id, int $user_id)
+    public function getObjectByReference(string $sid, int $a_ref_id, ?int $user_id = null)
     {
         $this->initAuth($sid);
         $this->initIlias();
@@ -178,7 +178,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         $xml_writer = new ilObjectXMLWriter();
         $xml_writer->enablePermissionCheck(true);
-        if ($user_id) {
+        if (is_int($user_id)) {
             $xml_writer->setUserId($user_id);
             $xml_writer->enableOperations(true);
         }
@@ -192,7 +192,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
     /**
      * @return soap_fault|SoapFault|string|null
      */
-    public function getObjectsByTitle(string $sid, string $a_title, int $user_id)
+    public function getObjectsByTitle(string $sid, string $a_title, ?int $user_id = null)
     {
         $this->initAuth($sid);
         $this->initIlias();
@@ -251,7 +251,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
 
         $xml_writer = new ilObjectXMLWriter();
         $xml_writer->enablePermissionCheck(true);
-        if ($user_id) {
+        if (is_int($user_id)) {
             $xml_writer->setUserId($user_id);
             $xml_writer->enableOperations(true);
         }
@@ -265,7 +265,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
     /**
      * @return soap_fault|SoapFault|string|null
      */
-    public function searchObjects(string $sid, array $types, string $key, string $combination, int $user_id)
+    public function searchObjects(string $sid, ?array $types, string $key, string $combination, ?int $user_id = null)
     {
         $this->initAuth($sid);
         $this->initIlias();
@@ -344,7 +344,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             $object_search = new ilLikeObjectSearch($query_parser);
             $object_search->setFilter($types);
             $res = $object_search->performSearch();
-            if ($user_id) {
+            if (is_int($user_id)) {
                 $res->setUserId($user_id);
             }
             $res->setMaxHits(100);
@@ -389,7 +389,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
     /**
      * @return soap_fault|SoapFault|string|null
      */
-    public function getTreeChilds(string $sid, int $ref_id, array $types, int $user_id)
+    public function getTreeChilds(string $sid, int $ref_id, ?array $types, ?int $user_id = null)
     {
         $this->initAuth($sid);
         $this->initIlias();
@@ -417,7 +417,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             );
         }
 
-        if (!$types) {
+        if (!is_array($types)) {
             $all = true;
         }
 
@@ -436,7 +436,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $xml_writer->enablePermissionCheck(true);
         $xml_writer->setObjects($objs);
         $xml_writer->enableOperations(true);
-        if ($user_id) {
+        if (is_int($user_id)) {
             $xml_writer->setUserId($user_id);
         }
 
@@ -449,7 +449,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
     /**
      * @return soap_fault|SoapFault|string|null
      */
-    public function getXMLTree(string $sid, int $ref_id, array $types, int $user_id)
+    public function getXMLTree(string $sid, int $ref_id, ?array $types, ?int $user_id =null)
     {
         $this->initAuth($sid);
         $this->initIlias();
@@ -489,7 +489,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
         $xml_writer->setObjects($nodes);
         $xml_writer->enableOperations(false);
 
-        if ($user_id) {
+        if (is_int($user_id)) {
             $xml_writer->setUserId($user_id);
         }
 

--- a/webservice/soap/include/inc.soap_functions.php
+++ b/webservice/soap/include/inc.soap_functions.php
@@ -173,7 +173,7 @@ class ilSoapFunctions
     /**
      * @return soap_fault|SoapFault|string|null
      */
-    public static function getObjectByReference(string $sid, int $a_ref_id, int $user_id)
+    public static function getObjectByReference(string $sid, int $a_ref_id, ?int $user_id = null)
     {
         include_once './webservice/soap/classes/class.ilSoapObjectAdministration.php';
         $soa = new ilSoapObjectAdministration();
@@ -183,7 +183,7 @@ class ilSoapFunctions
     /**
      * @return soap_fault|SoapFault|string|null
      */
-    public static function getObjectsByTitle(string $sid, string $a_title, int $user_id)
+    public static function getObjectsByTitle(string $sid, string $a_title, ?int $user_id = null)
     {
         include_once './webservice/soap/classes/class.ilSoapObjectAdministration.php';
         $soa = new ilSoapObjectAdministration();
@@ -243,7 +243,7 @@ class ilSoapFunctions
     /**
      * @return soap_fault|SoapFault|string|null
      */
-    public static function searchObjects(string $sid, array $types, string $key, string $combination, int $user_id)
+    public static function searchObjects(string $sid, array $types, string $key, string $combination, ?int $user_id = null)
     {
         include_once './webservice/soap/classes/class.ilSoapObjectAdministration.php';
         $soa = new ilSoapObjectAdministration();
@@ -263,7 +263,7 @@ class ilSoapFunctions
     /**
      * @return soap_fault|SoapFault|string|null
      */
-    public static function getXMLTree(string $sid, int $ref_id, array $types, int $user_id)
+    public static function getXMLTree(string $sid, int $ref_id, array $types, ?int $user_id = null)
     {
         include_once './webservice/soap/classes/class.ilSoapObjectAdministration.php';
         $soa = new ilSoapObjectAdministration();


### PR DESCRIPTION
in some functions, $user and $types should be optional parameters. in ILIAS 8 (and posibly 9/trunk) these parameters must be supplied, but the function itself contains checks for these paramaters. 
This PR contains a possible, but untested fix.
 