### PR TITLE
Object: switch to LOM API

### DIFF
--- a/components/ILIAS/ILIASObject/classes/Properties/class.ilObjectPropertiesAgregator.php
+++ b/components/ILIAS/ILIASObject/classes/Properties/class.ilObjectPropertiesAgregator.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\Object\Properties\ObjectTypeSpecificProperties\Factory as ObjectTypeSpecificPropertiesFactory;
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 
 /**
  * Description of class
@@ -30,7 +31,8 @@ class ilObjectPropertiesAgregator
     public function __construct(
         private ilObjectCorePropertiesRepository $core_properties_repository,
         private ilObjectAdditionalPropertiesRepository $additional_properties_repository,
-        private ObjectTypeSpecificPropertiesFactory $object_type_specific_properties_factory
+        private ObjectTypeSpecificPropertiesFactory $object_type_specific_properties_factory,
+        private LOMServices $lom_services
     ) {
     }
 
@@ -43,7 +45,7 @@ class ilObjectPropertiesAgregator
             $this->core_properties_repository,
             $this->additional_properties_repository->getFor($object_id),
             $this->additional_properties_repository,
-            new ilMD($object_id, 0, $core_properties->getType() ?? '')
+            $this->lom_services
         );
     }
 

--- a/components/ILIAS/ILIASObject/classes/Translation/class.ilObjectTranslation2TableGUI.php
+++ b/components/ILIAS/ILIASObject/classes/Translation/class.ilObjectTranslation2TableGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,10 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
 /**
  * TableGUI class for title/description translations
  *
@@ -27,6 +29,7 @@ class ilObjectTranslation2TableGUI extends ilTable2GUI
 {
     private const BASE_CMD = 'Translation';
     protected ilAccessHandler $access;
+    protected LOMServices $lom_services;
 
     protected int $nr;
 
@@ -41,6 +44,7 @@ class ilObjectTranslation2TableGUI extends ilTable2GUI
         global $DIC;
 
         $this->access = $DIC->access();
+        $this->lom_services = $DIC->learningObjectMetadata();
 
         parent::__construct($parent_obj, $parent_cmd);
 
@@ -108,7 +112,10 @@ class ilObjectTranslation2TableGUI extends ilTable2GUI
         $this->tpl->setVariable("NR", $this->nr);
 
         // lang selection
-        $languages = ilMDLanguageItem::_getLanguages();
+        $languages = [];
+        foreach ($this->lom_services->dataHelper()->getAllLanguages() as $language) {
+            $languages[$language->value()] = $language->presentableLabel();
+        }
         $this->tpl->setVariable(
             "LANG_SELECT",
             ilLegacyFormElementsUtil::formSelect(

--- a/components/ILIAS/ILIASObject/classes/Translation/class.ilObjectTranslationTableGUI.php
+++ b/components/ILIAS/ILIASObject/classes/Translation/class.ilObjectTranslationTableGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,10 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
 /**
  * TableGUI class for title/description translations
  *
@@ -26,6 +28,7 @@ declare(strict_types=1);
 class ilObjectTranslationTableGUI extends ilTable2GUI
 {
     protected ilAccessHandler $access;
+    protected LOMServices $lom_services;
 
     protected bool $incl_desc;
     protected string $base_cmd;
@@ -38,7 +41,9 @@ class ilObjectTranslationTableGUI extends ilTable2GUI
         string $base_cmd = "HeaderTitle"
     ) {
         global $DIC;
+
         $this->access = $DIC->access();
+        $this->lom_services = $DIC->learningObjectMetadata();
 
         parent::__construct($parent_obj, $parent_cmd);
         $this->incl_desc = $incl_desc;
@@ -86,7 +91,10 @@ class ilObjectTranslationTableGUI extends ilTable2GUI
         $this->tpl->setVariable("NR", $this->nr);
 
         // lang selection
-        $languages = ilMDLanguageItem::_getLanguages();
+        $languages = [];
+        foreach ($this->lom_services->dataHelper()->getAllLanguages() as $language) {
+            $languages[$language->value()] = $language->presentableLabel();
+        }
         $this->tpl->setVariable(
             "LANG_SELECT",
             ilLegacyFormElementsUtil::formSelect(

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
@@ -953,13 +953,23 @@ class ilObjectGUI implements ImplementsCreationCallback
 
         $class_name = 'ilObj' . $this->obj_definition->getClassName($this->requested_new_type);
 
+        /** @var ilObjectPropertyTitleAndDescription $title_and_description_prop */
+        $title_and_description_prop = $data['title_and_description'];
+
         $new_obj = new $class_name();
         $new_obj->setType($this->requested_new_type);
         $new_obj->processAutoRating();
+        /*
+         * Title and description needs to be set before calling ilObject::create
+         * at least preliminarily, because the creation of a new LOM set requires
+         * the object to have a non-null title.
+         */
+        $new_obj->setTitle($title_and_description_prop->getTitle());
+        $new_obj->setDescription($title_and_description_prop->getDescription());
         $new_obj->create();
 
         $new_obj->getObjectProperties()->storePropertyTitleAndDescription(
-            $data['title_and_description']
+            $title_and_description_prop
         );
         $new_obj->setTitle($new_obj->getObjectProperties()->getPropertyTitleAndDescription()->getTitle());
         $new_obj->setDescription($new_obj->getObjectProperties()->getPropertyTitleAndDescription()->getDescription());

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
@@ -953,26 +953,16 @@ class ilObjectGUI implements ImplementsCreationCallback
 
         $class_name = 'ilObj' . $this->obj_definition->getClassName($this->requested_new_type);
 
-        /** @var ilObjectPropertyTitleAndDescription $title_and_description_prop */
-        $title_and_description_prop = $data['title_and_description'];
-
         $new_obj = new $class_name();
         $new_obj->setType($this->requested_new_type);
         $new_obj->processAutoRating();
-        /*
-         * Title and description needs to be set before calling ilObject::create
-         * at least preliminarily, because the creation of a new LOM set requires
-         * the object to have a non-null title.
-         */
-        $new_obj->setTitle($title_and_description_prop->getTitle());
-        $new_obj->setDescription($title_and_description_prop->getDescription());
+        $new_obj->setTitle($data['title_and_description']->getTitle());
+        $new_obj->setDescription($data['title_and_description']->getDescription());
         $new_obj->create();
 
         $new_obj->getObjectProperties()->storePropertyTitleAndDescription(
-            $title_and_description_prop
+            $data['title_and_description']
         );
-        $new_obj->setTitle($new_obj->getObjectProperties()->getPropertyTitleAndDescription()->getTitle());
-        $new_obj->setDescription($new_obj->getObjectProperties()->getPropertyTitleAndDescription()->getDescription());
 
         $this->putObjectInTree($new_obj);
 

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectMetaDataGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectMetaDataGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilObjectMetaDataGUI
@@ -111,14 +111,12 @@ class ilObjectMetaDataGUI
                 }
             }
 
-            $md_obj = new ilMD($this->obj_id, (int) $this->sub_id, $this->getLOMType());
-
             if (!$this->in_workspace && $in_repository) {
                 // (parent) container taxonomies?
                 $this->tax_md_gui = new ilTaxMDGUI(
-                    $md_obj->getRBACId(),
-                    $md_obj->getObjId(),
-                    $md_obj->getObjType(),
+                    $this->obj_id,
+                    (int) $this->sub_id === 0 ? $this->obj_id : (int) $this->sub_id,
+                    $this->getLOMType(),
                     $this->ref_id
                 );
                 $tax_ids = $this->tax_md_gui->getSelectableTaxonomies();

--- a/components/ILIAS/ILIASObject/classes/ilObjectDIC.php
+++ b/components/ILIAS/ILIASObject/classes/ilObjectDIC.php
@@ -59,7 +59,8 @@ class ilObjectDIC extends PimpleContainer
         $this['object_properties_agregator'] = fn($c): \ilObjectPropertiesAgregator => new \ilObjectPropertiesAgregator(
             $c['core_properties_repository'],
             $c['additional_properties_repository'],
-            $c['object_type_specific_properties_factory']
+            $c['object_type_specific_properties_factory'],
+            $DIC->learningObjectMetadata()
         );
 
         $this['core_properties_repository'] = fn($c): \ilObjectCorePropertiesRepository

--- a/components/ILIAS/ILIASObject/classes/ilObjectDIC.php
+++ b/components/ILIAS/ILIASObject/classes/ilObjectDIC.php
@@ -60,7 +60,7 @@ class ilObjectDIC extends PimpleContainer
             $c['core_properties_repository'],
             $c['additional_properties_repository'],
             $c['object_type_specific_properties_factory'],
-            $DIC->learningObjectMetadata()
+            $DIC['learning_object_metadata']
         );
 
         $this['core_properties_repository'] = fn($c): \ilObjectCorePropertiesRepository

--- a/components/ILIAS/WebDAV/tests/dav/ilDAVContainerTest.php
+++ b/components/ILIAS/WebDAV/tests/dav/ilDAVContainerTest.php
@@ -23,6 +23,7 @@ use ILIAS\DI\Container;
 use Sabre\DAV\INode;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Exception\Forbidden;
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 
 require_once "./components/ILIAS/WebDAV/tests/webdav_overrides.php";
 require_once "./components/ILIAS/WebDAV/tests/ilWebDAVTestHelper.php";
@@ -60,6 +61,7 @@ class ilDAVContainerTest extends TestCase
         $DIC['resource_storage'] = $this->createMock(\ILIAS\ResourceStorage\Services::class);
         $DIC['refinery'] = $this->createMock(\ILIAS\Refinery\Factory::class);
         $DIC['object.customicons.factory'] = $this->createMock(ilObjectCustomIconFactory::class);
+        $DIC['learning_object_metadata'] = $this->createMock(LOMServices::class);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `Object` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).\

The new API is a bit more explicit and a bit more strict in certain places, which turned out to be particularly noticeable in the creation process of objects. For simplicity, the changes proposed here stay as close as possible to how things currently work. With  further restructurings of Object in mind, it's probably better to make the switch to the new API earlier rather than later, so that you know what you'll be working with.

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 