### PR TITLE
T&A 41759: Fixes access to 'Competences' tab of test

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -51,7 +51,7 @@ class ilAssQuestionSkillAssignmentsGUI
     private ilAssQuestionList $questionList;
     private int $questionContainerId;
     private bool $assignmentEditingEnabled;
-    private string $assignmentConfigurationHintMessage;
+    private ?string $assignmentConfigurationHintMessage = null;
 
     /**
      * @var array
@@ -95,10 +95,7 @@ class ilAssQuestionSkillAssignmentsGUI
         return $this->assignmentConfigurationHintMessage;
     }
 
-    /**
-     * @param string $assignmentConfigurationHintMessage
-     */
-    public function setAssignmentConfigurationHintMessage($assignmentConfigurationHintMessage): void
+    public function setAssignmentConfigurationHintMessage(?string $assignmentConfigurationHintMessage): void
     {
         $this->assignmentConfigurationHintMessage = $assignmentConfigurationHintMessage;
     }


### PR DESCRIPTION
When trying to access the Competences in a test you get an error. The issue seems to be an too early access to the membervariable $assignmentConfigurationHintMessage of ilAssQuestionSkillAssignmentsGUI. By setting it to null by default the issue seems to be resolved.

[Mantis: 41759](https://mantis.ilias.de/view.php?id=41759)