### PR TITLE
UI/DataTable: do not double actions with same key for multi-dropdown

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Table/AbstractTable.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/AbstractTable.php
@@ -188,7 +188,7 @@ abstract class AbstractTable extends Table implements JSBindable
      */
     public function getAllActions(): array
     {
-        return array_merge($this->actions_single, $this->actions_multi, $this->actions_std);
+        return array_replace($this->actions_single, $this->actions_multi, $this->actions_std);
     }
 
     public function getColumnCount(): int


### PR DESCRIPTION
Actions happend to appear more than once in the MultiAction Dropdown.