### PR TITLE
Survey/SurveyQuestionPool: switch to LOM API, LOM in export as tail dependency

### DIFF
--- a/components/ILIAS/Survey/Export/class.ilSurveyExporter.php
+++ b/components/ILIAS/Survey/Export/class.ilSurveyExporter.php
@@ -75,20 +75,36 @@ class ilSurveyExporter extends ilXmlExporter
         array $a_ids
     ): array {
         if ($a_entity === "svy") {
-            return array(
-                    array(
-                            "component" => "components/ILIAS/Survey",
-                            "entity" => "svy_quest_skill",
-                            "ids" => $a_ids),
-                    array(
-                            "component" => "components/ILIAS/Survey",
-                            "entity" => "svy_skill_threshold",
-                            "ids" => $a_ids),
-                    array(
-                            "component" => "components/ILIAS/Object",
-                            "entity" => "common",
-                            "ids" => $a_ids)
-            );
+            $dependencies = [
+                [
+                    "component" => "components/ILIAS/Survey",
+                    "entity" => "svy_quest_skill",
+                    "ids" => $a_ids
+                ],
+                [
+                    "component" => "components/ILIAS/Survey",
+                    "entity" => "svy_skill_threshold",
+                    "ids" => $a_ids
+                ],
+                [
+                    "component" => "components/ILIAS/Object",
+                    "entity" => "common",
+                    "ids" => $a_ids
+                ]
+            ];
+
+            $md_ids = [];
+            foreach ($a_ids as $id) {
+                $md_ids[] = $id . ":0:svy";
+            }
+            if ($md_ids !== []) {
+                $dependencies[] = [
+                    "component" => "components/ILIAS/MetaData",
+                    "entity" => "md",
+                    "ids" => $md_ids
+                ];
+            }
+            return $dependencies;
         }
         return array();
     }

--- a/components/ILIAS/Survey/Export/class.ilSurveyImporter.php
+++ b/components/ILIAS/Survey/Export/class.ilSurveyImporter.php
@@ -165,7 +165,7 @@ class ilSurveyImporter extends ilXmlImporter
             }
             $a_mapping->addMapping("components/ILIAS/Survey", "svy", (int) $a_id, $newObj->getId());
             $a_mapping->addMapping(
-                "Services/MetaData",
+                "components/ILIAS/MetaData",
                 "md",
                 $a_id . ":0:svy",
                 $newObj->getId() . ":0:svy"

--- a/components/ILIAS/Survey/Export/class.ilSurveyImporter.php
+++ b/components/ILIAS/Survey/Export/class.ilSurveyImporter.php
@@ -164,6 +164,12 @@ class ilSurveyImporter extends ilXmlImporter
                 $newObj->saveToDb();
             }
             $a_mapping->addMapping("components/ILIAS/Survey", "svy", (int) $a_id, $newObj->getId());
+            $a_mapping->addMapping(
+                "Services/MetaData",
+                "md",
+                $a_id . ":0:svy",
+                $newObj->getId() . ":0:svy"
+            );
         } else {
             $parser = new ilDataSetImportParser(
                 $a_entity,

--- a/components/ILIAS/Survey/Metadata/class.MetadataManager.php
+++ b/components/ILIAS/Survey/Metadata/class.MetadataManager.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Survey\Metadata;
+
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
+class MetadataManager
+{
+    protected LOMServices $lom_services;
+
+    public function __construct(LOMServices $lom_services)
+    {
+        $this->lom_services = $lom_services;
+    }
+
+    public function getAuthorsFromLOM(
+        int $obj_id,
+        int $sub_id,
+        string $type
+    ): string {
+        $path_to_authors = $this->lom_services->paths()->authors();
+        $author_data = $this->lom_services->read($obj_id, $sub_id, $type, $path_to_authors)
+                                          ->allData($path_to_authors);
+
+        return $this->lom_services->dataHelper()->makePresentableAsList(',', ...$author_data);
+    }
+
+    public function saveAuthorsInLOMIfNoLifecycleSet(
+        int $obj_id,
+        int $sub_id,
+        string $type,
+        string $author
+    ): void {
+        $path_to_lifecycle = $this->lom_services->paths()->custom()->withNextStep('lifeCycle')->get();
+        $path_to_authors = $this->lom_services->paths()->authors();
+
+        $reader = $this->lom_services->read($obj_id, $sub_id, $type, $path_to_lifecycle);
+        if (!is_null($reader->allData($path_to_lifecycle)->current())) {
+            return;
+        }
+
+        $this->lom_services->manipulate($obj_id, $sub_id, $type)
+                           ->prepareCreateOrUpdate($path_to_authors, $author)
+                           ->execute();
+    }
+}

--- a/components/ILIAS/Survey/Service/class.InternalDomainService.php
+++ b/components/ILIAS/Survey/Service/class.InternalDomainService.php
@@ -26,6 +26,7 @@ use ILIAS\Survey\Code\CodeManager;
 use ILIAS\Repository\GlobalDICDomainServices;
 use ILIAS\Survey\Editing\EditManager;
 use ILIAS\Survey\Sequence\SequenceManager;
+use ILIAS\Survey\Metadata\MetadataManager;
 
 class InternalDomainService
 {
@@ -132,5 +133,10 @@ class InternalDomainService
             $survey_id,
             $survey
         );
+    }
+
+    public function metadata(): MetadataManager
+    {
+        return new MetadataManager($this->learningObjectMetadata());
     }
 }

--- a/components/ILIAS/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPool.php
+++ b/components/ILIAS/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPool.php
@@ -96,8 +96,7 @@ class ilObjSurveyQuestionPool extends ilObject
         }
 
         // clone meta data
-        $md = new ilMD($this->getId(), 0, $this->getType());
-        $new_md = $md->cloneMD($newObj->getId(), 0, $newObj->getType());
+        $this->cloneMetaData($newObj);
 
         // update the metadata with the new title of the question pool
         $newObj->updateMetaData();


### PR DESCRIPTION
This PR replaces most usages of the old `MetaData` classes in `Survey` and `SurveyQuestionPool` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

As a part of this, LOM is now exported as a tail dependency of `Survey`, and not directly in its XML. Unfortunately, this was not possible for `SurveyQuestionPool`, since there the infrastructure of `Export` is largely sidestepped.

A few of the old `MetaData` classes are thus still in use, all related to export/import: `SurveyImportParser` uses a `ilMDSaxParser` to ensure that exports from previous ILIAS versions are still imported properly with their LOM. Also, `ilObjSurveyQuestionPool::toXML` uses `ilMD::toXML` to export LOM directly. The current plan is to remove these classes with ILIAS 11, which would lead to exports of Surveys from ILIAS 9 and below, and Question Pools from at least 10 and below to be imported in 11 without their LOM. I'll also put this up to discussion in one of the following JFs, but if you have any immediate objections to this plan, let me know.

Cheers, @schmitz-ilias