### PR TITLE
FileUpload: Adjusted assembly of rejection message in SVGBlacklistPreProcessor.php

### DIFF
--- a/components/ILIAS/FileUpload/src/Processor/SVGBlacklistPreProcessor.php
+++ b/components/ILIAS/FileUpload/src/Processor/SVGBlacklistPreProcessor.php
@@ -129,7 +129,7 @@ final class SVGBlacklistPreProcessor implements PreProcessor
         $this->rejection_message = $rejection_message ?? $this->rejection_message;
         $this->rejection_message_script = $additional_message_script ?? 'contains script tags';
         $this->rejection_message_base64 = $additional_message_base64 ?? 'contains base64 encoded content';
-        $this->rejection_message_elements = $additional_message_elements ?? 'contains not allowed or uknown elements or attributes';
+        $this->rejection_message_elements = $additional_message_elements ?? 'contains not allowed or unknown elements or attributes';
     }
 
     private function isSVG(Metadata $metadata): bool
@@ -199,13 +199,13 @@ final class SVGBlacklistPreProcessor implements PreProcessor
     {
         // Check for Base64 encoded Content
         if (preg_match(self::REGEX_BASE64, $raw_svg_content)) {
-            $this->rejection_message .= ' ' . $this->rejection_message_base64 . '.';
+            $this->rejection_message .= ' ' . $this->rejection_message_base64;
             return true;
         }
 
         // Check for script tags directly
         if (preg_match(self::REGEX_SCRIPT, $raw_svg_content)) {
-            $this->rejection_message .= ' ' . $this->rejection_message_script . '.';
+            $this->rejection_message .= ' ' . $this->rejection_message_script;
             return true;
         }
 

--- a/components/ILIAS/FileUpload/tests/Processor/SVGPreProcessorTest.php
+++ b/components/ILIAS/FileUpload/tests/Processor/SVGPreProcessorTest.php
@@ -100,7 +100,7 @@ aWUpJwpvbmVuZD0nYWxlcnQoIm9uZW5kIiknIHRvPSIjMDBGIiBiZWdpbj0iMXMiIGR1cj0iNXMiIC
 
         $this->assertFalse($result->getCode() === ProcessingStatus::OK);
         $this->assertTrue($result->getCode() === ProcessingStatus::DENIED);
-        $this->assertSame('The SVG file contains malicious code. (' . $type . ').', $result->getMessage());
+        $this->assertSame('The SVG file contains malicious code. (' . $type . ')', $result->getMessage());
     }
 
     public function testSaneSVG(): void


### PR DESCRIPTION
This PR is an addition to https://github.com/ILIAS-eLearning/ILIAS/pull/7444. The error messages implemented there were assembled with two punctuation marks because the punctuation was already part of the language variable and then added again in SVGBlacklistPreProcessor.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/147340168/d4f03864-d613-4bcf-b7bd-9eb93605a237)


For me it seemed more consistent to have the punctuation as a part of the language variable so I removed it from SVGBlacklistPreProcessor. 