### PR TITLE
LearningSequence: switch to LOM API

### DIFF
--- a/components/ILIAS/LearningSequence/classes/Player/class.ilLSViewFactory.php
+++ b/components/ILIAS/LearningSequence/classes/Player/class.ilLSViewFactory.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
 /**
  * Build a view.
  */
@@ -26,15 +28,18 @@ class ilLSViewFactory
     protected ilKioskModeService $kiosk_mode_service;
     protected ilLanguage $lng;
     protected ilAccess $access;
+    protected LOMServices $lom_services;
 
     public function __construct(
         ilKioskModeService $kiosk_mode_service,
         ilLanguage $lng,
-        ilAccess $access
+        ilAccess $access,
+        LOMServices $lom_services
     ) {
         $this->kiosk_mode_service = $kiosk_mode_service;
         $this->lng = $lng;
         $this->access = $access;
+        $this->lom_services = $lom_services;
     }
 
     public function getViewFor(LSLearnerItem $item): ILIAS\KioskMode\View
@@ -58,7 +63,8 @@ class ilLSViewFactory
         return new ilLegacyKioskModeView(
             $obj,
             $this->lng,
-            $this->access
+            $this->access,
+            $this->lom_services
         );
     }
 }

--- a/components/ILIAS/LearningSequence/classes/Player/class.ilLSViewFactory.php
+++ b/components/ILIAS/LearningSequence/classes/Player/class.ilLSViewFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 

--- a/components/ILIAS/LearningSequence/classes/class.ilLSLocalDI.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLSLocalDI.php
@@ -153,7 +153,8 @@ class ilLSLocalDI extends Container
             return new ilLSViewFactory(
                 $dic['service.kiosk_mode'],
                 $dic["lng"],
-                $dic["ilAccess"]
+                $dic["ilAccess"],
+                $dic->learningObjectMetadata()
             );
         };
 

--- a/components/ILIAS/LearningSequence/classes/class.ilLSLocalDI.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLSLocalDI.php
@@ -154,7 +154,7 @@ class ilLSLocalDI extends Container
                 $dic['service.kiosk_mode'],
                 $dic["lng"],
                 $dic["ilAccess"],
-                $dic->learningObjectMetadata()
+                $dic['learning_object_metadata']
             );
         };
 


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `LearningSequence` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Due to the current state of the trunk I was not able to test the changes, but since the footprint here is pretty small, the risk of breaking things further should be pretty low.

I tried to stick to what was already there in terms of dependency management, let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 