### PR TITLE
COPage: switch to LOM API

### DIFF
--- a/components/ILIAS/COPage/PC/FileList/class.ilPCFileListGUI.php
+++ b/components/ILIAS/COPage/PC/FileList/class.ilPCFileListGUI.php
@@ -305,9 +305,12 @@ class ilPCFileListGUI extends ilPageContentGUI
             $form->addItem($ti);
 
             // language
-            $lang = ilMDLanguageItem::_getLanguages();
+            $languages = [];
+            foreach ($this->lom_services->dataHelper()->getAllLanguages() as $language) {
+                $languages[$language->value()] = $language->presentableLabel();
+            }
             $si = new ilSelectInputGUI($lng->txt("language"), "flst_language");
-            $si->setOptions($lang);
+            $si->setOptions($languages);
             $form->addItem($si);
         }
 

--- a/components/ILIAS/COPage/PC/Paragraph/class.ilPCParagraph.php
+++ b/components/ILIAS/COPage/PC/Paragraph/class.ilPCParagraph.php
@@ -1933,6 +1933,10 @@ class ilPCParagraph extends ilPageContent
         ilPageObject $a_page,
         DOMDocument $a_domdoc
     ): void {
+        global $DIC;
+
+        $lom_services = $DIC->learningObjectMetadata();
+
         // not nice, should be set by context per method
         if ($a_page->getParentType() == "term" ||
             $a_page->getParentType() == "lm") {
@@ -1955,37 +1959,9 @@ class ilPCParagraph extends ilPageContent
             $meta_rep_id = $a_page->getParentId();
             $meta_id = $a_page->getId();
 
-            $md_obj = new ilMD($meta_rep_id, $meta_id, $meta_type);
-            $mkeywords = array();
-            $lang = "";
-            if (is_object($md_section = $md_obj->getGeneral())) {
-                foreach ($ids = $md_section->getKeywordIds() as $id) {
-                    $md_key = $md_section->getKeyword($id);
-                    $mkeywords[] = strtolower($md_key->getKeyword());
-                    if ($lang == "") {
-                        $lang = $md_key->getKeywordLanguageCode();
-                    }
-                }
-                if ($lang == "") {
-                    foreach ($ids = $md_section->getLanguageIds() as $id) {
-                        $md_lang = $md_section->getLanguage($id);
-                        if ($lang == "") {
-                            $lang = $md_lang->getLanguageCode();
-                        }
-                    }
-                }
-                foreach ($keywords as $k) {
-                    if (!in_array(strtolower($k), $mkeywords)) {
-                        if (trim($k) != "" && $lang != "") {
-                            $md_key = $md_section->addKeyword();
-                            $md_key->setKeyword(ilUtil::stripSlashes($k));
-                            $md_key->setKeywordLanguage(new ilMDLanguageItem($lang));
-                            $md_key->save();
-                        }
-                        $mkeywords[] = strtolower($k);
-                    }
-                }
-            }
+            $lom_services->manipulate($meta_rep_id, $meta_id, $meta_type)
+                         ->prepareCreateOrUpdate($lom_services->paths()->keywords(), ...$keywords)
+                         ->execute();
         }
     }
 

--- a/components/ILIAS/COPage/PC/Table/class.ilPCTableGUI.php
+++ b/components/ILIAS/COPage/PC/Table/class.ilPCTableGUI.php
@@ -382,9 +382,12 @@ class ilPCTableGUI extends ilPageContentGUI
         } else {
             $s_lang = $ilUser->getLanguage();
         }
-        $lang = ilMDLanguageItem::_getLanguages();
+        $languages = [];
+        foreach ($this->lom_services->dataHelper()->getAllLanguages() as $language) {
+            $languages[$language->value()] = $language->presentableLabel();
+        }
         $language = new ilSelectInputGUI($this->lng->txt("language"), "language");
-        $language->setOptions($lang);
+        $language->setOptions($languages);
         $language->setValue($s_lang);
         $this->form->addItem($language);
 

--- a/components/ILIAS/COPage/classes/class.ilPageContentGUI.php
+++ b/components/ILIAS/COPage/classes/class.ilPageContentGUI.php
@@ -18,7 +18,7 @@
 
 use ILIAS\COPage\PC\EditGUIRequest;
 use ILIAS\COPage\Editor\EditSessionRepository;
-
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 use ILIAS\Style;
 
 /**
@@ -38,6 +38,7 @@ class ilPageContentGUI
     public ilGlobalTemplateInterface $tpl;
     public ilLanguage $lng;
     public ilCtrl $ctrl;
+    protected LOMServices $lom_services;
     public ilPageObject $pg_obj;
     public string $hier_id = "";
     public DOMDocument $dom;
@@ -83,6 +84,7 @@ class ilPageContentGUI
         $this->lng = $lng;
         $this->pg_obj = $a_pg_obj;
         $this->ctrl = $ilCtrl;
+        $this->lom_services = $DIC->learningObjectMetadata();
         $this->content_obj = $a_content_obj;
         $service = $DIC->copage()->internal();
         $this->request = $service

--- a/components/ILIAS/COPage/classes/class.ilPageObject.php
+++ b/components/ILIAS/COPage/classes/class.ilPageObject.php
@@ -42,6 +42,8 @@ define("IL_INSERT_CHILD", 2);
 
 */
 
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
 /**
  * Class ilPageObject
  * Handles PageObjects of ILIAS Learning Modules (see ILIAS DTD)
@@ -66,6 +68,7 @@ abstract class ilPageObject
     protected ilObjUser $user;
     protected ilLanguage $lng;
     protected ilTree $tree;
+    protected LOMServices $lom_services;
     protected int $id;
     public ?DOMDocument $dom = null;
     public string $xml = "";
@@ -116,6 +119,7 @@ abstract class ilPageObject
         $this->lng = $DIC->language();
         $this->tree = $DIC->repositoryTree();
         $this->log = ilLoggerFactory::getLogger('copg');
+        $this->lom_services = $DIC->learningObjectMetadata();
 
         $this->reading_time_manager = new ILIAS\COPage\ReadingTime\ReadingTimeManager();
 


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `COPage` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Due to the current state of the trunk I was not able to test the changes in `ilPCParagraph`. I removed the language from the added keywords. It is not necessary for keywords to have a language, and the language that was set seemed like a guess anyways.

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 