### PR TITLE
Block: Preserve block title on slice

### DIFF
--- a/Services/Block/classes/class.ilBlockGUI.php
+++ b/Services/Block/classes/class.ilBlockGUI.php
@@ -550,7 +550,7 @@ abstract class ilBlockGUI
     {
         $data = $this->getData();
         $this->max_count = count($data);
-        $data = array_slice($data, $this->getOffset(), $this->getLimit());
+        $data = array_slice($data, $this->getOffset(), $this->getLimit(), true);
         $this->preloadData($data);
         return $data;
     }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41806

This is just a minor fix to preserve numeric titles in blocks.
Since PHP casts every numeric string key into an int and `array_slice` resets all integer keys, this causes that every numeric title ist displayed incremented from 0 instead of its number.