### PR TITLE
File: Prevent calling of undefined constants

### DIFF
--- a/Modules/File/classes/class.ilObjFileStakeholder.php
+++ b/Modules/File/classes/class.ilObjFileStakeholder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -33,7 +34,7 @@ class ilObjFileStakeholder extends AbstractResourceStakeholder
     public function __construct(protected int $owner = 6)
     {
         global $DIC;
-        $this->current_user = (int) ($DIC->isDependencyAvailable('user') ? $DIC->user()->getId() : ANONYMOUS_USER_ID);
+        $this->current_user = (int) ($DIC->isDependencyAvailable('user') ? $DIC->user()->getId() : 13);
     }
 
     /**


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41775

This replaces the call of the `ANONYMOUS_USER_ID` by a static.
Since this is already in a context where we don't have a user dependency, it is quite risky to assume the constant to be set IMO.