### PR TITLE
41874: Cron.php does not work (anymore) when account has IP restriction.

### DIFF
--- a/Services/Authentication/classes/Frontend/class.ilAuthFrontendCLI.php
+++ b/Services/Authentication/classes/Frontend/class.ilAuthFrontendCLI.php
@@ -26,4 +26,12 @@ declare(strict_types=1);
  */
 class ilAuthFrontendCLI extends ilAuthFrontend implements ilAuthFrontendInterface
 {
+  /**
+   * This overwrites ilAuthFrontend::checkIp used in ilAuthFrontend::authenticate
+   * since CLI does not set $_SERVER['REMOTE_ADDR']!
+   */
+  protected function checkIp(ilObjUser $user): bool
+  {
+    return true;
+  }
 }


### PR DESCRIPTION
Siehe https://mantis.ilias.de/view.php?id=41874

Sollte eigentlich die sauberste Lösung sein. Damit wird der IP-Check für Accounts über die Konsole deaktiviert und es funktioniert wieder wie mit ILIAS 7.x und bevor. Für Login-Versuche über das Web-UI von ILIAS sollte die IP-Sperre weiterhin gelten