### PR TITLE
Add Langfile Duplicate Identifier script for GitHook

### DIFF
--- a/scripts/check_langfile_duplicate_identifier.sh
+++ b/scripts/check_langfile_duplicate_identifier.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+. scripts/Import/Functions.sh
+
+exit_status=0
+
+if [ -z "${GHRUN}" ]
+then
+  langfiles=$(git diff --cached --name-only --diff-filter=ACM -- '*.lang')
+else
+  langfiles=$(get_changed_lang_files)
+fi
+
+for file in $langfiles
+do
+  # Find the duplicate identifiers
+  duplicate_identifiers=$(sed -n '/<!-- language file start -->/,$p' $file | awk -F '#:#' '{print tolower($2)}' | sort -f | uniq -d)
+
+  if [[ -n $duplicate_identifiers ]]; then
+     echo "In Datei ${file} gibt es Duplikate für folgende Identifier:"
+
+     # Loop through each duplicate identifier
+     for duplicate_identifier in $duplicate_identifiers; do
+        # Find all lines containing this exact duplicate and print the modules
+        IFS=$'\n' lines_with_duplicate=($(sed -n '/<!-- language file start -->/,$p' $file | awk -F '#:#' -v id="$duplicate_identifier" 'tolower($2) == tolower(id){print $1}'))
+        # Remove duplicates and create a comma separated list of unique modules
+        modules_with_duplicate=$(echo "${lines_with_duplicate[@]}" | tr ' ' '\n' | sort -fu | tr '\n' ',' | sed 's/,$//')
+        echo "Doppelter Identifier \"$duplicate_identifier\" in Modulen: $modules_with_duplicate"
+     done
+
+     # Mark that duplicates are found
+     exit_status=127
+  fi
+done
+
+exit $exit_status
+Footer
+© 2024 GitHub, Inc.
+Footer navigation
+Terms
+Privacy
+Security
+Status
+Docs
+Contact

--- a/scripts/check_langfile_duplicate_identifier.sh
+++ b/scripts/check_langfile_duplicate_identifier.sh
@@ -34,12 +34,3 @@ do
 done
 
 exit $exit_status
-Footer
-© 2024 GitHub, Inc.
-Footer navigation
-Terms
-Privacy
-Security
-Status
-Docs
-Contact

--- a/scripts/check_langfile_duplicate_identifier.sh
+++ b/scripts/check_langfile_duplicate_identifier.sh
@@ -16,20 +16,19 @@ do
   # Find the duplicate identifiers
   duplicate_identifiers=$(sed -n '/<!-- language file start -->/,$p' $file | awk -F '#:#' '{print tolower($2)}' | sort -f | uniq -d)
 
-  if [[ -n $duplicate_identifiers ]]; then
-     echo "In Datei ${file} gibt es Duplikate für folgende Identifier:"
+  if [ -n "$duplicate_identifiers" ]; then
+     echo "In file ${file} are duplicates for the following identifier:"
 
      # Loop through each duplicate identifier
      for duplicate_identifier in $duplicate_identifiers; do
         # Find all lines containing this exact duplicate and print the modules
-        IFS=$'\n' lines_with_duplicate=($(sed -n '/<!-- language file start -->/,$p' $file | awk -F '#:#' -v id="$duplicate_identifier" 'tolower($2) == tolower(id){print $1}'))
+        lines_with_duplicate=$(sed -n '/<!-- language file start -->/,$p' "$file" | awk -F '#:#' -v id="$duplicate_identifier" 'tolower($2) == tolower(id){print $1}')
         # Remove duplicates and create a comma separated list of unique modules
-        modules_with_duplicate=$(echo "${lines_with_duplicate[@]}" | tr ' ' '\n' | sort -fu | tr '\n' ',' | sed 's/,$//')
-        echo "Doppelter Identifier \"$duplicate_identifier\" in Modulen: $modules_with_duplicate"
+        modules_with_duplicate=$(echo "${lines_with_duplicate}" | tr ' ' '\n' | sort -fu | tr '\n' ',' | sed 's/,$//')
+        echo "Duplicate identifier \"$duplicate_identifier\" found in modules: $modules_with_duplicate"
      done
 
-     # Mark that duplicates are found
-     exit_status=127
+     exit_status=1
   fi
 done
 

--- a/scripts/check_langfile_duplicate_identifier.sh
+++ b/scripts/check_langfile_duplicate_identifier.sh
@@ -14,7 +14,7 @@ fi
 for file in $langfiles
 do
   # Find the duplicate identifiers
-  duplicate_identifiers=$(sed -n '/<!-- language file start -->/,$p' $file | awk -F '#:#' '{print tolower($2)}' | sort -f | uniq -d)
+  duplicate_identifiers=$(sed -n '/<!-- language file start -->/,$p' "$file" | awk -F '#:#' '{print tolower($2)}' | sort -f | uniq -d)
 
   if [ -n "$duplicate_identifiers" ]; then
      echo "In file ${file} are duplicates for the following identifier:"


### PR DESCRIPTION
Hey everyone,

This PR adds the Bash script check_langfile_duplicate_identifier.sh to be included in the GitHooks. The PR description also includes the necessary lines for /captainhook.json and .github/workflows/checks.yml.

Best regards!

1. To activate, these lines must be in the "/captainhook.json" file, in line 66
 ```
        {
        "action": "scripts/check_langfile_duplicate_identifier.sh",
        "options": [],
        "conditions": [
          {
            "exec": "\\CaptainHook\\App\\Hook\\Condition\\FileStaged\\Any",
            "args": [
              [
                "*.lang"
              ]
            ]
          }
        ]
      },
```
	  

2. To activate, these lines must be in the ".github/workflows/checks.yml" file - line 58  
```
      - name: Language Duplicate Identifier Check
        run: CI/check_langfile_duplicate_identifier.sh
        env:
          GHRUN: "yes"
          PR_NUMBER: ${{ github.event.number }}
          GH_SHA: ${{ github.sha }}
```