### PR TITLE
WOPI: WOPISrc should be urlencoded

### DIFF
--- a/Services/WOPI/classes/Embed/EmbeddedApplication.php
+++ b/Services/WOPI/classes/Embed/EmbeddedApplication.php
@@ -80,11 +80,11 @@ class EmbeddedApplication
             . '?'
             . self::WOPI_SRC
             . '='
-            . rtrim((string) $this->ilias_base_url, '/')
-            . RequestHandler::WOPI_BASE_URL
-            . RequestHandler::NAMESPACE_FILES
-            . '/'
-            . $this->identification->serialize();
+            . urlencode(rtrim((string) $this->ilias_base_url, '/')
+                        . RequestHandler::WOPI_BASE_URL
+                        . RequestHandler::NAMESPACE_FILES
+                        . '/'
+                        . $this->identification->serialize());
 
         if ($appendices !== []) {
             $url .= '&' . implode('&', $appendices);


### PR DESCRIPTION
This is necessary for Collabora Online 24.04 to work, otherwise it returns a 500 error.

Note: I have been unable to test with other WOPI clients.