### PR TITLE
Weblink: switch to LOM API, export LOM as tail dependency

### DIFF
--- a/components/ILIAS/WebResource/classes/class.ilObjLinkResourceGUI.php
+++ b/components/ILIAS/WebResource/classes/class.ilObjLinkResourceGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\HTTP\Services as HTTPService;
 use ILIAS\UI\Component\Component;
@@ -170,11 +170,6 @@ class ilObjLinkResourceGUI extends ilObject2GUI
         }
 
         if (!$this->getCreationMode()) {
-            ilMDUtils::_fillHTMLMetaTags(
-                $this->object->getId(),
-                $this->object->getId(),
-                'webr'
-            );
             $this->addHeaderAction();
         }
     }

--- a/components/ILIAS/WebResource/classes/class.ilWebLinkXmlParser.php
+++ b/components/ILIAS/WebResource/classes/class.ilWebLinkXmlParser.php
@@ -56,6 +56,8 @@ class ilWebLinkXmlParser extends ilMDSaxParser
     private bool $is_list = false;
     private string $list_title;
     private string $list_description;
+    private string $first_item_title;
+    private string $first_item_description;
 
     public function __construct(ilObjLinkResource $webr, string $xml)
     {
@@ -91,6 +93,11 @@ class ilWebLinkXmlParser extends ilMDSaxParser
             'il__' . $this->getMDObject()->getObjType() . '_' . $this->getMDObject()->getObjId()
         );
         $identifier->update();
+
+        // set title and description
+        $this->getWebLink()->setTitle($this->list_title ?? $this->first_item_title);
+        $this->getWebLink()->setDescription($this->list_description ?? $this->first_item_description);
+        $this->getWebLink()->update();
     }
 
     public function setWebLink(ilObjLinkResource $webl): void
@@ -381,10 +388,16 @@ class ilWebLinkXmlParser extends ilMDSaxParser
 
             case 'Title':
                 $this->current_title = trim($this->cdata);
+                if (!isset($this->first_item_title)) {
+                    $this->first_item_title = $this->current_title;
+                }
                 break;
 
             case 'Description':
                 $this->current_description = trim($this->cdata);
+                if (!isset($this->first_item_description)) {
+                    $this->first_item_description = $this->current_description;
+                }
                 break;
 
             case 'Target':

--- a/components/ILIAS/WebResource/classes/class.ilWebLinkXmlWriter.php
+++ b/components/ILIAS/WebResource/classes/class.ilWebLinkXmlWriter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * XML writer for weblinks
@@ -44,13 +44,13 @@ class ilWebLinkXmlWriter extends ilXmlWriter
     /**
      * @throws UnexpectedValueException Thrown if obj_id is not of type webr or no obj_id is given
      */
-    public function write(): void
+    public function write(bool $skip_lom = false): void
     {
         $this->init();
         if ($this->add_header) {
             $this->buildHeader();
         }
-        $this->weblink->toXML($this);
+        $this->weblink->toXML($this, $skip_lom);
     }
 
     /**

--- a/components/ILIAS/WebResource/classes/class.ilWebResourceExporter.php
+++ b/components/ILIAS/WebResource/classes/class.ilWebResourceExporter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Booking definition
@@ -51,7 +51,7 @@ class ilWebResourceExporter extends ilXmlExporter
         try {
             $this->writer = new ilWebLinkXmlWriter(false);
             $this->writer->setObjId((int) $a_id);
-            $this->writer->write();
+            $this->writer->write(true);
             return $this->writer->xmlDumpMem(false);
         } catch (UnexpectedValueException $e) {
             $this->logger->warning("Caught error: " . $e->getMessage());
@@ -74,6 +74,18 @@ class ilWebResourceExporter extends ilXmlExporter
             "entity" => "common",
             "ids" => $a_ids
         ];
+
+        $md_ids = [];
+        foreach ($a_ids as $id) {
+            $md_ids[] = $id . ':0:webr';
+        }
+        if (!empty($md_ids)) {
+            $deps[] = [
+                'component' => 'components/ILIAS/MetaData',
+                'entity' => 'md',
+                'ids' => $md_ids,
+            ];
+        }
 
         return $deps;
     }

--- a/components/ILIAS/WebResource/classes/class.ilWebResourceImporter.php
+++ b/components/ILIAS/WebResource/classes/class.ilWebResourceImporter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Webresource xml importer
@@ -72,6 +72,13 @@ class ilWebResourceImporter extends ilXmlImporter
                 'webr',
                 $a_id,
                 (string) $this->link->getId()
+            );
+
+            $a_mapping->addMapping(
+                'components/ILIAS/MetaData',
+                'md',
+                $a_id . ':0:webr',
+                $this->link->getId() . ':0:webr'
             );
         } catch (ilSaxParserException $e) {
             $this->logger->error(


### PR DESCRIPTION
This PR replaces most usages of the old `MetaData` classes in `WebResource` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md). As part of this, LOM of Weblinks is now exported as a tail dependency instead of directly in the Weblink XML.

There still remain some usages of the old `MetaData` classes to ensure that exports from previous releases are still imported properly with their LOM. The current plan is to remove these usages with ILIAS 11.

Due to the current state of the trunk I was not able to test the changes, but at least on 9 the export/import part seems to work.

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 