### PR TITLE
T&A 41605 Fix HTML escaping for single-line question answers

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -35,6 +35,8 @@ require_once './Modules/Test/classes/inc.AssessmentConstants.php';
  */
 class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjustable, ilObjAnswerScoringAdjustable, iQuestionCondition, ilAssSpecificFeedbackOptionLabelProvider
 {
+    use ChoiceQuestionAnswerTypeAwareTrait;
+
     /**
      * The given answers of the multiple choice question
      *
@@ -54,6 +56,10 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      */
     public $output_type;
 
+    /**
+     * @var bool
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0. Use isSingleLineAnswerType() instead.
+     */
     public $isSingleline;
     public $lastChange;
     public $feedback_setting;
@@ -65,14 +71,28 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
 
     /**
      * @param mixed $isSingleline
+     *
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0.
+     *             Use setAnswerType(ChoiceQuestionAnswerType::SINGLE_LINE) instead.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
      */
     public function setIsSingleline($isSingleline): void
     {
         $this->isSingleline = $isSingleline;
+        $this->setAnswerType($isSingleline ? ChoiceQuestionAnswerType::SINGLE_LINE : ChoiceQuestionAnswerType::MULTI_LINE);
     }
 
     /**
      * @return mixed
+     *
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0. Use isSingleLineAnswerType() instead.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
      */
     public function getIsSingleline()
     {
@@ -164,7 +184,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      */
     protected function rebuildThumbnails(): void
     {
-        if ($this->isSingleline && ($this->getThumbSize())) {
+        if ($this->isSingleLineAnswerType() && ($this->getThumbSize())) {
             foreach ($this->getAnswers() as $answer) {
                 if (strlen($answer->getImage())) {
                     $this->generateThumbForFile($this->getImagePath(), $answer->getImage());
@@ -241,7 +261,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             if ($data['thumb_size'] !== null && $data['thumb_size'] >= self::MINIMUM_THUMB_SIZE) {
                 $this->setThumbSize($data['thumb_size']);
             }
-            $this->isSingleline = ($data['allow_images']) ? false : true;
+            $this->setIsSingleline(($data['allow_images'] === '0') ? false : true);
             $this->lastChange = $data['tstamp'];
             $this->setSelectionLimit((int) $data['selection_limit'] > 0 ? (int) $data['selection_limit'] : null);
             $this->feedback_setting = $data['feedback_setting'];
@@ -703,7 +723,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         global $DIC;
         $ilDB = $DIC['ilDB'];
         $oldthumbsize = 0;
-        if ($this->isSingleline && ($this->getThumbSize())) {
+        if ($this->isSingleLineAnswerType() && ($this->getThumbSize())) {
             // get old thumbnail size
             $result = $ilDB->queryF(
                 "SELECT thumb_size FROM " . $this->getAdditionalTableName() . " WHERE question_fi = %s",
@@ -716,7 +736,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             }
         }
 
-        if (!$this->isSingleline) {
+        if (!$this->isSingleLineAnswerType()) {
             ilFileUtils::delDir($this->getImagePath());
         }
 
@@ -725,7 +745,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             $this->getAdditionalTableName(),
             [
                 'shuffle' => array('text', $this->getShuffle()),
-                'allow_images' => array('text', $this->isSingleline ? 0 : 1),
+                'allow_images' => array('text', $this->isSingleLineAnswerType() ? "1" : "0"),
                 'thumb_size' => array('integer', strlen($this->getThumbSize()) ? $this->getThumbSize() : null),
                 'selection_limit' => array('integer', $this->getSelectionLimit()),
                 'feedback_setting' => array('integer', $this->getSpecificFeedbackSetting())
@@ -928,7 +948,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
                     $result = 1;
                 } else {
                     // create thumbnail file
-                    if ($this->isSingleline && ($this->getThumbSize())) {
+                    if ($this->isSingleLineAnswerType() && ($this->getThumbSize())) {
                         $this->generateThumbForFile($imagepath, $image_filename);
                     }
                 }
@@ -1187,6 +1207,14 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         }
     }
 
+    /**
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0. Use isSingleLine() instead.
+     *             The new method name may be subject to change.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
+     */
     public function getMultilineAnswerSetting(): int
     {
         global $DIC;
@@ -1199,6 +1227,14 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         return $multilineAnswerSetting;
     }
 
+    /**
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0. Use setIsSingleLine() instead.
+     *             The new method name may be subject to change.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
+     */
     public function setMultilineAnswerSetting($a_setting = 0): void
     {
         global $DIC;
@@ -1482,6 +1518,15 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         return $config;
     }
 
+    /**
+     * @return bool
+     *
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0. Use isSingleLineAnswerType() instead.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
+     */
     public function isSingleline()
     {
         return (bool) $this->isSingleline;

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -86,8 +86,16 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
      * Get the single/multiline editing of answers
      * - The settings of an already saved question is preferred
      * - A new question will use the setting of the last edited question by the user
+     *
      * @param bool	$checkonly	get the setting for checking a POST
+     *
      * @return bool
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0. Use assMultipleChoice::isSingleline() instead.
+     *             The new method name may be subject to change.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
      */
     protected function getEditAnswersSingleLine($checkonly = false): bool
     {
@@ -696,7 +704,10 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
     {
         // Delete all existing answers and create new answers from the form data
         $this->object->flushAnswers();
-        $choice = $this->cleanupAnswerText($_POST['choice'], $this->object->isSingleline() === false);
+        $choice = $_POST['choice'];
+        if($this->object->hasAnswerTypeChanged() || !$this->object->isSingleline()) {
+            $choice = $this->cleanupAnswerText($choice, !$this->object->isSingleline());
+        }
         if ($this->object->isSingleline()) {
             foreach ($choice['answer'] as $index => $answertext) {
                 $answertext = htmlentities($answertext);

--- a/Modules/TestQuestionPool/classes/class.assSingleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoice.php
@@ -33,7 +33,7 @@ require_once './Modules/Test/classes/inc.AssessmentConstants.php';
  */
 class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjustable, ilObjAnswerScoringAdjustable, iQuestionCondition, ilAssSpecificFeedbackOptionLabelProvider
 {
-    private bool $isSingleline = true;
+    use ChoiceQuestionAnswerTypeAwareTrait;
 
     /**
     * The given answers of the single choice question
@@ -130,7 +130,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         }
         // kann das weg?
         $oldthumbsize = 0;
-        if ($this->isSingleline && ($this->getThumbSize())) {
+        if ($this->isSingleLineAnswerType() && ($this->getThumbSize())) {
             // get old thumbnail size
             $result = $ilDB->queryF(
                 "SELECT thumb_size FROM " . $this->getAdditionalTableName() . " WHERE question_fi = %s",
@@ -156,7 +156,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
     */
     protected function rebuildThumbnails(): void
     {
-        if ($this->isSingleline && ($this->getThumbSize())) {
+        if ($this->isSingleLineAnswerType() && ($this->getThumbSize())) {
             foreach ($this->getAnswers() as $answer) {
                 if (strlen($answer->getImage())) {
                     $this->generateThumbForFile($this->getImagePath(), $answer->getImage());
@@ -188,7 +188,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
                     $ext = 'JPEG';
                     break;
             }
-            ilShellUtil::convertImage($filename, $thumbpath, $ext, (string)$this->getThumbSize());
+            ilShellUtil::convertImage($filename, $thumbpath, $ext, (string) $this->getThumbSize());
         }
     }
 
@@ -226,7 +226,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
             if ($data['thumb_size'] !== null && $data['thumb_size'] >= self::MINIMUM_THUMB_SIZE) {
                 $this->setThumbSize($data['thumb_size']);
             }
-            $this->isSingleline = ($data['allow_images']) ? false : true;
+            $this->setIsSingleline(($data['allow_images'] === '0') ? false : true);
             $this->lastChange = $data['tstamp'];
             $this->feedback_setting = $data['feedback_setting'];
 
@@ -714,7 +714,7 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
             array(
                                 $this->getId(),
                                 $this->getShuffle(),
-                                ($this->isSingleline) ? "0" : "1",
+                                ($this->isSingleline) ? "1" : "0",
                                 (strlen($this->getThumbSize()) == 0) ? null : $this->getThumbSize()
                             )
         );
@@ -1167,6 +1167,13 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         }
     }
 
+    /**
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0. Use isSingleLineAnswerType() instead.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
+     */
     public function getMultilineAnswerSetting()
     {
         global $DIC;
@@ -1179,6 +1186,13 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         return $multilineAnswerSetting;
     }
 
+    /**
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0. Use setAnswerType() instead.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
+     */
     public function setMultilineAnswerSetting($a_setting = 0): void
     {
         global $DIC;
@@ -1359,14 +1373,33 @@ class assSingleChoice extends assQuestion implements ilObjQuestionScoringAdjusta
         }
     }
 
+    /**
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0. Use isSingleLineAnswerType() instead.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
+     */
     public function isSingleline(): bool
     {
-        return $this->isSingleline;
+        return $this->isSingleLineAnswerType();
     }
 
+    /**
+     * @param bool $isSingleline
+     *
+     * @return void
+     *
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0.
+     *             Use isSingleLineAnswerType(ChoiceQuestionAnswerType::SINGLE_LINE) instead.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
+     */
     public function setIsSingleline(bool $isSingleline): void
     {
-        $this->isSingleline = $isSingleline;
+        $this->setAnswerType($isSingleline ? ChoiceQuestionAnswerType::SINGLE_LINE : ChoiceQuestionAnswerType::MULTI_LINE);
     }
 
     public function getFeedbackSetting(): int

--- a/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -80,8 +80,17 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
      * Get the single/multiline editing of answers
      * - The settings of an already saved question is preferred
      * - A new question will use the setting of the last edited question by the user
+     *
      * @param bool	$checkonly	get the setting for checking a POST
+     *
      * @return bool
+     *
+     * @deprecated Deprecated since ILIAS 8.14, will be removed in ILIAS 10.0. Use assSingleChoice::isSingleline() instead.
+     *             The new method name may be subject to change.
+     *             The method will be removed due to its redundant nature and because this method implements specific
+     *             behaviour only for this question type. In order to maintain consistency and avoid unnecessary complexity
+     *             in the codebase, it's beneficial to remove such specific behaviors that are not shared across different
+     *             question types.
      */
     protected function getEditAnswersSingleLine($checkonly = false): bool
     {
@@ -639,7 +648,10 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
     {
         // Delete all existing answers and create new answers from the form data
         $this->object->flushAnswers();
-        $choice = $this->cleanupAnswerText($_POST['choice'], $this->object->isSingleline() === false);
+        $choice = $_POST['choice'];
+        if($this->object->hasAnswerTypeChanged() || !$this->object->isSingleline()) {
+            $choice = $this->cleanupAnswerText($choice, !$this->object->isSingleline());
+        }
         if ($this->object->isSingleline()) {
             foreach ($choice['answer'] as $index => $answertext) {
                 $answertext = htmlentities($answertext);

--- a/Modules/TestQuestionPool/classes/questions/ChoiceQuestionAnswerType.php
+++ b/Modules/TestQuestionPool/classes/questions/ChoiceQuestionAnswerType.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ChoiceQuestionAnswerType
+{
+    public const SINGLE_LINE = 'singleLine';
+    public const MULTI_LINE = 'multiLine';
+}

--- a/Modules/TestQuestionPool/classes/questions/ChoiceQuestionAnswerTypeAwareTrait.php
+++ b/Modules/TestQuestionPool/classes/questions/ChoiceQuestionAnswerTypeAwareTrait.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * This trait is used inside of question classes to track if the answer type has changed during the request.
+ */
+trait ChoiceQuestionAnswerTypeAwareTrait
+{
+    /**
+     * @var string The answer type of the question.
+     */
+    private string $answer_type = ChoiceQuestionAnswerType::SINGLE_LINE;
+
+    /**
+     * @var bool True, if the answer type has changed during the request.
+     */
+    private bool $answer_type_changed = false;
+
+    /**
+     * Returns the valid answer types for the question.
+     */
+    public function getValidAnswerTypes(): array
+    {
+        return [ChoiceQuestionAnswerType::SINGLE_LINE, ChoiceQuestionAnswerType::MULTI_LINE];
+    }
+
+    /**
+     * Returns the select options for the answer type used inside form elements.
+     */
+    public function getAnswerTypeSelectOptions(ilLanguage $lng): array
+    {
+        return [
+            ChoiceQuestionAnswerType::SINGLE_LINE => $lng->txt('answers_singleline'),
+            ChoiceQuestionAnswerType::MULTI_LINE => $lng->txt('answers_multiline')
+        ];
+    }
+
+    /**
+     * Set the answer type of the question.
+     */
+    public function setAnswerType(string $answer_type): void
+    {
+        $this->setAnswerTypeChanged($this->answer_type !== $answer_type);
+        $this->answer_type = $answer_type;
+    }
+
+    /**
+     * Returns the answer type of the question.
+     */
+    public function getAnswerType(): string
+    {
+        return $this->answer_type;
+    }
+
+    /**
+     * Returns true, if the answer type of the question is the given type.
+     */
+    public function isAnswerType(string $answerType): bool
+    {
+        return $this->getAnswerType() === $answerType;
+    }
+
+    public function isSingleLineAnswerType(): bool
+    {
+        return $this->isAnswerType(ChoiceQuestionAnswerType::SINGLE_LINE);
+    }
+
+    /**
+     * Returns true, if the given answer type is valid for the question.
+     */
+    public function isValidAnswerType($answerType): bool
+    {
+        return in_array($answerType, $this->getValidAnswerTypes());
+    }
+
+    /**
+     * Set true, if the answer type has changed.
+     * This method should be called from within the setter of the answer type.
+     */
+    protected function setAnswerTypeChanged(bool $changed): void
+    {
+        $this->answer_type_changed = $changed;
+    }
+
+    /**
+     * Returns true, if the answer type has changed.
+     */
+    public function hasAnswerTypeChanged(): bool
+    {
+        return $this->answer_type_changed;
+    }
+}


### PR DESCRIPTION
This PR addresses the issue reported in https://mantis.ilias.de/view.php?id=41605.

Previously, HTML escaping was applied to resolve https://mantis.ilias.de/view.php?id=36167, which removed all HTML tags from answer text. This commit updates the behavior to retain HTML tags in single-line answers unless the answer type has changed or the answer is in multiline mode. Additionally, it fixes an issue encountered after importing a question pool with single-choice questions using multiline answers. The system did not correctly detect the edit mode and displayed a multiline answer as a single-line input field containing all tags. This bug was reported by @dsstrassner. I was able to reproduce and fix it, though I could not find a related Mantis ticket.

This PR also introduces some deprecations on methods, which will be reworked or removed in ILIAS 10. These changes can be cherry-picked into release_9. For the trunk, I will prepare a separate PR to remove the deprecations and make further adjustments.