### PR TITLE
Dashboard: Remove key assumption and add strict casting

### DIFF
--- a/Services/Dashboard/Block/classes/class.ilDashboardBlockGUI.php
+++ b/Services/Dashboard/Block/classes/class.ilDashboardBlockGUI.php
@@ -47,7 +47,7 @@ abstract class ilDashboardBlockGUI extends ilBlockGUI implements ilDesktopItemHa
     protected Services $http;
     private Factory $refinery;
     protected ilPDSelectedItemsBlockViewSettings $viewSettings;
-    /** @var array<string, BlockDTO[]> */
+    /** @var array<BlockDTO[]> */
     protected array $data;
 
     public function __construct()
@@ -224,7 +224,7 @@ abstract class ilDashboardBlockGUI extends ilBlockGUI implements ilDesktopItemHa
     }
 
     /**
-     * @param array<string, BlockDTO[]> $a_data
+     * @param array<BlockDTO[]> $a_data
      */
     public function setData(array $a_data): void
     {
@@ -237,7 +237,7 @@ abstract class ilDashboardBlockGUI extends ilBlockGUI implements ilDesktopItemHa
     }
 
     /**
-     * @return array<string, BlockDTO[]>
+     * @return array<BlockDTO[]>
      */
     public function getData(): array
     {
@@ -245,7 +245,7 @@ abstract class ilDashboardBlockGUI extends ilBlockGUI implements ilDesktopItemHa
     }
 
     /**
-     * @return array<string, BlockDTO[]>
+     * @return array<BlockDTO[]>
      */
     public function groupItemsByStartDate(): array
     {
@@ -302,7 +302,7 @@ abstract class ilDashboardBlockGUI extends ilBlockGUI implements ilDesktopItemHa
     }
 
     /**
-     * @return array<string, BlockDTO[]>
+     * @return array<BlockDTO[]>
      */
     protected function groupItemsByType(): array
     {
@@ -337,7 +337,7 @@ abstract class ilDashboardBlockGUI extends ilBlockGUI implements ilDesktopItemHa
     }
 
     /**
-     * @return array<string, BlockDTO[]>
+     * @return array<BlockDTO[]>
      */
     protected function groupItemsByLocation(): array
     {
@@ -351,7 +351,7 @@ abstract class ilDashboardBlockGUI extends ilBlockGUI implements ilDesktopItemHa
         ));
         $this->object_cache->preloadReferenceCache($parent_ref_ids);
 
-        foreach ($data as $key => $item) {
+        foreach ($data as $item) {
             $parent_ref = $this->tree->getParentId($item->getRefId());
             if ($this->isRootNode($parent_ref)) {
                 $title = $this->getRepositoryTitle();
@@ -484,7 +484,7 @@ abstract class ilDashboardBlockGUI extends ilBlockGUI implements ilDesktopItemHa
     }
 
     /**
-     * @return array<string, BlockDTO[]>
+     * @return array<BlockDTO[]>
      */
     public function getItemGroups(): array
     {
@@ -598,7 +598,7 @@ abstract class ilDashboardBlockGUI extends ilBlockGUI implements ilDesktopItemHa
         $item_groups = $this->getItemGroups();
         foreach ($item_groups as $key => $item_group) {
             $group = new ilPDSelectedItemsBlockGroup();
-            $group->setLabel($key);
+            $group->setLabel((string) $key);
             $items = [];
             foreach ($item_group as $item) {
                 if ($this->rbacsystem->checkAccess('leave', $item->getRefId())) {

--- a/Services/Dashboard/Favourites/classes/class.ilFavouritesDBRepository.php
+++ b/Services/Dashboard/Favourites/classes/class.ilFavouritesDBRepository.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
  */
 class ilFavouritesDBRepository
 {
-    /** @var array<string, bool> */
+    /** @var array<bool> */
     public static array $is_desktop_item = [];
     protected ilDBInterface $db;
     protected ilTree $tree;

--- a/Services/Dashboard/Favourites/classes/class.ilFavouritesListGUI.php
+++ b/Services/Dashboard/Favourites/classes/class.ilFavouritesListGUI.php
@@ -59,7 +59,7 @@ class ilFavouritesListGUI
                 )->withLeadIcon($f->symbol()->icon()->custom(ilObject::_getIcon((int) $item->getObjId()), $item->getTitle()));
             }
             if (count($items) > 0) {
-                $item_groups[] = $f->item()->group($key, $items);
+                $item_groups[] = $f->item()->group((string) $key, $items);
             }
         }
         if (count($item_groups) > 0) {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41796

Since PHP auto-casts a numeric string key into integer, arrays can't be assumed to have exclusive strings as keys and therefore need to be cast.