### PR TITLE
StudyProgramme: switch to LOM API

### DIFF
--- a/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeSettingsGUI.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeSettingsGUI.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\UI\Component\Input\Factory;
 use ILIAS\UI\Implementation\Component\Input\Field\Factory as InputFieldFactory;
 use ILIAS\UI\Renderer;
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 
 /**
  * @ilCtrl_Calls ilObjStudyProgrammeSettingsGUI: ilStudyProgrammeCommonSettingsGUI
@@ -56,6 +57,7 @@ class ilObjStudyProgrammeSettingsGUI
     protected ilStudyProgrammeCommonSettingsGUI $common_settings_gui;
     protected ilTabsGUI $tabs;
     protected ILIAS\HTTP\Wrapper\RequestWrapper $request_wrapper;
+    protected LOMServices $lom_services;
 
     protected ?ilObjStudyProgramme $object;
     protected string $tmp_heading;
@@ -73,7 +75,8 @@ class ilObjStudyProgrammeSettingsGUI
         ilStudyProgrammeTypeRepository $type_repository,
         ilStudyProgrammeCommonSettingsGUI $common_settings_gui,
         ilTabsGUI $tabs,
-        ILIAS\HTTP\Wrapper\RequestWrapper $request_wrapper
+        ILIAS\HTTP\Wrapper\RequestWrapper $request_wrapper,
+        LOMServices $lom_services
     ) {
         $this->tpl = $tpl;
         $this->ctrl = $ilCtrl;
@@ -87,6 +90,7 @@ class ilObjStudyProgrammeSettingsGUI
         $this->common_settings_gui = $common_settings_gui;
         $this->tabs = $tabs;
         $this->request_wrapper = $request_wrapper;
+        $this->lom_services = $lom_services;
 
         $this->object = null;
 
@@ -263,8 +267,12 @@ class ilObjStudyProgrammeSettingsGUI
         InputFieldFactory $ff,
         ilObjectTranslation $trans
     ): ILIAS\UI\Component\Input\Field\Section {
-        $languages = ilMDLanguageItem::_getLanguages();
-        $lang = array_key_exists($trans->getDefaultLanguage(), $languages) ? $languages[$trans->getDefaultLanguage()] : '?';
+        $lang = '?';
+        foreach ($this->lom_services->dataHelper()->getAllLanguages() as $language) {
+            if ($language->value() === $trans->getDefaultLanguage()) {
+                $lang = $language->presentableLabel();
+            }
+        }
         return $ff->section(
             [
                 self::PROP_TITLE =>

--- a/components/ILIAS/StudyProgramme/classes/class.ilStudyProgrammeDIC.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilStudyProgrammeDIC.php
@@ -43,7 +43,7 @@ class ilStudyProgrammeDIC
                 ilOrgUnitGlobalSettings::getInstance(),
                 $DIC['ilObjDataCache'],
                 new ilOrgUnitPositionAccess($DIC['ilAccess']),
-                (int)$prg->getRefid()
+                (int) $prg->getRefid()
             );
         };
 
@@ -203,7 +203,8 @@ class ilStudyProgrammeDIC
                 $dic['model.Type.ilStudyProgrammeTypeRepository'],
                 $dic['ilStudyProgrammeCommonSettingsGUI'],
                 $DIC['ilTabs'],
-                $DIC->http()->wrapper()->query()
+                $DIC->http()->wrapper()->query(),
+                $DIC->learningObjectMetadata()
             );
         $dic['PRGMessages'] = static fn($dic) =>
             new ilPRGMessagePrinter(

--- a/components/ILIAS/StudyProgramme/classes/class.ilStudyProgrammeDIC.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilStudyProgrammeDIC.php
@@ -204,7 +204,7 @@ class ilStudyProgrammeDIC
                 $dic['ilStudyProgrammeCommonSettingsGUI'],
                 $DIC['ilTabs'],
                 $DIC->http()->wrapper()->query(),
-                $DIC->learningObjectMetadata()
+                $DIC['learning_object_metadata']
             );
         $dic['PRGMessages'] = static fn($dic) =>
             new ilPRGMessagePrinter(


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `StudyProgramme` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 