### PR TITLE
DataCollection: Remove legacy pagination and button on single views

### DIFF
--- a/components/ILIAS/DataCollection/classes/DetailedView/class.ilDclDetailedViewGUI.php
+++ b/components/ILIAS/DataCollection/classes/DetailedView/class.ilDclDetailedViewGUI.php
@@ -31,10 +31,6 @@ class ilDclDetailedViewGUI
     protected ilDclTable $table;
     protected int $tableview_id;
     protected ilDclBaseRecordModel $record_obj;
-    protected int $next_record_id = 0;
-    protected int $prev_record_id = 0;
-    protected int $current_record_position = 0;
-    protected array $record_ids = [];
     protected bool $is_enabled_paging = true;
     protected ilLanguage $lng;
     protected ilCtrlInterface $ctrl;
@@ -66,6 +62,11 @@ class ilDclDetailedViewGUI
                 'record_id',
                 $this->refinery->kindlyTo()->int()
             );
+        } elseif ($this->http->wrapper()->query()->has('record_pos')) {
+            $pos = $this->http->wrapper()->query()->retrieve('record_pos', $this->refinery->kindlyTo()->int());
+            $records = array_values(ilDclTableView::findOrGetInstance($tableview_id)->getTable()->getRecords());
+            $record = $records[$pos] ?? end($records);
+            $this->record_id = $record->getId();
         }
         if ($this->http->wrapper()->post()->has('record_id')) {
             $this->record_id = $this->http->wrapper()->post()->retrieve(
@@ -73,12 +74,11 @@ class ilDclDetailedViewGUI
                 $this->refinery->kindlyTo()->int()
             );
         }
-        $ref_id = $this->dcl_gui_object->getRefId();
 
         if ($this->record_id) {
             $this->record_obj = ilDclCache::getRecordCache($this->record_id);
             $this->table = $this->record_obj->getTable();
-            if (!$this->record_obj->hasPermissionToView($ref_id)) {
+            if (!$this->record_obj->hasPermissionToView($this->dcl_gui_object->getRefId())) {
                 $this->main_tpl->setOnScreenMessage('failure', $this->lng->txt('dcl_msg_no_perm_view'), true);
                 $this->ctrl->redirectByClass(ilDclRecordListGUI::class, "show");
             }
@@ -107,10 +107,6 @@ class ilDclDetailedViewGUI
         if ($this->http->wrapper()->query()->has('disable_paging')
             && $this->http->wrapper()->query()->retrieve('disable_paging', $this->refinery->kindlyTo()->bool())) {
             $this->is_enabled_paging = false;
-        }
-        // Find current, prev and next records for navigation
-        if ($this->is_enabled_paging) {
-            $this->determineNextPrevRecords();
         }
         $this->content_style_domain = $DIC->contentStyle()
                                           ->domain()
@@ -152,6 +148,12 @@ class ilDclDetailedViewGUI
         $this->main_tpl->setOnScreenMessage('info', $this->lng->txt('dcl_msg_info_alternatives'));
         $table_gui = new ilDclTableViewTableGUI($this, 'renderRecord', $this->table, $this->dcl_gui_object->getRefId());
         $tpl->setContent($table_gui->getHTML());
+    }
+
+    public function jumpToRecord(): void
+    {
+        $this->ctrl->setParameterByClass(self::class, 'record_id', $this->record_id);
+        $this->ctrl->redirectByClass(self::class, 'renderRecord');
     }
 
     public function renderRecord(bool $editComments = false): void
@@ -228,36 +230,29 @@ class ilDclDetailedViewGUI
         // Buttons for previous/next records
 
         if ($this->is_enabled_paging) {
-            $prevNextLinks = $this->renderPrevNextLinks();
-            $rctpl->setVariable('PREV_NEXT_RECORD_LINKS', $prevNextLinks);
-            $ilCtrl->clearParameters($this); // #14083
-            $rctpl->setVariable('FORM_ACTION', $ilCtrl->getFormAction($this));
-            $rctpl->setVariable('RECORD', $this->lng->txt('dcl_record'));
-            $rctpl->setVariable(
-                'RECORD_FROM_TOTAL',
-                sprintf(
-                    $this->lng->txt('dcl_record_from_total'),
-                    $this->current_record_position,
-                    count($this->record_ids)
-                )
+            $records = $this->table->getRecords();
+            $DIC->toolbar()->addComponent(
+                $DIC->ui()->factory()->viewControl()->pagination()
+                    ->withTargetURL($this->ctrl->getLinkTargetByClass(self::class, 'jumpToRecord'), 'record_pos')
+                    ->withPageSize(1)
+                    ->withDropdownAt(5)
+                    ->withDropdownLabel($this->lng->txt('entry_of'))
+                    ->withCurrentPage(array_search($this->record_id, array_keys($records)))
+                    ->withTotalEntries(count($records))
+                    ->withMaxPaginationButtons(20)
             );
-            $rctpl->setVariable('TABLEVIEW_ID', $this->tableview_id);
-            $rctpl->setVariable('SELECT_OPTIONS', $this->renderSelectOptions());
         }
 
-        // Edit Button
-        $ref_id = $this->http->wrapper()->query()->retrieve('ref_id', $this->refinery->kindlyTo()->int());
-
-        if ($this->record_obj->hasPermissionToEdit($ref_id)) {
-            $ilCtrl->setParameterByClass(ilDclRecordEditGUI::class, 'table_id', $this->table->getId());
-            $ilCtrl->setParameterByClass(ilDclRecordEditGUI::class, 'tableview_id', $this->tableview_id);
-            $ilCtrl->setParameterByClass(ilDclRecordEditGUI::class, 'redirect', ilDclRecordEditGUI::REDIRECT_DETAIL);
-            $ilCtrl->saveParameterByClass(ilDclRecordEditGUI::class, 'record_id');
-            $edit_button = $this->ui_factory->button()->standard(
+        if ($this->record_obj->hasPermissionToEdit($this->dcl_gui_object->getRefId())) {
+            $DIC->toolbar()->addSpacer('100%');
+            $this->ctrl->setParameterByClass(ilDclRecordEditGUI::class, 'table_id', $this->table->getId());
+            $this->ctrl->setParameterByClass(ilDclRecordEditGUI::class, 'tableview_id', $this->tableview_id);
+            $this->ctrl->setParameterByClass(ilDclRecordEditGUI::class, 'redirect', ilDclRecordEditGUI::REDIRECT_DETAIL);
+            $this->ctrl->saveParameterByClass(ilDclRecordEditGUI::class, 'record_id');
+            $DIC->toolbar()->addComponent($DIC->ui()->factory()->button()->standard(
                 $this->lng->txt('dcl_edit_record'),
-                $ilCtrl->getLinkTargetByClass(ilDclRecordEditGUI::class, 'edit')
-            );
-            $rctpl->setVariable('EDIT_RECORD_BUTTON', $this->renderer->render($edit_button));
+                $this->ctrl->getLinkTargetByClass(ilDclRecordEditGUI::class, 'edit')
+            ));
         }
 
         // Comments
@@ -320,71 +315,6 @@ class ilDclDetailedViewGUI
         }
     }
 
-    /**
-     * Find the previous/next record from the current position. Also determine position of current record in whole set.
-     */
-    protected function determineNextPrevRecords(): void
-    {
-        if (!ilSession::has("dcl_record_ids") || ilSession::get('dcl_record_ids') != $this->table->getId()) {
-            $this->loadSession();
-        }
-
-        if (ilSession::has("dcl_record_ids") && count(ilSession::get("dcl_record_ids"))) {
-            $this->record_ids = ilSession::get("dcl_record_ids");
-            foreach ($this->record_ids as $k => $recId) {
-                if ($recId == $this->record_id) {
-                    if ($k != 0) {
-                        $this->prev_record_id = $this->record_ids[$k - 1];
-                    }
-                    if (($k + 1) < count($this->record_ids)) {
-                        $this->next_record_id = $this->record_ids[$k + 1];
-                    }
-                    $this->current_record_position = $k + 1;
-                    break;
-                }
-            }
-        }
-    }
-
-    /**
-     * Determine and return the markup for the previous/next records
-     */
-    protected function renderPrevNextLinks(): string
-    {
-        global $DIC;
-        $ilCtrl = $DIC['ilCtrl'];
-        $ilCtrl->setParameter($this, 'tableview_id', $this->tableview_id);
-        $prevStr = $this->lng->txt('dcl_prev_record');
-        $nextStr = $this->lng->txt('dcl_next_record');
-        $ilCtrl->setParameter($this, 'record_id', $this->prev_record_id);
-        $url = $ilCtrl->getLinkTarget($this, 'renderRecord');
-        $out = ($this->prev_record_id) ? "<a href='$url'>$prevStr</a>" : "<span class='light'>$prevStr</span>";
-        $out .= " | ";
-        $ilCtrl->setParameter($this, 'record_id', $this->next_record_id);
-        $url = $ilCtrl->getLinkTarget($this, 'renderRecord');
-        $out .= ($this->next_record_id) ? "<a href='$url'>$nextStr</a>" : "<span class='light'>$nextStr</span>";
-
-        return $out;
-    }
-
-    /**
-     * Render select options
-     */
-    protected function renderSelectOptions(): string
-    {
-        $out = '';
-        foreach ($this->record_ids as $k => $recId) {
-            $selected = ($recId == $this->record_id) ? " selected" : "";
-            $out .= "<option value='$recId'$selected>" . ($k + 1) . "</option>";
-        }
-
-        return $out;
-    }
-
-    /**
-     * setOptions
-     * string $link_name
-     */
     private function setOptions(string $link_name): array
     {
         $options = [];
@@ -408,7 +338,7 @@ class ilDclDetailedViewGUI
         );
         //we then partially load the records. note that this also fills up session data.
         $this->table->getPartialRecords(
-            (string)$this->table->getId(),
+            (string) $this->table->getId(),
             $list->getOrderField(),
             $list->getOrderDirection(),
             $list->getLimit(),
@@ -417,13 +347,9 @@ class ilDclDetailedViewGUI
         );
     }
 
-    /**
-     * @return bool
-     */
     protected function checkAccess(): bool
     {
-        $ref_id = $this->dcl_gui_object->getRefId();
-        $has_accass = ilObjDataCollectionAccess::hasAccessTo($ref_id, $this->table->getId(), $this->tableview_id);
+        $has_accass = ilObjDataCollectionAccess::hasAccessTo($this->dcl_gui_object->getRefId(), $this->table->getId(), $this->tableview_id);
         $is_active = ilDclDetailedViewDefinition::isActive($this->tableview_id);
         return $has_accass && $is_active;
     }

--- a/components/ILIAS/DataCollection/templates/default/tpl.record_view.html
+++ b/components/ILIAS/DataCollection/templates/default/tpl.record_view.html
@@ -1,24 +1,4 @@
-<div class="ilDclRecordViewNavWrapper ilClearFloat">
-    <!-- BEGIN paging -->
-    <div class="ilDclRecordViewNav">
-        <span class="ilDclRecordViewRecordOfTotal light">({RECORD_FROM_TOTAL})</span>
-        {PREV_NEXT_RECORD_LINKS}
-        <label for="dcl_select_record" class="ilDclSelectRecord">{RECORD}</label>
-        <form action="{FORM_ACTION}" method="POST" name="dcl_change_record" class="ilDclChangeRecord">
-            <input type="hidden" name="cmd[renderRecord]" value="1">
-            <input type="hidden" name="tableview_id" value="{TABLEVIEW_ID}">
-            <select name="record_id" id="dcl_select_record" onchange="document.dcl_change_record.submit()">
-                {SELECT_OPTIONS}
-            </select>
-        </form>
-    </div>
-    <!-- END paging -->
-    <!-- BEGIN edit_record -->
-    <div class="ilDclEditRecordButtonWrapper">{EDIT_RECORD_BUTTON}</div>
-    <!-- END edit_record -->
-</div>
 <div class="ilc_page_cont_PageContainer">
     <div class="ilc_page_Page">{CONTENT}</div>
 </div>
-<div class="ilDclPermanentLinkWrapper">{PERMA_LINK}</div>
 {COMMENTS}

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -8824,6 +8824,7 @@ dcl#:#dcl_wrong_input_type#:#Der eingegebene Text passt nicht zum Typ dieses Fel
 dcl#:#dcl_wrong_length#:#Der eingegebene Text ist zu lang.
 dcl#:#dcl_wrong_regex#:#Der eingegebene Text passt nicht zur Spezifikation dieses Feldes (regulärer Ausdruck).
 dcl#:#dlc_xls_async_export#:#Asynchroner XLSX-Export
+dcl#:#entry_of#:#Eintrag %1$d von %2$d
 dcl#:#fieldtitle_allow_chars#:#Nicht Erlaubte Zeichen: %s
 dcl#:#fileupload_not_migrated#:#Die Datei wurde noch nicht migriert und kann deshalb nicht angezeigt werden. Bitte wenden Sie sich an Ihre Systemadministration.
 didactic#:#activate_exclusive_template#:#Standard ausgrauen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8818,6 +8818,7 @@ dcl#:#dcl_wrong_input_type#:#The value you entered does not match the specificat
 dcl#:#dcl_wrong_length#:#The text you entered is to long.
 dcl#:#dcl_wrong_regex#:#The text you entered does not match the specification for this field (Regular Expression).
 dcl#:#dlc_xls_async_export#:#Asynchronous XLSX-Export
+dcl#:#entry_of#:#Entry %1$d of %2$d
 dcl#:#fieldtitle_allow_chars#:#Not allowed chars: %s
 dcl#:#fileupload_not_migrated#:#File has not yet been migration and cannot be displayed. Please contact your System-Administrator.
 didactic#:#activate_exclusive_template#:#Grey Out Default


### PR DESCRIPTION
This is part of "Removing LUI".

Removes the legacy pagination and edit button from the single record view withing the DataCollection and replaces both with UI-Framework-Components.

