### PR TITLE
Remove ilObjGroup `getSubItems` implementation

### DIFF
--- a/Modules/Group/classes/class.ilObjGroup.php
+++ b/Modules/Group/classes/class.ilObjGroup.php
@@ -1604,32 +1604,4 @@ class ilObjGroup extends ilContainer implements ilMembershipRegistrationCodes
         $row = $ilDB->fetchAssoc($res);
         return (bool) $row['show_members'];
     }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function getSubItems(
-        bool $a_admin_panel_enabled = false,
-        bool $a_include_side_block = false,
-        int $a_get_single = 0,
-        \ilContainerUserFilter $container_user_filter = null
-    ): array {
-        // Caching
-        if (
-            isset($this->items[(int) $a_admin_panel_enabled][(int) $a_include_side_block]) &&
-            is_array($this->items[(int) $a_admin_panel_enabled][(int) $a_include_side_block])
-        ) {
-            return $this->items[(int) $a_admin_panel_enabled][(int) $a_include_side_block];
-        }
-        // Results are stored in $this->items
-        parent::getSubItems($a_admin_panel_enabled, $a_include_side_block, $a_get_single);
-        $this->items = ilContainerSessionsContentGUI::prepareSessionPresentationLimitation(
-            $this->items,
-            $this,
-            $a_admin_panel_enabled,
-            $a_include_side_block
-        );
-        return $this->items[(int) $a_admin_panel_enabled][(int) $a_include_side_block];
-    }
 } //END class.ilObjGroup


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41719

This function does nothing indifferent to the parent function, except calling an undefined method which results into an error.

Through this the `Group` will use the parent/container `getSubItem()` function just like any other container