### PR TITLE
Markdown: adjust markdown's headline configuration

### DIFF
--- a/components/ILIAS/CommonMarkExtension/CommonMarkCoreExtension.php
+++ b/components/ILIAS/CommonMarkExtension/CommonMarkCoreExtension.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\CommonMarkExtension\CommonMarkExtension;
+
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Extension\CommonMark\Delimiter\Processor\EmphasisDelimiterProcessor;
+use League\CommonMark\Extension\ConfigurableExtensionInterface;
+use League\CommonMark\Node as CoreNode;
+use League\CommonMark\Parser as CoreParser;
+use League\CommonMark\Renderer as CoreRenderer;
+use League\Config\ConfigurationBuilderInterface;
+use Nette\Schema\Expect;
+use League\CommonMark\Extension\CommonMark as CM;
+
+/**
+ * CommonMarkCoreExtension
+ *
+ * Replaces the core's CommonMarkCoreExtension and
+ * removes parsing of setext headings via CommonMarkHeadingStartParser
+ */
+final class CommonMarkCoreExtension implements ConfigurableExtensionInterface
+{
+    public function configureSchema(ConfigurationBuilderInterface $builder): void
+    {
+        $builder->addSchema('commonmark', Expect::structure([
+            'use_asterisk' => Expect::bool(true),
+            'use_underscore' => Expect::bool(true),
+            'enable_strong' => Expect::bool(true),
+            'enable_em' => Expect::bool(true),
+            'unordered_list_markers' => Expect::listOf('string')->min(1)->default(['*', '+', '-'])->mergeDefaults(false),
+        ]));
+    }
+
+    // phpcs:disable Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma,Squiz.WhiteSpace.SemicolonSpacing.Incorrect
+    public function register(EnvironmentBuilderInterface $environment): void
+    {
+        $environment
+            ->addBlockStartParser(new CM\Parser\Block\BlockQuoteStartParser(), 70)
+            ->addBlockStartParser(new CommonMarkHeadingStartParser(), 60)
+            ->addBlockStartParser(new CM\Parser\Block\FencedCodeStartParser(), 50)
+            ->addBlockStartParser(new CM\Parser\Block\HtmlBlockStartParser(), 40)
+            ->addBlockStartParser(new CM\Parser\Block\ThematicBreakStartParser(), 20)
+            ->addBlockStartParser(new CM\Parser\Block\ListBlockStartParser(), 10)
+            ->addBlockStartParser(new CM\Parser\Block\IndentedCodeStartParser(), -100)
+
+            ->addInlineParser(new CoreParser\Inline\NewlineParser(), 200)
+            ->addInlineParser(new CM\Parser\Inline\BacktickParser(), 150)
+            ->addInlineParser(new CM\Parser\Inline\EscapableParser(), 80)
+            ->addInlineParser(new CM\Parser\Inline\EntityParser(), 70)
+            ->addInlineParser(new CM\Parser\Inline\AutolinkParser(), 50)
+            ->addInlineParser(new CM\Parser\Inline\HtmlInlineParser(), 40)
+            ->addInlineParser(new CM\Parser\Inline\CloseBracketParser(), 30)
+            ->addInlineParser(new CM\Parser\Inline\OpenBracketParser(), 20)
+            ->addInlineParser(new CM\Parser\Inline\BangParser(), 10)
+
+            ->addRenderer(CM\Node\Block\BlockQuote::class, new CM\Renderer\Block\BlockQuoteRenderer(), 0)
+            ->addRenderer(CoreNode\Block\Document::class, new CoreRenderer\Block\DocumentRenderer(), 0)
+            ->addRenderer(CM\Node\Block\FencedCode::class, new CM\Renderer\Block\FencedCodeRenderer(), 0)
+            ->addRenderer(CM\Node\Block\Heading::class, new CM\Renderer\Block\HeadingRenderer(), 0)
+            ->addRenderer(CM\Node\Block\HtmlBlock::class, new CM\Renderer\Block\HtmlBlockRenderer(), 0)
+            ->addRenderer(CM\Node\Block\IndentedCode::class, new CM\Renderer\Block\IndentedCodeRenderer(), 0)
+            ->addRenderer(CM\Node\Block\ListBlock::class, new CM\Renderer\Block\ListBlockRenderer(), 0)
+            ->addRenderer(CM\Node\Block\ListItem::class, new CM\Renderer\Block\ListItemRenderer(), 0)
+            ->addRenderer(CoreNode\Block\Paragraph::class, new CoreRenderer\Block\ParagraphRenderer(), 0)
+            ->addRenderer(CM\Node\Block\ThematicBreak::class, new CM\Renderer\Block\ThematicBreakRenderer(), 0)
+
+            ->addRenderer(CM\Node\Inline\Code::class, new CM\Renderer\Inline\CodeRenderer(), 0)
+            ->addRenderer(CM\Node\Inline\Emphasis::class, new CM\Renderer\Inline\EmphasisRenderer(), 0)
+            ->addRenderer(CM\Node\Inline\HtmlInline::class, new CM\Renderer\Inline\HtmlInlineRenderer(), 0)
+            ->addRenderer(CM\Node\Inline\Image::class, new CM\Renderer\Inline\ImageRenderer(), 0)
+            ->addRenderer(CM\Node\Inline\Link::class, new CM\Renderer\Inline\LinkRenderer(), 0)
+            ->addRenderer(CoreNode\Inline\Newline::class, new CoreRenderer\Inline\NewlineRenderer(), 0)
+            ->addRenderer(CM\Node\Inline\Strong::class, new CM\Renderer\Inline\StrongRenderer(), 0)
+            ->addRenderer(CoreNode\Inline\Text::class, new CoreRenderer\Inline\TextRenderer(), 0)
+        ;
+
+        if ($environment->getConfiguration()->get('commonmark/use_asterisk')) {
+            $environment->addDelimiterProcessor(new EmphasisDelimiterProcessor('*'));
+        }
+
+        if ($environment->getConfiguration()->get('commonmark/use_underscore')) {
+            $environment->addDelimiterProcessor(new EmphasisDelimiterProcessor('_'));
+        }
+    }
+}

--- a/components/ILIAS/CommonMarkExtension/CommonMarkHeadingStartParser.php
+++ b/components/ILIAS/CommonMarkExtension/CommonMarkHeadingStartParser.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\CommonMarkExtension\CommonMarkExtension;
+
+use League\CommonMark\Parser\Block\BlockStart;
+use League\CommonMark\Parser\Block\BlockStartParserInterface;
+use League\CommonMark\Parser\Cursor;
+use League\CommonMark\Parser\MarkdownParserStateInterface;
+use League\CommonMark\Util\RegexHelper;
+use League\CommonMark\Extension\CommonMark\Parser\Block as PB;
+
+/**
+ * CommonMarkHeadingStartParser
+ *
+ * Only parses ATX headings, ignores setext headings
+ */
+class CommonMarkHeadingStartParser implements BlockStartParserInterface
+{
+    public function tryStart(Cursor $cursor, MarkdownParserStateInterface $parserState): ?BlockStart
+    {
+        if ($cursor->isIndented() || !\in_array($cursor->getNextNonSpaceCharacter(), ['#'], true)) {
+            return BlockStart::none();
+        }
+
+        $cursor->advanceToNextNonSpaceOrTab();
+
+        if ($atxHeading = self::getAtxHeader($cursor)) {
+            return BlockStart::of($atxHeading)->at($cursor);
+        }
+
+        return BlockStart::none();
+    }
+
+    private static function getAtxHeader(Cursor $cursor): ?PB\HeadingParser
+    {
+        $match = RegexHelper::matchFirst('/^#{1,6}(?:[ \t]+|$)/', $cursor->getRemainder());
+        if (!$match) {
+            return null;
+        }
+
+        $cursor->advanceToNextNonSpaceOrTab();
+        $cursor->advanceBy(\strlen($match[0]));
+
+        $level = \strlen(\trim($match[0]));
+        $str = $cursor->getRemainder();
+        $str = \preg_replace('/^[ \t]*#+[ \t]*$/', '', $str);
+        \assert(\is_string($str));
+        $str = \preg_replace('/[ \t]+#+[ \t]*$/', '', $str);
+        \assert(\is_string($str));
+
+        return new PB\HeadingParser($level, $str);
+    }
+}


### PR DESCRIPTION
This PR removes '-' and '=' in the headline configuration. As a result only '#' can be used as a markdown headline.
This avoids rendering of false headlines, e.g.:
- the user uses '-' to separate a headline or an email => 'Topic 1 - How to create a course'
- the user uses '-' to separate parts of an email like this '-----------'

This is also needed for the suggested [underline extension PR](https://github.com/ILIAS-eLearning/ILIAS/pull/7780) as it uses '--'.