### PR TITLE
Auth: `list-openid-connect-login` is not replaced if OIDC is not part…

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -1106,7 +1106,8 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
                 '[list-login-form]',
                 '[list-cas-login-form]',
                 '[list-saml-login]',
-                '[list-shibboleth-login-form]'
+                '[list-shibboleth-login-form]',
+                '[list-openid-connect-login]'
             ),
             array('', '', '', '', '', '', ''),
             $page_editor_html


### PR DESCRIPTION
… of the login page.

Mantis: https://mantis.ilias.de/view.php?id=41520

If approved, this MUST be picked to `release_9` and `trunk` as well.