### PR TITLE
[FEATURE] CI: JavaScript code-style exception

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,6 +54,14 @@
       {
         "devDependencies": true
       }
+    ],
+    // allow to reassign argument properties for e.g. altering
+    // HTMLElement styles and state.
+    "no-param-reassign": [
+      "error",
+      {
+        "props": false
+      }
     ]
   }
 }

--- a/docs/development/js-coding-style.md
+++ b/docs/development/js-coding-style.md
@@ -118,6 +118,12 @@ Airbnb requires ALL functions to be declared BEFORE they are used, which is unne
 functions are [hoisted](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting), which makes this rule obsolete.
 Therefore, we do not require function declarations to be placed before they are used.
 
+#### 4. Parameter Properties Reassignment
+
+Airbnb does not allow to manipulate/reassign parameters completely. However, reassigning **parameter properties** of 
+e.g. `HTMLElement`s is a common use-case, which has led to many unnecessary variables being initialised to work around
+this code-style rule. Therefore we allow the manipulation/reassignment of **parameter properties**.
+
 ## Applying Code Style
 
 ILIAS is using [ESLint](https://eslint.org/) to automatically check and/or fix JavaScript code according to the


### PR DESCRIPTION
Hi folks,

This PR introduces a new rule to our JavaScript code-style in form of an exception/deviation:

> Airbnb does not allow to manipulate/reassign parameters completely. However, reassigning **parameter properties** of e.g. `HTMLElement`s is a common use-case, which has led to many unnecessary variables being initialised to work around this code-style rule. Therefore we allow the manipulation/reassignment of **parameter properties**.

This partially supersedes [Airbnbs ruling to disallow parameter reassignments](https://github.com/airbnb/javascript?tab=readme-ov-file#functions--reassign-params) and will keep our JavaScript code more compact. Note that reassigning a parameter otherwise is still prohibited.

I have updated the according [ESLint configuration](https://eslint.org/docs/latest/rules/no-param-reassign#props) so these exceptions will no longer be recognised as an error.

Kind regards,
@thibsy 