### PR TITLE
T&A 41725: Fix Test Results "Access From" Minutes default to number of selected month

### DIFF
--- a/Modules/Test/classes/ScoreReporting/ilObjTestSettingsResultSummary.php
+++ b/Modules/Test/classes/ScoreReporting/ilObjTestSettingsResultSummary.php
@@ -66,7 +66,7 @@ class ilObjTestSettingsResultSummary extends TestSettings
         if ($reporting_date !== null) {
             $reporting_date = $reporting_date->setTimezone(
                 new DateTimeZone($environment['user_time_zone'])
-            )->format($environment['user_date_format']->toString() . ' H:m');
+            )->format($environment['user_date_format']->toString() . ' H:i');
         }
 
         $results_time_group = $f->switchableGroup(


### PR DESCRIPTION
This PR is related to the Mantis ticket https://mantis.ilias.de/view.php?id=41725.

Previously, an incorrect formatting character was used during DateTime formatting, causing the minutes in the time to display the month value from the date. This has now been corrected to ensure the DateTime is displayed as expected.

This fix can also be cherry-picked into ILIAS 9. In the Trunk version, this behavior has already been reworked and functions as expected.