### PR TITLE
Jour Fixe monolog dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -191,10 +191,10 @@
 		},
 		"monolog/monolog" : {
 			"source" : "https://github.com/Seldaek/monolog",
-			"used_version" : "v2.6.0",
+			"used_version" : "v2.9.3",
 			"wrapped_by" : "components/ILIAS/Logging",
 			"added_by" : "Stefan Meyer <smeyer.ilias@gmx.de>",
-			"last_update" : "2022-05-11",
+			"last_update" : "2024-06-07",
 			"last_update_by" : "Stefan Meyer <smeyer.ilias@gmx.de>",
 			"approved-by": "Jour Fixe",
 			"approved-date": "2015-09-07"


### PR DESCRIPTION
adds monolog dependency.

Monolog logging was integrated into ILIAS with release 5.1. [1]
Monolog is one of the main logging frameworks for PHP and offers features like formating, different appenders  and handlers.
Monolog is actively maintained. See github project [2]

[1] https://docu.ilias.de/goto_docu_wiki_wpage_151_1357.html
[2] https://github.com/Seldaek/monolog