### PR TITLE
User/Registration: Don't render empty "Other" section in legacy forms

### DIFF
--- a/Services/User/classes/class.ilUserProfile.php
+++ b/Services/User/classes/class.ilUserProfile.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-// mjansen@databay.de essential for mail constants, do not remove this include
-
 use ILIAS\Services\Mail\ilMailUserFieldChangeListener;
 
 /**
@@ -510,7 +508,7 @@ class ilUserProfile
             // next group? -> diplay subheader
             if (($p["group"] != $current_group) &&
                 self::userSettingVisible($f)) {
-                if (is_array($custom_fields) && !$custom_fields_done) {
+                if (is_array($custom_fields) && $custom_fields !== [] && !$custom_fields_done) {
                     // should be appended to "other" or at least before "settings"
                     if ($current_group == "other" || $p["group"] == "settings") {
                         // add "other" subheader
@@ -799,7 +797,7 @@ class ilUserProfile
         }
 
         // append custom fields as "other"
-        if (is_array($custom_fields) && !$custom_fields_done) {
+        if (is_array($custom_fields) && $custom_fields !== [] && !$custom_fields_done) {
             // add "other" subheader
             if ($current_group != "other") {
                 $sh = new ilFormSectionHeaderGUI();


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=41012

Both consumers of `\ilUserProfile::addStandardFieldsToForm` provide an empty array as default for `$custom_fields`, so we should check if it is empty when handling the custom fields while rendering the form.

Please check whether this must be picked to `release_9` and/or `trunk`.