### PR TITLE
[FIX] File extension missing when downloaded from data collection (#0041496)

### DIFF
--- a/Modules/DataCollection/classes/Content/class.ilDclRecordListGUI.php
+++ b/Modules/DataCollection/classes/Content/class.ilDclRecordListGUI.php
@@ -375,7 +375,7 @@ class ilDclRecordListGUI
                     return;
                 }
                 $filepath = $file_obj->getFile();
-                $filetitle = $file_obj->getTitle();
+                $filetitle = $file_obj->appendSuffixToTitle($file_obj->getTitle(), $file_obj->getFileName());
             }
 
             ilFileDelivery::deliverFileLegacy($filepath, $filetitle);


### PR DESCRIPTION
Ensure that files downloaded from data collections contain the file extension.

Bug report: https://mantis.ilias.de/view.php?id=41496