### PR TITLE
Dashboard Bugfix: Add IndividualAssessmentGUI to Dashboard ilCtrl path

### DIFF
--- a/Services/Dashboard/classes/class.ilDashboardGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardGUI.php
@@ -30,8 +30,8 @@ use ILIAS\GlobalScreen\ScreenContext\ContextServices;
  * @ilCtrl_Calls ilDashboardGUI: ilMyStaffGUI
  * @ilCtrl_Calls ilDashboardGUI: ilGroupUserActionsGUI, ilAchievementsGUI
  * @ilCtrl_Calls ilDashboardGUI: ilPDMailBlockGUI
- * @ilCtrl_Calls ilDashboardGUI: ilSelectedItemsBlockGUI, ilDashboardRecommendedContentGUI, ilMembershipBlockGUI, ilDashboardLearningSequenceGUI, ilStudyProgrammeDashboardViewGUI, ilObjStudyProgrammeGUI
- *
+ * @ilCtrl_Calls ilDashboardGUI: ilSelectedItemsBlockGUI, ilDashboardRecommendedContentGUI, ilMembershipBlockGUI, ilDashboardLearningSequenceGUI, ilStudyProgrammeDashboardViewGUI, ilObjStudyProgrammeGUI,
+ * @ilCtrl_Calls ilDashboardGUI: ilObjIndividualAssessmentGUI
  */
 class ilDashboardGUI implements ilCtrlBaseClassInterface
 {


### PR DESCRIPTION
Fixes ilCtrlException thrown with message "ilCtrl cannot find a path for 'ilobjindividualassessmentgui' that reaches 'ilDashboardGUI'"

pick to trunk as well