### PR TITLE
0041741: SOAP function Ilias.addUserRoleEntry and Ilias.deleteUserRoleEntry always throw an error

### DIFF
--- a/webservice/soap/classes/class.ilSoapRBACAdministration.php
+++ b/webservice/soap/classes/class.ilSoapRBACAdministration.php
@@ -115,12 +115,7 @@ class ilSoapRBACAdministration extends ilSoapAdministration
             return $this->raiseError('Check access failed. No permission to assign users', 'Server');
         }
 
-        if (!$rbacadmin->assignUser($role_id, $user_id)) {
-            return $this->raiseError(
-                'Error rbacadmin->assignUser()',
-                'Server'
-            );
-        }
+        $rbacadmin->assignUser($role_id, $user_id);
         return true;
     }
 
@@ -160,12 +155,7 @@ class ilSoapRBACAdministration extends ilSoapAdministration
             return $this->raiseError('Check access failed. No permission to deassign users', 'Server');
         }
 
-        if (!$rbacadmin->deassignUser($role_id, $user_id)) {
-            return $this->raiseError(
-                'Error rbacadmin->deassignUser()',
-                'Server'
-            );
-        }
+        $rbacadmin->deassignUser($role_id, $user_id);
         return true;
     }
 


### PR DESCRIPTION
Proposed fix for Ticket https://mantis.ilias.de/view.php?id=41741.

Removed the always false if check around assignUser and deassignUser, as that always throws an error now as both functions have a void return type.