### PR TITLE
[FIX] CI: use correct import paths

### DIFF
--- a/scripts/Copyright-Checker/copyright-checker.sh
+++ b/scripts/Copyright-Checker/copyright-checker.sh
@@ -173,7 +173,7 @@ function perform_copyright_check() {
 
 # this helper is only required if we are in a GitHub-run.
 if ! [ -z "${GHRUN}" ]; then
-  source "$(pwd)/CI/Import/Functions.sh"
+  source "$(pwd)/scripts/Import/Functions.sh"
 fi
 
 # run script with all supplied arguments and exit with the status code

--- a/scripts/Special-Char-Checker/special-char-checker.sh
+++ b/scripts/Special-Char-Checker/special-char-checker.sh
@@ -10,13 +10,13 @@
 # which are usually used by old printers. Sometimes these hidden characters
 # like hidden spaces, tabs or newlines are added to the code accidentally.
 
-source CI/Import/Functions.sh
+source scripts/Import/Functions.sh
 
 # get the files from this PR to the last head
 
 if [[ -z ${GHRUN} ]]
 then
-  CHANGED_FILES=$(find . -path ./libs -prune -o -type f -name '*.php')
+  CHANGED_FILES=$(find . -path ./vendor -prune -o -type f -name '*.php')
 else
   CHANGED_FILES=$(get_changed_files)
 fi
@@ -33,7 +33,7 @@ do
     continue
   fi
 
-  if [[ $FELONE == "./libs" ]]; then
+  if [[ $FELONE == "./vendor" ]]; then
     continue
   fi
 

--- a/scripts/sort_langfile_entries.sh
+++ b/scripts/sort_langfile_entries.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source CI/Import/Functions.sh
+source scripts/Import/Functions.sh
 
 CHECKS=true
 CHECKFLAG=${1}


### PR DESCRIPTION
Hi all,

I have recently [committed a change](https://github.com/ILIAS-eLearning/ILIAS/commit/cca848627e2227ab9e9aecef2f6e8294249a020e) which fixed some invalid paths, and noticed that other scripts are also affected by the same issue.

The following checks have not been checked for pull requests against trunk for some time now:
- Copyright check
- PHP code-style check
- Special characters check
- Language file sort check

This went unnoticed, because these scripts exited with `0` even though some files and functions could not be loaded  - so the workflows always passed. This should be a reminder to always check for the existence of files before using them, and to be careful with exit codes - especially for scripts used in GitHub actions.

Kind regards,
@thibsy 