### PR TITLE
T&A 24969: Conceptual issue with (de)activating public comments in pools

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -757,7 +757,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                     $this->db,
                     $this->user,
                     $this->refinery->random(),
-                    $this->global_screen
+                    $this->global_screen,
+                    $this->http,
+                    $this->refinery
                 );
 
                 $gui->initQuestion($this->fetchAuthoringQuestionIdParameter(), $this->object->getId());

--- a/Modules/TestQuestionPool/classes/QuestionTable.php
+++ b/Modules/TestQuestionPool/classes/QuestionTable.php
@@ -169,7 +169,7 @@ class QuestionTable extends ilAssQuestionList implements Table\DataRetrieval
     ): \Generator {
         $no_write_access = !($this->rbac->checkAccess('write', $this->request_ref_id));
         foreach ($this->getData($order, $range) as $idx => $record) {
-            $row_id = (string)$record['question_id'];
+            $row_id = (string) $record['question_id'];
             $record['created'] = (new \DateTimeImmutable())->setTimestamp($record['created']);
             $record['tstamp'] = (new \DateTimeImmutable())->setTimestamp($record['tstamp']);
             $lifecycle = ilAssQuestionLifecycle::getInstance($record['lifecycle']);
@@ -244,7 +244,7 @@ class QuestionTable extends ilAssQuestionList implements Table\DataRetrieval
             $this->buildAction('edit_page', 'single'),
             $this->buildAction('feedback', 'single'),
             $this->buildAction('hints', 'single'),
-            $this->buildAction('comments', 'single', true)
+            $this->showCommentAction() ? $this->buildAction('comments', 'single', true) : []
         );
     }
 
@@ -292,5 +292,11 @@ class QuestionTable extends ilAssQuestionList implements Table\DataRetrieval
             $list = array_reverse($list);
         }
         return $list;
+    }
+
+    private function showCommentAction(): bool
+    {
+        return $this->notes_service->domain()->commentsActive($this->parent_obj_id)
+            || $this->rbac->checkAccess('write', $this->request_ref_id);
     }
 }

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -26,6 +26,7 @@ use ILIAS\UI\URLBuilder;
 use ILIAS\UI\URLBuilderToken;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\GlobalScreen\Services as GlobalScreen;
+use ILIAS\HTTP\Services as HTTPServices;
 
 /**
  * Class ilObjQuestionPoolGUI
@@ -52,6 +53,7 @@ use ILIAS\GlobalScreen\Services as GlobalScreen;
  */
 class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 {
+    private HTTPServices $http;
     private HttpRequest $http_request;
     private QuestionInfoService $questioninfo;
     private \ILIAS\Filesystem\Util\Archive\LegacyArchives $archives;
@@ -90,7 +92,8 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->questioninfo = $DIC->testQuestionPool()->questionInfo();
         $this->qplrequest = $DIC->testQuestionPool()->internal()->request();
         $this->taxonomy = $DIC->taxonomy();
-        $this->http_request = $DIC->http()->request();
+        $this->http = $DIC->http();
+        $this->http_request = $this->http->request();
         $this->data_factory = new DataFactory();
         $this->archives = $DIC->legacyArchives();
         parent::__construct('', $this->qplrequest->raw('ref_id'), true, false);
@@ -235,7 +238,9 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                     $ilDB,
                     $ilUser,
                     $randomGroup,
-                    $this->global_screen
+                    $this->global_screen,
+                    $this->http,
+                    $this->refinery
                 );
 
                 $gui->initQuestion((int) $this->qplrequest->raw('q_id'), $this->object->getId());


### PR DESCRIPTION
The read and write access to QuestionPool comments is not checked properly and this should resolve that.

[Mantis: 24969](https://mantis.ilias.de/view.php?id=24969)