### PR TITLE
T&A 41706: Fix title max length inconsistency

### DIFF
--- a/Modules/LearningModule/classes/class.ilObjContentObjectGUI.php
+++ b/Modules/LearningModule/classes/class.ilObjContentObjectGUI.php
@@ -502,6 +502,7 @@ class ilObjContentObjectGUI extends ilObjectGUI
         // title
         $ti = new ilTextInputGUI($lng->txt("title"), "title");
         $ti->setRequired(true);
+        $ti->setMaxLength(255);
         $this->form->addItem($ti);
 
         // description

--- a/Modules/Test/classes/class.ilObjTestSettingsGeneralGUI.php
+++ b/Modules/Test/classes/class.ilObjTestSettingsGeneralGUI.php
@@ -548,6 +548,7 @@ class ilObjTestSettingsGeneralGUI extends ilTestSettingsGUI
 
         $title = new ilTextInputGUI($this->lng->txt("title"), "title");
         $title->setRequired(true);
+        $title->setMaxLength(255);
         if ($md_section !== null) {
             $title->setValue($md_section->getTitle());
         }
@@ -1541,8 +1542,8 @@ class ilObjTestSettingsGeneralGUI extends ilTestSettingsGUI
         $this->testOBJ->setShowFinalStatement((bool) $form->getInput('showfinalstatement'));
         $this->testOBJ->setFinalStatement($form->getInput('finalstatement') ?? '');
 
-        if ($this->formPropertyExists($form,'redirection_enabled')) {
-            if (empty($form->getInput('redirection_enabled'))){
+        if ($this->formPropertyExists($form, 'redirection_enabled')) {
+            if (empty($form->getInput('redirection_enabled'))) {
                 $this->testOBJ->setRedirectionMode(REDIRECT_NONE);
             } else {
                 $this->testOBJ->setRedirectionMode(($form->getInput('redirection_mode')));
@@ -1550,7 +1551,7 @@ class ilObjTestSettingsGeneralGUI extends ilTestSettingsGUI
         } else {
             $this->testOBJ->setRedirectionMode(REDIRECT_NONE);
         }
-        if ($this->formPropertyExists($form,'redirection_url')) {
+        if ($this->formPropertyExists($form, 'redirection_url')) {
             $this->testOBJ->setRedirectionUrl($form->getInput('redirection_url'));
         } else {
             $this->testOBJ->setRedirectionUrl(null);

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolSettingsGeneralGUI.php
@@ -228,6 +228,7 @@ class ilObjQuestionPoolSettingsGeneralGUI
 
         $title = new ilTextInputGUI($this->lng->txt("title"), "title");
         $title->setRequired(true);
+        $title->setMaxLength(255);
         $title->setValue($md_section->getTitle());
         $form->addItem($title);
 


### PR DESCRIPTION
This PR is related to Mantis https://mantis.ilias.de/view.php?id=41706 and adds a maximum length validation of 255 to Test, QuestionPool, and LearningModule. This should fix the inconsistency because the general title limit is 255, while the default ilTextInputGUI maximum length is set to 200.