### PR TITLE
Export: do not export tail dependencies if there are not entities

### DIFF
--- a/Services/Export/classes/class.ilExport.php
+++ b/Services/Export/classes/class.ilExport.php
@@ -602,6 +602,10 @@ class ilExport
         $this->log->debug("process tail dependencies of " . $a_entity);
         $sequence = $exp->getXmlExportTailDependencies($a_entity, $a_target_release, $a_id);
         foreach ($sequence as $s) {
+            if (empty((array) $s["ids"])) {
+                continue;
+            }
+
             $comp = explode("/", $s["component"]);
             $exp_class = "il" . $comp[1] . "Exporter";
             $s = $this->processExporter(

--- a/Services/Export/classes/class.ilExport.php
+++ b/Services/Export/classes/class.ilExport.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,9 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
+
 /**
  * Export
  * @author    Alex Killing <alex.killing@gmx.de>

--- a/Services/Export/classes/class.ilExport.php
+++ b/Services/Export/classes/class.ilExport.php
@@ -603,7 +603,7 @@ class ilExport
         $this->log->debug("process tail dependencies of " . $a_entity);
         $sequence = $exp->getXmlExportTailDependencies($a_entity, $a_target_release, $a_id);
         foreach ($sequence as $s) {
-            if (empty((array) $s["ids"])) {
+            if (empty((array) ($s["ids"] ?? []))) {
                 continue;
             }
 


### PR DESCRIPTION
This PR makes it so that tail dependencies are only exported if there are actual entities to export. In this past, this has lead to imports failing the validation via xsd. In current ILIAS 9 this does not seem to be a problem anymore, but the changes proposed here might make export/import a bit more robust in the future.