### PR TITLE
Add withMaxPaginationButtons to thread overview pagination

### DIFF
--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -839,6 +839,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
             ->withTargetURL($url, ilForumProperties::PAGE_NAME_THREAD_OVERVIEW)
             ->withTotalEntries($frm_object->getTopNumThreads())
             ->withPageSize(ilForumProperties::PAGE_SIZE_THREAD_OVERVIEW)
+            ->withMaxPaginationButtons(5)
             ->withCurrentPage($current_page);
 
         if ($found_threads === false) {


### PR DESCRIPTION
Forum pagination does not shrink with too many entries and exceeds page and block limits. 

![image](https://github.com/user-attachments/assets/0bf182a1-ff73-4d54-a796-77aec5a8e0c9)
