### PR TITLE
Phpunit code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ captainhook.local.json
 .php-cs-fixer.cache
 phpstan.local.neon
 phpstan-baseline.neon
+/scripts/PHPUnit/.phpunit.cache
 
 # File Delivery
 override.php

--- a/scripts/PHPUnit/phpunit.xml
+++ b/scripts/PHPUnit/phpunit.xml
@@ -1,8 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="../../vendor/composer/vendor/autoload.php" colors="true" beStrictAboutOutputDuringTests="true" beStrictAboutTestsThatDoNotTestAnything="true" failOnRisky="true" failOnWarning="true" backupGlobals="true" executionOrder="random" cacheResultFile=".phpunit.cache/test-results">
-  <testsuites>
-    <testsuite name="all">
-        <directory>../../components/*/*/tests/</directory>
-    </testsuite>
-  </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="../../vendor/composer/vendor/autoload.php"
+         colors="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         backupGlobals="true"
+         executionOrder="random"
+         cacheResultFile=".phpunit.cache/test-results"
+>
+    <testsuites>
+        <testsuite name="all">
+            <directory>../../components/*/*/tests/</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">../../components/*/*/</directory>
+        </include>
+        <exclude>
+            <directory>../../components/*/*/tests/</directory>
+            <directory>../../components/*/*/templates/</directory>
+            <directory>../../components/*/*/resources/</directory>
+        </exclude>
+    </source>
 </phpunit>


### PR DESCRIPTION
This PR enhances the current phpunit.xml file with a source directive to allow PHPUnit to generate code coverage during test execution.

Furthermore, a new entry has been added to the .gitignore file because the path for the PHPUnit cache results has changed following the recent migration to the new XML structure.