### PR TITLE
MediaCast deleted rows in release 8 also delete in class

### DIFF
--- a/Modules/MediaCast/classes/class.ilObjMediaCast.php
+++ b/Modules/MediaCast/classes/class.ilObjMediaCast.php
@@ -225,9 +225,6 @@ class ilObjMediaCast extends ilObject
             ", def_access" .
             ", sortmode" .
             ", viewmode" .
-            ", autoplaymode" .
-            ", nr_initial_videos" .
-            ", new_items_in_lp" .
             " ) VALUES (" .
             $ilDB->quote($this->getId(), "integer")
             . "," . $ilDB->quote((int) $this->getOnline(), "integer")
@@ -236,9 +233,6 @@ class ilObjMediaCast extends ilObject
             . "," . $ilDB->quote((int) $this->getDefaultAccess(), "integer")
             . "," . $ilDB->quote((int) $this->getOrder(), "integer")
             . "," . $ilDB->quote($this->getViewMode(), "text")
-            . "," . $ilDB->quote((int) $this->getAutoplayMode(), "integer")
-            . "," . $ilDB->quote((int) $this->getNumberInitialVideos(), "integer")
-            . "," . $ilDB->quote((int) $this->getNewItemsInLearningProgress(), "integer")
             . ")";
         $ilDB->manipulate($query);
         return $id;
@@ -260,9 +254,6 @@ class ilObjMediaCast extends ilObject
             ", def_access = " . $ilDB->quote($this->getDefaultAccess(), "integer") .
             ", sortmode = " . $ilDB->quote($this->getOrder(), "integer") .
             ", viewmode = " . $ilDB->quote($this->getViewMode(), "text") .
-            ", autoplaymode = " . $ilDB->quote($this->getAutoplayMode(), "integer") .
-            ", nr_initial_videos = " . $ilDB->quote($this->getNumberInitialVideos(), "integer") .
-            ", new_items_in_lp = " . $ilDB->quote($this->getNewItemsInLearningProgress(), "integer") .
             " WHERE id = " . $ilDB->quote($this->getId(), "integer");
 
         $ilDB->manipulate($query);
@@ -288,9 +279,6 @@ class ilObjMediaCast extends ilObject
         $this->setDefaultAccess((int) $rec["def_access"]);
         $this->setOrder((int) $rec["sortmode"]);
         $this->setViewMode((string) $rec["viewmode"]);
-        $this->setAutoplayMode((int) $rec["autoplaymode"]);
-        $this->setNumberInitialVideos((int) $rec["nr_initial_videos"]);
-        $this->setNewItemsInLearningProgress((bool) $rec["new_items_in_lp"]);
     }
 
 


### PR DESCRIPTION
In il_media_cast_data was deleted several rows that not deleted in update and read methode.
Getter and setter are not deleted because they call from outher classes.  That produce other bugs.
That is the solution for calling pages with uploaded audio streams.