### PR TITLE
8/Learning-Sequence push footer down 41463

### DIFF
--- a/Modules/LearningSequence/templates/default/tpl.kioskpage.html
+++ b/Modules/LearningSequence/templates/default/tpl.kioskpage.html
@@ -1,4 +1,4 @@
-<div id="il_center_col" class="col-sm-12">
+<div id="mainspacekeeper" class="col-sm-12">
 
 	<div class="ilLSOKioskModeObjectHeader">
 		<div class="media il_HeaderInner">

--- a/src/UI/templates/default/MainControls/mode_info.less
+++ b/src/UI/templates/default/MainControls/mode_info.less
@@ -6,21 +6,11 @@
   text-align: center;
 
   z-index: @il-mode-info-zindex;
-  position: absolute;
+  position: fixed;
   height: 100%;
   width: 100%;
   pointer-events: none;
 }
-
-.il-mode-info + div {
-  border: @il-mode-info-border;
-  border-top: 0 none;
-  
-  @media only screen and (max-width: @grid-float-breakpoint-max) {
-    padding-top: @il-mode-info-height;
-  }
-}
-
 
 .il-mode-info span.il-mode-info-content {
   margin: auto;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -10759,19 +10759,10 @@ footer {
   border-right: 3px solid #B54F00;
   text-align: center;
   z-index: 1010;
-  position: absolute;
+  position: fixed;
   height: 100%;
   width: 100%;
   pointer-events: none;
-}
-.il-mode-info + div {
-  border: 3px solid #B54F00;
-  border-top: 0 none;
-}
-@media only screen and (max-width: 768px) {
-  .il-mode-info + div {
-    padding-top: 30px;
-  }
 }
 .il-mode-info span.il-mode-info-content {
   margin: auto;
@@ -11444,7 +11435,7 @@ footer {
   grid-template-areas: "icon title close" "none description description" "none actions actions";
   grid-template-columns: 20px 1fr 20px;
   grid-gap: 9px;
-  box-shadow: 3px 9px 9px 0 rgba(0, 0, 0, 0.3);
+  box-shadow: 3px 9px 9px 0 rgb(0 0 0);
   transform: translateX(150%);
   transition: all 0.25s ease-in-out;
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41463

# Issue

Footer is not positioned at the bottom of the content area.
Header overlaps Slate and content area slightly.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/48b7fccd-773d-4196-8920-f72e39677570)

# Change

Learning Sequence kiosk mode had no content div that actually stretches and pushes the footer down. Used the mainspacekeeper ID for the content area in the html template which comes with the layout styling that was missing in this kiosk mode.

Deleted left overs from a previous implementation of the mode info.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/a99d7142-a9d6-44c4-81cd-66aab8bc4e36)

# Outlook

Footer issue needs to be solved in 9+ as well.
