### PR TITLE
ilUIPluginRouterGUI: Fix class paths handling

### DIFF
--- a/components/ILIAS/UIComponent/classes/class.ilUIPluginRouterGUI.php
+++ b/components/ILIAS/UIComponent/classes/class.ilUIPluginRouterGUI.php
@@ -41,7 +41,7 @@ class ilUIPluginRouterGUI implements ilCtrlBaseClassInterface
         $next_class = $this->ctrl->getNextClass($this);
         switch ($next_class) {
             default:
-                $class_file = $this->ctrl->lookupClassPath($next_class);
+                $class_file = '../' . ltrim($this->ctrl->lookupClassPath($next_class), './');
                 if (is_file($class_file)) {
                     include_once($class_file);
                     $gui = new $next_class();


### PR DESCRIPTION
This PR fixes the `ilCtrl` based routing if `ilUIPluginRouterGUI` is the base class. The `is_file` check does not work because paths returned by `ilCtrlInteface::lookupClassPath` are relative paths starting with `./components/*`.

Mantis Issue: https://mantis.ilias.de/view.php?id=41501