### PR TITLE
[Docu] Fixed Links in PRIVACY.mds

### DIFF
--- a/components/ILIAS/AdministrativeNotification/PRIVACY.md
+++ b/components/ILIAS/AdministrativeNotification/PRIVACY.md
@@ -5,7 +5,7 @@ Disclaimer: This documentation does not warrant completeness or correctness. Ple
 - User IDs of the persons that created and last updated the AdministrativeNotification entry as well as the timestamps of the creation and last update of the entry are stored. This data is stored in order to ensure internal traceability regarding timing and authorship in the event of any problems caused by the AdministrativeNotification entry.
 - User IDs of the persons that dismissed the notification are stored. This prevents the AdministrativeNotification service from showing dismissed notifications again.
 - The AdministrativeNotification service employs the following services, please consult the respective privacy.mds:
-  - [GlobalScreen](../../ILIAS/GlobalScreen_/PRIVACY.md)
+  - [GlobalScreen](../../ILIAS/GlobalScreen)
 
 ## Data being presented
 - The AdministrativeNotification service does not present any personal data.

--- a/components/ILIAS/AdministrativeNotification/PRIVACY.md
+++ b/components/ILIAS/AdministrativeNotification/PRIVACY.md
@@ -5,7 +5,7 @@ Disclaimer: This documentation does not warrant completeness or correctness. Ple
 - User IDs of the persons that created and last updated the AdministrativeNotification entry as well as the timestamps of the creation and last update of the entry are stored. This data is stored in order to ensure internal traceability regarding timing and authorship in the event of any problems caused by the AdministrativeNotification entry.
 - User IDs of the persons that dismissed the notification are stored. This prevents the AdministrativeNotification service from showing dismissed notifications again.
 - The AdministrativeNotification service employs the following services, please consult the respective privacy.mds:
-  - [GlobalScreen](../../ILIAS/GlobalScreen)
+  - [GlobalScreen](../../ILIAS/GlobalScreen/docs/PRIVACY.md)
 
 ## Data being presented
 - The AdministrativeNotification service does not present any personal data.

--- a/components/ILIAS/AdministrativeNotification/PRIVACY.md
+++ b/components/ILIAS/AdministrativeNotification/PRIVACY.md
@@ -1,11 +1,11 @@
 # AdministrativeNotification Privacy
-Disclaimer: This documentation does not warrant completeness or correctness. Please report any missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de) or contribute a fix via [Pull Request](docs/development/contributing.md#pull-request-to-the-repositories).
+Disclaimer: This documentation does not warrant completeness or correctness. Please report any missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de) or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 ## Data being stored
 - User IDs of the persons that created and last updated the AdministrativeNotification entry as well as the timestamps of the creation and last update of the entry are stored. This data is stored in order to ensure internal traceability regarding timing and authorship in the event of any problems caused by the AdministrativeNotification entry.
 - User IDs of the persons that dismissed the notification are stored. This prevents the AdministrativeNotification service from showing dismissed notifications again.
 - The AdministrativeNotification service employs the following services, please consult the respective privacy.mds:
-  - [GlobalScreen](../../components/ILIAS/GlobalScreen_/PRIVACY.md)
+  - [GlobalScreen](../../ILIAS/GlobalScreen_/PRIVACY.md)
 
 ## Data being presented
 - The AdministrativeNotification service does not present any personal data.

--- a/components/ILIAS/BookingManager/PRIVACY.md
+++ b/components/ILIAS/BookingManager/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../../docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 ## Integrated Services
 
@@ -11,8 +11,8 @@ or contribute a fix via [Pull Request](../../docs/development/contributing.md#pu
     - The **Object** service stores the account which created the
       object as it's owner and creation and update timestamps for the
       object.
-    - [AccessControl](../../Services/AccessControl/PRIVACY.md)
-    - [Info Screen Service](../../Services/InfoScreen/PRIVACY.md)
+    - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
+    - [Info Screen Service](../../ILIAS/InfoScreen/PRIVACY.md)
 
 ## Configuration
 

--- a/components/ILIAS/Exercise/PRIVACY.md
+++ b/components/ILIAS/Exercise/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../../docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 ## Integrated Services
 
@@ -12,8 +12,8 @@ or contribute a fix via [Pull Request](../../docs/development/contributing.md#pu
     - The **Object** service stores the account which created the
       object as it's owner and creation and update timestamps for the
       object.
-    - [AccessControl](../../Services/AccessControl/PRIVACY.md)
-    - [Info Screen Service](../../Services/InfoScreen/PRIVACY.md)
+    - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
+    - [Info Screen Service](../../ILIAS/InfoScreen/PRIVACY.md)
     - Dedicated assignment types allow to submit exported ILIAS objects as zip files. These objects are **Portfolios**, **Blogs**, **Wikis**.
     - Evaluation statements and notifications can be sent using the **Mail** service.
 

--- a/components/ILIAS/File/PRIVACY.md
+++ b/components/ILIAS/File/PRIVACY.md
@@ -2,7 +2,7 @@
 
 Disclaimer: This documentation does not warrant completeness or correctness. Please report any missing or wrong
 information using the [ILIAS issue tracker](https://mantis.ilias.de) or contribute a fix
-via [Pull Request](docs/development/contributing.md#pull-request-to-the-repositories).
+via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 ## General Information
 
@@ -15,15 +15,15 @@ File Object itself.
 ## Services being used
 
 - The File Object employs the following services, please consult the respective PRIVACY.mds:
-    - [InfoScreen](../../Services/InfoScreen/PRIVACY.md)
-    - [Metadata](../../Services/MetaData/Privacy.md)
-    - [AccessControl](../../Services/AccessControl/PRIVACY.md)
+    - [InfoScreen](../../ILIAS/InfoScreen/PRIVACY.md)
+    - [Metadata](../../ILIAS/MetaData/Privacy.md)
+    - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
     - ECS
-    - [IRSS](../../src/ResourceStorage/PRIVACY.md)
+    - IRSS
     - Learning Progress
-    - [News](../../Services/News/PRIVACY.md)
+    - [News](../../ILIAS/News/PRIVACY.md)
     - Object Service
-    - [Rating](../../Services/Rating/PRIVACY.md)
+    - [Rating](../../ILIAS/Rating/PRIVACY.md)
 
 ## Data being stored
 

--- a/components/ILIAS/File/PRIVACY.md
+++ b/components/ILIAS/File/PRIVACY.md
@@ -19,7 +19,7 @@ File Object itself.
     - [Metadata](../../ILIAS/MetaData/Privacy.md)
     - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
     - ECS
-    - IRSS
+    - [IRSS](../../ILIAS/ResourceStorage/docs/PRIVACY.md)
     - Learning Progress
     - [News](../../ILIAS/News/PRIVACY.md)
     - Object Service

--- a/components/ILIAS/Glossary/PRIVACY.md
+++ b/components/ILIAS/Glossary/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../../docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 ## Integrated Services
 
@@ -11,9 +11,9 @@ or contribute a fix via [Pull Request](../../docs/development/contributing.md#pu
       object as it's owner and creation and update timestamps for the
       object.
     - The **Metadata** service contains two branches: LOM and custom metdata. The LOM offers storing person dates like author. Custom metadata do contain user-created metadata sets which may contain personal data, which must be individually checked in the global administration.)
-    - [AccessControl](../../Services/AccessControl/PRIVACY.md)
-    - [Info Screen Service](../../Services/InfoScreen/PRIVACY.md)
-    - [COPage](../../Services/COPage/PRIVACY.md)
+    - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
+    - [Info Screen Service](../../ILIAS/InfoScreen/PRIVACY.md)
+    - [COPage](../../ILIAS/COPage/PRIVACY.md)
 
 
 ## Configuration

--- a/components/ILIAS/Help/PRIVACY.md
+++ b/components/ILIAS/Help/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../../docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 ## Integrated Services
 
@@ -11,8 +11,8 @@ or contribute a fix via [Pull Request](../../docs/development/contributing.md#pu
       object as it's owner and creation and update timestamps for the
       object.
     - The **Learning Module** service stores all the content of the help modules.
-    - [AccessControl](../../Services/AccessControl/PRIVACY.md)
-    - [COPage](../../Services/COPage/PRIVACY.md)
+    - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
+    - [COPage](../../ILIAS/COPage/PRIVACY.md)
 
 ## Data being stored
 

--- a/components/ILIAS/InfoScreen/PRIVACY.md
+++ b/components/ILIAS/InfoScreen/PRIVACY.md
@@ -2,18 +2,18 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../../docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 ## Integrated Services
 
 - The Info Screen component employs the following services, please consult the respective privacy.mds
   - The **Learning Progress** service manages data on access time specifically last time, number of accesses and the progress status specifically in progress, completed for each user accessing the object.
   - The **Metadata** service contains two branches: LOM and custom metdata. The LOM offers storing person dates like author. Custom metadata do contain user-created metadata sets which may contain personal data, which must be individually checked in the global administration.)
-  - [Notes Service](../../Services/Notes/PRIVACY.md)
+  - [Notes Service](../../ILIAS/Notes/PRIVACY.md)
   - The **Object** service stores the account which created the
     object as it's owner and creation and update timestamps for the
     object.
-  - [Tagging Service](../../Services/Tagging/PRIVACY.md)
+  - [Tagging Service](../../ILIAS/Tagging/PRIVACY.md)
   - WebDav Service
 
 ## Configuration
@@ -29,11 +29,11 @@ or contribute a fix via [Pull Request](../../docs/development/contributing.md#pu
 
 Since the component itself does not store any data, all data being presented is provided by the integrated services. So this is just an overview on personal data being presented, the privacy information of the services may contain detailed information.
 
-- Notes and comments, see [Notes Service](../../Services/Notes/PRIVACY.md)
+- Notes and comments, see [Notes Service](../../ILIAS/Notes/PRIVACY.md)
 - (Personal) learning progress status
 - Metadata, incl. author and contributor information
 - Object creation date and owner (this presentation requires "edit settings" (write) permission)
-- Personal Tags, see [Tagging Service](../../Services/Tagging/PRIVACY.md)
+- Personal Tags, see [Tagging Service](../../ILIAS/Tagging/PRIVACY.md)
 - Locking user (if WebDav is activated)
 
 ## Data being deleted

--- a/components/ILIAS/ItemGroup/PRIVACY.md
+++ b/components/ILIAS/ItemGroup/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../../docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 ## Integrated Services
 
@@ -10,7 +10,7 @@ or contribute a fix via [Pull Request](../../docs/development/contributing.md#pu
   - The **Object** service stores the account which created the
     object as it's owner and creation and update timestamps for the
     object.
-  - [AccessControl](../../Services/AccessControl/PRIVACY.md)
+  - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
 
 
 ## Data being stored

--- a/components/ILIAS/MediaCast/PRIVACY.md
+++ b/components/ILIAS/MediaCast/PRIVACY.md
@@ -13,16 +13,16 @@ or contribute a fix via [Pull Request](../../../docs/development/contributing.md
       object.
     - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
     - [Info Screen Service](../../ILIAS/InfoScreen/PRIVACY.md)
-    - [News Service](../../ILIAS/News/Privacy.md)
+    - [News Service](../../ILIAS/News/PRIVACY.md)
 
 ## General Information
 
-- The **[News Service](../../ILIAS/News/Privacy.md)** service is the foundation of the mediacast. A mediacast entry is a news item with an attached media object.
+- The **[News Service](../../ILIAS/News/PRIVACY.md)** service is the foundation of the mediacast. A mediacast entry is a news item with an attached media object.
 
 ## Configuration
 
 - **Global**
-    - The global mediacast administration allows to set the default access for mediacast entries. If set to **public**, the **RSS** representation will be accessible **without authentication**, see [News Service](../../SILIAS/News/Privacy.md) service.
+    - The global mediacast administration allows to set the default access for mediacast entries. If set to **public**, the **RSS** representation will be accessible **without authentication**, see [News Service](../../SILIAS/News/PRIVACY.md) service.
 - **Mediacast**
     - The mediacast settings allow to (de-)activate the RSS feed and to overwrite the default access (**public RSS** on/off).
 - **Mediacast Entry**

--- a/components/ILIAS/MediaCast/PRIVACY.md
+++ b/components/ILIAS/MediaCast/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../../docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 ## Integrated Services
 
@@ -11,18 +11,18 @@ or contribute a fix via [Pull Request](../../docs/development/contributing.md#pu
     - The **Object** service stores the account which created the
       object as it's owner and creation and update timestamps for the
       object.
-    - [AccessControl](../../Services/AccessControl/PRIVACY.md)
-    - [Info Screen Service](../../Services/InfoScreen/PRIVACY.md)
-    - [News Service](../../Services/News/Privacy.md)
+    - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
+    - [Info Screen Service](../../ILIAS/InfoScreen/PRIVACY.md)
+    - [News Service](../../ILIAS/News/Privacy.md)
 
 ## General Information
 
-- The **[News Service](../../Services/News/Privacy.md)** service is the foundation of the mediacast. A mediacast entry is a news item with an attached media object.
+- The **[News Service](../../ILIAS/News/Privacy.md)** service is the foundation of the mediacast. A mediacast entry is a news item with an attached media object.
 
 ## Configuration
 
 - **Global**
-    - The global mediacast administration allows to set the default access for mediacast entries. If set to **public**, the **RSS** representation will be accessible **without authentication**, see [News Service](../../Services/News/Privacy.md) service.
+    - The global mediacast administration allows to set the default access for mediacast entries. If set to **public**, the **RSS** representation will be accessible **without authentication**, see [News Service](../../SILIAS/News/Privacy.md) service.
 - **Mediacast**
     - The mediacast settings allow to (de-)activate the RSS feed and to overwrite the default access (**public RSS** on/off).
 - **Mediacast Entry**

--- a/components/ILIAS/MediaCast/PRIVACY.md
+++ b/components/ILIAS/MediaCast/PRIVACY.md
@@ -22,7 +22,7 @@ or contribute a fix via [Pull Request](../../../docs/development/contributing.md
 ## Configuration
 
 - **Global**
-    - The global mediacast administration allows to set the default access for mediacast entries. If set to **public**, the **RSS** representation will be accessible **without authentication**, see [News Service](../../SILIAS/News/PRIVACY.md) service.
+    - The global mediacast administration allows to set the default access for mediacast entries. If set to **public**, the **RSS** representation will be accessible **without authentication**, see [News Service](../../ILIAS/News/PRIVACY.md) service.
 - **Mediacast**
     - The mediacast settings allow to (de-)activate the RSS feed and to overwrite the default access (**public RSS** on/off).
 - **Mediacast Entry**

--- a/components/ILIAS/Portfolio/PRIVACY.md
+++ b/components/ILIAS/Portfolio/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../../docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 ## Integrated Services
 
@@ -10,7 +10,7 @@ or contribute a fix via [Pull Request](../../docs/development/contributing.md#pu
     - The **Object** service stores the account which created the
       object as it's owner and creation and update timestamps for the
       object.
-    - [COPage](../../Services/COPage/PRIVACY.md)
+    - [COPage](../../ILIAS/COPage/PRIVACY.md)
     - The **Blog** module allows to create blog postings shared with others. These blogs can be integrated into a portfolio.
     - The **User** service stores personal data like name, address and birthday.
     - The **Learning History** service collects data related to learning activites like received badges or successful completions of courses.
@@ -39,7 +39,7 @@ The main purpose of portfolios is to present information about its creator to ot
 
 ## Data being stored
 
-Single portfolio pages are stored using the [COPage](../../Services/COPage/PRIVACY.md) service. The author may include any personal content in these pages. The pages are not structured with any personal data related scheme (like e.g. the user service storing birthday, name or address information).
+Single portfolio pages are stored using the [COPage](../../ILIAS/COPage/PRIVACY.md) service. The author may include any personal content in these pages. The pages are not structured with any personal data related scheme (like e.g. the user service storing birthday, name or address information).
 
 The Blog module is being used to store blog postings. Similar almost everything included in a portfolio is data being stored by the integrated services.
 

--- a/components/ILIAS/Repository/PRIVACY.md
+++ b/components/ILIAS/Repository/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](./docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](../../../docs/development/contributing.md#pull-request-to-the-repositories).
 
 
 ## General Information

--- a/components/ILIAS/Repository/PRIVACY.md
+++ b/components/ILIAS/Repository/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../../docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](/docs/development/contributing.md#pull-request-to-the-repositories).
 
 
 ## General Information
@@ -12,7 +12,7 @@ The repository manages learning resources (aka objects) in a tree structure. Ple
 ## Integrated Services
 
 - In general the specific object components decide which sub-services they are using, you will find this information in the respective privacy.md files of these components. All object types are using the access control service:
-  - [AccessControl](../../Services/AccessControl/PRIVACY.md)
+  - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
 
 ## Configuration
 
@@ -27,7 +27,7 @@ The following configurations configure privacy related features:
 ## Data being stored
 
 - If a user selects a repository object as a "favourite" object, the user ID and the object ID are being stored together in table desktop_items. _Reason_: This data is essential to provide the Favourits feature at all.
-- Recommended content is managed by storing the object ID and the role ID. Content is currently only recommended to roles. User IDs are assigned to roles in the [AccessControl](../../Services/AccessControl/PRIVACY.md) service. 
+- Recommended content is managed by storing the object ID and the role ID. Content is currently only recommended to roles. User IDs are assigned to roles in the [AccessControl](../../ILIAS/AccessControl/PRIVACY.md) service. 
 - The service holds an implementation that to store user IDs to object IDs directly, however this is currently unused (and may never be used), see discussion at https://docu.ilias.de/goto_docu_wiki_wpage_5620_1357.html
 
 ## Data presentation

--- a/components/ILIAS/Repository/PRIVACY.md
+++ b/components/ILIAS/Repository/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](../docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](./docs/development/contributing.md#pull-request-to-the-repositories).
 
 
 ## General Information

--- a/components/ILIAS/Repository/PRIVACY.md
+++ b/components/ILIAS/Repository/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This documentation does not warrant completeness or correctness. Please report any
 missing or wrong information using the [ILIAS issue tracker](https://mantis.ilias.de)
-or contribute a fix via [Pull Request](/docs/development/contributing.md#pull-request-to-the-repositories).
+or contribute a fix via [Pull Request](../docs/development/contributing.md#pull-request-to-the-repositories).
 
 
 ## General Information

--- a/components/ILIAS/TestQuestionPool/PRIVACY.md
+++ b/components/ILIAS/TestQuestionPool/PRIVACY.md
@@ -23,7 +23,7 @@ but always at both.
   Owners of questions are stored in the TestQuestionPool as reference to the users id. 
   The data is required to manage detailed access and permissions on usage and editing of the question.
   
-- The TestQuestions Pool component employs the following services, please consult the respective privacy.mds: [Skill](../../Services/Skill/PRIVACY.md), [Metadata](../../Services/MetaData/Privacy.md), [AccessControl](../../Services/AccessControl/PRIVACY.md)
+- The TestQuestions Pool component employs the following services, please consult the respective privacy.mds: [Skill](../../Skill/PRIVACY.md), [Metadata](../../MetaData/Privacy.md), [AccessControl](../../AccessControl/PRIVACY.md)
 
 
 ## Data being presented 

--- a/components/ILIAS/TestQuestionPool/PRIVACY.md
+++ b/components/ILIAS/TestQuestionPool/PRIVACY.md
@@ -23,7 +23,7 @@ but always at both.
   Owners of questions are stored in the TestQuestionPool as reference to the users id. 
   The data is required to manage detailed access and permissions on usage and editing of the question.
   
-- The TestQuestions Pool component employs the following services, please consult the respective privacy.mds: [Skill](../../Skill/PRIVACY.md), [Metadata](../../MetaData/Privacy.md), [AccessControl](../../AccessControl/PRIVACY.md)
+- The TestQuestions Pool component employs the following services, please consult the respective privacy.mds: [Skill](../../ILIAS/Skill/PRIVACY.md), [Metadata](../../ILIAS/MetaData/Privacy.md), [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
 
 
 ## Data being presented 


### PR DESCRIPTION
As a result of the directory structure migration end of last year, several links in several PRIVACY.mds were leading to 404 pages. That issue has been taken care of with this PR.