### PR TITLE
10/Learning-Sequence push footer down 41463

### DIFF
--- a/components/ILIAS/LearningSequence/templates/default/tpl.kioskpage.html
+++ b/components/ILIAS/LearningSequence/templates/default/tpl.kioskpage.html
@@ -1,4 +1,4 @@
-<div id="il_center_col" class="col-sm-12">
+<div id="mainspacekeeper" class="col-sm-12">
 
 	<div class="ilLSOKioskModeObjectHeader">
 		<div class="media il_HeaderInner">


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41463
PR for 8: https://github.com/ILIAS-eLearning/ILIAS/pull/7672
PR for 9: https://github.com/ILIAS-eLearning/ILIAS/pull/7806

# Issue

Footer is not positioned at the bottom of the content area.
Header overlaps Slate and content area slightly.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/48b7fccd-773d-4196-8920-f72e39677570)

# Change

Learning Sequence kiosk mode had no content div that actually stretches and pushes the footer down. Used the mainspacekeeper ID for the content area in the html template which comes with the layout styling that was missing in this kiosk mode.

PR for 8 was accepted by JF.

![image](https://github.com/ILIAS-eLearning/ILIAS/assets/59924129/a99d7142-a9d6-44c4-81cd-66aab8bc4e36)
