### PR TITLE
Repository: switch to LOM API

### DIFF
--- a/components/ILIAS/Repository/Service/trait.GlobalDICDomainServices.php
+++ b/components/ILIAS/Repository/Service/trait.GlobalDICDomainServices.php
@@ -29,6 +29,7 @@ use ILIAS\Repository\Object\ObjectAdapterInterface;
 use ILIAS\Repository\Object\ObjectAdapter;
 use ILIAS\Repository\Profile\ProfileAdapter;
 use ILIAS\Repository\Resources\DomainService;
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 
 trait GlobalDICDomainServices
 {
@@ -119,6 +120,11 @@ trait GlobalDICDomainServices
     public function backgroundTasks(): \ILIAS\BackgroundTasks\BackgroundTaskServices
     {
         return $this->DIC->backgroundTasks();
+    }
+
+    public function learningObjectMetadata(): LOMServices
+    {
+        return $this->DIC->learningObjectMetadata();
     }
 
     public function resources(): DomainService


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `Repository` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Also included is the introduction of the API to `GlobalDICDomainServices`. This is not used in `Repository` itself, but is necessary to be able to use your dependency management when using the API in your other components (PRs will be provided in the future).

Cheers, @schmitz-ilias 