### PR TITLE
MediaObjects: switch to LOM API

### DIFF
--- a/components/ILIAS/MediaObjects/Creation/class.ilMediaCreationGUI.php
+++ b/components/ILIAS/MediaObjects/Creation/class.ilMediaCreationGUI.php
@@ -577,7 +577,17 @@ class ilMediaCreationGUI
             $form->setValuesByPost();
             $this->main_tpl->setContent($form->getHTML());
         } else {
+            $locationType = "Reference";
+            $url = $form->getInput("url");
+            $url_pi = pathinfo(basename($url));
+            $title = str_replace("_", " ", $url_pi["filename"]);
+
+            /*
+             * Creating the MediaObject also creates a LOM set for it,
+             * and a LOM set can not be created without a title.
+             */
             $mob = new ilObjMediaObject();
+            $mob->setTitle($title);
             $mob->create();
 
             //handle standard purpose
@@ -590,10 +600,6 @@ class ilMediaCreationGUI
             if (!is_dir($mob_dir)) {
                 $mob->createDirectory();
             }
-            $locationType = "Reference";
-            $url = $form->getInput("url");
-            $url_pi = pathinfo(basename($url));
-            $title = str_replace("_", " ", $url_pi["filename"]);
 
             // get mime type, if not already set!
             $format = ilObjMediaObject::getMimeType($url, true);
@@ -611,7 +617,6 @@ class ilMediaCreationGUI
             $mediaItem->setLocation($url);
             $mediaItem->setLocationType("Reference");
             $mediaItem->setHAlign("Left");
-            $mob->setTitle($title);
             try {
                 $mob->getExternalMetadata();
             } catch (Exception $e) {

--- a/components/ILIAS/MediaObjects/Metadata/class.MetadataManager.php
+++ b/components/ILIAS/MediaObjects/Metadata/class.MetadataManager.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\MediaObjects\Metadata;
+
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
+class MetadataManager
+{
+    protected LOMServices $lom_services;
+
+    public function __construct(LOMServices $lom_services)
+    {
+        $this->lom_services = $lom_services;
+    }
+
+    public function learningObjectMetadata(): LOMServices
+    {
+        return $this->lom_services;
+    }
+
+    public function getLOMLanguagesForSelectInputs(): array
+    {
+        $languages = [];
+        foreach ($this->lom_services->dataHelper()->getAllLanguages() as $language) {
+            $languages[$language->value()] = $language->presentableLabel();
+        }
+        return $languages;
+    }
+
+    public function getLOMLanguageCodes(): array
+    {
+        $languages = [];
+        foreach ($this->lom_services->dataHelper()->getAllLanguages() as $language) {
+            $languages[] = $language->value();
+        }
+        return $languages;
+    }
+}

--- a/components/ILIAS/MediaObjects/Service/class.InternalDomainService.php
+++ b/components/ILIAS/MediaObjects/Service/class.InternalDomainService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\MediaObjects;
 

--- a/components/ILIAS/MediaObjects/Service/class.InternalDomainService.php
+++ b/components/ILIAS/MediaObjects/Service/class.InternalDomainService.php
@@ -25,6 +25,7 @@ use ILIAS\MediaObjects\ImageMap\ImageMapManager;
 use ILIAS\Repository\GlobalDICDomainServices;
 use ILIAS\MediaObjects\MediaType\MediaTypeManager;
 use ILIAS\MediaObjects\Tracking\TrackingManager;
+use ILIAS\MediaObjects\Metadata\MetadataManager;
 
 /**
  * @author Alexander Killing <killing@leifos.de>
@@ -74,5 +75,10 @@ class InternalDomainService
         return new TrackingManager(
             $this
         );
+    }
+
+    public function metadata(): MetadataManager
+    {
+        return new MetadataManager($this->learningObjectMetadata());
     }
 }

--- a/components/ILIAS/MediaObjects/SubTitles/class.ilMobMultiSrtUpload.php
+++ b/components/ILIAS/MediaObjects/SubTitles/class.ilMobMultiSrtUpload.php
@@ -17,6 +17,7 @@
  *********************************************************************/
 
 use ILIAS\Repository\Resources\ZipAdapter;
+use ILIAS\MediaObjects\Metadata\MetadataManager;
 
 /**
  * Handler class for multi srt upload
@@ -28,6 +29,7 @@ class ilMobMultiSrtUpload
     protected ZipAdapter $zip;
     protected ilMobMultiSrtInt $multi_srt;
     protected ilLanguage $lng;
+    protected MetadataManager $md;
 
     /**
      * @param ilMobMultiSrtInt $a_multi_srt adapter implementation
@@ -39,6 +41,7 @@ class ilMobMultiSrtUpload
 
         $lng = $DIC->language();
         $this->zip = $DIC->mediaObjects()->internal()->domain()->resources()->zip();
+        $this->md = $DIC->mediaObjects()->internal()->domain()->metadata();
 
         $this->lng = $lng;
         $this->multi_srt = $a_multi_srt;
@@ -89,7 +92,7 @@ class ilMobMultiSrtUpload
     {
         $items = array();
 
-        $lang_codes = ilMDLanguageItem::_getPossibleLanguageCodes();
+        $lang_codes = $this->md->getLOMLanguageCodes();
 
         $dir = $this->getMultiSrtUploadDir();
         $files = ilFileUtils::getDir($dir);


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `MediaObjects` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

To not ruin your dependency management, I introduced a new `MetadataManager` in the `InternalDomainService`. I did not wrap all the used functionality, but instead decided to also offer the API itself through the `MetadataManager`. To me the fully wrapped version looked less readable (but I might of course be a bit biased). Further, because the new API is a bit more specific and a bit more strict in some places, a very slight rejiggering of the creation process of `MediaObjects` was necessary. 

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 