### PR TITLE
T&A 41620: Fix pasting crash after copying via bulk actions

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -490,6 +490,10 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                         $this->refinery->custom()->transformation(fn($v) => $v)
                     );
 
+                    if ($ids[0] === 'ALL_OBJECTS') {
+                        $ids = $this->object->getAllQuestionIds();
+                    }
+
                     if (is_null($ids)) {
                         $this->tpl->setOnScreenMessage('failure', $this->lng->txt('msg_no_questions_selected'), true);
                         $this->ctrl->redirect($this, 'questions');
@@ -1895,7 +1899,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             $this->taxonomy->domain(),
             $this->notes_service,
             $this->object->getId(),
-            (int)$this->qplrequest->getRefId()
+            (int) $this->qplrequest->getRefId()
         );
 
         /**

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -490,15 +490,14 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                         $this->refinery->custom()->transformation(fn($v) => $v)
                     );
 
-                    if ($ids[0] === 'ALL_OBJECTS') {
-                        $ids = $this->object->getAllQuestionIds();
-                    }
-
                     if (is_null($ids)) {
                         $this->tpl->setOnScreenMessage('failure', $this->lng->txt('msg_no_questions_selected'), true);
                         $this->ctrl->redirect($this, 'questions');
                     }
-                    if (! is_array($ids)) {
+                    if ($ids[0] === 'ALL_OBJECTS') {
+                        $ids = $this->object->getAllQuestionIds();
+                    }
+                    if (!is_array($ids)) {
                         $ids = explode(',', $ids);
                     }
                     $ids = array_map('intval', $ids);


### PR DESCRIPTION
This PR aims to address the problem reported in Mantis issue https://mantis.ilias.de/view.php?id=41620.

Copying questions from a question pool using the “Actions for Entire Table” button found under Bulk Actions and trying to paste them now results in the correct behavior. This has been accomplished by adding a check for ALL_OBJECTS which inserts all the needed IDs accordingly.

Kind regards.