### PR TITLE
SCORM Bugfix #0041637: Course Certificates aren't issued in the language of the receiving user in any case (month names)

### DIFF
--- a/components/ILIAS/ScormAicc/classes/Certificate/class.ilScormPlaceholderValues.php
+++ b/components/ILIAS/ScormAicc/classes/Certificate/class.ilScormPlaceholderValues.php
@@ -128,8 +128,10 @@ class ilScormPlaceholderValues implements ilCertificatePlaceholderValues
         $placeHolders['DATETIME_COMPLETED'] = '';
 
         if ($completionDate !== '') {
-            $placeHolders['DATE_COMPLETED'] = $this->dateHelper->formatDate($completionDate);
-            $placeHolders['DATETIME_COMPLETED'] = $this->dateHelper->formatDateTime($completionDate);
+            /** @var ilObjUser $user */
+            $user = $this->objectHelper->getInstanceByObjId($userId);
+            $placeHolders['DATE_COMPLETED'] = $this->dateHelper->formatDate($completionDate, $user);
+            $placeHolders['DATETIME_COMPLETED'] = $this->dateHelper->formatDateTime($completionDate, $user);
         }
 
         $olp = $this->objectLPHelper->getInstance($object->getId());

--- a/components/ILIAS/ScormAicc/tests/ilScormPlaceholderValuesTest.php
+++ b/components/ILIAS/ScormAicc/tests/ilScormPlaceholderValuesTest.php
@@ -71,11 +71,19 @@ class ilScormPlaceholderValuesTest extends ilCertificateBaseTestCase
         $objectMock->method('getId')
             ->willReturn(500);
 
-        $objectHelper = $this->getMockBuilder(ilCertificateObjectHelper::class)
+        $user_object = $this->getMockBuilder(ilObjUser::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
+        $objectHelper = $this->getMockBuilder(ilCertificateObjectHelper::class)
+            ->getMock();
         $objectHelper->method('getInstanceByObjId')
-            ->willReturn($objectMock);
+            ->willReturnMap(
+                [
+                    [200, $objectMock],
+                    [10, $user_object]
+                ]
+            );
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
             ->getMock();


### PR DESCRIPTION
references and depends on merge of https://github.com/ILIAS-eLearning/ILIAS/pull/7758

If approved, this MUST be picked to `release_10` as well.