### PR TITLE
UI: Remove StripTags from Text-Inputs

### DIFF
--- a/components/ILIAS/UI/src/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Factory.php
@@ -50,6 +50,10 @@ interface Factory
      *     3: >
      *         Text Input MUST NOT be used for letter-only input, an Alphabet Field
      *         is to be used instead.
+     *     4: >
+     *         If withoutStripTags is set, the consumer MUST make sure the value
+     *         is proberly sanitized before outputing it.
+     *
      *   interaction:
      *     1: >
      *         Text Input MUST limit the number of characters, if a certain length
@@ -450,6 +454,9 @@ interface Factory
      *     2: >
      *       Radios MAY also be used to select between two options
      *       where one is not automatically the inverse of the other
+     *     3: >
+     *         If withoutStripTags is set, the consumer MUST make sure the value
+     *         is proberly sanitized before outputing it.
      *   wording:
      *     1: Each option MUST be labeled.
      *     2: The options' labels MUST state something positive.

--- a/components/ILIAS/UI/src/Component/Input/Field/Text.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Text.php
@@ -36,4 +36,9 @@ interface Text extends FilterInput
      * Gets the max length of the text input
      */
     public function getMaxLength(): ?int;
+
+    /**
+     * Disable stripping tags from user input
+     */
+    public function withoutStripTags(): Text;
 }

--- a/components/ILIAS/UI/src/Component/Input/Field/Textarea.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Textarea.php
@@ -53,4 +53,9 @@ interface Textarea extends FormInput
      * bool if textarea has max or min number of character limit.
      */
     public function isLimited(): bool;
+
+    /**
+     * Disable removing tags on user input
+     */
+    public function withoutStripTags(): Textarea;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Text.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Text.php
@@ -42,7 +42,6 @@ class Text extends FormInput implements C\Input\Field\Text
         ?string $byline
     ) {
         parent::__construct($data_factory, $refinery, $label, $byline);
-        $this->setAdditionalTransformation($refinery->custom()->transformation(fn($v) => strip_tags($v)));
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Text.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Text.php
@@ -21,10 +21,10 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\UI\Component as C;
-use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Constraint;
 use Closure;
+use Generator;
 
 /**
  * This implements the text input.
@@ -118,12 +118,12 @@ class Text extends FormInput implements C\Input\Field\Text
     /**
      * @inheritdoc
      */
-    public function withInput(InputData $input): self
+    public function getOperations(): Generator
     {
         if ($this->strip_tags_from_input) {
-            $this->setAdditionalTransformation($this->refinery->custom()->transformation(fn($v) => strip_tags($v)));
+            yield $this->refinery->custom()->transformation(fn($v) => strip_tags($v));
         }
-        return parent::withInput($input);
+        yield from parent::getOperations();
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Text.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Text.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\UI\Component as C;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Constraint;
 use Closure;
@@ -31,6 +32,7 @@ use Closure;
 class Text extends FormInput implements C\Input\Field\Text
 {
     private ?int $max_length = null;
+    private bool $strip_tags_from_input = true;
 
     /**
      * @inheritdoc
@@ -111,5 +113,26 @@ class Text extends FormInput implements C\Input\Field\Text
     public function isComplex(): bool
     {
         return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withInput(InputData $input): self
+    {
+        if ($this->strip_tags_from_input) {
+            $this->setAdditionalTransformation($this->refinery->custom()->transformation(fn($v) => strip_tags($v)));
+        }
+        return parent::withInput($input);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withoutStripTags(): Text
+    {
+        $clone = clone $this;
+        $clone->strip_tags_from_input = false;
+        return $clone;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Textarea.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Textarea.php
@@ -47,9 +47,6 @@ class Textarea extends FormInput implements C\Input\Field\Textarea
         ?string $byline
     ) {
         parent::__construct($data_factory, $refinery, $label, $byline);
-        $this->setAdditionalTransformation(
-            $refinery->string()->stripTags()
-        );
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Textarea.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Textarea.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\UI\Component as C;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Constraint;
@@ -36,6 +37,8 @@ class Textarea extends FormInput implements C\Input\Field\Textarea
     protected ?int $max_limit = null;
 
     protected ?int $min_limit = null;
+
+    private bool $strip_tags_from_input = true;
 
     /**
      * @inheritdoc
@@ -137,5 +140,26 @@ class Textarea extends FormInput implements C\Input\Field\Textarea
 				il.UI.input.onFieldUpdate(event, '$id', $('#$id').val());
 			});
 			il.UI.input.onFieldUpdate(event, '$id', $('#$id').val());";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withInput(InputData $input): self
+    {
+        if ($this->strip_tags_from_input) {
+            $this->setAdditionalTransformation($this->refinery->custom()->transformation(fn($v) => strip_tags($v)));
+        }
+        return parent::withInput($input);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withoutStripTags(): C\Input\Field\Textarea
+    {
+        $clone = clone $this;
+        $clone->strip_tags_from_input = false;
+        return $clone;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Textarea.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Textarea.php
@@ -21,11 +21,11 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\UI\Component as C;
-use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Constraint;
 use Closure;
+use Generator;
 
 /**
  * This implements the textarea input.
@@ -145,12 +145,12 @@ class Textarea extends FormInput implements C\Input\Field\Textarea
     /**
      * @inheritdoc
      */
-    public function withInput(InputData $input): self
+    public function getOperations(): Generator
     {
         if ($this->strip_tags_from_input) {
-            $this->setAdditionalTransformation($this->refinery->custom()->transformation(fn($v) => strip_tags($v)));
+            yield $this->refinery->custom()->transformation(fn($v) => strip_tags($v));
         }
-        return parent::withInput($input);
+        yield from parent::getOperations();
     }
 
     /**

--- a/components/ILIAS/UI/tests/Component/Input/Field/TextInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TextInputTest.php
@@ -143,4 +143,29 @@ class TextInputTest extends ILIAS_UI_TestBase
         $value2 = $text2->getContent();
         $this->assertTrue($value2->isError());
     }
+
+    public function testStripsTags(): void
+    {
+        $f = $this->getFieldFactory();
+        $name = "name_0";
+        $text = $f->text("")
+            ->withNameFrom($this->name_source)
+            ->withInput(new DefInputData([$name => "<script>alert()</script>"]));
+
+        $content = $text->getContent();
+        $this->assertEquals("alert()", $content->value());
+    }
+
+    public function testWithoutStripsTags(): void
+    {
+        $f = $this->getFieldFactory();
+        $name = "name_0";
+        $text = $f->text("")
+            ->withNameFrom($this->name_source)
+            ->withoutStripTags()
+            ->withInput(new DefInputData([$name => "<script>alert()</script>"]));
+
+        $content = $text->getContent();
+        $this->assertEquals("<script>alert()</script>", $content->value());
+    }
 }

--- a/components/ILIAS/UI/tests/Component/Input/Field/TextInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TextInputTest.php
@@ -143,16 +143,4 @@ class TextInputTest extends ILIAS_UI_TestBase
         $value2 = $text2->getContent();
         $this->assertTrue($value2->isError());
     }
-
-    public function testStripsTags(): void
-    {
-        $f = $this->getFieldFactory();
-        $name = "name_0";
-        $text = $f->text("")
-            ->withNameFrom($this->name_source)
-            ->withInput(new DefInputData([$name => "<script>alert()</script>"]));
-
-        $content = $text->getContent();
-        $this->assertEquals("alert()", $content->value());
-    }
 }

--- a/components/ILIAS/UI/tests/Component/Input/Field/TextareaTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TextareaTest.php
@@ -225,4 +225,29 @@ class TextareaTest extends ILIAS_UI_TestBase
         ");
         $this->assertStringContainsString($expected, $this->render($textarea));
     }
+
+    public function testStripsTags(): void
+    {
+        $f = $this->getFieldFactory();
+        $name = "name_0";
+        $text = $f->textarea("")
+            ->withNameFrom($this->name_source)
+            ->withInput(new DefInputData([$name => "<script>alert()</script>"]));
+
+        $content = $text->getContent();
+        $this->assertEquals("alert()", $content->value());
+    }
+
+    public function testWithoutStripsTags(): void
+    {
+        $f = $this->getFieldFactory();
+        $name = "name_0";
+        $text = $f->textarea("")
+            ->withNameFrom($this->name_source)
+            ->withoutStripTags()
+            ->withInput(new DefInputData([$name => "<script>alert()</script>"]));
+
+        $content = $text->getContent();
+        $this->assertEquals("<script>alert()</script>", $content->value());
+    }
 }

--- a/components/ILIAS/UI/tests/Component/Input/Field/TextareaTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TextareaTest.php
@@ -225,16 +225,4 @@ class TextareaTest extends ILIAS_UI_TestBase
         ");
         $this->assertStringContainsString($expected, $this->render($textarea));
     }
-
-    public function testStripsTags(): void
-    {
-        $f = $this->getFieldFactory();
-        $name = "name_0";
-        $text = $f->textarea("")
-            ->withNameFrom($this->name_source)
-            ->withInput(new DefInputData([$name => "<script>alert()</script>"]));
-
-        $content = $text->getContent();
-        $this->assertEquals("alert()", $content->value());
-    }
 }


### PR DESCRIPTION
Hi all

While researching for [Inconsistent Handling of Titles and Description](https://mantis.ilias.de/view.php?id=41447) I came across this transformation in text- and textarea-inputs. I don't think this is the right behavior and it makes implementing the decision above not possible for the new settings form. I'm not adding this as an `Issue` right now, but as an `Improvement`, but I can a Mantis ticket if you prefer.

Thanks and best,
@kergomard 