### PR TITLE
T&A Bugfix #0029216: Missing Participant Results in Test Export/Import

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1340,43 +1340,29 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
         $map = $imp->getMapping();
         $map->addMapping('Modules/Test', 'tst', 'new_id', $newObj->getId());
 
+        $fileName = ilSession::get('tst_import_subdir') . '.zip';
+        $fullPath = ilSession::get('tst_import_dir') . '/' . $fileName;
+
         if (is_file(ilSession::get("tst_import_dir") . '/' . ilSession::get("tst_import_subdir") . "/manifest.xml")) {
             $newObj->saveToDb();
 
             ilSession::set('tst_import_idents', $_POST['ident'] ?? '');
             ilSession::set('tst_import_qst_parent', $questionParentObjId);
 
-            $fileName = ilSession::get('tst_import_subdir') . '.zip';
-            $fullPath = ilSession::get('tst_import_dir') . '/' . $fileName;
-
             $imp->importObject($newObj, $fullPath, $fileName, 'tst', 'Modules/Test', true);
         } else {
-            $qtiParser = new ilQTIParser(ilSession::get("tst_import_qti_file"), ilQTIParser::IL_MO_PARSE_QTI, $questionParentObjId, $_POST["ident"] ?? '');
-            if (!file_exists(ilSession::get("tst_import_results_file"))
-                && (!isset($_POST["ident"]) || !is_array($_POST["ident"]) || !count($_POST["ident"]))) {
-                $qtiParser->setIgnoreItemsEnabled(true);
-            }
-            $qtiParser->setTestObject($newObj);
-            $qtiParser->startParsing();
-            $newObj = $qtiParser->getTestObject();
-            $newObj->saveToDb();
-
-            $questionPageParser = new ilQuestionPageParser($newObj, ilSession::get("tst_import_xml_file"), ilSession::get("tst_import_subdir"));
-            $questionPageParser->setQuestionMapping($qtiParser->getImportMapping());
-            $questionPageParser->startParsing();
-
             $test_importer = new ilTestImporter();
-            $test_importer->addTexonomyAndQuestionsMapping($qtiParser->getQuestionIdMapping(), $newObj->getId(), $map);
-            $test_importer->importRandomQuestionSetConfig($newObj, ilSession::get("tst_import_xml_file"), $map);
+            $test_importer->setImport($imp);
+            $test_importer->setInstallId(IL_INST_ID);
+            $test_importer->setImportDirectory(ilSession::get("tst_import_dir") . '/' . ilSession::get("tst_import_subdir"));
+            $test_importer->init();
 
-            if (file_exists(ilSession::get("tst_import_results_file"))) {
-                $results = new ilTestResultsImportParser(ilSession::get("tst_import_results_file"), $newObj);
-                $results->setQuestionIdMapping($qtiParser->getQuestionIdMapping());
-                $results->startParsing();
-            }
-
-            $newObj->saveToDb();
-            $newObj->update();
+            $test_importer->importXmlRepresentation(
+                '',
+                0,
+                '',
+                $map,
+            );
         }
 
 

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1365,36 +1365,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
             $questionPageParser->setQuestionMapping($qtiParser->getImportMapping());
             $questionPageParser->startParsing();
 
-            foreach ($qtiParser->getQuestionIdMapping() as $oldQuestionId => $newQuestionId) {
-                $map->addMapping(
-                    "Services/Taxonomy",
-                    "tax_item",
-                    "tst:quest:$oldQuestionId",
-                    $newQuestionId
-                );
-
-                $map->addMapping(
-                    "Services/Taxonomy",
-                    "tax_item_obj_id",
-                    "tst:quest:$oldQuestionId",
-                    $newObj->getId()
-                );
-
-                $map->addMapping(
-                    "Modules/Test",
-                    "quest",
-                    $oldQuestionId,
-                    $newQuestionId
-                );
-            }
-
-            if ($newObj->isRandomTest()) {
-                $newObj->questions = [];
-                $parser = new ilObjTestXMLParser(ilSession::get("tst_import_xml_file"));
-                $parser->setTestOBJ($newObj);
-                $parser->setImportMapping($map);
-                $parser->startParsing();
-            }
+            $test_importer = new ilTestImporter();
+            $test_importer->addTexonomyAndQuestionsMapping($qtiParser->getQuestionIdMapping(), $newObj->getId(), $map);
+            $test_importer->importRandomQuestionSetConfig($newObj, ilSession::get("tst_import_xml_file"), $map);
 
             if (file_exists(ilSession::get("tst_import_results_file"))) {
                 $results = new ilTestResultsImportParser(ilSession::get("tst_import_results_file"), $newObj);

--- a/Modules/Test/classes/class.ilTestImporter.php
+++ b/Modules/Test/classes/class.ilTestImporter.php
@@ -93,31 +93,9 @@ class ilTestImporter extends ilXmlImporter
         $questionPageParser->setQuestionMapping($qtiParser->getImportMapping());
         $questionPageParser->startParsing();
 
-        foreach ($qtiParser->getQuestionIdMapping() as $oldQuestionId => $newQuestionId) {
-            $a_mapping->addMapping(
-                "Services/Taxonomy",
-                "tax_item",
-                "tst:quest:$oldQuestionId",
-                $newQuestionId
-            );
-
-            $a_mapping->addMapping(
-                "Services/Taxonomy",
-                "tax_item_obj_id",
-                "tst:quest:$oldQuestionId",
-                $newObj->getId()
-            );
-
-            $a_mapping->addMapping(
-                "Modules/Test",
-                "quest",
-                $oldQuestionId,
-                $newQuestionId
-            );
-        }
+        $a_mapping = $this->addTexonomyAndQuestionsMapping($qtiParser->getQuestionIdMapping(), $newObj->getId(), $a_mapping);
 
         if ($newObj->isRandomTest()) {
-            $newObj->questions = array();
             $this->importRandomQuestionSetConfig($newObj, $xml_file, $a_mapping);
         }
 
@@ -137,6 +115,33 @@ class ilTestImporter extends ilXmlImporter
         $this->importSkillLevelThresholds($a_mapping, $importedAssignmentList, $newObj, $xml_file);
 
         $a_mapping->addMapping("Modules/Test", "tst", $a_id, $newObj->getId());
+    }
+
+    public function addTexonomyAndQuestionsMapping(array $question_id_mapping, int $new_obj_id, ilImportMapping $mapping): ilImportMapping {
+        foreach ($question_id_mapping as $oldQuestionId => $newQuestionId) {
+            $mapping->addMapping(
+                "Services/Taxonomy",
+                "tax_item",
+                "tst:quest:$oldQuestionId",
+                $newQuestionId
+            );
+
+            $mapping->addMapping(
+                "Services/Taxonomy",
+                "tax_item_obj_id",
+                "tst:quest:$oldQuestionId",
+                $new_obj_id
+            );
+
+            $mapping->addMapping(
+                "Modules/Test",
+                "quest",
+                $oldQuestionId,
+                $newQuestionId
+            );
+        }
+
+        return $mapping;
     }
 
     /**
@@ -287,8 +292,9 @@ class ilTestImporter extends ilXmlImporter
         return $name;
     }
 
-    protected function importRandomQuestionSetConfig(ilObjTest $testOBJ, $xmlFile, $a_mapping)
+    public function importRandomQuestionSetConfig(ilObjTest $testOBJ, $xmlFile, $a_mapping)
     {
+        $testOBJ->questions = [];
         $parser = new ilObjTestXMLParser($xmlFile);
         $parser->setTestOBJ($testOBJ);
         $parser->setImportMapping($a_mapping);

--- a/Modules/Test/classes/class.ilTestImporter.php
+++ b/Modules/Test/classes/class.ilTestImporter.php
@@ -117,7 +117,8 @@ class ilTestImporter extends ilXmlImporter
         $a_mapping->addMapping("Modules/Test", "tst", $a_id, $newObj->getId());
     }
 
-    public function addTexonomyAndQuestionsMapping(array $question_id_mapping, int $new_obj_id, ilImportMapping $mapping): ilImportMapping {
+    public function addTexonomyAndQuestionsMapping(array $question_id_mapping, int $new_obj_id, ilImportMapping $mapping): ilImportMapping
+    {
         foreach ($question_id_mapping as $oldQuestionId => $newQuestionId) {
             $mapping->addMapping(
                 "Services/Taxonomy",


### PR DESCRIPTION
This bug was initially reported in https://mantis.ilias.de/view.php?id=29216. During the bug-fixing process, however, we discovered in #6335 that the issue was more complex than we originally thought.

As a result, we began working on a solution to ensure that the feature would not be abandoned. Before I arrived at a solution involving significant refactoring or a new implementation, I came across this bug fix, which appears to resolve the issue satisfactorily.

Further analysis is ongoing, and we are exploring additional ways to address the problem. However, this bug fix provides a quick solution that prevents the feature from being removed in version 10 and allows it to function properly in other versions as well.

Unfortunately, the solution impacts ilExportGUI, meaning this is not a localized bug fix in T&A. The core issue was that the import of the questions was not handled correctly because a shortcut through ilImport and ilExport was chosen. As a result, the export did not include a manifest file in the zip, leading to an exception in ilImport::doImportObject during the import process, which requires the manifest to function correctly.

This step is crucial to ensure that the questions are not lost. I have removed the shortcut, so the Test Import/Export now runs the entire way through ilImport/ilExport.

This is open for discussion and will be addressed further in our next T&A meeting. After we've decided on the best solution, I will implement fixes for all other versions.

Best @fhelfer 