### PR TITLE
Fix copyright checker for examples

### DIFF
--- a/components/ILIAS/UI/src/examples/Card/RepositoryObject/base.php
+++ b/components/ILIAS/UI/src/examples/Card/RepositoryObject/base.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Card\RepositoryObject;
 
-/* Copyright (c) 2016 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
-
 function base()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Card/RepositoryObject/with_object_icon.php
+++ b/components/ILIAS/UI/src/examples/Card/RepositoryObject/with_object_icon.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Card\RepositoryObject;
 
-/* Copyright (c) 2018 Jesús López <lopez@leifos.com> Extended GPL, see docs/LICENSE */
-
 function with_object_icon()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Card/RepositoryObject/with_object_icon_and_actions.php
+++ b/components/ILIAS/UI/src/examples/Card/RepositoryObject/with_object_icon_and_actions.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Card\RepositoryObject;
 
-/* Copyright (c) 2018 Jesús López <lopez@leifos.com> Extended GPL, see docs/LICENSE */
-
 function with_object_icon_and_actions()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Card/RepositoryObject/with_object_icon_and_certificate.php
+++ b/components/ILIAS/UI/src/examples/Card/RepositoryObject/with_object_icon_and_certificate.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Card\RepositoryObject;
 
-/* Copyright (c) 2018 Jesús López <lopez@leifos.com> Extended GPL, see docs/LICENSE */
-
 function with_object_icon_and_certificate()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Card/RepositoryObject/with_object_icon_and_progressmeter_mini.php
+++ b/components/ILIAS/UI/src/examples/Card/RepositoryObject/with_object_icon_and_progressmeter_mini.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Card\RepositoryObject;
 
-/* Copyright (c) 2018 Jesús López <lopez@leifos.com> Extended GPL, see docs/LICENSE */
-
 function with_object_icon_and_progressmeter_mini()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Card/Standard/base.php
+++ b/components/ILIAS/UI/src/examples/Card/Standard/base.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Card\Standard;
 
-/* Copyright (c) 2016 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
-
 function base()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Card/Standard/with_sections.php
+++ b/components/ILIAS/UI/src/examples/Card/Standard/with_sections.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Card\Standard;
 
-/* Copyright (c) 2016 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
-
 function with_sections()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Card/Standard/with_title_action.php
+++ b/components/ILIAS/UI/src/examples/Card/Standard/with_title_action.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Card\Standard;
 
-/* Copyright (c) 2016 Jesús López <lopez@leifos.de> Extended GPL, see docs/LICENSE */
-
 function with_title_action()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Chart/ScaleBar/base.php
+++ b/components/ILIAS/UI/src/examples/Chart/ScaleBar/base.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-/* Copyright (c) 2017 Alex Killing <killing@leifos.de> Extended GPL, see docs/LICENSE */
-
 namespace ILIAS\UI\examples\Chart\ScaleBar;
 
 function base()

--- a/components/ILIAS/UI/src/examples/Chart/ScaleBar/ten_items.php
+++ b/components/ILIAS/UI/src/examples/Chart/ScaleBar/ten_items.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-/* Copyright (c) 2017 Alex Killing <killing@leifos.de> Extended GPL, see docs/LICENSE */
-
 namespace ILIAS\UI\examples\Chart\ScaleBar;
 
 function ten_items()

--- a/components/ILIAS/UI/src/examples/Deck/base.php
+++ b/components/ILIAS/UI/src/examples/Deck/base.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Deck;
 
-/* Copyright (c) 2016 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
-
 function base()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Deck/repository.php
+++ b/components/ILIAS/UI/src/examples/Deck/repository.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Deck;
 
-/* Copyright (c) 2018 Jesús López <lopez@leifos.com> Extended GPL, see docs/LICENSE */
-
 function repository()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Deck/user.php
+++ b/components/ILIAS/UI/src/examples/Deck/user.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Deck;
 
-/* Copyright (c) 2016 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
-
 function user()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Deck/xl_card.php
+++ b/components/ILIAS/UI/src/examples/Deck/xl_card.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Deck;
 
-/* Copyright (c) 2016 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
-
 function xl_card()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Input/Field/ColorPicker/base.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/ColorPicker/base.php
@@ -2,22 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
-
 namespace ILIAS\UI\examples\Input\Field\ColorPicker;
 
 /**

--- a/components/ILIAS/UI/src/examples/Legacy/base.php
+++ b/components/ILIAS/UI/src/examples/Legacy/base.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Legacy;
 
-/* Copyright (c) 2016 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
-
 function base()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Legacy/inside_panel.php
+++ b/components/ILIAS/UI/src/examples/Legacy/inside_panel.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Legacy;
 
-/* Copyright (c) 2016 Timon Amstutz <timon.amstutz@ilub.unibe.ch> Extended GPL, see docs/LICENSE */
-
 function inside_panel()
 {
     //Init Factory and Renderer

--- a/components/ILIAS/UI/src/examples/Player/Audio/base.php
+++ b/components/ILIAS/UI/src/examples/Player/Audio/base.php
@@ -2,22 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
-
 namespace ILIAS\UI\examples\Player\Audio;
 
 function base()

--- a/components/ILIAS/UI/src/examples/Player/Video/video_mp4.php
+++ b/components/ILIAS/UI/src/examples/Player/Video/video_mp4.php
@@ -2,22 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
-
 namespace ILIAS\UI\examples\Player\Video;
 
 function video_mp4(): string

--- a/components/ILIAS/UI/src/examples/Player/Video/video_mp4_poster.php
+++ b/components/ILIAS/UI/src/examples/Player/Video/video_mp4_poster.php
@@ -2,22 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
-
 namespace ILIAS\UI\examples\Player\Video;
 
 function video_mp4_poster(): string

--- a/components/ILIAS/UI/src/examples/Player/Video/video_vimeo.php
+++ b/components/ILIAS/UI/src/examples/Player/Video/video_vimeo.php
@@ -2,22 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
-
 namespace ILIAS\UI\examples\Player\Video;
 
 function video_vimeo(): string

--- a/components/ILIAS/UI/src/examples/Player/Video/video_youtube.php
+++ b/components/ILIAS/UI/src/examples/Player/Video/video_youtube.php
@@ -2,22 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
-
 namespace ILIAS\UI\examples\Player\Video;
 
 function video_youtube(): string

--- a/components/ILIAS/UI/src/examples/Symbol/Glyph/Launch/launch.php
+++ b/components/ILIAS/UI/src/examples/Symbol/Glyph/Launch/launch.php
@@ -1,19 +1,4 @@
 <?php
-/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
 
 declare(strict_types=1);
 

--- a/components/ILIAS/UI/src/examples/Symbol/Glyph/Sortation/sortation.php
+++ b/components/ILIAS/UI/src/examples/Symbol/Glyph/Sortation/sortation.php
@@ -1,19 +1,4 @@
 <?php
-/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
 
 declare(strict_types=1);
 

--- a/scripts/Copyright-Checker/copyright-checker.sh
+++ b/scripts/Copyright-Checker/copyright-checker.sh
@@ -62,20 +62,35 @@ function is_copyright_valid() {
   local file_extension="${file##*.}"
   local offset=1
 
-  # since PSR-12 the php files will contain the copyright license as
-  # document-level comment, which starts on line 3.
-  if [ "php" = "${file_extension}" ]; then
-    offset=3
-  fi
+  is_ui_example "${file}"
+  local is_example=${?}
 
-  for copyright_line in "${COPYRIGHT_LINES[@]}"; do
-    local line_to_check="$(sed "${offset}q;d" "${file}")"
-    if ! [ "${copyright_line}" = "${line_to_check}" ]; then
-      return 1
+  if [ 1 -eq ${is_example} ]; then
+    if [ "php" = ${file_extension} ]; then
+      offset=3
     fi
+    for copyright_line in "${COPYRIGHT_LINES[@]}"; do
+      local line_to_check="$(sed "${offset}q;d" "${file}")"
+      if ! [ "${copyright_line}" = "${line_to_check}" ]; then
+        return 1
+      fi
 
-    offset=$((1 + ${offset}))
-  done
+      offset=$((1 + ${offset}))
+    done
+  else
+    local lines=$(wc -l < "${file}");
+    while [ ${offset} -lt ${lines} ]
+    do
+      local line_to_check="$(echo "$(sed "${offset}q;d" ${file})" | xargs)"
+      if echo "$line_to_check" | grep -q "^namespace "; then
+        return 0
+      fi
+      if echo "$line_to_check" | grep -q -e '^/\*' -e '^//' -e '^#'; then
+        return 2
+      fi
+      offset=$((1 + ${offset}))
+    done
+  fi
 
   return 0
 }
@@ -156,15 +171,12 @@ function perform_copyright_check() {
     is_copyright_valid "${file}"
     local is_valid="${?}"
 
-    is_ui_example "${file}"
-    local is_example="${?}"
-
-    # invert the copyright-check for UI examples, because we
-    # don't want them to have too much content.
-    if ([ 0 -eq ${is_example} ] && [ 0 -eq ${is_valid} ]) ||
-      ([ 1 -eq ${is_example} ] && [ 1 -eq ${is_valid} ]); then
+    if [ 1 -eq ${is_valid} ]; then
       printf "copyright is not as expected in %s\n" "${file}"
       exit_status=1
+    elif [ 2 -eq ${is_valid} ]; then
+      printf "copyright is not allowed in %s\n" "${file}"
+      exit_status=2
     fi
   done
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41651

This PR fixes the `copyright-checker.sh` to enforce explicitly no copyright inside the examples and removes current copyrights.