### PR TITLE
CI: Make unit test runner more verbose and add failing criteria

### DIFF
--- a/components/ILIAS/Component/tests/ilArtifactComponentRepositoryTest.php
+++ b/components/ILIAS/Component/tests/ilArtifactComponentRepositoryTest.php
@@ -96,6 +96,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
     protected ilComponentInfo $ser2;
     protected ilPluginSlotInfo $slt4;
     protected ilPluginInfo $plg2;
+    protected ilPluginInfo $plg3;
 
     protected function setUp(): void
     {

--- a/components/ILIAS/Component/tests/ilNullPluginStateDBTest.php
+++ b/components/ILIAS/Component/tests/ilNullPluginStateDBTest.php
@@ -21,6 +21,9 @@ use ILIAS\Data;
 
 class ilNullPluginStateDBTest extends TestCase
 {
+    protected ilPluginStateDB $db;
+    protected Data\Factory $data_factory;
+
     protected function setUp(): void
     {
         $this->db = new \ilNullPluginStateDB();

--- a/components/ILIAS/Course/tests/Certificate/ilCoursePlaceholderValuesTest.php
+++ b/components/ILIAS/Course/tests/Certificate/ilCoursePlaceholderValuesTest.php
@@ -38,6 +38,8 @@ use ilObjectCustomUserFieldsPlaceholderValues;
  */
 class ilCoursePlaceholderValuesTest extends TestCase
 {
+    protected ?Container $dic;
+
     protected function setUp(): void
     {
         if (!defined('ANONYMOUS_USER_ID')) {
@@ -45,11 +47,8 @@ class ilCoursePlaceholderValuesTest extends TestCase
         }
 
         global $DIC;
-
         $this->dic = is_object($DIC) ? clone $DIC : $DIC;
-
         $DIC = new Container();
-
         parent::setUp();
     }
 

--- a/components/ILIAS/StudyProgramme/tests/model/Settings/ilStudyProgrammeSettingsRepositoryTest.php
+++ b/components/ILIAS/StudyProgramme/tests/model/Settings/ilStudyProgrammeSettingsRepositoryTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 class ilStudyProgrammeSettingsRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     protected static $created;
+    protected ilDBInterface $db;
+    protected ilOrgUnitObjectTypePositionSetting $tps;
 
     protected function setUp(): void
     {

--- a/components/ILIAS/StudyProgramme/tests/model/Settings/ilStudyProgrammeSettingsTest.php
+++ b/components/ILIAS/StudyProgramme/tests/model/Settings/ilStudyProgrammeSettingsTest.php
@@ -21,11 +21,12 @@ declare(strict_types=1);
 class ilStudyProgrammeSettingsTest extends \PHPUnit\Framework\TestCase
 {
     protected $backupGlobals = false;
+    protected int $id = 123;
+    protected ilStudyProgrammeSettings $prg_settings;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->id = 123;
         $this->prg_settings = new ilStudyProgrammeSettings(
             $this->id,
             $this->createMock(ilStudyProgrammeTypeSettings::class),

--- a/components/ILIAS/StudyProgramme/tests/model/Settings/ilStudyProgrammeSubSettingsTest.php
+++ b/components/ILIAS/StudyProgramme/tests/model/Settings/ilStudyProgrammeSubSettingsTest.php
@@ -38,6 +38,7 @@ class ilStudyProgrammeSubSettingsTest extends \PHPUnit\Framework\TestCase
     protected ilLanguage $lng;
     protected Refinery $refinery;
     protected FieldFactory $field_factory;
+    protected DataFactory $data_factory;
 
     public function setUp(): void
     {

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlTestBase.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlTestBase.php
@@ -81,6 +81,11 @@ abstract class ViewControlTestBase extends ILIAS_UI_TestBase
     public function getUIFactory(): NoUIFactory
     {
         $factory = new class () extends NoUIFactory {
+            protected SignalGenerator $sig_gen;
+            public function __construct()
+            {
+                $this->sig_gen = new SignalGenerator();
+            }
             public function button(): I\Button\Factory
             {
                 return new I\Button\Factory(
@@ -96,7 +101,6 @@ abstract class ViewControlTestBase extends ILIAS_UI_TestBase
                 );
             }
         };
-        $factory->sig_gen = new SignalGenerator();
         return $factory;
     }
 

--- a/components/ILIAS/UI/tests/Component/Table/Column/ColumnTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/Column/ColumnTest.php
@@ -34,6 +34,8 @@ use ILIAS\UI\Component\Symbol\Glyph\Glyph as GlyphInterface;
  */
 class ColumnTest extends ILIAS_UI_TestBase
 {
+    protected ilLanguage $lng;
+
     public function setUp(): void
     {
         $lng = $this->getMockBuilder(\ilLanguage::class)

--- a/scripts/PHPUnit/phpunit.xml
+++ b/scripts/PHPUnit/phpunit.xml
@@ -1,8 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="../../vendor/composer/vendor/autoload.php" colors="true" beStrictAboutOutputDuringTests="true" beStrictAboutTestsThatDoNotTestAnything="true" failOnRisky="true" failOnWarning="true" backupGlobals="true" executionOrder="random" cacheResultFile=".phpunit.cache/test-results">
-  <testsuites>
-    <testsuite name="all">
-        <directory>../../components/*/*/tests/</directory>
-    </testsuite>
-  </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunAit.xsd"
+         bootstrap="../../vendor/composer/vendor/autoload.php"
+         colors="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         backupGlobals="true"
+         executionOrder="random"
+         cacheResultFile=".phpunit.cache/test-results">
+    <testsuites>
+        <testsuite name="all">
+            <directory>../../components/*/*/tests/</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>


### PR DESCRIPTION
This PR changes our unit test configuration by:

1. Letting tests fail on "Deprecations" and "Notices"
2. Displaying details on tests with errors/warnings/deprecations/notices