### PR TITLE
RessourceStorage: Add primary to ressource table

### DIFF
--- a/Services/ResourceStorage/classes/Setup/DB/class.ilResourceStorageDB80.php
+++ b/Services/ResourceStorage/classes/Setup/DB/class.ilResourceStorageDB80.php
@@ -344,4 +344,17 @@ SET il_resource_info.version_number = il_resource_revision.version_number
             'owner_id',
         );
     }
+
+    public function step_13(): void
+    {
+        if ($this->db->indexExistsByFields('il_resource_stkh_u', ['stakeholder_id'])) {
+            $this->db->dropIndexByFields('il_resource_stkh_u', ['stakeholder_id']);
+        }
+        if ($this->db->indexExistsByFields('il_resource_stkh_u', ['rid'])) {
+            $this->db->dropIndexByFields('il_resource_stkh_u', ['rid']);
+        }
+        if (!$this->db->primaryExistsByFields('il_resource_stkh_u', ['rid'])) {
+            $this->db->addPrimaryKey('il_resource_stkh_u', ['rid']);
+        }
+    }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41750

This adds a missing primary to increase the performance.
The key seems to be set in past as an index (ILIAS 6 maybe?) but is unset on newly installed/not migrated installations.