### PR TITLE
T&A 41847: Fixes error when entering info screen on test

### DIFF
--- a/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
+++ b/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
@@ -30,6 +30,8 @@ use ILIAS\MetaData\Services\Services as Metadata;
  */
 class ilInfoScreenGUI
 {
+    public const CMD_SHOW_SUMMARY = 'showSummary';
+
     protected \ILIAS\Repository\HTML\HTMLUtil $html;
     protected \ILIAS\DI\UIServices $ui;
     protected ?\ILIAS\UI\Component\MessageBox\MessageBox $mbox = null;

--- a/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
+++ b/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\InfoScreen\StandardGUIRequest;
 use ILIAS\MetaData\Services\Services as Metadata;

--- a/components/ILIAS/Test/classes/class.ilTestEvalObjectiveOrientedGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestEvalObjectiveOrientedGUI.php
@@ -76,7 +76,7 @@ class ilTestEvalObjectiveOrientedGUI extends ilTestServiceGUI
             $executable = $this->object->isExecutable($test_session, $test_session->getUserId());
 
             if ($executable["executable"]) {
-                $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+                $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
             }
         }
 

--- a/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
@@ -1131,7 +1131,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         $test_session = $this->testSessionFactory->getSession();
 
         if (!$this->object->getShowPassDetails()) {
-            $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         $active_id = $test_session->getActiveId();
@@ -1259,7 +1259,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         $uname = $this->object->userLookupFullName($user_id, true);
 
         if (!$this->object->canShowTestResults($test_session)) {
-            $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         $templatehead = new ilTemplate("tpl.il_as_tst_results_participants.html", true, true, "components/ILIAS/Test");
@@ -1347,7 +1347,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
     {
         if (!$this->object->getShowSolutionPrintview()) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt("no_permission"), true);
-            $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         $template = new ilTemplate("tpl.il_as_tst_info_list_of_answers.html", true, true, "components/ILIAS/Test");
@@ -1549,8 +1549,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 
                 // no break
             case ilTestPassDeletionConfirmationGUI::CONTEXT_INFO_SCREEN:
-
-                $this->ctrl->redirectByClass('ilObjTestGUI', 'infoScreen');
+                $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
     }
 

--- a/components/ILIAS/Test/classes/class.ilTestPasswordProtectionGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPasswordProtectionGUI.php
@@ -122,7 +122,7 @@ class ilTestPasswordProtectionGUI
 
     private function backToInfoScreenCmd(): void
     {
-        $this->ctrl->redirectByClass('ilObjTestGUI', 'infoScreen');
+        $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
     }
 
     private function setNextCommandClass(string $next_command_class): void

--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -204,7 +204,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
                     if (!$testPassesSelector->openPassExists()) {
                         $this->tpl->setOnScreenMessage('info', $this->lng->txt('tst_pass_finished'), true);
-                        $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+                        $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
                     }
                 }
 
@@ -239,7 +239,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
         if (!$executable['executable']) {
             $this->tpl->setOnScreenMessage('info', $executable['errormessage'], true);
-            $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
     }
 
@@ -287,7 +287,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         $tagging_gui = new ilTaggingGUI();
         $tagging_gui->setObject($this->object->getId(), $this->object->getType());
         $tagging_gui->saveInput();
-        $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+        $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
     }
 
     /**
@@ -669,7 +669,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
             $this->test_session->setAccessCodeToSession($_POST['anonymous_id']);
         }
 
-        $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+        $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
     }
 
     /**
@@ -696,7 +696,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         }
 
         $this->ctrl->setParameterByClass('ilObjTestGUI', 'lock', $testStartLock);
-        $this->ctrl->redirectByClass("ilobjtestgui", "redirectToInfoScreen");
+        $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
     }
 
     public function getLockParameter()

--- a/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetConfig.php
+++ b/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetConfig.php
@@ -402,7 +402,7 @@ class ilTestRandomQuestionSetConfig extends ilTestQuestionSetConfig
             case '':
 
                 $cmds = [
-                    'infoScreen', 'participants', 'npSetFilter', 'npResetFilter',
+                    ilInfoScreenGUI::CMD_SHOW_SUMMARY, 'participants', 'npSetFilter', 'npResetFilter',
                 ];
 
                 if (in_array($cmd, $cmds)) {

--- a/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetConfigGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetConfigGUI.php
@@ -134,7 +134,7 @@ class ilTestRandomQuestionSetConfigGUI
     {
         if (!$this->access->checkAccess("write", "", $this->test_obj->getRefId())) {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt("cannot_edit_test"), true);
-            $this->ctrl->redirectByClass('ilObjTestGUI', "infoScreen");
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         if ($this->isAvoidManipulationRedirectRequired()) {

--- a/components/ILIAS/Test/classes/class.ilTestServiceGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestServiceGUI.php
@@ -1079,14 +1079,14 @@ class ilTestServiceGUI
     {
         if (!$this->object->getShowSolutionDetails()) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt("no_permission"), true);
-            $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         $testSession = $this->testSessionFactory->getSession();
         $active_id = $testSession->getActiveId();
 
         if (!($active_id > 0)) {
-            $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         $this->ctrl->saveParameter($this, "pass");

--- a/components/ILIAS/Test/classes/class.ilTestTabsManager.php
+++ b/components/ILIAS/Test/classes/class.ilTestTabsManager.php
@@ -503,9 +503,8 @@ class ilTestTabsManager
         if ($this->isReadAccessGranted() && !$this->getTestOBJ()->getMainSettings()->getAdditionalSettings()->getHideInfoTab()) {
             $this->tabs->addTarget(
                 'info_short',
-                $this->ctrl->getLinkTargetByClass('ilObjTestGUI', 'infoScreen'),
-                ['infoScreen', 'outIntroductionPage', 'showSummary',
-                    'setAnonymousId', 'redirectToInfoScreen']
+                $this->ctrl->getLinkTargetByClass(ilInfoScreenGUI::class, ilInfoScreenGUI::CMD_SHOW_SUMMARY),
+                [ilInfoScreenGUI::CMD_SHOW_SUMMARY, 'outIntroductionPage', 'setAnonymousId', 'redirectToInfoScreen']
             );
         }
 

--- a/components/ILIAS/Test/src/Presentation/class.TestScreenGUI.php
+++ b/components/ILIAS/Test/src/Presentation/class.TestScreenGUI.php
@@ -35,6 +35,8 @@ use ILIAS\UI\Renderer as UIRenderer;
 use ILIAS\HTTP\Services as HTTPServices;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Test\Logging\TestParticipantInteractionTypes;
+use ilInfoScreenGUI;
+use ilObjTestGUI;
 
 /**
  * Class TestScreenGUI
@@ -88,7 +90,7 @@ class TestScreenGUI
         }
 
         if (!$this->object->getMainSettings()->getAdditionalSettings()->getHideInfoTab()) {
-            $this->ctrl->redirectByClass(\ilObjTestGUI::class, 'infoScreen');
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         $this->tpl->setOnScreenMessage('failure', sprintf(

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
@@ -24,6 +24,8 @@ use ilCtrlException;
 use ILIAS\Test\Logging\TestScoringInteraction;
 use ILIAS\Test\Logging\TestScoringInteractionTypes;
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
+use ilInfoScreenGUI;
+use ilObjTestGUI;
 
 /**
 * Scoring class for tests
@@ -83,7 +85,7 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
     {
         if (!$this->testrequest->isset('active_id') || $this->testrequest->int('active_id') === 0) {
             $this->tpl->setOnScreenMessage('failure', 'no active id given!', true);
-            $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         return $this->testrequest->int('active_id');
@@ -122,7 +124,7 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
         if (!\ilObjTestFolder::_mananuallyScoreableQuestionTypesExists()) {
             // allow only if at least one question type is marked for manual scoring
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt("manscoring_not_allowed"), true);
-            $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         $this->tabs->activateTab(\ilTestTabsManager::TAB_ID_MANUAL_SCORING);

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
@@ -22,6 +22,8 @@ namespace ILIAS\Test\Scoring\Manual;
 
 use ILIAS\Test\Logging\TestScoringInteractionTypes;
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
+use ilInfoScreenGUI;
+use ilObjTestGUI;
 
 class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
 {
@@ -49,7 +51,7 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
 
         if (!$this->test_access->checkScoreParticipantsAccess()) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('cannot_edit_test'), true);
-            $this->ctrl->redirectByClass('ilobjtestgui', 'infoScreen');
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         \iljQueryUtil::initjQuery();
@@ -165,7 +167,7 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
             }
 
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('cannot_edit_test'), true);
-            $this->ctrl->redirectByClass('ilobjtestgui', 'infoScreen');
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         if ($scoring === []) {

--- a/components/ILIAS/Test/src/Settings/MainSettings/class.SettingsMainGUI.php
+++ b/components/ILIAS/Test/src/Settings/MainSettings/class.SettingsMainGUI.php
@@ -37,6 +37,8 @@ use ILIAS\UI\Component\Input\Container\Form\Standard as StandardForm;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Refinery\Transformation as TransformationInterface;
 use ILIAS\Data\Factory as DataFactory;
+use ilInfoScreenGUI;
+use ilObjTestGUI;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\Refinery\Constraint;
 
@@ -122,7 +124,7 @@ class SettingsMainGUI extends TestSettingsGUI
     {
         if (!$this->access->checkAccess('write', '', $this->test_gui->getRefId())) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('cannot_edit_test'), true);
-            $this->ctrl->redirect($this->test_gui, 'infoScreen');
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         $cmd = $this->ctrl->getCmd(self::CMD_SHOW_FORM);

--- a/components/ILIAS/Test/src/Settings/ScoreReporting/class.SettingsScoringGUI.php
+++ b/components/ILIAS/Test/src/Settings/ScoreReporting/class.SettingsScoringGUI.php
@@ -30,6 +30,8 @@ use ILIAS\UI\Renderer as UIRenderer;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\UI\Component\Input\Container\Form\Form;
+use ilInfoScreenGUI;
+use ilObjTestGUI;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 /**
@@ -92,7 +94,7 @@ class SettingsScoringGUI extends TestSettingsGUI
     {
         if (!$this->access->checkAccess('write', '', $this->test_gui->getRefId())) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('cannot_edit_test'), true);
-            $this->ctrl->redirect($this->test_gui, 'infoScreen');
+            $this->ctrl->redirectByClass([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         $this->tabs->activateSubTab(\ilTestTabsManager::SETTINGS_SUBTAB_ID_SCORING);

--- a/components/ILIAS/Test/tests/ilObjTestGUITest.php
+++ b/components/ILIAS/Test/tests/ilObjTestGUITest.php
@@ -127,11 +127,10 @@ class ilObjTestGUITest extends ilTestBaseTestCase
         $ctrl_mock = $this->createMock(ilCtrl::class);
         $this->setGlobalVariable('ilCtrl', $ctrl_mock);
         $testObj = $this->getNewTestGUI();
-        $infoScreenGUI = $this->createMock(ilInfoScreenGUI::class);
         $ctrl_mock
             ->expects($this->once())
-            ->method('redirect')
-            ->with([$testObj, $infoScreenGUI], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
+            ->method('redirectByClass')
+            ->with([ilObjTestGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
 
         $testObj->runObject();
     }

--- a/components/ILIAS/Test/tests/ilObjTestGUITest.php
+++ b/components/ILIAS/Test/tests/ilObjTestGUITest.php
@@ -127,10 +127,11 @@ class ilObjTestGUITest extends ilTestBaseTestCase
         $ctrl_mock = $this->createMock(ilCtrl::class);
         $this->setGlobalVariable('ilCtrl', $ctrl_mock);
         $testObj = $this->getNewTestGUI();
+        $infoScreenGUI = $this->createMock(ilInfoScreenGUI::class);
         $ctrl_mock
             ->expects($this->once())
             ->method('redirect')
-            ->with($testObj, 'infoScreen');
+            ->with([$testObj, $infoScreenGUI], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
 
         $testObj->runObject();
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -352,7 +352,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 $ret = $this->ctrl->forwardCommand($exp_gui);
                 break;
 
-            case 'ilinfoscreengui':
+            case strtolower(ilInfoScreenGUI::class):
                 $this->infoScreenForward();
                 break;
 
@@ -1057,7 +1057,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $qsaImportFails = new ilAssQuestionSkillAssignmentImportFails($this->object->getId());
         $qsaImportFails->deleteRegisteredImportFails();
 
-        $this->ctrl->redirect($this, 'infoScreen');
+        $this->ctrl->redirectByClass([ilObjQuestionPoolGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
     }
 
     /**
@@ -1600,8 +1600,8 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         if ($currentUserHasReadAccess) {
             $this->tabs_gui->addTarget(
                 'info_short',
-                $this->ctrl->getLinkTarget($this, 'infoScreen'),
-                ['infoScreen', 'showSummary']
+                $this->ctrl->getLinkTargetByClass(ilInfoScreenGUI::class, ilInfoScreenGUI::CMD_SHOW_SUMMARY),
+                [ilInfoScreenGUI::CMD_SHOW_SUMMARY]
             );
         }
 
@@ -1699,19 +1699,6 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 $this->ctrl->getLinkTargetByClass('ilTaxonomySettingsGUI', ''),
             );
         }
-    }
-
-    /**
-     * this one is called from the info button in the repository
-     * not very nice to set cmdClass/Cmd manually, if everything
-     * works through ilCtrl in the future this may be changed
-     */
-    public function infoScreenObject(): void
-    {
-        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-        // $this->ctrl->setCmd('showSummary');
-        // $this->ctrl->setCmdClass('ilinfoscreengui');
-        $this->infoScreenForward();
     }
 
     public function infoScreenForward(): void

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
@@ -67,7 +67,7 @@ class ilObjQuestionPoolSettingsGeneralGUI
 
         if (!$this->access->checkAccess('write', '', $this->poolGUI->getRefId())) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('cannot_edit_question_pool'), true);
-            $this->ctrl->redirectByClass('ilObjQuestionPoolGUI', 'infoScreen');
+            $this->ctrl->redirectByClass([ilObjQuestionPoolGUI::class, ilInfoScreenGUI::class], ilInfoScreenGUI::CMD_SHOW_SUMMARY);
         }
 
         $this->tabs->activateTab('settings');


### PR DESCRIPTION
This pull request addresses a bug where attempting to open the info tab from a test in the ILIAS trunk results in an error page.
This is related to the Mantis Ticket https://mantis.ilias.de/view.php?id=41847