### PR TITLE
T&A 40791: Superglobals replacement in Test component

### DIFF
--- a/components/ILIAS/Test/classes/Confirmations/class.ilTestSettingsChangeConfirmationGUI.php
+++ b/components/ILIAS/Test/classes/Confirmations/class.ilTestSettingsChangeConfirmationGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
+
 /**
  * @author		Björn Heyser <bheyser@databay.de>
  * @version		$Id$
@@ -26,15 +28,14 @@ declare(strict_types=1);
  */
 class ilTestSettingsChangeConfirmationGUI extends ilConfirmationGUI
 {
-    protected ilObjTest $testOBJ;
     private ?string $oldQuestionSetType;
     private ?string $newQuestionSetType;
     private ?bool $questionLossInfoEnabled;
 
-    public function __construct(ilObjTest $testOBJ)
-    {
-        $this->testOBJ = $testOBJ;
-
+    public function __construct(
+        private readonly RequestDataCollector $testrequest,
+        protected readonly ilObjTest $testOBJ
+    ) {
         parent::__construct();
     }
 
@@ -93,15 +94,18 @@ class ilTestSettingsChangeConfirmationGUI extends ilConfirmationGUI
 
     public function populateParametersFromPost(): void
     {
-        foreach ($_POST as $key => $value) {
-            if (strcmp($key, "cmd") != 0) {
+        foreach ($this->testrequest->getPostKeys() as $key) {
+            if ($key !== 'cmd') {
+                $value = $this->testrequest->getArrayOfStringsOrStringFromPost($key);
+
                 if (is_array($value)) {
                     foreach ($value as $k => $v) {
                         $this->addHiddenItem("{$key}[{$k}]", $v);
                     }
-                } else {
-                    $this->addHiddenItem($key, $value);
+                    continue;
                 }
+
+                $this->addHiddenItem($key, $value);
             }
         }
     }

--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -693,6 +693,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                     $this->component_repository,
                     $this->getTestObject(),
                     $this->questionrepository,
+                    $this->testrequest,
                     $this->ref_id
                 );
                 $this->ctrl->forwardCommand($gui);
@@ -2199,7 +2200,8 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
        */
     public function participantsActionObject(): void
     {
-        $command = $this->testrequest->strVal('command');
+        $command = $this->testrequest->getStringFromPost('command', '');
+
         if ($command === '') {
             $method = $command . 'Object';
             if (method_exists($this, $method)) {
@@ -2385,10 +2387,11 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
     /**
      * Applies the selected test defaults
      */
-    public function applyDefaultsObject($confirmed = false)
+    public function applyDefaultsObject($confirmed = false): void
     {
-        $defaults = $this->testrequest->getArrayOfStringsFromPost('chb_defaults');
-        if ($defaults !== null && $defaults !== []) {
+        $defaults = $this->testrequest->getArrayOfIntsFromPost('chb_defaults');
+
+        if ($defaults !== []) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('tst_defaults_apply_select_one'));
 
             $this->defaultsObject();
@@ -2429,7 +2432,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
 
             default:
 
-                $confirmation = new ilTestSettingsChangeConfirmationGUI($this->getTestObject());
+                $confirmation = new ilTestSettingsChangeConfirmationGUI($this->testrequest, $this->getTestObject());
 
                 $confirmation->setFormAction($this->ctrl->getFormAction($this));
                 $confirmation->setCancel($this->lng->txt('cancel'), 'defaults');
@@ -2471,7 +2474,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
     */
     public function addDefaultsObject()
     {
-        $name = $this->testrequest->strVal('name');
+        $name = $this->testrequest->getStringFromPost('name');
         if ($name !== '') {
             $this->getTestObject()->addDefaults($name);
         } else {

--- a/components/ILIAS/Test/classes/class.ilTestDashboardGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestDashboardGUI.php
@@ -18,10 +18,9 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Renderer as UIRenderer;
-
-use ILIAS\Test\RequestDataCollector;
 
 /**
  * Class ilTestDashboardGUI
@@ -107,6 +106,9 @@ class ilTestDashboardGUI
         $this->objective_parent = $objective_parent;
     }
 
+    /**
+     * @throws ilCtrlException
+     */
     public function executeCommand(): void
     {
         if (!$this->getTestAccess()->checkManageParticipantsAccess()) {
@@ -149,7 +151,8 @@ class ilTestDashboardGUI
                     $this->lng,
                     $this->db,
                     $this->main_tpl,
-                    new ilTestParticipantAccessFilterFactory($this->access)
+                    new ilTestParticipantAccessFilterFactory($this->access),
+                    $this->testrequest
                 );
                 $this->ctrl->forwardCommand($gui);
                 break;

--- a/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
@@ -1535,12 +1535,12 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         $this->tpl->setContent($this->ctrl->getHTML($confirm));
     }
 
-    public function cancelDeletePass()
+    public function cancelDeletePass(): void
     {
-        $this->redirectToPassDeletionContext($_POST['context']);
+        $this->redirectToPassDeletionContext($this->testrequest->getStringFromPost('context'));
     }
 
-    private function redirectToPassDeletionContext($context)
+    private function redirectToPassDeletionContext($context): void
     {
         switch ($context) {
             case ilTestPassDeletionConfirmationGUI::CONTEXT_PASS_OVERVIEW:
@@ -1554,13 +1554,14 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         }
     }
 
-    public function performDeletePass()
+    /**
+     * @throws ilCtrlException|ilTestException
+     */
+    public function performDeletePass(): void
     {
-        if (isset($_POST['context']) && strlen($_POST['context'])) {
-            $context = $_POST['context'];
-        } else {
-            $context = ilTestPassDeletionConfirmationGUI::CONTEXT_PASS_OVERVIEW;
-        }
+        $context = $this->testrequest->getStringFromPost('context', ilTestPassDeletionConfirmationGUI::CONTEXT_PASS_OVERVIEW);
+        $active_fi = $this->testrequest->getIntFromPost('active_id', null);
+        $pass = $this->testrequest->getIntFromPost('pass', null);
 
         if (!$this->object->isPassDeletionAllowed()) {
             $this->redirectToPassDeletionContext($context);
@@ -1568,22 +1569,11 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 
         $ilDB = $this->db;
 
-        $active_fi = null;
-        $pass = null;
-
-        if (isset($_POST['active_id']) && (int) $_POST['active_id']) {
-            $active_fi = $_POST['active_id'];
-        }
-
-        if (isset($_POST['pass']) && is_numeric($_POST['pass'])) {
-            $pass = $_POST['pass'];
-        }
-
         if (is_null($active_fi) || is_null($pass)) {
             $this->ctrl->redirect($this, 'outUserResultsOverview');
         }
 
-        if ($pass == $this->object->_getResultPass($active_fi)) {
+        if ($pass === $this->object::_getResultPass($active_fi)) {
             $this->ctrl->redirect($this, 'outUserResultsOverview');
         }
 

--- a/components/ILIAS/Test/classes/class.ilTestParticipantsTimeExtensionGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestParticipantsTimeExtensionGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
+
 /**
  * Class ilTestParticipantsTimeExtensionGUI
  *
@@ -41,7 +43,8 @@ class ilTestParticipantsTimeExtensionGUI
         private illanguage $lng,
         private ilDBInterface $db,
         private ilGlobalTemplateInterface $main_tpl,
-        private ilTestParticipantAccessFilterFactory $participant_access_filter
+        private ilTestParticipantAccessFilterFactory $participant_access_filter,
+        private RequestDataCollector $testrequest
     ) {
     }
 
@@ -193,8 +196,16 @@ class ilTestParticipantsTimeExtensionGUI
         $extratime->setSize(5);
         $form->addItem($extratime);
 
-        if (is_array($_POST) && isset($_POST['cmd']['timing']) && $_POST['cmd']['timing'] != '') {
-            $form->setValuesByArray($_POST);
+        $cmd = $this->testrequest->getArrayOfStringsFromPost('cmd');
+
+        if (isset($cmd['timing']) && $cmd['timing'] !== '') {
+            $values = [];
+
+            foreach ($this->testrequest->getPostKeys() as $key) {
+                $values[$key] = $this->testrequest->getArrayOfStringsOrStringFromPost($key);
+            }
+
+            $form->setValuesByArray($values);
         }
 
         $form->addCommandButton(self::CMD_SET_TIMING, $this->lng->txt("save"));

--- a/components/ILIAS/Test/classes/class.ilTestPasswordProtectionGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPasswordProtectionGUI.php
@@ -109,9 +109,12 @@ class ilTestPasswordProtectionGUI
         );
     }
 
+    /**
+     * @throws ilCtrlException
+     */
     private function saveEnteredPasswordCmd(): void
     {
-        $this->password_checker->setUserEnteredPassword($_POST["password"]);
+        $this->password_checker->setUserEnteredPassword($this->testrequest->getStringFromPost('password'));
 
         if (!$this->password_checker->isUserEnteredPasswordCorrect()) {
             $this->password_checker->logWrongEnteredPassword();

--- a/components/ILIAS/Test/classes/class.ilTestSkillAdministrationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestSkillAdministrationGUI.php
@@ -18,10 +18,9 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
 use ILIAS\Test\Logging\TestLogger;
-
-use ILIAS\Refinery\Factory as Refinery;
 
 /**
  * @author		Björn Heyser <bheyser@databay.de>
@@ -40,13 +39,13 @@ class ilTestSkillAdministrationGUI
         private ilTabsGUI $tabs,
         private ilGlobalTemplateInterface $tpl,
         private ilLanguage $lng,
-        private Refinery $refinery,
         private ilDBInterface $db,
         private TestLogger $logger,
         private ilTree $tree,
         private ilComponentRepository $component_repository,
         private ilObjTest $test_obj,
         private GeneralQuestionPropertiesRepository $questionrepository,
+        private RequestDataCollector $testrequest,
         private int $ref_id
     ) {
     }
@@ -90,7 +89,14 @@ class ilTestSkillAdministrationGUI
 
             case 'iltestskilllevelthresholdsgui':
 
-                $gui = new ilTestSkillLevelThresholdsGUI($this->ctrl, $this->tpl, $this->lng, $this->db, $this->test_obj->getTestId());
+                $gui = new ilTestSkillLevelThresholdsGUI(
+                    $this->ctrl,
+                    $this->tpl,
+                    $this->lng,
+                    $this->db,
+                    $this->testrequest,
+                    $this->test_obj->getTestId()
+                );
                 $gui->setQuestionAssignmentColumnsEnabled(!$this->test_obj->isRandomTest());
                 $gui->setQuestionContainerId($this->test_obj->getId());
                 $this->ctrl->forwardCommand($gui);

--- a/components/ILIAS/Test/tests/confirmations/ilTestSettingsChangeConfirmationGUITest.php
+++ b/components/ILIAS/Test/tests/confirmations/ilTestSettingsChangeConfirmationGUITest.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-use ILIAS\DI\Container;
+use ILIAS\Test\RequestDataCollector;
 
 /**
  * Class ilTestSettingsChangeConfirmationGUITest
@@ -33,7 +33,8 @@ class ilTestSettingsChangeConfirmationGUITest extends ilTestBaseTestCase
         parent::setUp();
 
         $this->testSettingsChangeConfirmationGUI = new ilTestSettingsChangeConfirmationGUI(
-            $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock()
+            $this->createMock(RequestDataCollector::class),
+            $this->createMock(ilObjTest::class)
         );
     }
 

--- a/components/ILIAS/Test/tests/ilTestDashboardGUITest.php
+++ b/components/ILIAS/Test/tests/ilTestDashboardGUITest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
+
 /**
  * Class ilTestDashboardGUITest
  * @author Marvin Beym <mbeym@databay.de>
@@ -55,7 +57,7 @@ class ilTestDashboardGUITest extends ilTestBaseTestCase
             $DIC['ilTabs'],
             $DIC['ilToolbar'],
             $this->createMock(ilTestQuestionSetConfig::class),
-            $this->createMock(\ILIAS\Test\RequestDataCollector::class)
+            $this->createMock(RequestDataCollector::class)
         );
     }
 

--- a/components/ILIAS/Test/tests/ilTestParticipantsGUITest.php
+++ b/components/ILIAS/Test/tests/ilTestParticipantsGUITest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
+
 /**
  * Class ilTestParticipantsGUITest
  * @author Marvin Beym <mbeym@databay.de>
@@ -51,7 +53,7 @@ class ilTestParticipantsGUITest extends ilTestBaseTestCase
             $DIC['ilDB'],
             $DIC['ilTabs'],
             $DIC['ilToolbar'],
-            $this->createMock(\ILIAS\Test\RequestDataCollector::class)
+            $this->createMock(RequestDataCollector::class)
         );
     }
 

--- a/components/ILIAS/Test/tests/ilTestParticipantsTimeExtensionGUITest.php
+++ b/components/ILIAS/Test/tests/ilTestParticipantsTimeExtensionGUITest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
+
 /**
  * Class ilTestParticipantsTimeExtensionGUITest
  * @author Marvin Beym <mbeym@databay.de>
@@ -43,7 +45,8 @@ class ilTestParticipantsTimeExtensionGUITest extends ilTestBaseTestCase
             $DIC['lng'],
             $DIC['ilDB'],
             $DIC['tpl'],
-            $this->createMock(ilTestParticipantAccessFilterFactory::class)
+            $this->createMock(ilTestParticipantAccessFilterFactory::class),
+            $this->createMock(RequestDataCollector::class)
         );
     }
 

--- a/components/ILIAS/Test/tests/ilTestSkillAdministrationGUITest.php
+++ b/components/ILIAS/Test/tests/ilTestSkillAdministrationGUITest.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\Test\RequestDataCollector;
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
 
 /**
@@ -36,13 +37,13 @@ class ilTestSkillAdministrationGUITest extends ilTestBaseTestCase
             $this->createMock(ilTabsGUI::class),
             $this->createMock(ilGlobalPageTemplate::class),
             $this->createMock(ilLanguage::class),
-            $this->createMock(ILIAS\Refinery\Factory::class),
             $this->createMock(ilDBInterface::class),
             $this->createMock(ILIAS\Test\Logging\TestLogger::class),
             $this->createMock(ilTree::class),
             $this->createMock(ilComponentRepository::class),
             $this->getTestObjMock(),
             $this->createMock(GeneralQuestionPropertiesRepository::class),
+            $this->createMock(RequestDataCollector::class),
             201
         );
     }

--- a/components/ILIAS/Test/tests/ilTestSkillLevelThresholdsGUITest.php
+++ b/components/ILIAS/Test/tests/ilTestSkillLevelThresholdsGUITest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
+
 /**
  * Class ilTestSkillLevelThresholdsGUITest
  * @author Marvin Beym <mbeym@databay.de>
@@ -37,6 +39,7 @@ class ilTestSkillLevelThresholdsGUITest extends ilTestBaseTestCase
             $this->createMock(ilGlobalPageTemplate::class),
             $this->createMock(ilLanguage::class),
             $this->createMock(ilDBInterface::class),
+            $this->createMock(RequestDataCollector::class),
             $this->testId
         );
     }


### PR DESCRIPTION
Superglobal variables such as $_GET or $_POST should not be accessed directly. Instead, use the request and refinery mechanisms. Currently, there are four instances where this change is not feasible due to limitations in the request and refinery systems, but these will be addressed in the future.

[Mantis: 40791](https://mantis.ilias.de/view.php?id=40791)