### PR TITLE
T&A 41757: In Test using "Save and Return" or "Save and Continue" in Manual Scoring -> Scoring by Participant Tab throws error

### DIFF
--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\Test\Scoring\Manual;
 
+use ilCtrlException;
 use ILIAS\Test\Logging\TestScoringInteraction;
 use ILIAS\Test\Logging\TestScoringInteractionTypes;
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
@@ -344,6 +345,9 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
         return true;
     }
 
+    /**
+     * @throws ilCtrlException
+     */
     private function saveNextManScoringParticipantScreen(): void
     {
         $table = $this->buildManScoringParticipantsTable(true);
@@ -364,14 +368,17 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
                 $this->ctrl->redirect($this, 'showManScoringParticipantScreen');
             }
 
-            $this->ctrl->redirectByClass("iltestscoringgui", "showManScoringParticipantsTable");
+            $this->ctrl->redirectByClass(self::class, 'showManScoringParticipantsTable');
         }
     }
 
+    /**
+     * @throws ilCtrlException
+     */
     private function saveReturnManScoringParticipantScreen(): void
     {
         if ($this->saveManScoringParticipantScreen(false)) {
-            $this->ctrl->redirectByClass("iltestscoringgui", "showManScoringParticipantsTable");
+            $this->ctrl->redirectByClass(self::class, 'showManScoringParticipantsTable');
         }
     }
 


### PR DESCRIPTION
When trying to save the manual scoring for a test pass using the "Save and Return" or "Save and Continue" button an error is thrown. The class to be redirected to seems to have changed. By adjusting the code to use the correct class the issue seems to be fixed.

[Mantis: 41757](https://mantis.ilias.de/view.php?id=41757)