### PR TITLE
Search: add LSO and all remote objects to search results (38957, 37813)

### DIFF
--- a/Services/Search/classes/Like/class.ilAbstractSearch.php
+++ b/Services/Search/classes/Like/class.ilAbstractSearch.php
@@ -39,7 +39,8 @@ abstract class ilAbstractSearch
      * @var string[]
      */
     protected array $object_types = array('cat','dbk','crs','fold','frm','grp','lm','sahs','glo','mep','htlm','exc','file','qpl','tst','svy','spl',
-                         'chat','webr','mcst','sess','pg','st','wiki','book', 'copa');
+                                          'chat','webr','mcst','sess','pg','st','wiki','book', 'copa', 'lso',
+                                          'rcat', 'rcrs', 'rfil', 'rglo', 'rgrp', 'rlm', 'rtst', 'rwik');
 
     /**
      * @var int[]


### PR DESCRIPTION
This PR fixes [38957](https://mantis.ilias.de/view.php?id=38957) and [37813](https://mantis.ilias.de/view.php?id=37813), by appending the array of allowed object types in search. For LSO everything seems to work fine, but I was not able to test the changes for the remote objects. There could be follow-up issues similar to [38422](https://mantis.ilias.de/view.php?id=38422).

As discussed previously, I will provide a slightly more ambitious PR for trunk, so this only needs to be picked up to 9.