### PR TITLE
User Bugfix Fix Setup failing because DIC is array

### DIFF
--- a/components/ILIAS/User/classes/Avatar/class.ilUserProfilePictureStakeholder.php
+++ b/components/ILIAS/User/classes/Avatar/class.ilUserProfilePictureStakeholder.php
@@ -30,7 +30,7 @@ class ilUserProfilePictureStakeholder extends AbstractResourceStakeholder
     public function __construct()
     {
         global $DIC;
-        $this->default_owner = $DIC->isDependencyAvailable('user')
+        $this->default_owner = !is_array($DIC) && $DIC->isDependencyAvailable('user')
             ? $DIC->user()->getId()
             : (defined('SYSTEM_USER_ID') ? (int) SYSTEM_USER_ID : 6);
     }


### PR DESCRIPTION
```php
PHP Fatal error:  Uncaught Error: Call to a member function isDependencyAvailable() on array in /var/www/ilias_v2/ILIAS/components/ILIAS/your-component/classes/class.your-stakeholder.php:28
Stack trace:
#0 /var/www/ilias_v2/ILIAS/components/ILIAS/your-component/classes/Setup/class.your-migration.php(62): your-stakeholder->__construct()
#1 /var/www/ilias_v2/ILIAS/components/ILIAS/Setup/src/CLI/MigrateCommand.php(154): your-migration->prepare()
#2 /var/www/ilias_v2/ILIAS/components/ILIAS/Setup/src/CLI/MigrateCommand.php(83): ILIAS\Setup\CLI\MigrateCommand->listMigrations()
#3 /var/www/ilias_v2/ILIAS/vendor/composer/vendor/symfony/console/Command/Command.php(298): ILIAS\Setup\CLI\MigrateCommand->execute()
#4 /var/www/ilias_v2/ILIAS/vendor/composer/vendor/symfony/console/Application.php(1040): Symfony\Component\Console\Command\Command->run()
#5 /var/www/ilias_v2/ILIAS/vendor/composer/vendor/symfony/console/Application.php(301): Symfony\Component\Console\Application->doRunCommand()
#6 /var/www/ilias_v2/ILIAS/vendor/composer/vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun()
#7 /var/www/ilias_v2/ILIAS/components/ILIAS/Setup/src/CLI/App.php(53): Symfony\Component\Console\Application->run()
#8 /var/www/ilias_v2/ILIAS/artifacts/bootstrap_setup.php(3016): ILIAS\Setup\CLI\App->enter()
#9 /var/www/ilias_v2/ILIAS/cli/setup.php(21): entry_point()
#10 {main}
  thrown in /var/www/ilias_v2/ILIAS/components/ILIAS/DataCollection/classes/class.your-stakeholder.php on line 28
```