### PR TITLE
8/UI/mejs-videoplayer keyboard focus ILIAS style 34185

### DIFF
--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -16317,6 +16317,50 @@ span.bibl_text_inline_Emph {
   width: 100px;
   cursor: pointer;
 }
+.mejs__overlay-button:focus-visible,
+.mejs__container:focus-visible,
+.ilPlayerPreviewPlayButton:focus-visible,
+.mejs__time-total:focus-visible {
+  position: relative;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 4px;
+}
+.mejs__overlay-button:focus-visible::after,
+.mejs__container:focus-visible::after,
+.ilPlayerPreviewPlayButton:focus-visible::after,
+.mejs__time-total:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
+  outline: 3px solid #0078D7;
+}
+.mejs__overlay-button:active,
+.mejs__container:active,
+.ilPlayerPreviewPlayButton:active,
+.mejs__time-total:active,
+.mejs__overlay-button.engaged,
+.mejs__container.engaged,
+.ilPlayerPreviewPlayButton.engaged,
+.mejs__time-total.engaged {
+  outline: none;
+}
+.mejs__button button:focus-visible,
+.ilPageVideo button:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
+  outline-offset: initial;
+}
+.mejs__button button::after,
+.ilPageVideo button::after,
+.mejs__button button:focus:focus-visible::after,
+.ilPageVideo button:focus:focus-visible::after {
+  content: none;
+}
 .ilPlayerPreviewOverlay:hover .ilPlayerPreviewPlayButton {
   background-position: 0 -100px;
 }

--- a/templates/default/less/Services/MediaObjects/delos.less
+++ b/templates/default/less/Services/MediaObjects/delos.less
@@ -51,6 +51,17 @@
 	cursor: pointer;
 }
 
+.mejs__overlay-button,
+.mejs__container,
+.ilPlayerPreviewPlayButton,
+.mejs__time-total {
+	.il-focus();
+}
+.mejs__button button,
+.ilPageVideo button {
+	.il-focus-border-only();
+}
+
 .ilPlayerPreviewOverlay:hover .ilPlayerPreviewPlayButton {
 	background-position: 0 -100px;
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=34185
PR für ILIAS 9: https://github.com/ILIAS-eLearning/ILIAS/pull/7794

# Issue

Focus in video player is low contrast and not uniform with the rest of ILIAS.

![videoplayer_focus-incorrect](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/6081a9d6-f527-4dd9-ae58-0e5f63604a29)

# Change

Our il-focus mixins are now used to highlight player elements.

![videoplayer_focus-correct](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/ef580a3c-b350-4df3-ae01-07a891aad3e3)

# Outlook

Maybe we need an il-focus-thin mixin with a 1px white + 1 px blue + 1px white line that leaves selected icons more readable? UPDATE: Implemented in IL 9 version of this PR: https://github.com/ILIAS-eLearning/ILIAS/pull/7794