### PR TITLE
Auth: Fix wrong main bar items after forcing login via browser's back-button usage

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -1329,6 +1329,12 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
 
         $ilIliasIniFile = $DIC['ilIliasIniFile'];
 
+        if (!$DIC['ilAuthSession']->isExpired() &&
+            $DIC['ilAuthSession']->isAuthenticated() &&
+            !ilObjUser::_isAnonymous($DIC['ilAuthSession']->getUserId())) {
+            $this->ctrl->redirectToURL(ilUserUtil::getStartingPointAsUrl());
+        }
+
         $this->help->setSubScreenId('logout');
 
         $tpl = self::initStartUpTemplate("tpl.logout.html");

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -235,6 +235,9 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
                         'username' => $this->user->getLogin()
                     )
                 );
+
+                $this->dic->user()->setId($auth_session->getUserId());
+                $this->dic->user()->read();
             }
             $this->logger->debug('Show login page');
             if (isset($messages) && count($messages) > 0) {


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=27749

If approved, this must be cherry-picked to `release_9` and `trunk` as well.