### PR TITLE
Fix PublicAssetManager's path validation to also accept dots within path naming

### DIFF
--- a/components/ILIAS/Component/src/Resource/PublicAssetManager.php
+++ b/components/ILIAS/Component/src/Resource/PublicAssetManager.php
@@ -25,7 +25,7 @@ namespace ILIAS\Component\Resource;
  */
 class PublicAssetManager
 {
-    public const REGEXP = '%^(/[\w-]+)+$%';
+    public const REGEXP = '%^(/\w+|\w+[\-.]\w+)+$%';
 
     public const DONT_PURGE = ["data", "Customizing"];
 

--- a/components/ILIAS/Component/tests/Resource/PublicAssetManagerTest.php
+++ b/components/ILIAS/Component/tests/Resource/PublicAssetManagerTest.php
@@ -125,4 +125,48 @@ class PublicAssetManagerTest extends TestCase
         $this->assertEquals(["/public", "/public/second"], $this->manager->madeDir);
         $this->assertEquals([["/base/source1", "/public/target1"], ["/base/source2", "/public/second/target"]], $this->manager->copied);
     }
+
+    public function testValidFolderPaths(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->manager->buildPublicFolder("/base", "/public");
+        $this->manager->buildPublicFolder("/srv/demo10-ilias", "/public");
+        $this->manager->buildPublicFolder("/srv/demo10.ilias.de", "/public");
+    }
+
+    /**
+     * @dataProvider provideInvalidFolderPathData
+     */
+    public function testInvalidFolderPaths(string $ilias_base, string $target): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->manager->buildPublicFolder($ilias_base, $target);
+    }
+
+    public static function provideInvalidFolderPathData(): array
+    {
+        return [
+            'base - missing leading slash' => ['base', '/public'],
+            'base - extra trailing slash' => ['/base/', '/public'],
+            'base - dot only' => ['.', '/public'],
+            'base - dash only' => ['-', '/public'],
+            'base - invalid trailing dash' => ['/base/demo-', '/public'],
+            'base - invalid trailing dot' => ['/base/demo.', '/public'],
+            'base - invalid leading dash' => ['/base/.demo', '/public'],
+            'base - invalid leading dot' => ['/base/-demo', '/public'],
+            'base - invalid dot sub directory' => ['/./test', '/public'],
+            'base - invalid dash sub directory' => ['/-/test', '/public'],
+            'target - missing leading slash' => ['/base', 'public'],
+            'target - extra trailing slash' => ['/base', '/public/'],
+            'target - dot only' => ['/base', '.'],
+            'target - dash only' => ['/base', '-'],
+            'target - invalid trailing dash' => ['/base', '/public.'],
+            'target - invalid trailing dot' => ['/base', '/public-'],
+            'target - invalid leading dash' => ['/base', '/.public'],
+            'target - invalid leading dot' => ['/base', '/-public'],
+            'target - invalid dot sub directory' => ['/base', '/./public'],
+            'target - invalid dash sub directory' => ['/base', '/-/public'],
+        ];
+    }
 }


### PR DESCRIPTION
Currently, we are working on the initial setups based on the ILIAS trunk for development and testing purposes and have encountered an issue during the setup.

In our deployment, we use path-naming conventions that include "dots," e.g., "/var/www/demo10.ilias.de." We heavily rely on this naming convention, but currently, the "PublicAssetManager" does not allow such naming.

With this PR, I adjusted the regex to also allow dots inside the path. I also adjusted the regex to only allow dots and dashes inside the path if they are surrounded by other characters. Dots and dashes at the beginning or end, or without any other characters between the slashes, are still disallowed.

I also think that this issue is only a side effect. In my understanding, the main purpose of validating the path is to ensure that the user has inserted a correct configuration. With that said, as long as the path is valid, this regex should not complain about special characters like dots or dashes.