### PR TITLE
[FIX] #41560 UI: Footer Link Colours

### DIFF
--- a/src/UI/templates/default/MainControls/footer.less
+++ b/src/UI/templates/default/MainControls/footer.less
@@ -24,7 +24,10 @@ footer{
 			display: inline-block;
 			margin-right: @il-margin-xs-horizontal;
 			a, button {
-				color: @il-link-color;
+				color: @il-footer-link-color;
+			}
+			a:hover, button:hover {
+				color: @il-footer-link-hover-color;
 			}
 			button {
 				vertical-align: baseline;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -10733,6 +10733,10 @@ footer {
 .il-maincontrols-footer .il-footer-links li button {
   color: #4c6586;
 }
+.il-maincontrols-footer .il-footer-links li a:hover,
+.il-maincontrols-footer .il-footer-links li button:hover {
+  color: #3a4c65;
+}
 .il-maincontrols-footer .il-footer-links li button {
   vertical-align: baseline;
 }

--- a/templates/default/less/variables.less
+++ b/templates/default/less/variables.less
@@ -311,6 +311,9 @@ with the il- variable set here.
 @il-footer-height: 45px;
 //** controls margin from the footer to the main content, increase/decrase depending on the content (default, space for 4 lines).
 @il-footer-margin-bottom: 2*@il-line-height-computed*2;
+//** controls link colours inside the footer, see https://mantis.ilias.de/view.php?id=41560
+@il-footer-link-color: @il-link-color;
+@il-footer-link-hover-color: @il-link-hover-color;
 
 //== Buttons
 //


### PR DESCRIPTION
Hi folks,

This PR introduces two less variables `@il-footer-link-color` and `@il-footer-link-hover-color` which can be used to style links differently inside the footer. I defaulted them to the `@il-link-color` and `@il-link-hover-color` variables. This solutions is needed to address [a mantis issue](https://mantis.ilias.de/view.php?id=41560), which describes contrast issues with dark footer background colours.

While adding these variables I also noticed, the `@il-link-hover-color` was never assigned, so I have added this with the PR as well.

Kind regards,
@thibsy 