### PR TITLE
T&A 41371: Fix competence path not displaying properly

### DIFF
--- a/Modules/Test/templates/default/tpl.tst_skl_qst_assignment_row.html
+++ b/Modules/Test/templates/default/tpl.tst_skl_qst_assignment_row.html
@@ -5,6 +5,7 @@
 		<div class="small light">{QUESTION_DESCRIPTION}</div>
 	</td>
 	<!-- END question_title -->
+	<td style="display: none;"></td>
 	<td class="std">
 		<div>{COMPETENCE}</div>
 		<div class="small light">{COMPETENCE_PATH}</div>

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignment.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignment.php
@@ -38,6 +38,11 @@ class ilAssQuestionSkillAssignment
     private $db;
 
     /**
+     * @var ilLanguage
+     */
+    private $lng;
+
+    /**
      * @var integer
      */
     private $parentObjId;
@@ -89,6 +94,7 @@ class ilAssQuestionSkillAssignment
         global $DIC;
 
         $this->db = $db;
+        $this->lng = $DIC->language();
 
         $this->solutionComparisonExpressionList = new ilAssQuestionSolutionComparisonExpressionList($this->db);
         $this->skill_tree_service = $DIC->skills()->tree();
@@ -328,6 +334,10 @@ class ilAssQuestionSkillAssignment
 
         $nodes = array();
         foreach ($path as $node) {
+            if ($node['title'] === "Skill Tree Root Node") {
+                $node['title'] = $this->lng->txt('qpl_skill_tree_root_node_title');
+            }
+
             if ($node['child'] > 1 && $node['skill_id'] != $this->getSkillBaseId()) {
                 $nodes[] = $node['title'];
             }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1061,6 +1061,7 @@ assessment#:#qpl_skill_point_eval_by_quest_result#:#Ermittlung der Kompetenzpunk
 assessment#:#qpl_skill_point_eval_by_solution_compare#:#Ermittlung der Kompetenzpunkte durch Lösungsvergleich
 assessment#:#qpl_skill_point_eval_mode_quest_result#:#Antwortergebnis
 assessment#:#qpl_skill_point_eval_mode_solution_compare#:#Lösungsvergleich
+assessment#:#qpl_skill_tree_root_node_title#:#Startknoten
 assessment#:#qpl_skl_sub_tab_quest_assign#:#Fragen-Kompetenz-Zuordnung
 assessment#:#qpl_skl_sub_tab_usages#:#Vergabehäufigkeit
 assessment#:#qpl_sync_quest_skl_assigns_confirmation#:#Die Frage wurde aus einem anderen Magazinobjekt eingefügt. Soll die aktuelle Konfiguration von Kompetenzzuweisungen auf das Original der Frage übertragen werden?

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1061,6 +1061,7 @@ assessment#:#qpl_skill_point_eval_by_quest_result#:#Evaluation of Competence Poi
 assessment#:#qpl_skill_point_eval_by_solution_compare#:#Evaluation of Competence Points by Solution Compare
 assessment#:#qpl_skill_point_eval_mode_quest_result#:#Question Result
 assessment#:#qpl_skill_point_eval_mode_solution_compare#:#Solution Compare
+assessment#:#qpl_skill_tree_root_node_title#:#Skill Tree Root Node
 assessment#:#qpl_skl_sub_tab_quest_assign#:#Question/Competence Assignment
 assessment#:#qpl_skl_sub_tab_usages#:#Assignment Frequency
 assessment#:#qpl_sync_quest_skl_assigns_confirmation#:#The question was inserted from another repository object. Should the question's original be updated with the current config of competence assignments?


### PR DESCRIPTION
This PR aims to address the problem reported in Mantis issue https://mantis.ilias.de/view.php?id=41371.

When assigning one or multiple competences to a question in a test, the root node of the competence isn't properly displayed. To provide better readability, I have added language variables in both German and English to replace the root node title accordingly.

Adding onto that, I have also removed a CSS selector that added padding, which made the first competence not align with the others.

Kind regards.