### PR TITLE
Resolve DataCollection imports from ILIAS 8.12 and lower

### DIFF
--- a/Modules/DataCollection/classes/class.ilDataCollectionDataSet.php
+++ b/Modules/DataCollection/classes/class.ilDataCollectionDataSet.php
@@ -85,7 +85,7 @@ class ilDataCollectionDataSet extends ilDataSet
 
     public function getSupportedVersions(): array
     {
-        return ['4.5.0'];
+        return ['4.5.0', '8.13'];
     }
 
     /**
@@ -444,6 +444,11 @@ class ilDataCollectionDataSet extends ilDataSet
                                     $value = null;
                                 }
                                 break;
+                            case ilDclDatatype::INPUTFORMAT_TEXT:
+                                if (version_compare($a_schema_version, "8.13") < 0) {
+                                    $a_rec['value'] = str_replace('&lt;br /&gt;', '', $a_rec['value']);
+                                }
+                                // no break
                             default:
                                 $value = $a_rec['value'];
                                 if ($a_entity == 'il_dcl_stloc3_value' && empty($value)) {

--- a/Modules/DataCollection/classes/class.ilDataCollectionExporter.php
+++ b/Modules/DataCollection/classes/class.ilDataCollectionExporter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -13,8 +14,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
  * Class ilDataCollectionExporter
@@ -45,8 +45,13 @@ class ilDataCollectionExporter extends ilXmlExporter
             '4.5.0' => array(
                 'namespace' => 'https://www.ilias.de/Modules/DataCollection/dcl/4_5',
                 'xsd_file" => "ilias_dcl_4_5.xsd',
-                'uses_dataset' => true,
                 'min' => '4.5.0',
+                'max' => '8.12',
+            ),
+            '8.13' => array(
+                'namespace' => 'https://www.ilias.de/Modules/DataCollection/dcl/4_5',
+                'xsd_file" => "ilias_dcl_4_5.xsd',
+                'min' => '8.13',
                 'max' => '',
             ),
         );


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41529

Due to changes made [here](https://github.com/ILIAS-eLearning/ILIAS/pull/7575), exports from older ILIAS Versions create visible &lt;br /&gt; tags when imported into a newer ILIAS.

This PR resolves this by migrating the older export and removing the tag.