### PR TITLE
ContentPage: switch to LOM API

### DIFF
--- a/components/ILIAS/ContentPage/classes/class.ilObjContentPageGUI.php
+++ b/components/ILIAS/ContentPage/classes/class.ilObjContentPageGUI.php
@@ -24,6 +24,7 @@ use ILIAS\ContentPage\PageMetrics\PageMetricsRepositoryImp;
 use ILIAS\ContentPage\PageMetrics\Event\PageUpdatedEvent;
 use ILIAS\DI\Container;
 use ILIAS\HTTP\GlobalHttpState;
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 
 /**
  * Class ilObjContentPageGUI
@@ -53,6 +54,7 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
     private ilHelpGUI $help;
     private \ILIAS\DI\UIServices $uiServices;
     private readonly bool $in_page_editor_style_context;
+    private LOMServices $lom_services;
 
     public function __construct(int $a_id = 0, int $a_id_type = self::REPOSITORY_NODE_ID, int $a_parent_node_id = 0)
     {
@@ -66,6 +68,7 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
         $this->navHistory = $this->dic['ilNavigationHistory'];
         $this->help = $DIC['ilHelp'];
         $this->uiServices = $DIC->ui();
+        $this->lom_services = $DIC->learningObjectMetadata();
 
         $this->lng->loadLanguageModule('copa');
         $this->lng->loadLanguageModule('style');
@@ -603,14 +606,19 @@ class ilObjContentPageGUI extends ilObject2GUI implements ilContentPageObjectCon
         );
 
         if ($this->getCreationMode() !== true && count($this->object->getObjectTranslation()->getLanguages()) > 1) {
-            $languages = ilMDLanguageItem::_getLanguages();
+            $language = '';
+            foreach ($this->lom_services->dataHelper()->getAllLanguages() as $lom_lang) {
+                if ($lom_lang->value() === $this->object->getObjectTranslation()->getDefaultLanguage()) {
+                    $language = $lom_lang->presentableLabel();
+                }
+            }
             $a_form->getItemByPostVar('title')
                    ->setInfo(
                        implode(
                            ': ',
                            [
                                $this->lng->txt('language'),
-                               $languages[$this->object->getObjectTranslation()->getDefaultLanguage()]
+                               $language
                            ]
                        )
                    );


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `ContentPage` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 