### PR TITLE
9/UI/mejs-videoplayer keyboard focus ILIAS style 34185

### DIFF
--- a/templates/default/030-tools/_tool_focus-outline.scss
+++ b/templates/default/030-tools/_tool_focus-outline.scss
@@ -3,12 +3,12 @@
 // The offset should only be used if the contrast between the focus outline and the component is insufficient.
 $il-focus-outline-inner-width: 3px;
 $il-focus-outline-outer-width: 2px;
-$il-focus-outline-inner: $il-focus-outline-inner-width solid $il-focus-color;
-$il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protection-color;
 
 // KEYBOARD FOCUS DEFAULT
 // This is the mixin you should be using if possible
-@mixin il-focus(){
+@mixin il-focus($il-focus-outline-inner-width: $il-focus-outline-inner-width, $il-focus-outline-outer-width: $il-focus-outline-outer-width){
+	$il-focus-outline-inner: $il-focus-outline-inner-width solid $il-focus-color;
+	$il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protection-color;
 	&:focus {
 		outline: none;
     	outline-offset: 0px;
@@ -18,7 +18,7 @@ $il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protectio
 		// outermost protection color line
 		outline: $il-focus-outline-outer;
 		outline-offset: $il-focus-outline-outer-width + $il-focus-outline-inner-width;
-		
+
 		&::after {
 			content: " ";
 			position: absolute;
@@ -37,7 +37,9 @@ $il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protectio
 // KEYBOARD FOCUS FOR BUTTONS, INPUTS AND ELEMENTS WITH :AFTER
 // some elements like buttons and input field cannot display the il-focus mixin because of the :after element
 // in this case use this mixin instead
-@mixin il-focus-outline-only($clearAfter: false) {
+@mixin il-focus-outline-only($clearAfter: false, $il-focus-outline-inner-width: $il-focus-outline-inner-width, $il-focus-outline-outer-width: $il-focus-outline-outer-width) {
+	$il-focus-outline-inner: $il-focus-outline-inner-width solid $il-focus-color;
+	$il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protection-color;
 	&:focus-visible{
 		outline: $il-focus-outline-inner;
 		box-shadow: inset 0px 0px 0px $il-focus-outline-outer-width $il-focus-protection-color, 0px 0px 0px ($il-focus-outline-outer-width + $il-focus-outline-inner-width) $il-focus-protection-color;
@@ -52,10 +54,12 @@ $il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protectio
 // KEYBOARD FOCUS FOR Elements, that contain Elements that get Focus
 // some elements like file buttons and input field cannot display the il-focus mixin because they do not get focus directly
 // in this case use this mixin instead
-@mixin il-focus-within-outline-only($clearAfter: false) {
+@mixin il-focus-within-outline-only($clearAfter: false, $il-focus-outline-inner-width: $il-focus-outline-inner-width, $il-focus-outline-outer-width: $il-focus-outline-outer-width) {
+	$il-focus-outline-inner: $il-focus-outline-inner-width solid $il-focus-color;
+	$il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protection-color;
 	&:focus-within{
 		outline: $il-focus-outline-inner;
-		box-shadow: inset 0px 0px 0px 2px $il-focus-protection-color, 0px 0px 0px 6px $il-focus-protection-color;
+		box-shadow: inset 0px 0px 0px $il-focus-outline-outer-width $il-focus-protection-color, 0px 0px 0px (($il-focus-outline-outer-width*2) + $il-focus-outline-inner-width) red; // $il-focus-protection-color
 		@if $clearAfter {
 			&::after {
 				content: none;
@@ -68,11 +72,13 @@ $il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protectio
 // some elements at the edge do not show the focus outline because it's already offscreen
 // or for inline elements that break into multiple lines
 // in these cases use this mixin instead
-@mixin il-focus-border-only($clearAfter: false) {
+@mixin il-focus-border-only($clearAfter: false, $il-focus-outline-inner-width: $il-focus-outline-inner-width, $il-focus-outline-outer-width: $il-focus-outline-outer-width) {
+	$il-focus-outline-inner: $il-focus-outline-inner-width solid $il-focus-color;
+	$il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protection-color;
 	&:focus-visible {
 		outline: none;
 		border: $il-focus-outline-inner;
-		box-shadow: inset 0px 0px 0px 2px $il-focus-protection-color, 0px 0px 0px 2px $il-focus-protection-color;
+		box-shadow: inset 0px 0px 0px $il-focus-outline-outer-width $il-focus-protection-color, 0px 0px 0px $il-focus-outline-outer-width $il-focus-protection-color;
 		@if $clearAfter {
 			&::after {
 				content: none;

--- a/templates/default/060-elements/_elements_input.scss
+++ b/templates/default/060-elements/_elements_input.scss
@@ -1,8 +1,10 @@
 @use "../010-settings/" as *;
 @use "../010-settings/legacy-settings/legacy-settings_form" as *;
+@use "../030-tools/tool_focus-outline" as focus;
 
 button {
 	cursor: pointer;
+	@include focus.il-focus-outline-only();
 }
 
 textarea {

--- a/templates/default/070-components/legacy/Services/_component_mediaobjects.scss
+++ b/templates/default/070-components/legacy/Services/_component_mediaobjects.scss
@@ -1,4 +1,5 @@
 @use "../../../010-settings/" as *;
+@use "../../../030-tools/tool_focus-outline" as focus;
 
 /* Services/MediaObjects */
 
@@ -40,6 +41,26 @@
 
 .mejs-overlay-button {
 	background-image: url("#{$il-background-images-path}media/bigplay.svg");
+}
+
+.mejs__overlay-button,
+.ilPlayerPreviewPlayButton {
+	@include focus.il-focus();
+}
+
+.mejs__time-total {
+	@include focus.il-focus($il-focus-outline-inner-width: 1px, $il-focus-outline-outer-width: 1px);
+}
+
+.mejs__container {
+	@include focus.il-focus-border-only();
+}
+
+.mejs__button button,
+.ilPageVideo button,
+a.mejs__volume-slider {
+	@include focus.clear-focus-for-override();
+	@include focus.il-focus-border-only($il-focus-outline-inner-width: 1px, $il-focus-outline-outer-width: 1px);
 }
 
 .ilPlayerPreviewPlayButton {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2037,6 +2037,10 @@ body {
 button {
   cursor: pointer;
 }
+button:focus-visible {
+  outline: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
+}
 
 @media only screen and (max-width: 991px) {
   textarea {
@@ -15917,7 +15921,7 @@ div.ilHFormFooter .ilFormCmds {
 }
 .btn-file:focus-within {
   outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 6px #FFFFFF;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 7px red;
 }
 
 .btn-file input[type=file] {
@@ -16243,6 +16247,79 @@ a.mailunread, a.mailunread:visited {
 
 .mejs-overlay-button {
   background-image: url("./images/media/bigplay.svg");
+}
+
+.mejs__overlay-button:focus,
+.ilPlayerPreviewPlayButton:focus {
+  outline: none;
+  outline-offset: 0px;
+}
+.mejs__overlay-button:focus-visible,
+.ilPlayerPreviewPlayButton:focus-visible {
+  position: relative;
+  outline: 2px solid #FFFFFF;
+  outline-offset: 5px;
+}
+.mejs__overlay-button:focus-visible::after,
+.ilPlayerPreviewPlayButton:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 2px solid #FFFFFF;
+  outline: 3px solid #0078D7;
+}
+
+.mejs__time-total:focus {
+  outline: none;
+  outline-offset: 0px;
+}
+.mejs__time-total:focus-visible {
+  position: relative;
+  outline: 1px solid #FFFFFF;
+  outline-offset: 2px;
+}
+.mejs__time-total:focus-visible::after {
+  content: " ";
+  position: absolute;
+  top: -1px;
+  left: -1px;
+  right: -1px;
+  bottom: -1px;
+  border: 1px solid #FFFFFF;
+  outline: 1px solid #0078D7;
+}
+
+.mejs__container:focus-visible {
+  outline: none;
+  border: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 2px #FFFFFF;
+}
+
+.mejs__button button:focus,
+.ilPageVideo button:focus,
+a.mejs__volume-slider:focus {
+  border: inherit;
+  box-shadow: inherit;
+  outline: none;
+  outline-offset: 0px;
+}
+.mejs__button button:focus-visible,
+.ilPageVideo button:focus-visible,
+a.mejs__volume-slider:focus-visible {
+  border: inherit;
+  box-shadow: inherit;
+  outline: none;
+  outline-offset: 0px;
+}
+.mejs__button button:focus-visible,
+.ilPageVideo button:focus-visible,
+a.mejs__volume-slider:focus-visible {
+  outline: none;
+  border: 1px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 1px #FFFFFF, 0px 0px 0px 1px #FFFFFF;
 }
 
 .ilPlayerPreviewPlayButton {


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=34185
PR für ILIAS 8: https://github.com/ILIAS-eLearning/ILIAS/pull/7791

# Issue

Focus in video player is low contrast and not uniform with the rest of ILIAS.

![videoplayer_focus-incorrect](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/6081a9d6-f527-4dd9-ae58-0e5f63604a29)

# Change

Our il-focus mixins are now used to highlight player elements.
il-focus mixins now take parameters so a thinner focus line can be constructed for the small player icons.
HTML element button now has focus applied by default so dependencies should take ILIAS focus outlines unless they override them.

![videoplayer_focus-correct_il9](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/d80f1948-7e39-49fa-9760-35a319c84f22)
