### PR TITLE
Course: switch to LOM API

### DIFF
--- a/components/ILIAS/Course/classes/class.ilCourseContentGUI.php
+++ b/components/ILIAS/Course/classes/class.ilCourseContentGUI.php
@@ -22,6 +22,7 @@ use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Renderer as UIRenderer;
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 
 /**
  * Class ilCourseContentGUI
@@ -50,6 +51,7 @@ class ilCourseContentGUI
     protected Factory $refinery;
     protected UIFactory $ui_factory;
     protected UIRenderer $ui_renderer;
+    protected LOMServices $lom_services;
 
     public function __construct(ilContainerGUI $container_gui_obj)
     {
@@ -70,6 +72,7 @@ class ilCourseContentGUI
         $this->refinery = $DIC->refinery();
         $this->ui_factory = $DIC->ui()->factory();
         $this->ui_renderer = $DIC->ui()->renderer();
+        $this->lom_services = $DIC->learningObjectMetadata();
 
         $this->container_gui = $container_gui_obj;
         $this->container_obj = $this->container_gui->getObject();
@@ -411,7 +414,15 @@ class ilCourseContentGUI
             $this->tpl->setVariable("DESC", $item['description']);
             $this->tpl->parseCurrentBlock();
         }
-        if ($tlt = ilMDEducational::_getTypicalLearningTimeSeconds($item['obj_id'])) {
+
+        $tlt_data = $this->lom_services->read(
+            ilObject::_lookupObjId($item['ref_id']),
+            0,
+            $item['type'],
+            $this->lom_services->paths()->firstTypicalLearningTime()
+        )->firstData($this->lom_services->paths()->firstTypicalLearningTime());
+
+        if ($tlt = $this->lom_services->dataHelper()->durationToSeconds($tlt_data->value())) {
             $this->tpl->setCurrentBlock("tlt");
             $this->tpl->setVariable("TXT_TLT", $this->lng->txt('meta_typical_learning_time'));
             $this->tpl->setVariable("TLT_VAL", ilDatePresentation::secondsToString($tlt));

--- a/components/ILIAS/Course/classes/class.ilECSCourseSettings.php
+++ b/components/ILIAS/Course/classes/class.ilECSCourseSettings.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=0);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,10 @@ declare(strict_types=0);
  *
  *********************************************************************/
 
+declare(strict_types=0);
+
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
 /**
  * Class ilECSCourseSettings
  * @author  Stefan Meyer <smeyer.ilias@gmx.de>
@@ -26,6 +28,7 @@ declare(strict_types=0);
 class ilECSCourseSettings extends ilECSObjectSettings
 {
     protected ilLogger $logger;
+    protected LOMServices $lom_services;
 
     public function __construct(ilObject $a_content_object)
     {
@@ -45,11 +48,13 @@ class ilECSCourseSettings extends ilECSObjectSettings
         $json = $this->getJsonCore('application/ecs-course');
 
         // meta language
-        $lang = ilMDLanguage::_lookupFirstLanguage(
+        $lang = $this->lom_services->read(
             $this->content_obj->getId(),
             $this->content_obj->getId(),
-            $this->content_obj->getType()
-        );
+            $this->content_obj->getType(),
+            $this->lom_services->paths()->languages()
+        )->firstData($this->lom_services->paths()->languages())->value();
+
         if (strlen($lang) !== 0) {
             $json->lang = $lang . '_' . strtoupper($lang);
         }

--- a/components/ILIAS/Course/classes/class.ilObjCourseGUI.php
+++ b/components/ILIAS/Course/classes/class.ilObjCourseGUI.php
@@ -120,9 +120,6 @@ class ilObjCourseGUI extends ilContainerGUI
             return;
         }
 
-        // Fill meta header tags
-        ilMDUtils::_fillHTMLMetaTags($this->object->getId(), $this->object->getId(), 'crs');
-
         // Trac access
         if ($this->ctrl->getNextClass() != "ilcolumngui") {
             ilLearningProgress::_tracProgress(
@@ -202,9 +199,6 @@ class ilObjCourseGUI extends ilContainerGUI
         if (!$this->checkPermissionBool('read')) {
             $this->checkPermission('visible');
         }
-
-        // Fill meta header tags
-        ilMDUtils::_fillHTMLMetaTags($this->object->getId(), $this->object->getId(), 'crs');
 
         $this->tabs_gui->setTabActive('info_short');
         $files = ilCourseFile::_readFilesByCourse($this->object->getId());


### PR DESCRIPTION
This PR replaces most usages of the old `MetaData` classes in `Course` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

I was not able to test the changes related to ECS, but everything else seems to work fine.

There still remain some usages of the old `MetaData` classes to ensure that exports from ILIAS 8 and older are still imported properly with their LOM. The current plan is to remove these usages with ILIAS 11.

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 