### PR TITLE
T&A: fix inconsistent use of ServerRequestInterface and RequestInterface

### DIFF
--- a/components/ILIAS/HTTP/src/RawHTTPServices.php
+++ b/components/ILIAS/HTTP/src/RawHTTPServices.php
@@ -87,7 +87,7 @@ class RawHTTPServices implements GlobalHttpState
     /**
      * @inheritDoc
      */
-    public function request(): \Psr\Http\Message\RequestInterface
+    public function request(): \Psr\Http\Message\ServerRequestInterface
     {
         if ($this->request === null) {
             $this->request = $this->requestFactory->create();

--- a/components/ILIAS/HTTP/src/Services.php
+++ b/components/ILIAS/HTTP/src/Services.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -15,7 +13,10 @@ declare(strict_types=1);
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\HTTP;
 
@@ -80,7 +81,7 @@ class Services implements GlobalHttpState
      * @see        Services::wrapper();
      * @inheritDoc
      */
-    public function request(): RequestInterface
+    public function request(): ServerRequestInterface
     {
         return $this->raw()->request();
     }

--- a/components/ILIAS/Test/src/Logging/TestLogViewer.php
+++ b/components/ILIAS/Test/src/Logging/TestLogViewer.php
@@ -24,7 +24,6 @@ use ILIAS\Test\Export\CSVExportTrait;
 
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
 
-use Psr\Http\Message\RequestInterface;
 use ILIAS\HTTP\Wrapper\RequestWrapper;
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Renderer as UIRenderer;
@@ -34,6 +33,7 @@ use ILIAS\StaticURL\Services as StaticURLServices;
 use ILIAS\UI\URLBuilder;
 use ILIAS\UI\URLBuilderToken;
 use ILIAS\FileDelivery\Delivery\StreamDelivery;
+use Psr\Http\Message\ServerRequestInterface;
 
 class TestLogViewer
 {
@@ -45,7 +45,7 @@ class TestLogViewer
         private readonly TestLoggingRepository $logging_repository,
         private readonly TestLogger $logger,
         private readonly GeneralQuestionPropertiesRepository $question_repository,
-        private readonly RequestInterface $request,
+        private readonly ServerRequestInterface $request,
         private readonly RequestWrapper $request_wrapper,
         private readonly StaticURLServices $static_url,
         private readonly \ilUIService $ui_service,


### PR DESCRIPTION
While writing unit tests I noticed the inconsistent use of the ServerRequestInterface and RequestInterface in the class ILIAS\Test\Logging\TestLogViewer and wanted to change the type of the member variable $request to ServerRequestInterface. This change lead to several failing unit tests. The reason for this is the inaccuracy/ inconsistency of the used types in the ILIAS\HTTP\Services and ILIAS\http\RawHTTPServices classes.

As the member variable $request in ILIAS\http\RawHTTPServices has the type ServerRequestInterface, I decided to change the associated return types to this interface too.