### PR TITLE
Fix: Keep filter data during ui data table rendering

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
@@ -137,7 +137,7 @@ class Data extends AbstractTable implements T\Data
         }
 
         return [
-            $table->withFilter($filter_data),
+            $table,
             $view_controls
         ];
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -205,10 +205,8 @@ class Renderer extends AbstractComponentRenderer
         $tpl = $this->getTemplate("tpl.datatable.html", true, true);
         $component = $this->registerActions($component);
 
-        //TODO: Filter
-        $filter_data = [];
         [$component, $view_controls] = $component->applyViewControls(
-            $filter_data = [],
+            $component->getFilter() ?? [],
             $component->getAdditionalParameters()
         );
 
@@ -372,7 +370,7 @@ class Renderer extends AbstractComponentRenderer
 
         $actions = [];
         foreach ($component->getAllActions() as $action_id => $action) {
-            $component = $component->withAdditionalOnLoadCode($this->getActionRegistration((string)$action_id, $action));
+            $component = $component->withAdditionalOnLoadCode($this->getActionRegistration((string) $action_id, $action));
             if ($action->isAsync()) {
                 $signal = clone $component->getAsyncActionSignal();
                 $signal->addOption(Action::OPT_ACTIONID, $action_id);


### PR DESCRIPTION
While refactoring LUI to use UI DataTables, I discovered an issue in the current implementation related to a TODO item. The $filter_data array passed to the DataRetrieval methods is always empty. This happens because it gets overwritten with an empty array during the rendering process, which seems unintended given the TODO comment.

I modified the code to keep filter data already passed to the table like in the following snippet:

```php
$filter = $this->ui_service->filter()->standard(/*..*/)
    ->withRequest($request);

$this->ui_factory->table()->data(/*...*/)
    ->withRequest($request)
    ->withFilter($filter->getData());
            
$this->ui_renderder->render([
   $filter,
   $table
]);
```

With this usage and the adjustments from the commit, the `$filter_data` is filled inside the DataRetreival as expected.