### PR TITLE
T&A 35591: Add blue message boxes in sub-tabs Taxonomy of qpl, glo and cat to describe the function

### DIFF
--- a/Services/Taxonomy/Settings/class.ilTaxonomySettingsGUI.php
+++ b/Services/Taxonomy/Settings/class.ilTaxonomySettingsGUI.php
@@ -90,6 +90,8 @@ class ilTaxonomySettingsGUI
 
         $this->tabs->activateSubTab("tax_settings");
 
+        $this->tpl->setOnScreenMessage('info', $this->lng->txt('qpl_taxonomy_tab_info_message'));
+
         switch ($next_class) {
 
             case strtolower(ilObjTaxonomyGUI::class):

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to new content of this page. Old content will be removed.
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. The content from the old editor cannot be transferred. Please start adding new page content below. If you click the following link, the new content will be used.
 cntr#:#cntr_switched_editor#:#Switched to new content.
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Спазено сортиране.
 cntr#:#cntr_switch_to_new_editor_cmd#:# Превключване към тази страница за представяне
 cntr#:#cntr_switch_to_new_editor_message#:#Това е поддържаният стандартен редактор. Използвайте го, за да настроите страницата със съдържание. Ако щракнете върху следната връзка, представянето на съдържанието в хранилището ще премине от съдържанието на стария редактор към тази страница.
 cntr#:#cntr_switched_editor#:#Преминаване към ново съдържание.
-cntr#:#cntr_tax_list_info#:#Следващите таксономии са дефинирани за този обект.
 cntr#:#cntr_tax_none_available#:#Няма налични таксономии.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Определение на таксономия

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Řazení uloženo.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Přepnout zobrazení na tuto stránku
 cntr#:#cntr_switch_to_new_editor_message#:#To je podporovaný standardní editor. Použijte jej prosím k nastavení obsahu stránky. Pokud klepnete na následující odkaz, obsah zobrazení úložiště bude přepnut ze starého editoru obsahu na tuto stránku.
 cntr#:#cntr_switched_editor#:#Přepnuto na nový obsah.
-cntr#:#cntr_tax_list_info#:#Níže jsou uvedeny všechny taxonomie, které byly definovány pro tento objekt.
 cntr#:#cntr_tax_none_available#:#Nejsou k dispozici žádné taxonomie.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Definice taxonomie

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Rækkefølgen blev gemt
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to this page for presentation###15 09 2008 new variable
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. Please use it to setup the content page. If you click the following link, the content presentation in the repository will switch from the old editor's content to this page.###15 09 2008 new variable
 cntr#:#cntr_switched_editor#:#Skiftet til nye indhold
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1065,6 +1065,7 @@ assessment#:#qpl_skl_sub_tab_quest_assign#:#Fragen-Kompetenz-Zuordnung
 assessment#:#qpl_skl_sub_tab_usages#:#Vergabehäufigkeit
 assessment#:#qpl_sync_quest_skl_assigns_confirmation#:#Die Frage wurde aus einem anderen Magazinobjekt eingefügt. Soll die aktuelle Konfiguration von Kompetenzzuweisungen auf das Original der Frage übertragen werden?
 assessment#:#qpl_tab_competences#:#Kompetenzen
+assessment#:#qpl_taxonomy_tab_info_message#:#Taxonomien in Fragenpools klassifizieren und filtern die Fragen. Sie werden nach Aktivierung der Funktion im Reiter „Einstellungen“ im Filter im Reiter „Fragen“ angezeigt.
 assessment#:#qst_error_text_too_long#:#Einer oder mehrere der als fehlerhaft markierten Textelemente ist zu lang. Die maximale Länge für ein als fehlerhaft markiertes Textelement ist 150 Zeichen.
 assessment#:#qst_essay_allready_written_words#:#Bereits geschriebene Wörter:
 assessment#:#qst_essay_chars_remaining#:#Noch übrige Zeichen:
@@ -3397,7 +3398,6 @@ cntr#:#cntr_saved_sorting#:#Sortierung gespeichert
 cntr#:#cntr_switch_to_new_editor_cmd#:#Zu untenstehenden Inhalten wechseln. Alte Inhalte werden gelöscht.
 cntr#:#cntr_switch_to_new_editor_message#:#Dies ist der Standard-Seiteneditor. Wenn Sie ihn nutzen möchten, müssen Sie die Inhalte per Klick auf die Platzhalter unten hinzufügen. Wenn Sie auf den nachfolgenden Link klicken, werden die unterstehenden Inhalte für die Seitendarstellung genutzt.
 cntr#:#cntr_switched_editor#:#Auf neue Darstellung umgestellt
-cntr#:#cntr_tax_list_info#:#Nachfolgend sind alle Taxonomien gelistet, die für dieses Objekt definiert wurden.
 cntr#:#cntr_tax_none_available#:#Es gibt keine verfügbaren Taxonomien.
 cntr#:#cntr_tax_settings_info#:#Taxonomien in Kategorien klassifizieren und filtern die in der Kategorie enthaltenen Objekte. Nach dem Hinzufügen von Taxonomien können über die Reiter „Metadaten“ und die Unterreiter „Taxonomiezuordnung“ der jeweiligen Objekte Klassifizierungen vorgenommen werden. Taxonomien können zusätzlich im Seitenblock des Reiters „Inhalt“ der Kategorie angezeigt werden, um ein direktes Filtern der zugeordneten Objekte zu ermöglichen.
 cntr#:#cntr_taxonomy_definitions#:#Taxonomie-Definition

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -3398,7 +3398,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.###26 06 2009 new variable
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to this page for presentation
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. Please use it to setup the content page. If you click the following link, the content presentation in the repository will switch from the old editor's content to this page.
 cntr#:#cntr_switched_editor#:#Switched to new content.
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1065,6 +1065,7 @@ assessment#:#qpl_skl_sub_tab_quest_assign#:#Question/Competence Assignment
 assessment#:#qpl_skl_sub_tab_usages#:#Assignment Frequency
 assessment#:#qpl_sync_quest_skl_assigns_confirmation#:#The question was inserted from another repository object. Should the question's original be updated with the current config of competence assignments?
 assessment#:#qpl_tab_competences#:#Competences
+assessment#:#qpl_taxonomy_tab_info_message#:#Taxonomies in question pools can be used to filter the questions. After activating the function in the "Settings" tab, they are displayed in the filter in the "Questions" tab.
 assessment#:#qst_error_text_too_long#:#One or more text elements marked as erroneous are too long. The maximum size for a text element marked as erroneous is 150 characters:
 assessment#:#qst_essay_allready_written_words#:#Already entered words:
 assessment#:#qst_essay_chars_remaining#:#Remaining characters:
@@ -3397,7 +3398,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to new content of this page. Old content will be removed.
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. The content from the old editor cannot be transferred. Please start adding new page content below. If you click the following link, the new content will be used.
 cntr#:#cntr_switched_editor#:#Switched to new content.
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -3399,7 +3399,6 @@ cntr#:#cntr_saved_sorting#:#Guardar ordenación
 cntr#:#cntr_switch_to_new_editor_cmd#:#Cambie a esta página para presentación
 cntr#:#cntr_switch_to_new_editor_message#:#Este es el editor estándar. Por favor, úselo para configurar el contenido de la página. Si hace click en el siguiente enlace, el contenido de la presentación será copiado del antiguo editor de contenidos de esta pagina.
 cntr#:#cntr_switched_editor#:#Cambiar a los contenidos nuevos.
-cntr#:#cntr_tax_list_info#:#A continuación todas las taxonomías que se han definido para este elemento.
 cntr#:#cntr_tax_none_available#:#No hay taxonomías disponibles.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Definición de Taxonomía

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Sorteerimine salvestatud.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Lülita sellele lehele esitluse jaoks
 cntr#:#cntr_switch_to_new_editor_message#:#See on toetatud standardiga redaktor. Palun kasuta seda sisulehe häälestamisel. Kui klikkad järgmisel lingil, lülitub sisu esitus vanalt redaktorilt ümber siia lehele.
 cntr#:#cntr_switched_editor#:#Lülitatud uude sisusse.
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to new content of this page. Old content will be removed.
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. The content from the old editor cannot be transferred. Please start adding new page content below. If you click the following link, the new content will be used.
 cntr#:#cntr_switched_editor#:#Switched to new content.
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Classement Enregistré.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Basculer à  cette page pour la présentation
 cntr#:#cntr_switch_to_new_editor_message#:#Ceci est l'éditeur standard. Veuillez l'utiliser pour mettre à  jour le contenu de la page. Si vous cliquez sur le lien suivant, le contenu de la présentation dans le catalogue sera basculer de l'ancien éditeur dans cette page.
 cntr#:#cntr_switched_editor#:#Nouveau contenu adopté.
-cntr#:#cntr_tax_list_info#:#Voici toutes les taxonomies qui ont été définis pour cet objet.
 cntr#:#cntr_tax_none_available#:#Il n’y a plus de taxonomies de disponibles.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Définition de la Taxinomie

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Sortiranje spremljeno.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Prebacite se na novi sadržaj ove stranice. Stari će se sadržaj ukloniti.
 cntr#:#cntr_switch_to_new_editor_message#:#Ovo je podržani standardni urednik. Sadržaj iz starog urednika ne može se prenijeti. Počnite dodavati novi sadržaj stranice u nastavku. Ako kliknete sljedeću poveznicu, koristit će se novi sadržaj.
 cntr#:#cntr_switched_editor#:#Prebačen na novi sadržaj.
-cntr#:#cntr_tax_list_info#:#U nastavku su navedene sve taksonomije koje su definirane za ovaj objekt.
 cntr#:#cntr_tax_none_available#:#Ne postoje dostupne taksonomije.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Definicija taksonomije

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Rendezés mentése sikerült
 cntr#:#cntr_switch_to_new_editor_cmd#:#Új tartalom kapcsolása ehhez a laphoz. A régi tartalom eltávolításra kerül.
 cntr#:#cntr_switch_to_new_editor_message#:#Ez a támogatott szabványos szerkesztő. A régi szerkesztő tartalma nem hozható át. Lentebb vegyen fel új laptartalmat. Ha az alábbi linkre kattint, az új tartalom kerül használatra.
 cntr#:#cntr_switched_editor#:#Új tartalomhoz kapcsolva.
-cntr#:#cntr_tax_list_info#:#Ehhez az objektumhoz definiált összes taxonómia felsorolása.
 cntr#:#cntr_tax_none_available#:#Nincsenek elérhető taxonómiák.
 cntr#:#cntr_tax_settings_info#:#A kategóriákban lévő taxonómiák osztályozzák és szűrik a kategóriában lévő objektumokat. A taxonómiák hozzáadása után a besorolásokat a megfelelő objektumok 'Metaadatok' és 'Taxonómia hozzárendelése' allapjain lehet elvégezni. A taxonómiák emellett a kategória 'Tartalom' lapjának oldalsó blokkjában is megjeleníthetők, így lehetővé válik a hozzárendelt objektumok közvetlen szűrése is.
 cntr#:#cntr_taxonomy_definitions#:#Taxonómia meghatározása
@@ -6517,7 +6516,7 @@ content#:#cont_file_renamed#:#A fájl neve megváltozott.
 content#:#cont_file_unzipped#:#A fájlt kicsomagoltuk.
 content#:#cont_files#:#Fájlok
 content#:#cont_finish_editing#:#Szerkesztés befejezése
-content#:#cont_finish_table_editing#:#Adattábla szerkesztésének befejezése 
+content#:#cont_finish_table_editing#:#Adattábla szerkesztésének befejezése
 content#:#cont_first_open#:#Első panel kinyitva
 content#:#cont_first_page#:#Első oldal
 content#:#cont_first_row_style#:#Első sor stílusosztálya
@@ -9371,9 +9370,9 @@ exc#:#exc_msg_new_feedback_file_uploaded#:#'%s' beadandó feladathoz új visszaj
 exc#:#exc_msg_new_feedback_file_uploaded2#:#ezúton tájékoztatjuk, hogy új visszajelzésfájlt töltöttek fel az Ön megoldásához.
 exc#:#exc_msg_new_feedback_text_uploaded#:#'%s' beadandó feladathoz új megjegyzés jött létre
 exc#:#exc_msg_new_feedback_text_uploaded2#:#ezúton tájékoztatjuk, hogy egy tutor megjegyzést írt Önnek.
-exc#:#exc_msg_new_message_from_pf_giver#:#'%s' feladathoz egy visszajelző üzenetet küldött. 
+exc#:#exc_msg_new_message_from_pf_giver#:#'%s' feladathoz egy visszajelző üzenetet küldött.
 exc#:#exc_msg_new_message_from_pf_giver2#:#Egy visszajelző üzenetet küldött Önnek:
-exc#:#exc_msg_new_message_from_pf_recipient#:#'%s' feladathoz egy visszajelzett üzenetet küldött. 
+exc#:#exc_msg_new_message_from_pf_recipient#:#'%s' feladathoz egy visszajelzett üzenetet küldött.
 exc#:#exc_msg_new_message_from_pf_recipient2#:#egy visszajelzett üzenetet küldött Önnek:
 exc#:#exc_msg_participants_removed#:#A résztvevőket eltávolítottuk a beadandó feladatból.
 exc#:#exc_msg_public_submission#:#Összes megoldást publikáltuk a határidő után.
@@ -13636,7 +13635,7 @@ ps#:#ps_export_excel#:#Excel-export indítása
 ps#:#ps_export_files#:#Exportfájlok
 ps#:#ps_export_groups#:#Felhasználó profiladatainak exportálásának engedélyezése csoportokban
 ps#:#ps_export_member#:#Tagok
-ps#:#ps_export_prgs#:#A Képzési programban a felhasználó profiladatok exportálásának engedélyezése 
+ps#:#ps_export_prgs#:#A Képzési programban a felhasználó profiladatok exportálásának engedélyezése
 ps#:#ps_export_settings#:#Exportbeállítások
 ps#:#ps_export_sub#:#Feliratkozottak
 ps#:#ps_export_tutor#:#Tutorok
@@ -13907,7 +13906,7 @@ rbac#:#crsr_copy#:#A felhasználó másolhat kurzuslinket
 rbac#:#crsr_delete#:#A felhasználó áthelyezhet vagy törölhet kurzuslinket
 rbac#:#crsr_edit_learning_progress#:#A felhasználó módosíthatja a tanulási haladás beállításait
 rbac#:#crsr_edit_permission#:#A felhasználó módosíthatja a jogosultsági beállításokat
-rbac#:#crsr_read_learning_progress#:#A felhasználó megtekintheti a többi felhasználó tanulási haladását 
+rbac#:#crsr_read_learning_progress#:#A felhasználó megtekintheti a többi felhasználó tanulási haladását
 rbac#:#crsr_visible#:#A kurzuslink látható
 rbac#:#crsr_write#:#A felhasználó szerkesztheti kurzuslinket
 rbac#:#crss_edit_permission#:#A felhasználó módosíthatja a Rendszerbeállítások » Kurzus jogosultsági beállításait

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -3396,7 +3396,6 @@ cntr#:#cntr_saved_sorting#:#Ordinamento salvato.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Visualizza il nuovo contenuto della pagina. Il vecchio contenuto sarà rimosso
 cntr#:#cntr_switch_to_new_editor_message#:#Questo è l'editor standard di ILIAS. Non è possibile trasferire contenuti dal vecchio editor. Inizia aggiungendo nuovi contenuti in basso. Se clicchi sul link che segue i nuovi contenuti saranno in uso.
 cntr#:#cntr_switched_editor#:#Nuovo contenuto visualizzato
-cntr#:#cntr_tax_list_info#:#Le seguenti sono tutte le tassonomie definite per questo oggetto.
 cntr#:#cntr_tax_none_available#:#Non ci sono tassonomie disponibili.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Definizione tassonomia

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -3197,7 +3197,7 @@ cmix#:#conf_user_ident_il_uuid_user_id#:#E-Mailアドレスで書式化された
 cmix#:#conf_user_ident_il_uuid_user_id_info#:#これはコール毎にユニークですが、ユーザに関して直接結論つけされる事を許容願います。
 cmix#:#conf_user_ident_info#:#標準はemailアドレスに準じます。ユニークなILIASプラットフォームIDは:
 cmix#:#conf_user_ident_real_email#:#E-Mail Address
-cmix#:#conf_user_ident_real_email_info#:#IDとしてユーザのメールアドレスを送信 (Warning: E-Mailアドレスは複数のユーザで使用されている可能性があります) 
+cmix#:#conf_user_ident_real_email_info#:#IDとしてユーザのメールアドレスを送信 (Warning: E-Mailアドレスは複数のユーザで使用されている可能性があります)
 cmix#:#conf_user_name#:#ユーザ名
 cmix#:#conf_user_name_firstname#:#氏名
 cmix#:#conf_user_name_firstname_info#:#ILIASからユーザ名の氏名を送信
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#並び替えを保存
 cntr#:#cntr_switch_to_new_editor_cmd#:#新しいコンテンツのページに切り替える。古いコンテンツを削除。
 cntr#:#cntr_switch_to_new_editor_message#:#サポートされている標準的なエディターです。古いエディターからコンテンツは引き継がれません。以下の新しいページコンテンツへ追加を開始してください。次のリンクをクリックすると新しいコンテンツが使用されます。
 cntr#:#cntr_switched_editor#:#新しいコンテンツへ切り替えられました。
-cntr#:#cntr_tax_list_info#:#以下はこのオブジェスト用として定義されている分類です。
 cntr#:#cntr_tax_none_available#:#分類は利用できません。
 cntr#:#cntr_tax_settings_info#:#カテゴリーの分類学はカテゴリーに含まれるオブジェクトを分類しフィルターします。分類学を追加すると、それぞれのオブジェクトの"メタデータ" タブと"分類学割り当て" サブタブを通して分類されます。 分類学は、 割り当てられたオブジェクトの直接フィルタを有効にするカテゴリのサイドブロック"コンテンツ" タブ 内に表示できます。
 cntr#:#cntr_taxonomy_definitions#:#分類定義
@@ -8893,7 +8892,7 @@ dpro#:#dpro_once#:#一度承諾
 dpro#:#dpro_reset_for_all_users#:#データ保護宣言をリセットする。
 dpro#:#dpro_status_enable#:#データ保護宣言を有効化
 dpro#:#dpro_status_enable_desc#:#可能であれば、ユーザの初回ログインの際に新規ユーザ用の登録フォームの最後に個別言語単位でデータ保護宣言ドキュメントを表示します。 ILIASへ入る前にデータ保護宣言への承諾が必須です。
-dpro#:#dpro_sure_reset_tos#:#システムの全ユーザ用のデータ保護宣言を本当にリセットしますか？例として、SOAPwebサービスお使ってるアカウントに対しても適用されます。 
+dpro#:#dpro_sure_reset_tos#:#システムの全ユーザ用のデータ保護宣言を本当にリセットしますか？例として、SOAPwebサービスお使ってるアカウントに対しても適用されます。
 dpro#:#dpro_withdrawal_usr_deletion#:#データ保護宣言撤回に対するアカウント削除
 dpro#:#dpro_withdrawal_usr_deletion_desc#:#以前承諾したデータ保護宣言ドキュメントの承諾をユーザが撤回するとユーザのアカウント削除につながることになります。
 ecs#:#cert_serial#:#証明書シリアル番号
@@ -9496,7 +9495,7 @@ exc#:#exc_received_feedback#:#受信済のフィードバック
 exc#:#exc_rel_last_submission#:#最終可能性の提出物
 exc#:#exc_rel_last_submission_info#:#このオプションdateを設定すると全てのユーザはこの期限が来るまでに提出する必要があります。
 exc#:#exc_rel_start_latest_lead_text#:# %s が最終
-exc#:#exc_rel_start_lead_text#:#開始後の提出日にち %s 
+exc#:#exc_rel_start_lead_text#:#開始後の提出日にち %s
 exc#:#exc_relative_date#:#相対日数
 exc#:#exc_relative_date_info#:#期限はユーザが課題を開始する時間に応じて個別に設定されます。
 exc#:#exc_rem_time_after_start#:#開始後の残り時間
@@ -11010,7 +11009,7 @@ lti#:#clti_privacy_name_fullname#:#フルネーム
 lti#:#clti_privacy_name_fullname_info#:#タイトル, first name, last nameを送信
 lti#:#clti_privacy_name_info#:#ユーザ名の送信は通常必須ではありません。
 lti#:#clti_privacy_name_lastname#:#タイトルとlast name
-lti#:#clti_privacy_name_lastname_info#:#Mister または Ms/Mrs(特に指示がない限り) と last nameを送信 
+lti#:#clti_privacy_name_lastname_info#:#Mister または Ms/Mrs(特に指示がない限り) と last nameを送信
 lti#:#clti_privacy_name_none#:#なし
 lti#:#clti_privacy_name_none_info#:#名前に代えて '-' を送信
 lti#:#consumers#:#Consumer
@@ -15217,7 +15216,7 @@ search#:#search_choose_object_type#:#オブジェクトタイプを一つ選ん�
 search#:#search_content#:#ページコンテンツ
 search#:#search_created_after#:#後に作成されたオブジェクト
 search#:#search_created_before#:#. . .以前に作成されたオブジェクト
-search#:#search_created_on#:#. . .に作成されたオブジェクト. . . 
+search#:#search_created_on#:#. . .に作成されたオブジェクト. . .
 search#:#search_crs_title#:#コース名
 search#:#search_details_info#:#詳細検索。1つまたは複数のリソースの種類を選択してください。
 search#:#search_direct#:#ダイレクト検索
@@ -15680,7 +15679,7 @@ style#:#scss_folder_reset#:#Scss フォルダをリセット
 style#:#scss_folder_updated#:#Scss フォルダが更新されました
 style#:#scss_scss_installation_detected#:#Scss/sass インストールが検出されました:
 style#:#scss_variable_empty#:#この変数は空です。設定ファイルからデフォルトが設定されました。コンパイル前にこれが正しい事を確認してください。
-style#:#scss_variables_empty_might_have_changed#:#フォームには空の変数があります。このフォームをロードされてから設定ファイルを変更した可能性があります。設定ファイルのデフォルトは空フィールドが設定されます。コンパイル前にそれらの空フィールドにマークを確認して設定ファイルへ値を保存してください。 
+style#:#scss_variables_empty_might_have_changed#:#フォームには空の変数があります。このフォームをロードされてから設定ファイルを変更した可能性があります。設定ファイルのデフォルトは空フィールドが設定されます。コンパイル前にそれらの空フィールドにマークを確認して設定ファイルへ値を保存してください。
 style#:#scss_variables_file_not_included#:#scss 変数ファイル:
 style#:#select_icon#:#アイコンを選択
 style#:#settings_of_style#:#スタイルを管理
@@ -15703,7 +15702,7 @@ style#:#sty_add_color#:#カラーを追加
 style#:#sty_add_content_style#:#コンテンツスタイルを追加
 style#:#sty_add_image#:#イメージを追加
 style#:#sty_add_media_query#:#メディアクエリーを追加
-style#:#sty_add_media_query_info#:#例:ブラウザーウインドウが600px以下または印刷機器の"印刷"が "スクリーンのみで(max-width: 600px)" 
+style#:#sty_add_media_query_info#:#例:ブラウザーウインドウが600px以下または印刷機器の"印刷"が "スクリーンのみで(max-width: 600px)"
 style#:#sty_add_pgl#:#ページレイアウトを追加
 style#:#sty_add_template#:#テンプレートを追加
 style#:#sty_added_characteristic#:#スタイルクラスを追加しました。

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#შენახული დახარისხე
 cntr#:#cntr_switch_to_new_editor_cmd#:#გავართოთ ამ გვერდის ახალ შინაარსზე. ძველი შინაარსი ამოიშლება
 cntr#:#cntr_switch_to_new_editor_message#:#ეს არის მხარდაჭერილი სტანდარტული რედაქტორი. ძველი რედაქციიდან შინაარსის გადმოტანა შეუძლებელია. გთხოვთ ახაი გვერდის დამატება ქვემოთ. თუ თქვენ დააჭერთ შემდეგ ლინკს, ახალი შინაარსი გამოიყენება
 cntr#:#cntr_switched_editor#:#ახალ შინაარსზე გადართულია
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.###26 06 2009 new variable
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to this page for presentation###15 09 2008 new variable
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. Please use it to setup the content page. If you click the following link, the content presentation in the repository will switch from the old editor's content to this page.###15 09 2008 new variable
 cntr#:#cntr_switched_editor#:#Switched to new content.###15 09 2008 new variable
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Volgorde opslaan
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to this page for presentation
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. Please use it to setup the content page. If you click the following link, the content presentation in the repository will switch from the old editor's content to this page.
 cntr#:#cntr_switched_editor#:#Switched to new content.
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###06 02 2015 new variable
 cntr#:#cntr_tax_none_available#:#Er zijn geen taxonomieën beschikbaar
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###06 02 2015 new variable

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Zapisz sortowanie
 cntr#:#cntr_switch_to_new_editor_cmd#:#Przejdź do poniższych treści. Poprzednie treści zostały usunięte.
 cntr#:#cntr_switch_to_new_editor_message#:#To jest domyślny edytor stron. Jeśli chcesz z niego korzystać, musisz dodać treści kliknięciem na pola do wypełnienia znajdujące się na dole. Jeśli klikniesz w poniższy link, poniższe treści zostaną dodane na stronę.
 cntr#:#cntr_switched_editor#:#Przejście na nowy wygląd
-cntr#:#cntr_tax_list_info#:#Poniżej znajduje się zestawienie wszystkich klasyfikacji, które zostały zdefiniowane dla tego obiektu.
 cntr#:#cntr_tax_none_available#:#Brak dostępnych klasyfikacji.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Definicja klasyfikacji

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Ordenação guardada.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Copiar
 cntr#:#cntr_switch_to_new_editor_message#:#Copiar
 cntr#:#cntr_switched_editor#:#Mudou para novo conteúdo.
-cntr#:#cntr_tax_list_info#:#O que se segue são tudo taxonomias que foram definidas para este objeto.
 cntr#:#cntr_tax_none_available#:#Não existem taxonomias disponíveis.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Definição de taxonomia

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.###26 06 2009 new variable
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to this page for presentation###15 09 2008 new variable
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. Please use it to setup the content page. If you click the following link, the content presentation in the repository will switch from the old editor's content to this page.###15 09 2008 new variable
 cntr#:#cntr_switched_editor#:#Switched to new content.###15 09 2008 new variable
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to this page for presentation
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. Please use it to setup the content page. If you click the following link, the content presentation in the repository will switch from the old editor's content to this page.
 cntr#:#cntr_switched_editor#:#Switched to new content.
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Řazení uloženo.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Přepnout zobrazení na tuto stránku
 cntr#:#cntr_switch_to_new_editor_message#:#To je podporovaný standardní editor. Použijte jej prosím k nastavení obsahu stránky. Pokud klepnete na následující odkaz, obsah zobrazení úložiště bude přepnut ze starého editoru obsahu na tuto stránku.
 cntr#:#cntr_switched_editor#:#Přepnuto na nový obsah.
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -3395,7 +3395,6 @@ cntr#:#cntr_saved_sorting#:#Razvrstitev je shranjena
 cntr#:#cntr_switch_to_new_editor_cmd#:#Zamenjaj na spodnjo vsebino. Stara vsebina bo izbrisana.
 cntr#:#cntr_switch_to_new_editor_message#:#To je privzet urejevalnik strani. Če ga želite uporabiti, morate vsebino s klikom dodati na rezervirana mesta spodaj. Če kliknete na naslednjo povezavo, bo spodnja vsebina uporabljena za prikaz strani.
 cntr#:#cntr_switched_editor#:#Preklopljeno na nov prikaz
-cntr#:#cntr_tax_list_info#:#V nadaljevanju so navedene vse taksonomije, ki so bile definirane za ta objekt.
 cntr#:#cntr_tax_none_available#:#Ni razpoložljivih taksonomij.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Definicija taksonomije

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.###26 06 2009 new variable
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to this page for presentation###15 09 2008 new variable
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. Please use it to setup the content page. If you click the following link, the content presentation in the repository will switch from the old editor's content to this page.###15 09 2008 new variable
 cntr#:#cntr_switched_editor#:#Switched to new content.###15 09 2008 new variable
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.###26 06 2009 new variable
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to this page for presentation###15 09 2008 new variable
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. Please use it to setup the content page. If you click the following link, the content presentation in the repository will switch from the old editor's content to this page.###15 09 2008 new variable
 cntr#:#cntr_switched_editor#:#Switched to new content.###15 09 2008 new variable
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Sortering sparad
 cntr#:#cntr_switch_to_new_editor_cmd#:#Byt till innehållet nedan. Gammalt innehåll kommer att raderas.
 cntr#:#cntr_switch_to_new_editor_message#:#Detta är standardredigeraren för sidor. Om du vill använda den måste du lägga till innehållet genom att klicka på platshållarna nedan. Om du klickar på länken nedan kommer innehållet nedan att användas för att visa sidan.
 cntr#:#cntr_switched_editor#:#Konverterad till ny representation
-cntr#:#cntr_tax_list_info#:#Alla taxonomier som har definierats för detta objekt listas nedan.
 cntr#:#cntr_tax_none_available#:#Det finns inga tillgängliga taxonomier.
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Definition av taxonomi

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Sıralama Kaydedildi.
 cntr#:#cntr_switch_to_new_editor_cmd#:#Bu sayfayı yeni içerik Anahtarı. Alt içerik silinecektir.
 cntr#:#cntr_switch_to_new_editor_message#:#Bu desteklenen standart bir editördür. Eski editörü içeriği transfer edilemez. Aşağıda yeni bir sayfa içerik eklemeye başlayın lütfen. Eğer aşağıdaki bağlantıyı tıklarsanız, yeni içerik kullanılacaktır.
 cntr#:#cntr_switched_editor#:#yeni içerik geçildi.
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -3397,7 +3397,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.###26 06 2009 new variable
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to this page for presentation###15 09 2008 new variable
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. Please use it to setup the content page. If you click the following link, the content presentation in the repository will switch from the old editor's content to this page.###15 09 2008 new variable
 cntr#:#cntr_switched_editor#:#Switched to new content.###15 09 2008 new variable
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -3399,7 +3399,6 @@ cntr#:#cntr_saved_sorting#:#Saved Sorting.###26 06 2009 new variable
 cntr#:#cntr_switch_to_new_editor_cmd#:#Switch to this page for presentation###15 09 2008 new variable
 cntr#:#cntr_switch_to_new_editor_message#:#This is the supported standard editor. Please use it to setup the content page. If you click the following link, the content presentation in the repository will switch from the old editor's content to this page.###15 09 2008 new variable
 cntr#:#cntr_switched_editor#:#Switched to new content.###15 09 2008 new variable
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -3396,7 +3396,6 @@ cntr#:#cntr_saved_sorting#:#已保存的排序
 cntr#:#cntr_switch_to_new_editor_cmd#:#切换到这个页面介绍
 cntr#:#cntr_switch_to_new_editor_message#:#这是已支持的标准编辑器。请使用它设置内容页面。如果您点击下面的链接，知识库中的内容介绍将从老编辑器的内容切换到这个页面。
 cntr#:#cntr_switched_editor#:#已切换到新内容。
-cntr#:#cntr_tax_list_info#:#The following are all taxonomies that have been defined for this object.###27 01 2015 new variable
 cntr#:#cntr_tax_none_available#:#There are no taxonomies available.###26 09 2014 new variable
 cntr#:#cntr_tax_settings_info#:#Taxonomies in categories classify and filter the objects contained in the category. After adding taxonomies, classifications can be made via the "Metadata" tabs and the "Taxonomy Assignment" sub-tabs of the respective objects. Taxonomies can additionally be displayed in the side block of the category's "Contents" tab to enable direct filtering of the assigned objects.###30 04 2024 new variable
 cntr#:#cntr_taxonomy_definitions#:#Taxonomy Definition###27 01 2015 new variable


### PR DESCRIPTION
A blue message box with additional information about taxonomies is missing in the question pool view.

[Mantis: 35591](https://mantis.ilias.de/view.php?id=35591)