### PR TITLE
T&A: fix return in method buildScoringInteractionFromId of class ILIAS\Test\Logging\TestLoggingDatabaseRepository

### DIFF
--- a/components/ILIAS/Test/src/Logging/TestLoggingDatabaseRepository.php
+++ b/components/ILIAS/Test/src/Logging/TestLoggingDatabaseRepository.php
@@ -297,7 +297,7 @@ class TestLoggingDatabaseRepository implements TestLoggingRepository
             return null;
         }
 
-        return $this->factory->buildParticipantInteractionFromDBValues($this->db->fetchObject($query));
+        return $this->factory->buildScoringInteractionFromDBValues($this->db->fetchObject($query));
     }
 
     private function buildErrorFromId(int $id): ?TestError


### PR DESCRIPTION
While writing Unittests I came across this little mistake in the implementation and decided to provide a quick fix.