### PR TITLE
Registration: Fix translation in `MessageBox > Failure` after failed …

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -1783,6 +1783,8 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
 
     public function confirmRegistration(): void
     {
+        $this->lng->loadLanguageModule('registration');
+
         ilUtil::setCookie('iltest', 'cookie', false);
         $regitration_hash = '';
         if ($this->http->wrapper()->query()->has('rh')) {


### PR DESCRIPTION
…confirmation

See: https://mantis.ilias.de/view.php?id=41704

If approved, this must be picked to `release_9` and `trunk` as well.