### PR TITLE
Test: Fix ilUserCertificateRepository::__construct(): Argument #2 ($l…

### DIFF
--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -1514,7 +1514,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 
     public function outCertificate()
     {
-        $ilUserCertificateRepository = new ilUserCertificateRepository($this->db, $this->logging_services);
+        $ilUserCertificateRepository = new ilUserCertificateRepository($this->db, $this->logging_services->root());
         $pdfGenerator = new ilPdfGenerator($ilUserCertificateRepository);
 
         $pdfAction = new ilCertificatePdfAction(


### PR DESCRIPTION
…ogger) must be of type ?ilLogger

Mantis: https://mantis.ilias.de/view.php?id=41662