### PR TITLE
CmiXapi: switch to LOM API, LOM in export as tail dependency

### DIFF
--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiDataSet.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiDataSet.php
@@ -190,8 +190,7 @@ class ilCmiXapiDataSet extends ilDataSet
 
         $this->_archive['files'] = [
             "properties" => "properties.xml",
-            "metadata" => "metadata.xml",
-            "manifest" => 'manifest.xml',
+            "manifest" => 'manifest.xml'
         ];
         if (false !== strpos($this->data['SourceType'], 'local')) {
             $this->_archive['files']['content'] = "content.zip";
@@ -208,12 +207,6 @@ class ilCmiXapiDataSet extends ilDataSet
             mkdir($this->_archive['directories']['tempDir'], 0755, true);
             //$DIC->filesystem()->storage()->createDir($this->_archive['directories']['tempDir']);
         }
-
-        // build metadata xml file
-        file_put_contents(
-            $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['metadata'],
-            $this->buildMetaData($id)
-        );
 
         // build manifest xml file
         file_put_contents(
@@ -252,10 +245,6 @@ class ilCmiXapiDataSet extends ilDataSet
             $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['manifest'],
             $this->_archive['directories']['archiveDir'] . '/' . "manifest.xml"
         );
-        $zArchive->addFile(
-            $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['metadata'],
-            $this->_archive['directories']['archiveDir'] . '/' . "metadata.xml"
-        );
         if (isset($this->_archive['files']['content'])) {
             $zArchive->addFile(
                 $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['content'],
@@ -273,7 +262,6 @@ class ilCmiXapiDataSet extends ilDataSet
         */
 
         // unlink tempDir and its content
-        unlink($this->_archive['directories']['tempDir'] . "/metadata.xml");
         unlink($this->_archive['directories']['tempDir'] . "/manifest.xml");
         unlink($this->_archive['directories']['tempDir'] . "/properties.xml");
         if (isset($this->_archive['files']['content'])) {
@@ -360,13 +348,6 @@ class ilCmiXapiDataSet extends ilDataSet
         //var_dump($this->data); exit;
     }
 
-    public function buildMetaData(int $id): string
-    {
-        $md2xml = new ilMD2XML($id, $id, "cmix");
-        $md2xml->startExport();
-        return $md2xml->getXML();
-    }
-
     private function buildManifest(): string
     {
         $manWriter = new ilXmlWriter();
@@ -428,6 +409,12 @@ class ilCmiXapiDataSet extends ilDataSet
 
                 //$this->current_obj = $newObj;
                 $a_mapping->addMapping("components/ILIAS/CmiXapi", "cmix", $a_rec["Id"], (string) $newObj->getId());
+                $a_mapping->addMapping(
+                    "components/ILIAS/MetaData",
+                    "md",
+                    $a_rec["Id"] . ":0:cmix",
+                    $newObj->getId() . ":0:cmix"
+                );
                 break;
         }
     }

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiDataSet.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiDataSet.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilCmiXapiDataSet

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiExporter.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiExporter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilCmiXapiExporter

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiExporter.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiExporter.php
@@ -62,6 +62,28 @@ class ilCmiXapiExporter extends ilXmlExporter
         return $this->_dataset->getCmiXapiXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 
+    public function getXmlExportTailDependencies(
+        string $a_entity,
+        string $a_target_release,
+        array $a_ids
+    ): array {
+        $dependencies = [];
+
+        $md_ids = [];
+        foreach ($a_ids as $id) {
+            $md_ids[] = $id . ":0:cmix";
+        }
+        if ($md_ids !== []) {
+            $dependencies[] = [
+                "component" => "components/ILIAS/MetaData",
+                "entity" => "md",
+                "ids" => $md_ids
+            ];
+        }
+
+        return $dependencies;
+    }
+
     /**
      * @return array<string, array<string, string|bool>>
      */


### PR DESCRIPTION
This PR replaces most usages of the old `MetaData` classes in `CmiXapi` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

As a part of this, LOM is exported as a tail dependency of CmiXapi, and not as `metadata.xml`. As far as I can tell, `metadata.xml` was never taken into account anyways when importing CmiXapi, or am I missing something? In my (admittedly limited) tests, LOM of CmiXapi Objects is currently lost when exporting/importing, so this PR would fix that (or add the functionality in the first place).

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias