### PR TITLE
9/Learning-Sequence push footer down 41463

### DIFF
--- a/Modules/LearningSequence/templates/default/tpl.kioskpage.html
+++ b/Modules/LearningSequence/templates/default/tpl.kioskpage.html
@@ -1,4 +1,4 @@
-<div id="il_center_col" class="col-sm-12">
+<div id="mainspacekeeper" class="col-sm-12">
 
 	<div class="ilLSOKioskModeObjectHeader">
 		<div class="media il_HeaderInner">

--- a/templates/default/070-components/UI-framework/MainControls/_ui-component_mode_info.scss
+++ b/templates/default/070-components/UI-framework/MainControls/_ui-component_mode_info.scss
@@ -15,7 +15,7 @@ $il-mode-info-shadow: $il-shadow--large;
 
 .c-mode-info {
   display: flex;
-  position: absolute;
+  position: fixed;
   z-index: $il-mode-info-zindex;
   width: 100%;
   align-items: start;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6595,7 +6595,7 @@ footer {
  */
 .c-mode-info {
   display: flex;
-  position: absolute;
+  position: fixed;
   z-index: 1010;
   width: 100%;
   align-items: start;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41463
PR for 8: https://github.com/ILIAS-eLearning/ILIAS/pull/7672

# Issue

Footer is not positioned at the bottom of the content area.
Header overlaps Slate and content area slightly.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/48b7fccd-773d-4196-8920-f72e39677570)

# Change

Learning Sequence kiosk mode had no content div that actually stretches and pushes the footer down. Used the mainspacekeeper ID for the content area in the html template which comes with the layout styling that was missing in this kiosk mode.

PR for 8 was accepted by JF.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/a99d7142-a9d6-44c4-81cd-66aab8bc4e36)
