### PR TITLE
9/UI/metabar slates not visible in Safari 40968

### DIFF
--- a/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
+++ b/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
@@ -316,7 +316,6 @@ footer {
 	header {
 		position: -webkit-sticky;
 		position: sticky;
-		overflow-x: clip;
 		width: 100%;
 		top: 0;
 	}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -5289,7 +5289,6 @@ footer {
   header {
     position: -webkit-sticky;
     position: sticky;
-    overflow-x: clip;
     width: 100%;
     top: 0;
   }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=40968

# Issue

(Some) Metabar slides do not appear on mobile breakpoint in Safari/Webkit.

![metbar-slate-not-visible](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/10b19ae9-9bd9-45c6-8bea-63125de8f8ed)

# Change

The issue seems to be caused by `overflow-x: clip;` on the header, which no longer seems to be needed as currently no unwanted scrollbars seem to form. Strangely, `overflow-x: clip;` is actually supported by Safari/Webkit, just something along the chain of `position: sticky;` and `position: absolute;` causes a broken rendering (y expansion also gets clipped).

![metbar-slate-visible-again](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/31bf37a5-cedf-4df4-a75a-d9bd04ba27c2)

# Impact

Removing `overflow-x: clip;` which was likely introduced to combat an unwanted scrollbar might cause said scrollbar to show up again under conditions that I can currently not reproduce. If there now is an unwanted scrollbar appearing, it's probably wise to directly fix the cause of the scrollbar rather than to clip the header.