### PR TITLE
T&A 41768: Fixes add a question from a test to a question pool error

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -2926,10 +2926,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
 
     public function copyAndLinkToQuestionpoolObject()
     {
-        if (
-            'copyAndLinkToQuestionpool' == $this->ctrl->getCmd() &&
-            (!$this->testrequest->isset('q_id') || !is_array($this->testrequest->raw('q_id')))
-        ) {
+        if (!$this->testrequest->isset('q_id') || !is_array($this->testrequest->raw('q_id'))) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('tst_no_question_selected_for_moving_to_qpl'), true);
             $this->ctrl->redirect($this, self::SHOW_QUESTIONS_CMD);
         }

--- a/components/ILIAS/Test/src/Questions/QuestionsTable.php
+++ b/components/ILIAS/Test/src/Questions/QuestionsTable.php
@@ -338,7 +338,7 @@ class QuestionsTable
                     $gui_call('setMessage', ['failure', 'no_selection']);
                     break;
                 }
-                $gui_call('copyAndLinkToQuestionpool', [$row_ids]);
+                $gui_call('copyAndLinkToQuestionpoolObject', [$row_ids]);
                 break;
 
             default:


### PR DESCRIPTION
When you try to add a question from a test into a question pool you get an error. By appending 'Object' to the called method name string, the issue seems to be resolved. 

[Mantis: 41768](https://mantis.ilias.de/view.php?id=41768)