### PR TITLE
Test/TestQuestionPool: LOM as tail dependency in export

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -4127,9 +4127,6 @@ class ilObjTest extends ilObject
     {
         $this->mob_ids = [];
 
-        // MetaData
-        $this->exportXMLMetaData($a_xml_writer);
-
         // PageObjects
         $expLog->write(date("[y-m-d H:i:s] ") . "Start Export Page Objects");
         $this->bench->start("ContentObjectExport", "exportPageObjects");
@@ -4150,20 +4147,6 @@ class ilObjTest extends ilObject
         $this->exportFileItems($a_target_dir, $expLog);
         $this->bench->stop("ContentObjectExport", "exportFileItems");
         $expLog->write(date("[y-m-d H:i:s] ") . "Finished Export File Items");
-    }
-
-    /**
-    * export content objects meta data to xml (see ilias_co.dtd)
-    *
-    * @param	object		$a_xml_writer	ilXmlWriter object that receives the
-    *										xml data
-    */
-    public function exportXMLMetaData(&$a_xml_writer)
-    {
-        $md2xml = new ilMD2XML($this->getId(), 0, $this->getType());
-        $md2xml->setExportMode(true);
-        $md2xml->startExport();
-        $a_xml_writer->appendXML($md2xml->getXML());
     }
 
     /**

--- a/components/ILIAS/Test/classes/class.ilTestExporter.php
+++ b/components/ILIAS/Test/classes/class.ilTestExporter.php
@@ -101,6 +101,19 @@ class ilTestExporter extends ilXmlExporter
                 'ids' => $a_ids
             ];
 
+
+            $md_ids = [];
+            foreach ($a_ids as $id) {
+                $md_ids[] = $id . ':0:tst';
+            }
+            if ($md_ids !== []) {
+                $deps[] = [
+                    'component' => 'components/ILIAS/MetaData',
+                    'entity' => 'md',
+                    'ids' => $md_ids
+                ];
+            }
+
             return $deps;
         }
 

--- a/components/ILIAS/Test/classes/class.ilTestImporter.php
+++ b/components/ILIAS/Test/classes/class.ilTestImporter.php
@@ -164,6 +164,12 @@ class ilTestImporter extends ilXmlImporter
         $this->importSkillLevelThresholds($a_mapping, $importedAssignmentList, $new_obj, $xmlfile);
 
         $a_mapping->addMapping("components/ILIAS/Test", "tst", (string) $a_id, (string) $new_obj->getId());
+        $a_mapping->addMapping(
+            "components/ILIAS/MetaData",
+            "md",
+            $a_id . ":0:tst",
+            $new_obj->getId() . ":0:tst"
+        );
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPool.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPool.php
@@ -58,7 +58,7 @@ class ilObjQuestionPool extends ilObject
 
         $this->type = 'qpl';
 
-        parent::__construct($a_id, $a_call_by_reference);
+        parent::__construct((int) $a_id, $a_call_by_reference);
 
         $this->skill_service_enabled = false;
     }
@@ -401,11 +401,10 @@ class ilObjQuestionPool extends ilObject
         $skillQuestionAssignmentExporter->export();
     }
 
-    public function exportTitleAndDescription(&$a_xml_writer): void
+    public function exportTitleAndDescription(ilXmlWriter &$a_xml_writer): void
     {
-        $title_xml = '<Title>' . $this->getTitle() . '</Title>';
-        $description_xml = '<Description>' . $this->getDescription() . '</Description>';
-        $a_xml_writer->appendXML($title_xml . $description_xml);
+        $a_xml_writer->xmlElement('Title', null, $this->getTitle());
+        $a_xml_writer->xmlElement('Description', null, $this->getDescription());
     }
 
     public function modifyExportIdentifier($a_tag, $a_param, $a_value)

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPool.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPool.php
@@ -351,7 +351,7 @@ class ilObjQuestionPool extends ilObject
         $a_xml_writer->xmlStartTag('ContentObject', $attrs);
 
         // MetaData
-        $this->exportXMLMetaData($a_xml_writer);
+        $this->exportTitleAndDescription($a_xml_writer);
 
         // Settings
         $this->exportXMLSettings($a_xml_writer);
@@ -401,18 +401,11 @@ class ilObjQuestionPool extends ilObject
         $skillQuestionAssignmentExporter->export();
     }
 
-    /**
-     * export content objects meta data to xml (see ilias_co.dtd)
-     *
-     * @param object $a_xml_writer            ilXmlWriter object that receives the
-     *                                        xml data
-     */
-    public function exportXMLMetaData(&$a_xml_writer): void
+    public function exportTitleAndDescription(&$a_xml_writer): void
     {
-        $md2xml = new ilMD2XML($this->getId(), 0, $this->getType());
-        $md2xml->setExportMode(true);
-        $md2xml->startExport();
-        $a_xml_writer->appendXML($md2xml->getXML());
+        $title_xml = '<Title>' . $this->getTitle() . '</Title>';
+        $description_xml = '<Description>' . $this->getDescription() . '</Description>';
+        $a_xml_writer->appendXML($title_xml . $description_xml);
     }
 
     public function modifyExportIdentifier($a_tag, $a_param, $a_value)

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolXMLParser.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolXMLParser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolXMLParser.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolXMLParser.php
@@ -69,15 +69,8 @@ class ilObjQuestionPoolXMLParser extends ilSaxParser
                 break;
 
             case 'Title':
-                if ($this->inMetaDataTag && $this->inMdGeneralTag) {
-                    $this->cdata = '';
-                }
-                break;
-
             case 'Description':
-                if ($this->inMetaDataTag && $this->inMdGeneralTag) {
-                    $this->cdata = '';
-                }
+                $this->cdata = '';
                 break;
 
             case 'Settings':
@@ -108,7 +101,7 @@ class ilObjQuestionPoolXMLParser extends ilSaxParser
                 break;
 
             case 'Title':
-                if ($this->inMetaDataTag && $this->inMdGeneralTag && !$this->description_processed) {
+                if (!$this->title_processed) {
                     $this->poolOBJ->setTitle($this->cdata);
                     $this->title_processed = true;
                     $this->cdata = '';
@@ -116,7 +109,7 @@ class ilObjQuestionPoolXMLParser extends ilSaxParser
                 break;
 
             case 'Description':
-                if ($this->inMetaDataTag && $this->inMdGeneralTag && !$this->description_processed) {
+                if (!$this->description_processed) {
                     $this->poolOBJ->setDescription($this->cdata);
                     $this->description_processed = true;
                     $this->cdata = '';

--- a/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolExporter.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolExporter.php
@@ -91,6 +91,18 @@ class ilTestQuestionPoolExporter extends ilXmlExporter
                 ];
             }
 
+            $md_ids = [];
+            foreach ($a_ids as $id) {
+                $md_ids[] = $id . ':0:qpl';
+            }
+            if ($md_ids !== []) {
+                $deps[] = [
+                    'component' => 'components/ILIAS/MetaData',
+                    'entity' => 'md',
+                    'ids' => $md_ids
+                ];
+            }
+
             return $deps;
         }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -143,6 +143,13 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
         $this->importQuestionSkillAssignments($xmlfile, $a_mapping, $new_obj->getId());
 
         $a_mapping->addMapping("components/ILIAS/TestQuestionPool", "qpl", $a_id, (string) $new_obj->getId());
+        $a_mapping->addMapping(
+            "components/ILIAS/MetaData",
+            "md",
+            $a_id . ":0:qpl",
+            $new_obj->getId() . ":0:qpl"
+        );
+
 
         $new_obj->saveToDb();
     }


### PR DESCRIPTION
This PR replaces almost all usages of the old `MetaData` classes in `Test` and `TestQuestionPool` related to export/import. For everything else, see #7923.

From what I could gather from [28891](https://mantis.ilias.de/view.php?id=28891) and a bit of testing, LOM of `Tests` and `TestQuestionPools` is currently directly included in the XML of the Test(QuestionPool) itself, but is not actually imported. When importing Tests, the LOM seems completely unused, and TestQuestionPools only use title and description.

This PR includes LOM as a tail dependency in the exports, and removes it from the XML of the objects themselves. Further, it adds fields for title and description to the XML for TestQuestionPools, and makes sure they are read out on import. Unfortunately, tail dependencies do not apply everywhere. Exports of TestQuestionPools via the question table, and exports of Tests with results of participants sidestep the `Export` infrastructure somewhat, so this PR will simply remove LOM from those types of exports.

If you prefer consistency between export types, I could also rewrite this PR to only remove the LOM from exports, without adding it back in as a tail dependency. Keeping the LOM for some or all types of exports does not have much value in my opinion: it is currently not imported, and is also not in a format that could be imported in the future.

Be aware that I tested most of these changes in 9, because import/export is currently broken in trunk.

With this PR and #7923, the only usage of old `MetaData` classes in `Tests` and `TestQuestionPools` are `ilMD` and `ilMDSaxParser` in `ilQuestionPageParser`. As far as I can see, the only purpose their inclusion serves is the import of LOM of MediaObjects that might be included in Question Pages. `ilMD` and `ilMDSaxParser` are deprecated (as of a few weeks ago), and will be removed with ILIAS 11, but even if they are not replaced in `ilQuestionPageParser` I think the loss of functionality is bearable. Let me know if you have a strong opinion about this, I will also put it up for discussion in an upcoming JF along with a few similar cases.

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias