### PR TITLE
T&A 41483: Fix generic title of modal when correcting cloze question

### DIFF
--- a/Modules/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
@@ -172,7 +172,7 @@ class ilAnswerFrequencyStatisticTableGUI extends ilTable2GUI
         $data['question_index'] = $this->getQuestionIndex();
 
         $form = $answer_form_builder->buildAddAnswerForm($data);
-        $modal = $ui_factory->modal()->roundtrip('titel', $form);
+        $modal = $ui_factory->modal()->roundtrip($this->question->getTitle(), $form);
 
         $show_modal_button = $ui_factory->button()->standard(
             $this->language->txt('tst_corr_add_as_answer_btn'),


### PR DESCRIPTION
This PR aims to address the problem reported in Mantis issue https://mantis.ilias.de/view.php?id=41483.

When correcting a cloze question and accepting the user's answer, the generic title "titel" is shown in the modal. This has now been updated to show the current question title as suggested in the ticket.

These changes may also be cherry-picked into release_9.

Kind regards.