### PR TITLE
T&A 41611: Fix regex for gaps in cloze questions in learning modules

### DIFF
--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -673,7 +673,7 @@ ilias.questions.initClozeTest = function(a_id) {
 		closecounter++;
 		return input.outerHTML();
 	 };
-	var parsed=jQuery("div#"+a_id).get(0).innerHTML.replace(/\[gap\][^\[]+\[\/gap\]/g,
+	var parsed=jQuery("div#"+a_id).get(0).innerHTML.replace(/\[gap[\s\S\d]*?\](.*?)\[\/gap\]/g,
         () => {return _initClozeTestCallBack();});
 	jQuery("div#"+a_id).html(parsed);
 };


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41611

As suggested, I replaced the old regex with the one used for cloze questions in Tests.


cc @thojou 

