### PR TITLE
Fix skin path in html exports

### DIFF
--- a/Services/Style/System/classes/class.ilSystemStyleHTMLExport.php
+++ b/Services/Style/System/classes/class.ilSystemStyleHTMLExport.php
@@ -65,10 +65,14 @@ class ilSystemStyleHTMLExport
 
     public function export(): void
     {
+        $location_stylesheet = ilUtil::getStyleSheetLocation('filesystem');
+
+        // Fix skin path
+        $this->style_dir = dirname($this->style_dir, 2) . DIRECTORY_SEPARATOR . dirname($location_stylesheet);
+
         $this->createDirectories();
 
         // export system style sheet
-        $location_stylesheet = ilUtil::getStyleSheetLocation('filesystem');
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator(dirname($location_stylesheet), FilesystemIterator::SKIP_DOTS),
             RecursiveIteratorIterator::SELF_FIRST


### PR DESCRIPTION
Hi, currently in learning modules HTML exports, all the images, fonts, etc. are copied into the `templates/default` path of the export, but exported modules uses the skin path, and so they are never found.

Before modification:

![Screenshot 2024-07-20 125646](https://github.com/user-attachments/assets/c82f96aa-0d58-48d5-9c64-9570213b66a0)

After:

![Screenshot 2024-07-20 125700](https://github.com/user-attachments/assets/21e8b9f7-bf77-4b4b-bae2-ea9839af7b75)

I know it might not be the best solution, I would just like to point out this problem.