### PR TITLE
Feature: New taxonomy filters to use taxonomies in the question selection for fixed tests

### DIFF
--- a/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
@@ -101,11 +101,15 @@ class ilTestQuestionBrowserTableGUI
         $this->ctrl->setParameter($this, self::MODE_PARAMETER, $this->testrequest->raw(self::MODE_PARAMETER));
         $action = $this->ctrl->getLinkTarget($this, self::CMD_BROWSE_QUESTIONS);
 
+        $mode = $this->ctrl->getParameterArrayByClass(self::class)[self::MODE_PARAMETER];
+        $parent_title = ($mode === self::MODE_BROWSE_TESTS ? 'test_title' : 'tst_source_question_pool');
+
         $filter = (new QuestionsBrowserFilter(
             $this->ui_service,
             $this->lng,
             $this->ui_factory,
-            'question_browser_filter'
+            'question_browser_filter',
+            $parent_title
         ))->getComponent($action, $this->http_state->request());
 
         $this->main_tpl->setContent(
@@ -123,7 +127,8 @@ class ilTestQuestionBrowserTableGUI
                     $this->tree,
                     $this->testrequest,
                     $this->taxonomy,
-                    $this->questionPoolLinkBuilder
+                    $this->questionPoolLinkBuilder,
+                    $parent_title
                 ))->getComponent(
                     $this->http_state->request(),
                     $this->ui_service->filter()->getData($filter)

--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -62,6 +62,7 @@ use ILIAS\Filesystem\Stream\Streams;
 use ILIAS\Filesystem\Util\Archive\Archives;
 use ILIAS\Skill\Service\SkillService;
 use ILIAS\ResourceStorage\Services as IRSS;
+use ILIAS\Taxonomy\DomainService as TaxonomyService;
 
 /**
  * Class ilObjTestGUI
@@ -153,6 +154,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
     protected ?QuestionsTableQuery $table_query = null;
     protected ?QuestionsTableActions $table_actions = null;
     protected DataFactory $data_factory;
+    protected TaxonomyService $taxonomy;
 
     protected bool $create_question_mode;
 
@@ -182,7 +184,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
         $this->archives = $DIC->archives();
         $this->type = 'tst';
         $this->data_factory = new DataFactory();
-        $this->ui_service = $DIC->uiService();
+        $this->taxonomy = $DIC->taxonomy()->domain();
 
         $local_dic = TestDIC::dic();
         $this->questionrepository = $local_dic['question.general_properties.repository'];
@@ -680,11 +682,15 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                     $this->ui_factory,
                     $this->ui_renderer,
                     $this->testrequest,
+                    $this->questionrepository,
+                    $this->lng,
+                    $this->ctrl,
+                    $this->tpl,
+                    $this->ui_service,
+                    $this->data_factory,
+                    $this->taxonomy,
                     $this->title_builder,
-                    $this->questionrepository
                 );
-                $gui->setWriteAccess($this->access->checkAccess("write", "", $this->ref_id));
-                $gui->init();
                 $this->ctrl->forwardCommand($gui);
                 break;
 
@@ -1842,16 +1848,24 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
 
         $this->toolbar->addButton($this->lng->txt('ass_create_question'), $this->ctrl->getLinkTarget($this, 'createQuestionForm'));
         $this->toolbar->addSeparator();
-        $this->populateQuestionBrowserToolbarButtons($this->toolbar, ilTestQuestionBrowserTableGUI::CONTEXT_LIST_VIEW);
+        $this->populateQuestionBrowserToolbarButtons($this->toolbar);
+
+        $this->tpl->setCurrentBlock("adm_content");
+        $this->tpl->setVariable("ACTION_QUESTION_FORM", $this->ctrl->getFormAction($this));
+        $this->tpl->setVariable(
+            'QUESTIONBROWSER',
+            $this->ui_renderer->render(
+                $this->getTable()
+                ->withQuestionEditing(!$has_started_test_runs)
+                ->getTableComponent($this->object->getTestQuestions())
+                ->withOrderingDisabled($has_started_test_runs)
+            )
+        );
+        $this->tpl->parseCurrentBlock();
     }
 
-    private function populateQuestionBrowserToolbarButtons(ilToolbarGUI $toolbar, string $context): void
+    private function populateQuestionBrowserToolbarButtons(ilToolbarGUI $toolbar): void
     {
-        $this->ctrl->setParameterByClass(
-            ilTestQuestionBrowserTableGUI::class,
-            ilTestQuestionBrowserTableGUI::CONTEXT_PARAMETER,
-            $context
-        );
         $this->ctrl->setParameterByClass(
             ilTestQuestionBrowserTableGUI::class,
             ilTestQuestionBrowserTableGUI::MODE_PARAMETER,
@@ -1859,7 +1873,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
         );
 
         $toolbar->addButton(
-            $this->lng->txt("tst_browse_for_qpl_questions"),
+            $this->lng->txt('tst_browse_for_qpl_questions'),
             $this->ctrl->getLinkTargetByClass(
                 ilTestQuestionBrowserTableGUI::class,
                 ilTestQuestionBrowserTableGUI::CMD_BROWSE_QUESTIONS
@@ -1873,7 +1887,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
         );
 
         $toolbar->addButton(
-            $this->lng->txt("tst_browse_for_tst_questions"),
+            $this->lng->txt('tst_browse_for_tst_questions'),
             $this->ctrl->getLinkTargetByClass(
                 ilTestQuestionBrowserTableGUI::class,
                 ilTestQuestionBrowserTableGUI::CMD_BROWSE_QUESTIONS

--- a/components/ILIAS/Test/src/Questions/QuestionsBrowserFilter.php
+++ b/components/ILIAS/Test/src/Questions/QuestionsBrowserFilter.php
@@ -28,7 +28,6 @@ use ILIAS\UI\Component\Input\Container\Filter\Filter;
 use ilLanguage;
 use ilObjQuestionPool;
 use ilUIService;
-
 use Psr\Http\Message\ServerRequestInterface;
 
 class QuestionsBrowserFilter
@@ -37,7 +36,8 @@ class QuestionsBrowserFilter
         private readonly ilUIService $ui_service,
         private readonly ilLanguage $lng,
         private readonly UIFactory $ui_factory,
-        private readonly string $filter_id
+        private readonly string $filter_id,
+        private readonly string $parent_title
     ) {
     }
 
@@ -86,7 +86,7 @@ class QuestionsBrowserFilter
             'type' => [$input->select($this->lng->txt('tst_question_type'), $this->resolveQuestionTypeFilterOptions()), true],
             'author' => [$input->text($this->lng->txt('author')), false],
             'lifecycle' => [$input->select($this->lng->txt('qst_lifecycle'), $lifecycle_options), false],
-            'parent_title' => [$input->text($this->lng->txt('parent_title')), true],
+            'parent_title' => [$input->text($this->lng->txt($this->parent_title)), true],
             'taxonomy_title' => [$input->text($this->lng->txt('taxonomy_title')), false],
             'taxonomy_node_title' => [$input->text($this->lng->txt('taxonomy_node_title')), false],
             'feedback' => [$input->select($this->lng->txt('feedback'), $yes_no_all_options), false],

--- a/components/ILIAS/Test/src/Questions/QuestionsBrowserFilter.php
+++ b/components/ILIAS/Test/src/Questions/QuestionsBrowserFilter.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Test\Questions;
+
+use ilAssQuestionLifecycle;
+use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
+use ILIAS\UI\Component\Input\Input;
+use ILIAS\UI\Factory as UIFactory;
+use ILIAS\UI\Component\Input\Container\Filter\Filter;
+use ilLanguage;
+use ilObjQuestionPool;
+use ilUIService;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class QuestionsBrowserFilter
+{
+    public function __construct(
+        private readonly ilUIService $ui_service,
+        private readonly ilLanguage $lng,
+        private readonly UIFactory $ui_factory,
+        private readonly string $filter_id
+    ) {
+    }
+
+    public function getComponent(string $action, ServerRequestInterface $request): Filter
+    {
+        $filter_inputs = [];
+        $is_input_initially_rendered = [];
+        $field_factory = $this->ui_factory->input()->field();
+
+        foreach ($this->getFields($field_factory) as $filter_id => $filter) {
+            [$filter_inputs[$filter_id], $is_input_initially_rendered[$filter_id]] = $filter;
+        }
+
+        $component = $this->ui_service->filter()->standard(
+            $this->filter_id,
+            $action,
+            $filter_inputs,
+            $is_input_initially_rendered,
+            true,
+            true
+        );
+
+        return $request->getMethod() === 'POST' ? $component->withRequest($request) : $component;
+    }
+
+    /**
+     * @param FieldFactory $input
+     *
+     * @return array<string, array<Input, bool>>
+     */
+    private function getFields(FieldFactory $input): array
+    {
+        $lifecycle_options = array_merge(
+            ['' => $this->lng->txt('qst_lifecycle_filter_all')],
+            ilAssQuestionLifecycle::getDraftInstance()->getSelectOptions($this->lng)
+        );
+        $yes_no_all_options = [
+            '' => $this->lng->txt('resulttable_all'),
+            'true' => $this->lng->txt('yes'),
+            'false' => $this->lng->txt('no')
+        ];
+
+        return [
+            'title' => [$input->text($this->lng->txt('tst_question_title')), true],
+            'description' => [$input->text($this->lng->txt('description')), false],
+            'type' => [$input->select($this->lng->txt('tst_question_type'), $this->resolveQuestionTypeFilterOptions()), true],
+            'author' => [$input->text($this->lng->txt('author')), false],
+            'lifecycle' => [$input->select($this->lng->txt('qst_lifecycle'), $lifecycle_options), false],
+            'parent_title' => [$input->text($this->lng->txt('parent_title')), true],
+            'taxonomy_title' => [$input->text($this->lng->txt('taxonomy_title')), false],
+            'taxonomy_node_title' => [$input->text($this->lng->txt('taxonomy_node_title')), false],
+            'feedback' => [$input->select($this->lng->txt('feedback'), $yes_no_all_options), false],
+            'hints' => [$input->select($this->lng->txt('hints'), $yes_no_all_options), false],
+        ];
+    }
+
+    private function resolveQuestionTypeFilterOptions(): array
+    {
+        $question_type_options = ['' => $this->lng->txt('filter_all_question_types')];
+
+        foreach (ilObjQuestionPool::_getQuestionTypes() as $translation => $row) {
+            $question_type_options[$row['type_tag']] = $translation;
+        }
+        return $question_type_options;
+    }
+}

--- a/components/ILIAS/Test/src/Questions/QuestionsBrowserTable.php
+++ b/components/ILIAS/Test/src/Questions/QuestionsBrowserTable.php
@@ -202,7 +202,7 @@ class QuestionsBrowserTable implements DataRetrieval
         );
     }
 
-    private function loadRecords(?array $filter): array
+    public function loadRecords(?array $filter): array
     {
         $filter ??= [];
         if ($this->records !== null) {

--- a/components/ILIAS/Test/src/Questions/QuestionsBrowserTable.php
+++ b/components/ILIAS/Test/src/Questions/QuestionsBrowserTable.php
@@ -1,0 +1,360 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Test\Questions;
+
+use ILIAS\Taxonomy\DomainService as TaxonomyService;
+use GuzzleHttp\Psr7\ServerRequest;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Data\Order;
+use ILIAS\Data\Range;
+use ILIAS\Test\RequestDataCollector;
+use ILIAS\UI\Component\Table\Action\Standard as TableAction;
+use ILIAS\UI\Component\Table\Column\Column;
+use ILIAS\UI\Component\Table\DataRetrieval;
+use ILIAS\UI\Component\Table\DataRowBuilder;
+use ILIAS\UI\Factory as UIFactory;
+use ILIAS\UI\Renderer as UIRenderer;
+use ILIAS\UI\URLBuilder;
+use ilTestQuestionBrowserTableGUI;
+use Psr\Http\Message\ServerRequestInterface;
+use ILIAS\UI\Component\Table\Data;
+
+class QuestionsBrowserTable implements DataRetrieval
+{
+    public const ACTION_INSERT = 'insert';
+
+    private ?array $records = null;
+
+    public function __construct(
+        protected readonly string $table_id,
+        protected UIFactory $ui_factory,
+        protected UIRenderer $ui_renderer,
+        protected \ilLanguage $lng,
+        protected \ilCtrl $ctrl,
+        protected DataFactory $data_factory,
+        protected \ilAssQuestionList $question_list,
+        protected \ilObjTest $test_obj,
+        protected \ilTree $tree,
+        protected RequestDataCollector $testrequest,
+        protected TaxonomyService $taxonomy,
+        protected \Closure $getQuestionPoolLink
+    ) {
+    }
+
+    public function getComponent(ServerRequestInterface $request, ?array $filter): Data
+    {
+        return $this->ui_factory->table()->data(
+            $this->lng->txt('list_of_questions'),
+            $this->getColumns(),
+            $this
+        )
+            ->withId($this->table_id)
+            ->withActions($this->getActions())
+            ->withRequest($request)
+            ->withFilter($filter);
+    }
+
+    /**
+     * @return array<string, Column>
+     */
+    public function getColumns(): array
+    {
+        $column_factory = $this->ui_factory->table()->column();
+        $icon_factory = $this->ui_factory->symbol()->icon();
+        $iconYes = $icon_factory->custom('assets/images/standard/icon_checked.svg', 'yes');
+        $iconNo = $icon_factory->custom('assets/images/standard/icon_unchecked.svg', 'no');
+        $dateFormat = $this->data_factory->dateFormat()->withTime24($this->data_factory->dateFormat()->germanShort());
+
+        return [
+            'title' => $column_factory->text(
+                $this->lng->txt('tst_question_title')
+            )->withIsOptional(false, true),
+            'description' => $column_factory->text(
+                $this->lng->txt('description')
+            )->withIsOptional(false, true),
+            'type_tag' => $column_factory->text(
+                $this->lng->txt('tst_question_type')
+            )->withIsOptional(false, true),
+            'points' => $column_factory->text(
+                $this->lng->txt('points')
+            )->withIsOptional(false, true),
+            'author' => $column_factory->text(
+                $this->lng->txt('author')
+            )->withIsOptional(true, false),
+            'lifecycle' => $column_factory->text(
+                $this->lng->txt('qst_lifecycle')
+            )->withIsOptional(true, false),
+            'parent_title' => $column_factory->text(
+                $this->lng->txt('parent_title')
+            )->withIsOptional(false, true),
+            'taxonomies' => $column_factory->text(
+                $this->lng->txt('qpl_settings_subtab_taxonomies')
+            )->withIsOptional(false, true),
+            'feedback' => $column_factory->boolean(
+                $this->lng->txt('feedback'),
+                $iconYes,
+                $iconNo
+            )->withIsOptional(true, false),
+            'hints' => $column_factory->boolean(
+                $this->lng->txt('hints'),
+                $iconYes,
+                $iconNo
+            )->withIsOptional(true, false),
+            'created' => $column_factory->date(
+                $this->lng->txt('created'),
+                $dateFormat
+            )->withIsOptional(true, false),
+            'tstamp' => $column_factory->date(
+                $this->lng->txt('updated'),
+                $dateFormat
+            )->withIsOptional(true, false)
+        ];
+    }
+
+    /**
+     * @return array<string, TableAction>
+     * @throws \ilCtrlException
+     */
+    public function getActions(): array
+    {
+        return [self::ACTION_INSERT => $this->getInsertAction()];
+    }
+
+    /**
+     * @throws \ilCtrlException
+     */
+    private function getInsertAction(): TableAction
+    {
+        $url_builder = new URLBuilder($this->data_factory->uri(
+            ServerRequest::getUriFromGlobals() . $this->ctrl->getLinkTargetByClass(
+                ilTestQuestionBrowserTableGUI::class,
+                ilTestQuestionBrowserTableGUI::CMD_INSERT_QUESTIONS
+            )
+        ));
+
+        [$url_builder, $row_id_token] = $url_builder->acquireParameters(['qlist'], 'q_id');
+
+        return $this->ui_factory->table()->action()->standard(
+            $this->lng->txt('insert'),
+            $url_builder,
+            $row_id_token
+        );
+    }
+
+    public function getRows(
+        DataRowBuilder $row_builder,
+        array $visible_column_ids,
+        Range $range,
+        Order $order,
+        ?array $filter_data,
+        ?array $additional_parameters
+    ): \Generator {
+        foreach ($this->getViewControlledRecords($filter_data, $range, $order) as $record) {
+            $question_id = $record['question_id'];
+
+            $record['type_tag'] = $this->lng->txt($record['type_tag']);
+            $record['complete'] = (bool) $record['complete'];
+            $record['lifecycle'] = \ilAssQuestionLifecycle::getInstance($record['lifecycle'])->getTranslation($this->lng) ?? '';
+            $record['qpl'] = call_user_func($this->getQuestionPoolLink, $record['orig_obj_fi'] ?? null);
+
+            $record['created'] = (new \DateTimeImmutable())->setTimestamp($record['created']);
+            $record['tstamp'] = (new \DateTimeImmutable())->setTimestamp($record['tstamp']);
+            $record['taxonomies'] = $this->resolveTaxonomiesRowData($record['obj_fi'], $question_id);
+
+            yield $row_builder->buildDataRow((string) $question_id, $record);
+        }
+    }
+
+    public function getTotalRowCount(?array $filter_data, ?array $additional_parameters): int
+    {
+        return count($this->loadRecords($filter_data));
+    }
+
+    private function getViewControlledRecords(?array $filter_data, Range $range, Order $order)
+    {
+        return $this->limitRecords(
+            $this->sortRecords(
+                $this->loadRecords($filter_data),
+                $order
+            ),
+            $range
+        );
+    }
+
+    private function loadRecords(array $filter): array
+    {
+        if ($this->records !== null) {
+            return $this->records;
+        }
+
+        if ($this->testrequest->raw(ilTestQuestionBrowserTableGUI::MODE_PARAMETER) === ilTestQuestionBrowserTableGUI::MODE_BROWSE_TESTS) {
+            $this->question_list->setParentObjectType('tst');
+            $this->question_list->setQuestionInstanceTypeFilter(\ilAssQuestionList::QUESTION_INSTANCE_TYPE_ALL);
+            $this->question_list->setExcludeQuestionIdsFilter($this->test_obj->getQuestions());
+        } else {
+            $this->question_list->setParentObjIdsFilter($this->getQuestionParentObjIds(ilTestQuestionBrowserTableGUI::REPOSITORY_ROOT_NODE_ID));
+            $this->question_list->setQuestionInstanceTypeFilter(\ilAssQuestionList::QUESTION_INSTANCE_TYPE_ORIGINALS);
+            $this->question_list->setExcludeQuestionIdsFilter($this->test_obj->getExistingQuestions());
+        }
+
+        foreach (array_filter($filter) as $item => $value) {
+            switch ($item) {
+                case 'title':
+                case 'description':
+                case 'type':
+                case 'author':
+                case 'lifecycle':
+                case 'parent_title':
+                case 'taxonomy_title':
+                case 'taxonomy_node_title':
+                    if ($value !== '') {
+                        $this->question_list->addFieldFilter($item, $value);
+                    }
+                    break;
+                case 'commented':
+                    if ($value !== '') {
+                        $this->question_list->setCommentFilter((int) $value);
+                    }
+                    break;
+                case 'taxonomies':
+                    if ($value === '') {
+                        $this->question_list->addTaxonomyFilterNoTaxonomySet(true);
+                        break;
+                    }
+
+                    $tax_nodes = explode('-', $value);
+                    $this->question_list->addTaxonomyFilter(
+                        array_shift($tax_nodes),
+                        $tax_nodes,
+                        $this->test_obj->getId(),
+                        $this->test_obj->getType()
+                    );
+                    break;
+                default:
+                    $this->question_list->addFieldFilter($item, $value);
+            }
+        }
+
+        $this->question_list->load();
+        return $this->records = $this->question_list->getQuestionDataArray();
+    }
+
+    private function getQuestionParentObjIds(int $repositoryRootNode): array
+    {
+        $parents = $this->tree->getSubTree(
+            $this->tree->getNodeData($repositoryRootNode),
+            true,
+            ['qpl']
+        );
+
+        $parentIds = [];
+
+        foreach ($parents as $nodeData) {
+            if ((int) $nodeData['obj_id'] === $this->test_obj->getId()) {
+                continue;
+            }
+
+            $parentIds[$nodeData['obj_id']] = $nodeData['obj_id'];
+        }
+
+        $parentIds = array_map('intval', array_values($parentIds));
+        $available_pools = array_map('intval', array_keys(\ilObjQuestionPool::_getAvailableQuestionpools(true)));
+        return array_intersect($parentIds, $available_pools);
+    }
+
+    /**
+     * @throws \ilTaxonomyException
+     */
+    private function resolveTaxonomiesRowData(int $obj_fi, int $questionId): string
+    {
+        $available_taxonomy_ids = $this->taxonomy->getUsageOfObject($obj_fi);
+        $data = $this->loadTaxonomyAssignmentData($obj_fi, $questionId, $available_taxonomy_ids);
+
+        $taxonomies = [];
+
+        foreach ($data as $taxonomyId => $taxData) {
+            $taxonomies[] = \ilObject::_lookupTitle($taxonomyId);
+            $taxonomies[] = $this->ui_renderer->render(
+                $this->ui_factory->listing()->unordered(
+                    array_map(static function ($node) {
+                        return \ilTaxonomyNode::_lookupTitle($node['node_id']);
+                    }, $taxData)
+                )
+            );
+        }
+
+        return implode('', $taxonomies);
+    }
+
+    /**
+     * @throws \ilTaxonomyException
+     */
+    private function loadTaxonomyAssignmentData(int $parentObjId, int $questionId, array $available_taxonomy_ids): array
+    {
+        $taxonomyAssignmentData = [];
+
+        foreach ($available_taxonomy_ids as $taxId) {
+            $taxTree = new \ilTaxonomyTree($taxId);
+            $assignments = (new \ilTaxNodeAssignment(
+                'qpl',
+                $parentObjId,
+                'quest',
+                $taxId
+            ))->getAssignmentsOfItem($questionId);
+
+            foreach ($assignments as $assData) {
+                $taxId = $assData['tax_id'];
+                if (!isset($taxonomyAssignmentData[$taxId])) {
+                    $taxonomyAssignmentData[$taxId] = [];
+                }
+
+                $nodeId = $assData['node_id'];
+                $assData['node_lft'] = $taxTree->getNodeData($nodeId)['lft'];
+                $taxonomyAssignmentData[$taxId][$nodeId] = $assData;
+            }
+        }
+
+        return $taxonomyAssignmentData;
+    }
+
+    private function sortRecords(array $records, Order $order): array
+    {
+        [$order_field, $order_direction] = $order->join(
+            '',
+            fn(string $index, string $key, string $value): array => [$key, $value]
+        );
+
+        usort($records, static function (array $a, array $b) use ($order_field): int {
+            if (is_numeric($a[$order_field]) || is_bool($a[$order_field]) || is_array($a[$order_field])) {
+                return $a[$order_field] <=> $b[$order_field];
+            }
+
+            return strcmp($a[$order_field] ?? '', $b[$order_field] ?? '');
+        });
+
+        return $order_direction === $order::DESC ? array_reverse($records) : $records;
+    }
+
+    private function limitRecords(array $records, Range $range): array
+    {
+        return \array_slice($records, $range->getStart(), $range->getLength());
+    }
+}

--- a/components/ILIAS/Test/src/Questions/QuestionsBrowserTable.php
+++ b/components/ILIAS/Test/src/Questions/QuestionsBrowserTable.php
@@ -156,7 +156,7 @@ class QuestionsBrowserTable implements DataRetrieval
         [$url_builder, $row_id_token] = $url_builder->acquireParameters(['qlist'], 'q_id');
 
         return $this->ui_factory->table()->action()->standard(
-            $this->lng->txt('insert'),
+            $this->lng->txt('tst_insert_in_test'),
             $url_builder,
             $row_id_token
         );

--- a/components/ILIAS/Test/tests/tables/ilTestQuestionBrowserTableGUITest.php
+++ b/components/ILIAS/Test/tests/tables/ilTestQuestionBrowserTableGUITest.php
@@ -82,21 +82,19 @@ class ilTestQuestionBrowserTableGUITest extends ilTestBaseTestCase
             $this->createMock(ILIAS\UI\Factory::class),
             $this->createMock(ILIAS\UI\Renderer::class),
             $this->createMock(ILIAS\Test\RequestDataCollector::class),
+            $this->createMock(ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository::class),
+            $lng_mock,
+            $ctrl_mock,
+            $mainTpl_mock,
+            $this->createMock(ilUIService::class),
+            $this->createMock(ILIAS\Data\Factory::class),
+            $this->createMock(ILIAS\Taxonomy\DomainService::class),
             $this->createMock(ILIAS\Test\Utilities\TitleColumnsBuilder::class),
-            $this->createMock(ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository::class)
         );
     }
 
     public function test_instantiateObject_shouldReturnInstance(): void
     {
         $this->assertInstanceOf(ilTestQuestionBrowserTableGUI::class, $this->tableGui);
-    }
-
-    public function testWriteAccess(): void
-    {
-        $this->tableGui->setWriteAccess(false);
-        $this->assertFalse($this->tableGui->hasWriteAccess());
-        $this->tableGui->setWriteAccess(true);
-        $this->assertTrue($this->tableGui->hasWriteAccess());
     }
 }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -267,10 +267,99 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
                         $expressions[] = $this->db->like('object_data.title', 'text', "%%$fieldValue%%");
                     }
                     break;
+                case 'taxonomy_title':
+                    if ($fieldValue !== '') {
+                        $expressions[] = $this->getTaxonomyTitleFilterExpression($fieldValue);
+                    }
+                    break;
+                case 'taxonomy_node_title':
+                    if ($fieldValue !== '') {
+                        $expressions[] = $this->getTaxonomyNodeTitleFilterExpression($fieldValue);
+                    }
+                    break;
+                case 'feedback':
+                    if ($fieldValue === 'false') {
+                        $expressions[] = 'qpl_fb_generic.question_fi IS NULL';
+                    }
+                    break;
+                case 'hints':
+                    if ($fieldValue === 'false') {
+                        $expressions[] = 'qpl_hints.qht_question_fi IS NULL';
+                    }
+                    break;
             }
         }
 
         return $expressions;
+    }
+
+    private function getTaxonomyTitleFilterExpression(string $taxonomyTitle): ?string
+    {
+        $this->join_obj_data = true;
+        return 'tax_node_assignment.tax_id IN (SELECT obj_id FROM object_data WHERE'
+            . $this->db->like('object_data.title', 'text', '%' . $taxonomyTitle . '%')
+            . ' AND type = \'tax\')'
+        ;
+    }
+
+    private function getTaxonomyNodeTitleFilterExpression(string $taxonomyNodeTitle): ?string
+    {
+        $this->join_obj_data = true;
+        return 'tax_node_assignment.node_id IN (SELECT obj_id FROM tax_node WHERE'
+            . $this->db->like('tax_node.title', 'text', '%' . $taxonomyNodeTitle . '%')
+            . ' AND type = \'taxn\')'
+        ;
+    }
+
+    private function handleTaxonomyInnerJoin(string $tableJoin): string
+    {
+        if (
+            ($this->fieldFilters['taxonomy_title'] ?? '') !== ''
+            || ($this->fieldFilters['taxonomy_node_title'] ?? '') !== ''
+        ) {
+            $SQL = 'INNER JOIN tax_node_assignment ON object_data.obj_id = tax_node_assignment.obj_id';
+            if (!str_contains($tableJoin, $SQL)) {
+                $tableJoin .= $SQL;
+            }
+        }
+
+        return $tableJoin;
+    }
+
+    private function handleFeedbackJoin(string $tableJoin): string
+    {
+        $feedback_join = match ($this->fieldFilters['feedback'] ?? null) {
+            'true' => 'INNER',
+            'false' => 'LEFT',
+            default => null
+        };
+
+        if (isset($feedback_join)) {
+            $SQL = $feedback_join . ' JOIN qpl_fb_generic ON qpl_fb_generic.question_fi = qpl_questions.question_id ';
+            if (!str_contains($tableJoin, $SQL)) {
+                $tableJoin .= $SQL;
+            }
+        }
+
+        return $tableJoin;
+    }
+
+    private function handleHintJoin(string $tableJoin): string
+    {
+        $feedback_join = match ($this->fieldFilters['hints'] ?? null) {
+            'true' => 'INNER',
+            'false' => 'LEFT',
+            default => null
+        };
+
+        if (isset($feedback_join)) {
+            $SQL = $feedback_join . ' JOIN qpl_hints ON qpl_hints.qht_question_fi = qpl_questions.question_id ';
+            if (!str_contains($tableJoin, $SQL)) {
+                $tableJoin .= $SQL;
+            }
+        }
+
+        return $tableJoin;
     }
 
     private function getTaxonomyFilterExpressions(): array
@@ -437,13 +526,16 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 			";
         }
 
-        if ($this->getParentObjectType() === 'tst'
-            && $this->getQuestionInstanceTypeFilter() === self::QUESTION_INSTANCE_TYPE_ALL) {
-            $tableJoin .= "
-            						INNER JOIN	tst_test_question tstquest
-			ON			tstquest.question_fi = qpl_questions.question_id
-			";
+        if (
+            $this->getParentObjectType() === 'tst'
+            && $this->getQuestionInstanceTypeFilter() === self::QUESTION_INSTANCE_TYPE_ALL
+        ) {
+            $tableJoin .= " INNER JOIN tst_test_question ON tst_test_question.question_fi = qpl_questions.question_id ";
         }
+
+        $tableJoin = $this->handleTaxonomyInnerJoin($tableJoin);
+        $tableJoin = $this->handleFeedbackJoin($tableJoin);
+        $tableJoin = $this->handleHintJoin($tableJoin);
 
         if ($this->getAnswerStatusActiveId()) {
             $tableJoin .= "

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -267,16 +267,6 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
                         $expressions[] = $this->db->like('object_data.title', 'text', "%%$fieldValue%%");
                     }
                     break;
-                case 'taxonomy_title':
-                    if ($fieldValue !== '') {
-                        $expressions[] = $this->getTaxonomyTitleFilterExpression($fieldValue);
-                    }
-                    break;
-                case 'taxonomy_node_title':
-                    if ($fieldValue !== '') {
-                        $expressions[] = $this->getTaxonomyNodeTitleFilterExpression($fieldValue);
-                    }
-                    break;
                 case 'feedback':
                     if ($fieldValue === 'false') {
                         $expressions[] = 'qpl_fb_generic.question_fi IS NULL';
@@ -291,39 +281,6 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         }
 
         return $expressions;
-    }
-
-    private function getTaxonomyTitleFilterExpression(string $taxonomyTitle): ?string
-    {
-        $this->join_obj_data = true;
-        return 'tax_node_assignment.tax_id IN (SELECT obj_id FROM object_data WHERE'
-            . $this->db->like('object_data.title', 'text', '%' . $taxonomyTitle . '%')
-            . ' AND type = \'tax\')'
-        ;
-    }
-
-    private function getTaxonomyNodeTitleFilterExpression(string $taxonomyNodeTitle): ?string
-    {
-        $this->join_obj_data = true;
-        return 'tax_node_assignment.node_id IN (SELECT obj_id FROM tax_node WHERE'
-            . $this->db->like('tax_node.title', 'text', '%' . $taxonomyNodeTitle . '%')
-            . ' AND type = \'taxn\')'
-        ;
-    }
-
-    private function handleTaxonomyInnerJoin(string $tableJoin): string
-    {
-        if (
-            ($this->fieldFilters['taxonomy_title'] ?? '') !== ''
-            || ($this->fieldFilters['taxonomy_node_title'] ?? '') !== ''
-        ) {
-            $SQL = 'INNER JOIN tax_node_assignment ON object_data.obj_id = tax_node_assignment.obj_id';
-            if (!str_contains($tableJoin, $SQL)) {
-                $tableJoin .= $SQL;
-            }
-        }
-
-        return $tableJoin;
     }
 
     private function handleFeedbackJoin(string $tableJoin): string
@@ -533,7 +490,6 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             $tableJoin .= " INNER JOIN tst_test_question ON tst_test_question.question_fi = qpl_questions.question_id ";
         }
 
-        $tableJoin = $this->handleTaxonomyInnerJoin($tableJoin);
         $tableJoin = $this->handleFeedbackJoin($tableJoin);
         $tableJoin = $this->handleHintJoin($tableJoin);
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -598,6 +598,7 @@ assessment#:#correct_answers#:#Richtige Antworten
 assessment#:#counter#:#Zähler
 assessment#:#create_gaps#:#Lücken erzeugen und aktualisieren
 assessment#:#create_new#:#Erstelle neue
+assessment#:#created#:#Erstellt
 assessment#:#customstyle#:#Eigenes Stylesheet
 assessment#:#dashboard_tab#:#Teilnehmer
 assessment#:#date_time#:#Datum und Uhrzeit
@@ -988,6 +989,7 @@ assessment#:#ordertext_info#:#Bitte geben Sie den Text in der Reihenfolge ein, i
 assessment#:#out_of_range#:#Ausserhalb des Bereichs
 assessment#:#output#:#Ausgabe
 assessment#:#output_mode#:#Ausgabemodus
+assessment#:#parent_title#:#Elternobjekt Titel
 assessment#:#parseQuestion#:#Frage analysieren
 assessment#:#part_received_a_of_b_points#:#Der Teilnehmer hat %s von %s möglichen Punkten erreicht.
 assessment#:#participants#:#Teilnehmer
@@ -1269,6 +1271,8 @@ assessment#:#ta_resulttable_vc_mode_aria#:#Anzeigeoptionen für Fragen
 assessment#:#tab_nest_answers#:#Einrückung
 assessment#:#tax_filter#:#Taxonomie
 assessment#:#tax_filter_notax#:#Fragen ohne zugeordnete Taxonomie
+assessment#:#taxonomy_node_title#:#Taxonomie Knoten Titel
+assessment#:#taxonomy_title#:#Taxonomie Titel
 assessment#:#term#:#Term
 assessment#:#term_image#:#Bild
 assessment#:#term_text#:#Text
@@ -2038,6 +2042,7 @@ assessment#:#unit_placeholder#:#** Neue Einheit **
 assessment#:#units#:#Einheiten
 assessment#:#unlimited#:#unbegrenzt
 assessment#:#unlock#:#Entsperren
+assessment#:#updated#:#Aktualisiert
 assessment#:#uploaded_material#:#Hochgeladene Materialien
 assessment#:#use_previous_solution#:#Verwende vorherige Lösung
 assessment#:#use_previous_solution_advice#:#Die angezeigte Lösung wurde vormals von Ihnen abgegeben. Sie müssen die Übernahme dieser Lösung unterhalb der Frage bestätigen, falls Sie die Lösung ohne Änderungen übernehmen wollen.

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1548,6 +1548,7 @@ assessment#:#tst_input_dynamic_question_set_question_ordering_by_date#:#Ordne Fr
 assessment#:#tst_input_dynamic_question_set_question_ordering_by_tax#:#Ordne Fragen nach Taxonomieknoten
 assessment#:#tst_input_dynamic_question_set_source_questionpool#:#Fragenpool
 assessment#:#tst_input_dynamic_question_set_taxonomie_filter_enabled#:#Zeige Taxonomiefilter
+assessment#:#tst_insert_in_test#:#In Test einfügen
 assessment#:#tst_insert_missing_question#:#Bitte wählen Sie mindestens eine Frage aus, die Sie in dem Test hinzufügen wollen!
 assessment#:#tst_insert_questions#:#Sind Sie sicher, dass Sie die folgenden Fragen dem Test hinzufügen wollen?
 assessment#:#tst_instant_feedback#:#Direkte Rückmeldung

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -989,7 +989,6 @@ assessment#:#ordertext_info#:#Bitte geben Sie den Text in der Reihenfolge ein, i
 assessment#:#out_of_range#:#Ausserhalb des Bereichs
 assessment#:#output#:#Ausgabe
 assessment#:#output_mode#:#Ausgabemodus
-assessment#:#parent_title#:#Elternobjekt Titel
 assessment#:#parseQuestion#:#Frage analysieren
 assessment#:#part_received_a_of_b_points#:#Der Teilnehmer hat %s von %s möglichen Punkten erreicht.
 assessment#:#participants#:#Teilnehmer
@@ -1297,6 +1296,7 @@ assessment#:#test_question_set_type_random_info#:#Jedem Teilnehmenden werden unt
 assessment#:#test_results#:#Bekanntgabe des Testergebnisses
 assessment#:#test_scoring#:#Bewertung des Tests
 assessment#:#test_template_reset#:#Die Vorlage wurde entfernt.
+assessment#:#test_title#:#Test Titel
 assessment#:#test_using_template#:#Dieser Test verwendet die Vorlage %s. Wenn Sie keine Vorlage und alle Einstellungen verwenden wollen, klicken Sie bitte hier: %s.
 assessment#:#test_using_template_link#:#Vorlage nicht mehr verwenden
 assessment#:#text_correct#:#Korrekter Text

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -598,6 +598,7 @@ assessment#:#correct_answers#:#Correct Answers
 assessment#:#counter#:#Counter
 assessment#:#create_gaps#:#Create and Refresh Gaps
 assessment#:#create_new#:#Create New
+assessment#:#created#:#Created
 assessment#:#customstyle#:#Custom Style
 assessment#:#dashboard_tab#:#Participants
 assessment#:#date_time#:#Date and Time
@@ -988,6 +989,7 @@ assessment#:#ordertext_info#:#Please enter the text that should be ordered horiz
 assessment#:#out_of_range#:#Out of range
 assessment#:#output#:#Output
 assessment#:#output_mode#:#Output Mode
+assessment#:#parent_title#:#Parent Object Title
 assessment#:#parseQuestion#:#Parse Question
 assessment#:#part_received_a_of_b_points#:#The participant received %s of %s possible points
 assessment#:#participants#:#Participants
@@ -1269,6 +1271,8 @@ assessment#:#ta_resulttable_vc_mode_aria#:#switch question mode
 assessment#:#tab_nest_answers#:#Nesting
 assessment#:#tax_filter#:#Taxonomy
 assessment#:#tax_filter_notax#:#Questions without assigned Taxonomy
+assessment#:#taxonomy_node_title#:#Taxonomy Node Title
+assessment#:#taxonomy_title#:#Taxonomy Title
 assessment#:#term#:#Term
 assessment#:#term_image#:#Term Image
 assessment#:#term_text#:#Term Text
@@ -2038,6 +2042,7 @@ assessment#:#unit_placeholder#:#** New Unit **
 assessment#:#units#:#Units
 assessment#:#unlimited#:#unlimited
 assessment#:#unlock#:#Unlock
+assessment#:#updated#:#Updated
 assessment#:#uploaded_material#:#Uploaded Material
 assessment#:#use_previous_solution#:#Use Previous Solution
 assessment#:#use_previous_solution_advice#:#The shown solution for the question is your previously given one. You have to confirm the adoption of the solution, if you like to use it without any change.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1548,6 +1548,7 @@ assessment#:#tst_input_dynamic_question_set_question_ordering_by_date#:#Order Qu
 assessment#:#tst_input_dynamic_question_set_question_ordering_by_tax#:#Order Questions by Taxonomy
 assessment#:#tst_input_dynamic_question_set_source_questionpool#:#Source Question Pool
 assessment#:#tst_input_dynamic_question_set_taxonomie_filter_enabled#:#Provide Taxonomy Filter
+assessment#:#tst_insert_in_test#:#Insert in Test
 assessment#:#tst_insert_missing_question#:#Please select at least one question to insert it into the test!
 assessment#:#tst_insert_questions#:#Are you sure you want to insert the following question(s) to the test?
 assessment#:#tst_instant_feedback#:#Instant Feedback

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -989,7 +989,6 @@ assessment#:#ordertext_info#:#Please enter the text that should be ordered horiz
 assessment#:#out_of_range#:#Out of range
 assessment#:#output#:#Output
 assessment#:#output_mode#:#Output Mode
-assessment#:#parent_title#:#Parent Object Title
 assessment#:#parseQuestion#:#Parse Question
 assessment#:#part_received_a_of_b_points#:#The participant received %s of %s possible points
 assessment#:#participants#:#Participants
@@ -1297,6 +1296,7 @@ assessment#:#test_question_set_type_random_info#:#Each test participant will see
 assessment#:#test_results#:#Summary Test Results
 assessment#:#test_scoring#:#Scoring Options
 assessment#:#test_template_reset#:#The template has been removed.
+assessment#:#test_title#:#Test Title
 assessment#:#test_using_template#:#This test uses the template %s. If you do not want to use a template and have access to all settings, please click here: %s.
 assessment#:#test_using_template_link#:#Do not use template anymore
 assessment#:#text_correct#:#Correct Text


### PR DESCRIPTION
This is the implentation of the Feature Wiki entry [New taxonomy filters to use taxonomies in the question selection for fixed tests](https://docu.ilias.de/go/wiki/wpage_8158_1357).

I believe all the requested features are implemented according to the Request.

### Important!
The filtering of the data is dependent on this https://github.com/ILIAS-eLearning/ILIAS/pull/7940 PR.