### PR TITLE
Group: remove usages of ilMDUtils

### DIFF
--- a/components/ILIAS/Group/classes/class.ilObjGroupGUI.php
+++ b/components/ILIAS/Group/classes/class.ilObjGroupGUI.php
@@ -445,12 +445,6 @@ class ilObjGroupGUI extends ilContainerGUI
             'grp'
         );
 
-        ilMDUtils::_fillHTMLMetaTags(
-            $this->object->getId(),
-            $this->object->getId(),
-            'grp'
-        );
-
         if ($this->isActiveAdministrationPanel()) {
             parent::renderObject();
             $this->addAdoptContentLinkToToolbar();
@@ -1204,12 +1198,6 @@ class ilObjGroupGUI extends ilContainerGUI
         if (!$this->checkPermissionBool('read')) {
             $this->checkPermission('visible');
         }
-
-        ilMDUtils::_fillHTMLMetaTags(
-            $this->object->getId(),
-            $this->object->getId(),
-            'grp'
-        );
 
         $info = new ilInfoScreenGUI($this);
 


### PR DESCRIPTION
This PR removes all usages of the outdated method `ilMDUtils::ilMDUtils::_fillHTMLMetaTags` from `Group`.

The only occurrences of the old `MetaData` classes in `Group` are there to ensure that exports from ILIAS 8 and older are still imported properly with their LOM. The current plan is to remove these usages with ILIAS 11.

Cheers, @schmitz-ilias 