### PR TITLE
CI: Potential fix for missing problems in `php-cs-fixer` run

### DIFF
--- a/CI/PHP-CS-Fixer/run_check.sh
+++ b/CI/PHP-CS-Fixer/run_check.sh
@@ -19,7 +19,7 @@ else
   	if [ -f ${FILE} ]
   	then
 	  	echo "Check file: ${FILE}"
-	  	RUNCSFIXER=$(libs/composer/vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --config=./CI/PHP-CS-Fixer/code-format.php_cs ${FILE})
+	  	RUNCSFIXER=$(libs/composer/vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --show-progress=none --diff -vvv --config=./CI/PHP-CS-Fixer/code-format.php_cs ${FILE})
 	  	RESULT=$?
 	  	if [[ ${RESULT} -ne 0 ]]
 	  	then


### PR DESCRIPTION
Currently the `php-cs-fixer` check returns the correct result when detecting violations, but unfortunately 1 cannot see any detailed results, e.g. which files are violating our code style.

I noticed that the progress bar seems to be displayed in an odd way, instead of a modified line the bar seems to be rendered on multiple lines (I guess overlaying the reported problems).

See:

![41874-Cron-php-does-not-work-anymore-when-account-has-IP-restriction-·-ILIAS-eLearning-ILIAS-a8894d2](https://github.com/user-attachments/assets/53143d10-ec7a-4fde-9ee5-20b87c4ec303)
