### PR TITLE
Repository/Session: include session date in last visited (36691)

### DIFF
--- a/Modules/Session/classes/class.ilObjSessionGUI.php
+++ b/Modules/Session/classes/class.ilObjSessionGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +14,9 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+
+declare(strict_types=1);
 
 /**
 *
@@ -175,7 +174,8 @@ class ilObjSessionGUI extends ilObjectGUI implements ilDesktopItemHandling
             $GLOBALS['DIC']['ilNavigationHistory']->addItem(
                 $this->requested_ref_id,
                 ilLink::_getLink($this->requested_ref_id, 'sess'),
-                'sess'
+                'sess',
+                $this->object->getPresentationTitle()
             );
         }
 
@@ -212,12 +212,12 @@ class ilObjSessionGUI extends ilObjectGUI implements ilDesktopItemHandling
                 break;
 
             case "ilexportgui":
-//				$this->prepareOutput();
+                //				$this->prepareOutput();
                 $this->tabs_gui->setTabActive("export");
                 $exp_gui = new ilExportGUI($this);
                 $exp_gui->addFormat("xml");
                 $ret = $this->ctrl->forwardCommand($exp_gui);
-//				$this->tpl->show();
+                //				$this->tpl->show();
                 break;
 
             case "ilcommonactiondispatchergui":
@@ -275,7 +275,7 @@ class ilObjSessionGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $cmd .= "Object";
                 $this->$cmd();
 
-            break;
+                break;
         }
 
         $this->addHeaderAction();

--- a/Services/Navigation/classes/class.ilNavigationHistory.php
+++ b/Services/Navigation/classes/class.ilNavigationHistory.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=0);
+
 /**
  * Navigation History of Repository Items
  *
@@ -164,6 +166,9 @@ class ilNavigationHistory
                                 : ilLink::_getLink((int) $rec["ref_id"]);
                         if ($rec["sub_obj_id"] != "") {
                             $title = $rec["title"];
+                        } elseif ($rec["type"] === "sess") {
+                            $sess = new ilObjSession($rec["ref_id"]);
+                            $title = $sess->getPresentationTitle();
                         } else {
                             $title = ilObject::_lookupTitle(ilObject::_lookupObjId((int) $rec["ref_id"]));
                         }


### PR DESCRIPTION
This PR fixes [36691](https://mantis.ilias.de/view.php?id=36691).

Unfortunately, a small change was necessary to Navigation, introducing a different handling for the title specifically for sessions: since Navigation refreshes the title of previously persisted last-visited-entries via `ilObject::_lookupTitle` basically directly from obj_data, there is no way for the Session to interfere and set its title correctly from the outside. I couldn't find an easy way around this, let me know if I missed something.

