### PR TITLE
fix type error

### DIFF
--- a/Modules/Poll/classes/class.ilObjPollGUI.php
+++ b/Modules/Poll/classes/class.ilObjPollGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\UI\Factory;
 use ILIAS\UI\Renderer;
@@ -613,7 +613,7 @@ class ilObjPollGUI extends ilObject2GUI
 
             // #11810
             ilUtil::redirect(ilLink::_getLink($container_id) .
-                "#poll" . ilObject::_lookupObjId($id[0]));
+                "#poll" . ilObject::_lookupObjId($ref_id));
         }
     }
 }


### PR DESCRIPTION
possible fix for mantis 41587

$ref_id was already typecasted to int and null-checked, si I used it in line 616 instead of $id[0] to fix type error

Copyright notice is adjusted, too