### PR TITLE
[FIX] increase max object import-id length to 255 characters.

### DIFF
--- a/Services/Object/classes/Setup/class.ilObjectDBUpdateSteps.php
+++ b/Services/Object/classes/Setup/class.ilObjectDBUpdateSteps.php
@@ -40,4 +40,16 @@ class ilObjectDBUpdateSteps implements \ilDatabaseUpdateSteps
 
         $this->db->modifyTableColumn("object_translation", "title", $field);
     }
+
+    /**
+     * Increases the maximum length of object import-ids from 50 to 255 characters.
+     */
+    public function step_2(): void
+    {
+        $this->db->modifyTableColumn("object_data", "import_id", [
+            "type" => \ilDBConstants::T_TEXT,
+            "length" => 255,
+            "notnull" => false
+        ]);
+    }
 }


### PR DESCRIPTION
Hi folks,

This PR simply increases the maximum length of ILIAS object import-ids from **50** characters to **255**.
We have recently hit this capacity for one of our customer installations, which uses somewhat complex external ids.
Therefore, I suggest to increase this limitation.

Kind regards,
@thibsy 