### PR TITLE
Remove falsely added NPM package `linkify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "chart.js": "^4.4.1",
         "dropzone": "^5.9.3",
         "jquery": "^3.6.0",
-        "linkify": "^0.2.1",
         "linkifyjs": "^4.1.3",
         "moment": "^2.29.4",
         "tinymce": "^6.8.4"
@@ -4513,11 +4512,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
-    },
-    "node_modules/linkify": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/linkify/-/linkify-0.2.1.tgz",
-      "integrity": "sha512-Esq4rfRRHmH3RTqAsnGq33MwE0HqyeNWHpNbWFsV8jEnuPKseiOPjzWvK2i3REqwZpnbCxTh1yxAKzceKKFDGQ=="
     },
     "node_modules/linkifyjs": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "chart.js": "^4.4.1",
     "dropzone": "^5.9.3",
     "jquery": "^3.6.0",
-    "linkify": "^0.2.1",
     "linkifyjs": "^4.1.3",
     "moment": "^2.29.4",
     "tinymce": "^6.8.4"


### PR DESCRIPTION
There are to similar named NPM packages: _linkify_ and _linkifyjs_. The former is a library that is abandoned and which we never used in previous ILIAS releases and the latter is the package we want. Currently both packages are present in the package.json.

This PR removes the abandoned _linkify_ package.

The package _linkify_ was added with this commit: https://github.com/ILIAS-eLearning/ILIAS/commit/e1cb179f060a0bf4cdc6985c6af1d124bde6abcc

linkify: https://www.npmjs.com/package/linkify
vs.
linkifyjs: https://www.npmjs.com/package/linkifyjs