### PR TITLE
T&A: Remove unnecessary getCorrectedLangVarForKey function

### DIFF
--- a/components/ILIAS/Test/src/Logging/AdditionalInformationGenerator.php
+++ b/components/ILIAS/Test/src/Logging/AdditionalInformationGenerator.php
@@ -335,11 +335,6 @@ class AdditionalInformationGenerator
         return "{{ {$lang_var} }}";
     }
 
-    private function getCorrectedLangVarForKey(string $key): string
-    {
-        return $key;
-    }
-
     private function parseValue(
         int|string $key,
         string|int|float|array $value,


### PR DESCRIPTION
When writing unit tests, I encountered the getCorrectedLangVarForKey function, which when observed had no usages and returned the provided key parameter back with no modifications.

Due to this, I have made this pull request which removes the function.

Kind Regards.