### PR TITLE
T&A 40598: Instant Feedback in Kprim Question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
@@ -738,7 +738,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
     private function populateSpecificFeedbackInline($user_solution, $answer_id, $template): void
     {
         if ($this->object->getSpecificFeedbackSetting() == ilAssConfigurableMultiOptionQuestionFeedback::FEEDBACK_SETTING_CHECKED) {
-            if ($user_solution[$answer_id]) {
+            if (isset($user_solution[$answer_id])) {
                 $fb = $this->object->feedbackOBJ->getSpecificAnswerFeedbackTestPresentation($this->object->getId(), 0, $answer_id);
                 if (strlen($fb)) {
                     $template->setCurrentBlock("feedback");


### PR DESCRIPTION
Mantisticket: https://mantis.ilias.de/view.php?id=40598

In Mantis the proposed solution was to  remove the feedback option "Show answer specific feedback for all chosen/selected answers." in KPrim-Questions. 
We determined that this feedback option is also in use in Single and Multiplechoice Question. In agreement with @dsstrassner we decided to try and fix the bug rather than removing the functionality. 

