### PR TITLE
T&A 41688: Fix phpunit test execution for failing seeds.

### DIFF
--- a/components/ILIAS/Test/tests/ilTestBaseTestCase.php
+++ b/components/ILIAS/Test/tests/ilTestBaseTestCase.php
@@ -66,6 +66,8 @@ class ilTestBaseTestCase extends TestCase
         $this->addGlobal_static_url();
         $this->addGlobal_upload();
 
+        $this->defineGlobalConstants();
+
         parent::setUp();
     }
 

--- a/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
+++ b/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
@@ -30,6 +30,31 @@ use GuzzleHttp\Psr7\Uri as GuzzleURI;
 
 trait ilTestBaseTestCaseTrait
 {
+    protected function defineGlobalConstants(): void
+    {
+        if (!defined("ILIAS_HTTP_PATH")) {
+            define("ILIAS_HTTP_PATH", "http://localhost");
+        }
+        if (!defined("CLIENT_DATA_DIR")) {
+            define("CLIENT_DATA_DIR", "/var/iliasdata");
+        }
+        if (!defined("ANONYMOUS_USER_ID")) {
+            define("ANONYMOUS_USER_ID", 13);
+        }
+        if (!defined("ROOT_FOLDER_ID")) {
+            define("ROOT_FOLDER_ID", 8);
+        }
+        if (!defined("ILIAS_LOG_ENABLED")) {
+            define("ILIAS_LOG_ENABLED", true);
+        }
+        if (!defined("ILIAS_LOG_DIR")) {
+            define("ILIAS_LOG_DIR", '/var/log');
+        }
+        if (!defined("ILIAS_LOG_FILE")) {
+            define("ILIAS_LOG_FILE", '/var/log/ilias.log');
+        }
+    }
+
     /**
      * @param string $name
      * @param mixed  $value

--- a/components/ILIAS/TestQuestionPool/tests/assBaseTestCase.php
+++ b/components/ILIAS/TestQuestionPool/tests/assBaseTestCase.php
@@ -58,27 +58,8 @@ abstract class assBaseTestCase extends TestCase
         $this->addGlobal_upload();
         $this->addGlobal_ilCtrl();
 
-        if (!defined("ILIAS_HTTP_PATH")) {
-            define("ILIAS_HTTP_PATH", "http://localhost");
-        }
-        if (!defined("CLIENT_DATA_DIR")) {
-            define("CLIENT_DATA_DIR", "/var/iliasdata");
-        }
-        if (!defined("ANONYMOUS_USER_ID")) {
-            define("ANONYMOUS_USER_ID", 13);
-        }
-        if (!defined("ROOT_FOLDER_ID")) {
-            define("ROOT_FOLDER_ID", 8);
-        }
-        if (!defined("ILIAS_LOG_ENABLED")) {
-            define("ILIAS_LOG_ENABLED", true);
-        }
-        if (!defined("ILIAS_LOG_DIR")) {
-            define("ILIAS_LOG_DIR", '/var/log');
-        }
-        if (!defined("ILIAS_LOG_FILE")) {
-            define("ILIAS_LOG_FILE", '/var/log/ilias.log');
-        }
+        $this->defineGlobalConstants();
+
         parent::setUp();
     }
 


### PR DESCRIPTION
This PR is related to Mantis ticket [41688](https://mantis.ilias.de/view.php?id=41688).

Within the T&A components, there are multiple base TestCase classes implemented. These implementations have diverged from each other, which may lead to failing tests if the class defining the missing global constants is not called before the test cases that require these definitions.

To address this problem and reduce duplicated code, the global constant definition during PHPUnit tests has been moved to a common trait, which will be used in both test base classes.

I checked the changes against the seeds reported in the Mantis ticket and achieved 100% passing tests:

Seeds:

* 1718723968
* 1721381185