### PR TITLE
ILIAS UI: add checked and unchecked to glyphs

### DIFF
--- a/components/ILIAS/UI/src/Component/Symbol/Glyph/Factory.php
+++ b/components/ILIAS/UI/src/Component/Symbol/Glyph/Factory.php
@@ -687,7 +687,6 @@ interface Factory
      */
     public function angry(?string $action = null): Glyph;
 
-
     /**
      * ---
      * description:
@@ -1434,7 +1433,6 @@ interface Factory
      */
     public function link(?string $action = null): Glyph;
 
-
     /**
      * ---
      * description:
@@ -1562,7 +1560,6 @@ interface Factory
      */
     public function sort(?string $action = null): Glyph;
 
-
     /**
      * ---
      * description:
@@ -1584,7 +1581,6 @@ interface Factory
      * @return  \ILIAS\UI\Component\Symbol\Glyph\Glyph
      */
     public function columnSelection(?string $action = null): Glyph;
-
 
     /**
      * ---
@@ -1645,4 +1641,52 @@ interface Factory
      * @return  \ILIAS\UI\Component\Symbol\Glyph\Glyph
      */
     public function dragHandle(?string $action = null): Glyph;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      The Checked Glyph indicates a positive status (e.g. approved/complete/ok/yes/finished/passed)
+     *   composition: >
+     *      The Checked Glyph uses a checkmark.
+     * context:
+     *    - The Checked Glyph can be used in combination with the Unchecked Glyph to display binary states.
+     * rules:
+     *   accessibility:
+     *      1: >
+     *         The aria-label MUST be 'checked'.
+     *   style:
+     *      1: >
+     *         The Checked Glyph SHOULD display a checkmark in the geometric focus of a mono-colored symmetric shape
+     *   usage:
+     *      1: >
+     *         The Checked Glyph SHOULD be used to display a unary state or one option of a binary state.
+     * ---
+     * @return  \ILIAS\UI\Component\Symbol\Glyph\Glyph
+     */
+    public function checked(): Glyph;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      The Unchecked Glyph indicates a negative status (e.g. disapproved/blocked/no/failed/rejected)
+     *   composition: >
+     *      The Unchecked Glyph uses a diagonal cross.
+     * context:
+     *    - The Unchecked Glyph can be used in combination with the Checked Glyph to display binary states.
+     * rules:
+     *   accessibility:
+     *      1: >
+     *         The aria-label MUST be 'unchecked'.
+     *   style:
+     *      1: >
+     *         The Unchecked Glyph SHOULD display a symmetric diagonal cross in the geometric focus of a mono-colored symmetric shape
+     *   usage:
+     *      1: >
+     *         The Unchecked Glyph SHOULD be used to display a unary state or one option of a binary state.
+     * ---
+     * @return  \ILIAS\UI\Component\Symbol\Glyph\Glyph
+     */
+    public function unchecked(): Glyph;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Glyph/Factory.php
@@ -313,4 +313,14 @@ class Factory implements G\Factory
     {
         return new Glyph(G\Glyph::DRAG_HANDLE, "drag_handle", $action);
     }
+
+    public function checked(): G\Glyph
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
+
+    public function unchecked(): G\Glyph
+    {
+        throw new \ILIAS\UI\NotImplementedException();
+    }
 }

--- a/components/ILIAS/UI/src/examples/Symbol/Glyph/Checked/checked.php
+++ b/components/ILIAS/UI/src/examples/Symbol/Glyph/Checked/checked.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Symbol\Glyph\Checked;
+
+/**
+ * ---
+ * description: >
+ *   Example for rendering a Checked Glyph.
+ *
+ * expected output: >
+ * *   Active:
+ * *   ILIAS shows a monochrome heart symbol on a grey background. Moving the cursor above the symbol will darken it's
+ * *   color slightly. Additionally the cursor's form will change and it indicates a linking.
+ * *
+ * *   Inactive:
+ * *   ILIAS shows the same symbol, but it's greyed out. Moving the cursor will not change the presentation.
+ * *
+ * *   Highlighted:
+ * *   ILIAS shows the same symbol but it's highlighted particularly. Moving the cursor above the symbol will darken it's
+ * *   color slightly. Additionally the cursor's form will change and it indicates a linking.
+ * * ---
+ */
+function checked()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $glyph = $f->symbol()->glyph()->checked();
+
+    //Showcase the various states of this Glyph
+    $list = $f->listing()->descriptive([
+        "Active" => $glyph,
+        "Inactive" => $glyph->withUnavailableAction(),
+        "Highlighted" => $glyph->withHighlight()
+    ]);
+
+    return $renderer->render($list);
+}

--- a/components/ILIAS/UI/src/examples/Symbol/Glyph/Unchecked/unchecked.php
+++ b/components/ILIAS/UI/src/examples/Symbol/Glyph/Unchecked/unchecked.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Symbol\Glyph\Unchecked;
+
+/**
+ * ---
+ * description: >
+ *   Example for rendering a Unchecked Glyph.
+ *
+ * expected output: >
+ * *   Active:
+ * *   ILIAS shows a monochrome heart symbol on a grey background. Moving the cursor above the symbol will darken it's
+ * *   color slightly. Additionally the cursor's form will change and it indicates a linking.
+ * *
+ * *   Inactive:
+ * *   ILIAS shows the same symbol, but it's greyed out. Moving the cursor will not change the presentation.
+ * *
+ * *   Highlighted:
+ * *   ILIAS shows the same symbol but it's highlighted particularly. Moving the cursor above the symbol will darken it's
+ * *   color slightly. Additionally the cursor's form will change and it indicates a linking.
+ * * ---
+ */
+function unchecked()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $glyph = $f->symbol()->glyph()->unchecked();
+
+    //Showcase the various states of this Glyph
+    $list = $f->listing()->descriptive([
+        "Active" => $glyph,
+        "Inactive" => $glyph->withUnavailableAction(),
+        "Highlighted" => $glyph->withHighlight()
+    ]);
+
+    return $renderer->render($list);
+}


### PR DESCRIPTION
This PR proposes to add the custom "checked" and "unchecked" to the glyphs, since both are very commonly used in a wide range of cases.

ATM the symbols can only be added via UI-Factory through a custom icon with...
-  a static path, which ignores skin interference
- `getImagePath()`, which is deprecated.