### PR TITLE
Glossary: switch to LOM API

### DIFF
--- a/components/ILIAS/Glossary/Export/class.ilGlossaryExporter.php
+++ b/components/ILIAS/Glossary/Export/class.ilGlossaryExporter.php
@@ -123,6 +123,18 @@ class ilGlossaryExporter extends ilXmlExporter
                 "entity" => "common",
                 "ids" => $a_ids);
 
+            $md_ids = [];
+            foreach ($a_ids as $crs_id) {
+                $md_ids[] = $crs_id . ":0:glo";
+            }
+            if ($md_ids !== []) {
+                $deps[] = [
+                    "component" => "components/ILIAS/MetaData",
+                    "entity" => "md",
+                    "ids" => $md_ids
+                ];
+            }
+
             return $deps;
         }
         return array();

--- a/components/ILIAS/Glossary/Metadata/class.MetadataManager.php
+++ b/components/ILIAS/Glossary/Metadata/class.MetadataManager.php
@@ -20,10 +20,24 @@ declare(strict_types=1);
 
 namespace ILIAS\Glossary\Metadata;
 
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
 class MetadataManager
 {
-    public function __construct()
+    protected LOMServices $lom_services;
+
+    public function __construct(LOMServices $lom_services)
     {
+        $this->lom_services = $lom_services;
+    }
+
+    public function getLOMLanguagesForSelectInputs(): array
+    {
+        $languages = [];
+        foreach ($this->lom_services->dataHelper()->getAllLanguages() as $language) {
+            $languages[$language->value()] = $language->presentableLabel();
+        }
+        return $languages;
     }
 
     /**

--- a/components/ILIAS/Glossary/Service/class.InternalDomainService.php
+++ b/components/ILIAS/Glossary/Service/class.InternalDomainService.php
@@ -89,7 +89,7 @@ class InternalDomainService
 
     public function metadata(): MetadataManager
     {
-        return new MetadataManager();
+        return new MetadataManager($this->learningObjectMetadata());
     }
 
     public function presentation(\ilObjGlossary $glossary, int $user_id = 0): PresentationManager

--- a/components/ILIAS/Glossary/Term/class.ilGlossaryTerm.php
+++ b/components/ILIAS/Glossary/Term/class.ilGlossaryTerm.php
@@ -638,6 +638,10 @@ class ilGlossaryTerm
         int $a_term_id,
         int $a_glossary_id
     ): int {
+        global $DIC;
+
+        $lom_services = $DIC->learningObjectMetadata();
+
         $old_term = new ilGlossaryTerm($a_term_id);
 
         // copy the term
@@ -648,18 +652,6 @@ class ilGlossaryTerm
         $new_term->setShortText($old_term->getShortText());
         $new_term->setShortTextDirty($old_term->getShortTextDirty());
         $new_term->create();
-
-        // copy meta data
-        $md = new ilMD(
-            $old_term->getGlossaryId(),
-            $old_term->getPageObject()->getId(),
-            $old_term->getPageObject()->getParentType()
-        );
-        $new_md = $md->cloneMD(
-            $a_glossary_id,
-            $new_term->getPageObject()->getId(),
-            $old_term->getPageObject()->getParentType()
-        );
 
         $new_page = $new_term->getPageObject();
         $old_term->getPageObject()->copy($new_page->getId(), $new_page->getParentType(), $new_page->getParentId(), true);

--- a/components/ILIAS/Glossary/Term/class.ilGlossaryTerm.php
+++ b/components/ILIAS/Glossary/Term/class.ilGlossaryTerm.php
@@ -638,10 +638,6 @@ class ilGlossaryTerm
         int $a_term_id,
         int $a_glossary_id
     ): int {
-        global $DIC;
-
-        $lom_services = $DIC->learningObjectMetadata();
-
         $old_term = new ilGlossaryTerm($a_term_id);
 
         // copy the term

--- a/components/ILIAS/Glossary/Term/class.ilGlossaryTermGUI.php
+++ b/components/ILIAS/Glossary/Term/class.ilGlossaryTermGUI.php
@@ -182,7 +182,7 @@ class ilGlossaryTermGUI
 
         $lang = new ilSelectInputGUI($this->lng->txt("language"), "term_language");
         $lang->setRequired(true);
-        $lang->setOptions(ilMDLanguageItem::_getLanguages());
+        $lang->setOptions($this->domain->metadata()->getLOMLanguagesForSelectInputs());
         $lang->setValue($this->term->getLanguage());
         $form->addItem($lang);
 

--- a/components/ILIAS/Glossary/Term/class.ilTermDefinitionBulkCreationGUI.php
+++ b/components/ILIAS/Glossary/Term/class.ilTermDefinitionBulkCreationGUI.php
@@ -3,14 +3,17 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
+ *
  *********************************************************************/
 
 declare(strict_types=1);

--- a/components/ILIAS/Glossary/Term/class.ilTermDefinitionBulkCreationGUI.php
+++ b/components/ILIAS/Glossary/Term/class.ilTermDefinitionBulkCreationGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -14,6 +12,8 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Glossary\InternalDomainService;
 use ILIAS\Glossary\InternalGUIService;
@@ -115,7 +115,7 @@ class ilTermDefinitionBulkCreationGUI
         $form->select(
             "term_language",
             $lng->txt("language"),
-            ilMDLanguageItem::_getLanguages(),
+            $this->domain->metadata()->getLOMLanguagesForSelectInputs(),
             "",
             $s_lang
         )

--- a/components/ILIAS/Glossary/classes/class.ilObjGlossary.php
+++ b/components/ILIAS/Glossary/classes/class.ilObjGlossary.php
@@ -651,10 +651,16 @@ class ilObjGlossary extends ilObject implements ilAdvancedMetaDataSubItems
     public function exportXMLMetaData(
         ilXmlWriter $a_xml_writer
     ): void {
-        $md2xml = new ilMD2XML($this->getId(), 0, $this->getType());
+        /*
+         * As far as I can tell, this is not in use anymore.
+         * It followed usages up to ilObjGlossaryGUI::export
+         * and ilObjGlossary::getXMLZip, both of which are not
+         * used anywhere.
+         */
+        /*$md2xml = new ilMD2XML($this->getId(), 0, $this->getType());
         $md2xml->setExportMode(true);
         $md2xml->startExport();
-        $a_xml_writer->appendXML($md2xml->getXML());
+        $a_xml_writer->appendXML($md2xml->getXML());*/
     }
 
     public function exportXMLMediaObjects(

--- a/components/ILIAS/Glossary/classes/class.ilObjGlossaryGUI.php
+++ b/components/ILIAS/Glossary/classes/class.ilObjGlossaryGUI.php
@@ -802,7 +802,7 @@ class ilObjGlossaryGUI extends ilObjectGUI implements \ILIAS\Taxonomy\Settings\M
 
         // language
         $this->lng->loadLanguageModule("meta");
-        $lang = ilMDLanguageItem::_getLanguages();
+        $lang = $this->domain->metadata()->getLOMLanguagesForSelectInputs();
         $session_lang = $this->term_manager->getSessionLang();
         if ($session_lang != "") {
             $s_lang = $session_lang;


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `Glossary` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

I stumbled on some export related methods that seemed unused. I didn't feel comfortable ripping out all the wiring myself, so I only took out the LOM part, and left a hopefully helpful comment so you can follow up at some point (see `ilObjGlossary::exportXMLMetaData`). I also removed a last remnant of Terms having had LOM in `ilGlossaryTerm::_copyTerm`.

I also noticed that the export mechanism that is actually in use does not include LOM in the export (but import mapping for LOM is already in place). I added the last little part needed so that LOM is imported and exported with Glossaries. It might be worthwhile to also include this change in the productive releases. I can provide a separate PR for that if you want, let me know.

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 