### PR TITLE
File: Fix `explode`-ing `null` instead of `string` in `\ilObjFileInfo…

### DIFF
--- a/Modules/File/classes/Info/class.ilObjFileInfoRepository.php
+++ b/Modules/File/classes/Info/class.ilObjFileInfoRepository.php
@@ -60,7 +60,7 @@ class ilObjFileInfoRepository
     private function initInlineSuffixes(): array
     {
         $settings = new ilSetting('file_access');
-        return array_map('strtolower', explode(" ", $settings->get('inline_file_extensions')));
+        return array_map('strtolower', explode(' ', $settings->get('inline_file_extensions', '')));
     }
 
     public function preloadData(array $object_ids): void


### PR DESCRIPTION
…Repository::initInlineSuffixes`

If approved, this should be picked to all maintained releases, if necessary.