### PR TITLE
T&A: Fix return of wrong instance in method buildTestQuestionAdministrationInteraction of Ilias\Test\Logging\Factory

### DIFF
--- a/components/ILIAS/Test/src/Logging/Factory.php
+++ b/components/ILIAS/Test/src/Logging/Factory.php
@@ -64,7 +64,7 @@ class Factory
         TestQuestionAdministrationInteractionTypes $type,
         array $additional_data
     ): TestQuestionAdministrationInteraction {
-        return new TestAdministrationInteraction(
+        return new TestQuestionAdministrationInteraction(
             $ref_id,
             $qst_id,
             $admin_id,


### PR DESCRIPTION
While writing Unittests I came across this little mistake in the implementation and decided to provide a quick fix.