### PR TITLE
Tracking: switch to LOM API

### DIFF
--- a/components/ILIAS/Tracking/classes/class.ilLPStatus.php
+++ b/components/ILIAS/Tracking/classes/class.ilLPStatus.php
@@ -114,9 +114,19 @@ class ilLPStatus
         return array();
     }
 
-    public static function _getTypicalLearningTime(int $a_obj_id): int
+    public static function _getTypicalLearningTime(string $type, int $obj_id, int $sub_id = 0): int
     {
-        return ilMDEducational::_getTypicalLearningTimeSeconds($a_obj_id);
+        global $DIC;
+
+        $lom_services = $DIC->learningObjectMetadata();
+        $paths = $lom_services->paths();
+        $data_helper = $lom_services->dataHelper();
+
+        $value = $lom_services->read($obj_id, $sub_id, $type, $paths->firstTypicalLearningTime())
+                              ->firstData($paths->firstTypicalLearningTime())
+                              ->value();
+
+        return $data_helper->durationToSeconds($value);
     }
 
     /**

--- a/components/ILIAS/Tracking/classes/class.ilLPStatus.php
+++ b/components/ILIAS/Tracking/classes/class.ilLPStatus.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=0);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,6 +15,8 @@ declare(strict_types=0);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=0);
 
 /**
  * Abstract class ilLPStatus for all learning progress modes

--- a/components/ILIAS/Tracking/classes/class.ilLPStatusWrapper.php
+++ b/components/ILIAS/Tracking/classes/class.ilLPStatusWrapper.php
@@ -143,7 +143,7 @@ class ilLPStatusWrapper
     /**
      * Reads Typical learning time. Mode collection is recursive for all assigned items
      */
-    public static function _getTypicalLearningTime(int $a_obj_id): int
+    public static function _getTypicalLearningTime(string $type, int $a_obj_id): int
     {
         static $cache = array();
 
@@ -152,7 +152,7 @@ class ilLPStatusWrapper
         }
 
         $class = ilLPStatusFactory::_getClassById($a_obj_id);
-        $cache[$a_obj_id] = $class::_getTypicalLearningTime($a_obj_id);
+        $cache[$a_obj_id] = $class::_getTypicalLearningTime($type, $a_obj_id);
 
         return $cache[$a_obj_id];
     }

--- a/components/ILIAS/Tracking/classes/class.ilLPStatusWrapper.php
+++ b/components/ILIAS/Tracking/classes/class.ilLPStatusWrapper.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=0);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+declare(strict_types=0);
 
 /**
  * Class ilLPStatusWrapper

--- a/components/ILIAS/Tracking/classes/class.ilLearningProgressBaseGUI.php
+++ b/components/ILIAS/Tracking/classes/class.ilLearningProgressBaseGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=0);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=0);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=0);
 
 use ILIAS\Refinery\Factory as RefineryFactory;
 use ILIAS\HTTP\Services as HttpServices;

--- a/components/ILIAS/Tracking/classes/collection/class.ilLPCollectionOfLMChapters.php
+++ b/components/ILIAS/Tracking/classes/collection/class.ilLPCollectionOfLMChapters.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=0);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+declare(strict_types=0);
 
 /**
  * LP collection of learning module chapters

--- a/components/ILIAS/Tracking/classes/collection/class.ilLPCollectionOfLMChapters.php
+++ b/components/ILIAS/Tracking/classes/collection/class.ilLPCollectionOfLMChapters.php
@@ -29,7 +29,8 @@ class ilLPCollectionOfLMChapters extends ilLPCollection
             $tree->setTreeTablePK("lm_id");
             foreach ($tree->getChilds($tree->readRootId()) as $child) {
                 if ($child["type"] == "st") {
-                    $child["tlt"] = ilMDEducational::_getTypicalLearningTimeSeconds(
+                    $child["tlt"] = ilLPStatus::_getTypicalLearningTime(
+                        $child["type"],
                         $obj_id,
                         $child["obj_id"]
                     );

--- a/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfObjectsGUI.php
+++ b/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfObjectsGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=0);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=0);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=0);
 
 /**
  * Class ilObjUserTrackingGUI

--- a/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfObjectsGUI.php
+++ b/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfObjectsGUI.php
@@ -224,7 +224,7 @@ class ilLPListOfObjectsGUI extends ilLearningProgressBaseGUI
 
         $info = new ilInfoScreenGUI($this);
         $info->setFormAction($this->ctrl->getFormAction($this));
-        $this->__showObjectDetails($info, $this->details_obj_id);
+        $this->__showObjectDetails($info, $this->details_obj_id, $this->details_type);
 
         $user_id = $this->initUserIdFromQuery();
         $this->tpl->setVariable(
@@ -258,7 +258,7 @@ class ilLPListOfObjectsGUI extends ilLearningProgressBaseGUI
 
         $info = new ilInfoScreenGUI($this);
         $info->setFormAction($this->ctrl->getFormAction($this));
-        if ($this->__showObjectDetails($info, $this->details_obj_id)) {
+        if ($this->__showObjectDetails($info, $this->details_obj_id, $this->details_type)) {
             $this->tpl->setCurrentBlock("info");
             $this->tpl->setVariable("INFO_TABLE", $info->getHTML());
             $this->tpl->parseCurrentBlock();
@@ -329,7 +329,7 @@ class ilLPListOfObjectsGUI extends ilLearningProgressBaseGUI
 
         $info = new ilInfoScreenGUI($this);
         $info->setFormAction($this->ctrl->getFormAction($this));
-        $this->__showObjectDetails($info, $this->details_obj_id);
+        $this->__showObjectDetails($info, $this->details_obj_id, $this->details_type);
         // $this->__appendLPDetails($info,$this->details_obj_id,$user_id);
         $this->tpl->setVariable("INFO_TABLE", $info->getHTML());
 
@@ -433,7 +433,7 @@ class ilLPListOfObjectsGUI extends ilLearningProgressBaseGUI
         );
         $info = new ilInfoScreenGUI($this);
         $info->setFormAction($this->ctrl->getFormAction($this));
-        if ($this->__showObjectDetails($info, $this->details_obj_id)) {
+        if ($this->__showObjectDetails($info, $this->details_obj_id, $this->details_type)) {
             $this->tpl->setCurrentBlock("info");
             $this->tpl->setVariable("INFO_TABLE", $info->getHTML());
             $this->tpl->parseCurrentBlock();

--- a/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfProgressGUI.php
+++ b/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfProgressGUI.php
@@ -153,7 +153,7 @@ class ilLPListOfProgressGUI extends ilLearningProgressBaseGUI
             $this->details_obj_id,
             $this->tracked_user->getId()
         );
-        $this->__showObjectDetails($info, $this->details_obj_id, false);
+        $this->__showObjectDetails($info, $this->details_obj_id, $this->details_type, false);
 
         // Finally set template variable
         $this->tpl->setVariable("LM_INFO", $info->getHTML());

--- a/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfProgressGUI.php
+++ b/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfProgressGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=0);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=0);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=0);
 
 /**
  * Class ilLPListOfProgress

--- a/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfSettingsGUI.php
+++ b/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfSettingsGUI.php
@@ -409,21 +409,24 @@ class ilLPListOfSettingsGUI extends ilLearningProgressBaseGUI
      */
     protected function updateTLT(): void
     {
+        $paths = $this->lom_services->paths();
+        $data_helper = $this->lom_services->dataHelper();
+
         $tlt = (array) ($this->http->request()->getParsedBody()['tlt'] ?? []);
         foreach ($tlt as $item_id => $item) {
-            $md_obj = new ilMD($this->getObjId(), $item_id, 'st');
-            if (!is_object($md_section = $md_obj->getEducational())) {
-                $md_section = $md_obj->addEducational();
-                $md_section->save();
-            }
-            $md_section->setPhysicalTypicalLearningTime(
+            $lom_duration = $data_helper->durationFromIntegers(
+                null,
                 (int) $item['mo'],
                 (int) $item['d'],
                 (int) $item['h'],
                 (int) $item['m'],
-                0
+                null
             );
-            $md_section->update();
+            $this->lom_services->manipulate($this->getObjId(), $item_id, 'st')
+                               ->prepareCreateOrUpdate(
+                                   $paths->firstTypicalLearningTime(),
+                                   $lom_duration
+                               )->execute();
         }
 
         // refresh learning progress

--- a/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfSettingsGUI.php
+++ b/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfSettingsGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=0);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,7 @@ declare(strict_types=0);
  *
  *********************************************************************/
 
+declare(strict_types=0);
 
 /**
  * Class ilLPListOfSettingsGUI

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusCollection.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusCollection.php
@@ -243,21 +243,24 @@ class ilLPStatusCollection extends ilLPStatus
         return $status_info;
     }
 
-    public static function _getTypicalLearningTime(int $a_obj_id): int
+    public static function _getTypicalLearningTime(string $type, int $obj_id, int $sub_id = 0): int
     {
         global $DIC;
 
         $ilObjDataCache = $DIC['ilObjDataCache'];
 
-        if ($ilObjDataCache->lookupType($a_obj_id) == 'sahs') {
-            return parent::_getTypicalLearningTime($a_obj_id);
+        if ($type == 'sahs') {
+            return parent::_getTypicalLearningTime($type, $obj_id);
         }
 
         $tlt = 0;
-        $status_info = ilLPStatusWrapper::_getStatusInfo($a_obj_id);
+        $status_info = ilLPStatusWrapper::_getStatusInfo($obj_id);
         foreach ($status_info['collections'] as $item) {
+            $obj_id = $ilObjDataCache->lookupObjId((int) $item);
+            $type = $ilObjDataCache->lookupType($obj_id);
             $tlt += ilLPStatusWrapper::_getTypicalLearningTime(
-                $ilObjDataCache->lookupObjId((int) $item)
+                $type,
+                $obj_id
             );
         }
         return $tlt;

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusCollectionTLT.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusCollectionTLT.php
@@ -1,7 +1,22 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=0);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**
  * Seems to only be used for collections of LM chapters.

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusCollectionTLT.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusCollectionTLT.php
@@ -4,6 +4,7 @@ declare(strict_types=0);
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**
+ * Seems to only be used for collections of LM chapters.
  * @author  Jörg Lützenkirchen <luetzenkirchen@leifos.com>
  * @package ilias-tracking
  */
@@ -65,7 +66,12 @@ class ilLPStatusCollectionTLT extends ilLPStatus
                 $status_info["in_progress"][$item_id] = array();
                 $status_info["completed"][$item_id] = array();
 
-                $status_info["tlt"][$item_id] = ilMDEducational::_getTypicalLearningTimeSeconds(
+                /*
+                 * Seems to only be used for collections of LM chapters,
+                 * so we manually set 'st' for chapters here.
+                 */
+                $status_info["tlt"][$item_id] = parent::_getTypicalLearningTime(
+                    'st',
                     $a_obj_id,
                     $item_id
                 );

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusTypicalLearningTime.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusTypicalLearningTime.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=0);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+declare(strict_types=0);
 
 /**
  * @author     Stefan Meyer <meyer@leifos.com>

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusTypicalLearningTime.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusTypicalLearningTime.php
@@ -52,7 +52,13 @@ class ilLPStatusTypicalLearningTime extends ilLPStatus
 
     public static function _getStatusInfo(int $a_obj_id): array
     {
-        $status_info['tlt'] = ilMDEducational::_getTypicalLearningTimeSeconds(
+        global $DIC;
+
+        /** @var ilObjectDataCache $ilObjDataCache */
+        $ilObjDataCache = $DIC['ilObjDataCache'];
+
+        $status_info['tlt'] = parent::_getTypicalLearningTime(
+            $ilObjDataCache->lookupType($a_obj_id),
             $a_obj_id
         );
         return $status_info;
@@ -91,7 +97,10 @@ class ilLPStatusTypicalLearningTime extends ilLPStatus
         int $a_usr_id,
         ?object $a_obj = null
     ): int {
-        $tlt = ilMDEducational::_getTypicalLearningTimeSeconds($a_obj_id);
+        $tlt = parent::_getTypicalLearningTime(
+            $this->ilObjDataCache->lookupType($a_obj_id),
+            $a_obj_id
+        );
         $re = ilChangeEvent::_lookupReadEvents($a_obj_id, $a_usr_id);
         $spent = (int) ($re[0]["spent_seconds"] ?? 0);
 


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `Tracking` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 