### PR TITLE
T&A: 37677, Fix wrong order of units in formula question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
@@ -116,13 +116,19 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
         }
     }
 
-    public function getResultUnits($result)
+    public function getResultUnits(assFormulaQuestionResult $result): array
     {
-        if (array_key_exists($result->getResult(), $this->resultunits)) {
-            return $this->resultunits[$result->getResult()];
-        } else {
-            return array();
+        if (!isset($this->resultunits[$result->getResult()])) {
+            return [];
         }
+
+        $result_units = $this->resultunits[$result->getResult()];
+
+        usort($result_units, static function (assFormulaQuestionUnit $a, assFormulaQuestionUnit $b) {
+            return $a->getSequence() <=> $b->getSequence();
+        });
+
+        return $result_units;
     }
 
     public function getAllResultUnits(): array
@@ -318,10 +324,11 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
                 }
 
                 $units = "";
-                if (count($this->getResultUnits($resObj)) > 0) {
+                $result_units = $this->getResultUnits($resObj);
+                if (count($result_units) > 0) {
                     if ($forsolution) {
                         if (is_array($userdata)) {
-                            foreach ($this->getResultUnits($resObj) as $unit) {
+                            foreach ($result_units as $unit) {
                                 if (isset($userdata[$result]["unit"]) && $userdata[$result]["unit"] == $unit->getId()) {
                                     $units = $unit->getUnit();
                                 }
@@ -334,7 +341,7 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition
                     } else {
                         $units = '<select name="result_' . $result . '_unit">';
                         $units .= '<option value="-1">' . $this->lng->txt("select_unit") . '</option>';
-                        foreach ($this->getResultUnits($resObj) as $unit) {
+                        foreach ($result_units as $unit) {
                             $units .= '<option value="' . $unit->getId() . '"';
                             if (array_key_exists($result, $userdata) &&
                                 is_array($userdata[$result]) &&


### PR DESCRIPTION
When creating a formula question you can use units and select a sequence of these units.
If the sequence of these units is changed, the user is still shown the orginal creation order.

I believe this is a valid solution for the issue.

[Mantis: 37677](https://mantis.ilias.de/view.php?id=37677)