### PR TITLE
[FIX] ActiveRecord: PHP 8 dynamic properties

### DIFF
--- a/Services/ActiveRecord/class.ActiveRecord.php
+++ b/Services/ActiveRecord/class.ActiveRecord.php
@@ -24,6 +24,7 @@
  * @description
  * @version 2.0.7
  */
+#[\AllowDynamicProperties]
 abstract class ActiveRecord
 {
     protected bool $ar_safe_read = true;
@@ -721,13 +722,13 @@ abstract class ActiveRecord
             $str[0] = strtoupper($str[0]);
         }
 
-        return preg_replace_callback('/_([a-z])/', fn ($c): string => strtoupper($c[1]), $str);
+        return preg_replace_callback('/_([a-z])/', fn($c): string => strtoupper($c[1]), $str);
     }
 
     protected static function fromCamelCase(string $str): ?string
     {
         $str[0] = strtolower($str[0]);
 
-        return preg_replace_callback('/([A-Z])/', fn ($c): string => "_" . strtolower($c[1]), $str);
+        return preg_replace_callback('/([A-Z])/', fn($c): string => "_" . strtolower($c[1]), $str);
     }
 }


### PR DESCRIPTION
Hi @chfsx,

I noticed a deprecation notice triggered by `ActiveRecord::buildFromArray()` in case of joins, since (if I understood correctly) the joined data is added to the object on which the first join is invoked on, adding the properties dynamically until now. [Since PHP 8.2 this triggers a deprecation notice](https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties) if dynamic properties are created without implementing the corresponding magic methods `__get()` and `__set()`. [According to the manual](https://www.php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.members) it makes sense to accompany them by the `__isset()` and `__unset()` methods - so I implemented them as well.

Let me know if you want to follow up on this.

Kind regards,
@thibsy 