### PR TITLE
T&A: fix call of TestError constructor in method createTestErrorFromContext of class Ilias\Test\Logging\TestLogger

### DIFF
--- a/components/ILIAS/Test/src/Logging/TestLogger.php
+++ b/components/ILIAS/Test/src/Logging/TestLogger.php
@@ -39,7 +39,6 @@ class TestLogger implements LoggerInterface
         private readonly Factory $interaction_factory,
         private readonly AdditionalInformationGenerator $additional_information,
         private readonly \ilComponentLogger $component_logger,
-        private readonly \ilLanguage $lng
     ) {
     }
 
@@ -207,7 +206,6 @@ class TestLogger implements LoggerInterface
     private function createTestErrorFromContext(array $context, string $message): TestError
     {
         return new TestError(
-            $this->lng,
             $context['ref_id'],
             $context ['question_id'] ?? null,
             $context['administrator'] ?? null,

--- a/components/ILIAS/Test/src/TestDIC.php
+++ b/components/ILIAS/Test/src/TestDIC.php
@@ -121,8 +121,7 @@ class TestDIC extends PimpleContainer
                     $DIC['refinery'],
                     $c['question.general_properties.repository']
                 ),
-                \ilLoggerFactory::getLogger('tst'),
-                $DIC['lng']
+                \ilLoggerFactory::getLogger('tst')
             );
 
         $dic['logging.viewer'] = static fn($c): TestLogViewer =>


### PR DESCRIPTION
While writing Unittests I came across this little mistake in the implementation and decided to provide a quick fix.