### PR TITLE
Course Bugfix #0041637: Course Certificates aren't issued in the language of the receiving user in any case (month names)

### DIFF
--- a/components/ILIAS/Course/classes/Certificate/CoursePlaceholderValues.php
+++ b/components/ILIAS/Course/classes/Certificate/CoursePlaceholderValues.php
@@ -137,12 +137,14 @@ class CoursePlaceholderValues implements ilCertificatePlaceholderValues
             $completionDate = $this->lpStatusHelper->lookupStatusChanged($objId, $userId);
         }
 
+        /** @var ilObjUser $user */
+        $user = $this->objectHelper->getInstanceByObjId($userId);
         if ($this->hasCompletionDate($completionDate)) {
-            $placeholders['DATE_COMPLETED'] = $this->dateHelper->formatDate($completionDate);
-            $placeholders['DATETIME_COMPLETED'] = $this->dateHelper->formatDateTime($completionDate);
+            $placeholders['DATE_COMPLETED'] = $this->dateHelper->formatDate($completionDate, $user);
+            $placeholders['DATETIME_COMPLETED'] = $this->dateHelper->formatDateTime($completionDate, $user);
         }
 
-        $lng_code = ilObjUser::_lookupLanguage($userId);
+        $lng_code = $user->getLanguage();
         $course_translation = $courseObject->getObjectTranslation();
         $title = $courseObject->getTitle();
         if ($course_translation instanceof ilObjectTranslation) {


### PR DESCRIPTION
references and depends on merge of #7758