### PR TITLE
Introduce keys method to RequestWrapper

### DIFF
--- a/components/ILIAS/HTTP/src/Wrapper/ArrayBasedRequestWrapper.php
+++ b/components/ILIAS/HTTP/src/Wrapper/ArrayBasedRequestWrapper.php
@@ -58,4 +58,12 @@ class ArrayBasedRequestWrapper implements RequestWrapper
     {
         return isset($this->raw_values[$key]);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function keys(): array
+    {
+        return array_keys($this->raw_values);
+    }
 }

--- a/components/ILIAS/HTTP/src/Wrapper/RequestWrapper.php
+++ b/components/ILIAS/HTTP/src/Wrapper/RequestWrapper.php
@@ -34,4 +34,11 @@ interface RequestWrapper
 
 
     public function has(string $key): bool;
+
+    /**
+     * Get all keys from the request
+     *
+     * @return array<string|int>
+     */
+    public function keys(): array;
 }

--- a/components/ILIAS/HTTP/tests/Services/WrapperTest.php
+++ b/components/ILIAS/HTTP/tests/Services/WrapperTest.php
@@ -82,6 +82,7 @@ class WrapperTest extends AbstractBaseTestCase
         $this->assertTrue($query->has('key_one'));
         $this->assertTrue($query->has('key_two'));
         $this->assertFalse($query->has('key_three'));
+        $this->assertEquals(['key_one', 'key_two'], $query->keys());
 
         $string_trafo = $this->refinery->kindlyTo()->string();
         $int_trafo = $this->refinery->kindlyTo()->int();
@@ -106,6 +107,7 @@ class WrapperTest extends AbstractBaseTestCase
         $this->assertTrue($post->has('key_one'));
         $this->assertTrue($post->has('key_two'));
         $this->assertFalse($post->has('key_three'));
+        $this->assertEquals(['key_one', 'key_two'], $post->keys());
 
         $string_trafo = $this->refinery->kindlyTo()->string();
         $int_trafo = $this->refinery->kindlyTo()->int();
@@ -130,6 +132,7 @@ class WrapperTest extends AbstractBaseTestCase
         $this->assertTrue($cookie->has('key_one'));
         $this->assertTrue($cookie->has('key_two'));
         $this->assertFalse($cookie->has('key_three'));
+        $this->assertEquals(['key_one', 'key_two'], $cookie->keys());
 
         $string_trafo = $this->refinery->kindlyTo()->string();
         $int_trafo = $this->refinery->kindlyTo()->int();


### PR DESCRIPTION
During the refactoring of legacy global accesses to `$_GET` and `$_POST`, we discovered some special use cases that are currently not implementable with the existing state of the request wrapper.

There are parts of the code that require looping over global variables to access multiple values based on a key pattern or to forward parameters to another request.

To support these special use cases via the new `RequestWrapper` API, a new method, `keys`, has been introduced. This method returns all parameter names from the respective `$_GET`, `$_POST`, or  `$_COOKIE` requests.

Using this method, the user can loop over the list of keys, apply their conditions, and still use the `retrieve` method to get the actual value, possibly applying some sort of transformer.

The most simplistic use case is shown in the following example:

**Before**

```php
foreach ($_POST as $key => $value) {
   // access $value
}
```

**After**

```php
global $DIC;

$postWrapper = $DIC->http()->wrapper()->post();
$refinery = $DIC->refinery();

foreach ($postWrapper->keys() as $key) {
    $value = $postWrapper->retrieve($key, $refinery->identity());
    // access $value
}
```

It should be noted that using the "identity" transformation is not ideal and should be replaced with something more meaningful that adds real validation to the transformation.

This PR is also related to #7803.