### PR TITLE
T&A 41754: Icons in grading system settings of a test are not loading properly

### DIFF
--- a/components/ILIAS/Test/src/Scoring/Marks/MarkSchemaTable.php
+++ b/components/ILIAS/Test/src/Scoring/Marks/MarkSchemaTable.php
@@ -58,12 +58,12 @@ class MarkSchemaTable implements DataRetrieval
                 'passed' => $f->column()->boolean(
                     $this->lng->txt('tst_mark_passed'),
                     $this->ui_factory->symbol()->icon()->custom(
-                        'templates/default/images/standard/icon_checked.svg',
+                        'assets/images/standard/icon_checked.svg',
                         $this->lng->txt('yes'),
                         'small'
                     ),
                     $this->ui_factory->symbol()->icon()->custom(
-                        'templates/default/images/standard/icon_unchecked.svg',
+                        'assets/images/standard/icon_unchecked.svg',
                         $this->lng->txt('no'),
                         'small'
                     )


### PR DESCRIPTION
The icons in the grading system settings of a test are not loading. The file path seems to be incorrect. Changing the path to a existing icon fixes the issue.

[Mantis: 41754](https://mantis.ilias.de/view.php?id=41754)