### PR TITLE
Object: Fix default command target for SAHS list items

### DIFF
--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -3162,7 +3162,7 @@ class ilObjectListGUI
             $modifySAHS = $this->modifySAHSlaunch($def_command['link'], $def_command['frame']);
             $def_command['link'] = $modifySAHS[0];
             $def_command['frame'] = $modifySAHS[1];
-            $new_viewport = !in_array($this->getDefaultCommand()['frame'], ['', '_top', '_self', '_parent'], true); // Cannot use $def_command['frame']. $this->default_command has been edited.
+            $new_viewport = !in_array($def_command['frame'], ['', '_top', '_self', '_parent'], true);
             $link = $this->ui->factory()
                              ->link()
                              ->standard($this->getTitle(), $def_command['link'])


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=31690


This restores a fix from 2022 (https://github.com/ILIAS-eLearning/ILIAS/pull/4622) where this was resolved.
Unfortunately, the used parameter then seems to be not in use anymore due to the refactoring of the component.