### PR TITLE
Fix rollup config for Bar Chart JS

### DIFF
--- a/src/UI/templates/js/Chart/Bar/dist/bar.js
+++ b/src/UI/templates/js/Chart/Bar/dist/bar.js
@@ -14,49 +14,18 @@ var horizontal = function() {
   return {
     init: init
   };
-}
-
-var vertical = function() {
-
-  var init = function(element, preferences, series, yLabels, tooltips){
-    determineYLabels(preferences, yLabels);
-    determineToolTipYLabels(preferences, yLabels, tooltips);
-
-    var chart = new Chart(document.getElementById(element.id), {
-      type: 'bar',
-      data: series,
-      options: preferences,
-    });
-  };
-
-  return {
-    init: init
-  };
-}
+};
 
 function determineXLabels(preferences, xLabels) {
   // Replace labels on x-axes with custom values if defined. If not, use default numeric values.
   if (Object.keys(xLabels).length != 0) {
     preferences.scales.x.ticks.callback = function (value, index, values) {
       return xLabels[index];
-    }
+    };
   } else {
     preferences.scales.x.ticks.callback = function (value, index, values) {
       return value;
-    }
-  }
-}
-
-function determineYLabels(preferences, yLabels) {
-  // Replace labels on x-axes with custom values if defined. If not, use default numeric values.
-  if (Object.keys(yLabels).length != 0) {
-    preferences.scales.y.ticks.callback = function (value, index, values) {
-      return yLabels[index];
-    }
-  } else {
-    preferences.scales.y.ticks.callback = function (value, index, values) {
-      return value;
-    }
+    };
   }
 }
 
@@ -76,6 +45,37 @@ function determineToolTipXLabels(preferences, axisLabels, tooltips) {
       label = label + context.formattedValue;
     }
     return label;
+  };
+}
+
+var vertical = function() {
+
+  var init = function(element, preferences, series, yLabels, tooltips){
+    determineYLabels(preferences, yLabels);
+    determineToolTipYLabels(preferences, yLabels, tooltips);
+
+    var chart = new Chart(document.getElementById(element.id), {
+      type: 'bar',
+      data: series,
+      options: preferences,
+    });
+  };
+
+  return {
+    init: init
+  };
+};
+
+function determineYLabels(preferences, yLabels) {
+  // Replace labels on x-axes with custom values if defined. If not, use default numeric values.
+  if (Object.keys(yLabels).length != 0) {
+    preferences.scales.y.ticks.callback = function (value, index, values) {
+      return yLabels[index];
+    };
+  } else {
+    preferences.scales.y.ticks.callback = function (value, index, values) {
+      return value;
+    };
   }
 }
 
@@ -95,9 +95,8 @@ function determineToolTipYLabels(preferences, axisLabels, tooltips) {
       label = label + context.formattedValue;
     }
     return label;
-  }
+  };
 }
-
 
 il = il || {};
 il.UI = il.UI || {};

--- a/src/UI/templates/js/Chart/Bar/rollup.config.js
+++ b/src/UI/templates/js/Chart/Bar/rollup.config.js
@@ -1,7 +1,7 @@
 export default {
   input: './src/bar.js',
   output: {
-    file: './dist/filter.js',
+    file: './dist/bar.js',
     format: 'es'
   }
 };

--- a/src/UI/templates/js/Chart/Bar/src/bar.horizontal.js
+++ b/src/UI/templates/js/Chart/Bar/src/bar.horizontal.js
@@ -14,18 +14,18 @@ var horizontal = function() {
   return {
     init: init
   };
-}
+};
 
 function determineXLabels(preferences, xLabels) {
   // Replace labels on x-axes with custom values if defined. If not, use default numeric values.
   if (Object.keys(xLabels).length != 0) {
     preferences.scales.x.ticks.callback = function (value, index, values) {
       return xLabels[index];
-    }
+    };
   } else {
     preferences.scales.x.ticks.callback = function (value, index, values) {
       return value;
-    }
+    };
   }
 }
 
@@ -45,7 +45,7 @@ function determineToolTipXLabels(preferences, axisLabels, tooltips) {
       label = label + context.formattedValue;
     }
     return label;
-  }
+  };
 }
 
 export default horizontal;

--- a/src/UI/templates/js/Chart/Bar/src/bar.vertical.js
+++ b/src/UI/templates/js/Chart/Bar/src/bar.vertical.js
@@ -14,18 +14,18 @@ var vertical = function() {
   return {
     init: init
   };
-}
+};
 
 function determineYLabels(preferences, yLabels) {
   // Replace labels on x-axes with custom values if defined. If not, use default numeric values.
   if (Object.keys(yLabels).length != 0) {
     preferences.scales.y.ticks.callback = function (value, index, values) {
       return yLabels[index];
-    }
+    };
   } else {
     preferences.scales.y.ticks.callback = function (value, index, values) {
       return value;
-    }
+    };
   }
 }
 
@@ -45,7 +45,7 @@ function determineToolTipYLabels(preferences, axisLabels, tooltips) {
       label = label + context.formattedValue;
     }
     return label;
-  }
+  };
 }
 
 export default vertical;


### PR DESCRIPTION
While I was working on #7691, I have found out by the way that the rollup config for the Bar Chart JS is faulty.
Please also cherry-pick to release 9 and trunk.