### PR TITLE
trunk StatusCommand: implement a lazy filter

### DIFF
--- a/components/ILIAS/BackgroundTasks_/classes/Setup/class.ilBackgroundTasksMetricsCollectedObjective.php
+++ b/components/ILIAS/BackgroundTasks_/classes/Setup/class.ilBackgroundTasksMetricsCollectedObjective.php
@@ -39,12 +39,12 @@ class ilBackgroundTasksMetricsCollectedObjective extends Setup\Metrics\Collected
 
         $storage->storeConfigText(
             "type",
-            $ini->readVariable("background_tasks", "concurrency"),
+            fn() => $ini->readVariable("background_tasks", "concurrency"),
             "The type of execution used for background tasks"
         );
         $storage->storeConfigGauge(
             "max_number_of_concurrent_tasks",
-            (int) $ini->readVariable("background_tasks", "number_of_concurrent_tasks"),
+            fn() => (int) $ini->readVariable("background_tasks", "number_of_concurrent_tasks"),
             "The maximum amount of concurrent tasks used to run background tasks."
         );
     }

--- a/components/ILIAS/Chatroom/classes/Setup/class.ilChatroomMetricsCollectedObjective.php
+++ b/components/ILIAS/Chatroom/classes/Setup/class.ilChatroomMetricsCollectedObjective.php
@@ -54,46 +54,46 @@ class ilChatroomMetricsCollectedObjective extends Setup\Metrics\CollectedObjecti
         if (count($settings) > 0) {
             $storage->storeConfigText(
                 'address',
-                $settings['address'] ?? '',
+                fn() => $settings['address'] ?? '',
                 'IP-Address/FQN of Chat Server.'
             );
             $storage->storeConfigText(
                 'port',
-                (string) ($settings['port'] ?? ''),
+                fn() => (string) ($settings['port'] ?? ''),
                 'Port of the chat server.'
             );
             $storage->storeConfigText(
                 'sub_directory',
-                $settings['sub_directory'] ?? '',
+                fn() => $settings['sub_directory'] ?? '',
                 'http(s)://[IP/Domain]/[SUB_DIRECTORY]'
             );
 
             $storage->storeConfigText(
                 'protocol',
-                $settings['protocol'] ?? '',
+                fn() => $settings['protocol'] ?? '',
                 'Protocol used for connection (http/https).'
             );
 
             if (isset($settings['protocol']) && $settings['protocol'] === 'https') {
                 $cert = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
-                    $settings['cert'] ?? ''
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::TEXT,
+                    fn() => $settings['cert'] ?? ''
                 );
                 $key = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
-                    $settings['key'] ?? ''
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::TEXT,
+                    fn() => $settings['key'] ?? ''
                 );
                 $dhparam = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
-                    $settings['dhparam'] ?? ''
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::TEXT,
+                    fn() => $settings['dhparam'] ?? ''
                 );
                 $https = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_COLLECTION,
-                    [
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::COLLECTION,
+                    fn() => [
                         'cert' => $cert,
                         'key' => $key,
                         'dhparam' => $dhparam,
@@ -105,30 +105,30 @@ class ilChatroomMetricsCollectedObjective extends Setup\Metrics\CollectedObjecti
 
             $storage->storeConfigText(
                 'log',
-                (string) ($settings['log'] ?? ''),
+                fn() => (string) ($settings['log'] ?? ''),
                 "Absolute server path to the chat server's log file."
             );
             $storage->storeConfigText(
                 'log_level',
-                $settings['log_level'] ?? '',
+                fn() => $settings['log_level'] ?? '',
                 'Possible values are emerg, alert, crit error, warning, notice, info, debug, silly.'
             );
             $storage->storeConfigText(
                 'error_log',
-                $settings['error_log'] ?? '',
+                fn() => $settings['error_log'] ?? '',
                 "Absolute server path to the chat server's error log file."
             );
 
             if (isset($settings['ilias_proxy']) && $settings['ilias_proxy']) {
                 $ilias_url = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
-                    $settings['ilias_url'] ?? ''
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::TEXT,
+                    fn() => $settings['ilias_url'] ?? ''
                 );
                 $ilias_proxy = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_COLLECTION,
-                    [
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::COLLECTION,
+                    fn() => [
                         'ilias_url' => $ilias_url
                     ],
                     'Holds proxy url if ILIAS proxy is enabled.'
@@ -137,21 +137,21 @@ class ilChatroomMetricsCollectedObjective extends Setup\Metrics\CollectedObjecti
             } else {
                 $storage->storeConfigBool(
                     'ilias_proxy',
-                    false,
+                    fn() => false,
                     'Holds proxy url if ILIAS proxy is enabled.'
                 );
             }
 
             if (isset($settings['client_proxy']) && $settings['client_proxy']) {
                 $client_url = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
-                    $settings['client_url'] ?? ''
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::TEXT,
+                    fn() => $settings['client_url'] ?? ''
                 );
                 $client_proxy = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_COLLECTION,
-                    [
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::COLLECTION,
+                    fn() => [
                         'client_url' => $client_url
                     ],
                     'Holds proxy url if client proxy is enabled.'
@@ -160,31 +160,31 @@ class ilChatroomMetricsCollectedObjective extends Setup\Metrics\CollectedObjecti
             } else {
                 $storage->storeConfigBool(
                     'client_proxy',
-                    false,
+                    fn() => false,
                     'Holds proxy url if client proxy is enabled.'
                 );
             }
 
             if (isset($settings['deletion_mode']) && $settings['deletion_mode']) {
                 $deletion_unit = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
-                    $settings['deletion_unit'] ?? ''
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::TEXT,
+                    fn() => $settings['deletion_unit'] ?? ''
                 );
                 $deletion_value = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
-                    (string) ($settings['deletion_value'] ?? '')
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::TEXT,
+                    fn() => (string) ($settings['deletion_value'] ?? '')
                 );
                 $deletion_time = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
-                    $settings['deletion_time'] ?? ''
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::TEXT,
+                    fn() => $settings['deletion_time'] ?? ''
                 );
                 $deletion_mode = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_COLLECTION,
-                    [
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::COLLECTION,
+                    fn() => [
                         'deletion_unit' => $deletion_unit,
                         'deletion_value' => $deletion_value,
                         'deletion_time' => $deletion_time,

--- a/components/ILIAS/Database/classes/Setup/class.ilDatabaseMetricsCollectedObjective.php
+++ b/components/ILIAS/Database/classes/Setup/class.ilDatabaseMetricsCollectedObjective.php
@@ -40,32 +40,32 @@ class ilDatabaseMetricsCollectedObjective extends Setup\Metrics\CollectedObjecti
         if ($client_ini) {
             $storage->storeConfigText(
                 "type",
-                $client_ini->readVariable("db", "type") ?? "mysql",
+                fn() => $client_ini->readVariable("db", "type") ?? "mysql",
                 "The storage backend that is used for the database."
             );
             $storage->storeConfigText(
                 "host",
-                $client_ini->readVariable("db", "host"),
+                fn() => $client_ini->readVariable("db", "host"),
                 "The host where the storage backend is located."
             );
             $storage->storeConfigText(
                 "port",
-                $client_ini->readVariable("db", "port"),
+                fn() => $client_ini->readVariable("db", "port"),
                 "The port where the storage backend is located at the host."
             );
             $storage->storeConfigText(
                 "name",
-                $client_ini->readVariable("db", "name"),
+                fn() => $client_ini->readVariable("db", "name"),
                 "The name of the database in the storage backend."
             );
             $storage->storeConfigText(
                 "user",
-                $client_ini->readVariable("db", "user"),
+                fn() => $client_ini->readVariable("db", "user"),
                 "The user to be used for the storage backend."
             );
             $storage->storeConfigText(
                 "pass",
-                PHP_SAPI === 'cli' ? $client_ini->readVariable("db", "pass") : '********',
+                fn() => PHP_SAPI === 'cli' ? $client_ini->readVariable("db", "pass") : '********',
                 "The password for the user for the storage backend."
             );
         }
@@ -138,17 +138,17 @@ class ilDatabaseMetricsCollectedObjective extends Setup\Metrics\CollectedObjecti
 
             $storage->storeStableCounter(
                 "custom_version",
-                $db_update->getCustomUpdatesCurrentVersion() ?? 0,
+                fn() => $db_update->getCustomUpdatesCurrentVersion() ?? 0,
                 "The version of the custom database schema that is currently installed."
             );
             $storage->storeStableCounter(
                 "available_custom_version",
-                $db_update->getCustomUpdatesFileVersion() ?? 0,
+                fn() => $db_update->getCustomUpdatesFileVersion() ?? 0,
                 "The version of the custom database schema that is available in the current source."
             );
             $storage->storeStableBool(
                 "custom_update_required",
-                $db_update->customUpdatesAvailable(),
+                fn() => $db_update->customUpdatesAvailable(),
                 "Does the database require a custom update?"
             );
         } finally {

--- a/components/ILIAS/Database/classes/Setup/class.ilDatabaseUpdateStepsMetricsCollectedObjective.php
+++ b/components/ILIAS/Database/classes/Setup/class.ilDatabaseUpdateStepsMetricsCollectedObjective.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\Setup\Metrics\Metric;
@@ -40,30 +40,30 @@ class ilDatabaseUpdateStepsMetricsCollectedObjective extends Setup\Metrics\Colle
         $step_reader = $environment->getResource(ilDBStepReader::class);
 
         $version = new Metric(
-            Metric::STABILITY_STABLE,
-            Metric::TYPE_TEXT,
-            (string) ($execution_log->getLastFinishedStep($this->step_class))
+            Setup\Metrics\MetricStability::STABLE,
+            Setup\Metrics\MetricType::TEXT,
+            fn() => (string) ($execution_log->getLastFinishedStep($this->step_class))
         );
 
         $available_version = new Metric(
-            Metric::STABILITY_STABLE,
-            Metric::TYPE_TEXT,
-            (string) $step_reader->getLatestStepNumber($this->step_class, self::STEP_METHOD_PREFIX)
+            Setup\Metrics\MetricStability::STABLE,
+            Setup\Metrics\MetricType::TEXT,
+            fn() => (string) $step_reader->getLatestStepNumber($this->step_class, self::STEP_METHOD_PREFIX)
         );
 
         $update_required = new Metric(
-            Metric::STABILITY_STABLE,
-            Metric::TYPE_BOOL,
-            $execution_log->getLastFinishedStep($this->step_class) !== $step_reader->getLatestStepNumber(
+            Setup\Metrics\MetricStability::STABLE,
+            Setup\Metrics\MetricType::BOOL,
+            fn() => $execution_log->getLastFinishedStep($this->step_class) !== $step_reader->getLatestStepNumber(
                 $this->step_class,
                 self::STEP_METHOD_PREFIX
             )
         );
 
         $collection = new Metric(
-            Metric::STABILITY_STABLE,
-            Metric::TYPE_COLLECTION,
-            [
+            Setup\Metrics\MetricStability::STABLE,
+            Setup\Metrics\MetricType::COLLECTION,
+            fn() => [
                 "version" => $version,
                 "available_version" => $available_version,
                 "update_required" => $update_required

--- a/components/ILIAS/Filesystem/classes/Setup/class.ilFileSystemMetricsCollectedObjective.php
+++ b/components/ILIAS/Filesystem/classes/Setup/class.ilFileSystemMetricsCollectedObjective.php
@@ -37,7 +37,7 @@ class ilFileSystemMetricsCollectedObjective extends Setup\Metrics\CollectedObjec
         if ($ini) {
             $storage->storeConfigText(
                 "data_dir",
-                $ini->readVariable("clients", "datadir"),
+                fn() => $ini->readVariable("clients", "datadir"),
                 "Filesystem location where ILIAS stores data outside of direct web access."
             );
         }

--- a/components/ILIAS/GlobalCache_/classes/Setup/class.ilGlobalCacheMetricsCollectedObjective.php
+++ b/components/ILIAS/GlobalCache_/classes/Setup/class.ilGlobalCacheMetricsCollectedObjective.php
@@ -21,6 +21,8 @@ use ILIAS\Setup\Environment;
 use ILIAS\Setup\Metrics\Storage;
 use ILIAS\Cache\Config;
 use ILIAS\Setup\Metrics\Metric;
+use ILIAS\Setup\Metrics\MetricStability;
+use ILIAS\Setup\Metrics\MetricType;
 use ILIAS\Setup;
 
 class ilGlobalCacheMetricsCollectedObjective extends CollectedObjective
@@ -47,12 +49,12 @@ class ilGlobalCacheMetricsCollectedObjective extends CollectedObjective
         $service = $config->getAdaptorName();
         $storage->storeConfigText(
             "service",
-            $service,
+            fn() => $service,
             "The backend that is used for the ILIAS cache."
         );
         $storage->storeConfigBool(
             "active",
-            $config->isActivated()
+            fn() => $config->isActivated()
         );
 
         $servers = $config->getNodes();
@@ -63,25 +65,25 @@ class ilGlobalCacheMetricsCollectedObjective extends CollectedObjective
             $server_collection = [];
             foreach ($servers as $server) {
                 $host = new Metric(
-                    Metric::STABILITY_CONFIG,
-                    Metric::TYPE_TEXT,
-                    $server->getHost()
+                    MetricStability::CONFIG,
+                    MetricType::TEXT,
+                    fn() => $server->getHost()
                 );
                 $port = new Metric(
-                    Metric::STABILITY_CONFIG,
-                    Metric::TYPE_GAUGE,
-                    $server->getPort()
+                    MetricStability::CONFIG,
+                    MetricType::GAUGE,
+                    fn() => $server->getPort()
                 );
                 $weight = new Metric(
-                    Metric::STABILITY_CONFIG,
-                    Metric::TYPE_GAUGE,
-                    $server->getWeight()
+                    MetricStability::CONFIG,
+                    MetricType::GAUGE,
+                    fn() => $server->getWeight()
                 );
 
                 $server_collection[] = new Metric(
-                    Metric::STABILITY_CONFIG,
-                    Metric::TYPE_COLLECTION,
-                    [
+                    MetricStability::CONFIG,
+                    MetricType::COLLECTION,
+                    fn() => [
                         "host" => $host,
                         "port" => $port,
                         "weight" => $weight
@@ -91,9 +93,9 @@ class ilGlobalCacheMetricsCollectedObjective extends CollectedObjective
             }
 
             $nodes = new Metric(
-                Metric::STABILITY_CONFIG,
-                Metric::TYPE_COLLECTION,
-                $server_collection,
+                MetricStability::CONFIG,
+                MetricType::COLLECTION,
+                fn() => $server_collection,
                 "Collection of configured memcached nodes."
             );
             $storage->store("memcached_nodes", $nodes);
@@ -102,15 +104,15 @@ class ilGlobalCacheMetricsCollectedObjective extends CollectedObjective
         $component_activation = [];
         foreach (ilGlobalCache::getAvailableComponents() as $component) {
             $component_activation[$component] = new Metric(
-                Metric::STABILITY_CONFIG,
-                Metric::TYPE_BOOL,
-                $config->isComponentActivated($component)
+                MetricStability::CONFIG,
+                MetricType::BOOL,
+                fn() => $config->isComponentActivated($component)
             );
         }
         $component_activation = new Metric(
-            Metric::STABILITY_CONFIG,
-            Metric::TYPE_COLLECTION,
-            $component_activation,
+            MetricStability::CONFIG,
+            MetricType::COLLECTION,
+            fn() => $component_activation,
             "Which components are activated to use caching?"
         );
         $storage->store(

--- a/components/ILIAS/Http_/classes/Setup/class.ilHttpMetricsCollectedObjective.php
+++ b/components/ILIAS/Http_/classes/Setup/class.ilHttpMetricsCollectedObjective.php
@@ -1,20 +1,23 @@
 <?php
 
-use ILIAS\Setup;
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+use ILIAS\Setup;
+
 class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
 {
     /**
@@ -35,32 +38,32 @@ class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
         if ($ilias_ini) {
             $storage->storeConfigText(
                 "http_path",
-                $ilias_ini->readVariable("server", "http_path"),
+                fn() => $ilias_ini->readVariable("server", "http_path"),
                 "URL of the server."
             );
             $storage->storeConfigText(
                 "https forced",
-                $ilias_ini->readVariable("https", "forced"),
+                fn() => $ilias_ini->readVariable("https", "forced"),
                 ""
             );
 
             if ($ilias_ini->readVariable("https", "auto_https_detect_enabled")) {
                 $header_name = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
-                    $ilias_ini->readVariable("https", "auto_https_detect_header_name"),
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::TEXT,
+                    fn() => $ilias_ini->readVariable("https", "auto_https_detect_header_name"),
                     "The name of the header used for https detection in requests."
                 );
                 $header_value = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_TEXT,
-                    $ilias_ini->readVariable("https", "auto_https_detect_header_value"),
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::TEXT,
+                    fn() => $ilias_ini->readVariable("https", "auto_https_detect_header_value"),
                     "The value in the named header that indicates usage of https in requests."
                 );
                 $https_metrics = new Setup\Metrics\Metric(
-                    Setup\Metrics\Metric::STABILITY_CONFIG,
-                    Setup\Metrics\Metric::TYPE_COLLECTION,
-                    [
+                    Setup\Metrics\MetricStability::CONFIG,
+                    Setup\Metrics\MetricType::COLLECTION,
+                    fn() => [
                         "header_name" => $header_name,
                         "header_value" => $header_value
                     ],
@@ -70,7 +73,7 @@ class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
             } else {
                 $storage->storeConfigBool(
                     "https_autodetection",
-                    false,
+                    fn() => false,
                     "Does the server attempt to detect https in incoming requests?"
                 );
             }
@@ -84,21 +87,21 @@ class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
 
         if ($settings->get("proxy_status")) {
             $host = new Setup\Metrics\Metric(
-                Setup\Metrics\Metric::STABILITY_CONFIG,
-                Setup\Metrics\Metric::TYPE_TEXT,
-                $settings->get("proxy_host"),
+                Setup\Metrics\MetricStability::CONFIG,
+                Setup\Metrics\MetricType::TEXT,
+                fn() => $settings->get("proxy_host"),
                 "The host of the proxy."
             );
             $port = new Setup\Metrics\Metric(
-                Setup\Metrics\Metric::STABILITY_CONFIG,
-                Setup\Metrics\Metric::TYPE_TEXT,
-                $settings->get("proxy_port"),
+                Setup\Metrics\MetricStability::CONFIG,
+                Setup\Metrics\MetricType::TEXT,
+                fn() => $settings->get("proxy_port"),
                 "The port of the proxy."
             );
             $proxy = new Setup\Metrics\Metric(
-                Setup\Metrics\Metric::STABILITY_CONFIG,
-                Setup\Metrics\Metric::TYPE_COLLECTION,
-                [
+                Setup\Metrics\MetricStability::CONFIG,
+                Setup\Metrics\MetricType::COLLECTION,
+                fn() => [
                     "host" => $host,
                     "port" => $port
                 ],
@@ -108,7 +111,7 @@ class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
         } else {
             $storage->storeConfigBool(
                 "proxy",
-                false,
+                fn() => false,
                 "Does the server use a proxy for outgoing connections?"
             );
         }

--- a/components/ILIAS/Language/classes/Setup/class.ilLanguageMetricsCollectedObjective.php
+++ b/components/ILIAS/Language/classes/Setup/class.ilLanguageMetricsCollectedObjective.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  ********************************************************************
  */
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 
@@ -53,7 +53,7 @@ class ilLanguageMetricsCollectedObjective extends Setup\Metrics\CollectedObjecti
         if ($client_ini) {
             $storage->storeConfigText(
                 "default_language",
-                $client_ini->readVariable("language", "default"),
+                fn() => $client_ini->readVariable("language", "default"),
                 "The language that is used by default."
             );
         }
@@ -72,30 +72,30 @@ class ilLanguageMetricsCollectedObjective extends Setup\Metrics\CollectedObjecti
         $local_languages = $this->il_setup_language->getLocalLanguages();
         foreach ($this->il_setup_language->getInstalledLanguages() as $lang) {
             $local_file = new Setup\Metrics\Metric(
-                Setup\Metrics\Metric::STABILITY_STABLE,
-                Setup\Metrics\Metric::TYPE_BOOL,
-                in_array($lang, $local_languages, true),
+                Setup\Metrics\MetricStability::STABLE,
+                Setup\Metrics\MetricType::BOOL,
+                fn() => in_array($lang, $local_languages, true),
                 "Is there a local language file for the language?"
             );
             $local_changes = new Setup\Metrics\Metric(
-                Setup\Metrics\Metric::STABILITY_STABLE,
-                Setup\Metrics\Metric::TYPE_BOOL,
-                count($this->il_setup_language->getLocalChanges($lang)) > 0,
+                Setup\Metrics\MetricStability::STABLE,
+                Setup\Metrics\MetricType::BOOL,
+                fn() => count($this->il_setup_language->getLocalChanges($lang)) > 0,
                 "Are there local changes for the language?"
             );
             $installed_languages[$lang] = new Setup\Metrics\Metric(
-                Setup\Metrics\Metric::STABILITY_STABLE,
-                Setup\Metrics\Metric::TYPE_COLLECTION,
-                [
+                Setup\Metrics\MetricStability::STABLE,
+                Setup\Metrics\MetricType::COLLECTION,
+                fn() => [
                     "local_file" => $local_file,
                     "local_changes" => $local_changes
                 ]
             );
         }
         $installed_languages = new Setup\Metrics\Metric(
-            Setup\Metrics\Metric::STABILITY_STABLE,
-            Setup\Metrics\Metric::TYPE_COLLECTION,
-            $installed_languages
+            Setup\Metrics\MetricStability::STABLE,
+            Setup\Metrics\MetricType::COLLECTION,
+            fn() => $installed_languages
         );
         $storage->store(
             "installed_languages",

--- a/components/ILIAS/Logging/classes/Setup/class.ilLoggingMetricsCollectedObjective.php
+++ b/components/ILIAS/Logging/classes/Setup/class.ilLoggingMetricsCollectedObjective.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 /* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
@@ -26,17 +42,17 @@ class ilLoggingMetricsCollectedObjective extends CollectedObjective
 
         $storage->storeConfigBool(
             "enable",
-            (bool) $ini->readVariable("log", "enabled"),
+            fn() => (bool) $ini->readVariable("log", "enabled"),
             "Is the logging enabled on the installation?"
         );
         $storage->storeConfigText(
             "path_to_logfile",
-            $ini->readVariable("log", "path") . "/" . $ini->readVariable("log", "file"),
+            fn() => $ini->readVariable("log", "path") . "/" . $ini->readVariable("log", "file"),
             "The path to the logfile."
         );
         $storage->storeConfigText(
             "errorlog_dir",
-            $ini->readVariable("log", "error_path"),
+            fn() => $ini->readVariable("log", "error_path"),
             "The path to the directory where error protocols are stored."
         );
     }

--- a/components/ILIAS/MathJax/classes/Setup/class.ilMathJaxMetricsCollectedObjective.php
+++ b/components/ILIAS/MathJax/classes/Setup/class.ilMathJaxMetricsCollectedObjective.php
@@ -39,9 +39,9 @@ class ilMathJaxMetricsCollectedObjective extends Setup\Metrics\CollectedObjectiv
         $setup_config = new ilMathJaxSetupConfig([]);
         foreach ($setup_config->getDataFromConfig($config) as $key => $value) {
             if (is_bool($value)) {
-                $storage->storeStableBool($key, $value);
+                $storage->storeStableBool($key, fn() => $value);
             } else {
-                $storage->storeStableText($key, (string) $value);
+                $storage->storeStableText($key, fn() => (string) $value);
             }
         }
     }

--- a/components/ILIAS/MediaObjects/classes/Setup/class.ilMediaObjectMetricsCollectedObjective.php
+++ b/components/ILIAS/MediaObjects/classes/Setup/class.ilMediaObjectMetricsCollectedObjective.php
@@ -39,7 +39,7 @@ class ilMediaObjectMetricsCollectedObjective extends Setup\Metrics\CollectedObje
 
         $storage->storeConfigText(
             "path_to_ffmpeg",
-            $ini->readVariable("tools", "ffmpeg"),
+            fn() => $ini->readVariable("tools", "ffmpeg"),
             "The path to the binary of ffmpeg to convert videos."
         );
     }

--- a/components/ILIAS/Setup/src/CLI/StatusCommand.php
+++ b/components/ILIAS/Setup/src/CLI/StatusCommand.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\Setup\CLI;
 
 use ILIAS\Setup\AgentFinder;
@@ -25,6 +25,7 @@ use ILIAS\Setup\ArrayEnvironment;
 use ILIAS\Setup\Objective\Tentatively;
 use ILIAS\Setup\Metrics;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use ILIAS\Setup\Agent;
@@ -49,19 +50,23 @@ class StatusCommand extends Command
     {
         $this->setDescription("Collect and show status information about the installation.");
         $this->configureCommandForPlugins();
+        $this->addOption("filter", "f", InputOption::VALUE_REQUIRED, "filter for specific information");
     }
 
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $agent = $this->getRelevantAgent($input);
-
-        $output->write($this->getMetrics($agent)->toYAML() . "\n");
+        $filter = "";
+        if ($input->hasOption("filter") && $input->getOption("filter") != "") {
+            $filter = $input->getOption("filter");
+        }
+        $output->write($this->getMetrics($agent, $filter)->toYAML() . "\n");
 
         return 0;
     }
 
-    public function getMetrics(Agent $agent): Metrics\Metric
+    public function getMetrics(Agent $agent, string $filter = ""): Metrics\Metric
     {
         // ATTENTION: Don't do this (in general), please have a look at the comment
         // in ilIniFilesLoadedObjective.
@@ -76,20 +81,59 @@ class StatusCommand extends Command
         $this->achieveObjective($objective, $environment);
 
         $metric = $storage->asMetric();
-        list($config, $other) = $metric->extractByStability(Metrics\Metric::STABILITY_CONFIG);
-        if ($other) {
+
+        list($show_config_section, $metric) = $this->filter($filter, $metric);
+
+        $type = Metrics\MetricType::COLLECTION;
+        list($config, $other) = $metric->extractByStability(Metrics\MetricStability::CONFIG);
+        $values = [];
+        if ($other && !$show_config_section) {
             $values = $other->getValue();
-        } else {
-            $values = [];
+            $type = $metric->getType();
         }
+
         if ($config) {
-            $values["config"] = $config;
+            if ($show_config_section) {
+                $values = $config->getValue();
+                $type = $config->getType();
+            } else {
+                $values["config"] = $config;
+            }
         }
 
         return new Metrics\Metric(
-            Metrics\Metric::STABILITY_MIXED,
-            Metrics\Metric::TYPE_COLLECTION,
-            $values
+            Metrics\MetricStability::VOLATILE,
+            $type,
+            fn() => $values
         );
+    }
+
+    protected function filter(string $filter, Metrics\Metric $metric): array
+    {
+        $show_config_section = false;
+        if ($filter != "") {
+            $filter = explode(".", $filter);
+
+            if ($filter[0] === "config") {
+                array_shift($filter);
+                $show_config_section = true;
+            } else {
+                $show_config_section = false;
+            }
+
+            while (count($filter) > 0) {
+                if ($metric->getType() !== Metrics\MetricType::COLLECTION) {
+                    throw new \RuntimeException("Cannot find key...");
+                }
+
+                $current = array_shift($filter);
+                $metrics = $metric->getValue();
+                if (!array_key_exists($current, $metrics)) {
+                    throw new \RuntimeException("Cannot find key...");
+                }
+                $metric = $metrics[$current];
+            }
+        }
+        return array($show_config_section, $metric);
     }
 }

--- a/components/ILIAS/Setup/src/Metrics/ArrayStorage.php
+++ b/components/ILIAS/Setup/src/Metrics/ArrayStorage.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\Setup\Metrics;
 
@@ -71,9 +71,9 @@ class ArrayStorage implements Storage
     protected function doAsMetric(array $cur): Metric
     {
         return new Metric(
-            Metric::STABILITY_MIXED,
-            Metric::TYPE_COLLECTION,
-            array_map(
+            MetricStability::MIXED,
+            MetricType::COLLECTION,
+            fn() => array_map(
                 function ($v) {
                     if (is_array($v)) {
                         return $this->doAsMetric($v);

--- a/components/ILIAS/Setup/src/Metrics/MetricStability.php
+++ b/components/ILIAS/Setup/src/Metrics/MetricStability.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Setup\Metrics;
+
+enum MetricStability
+{
+    /**
+     * The stability of a metric tells how often we expect changes in the metric.
+     */
+    // Config metrics only change when some administrator explicitely changes
+    // a configuration.
+    case CONFIG;
+    // Stable metric only change occassionally when some change in the installation
+    // happened, e.g. a config change or an update.
+    case STABLE;
+    // Volatile metrics may change at every time even unexpectedly.
+    case VOLATILE;
+    // This should only be used for collections with mixed content.
+    case MIXED;
+}

--- a/components/ILIAS/Setup/src/Metrics/MetricType.php
+++ b/components/ILIAS/Setup/src/Metrics/MetricType.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Setup\Metrics;
+
+enum MetricType
+{
+    /**
+     * The type of the metric tells what to expect of the values.
+     */
+    // Simply a yes or a no.
+    case BOOL;
+    // A number that always increases.
+    case COUNTER;
+    // A numeric value to measure some quantity of the installation.
+    case GAUGE;
+    // A timestamp to inform about a certain event in the installation.
+    case TIMESTAMP;
+    // Some textual information about the installation. Prefer using one of the
+    // other types.
+    case TEXT;
+    // A collection of metrics that contains multiple named metrics.
+    case COLLECTION;
+}

--- a/components/ILIAS/Setup/src/Metrics/Storage.php
+++ b/components/ILIAS/Setup/src/Metrics/Storage.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\Setup\Metrics;
 
 interface Storage
@@ -29,21 +29,21 @@ interface Storage
 
     // Convenience methods to store the common types of metrics.
 
-    public function storeConfigBool(string $key, bool $value, string $description = null): void;
-    public function storeConfigCounter(string $key, int $value, string $description = null): void;
-    public function storeConfigGauge(string $key, $value, string $description = null): void;
-    public function storeConfigTimestamp(string $key, \DateTimeImmutable $value, string $description = null): void;
-    public function storeConfigText(string $key, string $value, string $description = null): void;
+    public function storeConfigBool(string $key, callable $config_bool_callable, string $description = null): void;
+    public function storeConfigCounter(string $key, callable $config_counter_callable, string $description = null): void;
+    public function storeConfigGauge(string $key, callable $config_gauge_callable, string $description = null): void;
+    public function storeConfigTimestamp(string $key, callable $config_timestamp_callable, string $description = null): void;
+    public function storeConfigText(string $key, callable $config_text_callable, string $description = null): void;
 
-    public function storeStableBool(string $key, bool $value, string $description = null): void;
-    public function storeStableCounter(string $key, int $value, string $description = null): void;
-    public function storeStableGauge(string $key, $value, string $description = null): void;
-    public function storeStableTimestamp(string $key, \DateTimeImmutable $value, string $description = null): void;
-    public function storeStableText(string $key, string $value, string $description = null): void;
+    public function storeStableBool(string $key, callable $stable_bool_callable, string $description = null): void;
+    public function storeStableCounter(string $key, callable $stable_counter_callable, string $description = null): void;
+    public function storeStableGauge(string $key, callable $stable_gauge_callable, string $description = null): void;
+    public function storeStableTimestamp(string $key, callable $stable_timestamp_callable, string $description = null): void;
+    public function storeStableText(string $key, callable $stable_text_callable, string $description = null): void;
 
-    public function storeVolatileBool(string $key, bool $value, string $description = null): void;
-    public function storeVolatileCounter(string $key, int $value, string $description = null): void;
-    public function storeVolatileGauge(string $key, $value, string $description = null): void;
-    public function storeVolatileTimestamp(string $key, \DateTimeImmutable $value, string $description = null): void;
-    public function storeVolatileText(string $key, string $value, string $description = null): void;
+    public function storeVolatileBool(string $key, callable $volatile_bool_callable, string $description = null): void;
+    public function storeVolatileCounter(string $key, callable $volatile_counter_callable, string $description = null): void;
+    public function storeVolatileGauge(string $key, callable $volatile_gauge_callable, string $description = null): void;
+    public function storeVolatileTimestamp(string $key, callable $volatile_timestamp_callable, string $description = null): void;
+    public function storeVolatileText(string $key, callable $volatile_text_callable, string $description = null): void;
 }

--- a/components/ILIAS/Setup/src/Metrics/StorageConvenience.php
+++ b/components/ILIAS/Setup/src/Metrics/StorageConvenience.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,9 +16,13 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\Setup\Metrics;
 
 use ILIAS\Setup\Metrics\Metric as M;
+use ILIAS\Setup\Metrics\MetricType as MT;
+use ILIAS\Setup\Metrics\MetricStability as MS;
 
 /**
  * Implements the convenience methods of Storage over Storage::store
@@ -29,125 +31,170 @@ trait StorageConvenience
 {
     abstract public function store(string $key, M $metric): void;
 
-    public function storeConfigBool(string $key, bool $value, string $description = null): void
+    public function storeConfigBool(string $key, callable $config_bool_callable, string $description = null): void
     {
+        if (!is_bool($config_bool_callable())) {
+            throw new \InvalidArgumentException('Bool callable must return a boolean');
+        }
         $this->store(
             $key,
-            new M(M::STABILITY_CONFIG, M::TYPE_BOOL, $value, $description)
+            new M(MS::CONFIG, MT::BOOL, $config_bool_callable, $description)
         );
     }
 
-    public function storeConfigCounter(string $key, int $value, string $description = null): void
+    public function storeConfigCounter(string $key, callable $config_counter_callable, string $description = null): void
     {
+        if (!is_int($config_counter_callable())) {
+            throw new \InvalidArgumentException('Counter callable must return an integer');
+        }
         $this->store(
             $key,
-            new M(M::STABILITY_CONFIG, M::TYPE_COUNTER, $value, $description)
+            new M(MS::CONFIG, MT::COUNTER, $config_counter_callable, $description)
         );
     }
 
-    public function storeConfigGauge(string $key, $value, string $description = null): void
+    public function storeConfigGauge(string $key, callable $config_gauge_callable, string $description = null): void
     {
+        if (!is_int($config_gauge_callable()) && !is_double($config_gauge_callable)) {
+            throw new \InvalidArgumentException('Gauge callable must return an integer or double');
+        }
         $this->store(
             $key,
-            new M(M::STABILITY_CONFIG, M::TYPE_GAUGE, $value, $description)
+            new M(MS::CONFIG, MT::GAUGE, $config_gauge_callable, $description)
         );
     }
 
-    public function storeConfigTimestamp(string $key, \DateTimeImmutable $value, string $description = null): void
+    public function storeConfigTimestamp(string $key, callable $config_timestamp_callable, string $description = null): void
     {
+        if (get_class($config_timestamp_callable()) != \DateTimeImmutable::class) {
+            throw new \InvalidArgumentException('Timestamp callable must return a DateTimeImmutable');
+        }
         $this->store(
             $key,
-            new M(M::STABILITY_CONFIG, M::TYPE_TIMESTAMP, $value, $description)
+            new M(MS::CONFIG, MT::TIMESTAMP, $config_timestamp_callable, $description)
         );
     }
 
-    public function storeConfigText(string $key, string $value, string $description = null): void
+    public function storeConfigText(string $key, callable $config_text_callable, string $description = null): void
     {
+        if (!is_string($config_text_callable())) {
+            throw new \InvalidArgumentException('String callable must return a string');
+        }
         $this->store(
             $key,
-            new M(M::STABILITY_CONFIG, M::TYPE_TEXT, $value, $description)
-        );
-    }
-
-
-    public function storeStableBool(string $key, bool $value, string $description = null): void
-    {
-        $this->store(
-            $key,
-            new M(M::STABILITY_STABLE, M::TYPE_BOOL, $value, $description)
-        );
-    }
-
-    public function storeStableCounter(string $key, int $value, string $description = null): void
-    {
-        $this->store(
-            $key,
-            new M(M::STABILITY_STABLE, M::TYPE_COUNTER, $value, $description)
-        );
-    }
-
-    public function storeStableGauge(string $key, $value, string $description = null): void
-    {
-        $this->store(
-            $key,
-            new M(M::STABILITY_STABLE, M::TYPE_GAUGE, $value, $description)
-        );
-    }
-
-    public function storeStableTimestamp(string $key, \DateTimeImmutable $value, string $description = null): void
-    {
-        $this->store(
-            $key,
-            new M(M::STABILITY_STABLE, M::TYPE_TIMESTAMP, $value, $description)
-        );
-    }
-
-    public function storeStableText(string $key, string $value, string $description = null): void
-    {
-        $this->store(
-            $key,
-            new M(M::STABILITY_STABLE, M::TYPE_TEXT, $value, $description)
+            new M(MS::CONFIG, MT::TEXT, $config_text_callable, $description)
         );
     }
 
 
-    public function storeVolatileBool(string $key, bool $value, string $description = null): void
+    public function storeStableBool(string $key, callable $stable_bool_callable, string $description = null): void
     {
+        if (!is_bool($stable_bool_callable())) {
+            throw new \InvalidArgumentException('Bool callable must return a boolean');
+        }
         $this->store(
             $key,
-            new M(M::STABILITY_VOLATILE, M::TYPE_BOOL, $value, $description)
+            new M(MS::CONFIG, MT::BOOL, $stable_bool_callable, $description)
         );
     }
 
-    public function storeVolatileCounter(string $key, int $value, string $description = null): void
+    public function storeStableCounter(string $key, callable $stable_counter_callable, string $description = null): void
     {
+        if (!is_int($stable_counter_callable())) {
+            throw new \InvalidArgumentException('Counter callable must return an integer');
+        }
         $this->store(
             $key,
-            new M(M::STABILITY_VOLATILE, M::TYPE_COUNTER, $value, $description)
+            new M(MS::CONFIG, MT::COUNTER, $stable_counter_callable, $description)
         );
     }
 
-    public function storeVolatileGauge(string $key, $value, string $description = null): void
+    public function storeStableGauge(string $key, callable $stable_gauge_callable, string $description = null): void
     {
+        if (!is_int($stable_gauge_callable()) && !is_double($stable_gauge_callable)) {
+            throw new \InvalidArgumentException('Gauge callable must return an integer or double');
+        }
         $this->store(
             $key,
-            new M(M::STABILITY_VOLATILE, M::TYPE_GAUGE, $value, $description)
+            new M(MS::CONFIG, MT::GAUGE, $stable_gauge_callable, $description)
         );
     }
 
-    public function storeVolatileTimestamp(string $key, \DateTimeImmutable $value, string $description = null): void
+    public function storeStableTimestamp(string $key, callable $stable_timestamp_callable, string $description = null): void
     {
+        if (get_class($stable_timestamp_callable()) != \DateTimeImmutable::class) {
+            throw new \InvalidArgumentException('Timestamp callable must return a DateTimeImmutable');
+        }
         $this->store(
             $key,
-            new M(M::STABILITY_VOLATILE, M::TYPE_TIMESTAMP, $value, $description)
+            new M(MS::CONFIG, MT::TIMESTAMP, $stable_timestamp_callable, $description)
         );
     }
 
-    public function storeVolatileText(string $key, string $value, string $description = null): void
+    public function storeStableText(string $key, callable $stable_text_callable, string $description = null): void
     {
+        if (!is_string($stable_text_callable())) {
+            throw new \InvalidArgumentException('String callable must return a string');
+        }
         $this->store(
             $key,
-            new M(M::STABILITY_VOLATILE, M::TYPE_TEXT, $value, $description)
+            new M(MS::CONFIG, MT::TEXT, $stable_text_callable, $description)
+        );
+    }
+
+
+    public function storeVolatileBool(string $key, callable $volatile_bool_callable, string $description = null): void
+    {
+        if (!is_bool($volatile_bool_callable())) {
+            throw new \InvalidArgumentException('Bool callable must return a boolean');
+        }
+        $this->store(
+            $key,
+            new M(MS::CONFIG, MT::BOOL, $volatile_bool_callable, $description)
+        );
+    }
+
+    public function storeVolatileCounter(string $key, callable $volatile_counter_callable, string $description = null): void
+    {
+        if (!is_int($volatile_counter_callable())) {
+            throw new \InvalidArgumentException('Counter callable must return an integer');
+        }
+        $this->store(
+            $key,
+            new M(MS::CONFIG, MT::COUNTER, $volatile_counter_callable, $description)
+        );
+    }
+
+    public function storeVolatileGauge(string $key, callable $volatile_gauge_callable, string $description = null): void
+    {
+        if (!is_int($volatile_gauge_callable()) && !is_double($volatile_gauge_callable)) {
+            throw new \InvalidArgumentException('Gauge callable must return an integer or double');
+        }
+        $this->store(
+            $key,
+            new M(MS::CONFIG, MT::GAUGE, $volatile_gauge_callable, $description)
+        );
+    }
+
+    public function storeVolatileTimestamp(string $key, callable $volatile_timestamp_callable, string $description = null): void
+    {
+        if (get_class($volatile_timestamp_callable()) != \DateTimeImmutable::class) {
+            throw new \InvalidArgumentException('Timestamp callable must return a DateTimeImmutable');
+        }
+        $this->store(
+            $key,
+            new M(MS::CONFIG, MT::TIMESTAMP, $volatile_timestamp_callable, $description)
+        );
+    }
+
+    public function storeVolatileText(string $key, callable $volatile_text_callable, string $description = null): void
+    {
+        if (!is_string($volatile_text_callable())) {
+            throw new \InvalidArgumentException('String callable must return a string');
+        }
+        $this->store(
+            $key,
+            new M(MS::CONFIG, MT::TEXT, $volatile_text_callable, $description)
         );
     }
 }

--- a/components/ILIAS/Setup/tests/CLI/StatusCommandTest.php
+++ b/components/ILIAS/Setup/tests/CLI/StatusCommandTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,14 +16,24 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\Tests\Setup\CLI;
 
 use ILIAS\Setup;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Tester\CommandTester;
 use ILIAS\Setup\Metrics;
+use PHPUnit\Framework\TestCase;
 use ILIAS\Setup\Metrics\Metric as M;
-use Hamcrest\Core\Set;
+use ILIAS\Setup\Metrics\MetricType as MT;
+use ILIAS\Setup\Metrics\MetricStability as MS;
+
+class StatusCommandDummy extends Setup\CLI\StatusCommand
+{
+    public function dummy_filter(string $filter, Metrics\Metric $metric): array
+    {
+        return $this->filter($filter, $metric);
+    }
+}
 
 class StatusCommandTest extends TestCase
 {
@@ -36,7 +44,7 @@ class StatusCommandTest extends TestCase
         $storage = new Metrics\ArrayStorage();
         $objective = $this->createMock(Setup\Objective::class);
         $agent = $this->createMock(Setup\AgentCollection::class);
-        $expected = new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, []);
+        $expected = new M(MS::VOLATILE, MT::COLLECTION, fn() => []);
 
         $agent
             ->expects($this->once())
@@ -47,5 +55,130 @@ class StatusCommandTest extends TestCase
         $result = $obj->getMetrics($agent);
 
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @dataProvider metricProvider
+     */
+    public function testMetricsFilterWithEmptyFilter(
+        Metrics\Metric $metric,
+        Metrics\Metric $expected_metric,
+        string $filter,
+        bool $show_config_section,
+        bool $success
+    ): void {
+        $agent_finder = $this->createMock(Setup\AgentFinder::class);
+        $obj = new StatusCommandDummy($agent_finder);
+
+        if (!$success) {
+            $this->expectException(\RuntimeException::class);
+        }
+
+        $result = $obj->dummy_filter($filter, $metric);
+
+        $this->assertEquals($show_config_section, $result[0]);
+        $this->assertEquals($expected_metric, $result[1]);
+    }
+
+    public static function metricProvider(): array
+    {
+        return [
+            "non_filter" => [
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => []),
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => []),
+                "",
+                false,
+                true
+            ],
+            "non_collection_1" => [
+                new M(MS::VOLATILE, MT::TEXT, fn() => "test"),
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => []),
+                "test",
+                false,
+                false
+            ],
+            "non_collection_2" => [
+                new M(MS::VOLATILE, MT::COUNTER, fn() => 2),
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => []),
+                "test",
+                false,
+                false
+            ],
+            "non_collection_3" => [
+                new M(MS::VOLATILE, MT::BOOL, fn() => false),
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => []),
+                "test",
+                false,
+                false
+            ],
+            "non_collection_4" => [
+                new M(MS::VOLATILE, MT::GAUGE, fn() => 3.14),
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => []),
+                "test",
+                false,
+                false
+            ],
+            "non_collection_5" => [
+                new M(MS::VOLATILE, MT::TIMESTAMP, fn() => new \DateTimeImmutable()),
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => []),
+                "test",
+                false,
+                false
+            ],
+            "deep_1" => [
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => [
+                    "foo" => new M(MS::VOLATILE, MT::TEXT, fn() => "foo"),
+                    "bar" => new M(MS::VOLATILE, MT::TEXT, fn() => "bar")
+                ]),
+                new M(MS::VOLATILE, MT::TEXT, fn() => "bar"),
+                "bar",
+                false,
+                true
+            ],
+            "deep_2" => [
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => [
+                    "foo" => new M(MS::VOLATILE, MT::COLLECTION, fn() => [
+                        "foobar" => new M(MS::VOLATILE, MT::TEXT, fn() => "foobar")
+                    ]),
+                    "bar" => new M(MS::VOLATILE, MT::TEXT, fn() => "bar")
+                ]),
+                new M(MS::VOLATILE, MT::TEXT, fn() => "bar"),
+                "foo.foobar",
+                false,
+                true
+            ],
+            "non_existing_key" => [
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => [
+                    "foo" => new M(MS::VOLATILE, MT::TEXT, fn() => "foo"),
+                    "bar" => new M(MS::VOLATILE, MT::TEXT, fn() => "bar")
+                ]),
+                new M(MS::VOLATILE, MT::TEXT, fn() => "bar"),
+                "no_key",
+                false,
+                false
+            ],
+            "deep_config_1" => [
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => [
+                    "foo" => new M(MS::VOLATILE, MT::TEXT, fn() => "foo"),
+                    "bar" => new M(MS::VOLATILE, MT::TEXT, fn() => "bar")
+                ]),
+                new M(MS::VOLATILE, MT::TEXT, fn() => "bar"),
+                "config.bar",
+                true,
+                true
+            ],
+            "deep_config_2" => [
+                new M(MS::VOLATILE, MT::COLLECTION, fn() => [
+                    "foo" => new M(MS::VOLATILE, MT::COLLECTION, fn() => [
+                        "foobar" => new M(MS::VOLATILE, MT::TEXT, fn() => "foobar")
+                    ]),
+                    "bar" => new M(MS::VOLATILE, MT::TEXT, fn() => "bar")
+                ]),
+                new M(MS::VOLATILE, MT::TEXT, fn() => "bar"),
+                "config.foo.foobar",
+                true,
+                true
+            ],
+        ];
     }
 }

--- a/components/ILIAS/Setup/tests/Metrics/ArrayStorageTest.php
+++ b/components/ILIAS/Setup/tests/Metrics/ArrayStorageTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,10 +16,14 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\Tests\Setup\Metrics;
 
 use ILIAS\Setup\Metrics;
 use ILIAS\Setup\Metrics\Metric as M;
+use ILIAS\Setup\Metrics\MetricType as MT;
+use ILIAS\Setup\Metrics\MetricStability as MS;
 use PHPUnit\Framework\TestCase;
 
 class ArrayStorageTest extends TestCase
@@ -35,8 +37,8 @@ class ArrayStorageTest extends TestCase
 
     public function testBasicStorage(): void
     {
-        $m1 = new M(M::STABILITY_CONFIG, M::TYPE_BOOL, true, "desc1");
-        $m2 = new M(M::STABILITY_CONFIG, M::TYPE_BOOL, true, "desc2");
+        $m1 = new M(MS::CONFIG, MT::BOOL, fn() => true, "desc1");
+        $m2 = new M(MS::CONFIG, MT::BOOL, fn() => true, "desc2");
 
         $this->storage->store("m1", $m1);
         $this->storage->store("m2", $m2);
@@ -51,8 +53,8 @@ class ArrayStorageTest extends TestCase
 
     public function testOverwrites(): void
     {
-        $m1 = new M(M::STABILITY_CONFIG, M::TYPE_BOOL, true, "desc1");
-        $m2 = new M(M::STABILITY_CONFIG, M::TYPE_BOOL, true, "desc2");
+        $m1 = new M(MS::CONFIG, MT::BOOL, fn() => true, "desc1");
+        $m2 = new M(MS::CONFIG, MT::BOOL, fn() => true, "desc2");
 
         $this->storage->store("m1", $m1);
         $this->storage->store("m1", $m2);
@@ -66,7 +68,7 @@ class ArrayStorageTest extends TestCase
 
     public function testNesting(): void
     {
-        $m1 = new M(M::STABILITY_CONFIG, M::TYPE_BOOL, true, "desc1");
+        $m1 = new M(MS::CONFIG, MT::BOOL, fn() => true, "desc1");
 
         $this->storage->store("a.b.c", $m1);
 
@@ -83,16 +85,16 @@ class ArrayStorageTest extends TestCase
 
     public function testAsMetric(): void
     {
-        $this->storage->store("a", new M(M::STABILITY_STABLE, M::TYPE_COUNTER, 0));
-        $this->storage->store("b.c", new M(M::STABILITY_VOLATILE, M::TYPE_BOOL, true));
+        $this->storage->store("a", new M(MS::STABLE, MT::COUNTER, fn() => 0));
+        $this->storage->store("b.c", new M(MS::VOLATILE, MT::BOOL, fn() => true));
 
         $expected = new M(
-            M::STABILITY_MIXED,
-            M::TYPE_COLLECTION,
-            [
-                "a" => new M(M::STABILITY_STABLE, M::TYPE_COUNTER, 0),
-                "b" => new M(M::STABILITY_MIXED, M::TYPE_COLLECTION, [
-                    "c" => new M(M::STABILITY_VOLATILE, M::TYPE_BOOL, true)
+            MS::MIXED,
+            MT::COLLECTION,
+            fn() => [
+                "a" => new M(MS::STABLE, MT::COUNTER, fn() => 0),
+                "b" => new M(MS::MIXED, MT::COLLECTION, fn() => [
+                    "c" => new M(MS::VOLATILE, MT::BOOL, fn() => true)
                 ])
             ]
         );

--- a/components/ILIAS/Setup/tests/Metrics/StorageOnPathWrapperTest.php
+++ b/components/ILIAS/Setup/tests/Metrics/StorageOnPathWrapperTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,10 +16,14 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\Tests\Setup\Metrics;
 
 use ILIAS\Setup\Metrics;
 use ILIAS\Setup\Metrics\Metric as M;
+use ILIAS\Setup\Metrics\MetricType as MT;
+use ILIAS\Setup\Metrics\MetricStability as MS;
 use PHPUnit\Framework\TestCase;
 
 class StorageOnPathWrapperTest extends TestCase
@@ -40,7 +42,7 @@ class StorageOnPathWrapperTest extends TestCase
     public function testStoresToPath(): void
     {
         $key = "key";
-        $m = new M(M::STABILITY_CONFIG, M::TYPE_BOOL, true, "desc");
+        $m = new M(MS::CONFIG, MT::BOOL, fn() => true, "desc");
 
         $this->storage->expects($this->once())
             ->method("store")

--- a/components/ILIAS/Style/classes/Setup/class.ilStyleMetricsCollectedObjective.php
+++ b/components/ILIAS/Style/classes/Setup/class.ilStyleMetricsCollectedObjective.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 /* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
 
 use ILIAS\Setup;
@@ -22,12 +38,12 @@ class ilStyleMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
 
         $storage->storeConfigBool(
             "manage_system_styles",
-            $ini->readVariable("tools", "enable_system_styles_management"),
+            fn() => $ini->readVariable("tools", "enable_system_styles_management"),
             "Can users manage system styles from within the installation?"
         );
         $storage->storeConfigText(
             "path_to_scss",
-            $ini->readVariable("tools", "scss"),
+            fn() => $ini->readVariable("tools", "scss"),
             "The path to the binary that is used for compiling scss."
         );
     }

--- a/components/ILIAS/SystemFolder/classes/Setup/class.ilSystemFolderMetricsCollectedObjective.php
+++ b/components/ILIAS/SystemFolder/classes/Setup/class.ilSystemFolderMetricsCollectedObjective.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 /* Copyright (c) 2020 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
 
 use ILIAS\Setup;
@@ -21,24 +37,24 @@ class ilSystemFolderMetricsCollectedObjective extends Setup\Metrics\CollectedObj
         }
         $settings = $factory->settingsFor("common");
         $firstname = new Setup\Metrics\Metric(
-            Setup\Metrics\Metric::STABILITY_CONFIG,
-            Setup\Metrics\Metric::TYPE_TEXT,
-            $settings->get("admin_firstname", "")
+            Setup\Metrics\MetricStability::CONFIG,
+            Setup\Metrics\MetricType::TEXT,
+            fn() => $settings->get("admin_firstname", "")
         );
         $lastname = new Setup\Metrics\Metric(
-            Setup\Metrics\Metric::STABILITY_CONFIG,
-            Setup\Metrics\Metric::TYPE_TEXT,
-            $settings->get("admin_lastname", "")
+            Setup\Metrics\MetricStability::CONFIG,
+            Setup\Metrics\MetricType::TEXT,
+            fn() => $settings->get("admin_lastname", "")
         );
         $email = new Setup\Metrics\Metric(
-            Setup\Metrics\Metric::STABILITY_CONFIG,
-            Setup\Metrics\Metric::TYPE_TEXT,
-            $settings->get("admin_email", "")
+            Setup\Metrics\MetricStability::CONFIG,
+            Setup\Metrics\MetricType::TEXT,
+            fn() => $settings->get("admin_email", "")
         );
         $contact = new Setup\Metrics\Metric(
-            Setup\Metrics\Metric::STABILITY_CONFIG,
-            Setup\Metrics\Metric::TYPE_COLLECTION,
-            [
+            Setup\Metrics\MetricStability::CONFIG,
+            Setup\Metrics\MetricType::COLLECTION,
+            fn() => [
                 "firstname" => $firstname,
                 "lastname" => $lastname,
                 "email" => $email

--- a/components/ILIAS/Tree/classes/Setup/class.ilTreeMetricsCollectedObjective.php
+++ b/components/ILIAS/Tree/classes/Setup/class.ilTreeMetricsCollectedObjective.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup\Metrics\CollectedObjective;
 use ILIAS\Setup\Environment;
@@ -45,7 +45,7 @@ class ilTreeMetricsCollectedObjective extends CollectedObjective
 
         $storage->storeConfigText(
             'Tree Implementation',
-            $settings->get('main_tree_impl', 'ns') === 'ns' ? 'Nested Set' : 'Materialized Path',
+            fn() => $settings->get('main_tree_impl', 'ns') === 'ns' ? 'Nested Set' : 'Materialized Path',
             'The database implementation of the ILIAS repository tree.'
         );
     }

--- a/components/ILIAS/Utilities/classes/Setup/class.ilUtilitiesMetricsCollectedObjective.php
+++ b/components/ILIAS/Utilities/classes/Setup/class.ilUtilitiesMetricsCollectedObjective.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 
@@ -38,17 +38,17 @@ class ilUtilitiesMetricsCollectedObjective extends Setup\Metrics\CollectedObject
 
         $storage->storeConfigText(
             "path_to_convert",
-            $ini->readVariable("tools", "convert"),
+            fn() => $ini->readVariable("tools", "convert"),
             "The path to the binary from imagemagick that is used to convert images."
         );
         $storage->storeConfigText(
             "path_to_zip",
-            $ini->readVariable("tools", "zip"),
+            fn() => $ini->readVariable("tools", "zip"),
             "The path to the binary that is used for zipping files."
         );
         $storage->storeConfigText(
             "path_to_unzip",
-            $ini->readVariable("tools", "unzip"),
+            fn() => $ini->readVariable("tools", "unzip"),
             "The path to the binary that is used for unzipping files."
         );
     }

--- a/components/ILIAS/VirusScanner_/classes/Setup/class.ilVirusScannerMetricsCollectedObjective.php
+++ b/components/ILIAS/VirusScanner_/classes/Setup/class.ilVirusScannerMetricsCollectedObjective.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 
@@ -42,29 +42,29 @@ class ilVirusScannerMetricsCollectedObjective extends Setup\Metrics\CollectedObj
         $virus_scanner = $ini->readVariable("tools", "vscantype");
         $storage->storeConfigText(
             "virusscanner",
-            $virus_scanner,
+            fn() => $virus_scanner,
             "The engine that is used for virus scanning."
         );
 
         if ($virus_scanner === ilVirusScannerSetupConfig::VIRUS_SCANNER_ICAP) {
             $storage->storeConfigText(
                 "icap_client_path",
-                $ini->readVariable("tools", "icap_client_path"),
+                fn() => $ini->readVariable("tools", "icap_client_path"),
                 "The configured ICAP client path."
             );
             $storage->storeConfigText(
                 "icap_host",
-                $ini->readVariable("tools", "icap_host"),
+                fn() => $ini->readVariable("tools", "icap_host"),
                 "The configured ICAP host."
             );
             $storage->storeConfigText(
                 "icap_port",
-                $ini->readVariable("tools", "icap_port"),
+                fn() => $ini->readVariable("tools", "icap_port"),
                 "The configured ICAP port."
             );
             $storage->storeConfigText(
                 "icap_service_name",
-                $ini->readVariable("tools", "icap_service_name"),
+                fn() => $ini->readVariable("tools", "icap_service_name"),
                 "The configured ICAP service name."
             );
         } elseif (is_string($virus_scanner) &&
@@ -72,12 +72,12 @@ class ilVirusScannerMetricsCollectedObjective extends Setup\Metrics\CollectedObj
             $virus_scanner !== ilVirusScannerSetupConfig::VIRUS_SCANNER_NONE) {
             $storage->storeConfigText(
                 "path_to_scan",
-                $ini->readVariable("tools", "scancommand"),
+                fn() => $ini->readVariable("tools", "scancommand"),
                 "The path to the binary that is used for virus scanning."
             );
             $storage->storeConfigText(
                 "path_to_clean",
-                $ini->readVariable("tools", "cleancommand"),
+                fn() => $ini->readVariable("tools", "cleancommand"),
                 "The path to the binary that is used for cleaning up after virus scanning."
             );
         }

--- a/components/ILIAS/setup_/README.md
+++ b/components/ILIAS/setup_/README.md
@@ -98,6 +98,9 @@ system where ILIAS was not installed, for example, the output only contains the
 information that ilias is not installed. The command also reports on the configuration
 of the installation.
 
+Use the -f option to pass filtering options to the command. The command could then look like this:
+`php setup/setup.php status -f config.common`. Here only the common section under config would be output.
+
 The output of the command is formatted as YAML to be easily readable by people and
 machines. So we encourage you to use this command for monitoring your system and
 also request status information via our feature process that you are interested in.

--- a/components/ILIAS/setup_/classes/class.ilSetupMetricsCollectedObjective.php
+++ b/components/ILIAS/setup_/classes/class.ilSetupMetricsCollectedObjective.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Setup;
 
@@ -41,30 +41,30 @@ class ilSetupMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
         $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
         $storage->storeStableBool(
             "is_installed",
-            $ini !== null && $client_ini !== null,
+            fn() => $ini !== null && $client_ini !== null,
             "Are there any indications an installation was performed?"
         );
         $client_id = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_ID);
         if ($client_id) {
             $storage->storeConfigText(
                 "client_id",
-                $client_id,
+                fn() => $client_id,
                 "Id of the ILIAS client."
             );
         }
-        $settings_factory  = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
+        $settings_factory = $environment->getResource(Setup\Environment::RESOURCE_SETTINGS_FACTORY);
         if ($settings_factory) {
             $common_settings = $settings_factory->settingsFor("common");
             $nic_enabled = $common_settings->get("nic_enabled") == "1";
             $storage->storeStableBool(
                 "nic_enabled",
-                $nic_enabled,
+                fn() => $nic_enabled,
                 "Is the installation registered at the ILIAS NIC server?"
             );
             if ($nic_enabled) {
                 $storage->storeConfigText(
                     "inst_id",
-                    $common_settings->get("inst_id"),
+                    fn() => $common_settings->get("inst_id"),
                     "The id of the installation as provided by the ILIAS NIC server."
                 );
             }


### PR DESCRIPTION
Metric now uses a callable as the third parameter. This means that only the requested values are queried when filtering in the status command.

To use the filter in the status command, simply add the -f option. This is followed by the filter string separated by a period.
For example:

php setup/setup.php status -f config.common