### PR TITLE
Multilingualism: switch to LOM API

### DIFF
--- a/components/ILIAS/Multilingualism/classes/class.ilMultilingualismGUI.php
+++ b/components/ILIAS/Multilingualism/classes/class.ilMultilingualismGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
 /**
  * GUI class for object translation handling.
  * @author Alexander Killing <killing@leifos.de>
@@ -29,6 +31,7 @@ class ilMultilingualismGUI
     protected ilGlobalTemplateInterface $tpl;
     protected ilToolbarGUI $toolbar;
     protected ilObjUser $user;
+    protected LOMServices $lom_services;
     protected ilMultilingualism $obj_trans;
     protected bool $title_descr_only = true;
     protected string $start_title = "";
@@ -46,6 +49,7 @@ class ilMultilingualismGUI
         $this->lng->loadLanguageModule('obj');
         $this->ctrl = $DIC->ctrl();
         $this->tpl = $DIC->ui()->mainTemplate();
+        $this->lom_services = $DIC->learningObjectMetadata();
 
         $this->obj_trans = ilMultilingualism::getInstance($a_obj_id, $a_type);
         $this->request = new \ILIAS\Multilingualism\StandardGUIRequest(
@@ -233,9 +237,13 @@ class ilMultilingualismGUI
 
         $form = new ilPropertyFormGUI();
 
+        $options = [];
+        foreach ($this->lom_services->dataHelper()->getAllLanguages() as $language) {
+            $options[$language->value()] = $language->presentableLabel();
+        }
+
         // master language
         if (!$a_add) {
-            $options = ilMDLanguageItem::_getLanguages();
             $si = new ilSelectInputGUI($lng->txt("obj_master_lang"), "master_lang");
             $si->setOptions($options);
             $si->setValue($ilUser->getLanguage());
@@ -244,7 +252,6 @@ class ilMultilingualismGUI
 
         // additional languages
         if ($a_add) {
-            $options = ilMDLanguageItem::_getLanguages();
             $options = array("" => $lng->txt("please_select")) + $options;
             $si = new ilSelectInputGUI($lng->txt("obj_additional_langs"), "additional_langs");
             $si->setOptions($options);

--- a/components/ILIAS/Multilingualism/classes/class.ilMultilingualismTableGUI.php
+++ b/components/ILIAS/Multilingualism/classes/class.ilMultilingualismTableGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
 /**
  * TableGUI class for title/description translations
  *
@@ -28,6 +30,7 @@ class ilMultilingualismTableGUI extends ilTable2GUI
     protected string $base_cmd;
     protected bool $incl_desc;
     protected ilAccessHandler $access;
+    protected LOMServices $lom_services;
 
     public function __construct(
         object $a_parent_obj,
@@ -42,6 +45,7 @@ class ilMultilingualismTableGUI extends ilTable2GUI
         $this->lng = $DIC->language();
         $this->access = $DIC->access();
         $ilCtrl = $DIC->ctrl();
+        $this->lom_services = $DIC->learningObjectMetadata();
 
         parent::__construct($a_parent_obj, $a_parent_cmd);
         $this->incl_desc = $a_incl_desc;
@@ -61,7 +65,7 @@ class ilMultilingualismTableGUI extends ilTable2GUI
 
         $this->setEnableHeader(true);
         $this->setFormAction($ilCtrl->getFormAction($a_parent_obj));
-        $this->setRowTemplate("tpl.obj_translation2_row.html", "components/ILIAS/Object");
+        $this->setRowTemplate("tpl.obj_translation2_row.html", "components/ILIAS/ILIASObject");
         $this->disable("footer");
         $this->setEnableTitle(true);
 
@@ -112,7 +116,10 @@ class ilMultilingualismTableGUI extends ilTable2GUI
         $this->tpl->setVariable("NR", $this->nr);
 
         // lang selection
-        $languages = ilMDLanguageItem::_getLanguages();
+        $languages = [];
+        foreach ($this->lom_services->dataHelper()->getAllLanguages() as $language) {
+            $languages[$language->value()] = $language->presentableLabel();
+        }
         $this->tpl->setVariable(
             "LANG_SELECT",
             ilLegacyFormElementsUtil::formSelect(


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `Multilingualism` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Cheers, @schmitz-ilias 