### PR TITLE
T&A, fix Test for QuestionpoolExport

### DIFF
--- a/components/ILIAS/TestQuestionPool/tests/assBaseTestCase.php
+++ b/components/ILIAS/TestQuestionPool/tests/assBaseTestCase.php
@@ -79,6 +79,9 @@ abstract class assBaseTestCase extends TestCase
         if (!defined("ILIAS_LOG_FILE")) {
             define("ILIAS_LOG_FILE", '/var/log/ilias.log');
         }
+        if (!defined("IL_INST_ID")) {
+            define("IL_INST_ID", 0);
+        }
         parent::setUp();
     }
 


### PR DESCRIPTION
Seed: 1719492809

1) ilQuestionpoolExportTest::testConstruct
Error: Undefined constant "IL_INST_ID"
/home/runner/work/ILIAS/ILIAS/components/ILIAS/TestQuestionPool/classes/class.ilQuestionpoolExport.php:62
/home/runner/work/ILIAS/ILIAS/components/ILIAS/TestQuestionPool/tests/ilQuestionpoolExportTest.php:41