### PR TITLE
[FIX] #41560 UI: Footer Link Colours Sass

### DIFF
--- a/templates/default/010-settings/_settings_footer.scss
+++ b/templates/default/010-settings/_settings_footer.scss
@@ -1,6 +1,8 @@
 @use "./_settings_color-palette.scss" as s-color;
 
 //** footer
+$il-footer-link-hover-color: s-color.$il-link-hover-color !default;
+$il-footer-link-color: s-color.$il-link-color !default;
 $il-footer-bg-color: s-color.$il-main-bg !default;
 $il-footer-color: s-color.$il-text-color !default;
 $il-footer-height: 45px !default;

--- a/templates/default/070-components/UI-framework/MainControls/_ui-component_footer.scss
+++ b/templates/default/070-components/UI-framework/MainControls/_ui-component_footer.scss
@@ -32,7 +32,10 @@ footer{
 			display: inline-block;
 			margin-right: $il-margin-xs-horizontal;
 			a, button {
-				color: $il-link-color;
+				color: $il-footer-link-color;
+			}
+			a:hover, button:hover {
+				color: $il-footer-link-hover-color;
 			}
 			button {
 				vertical-align: baseline;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6230,6 +6230,9 @@ footer {
 .il-maincontrols-footer .il-footer-links li a, .il-maincontrols-footer .il-footer-links li button {
   color: #4c6586;
 }
+.il-maincontrols-footer .il-footer-links li a:hover, .il-maincontrols-footer .il-footer-links li button:hover {
+  color: #3a4c65;
+}
 .il-maincontrols-footer .il-footer-links li button {
   vertical-align: baseline;
 }


### PR DESCRIPTION
Hi folks,

This is a follow-up of #7719, which has introduced Less variables to address [an accessibility issue](https://mantis.ilias.de/view.php?id=41560). I have introduced the same variables for Sass with this PR, along with fixing the appliance of the missing link hover colour.

Please note the variables currently don't show up in the configuration screen of skins (`ilSystemStyleScssGUI`), but I could not figure out why. Maybe there is something wrong with the form-build mechanism? If I missed something, let me know.

Kind regards,
@thibsy 