### PR TITLE
[FIX] UI #37494: distinguish and apply array-parameters (#6279)

### DIFF
--- a/src/UI/templates/js/Core/dist/core.js
+++ b/src/UI/templates/js/Core/dist/core.js
@@ -162,6 +162,93 @@ var il = il || {};
      ********************************************************************
      */
 
+
+    const URLBuilderTokenSeparator = '_';
+    const URLBuilderTokenLength = 24;
+
+    class URLBuilderToken {
+      /**
+         * @type {string[]}
+         */
+      #namespace = [];
+
+      /**
+         * @type {string}
+         */
+      #parameterName = '';
+
+      /**
+         * @type {string|null}
+         */
+      #token = null;
+
+      /**
+       * @type {string}
+       */
+      #name = '';
+
+      /**
+         * @param {string[]} namespace
+         * @param {string} parameterName
+         * @param {string|null} token
+         */
+      constructor(namespace, parameterName, token = null) {
+        this.#namespace = namespace;
+        this.#parameterName = parameterName;
+        this.#token = token;
+        if (this.#token === null) {
+          this.#token = URLBuilderToken.createToken();
+        }
+        this.#name = this.#namespace.join(URLBuilderTokenSeparator) + URLBuilderTokenSeparator;
+        this.#name += this.#parameterName;
+      }
+
+      /**
+         * @returns {string|null}
+         */
+      getToken() {
+        return this.#token;
+      }
+
+      /**
+         * @returns {string}
+         */
+      getName() {
+        return this.#name;
+      }
+
+      /**
+         * @returns {string}
+         */
+      static createToken() {
+        let token = '';
+        const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        const charactersLength = characters.length;
+        while (token.length < URLBuilderTokenLength) {
+          token += characters.charAt(Math.floor(Math.random() * charactersLength));
+        }
+        return token;
+      }
+    }
+
+    /**
+     * This file is part of ILIAS, a powerful learning management system
+     * published by ILIAS open source e-Learning e.V.
+     *
+     * ILIAS is licensed with the GPL-3.0,
+     * see https://www.gnu.org/licenses/gpl-3.0.en.html
+     * You should have received a copy of said license along with the
+     * source code, too.
+     *
+     * If this is not the case or you just want to try ILIAS, you'll find
+     * us at:
+     * https://www.ilias.de
+     * https://github.com/ILIAS-eLearning
+     *
+     ********************************************************************
+     */
+
+
     const URLBuilderUrlMaxLength = 2048;
     const URLBuilderSeparator = '_';
 
@@ -335,10 +422,7 @@ var il = il || {};
         this.#parameters.set(parameter, value ?? '');
         this.#tokens.set(parameter, newToken);
 
-        return {
-          url: this,
-          token: newToken,
-        };
+        return [this, newToken];
       }
 
       /**

--- a/tests/UI/Client/URLBuilder.test.js
+++ b/tests/UI/Client/URLBuilder.test.js
@@ -55,8 +55,7 @@ describe('URLBuilder Test', () => {
   it('acquireParameter()', () => {
     const u = new URLBuilder(new URL('https://www.ilias.de/ilias.php?a=1#123'));
     const result = u.acquireParameter(['testing'], 'name');
-    const { url } = result;
-    const { token } = result;
+    const [url, token] = result;
     expect(url).to.be.instanceOf(URLBuilder);
     expect(token).to.be.instanceOf(URLBuilderToken);
     expect(token.getName()).to.eql('testing_name');
@@ -68,25 +67,25 @@ describe('URLBuilder Test', () => {
   it('acquireParameter() with long namespace', () => {
     const u = new URLBuilder(new URL('https://www.ilias.de/ilias.php?a=1#123'));
     const result = u.acquireParameter(['testing', 'my', 'object'], 'name');
-    const { url } = result;
+    const [url] = result;
     expect(url.getUrl().toString()).to.eql('https://www.ilias.de/ilias.php?a=1&testing_my_object_name=#123');
   });
 
   it('acquireParameter() with value', () => {
     const u = new URLBuilder(new URL('https://www.ilias.de/ilias.php?a=1#123'));
     const result = u.acquireParameter(['testing'], 'name', 'foo');
-    const { url } = result;
+    const [url] = result;
     expect(url.getUrl().toString()).to.eql('https://www.ilias.de/ilias.php?a=1&testing_name=foo#123');
   });
 
   it('acquireParameter() with same name', () => {
     const u = new URLBuilder(new URL('https://www.ilias.de/ilias.php?a=1#123'));
     const result = u.acquireParameter(['testing'], 'name', 'foo');
-    const { url } = result;
+    const [url] = result;
     expect(url.getUrl().toString()).to.eql('https://www.ilias.de/ilias.php?a=1&testing_name=foo#123');
 
     const result2 = url.acquireParameter(['nottesting'], 'name', 'bar');
-    const { url: url2 } = result2;
+    const [url2] = result2;
     expect(url2.getUrl().toString()).to.eql('https://www.ilias.de/ilias.php?a=1&testing_name=foo&nottesting_name=bar#123');
   });
 
@@ -105,20 +104,32 @@ describe('URLBuilder Test', () => {
   it('writeParameter()', () => {
     const u = new URLBuilder(new URL('https://www.ilias.de/ilias.php?a=1#123'));
     const result = u.acquireParameter(['testing'], 'name', 'foo');
-    let { url } = result;
-    const { token } = result;
+    let url = result.shift();
+    const token = result.shift();
     expect(url.getUrl().toString()).to.eql('https://www.ilias.de/ilias.php?a=1&testing_name=foo#123');
 
     url = url.writeParameter(token, 'bar');
     expect(url).to.be.instanceOf(URLBuilder);
     expect(url.getUrl().toString()).to.eql('https://www.ilias.de/ilias.php?a=1&testing_name=bar#123');
+
+    const u1 = new URLBuilder(new URL('https://www.ilias.de/ilias.php?a=1#123'));
+    const result1 = u1.acquireParameter(['testing'], 'arr');
+    url = result1.shift();
+    const token1 = result1.shift();
+    url = url.writeParameter(token1, ['foo', 'bar']);
+    expect(url.getUrl().toString()).to.eql(
+      'https://www.ilias.de/ilias.php?a=1'
+       + `&${encodeURIComponent('testing_arr')}%5B%5D=foo`
+       + `&${encodeURIComponent('testing_arr')}%5B%5D=bar`
+       + '#123',
+    );
   });
 
   it('deleteParameter()', () => {
     const u = new URLBuilder(new URL('https://www.ilias.de/ilias.php?a=1#123'));
     const result = u.acquireParameter(['testing'], 'name', 'foo');
-    let { url } = result;
-    const { token } = result;
+    let url = result.shift();
+    const token = result.shift();
     expect(url.getUrl().toString()).to.eql('https://www.ilias.de/ilias.php?a=1&testing_name=foo#123');
 
     url = url.deleteParameter(token);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38100

* UI, URLBuilder: distinguish and apply array-parameters
* UI, URLBuilder: store array-params as array, repeat on output
* UI, URLBuilder: align PHPparts to not index array-params
* UI, URLBuilder: do not encode brackets of array-params
* UI, URLBuilder: add some docu concerning array-params