### PR TITLE
LegalDocuments: Add public api for tos and dpro

### DIFF
--- a/components/ILIAS/DataProtection/README.md
+++ b/components/ILIAS/DataProtection/README.md
@@ -1,0 +1,11 @@
+# DataProtection Service
+
+## Public API
+
+The public API of this service can be accessed in the followin way:
+
+```php
+$api = $DIC['legalDocuments']->provide(\ILIAS\DataProtection\Consumer::ID)->publicApi();
+```
+
+Additionally to the required interface the returned object is an instance of `ILIAS\LegalDocuments\ConsumerToolbox\ConsumerSlots\PublicApi`.

--- a/components/ILIAS/DataProtection/tests/ConsumerTest.php
+++ b/components/ILIAS/DataProtection/tests/ConsumerTest.php
@@ -61,10 +61,11 @@ class ConsumerTest extends TestCase
         $slot = $this->mock(UseSlot::class);
         $slot->expects(self::once())->method('hasDocuments')->willReturn($slot);
         $slot->expects(self::once())->method('hasHistory')->willReturn($slot);
+        $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
 
         $instance = new Consumer($container);
 
-        $instance->uses($slot, $this->mock(LazyProvide::class));
+        $this->assertSame($slot, $instance->uses($slot, $this->mock(LazyProvide::class)));
     }
 
     public function testUsesWithoutAcceptance(): void
@@ -93,10 +94,11 @@ class ConsumerTest extends TestCase
         $slot->expects(self::once())->method('showOnLoginPage')->willReturn($slot);
         $slot->expects(self::once())->method('showInFooter')->willReturn($slot);
         $slot->expects(self::once())->method('hasPublicPage')->willReturn($slot);
+        $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
 
         $instance = new Consumer($container);
 
-        $instance->uses($slot, $this->mock(LazyProvide::class));
+        $this->assertSame($slot, $instance->uses($slot, $this->mock(LazyProvide::class)));
     }
 
     public function testUses(): void
@@ -131,9 +133,11 @@ class ConsumerTest extends TestCase
         $slot->expects(self::once())->method('onSelfRegistration')->willReturn($slot);
         $slot->expects(self::once())->method('hasOnlineStatusFilter')->willReturn($slot);
         $slot->expects(self::once())->method('hasUserManagementFields')->willReturn($slot);
+        $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
+        $slot->expects(self::once())->method('canReadInternalMails')->willReturn($slot);
 
         $instance = new Consumer($container);
 
-        $instance->uses($slot, $this->mock(LazyProvide::class));
+        $this->assertSame($slot, $instance->uses($slot, $this->mock(LazyProvide::class)));
     }
 }

--- a/components/ILIAS/LegalDocuments/README.md
+++ b/components/ILIAS/LegalDocuments/README.md
@@ -126,7 +126,7 @@ The process will look like this:
 2. On the loggout page `WithdrawProcess::showValidatePasswordMessage` will be called and all returned components will be rendered.
 3. When the user is logging in again `WithdrawProcess::isOnGoing` should return `true`.
 4. As long as `WithdrawProcess::isOnGoing` returns `true` the user is redirected to a withdrawal GUI. There `WithdrawProcess::showWithdraw` will be called
-   and the returned `ILIAS\LegalDocument\PageFragemnt` will be rendered. To provide a form all commands to the given gui class will `WithdrawProcess::showWithdraw` again.
+   and the returned `ILIAS\LegalDocuments\PageFragemnt` will be rendered. To provide a form all commands to the given gui class will `WithdrawProcess::showWithdraw` again.
 5. When `WithdrawProcess::showWithdraw` calls `$DIC['legalDocuments']->provide('my-consumer')->withdrawal()->finishAndLogout()` the withdrawal is completed.
 6. After completion the user will be logged out and `WithdrawProcess::withdrawalFinished` is called on the `logout.php` page (the user is not available anymore).
 
@@ -157,7 +157,7 @@ To create the URL to the public page use: `$DIC['legalDocuments']->provide('my-c
 This is a hook. And a service.
 
 This will provide an informative page for logged out users.
-The callback will be called with a gui class and a command and must return a `ILIAS\LegalDocument\PageFragemnt` which will be rendered.
+The callback will be called with a gui class and a command and must return a `ILIAS\LegalDocuments\PageFragemnt` which will be rendered.
 
 To create the URL to the public page use: `$DIC['legalDocuments']->provide('my-consumer')->publicPage()->url()`.
 
@@ -206,28 +206,43 @@ This is a simple hook.
 The slot expects a `ILIAS\Refinery\Constraint`. The Constraint will receive a `ilObjUser`.
 When the user should not be able to use the soap API the constraint must reject the user.
 
+
+### UseSlot::hasPublicApi
+
+This is a simple hook.
+
+The slot expects an instance of `ILIAS\LegalDocuments\ConsumerSlots\PublicApi`.
+As this is the main entry point to access specific parts of the corresponding Consumer one is encouraged to add additional methods besides the ones defined in `ILIAS\LegalDocuments\ConsumerSlots\PublicApi`.
+The public API of a consumer can be accessed in the followin way:
+
+```php
+$api = $DIC['legalDocuments']->provide(Consumer::ID)->publicApi();
+```
+
+which will return the object given to `UseSlot::hasPublicApi`.
+
 ## 2. Administration
 
 The following classes can be used freely to create one's own administration:
 - `ilLegalDocumentsAdministrationGUI` A GUI to which can be redirected to.
-- `ILIAS\LegalDocument\Administration` A class which provides building blocks to create a administration
+- `ILIAS\LegalDocuments\Administration` A class which provides building blocks to create a administration
   (and which is used and accessible from and by `ilLegalDocumentsAdministrationGUI`)
-- `ILIAS\LegalDocument\Config` A wrapper to provide direct access to $DIC['legalDocuments']->provide('my-consumer')` and automatically handle write restrictions.
+- `ILIAS\LegalDocuments\Config` A wrapper to provide direct access to $DIC['legalDocuments']->provide('my-consumer')` and automatically handle write restrictions.
 
 Additionally with `ProvideDocument::table` and `ProvideHistory::table` a table can be created for the administration.
 
 ### 3. ConsumerToolbox
 
-The services TermsOfService and LegalDocument contain a lot of the same functionality.
+The services TermsOfService and LegalDocuments contain a lot of the same functionality.
 For that reason the ConsumerToolbox provides default implementations for many of the conumer slots as well as new interfaces which the default implementations require instead.
 
 The ConsumerToolbox can be used* when the service can implement the following 2 interfaces:
-- `ILIAS\LegalDocument\ConsumerToolbox\Setting`
-- `ILIAS\LegalDocument\ConsumerToolbox\UserSettings`
+- `ILIAS\LegalDocuments\ConsumerToolbox\Setting`
+- `ILIAS\LegalDocuments\ConsumerToolbox\UserSettings`
 
 (*) Parts of the ConsumerToolbox can still be used withoput these interfaces.
 
-To simplify the object creation, `ILIAS\LegalDocument\ConsumerToolbox\Blocks` can be used.
+To simplify the object creation, `ILIAS\LegalDocuments\ConsumerToolbox\Blocks` can be used.
 
 Here a dummy example to use the ConsumerToolbox to add slots:
 ```php

--- a/components/ILIAS/LegalDocuments/classes/ConsumerSlots/PublicApi.php
+++ b/components/ILIAS/LegalDocuments/classes/ConsumerSlots/PublicApi.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\LegalDocuments\ConsumerSlots;
+
+use ilObjUser;
+
+interface PublicApi
+{
+    public function active(): bool;
+    public function agreed(ilObjUser $user): bool;
+}

--- a/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/Agreement.php
+++ b/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/Agreement.php
@@ -85,7 +85,7 @@ final class Agreement implements AgreementInterface
     public function needsToAgree(): bool
     {
         return !$this->user->cannotAgree()
-            && ($this->user->neverAgreed() || $this->user->needsToAcceptNewDocument());
+            && $this->user->needsToAcceptNewDocument();
     }
 
     private function showDocument(): Component

--- a/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/PublicApi.php
+++ b/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/PublicApi.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\LegalDocuments\ConsumerToolbox\ConsumerSlots;
+
+use DateTimeImmutable;
+use ILIAS\LegalDocuments\ConsumerSlots\PublicApi as PublicApiInterface;
+use ILIAS\LegalDocuments\ConsumerToolbox\User;
+use ilObjUser;
+use WeakMap;
+use Closure;
+
+class PublicApi implements PublicApiInterface
+{
+    /**
+     * @var WeakMap<ilObjUser, User>
+     */
+    private readonly WeakMap $cache;
+
+    public function __construct(private readonly bool $active, private readonly Closure $build_user)
+    {
+        $this->cache = new WeakMap();
+    }
+
+    /**
+     * Returns wether or not the corresponding consumer is active.
+     * Please note that this doesn't influence the other methods.
+     */
+    public function active(): bool
+    {
+        return $this->active;
+    }
+
+    public function agreed(ilObjUser $user): bool
+    {
+        return $this->everAgreed($user);
+    }
+
+    public function agreedToCurrentlyMatchingDocument(ilObjUser $user): bool
+    {
+        return !$this->user($user)->needsToAcceptNewDocument();
+    }
+
+    public function everAgreed(ilObjUser $user): bool
+    {
+        return !$this->user($user)->neverAgreed();
+    }
+
+    public function canAgree(ilObjUser $user): bool
+    {
+        return !$this->user($user)->cannotAgree();
+    }
+
+    public function needsToAgree(ilObjUser $user): bool
+    {
+        return !$this->canAgree($user)
+            && $this->user($user)->needsToAcceptNewDocument();
+    }
+
+    public function agreeDate(ilObjUser $user): ?DateTimeImmutable
+    {
+        return $this->user($user)->agreeDate()->value();
+    }
+
+    private function user(ilObjUser $user): User
+    {
+        if (!isset($this->cache[$user])) {
+            $this->cache[$user] = ($this->build_user)($user);
+        }
+
+        return $this->cache[$user];
+    }
+}

--- a/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/User.php
+++ b/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/User.php
@@ -86,6 +86,10 @@ class User
 
     public function needsToAcceptNewDocument(): bool
     {
+        if ($this->neverAgreed()) {
+            return true;
+        }
+
         $true = fn() => new Ok(true);
         $db = $this->legal_documents->history();
 

--- a/components/ILIAS/LegalDocuments/classes/LazyProvide.php
+++ b/components/ILIAS/LegalDocuments/classes/LazyProvide.php
@@ -25,6 +25,7 @@ use ILIAS\LegalDocuments\Provide\ProvidePublicPage;
 use ILIAS\LegalDocuments\Provide\ProvideDocument;
 use ILIAS\LegalDocuments\Provide\ProvideHistory;
 use ILIAS\LegalDocuments\Provide\ProvideWithdrawal;
+use ILIAS\LegalDocuments\ConsumerSlots\PublicApi;
 
 class LazyProvide extends Provide
 {
@@ -66,5 +67,15 @@ class LazyProvide extends Provide
     public function allowEditing(): Provide
     {
         return ($this->provide)()->allowEditing();
+    }
+
+    public function publicApi(): ?PublicApi
+    {
+        return ($this->provide)()->publicApi();
+    }
+
+    public function id(): string
+    {
+        return ($this->provide)()->id();
     }
 }

--- a/components/ILIAS/LegalDocuments/classes/Provide.php
+++ b/components/ILIAS/LegalDocuments/classes/Provide.php
@@ -26,6 +26,7 @@ use ILIAS\LegalDocuments\Provide\ProvidePublicPage;
 use ILIAS\LegalDocuments\Provide\ProvideDocument;
 use ILIAS\LegalDocuments\Provide\ProvideHistory;
 use ILIAS\LegalDocuments\Provide\ProvideWithdrawal;
+use ILIAS\LegalDocuments\ConsumerSlots\PublicApi;
 
 class Provide
 {
@@ -66,6 +67,11 @@ class Provide
     public function allowEditing(): self
     {
         return new self($this->id, $this->internal, $this->container, 'writable-document');
+    }
+
+    public function publicApi(): ?PublicApi
+    {
+        return $this->internal->get('public-api', $this->id);
     }
 
     public function id(): string

--- a/components/ILIAS/LegalDocuments/classes/UseSlot.php
+++ b/components/ILIAS/LegalDocuments/classes/UseSlot.php
@@ -24,6 +24,7 @@ use ILIAS\LegalDocuments\ConsumerSlots\Agreement;
 use ILIAS\LegalDocuments\ConsumerSlots\CriterionToCondition;
 use ILIAS\LegalDocuments\ConsumerSlots\SelfRegistration;
 use ILIAS\LegalDocuments\ConsumerSlots\WithdrawProcess;
+use ILIAS\LegalDocuments\ConsumerSlots\PublicApi;
 use ILIAS\Refinery\Constraint;
 use ILIAS\UI\Component\MainControls\Footer;
 use ilObjUser;
@@ -72,4 +73,5 @@ interface UseSlot
     public function onSelfRegistration(SelfRegistration $self_registration): self;
     public function canReadInternalMails(Constraint $constraint): self;
     public function canUseSoapApi(Constraint $constraint): self;
+    public function hasPublicApi(PublicApi $api): self;
 }

--- a/components/ILIAS/LegalDocuments/classes/Wiring.php
+++ b/components/ILIAS/LegalDocuments/classes/Wiring.php
@@ -30,6 +30,7 @@ use ILIAS\LegalDocuments\GotoLink\ConditionalGotoLink;
 use ILIAS\LegalDocuments\ConsumerSlots\Agreement;
 use ILIAS\LegalDocuments\ConsumerSlots\SelfRegistration;
 use ILIAS\LegalDocuments\ConsumerSlots\WithdrawProcess;
+use ILIAS\LegalDocuments\ConsumerSlots\PublicApi;
 use ILIAS\LegalDocuments\Provide\Document;
 use ILIAS\LegalDocuments\Provide\History;
 use ILIAS\LegalDocuments\Value\Target;
@@ -138,6 +139,11 @@ class Wiring implements UseSlot
     public function hasUserManagementFields(callable $field_value): self
     {
         return $this->addTo('user-management-fields', $this->slot->id(), $field_value);
+    }
+
+    public function hasPublicApi(PublicApi $api): self
+    {
+        return $this->addTo('public-api', $this->slot->id(), $api);
     }
 
     public function map(): Map

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/AgreementTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/AgreementTest.php
@@ -98,7 +98,6 @@ class AgreementTest extends TestCase
         $instance = new Agreement(
             $this->mockTree(User::class, [
                 'cannotAgree' => true,
-                'neverAgreed' => true,
                 'didNotAcceptCurrentVersion' => true,
             ]),
             $this->mock(Settings::class),
@@ -110,30 +109,12 @@ class AgreementTest extends TestCase
         $this->assertFalse($instance->needsToAgree());
     }
 
-    public function testNeverAgreed(): void
-    {
-        $instance = new Agreement(
-            $this->mockTree(User::class, [
-                'cannotAgree' => false,
-                'neverAgreed' => false,
-                'needsToAcceptNewDocument' => true,
-            ]),
-            $this->mock(Settings::class),
-            $this->mock(UI::class),
-            $this->mock(Routing::class),
-            $this->fail(...)
-        );
-
-        $this->assertTrue($instance->needsToAgree());
-    }
-
     public function testDidNotAcceptCurrentVersion(): void
     {
         $instance = new Agreement(
             $this->mockTree(User::class, [
                 'cannotAgree' => false,
-                'neverAgreed' => true,
-                'needsToAcceptNewDocument' => false,
+                'needsToAcceptNewDocument' => true,
             ]),
             $this->mock(Settings::class),
             $this->mock(UI::class),

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/PublicApiTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/ConsumerSlots/PublicApiTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\LegalDocuments\test\ConsumerToolbox\ConsumerSlots;
+
+use DateTimeImmutable;
+use ilObjUser;
+use ILIAS\LegalDocuments\ConsumerToolbox\User;
+use ILIAS\LegalDocuments\test\ContainerMock;
+use ILIAS\LegalDocuments\ConsumerToolbox\ConsumerSlots\PublicApi;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../ContainerMock.php';
+
+class PublicApiTest extends TestCase
+{
+    use ContainerMock;
+
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(PublicApi::class, new PublicApi(false, $this->fail(...)));
+    }
+
+    public function testActive(): void
+    {
+        $this->assertTrue((new PublicApi(true, $this->fail(...)))->active());
+        $this->assertFalse((new PublicApi(false, $this->fail(...)))->active());
+    }
+
+    public function testAgreed(): void
+    {
+        $this->assertTrueFalseForMethod('agreed', fn(bool $b) => ['neverAgreed' => !$b]);
+    }
+
+    public function testEverAgreed(string $method = 'everAgreed'): void
+    {
+        $this->assertTrueFalseForMethod('agreed', fn(bool $b) => ['neverAgreed' => !$b]);
+    }
+
+    public function testAgreedToCurrentlyMatchingDocument(): void
+    {
+        $this->assertTrueFalseForMethod('agreedToCurrentlyMatchingDocument', fn(bool $b) => [
+            'needsToAcceptNewDocument' => !$b,
+        ]);
+    }
+
+    public function testCanAgree(): void
+    {
+        $this->assertTrueFalseForMethod('canAgree', fn(bool $b) => [
+            'cannotAgree' => !$b,
+        ]);
+    }
+
+    public function testNeedsToAgree(): void
+    {
+        $this->assertSameValues('needsToAgree', [
+            [true,  ['cannotAgree' => true, 'needsToAcceptNewDocument' => true]],
+            [false, ['cannotAgree' => false, 'needsToAcceptNewDocument' => true]],
+            [false, ['cannotAgree' => true, 'needsToAcceptNewDocument' => false]],
+            [false, ['cannotAgree' => false, 'needsToAcceptNewDocument' => false]],
+        ]);
+    }
+
+    public function testAgreeDate(): void
+    {
+        $d = new DateTimeImmutable();
+        $this->assertSameValues('agreeDate', [
+            [$d, ['agreeDate' => ['value' => $d]]],
+            [null, ['agreeDate' => ['value' => null]]],
+        ]);
+    }
+
+    private function assertTrueFalseForMethod(string $method, callable $dpro_user_tree)
+    {
+        $this->assertSameValues($method, [
+            [true, $dpro_user_tree(true)],
+            [false, $dpro_user_tree(false)]
+        ]);
+    }
+
+    private function assertSameValues(string $method, array $compare): void
+    {
+        $user = $this->mock(ilObjUser::class);
+        $dpro_user = fn($ret) => $this->mockTree(User::class, $dpro_user_tree($ret));
+
+        foreach ($compare as $pair) {
+            $this->assertSame($pair[0], (new PublicApi(true, fn() => $this->mockTree(User::class, $pair[1])))->$method($user));
+        }
+    }
+}

--- a/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/UserTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConsumerToolbox/UserTest.php
@@ -169,6 +169,19 @@ class UserTest extends TestCase
         $this->assertTrue($instance->didNotAcceptCurrentVersion());
     }
 
+    public function testNeedsToAcceptNewDocumentWhereNeverAgreed(): void
+    {
+        $instance = new User(
+            $this->mock(ilObjUser::class),
+            $this->mock(Settings::class),
+            $this->mockTree(UserSettings::class, ['agreeDate' => ['value' => null]]),
+            $this->mock(Provide::class),
+            $this->mock(Clock::class)
+        );
+
+        $this->assertTrue($instance->needsToAcceptNewDocument());
+    }
+
     public function testNeedsToAcceptNewDocumentReturnsTrue(): void
     {
         $user = $this->mock(ilObjUser::class);
@@ -177,7 +190,7 @@ class UserTest extends TestCase
         $instance = new User(
             $user,
             $this->mockTree(Settings::class, ['validateOnLogin' => ['value' => true]]),
-            $this->mock(UserSettings::class),
+            $this->mockTree(UserSettings::class, ['agreeDate' => ['value' => new DateTimeImmutable()]]),
             $this->mockTree(Provide::class, ['history' => $history]),
             $this->mock(Clock::class)
         );
@@ -194,7 +207,7 @@ class UserTest extends TestCase
         $instance = new User(
             $user,
             $this->mockTree(Settings::class, ['validateOnLogin' => ['value' => true]]),
-            $this->mock(UserSettings::class),
+            $this->mockTree(UserSettings::class, ['agreeDate' => ['value' => new DateTimeImmutable()]]),
             $this->mockTree(Provide::class, [
                 'document' => $this->mockMethod(ProvideDocument::class, 'documentMatches', [$document, $user], true),
                 'history' => $history,

--- a/components/ILIAS/LegalDocuments/tests/ContainerMock.php
+++ b/components/ILIAS/LegalDocuments/tests/ContainerMock.php
@@ -60,6 +60,7 @@ trait ContainerMock
         foreach ($tree as $name => $value) {
             $type = (string) $r->getMethod($name)->getReturnType();
             $type = $type === 'self' ? $class : $type;
+            $type = preg_replace('/^\?/', '', $type);
             $mock->method($name)->willReturn(
                 class_exists($type) || interface_exists($type) ?
                 (is_array($value) ? $this->mockTree($type, $value) : $value) :

--- a/components/ILIAS/LegalDocuments/tests/LazyProvideTest.php
+++ b/components/ILIAS/LegalDocuments/tests/LazyProvideTest.php
@@ -39,10 +39,10 @@ class LazyProvideTest extends TestCase
     /**
      * @dataProvider methods
      */
-    public function testMethods(string $method): void
+    public function testMethods(string $method, $return = []): void
     {
         $called = false;
-        $provide = $this->mockTree(Provide::class, [$method => []]);
+        $provide = $this->mockTree(Provide::class, [$method => $return]);
 
         $create = function () use (&$called, $provide) {
             $called = true;
@@ -63,6 +63,8 @@ class LazyProvideTest extends TestCase
             ['document'],
             ['history'],
             ['allowEditing'],
+            ['publicApi'],
+            ['id', ''],
         ];
     }
 }

--- a/components/ILIAS/LegalDocuments/tests/ProvideTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ProvideTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\LegalDocuments\test;
 
+use ILIAS\LegalDocuments\ConsumerSlots\PublicApi;
 use ILIAS\LegalDocuments\Provide\ProvideHistory;
 use ILIAS\LegalDocuments\Provide\ProvidePublicPage;
 use ILIAS\LegalDocuments\Provide\ProvideDocument;
@@ -107,6 +108,16 @@ class ProvideTest extends TestCase
         $instance = new Provide('foo', $internal, $this->mock(Container::class));
         $instance->document();
         $instance->allowEditing()->document();
+    }
+
+    public function testPublicApi(): void
+    {
+        $public_api = $this->mock(PublicApi::class);
+        $internal = $this->mockMethod(Internal::class, 'get', ['public-api', 'foo'], $public_api);
+
+        $instance = new Provide('foo', $internal, $this->mock(Container::class));
+
+        $this->assertSame($public_api, $instance->publicApi());
     }
 
     public function testId(): void

--- a/components/ILIAS/LegalDocuments/tests/WiringTest.php
+++ b/components/ILIAS/LegalDocuments/tests/WiringTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\LegalDocuments\test;
 
+use ILIAS\LegalDocuments\ConsumerSlots\PublicApi;
 use ILIAS\Refinery\Constraint;
 use ILIAS\LegalDocuments\ConsumerSlots\SelfRegistration;
 use ILIAS\LegalDocuments\Provide\ProvideDocument;
@@ -184,6 +185,19 @@ class WiringTest extends TestCase
         );
 
         $this->assertSame($map, $instance->hasUserManagementFields($proc)->map());
+    }
+
+    public function testHasPublicApi(): void
+    {
+        $map = $this->mock(Map::class);
+        $public_api = $this->mock(PublicApi::class);
+
+        $instance = new Wiring(
+            $this->mockTree(SlotConstructor::class, ['id' => 'foo']),
+            $this->mockMethod(Map::class, 'set', ['public-api', 'foo', $public_api], $map)
+        );
+
+        $this->assertSame($map, $instance->hasPublicApi($public_api)->map());
     }
 
     public function testMap(): void

--- a/components/ILIAS/TermsOfService/README.md
+++ b/components/ILIAS/TermsOfService/README.md
@@ -1,0 +1,11 @@
+# TermsOfService Service
+
+## Public API
+
+The public API of this service can be accessed in the followin way:
+
+```php
+$api = $DIC['legalDocuments']->provide(\ILIAS\TermsOfService\Consumer::ID)->publicApi();
+```
+
+Additionally to the required interface the returned object is an instance of `ILIAS\LegalDocuments\ConsumerToolbox\ConsumerSlots\PublicApi`.

--- a/components/ILIAS/TermsOfService/tests/ConsumerTest.php
+++ b/components/ILIAS/TermsOfService/tests/ConsumerTest.php
@@ -61,6 +61,7 @@ class ConsumerTest extends TestCase
         $slot = $this->mock(UseSlot::class);
         $slot->expects(self::once())->method('hasDocuments')->willReturn($slot);
         $slot->expects(self::once())->method('hasHistory')->willReturn($slot);
+        $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
 
         $instance = new Consumer($container);
 
@@ -89,6 +90,7 @@ class ConsumerTest extends TestCase
         $slot->expects(self::once())->method('onSelfRegistration')->willReturn($slot);
         $slot->expects(self::once())->method('hasOnlineStatusFilter')->willReturn($slot);
         $slot->expects(self::once())->method('hasUserManagementFields')->willReturn($slot);
+        $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
 
         $instance = new Consumer($container);
 


### PR DESCRIPTION
This PR adds a public API for the `TermsOfService` and `DataProtection`.

The API defined will be accessible via:
`$DIC['legalDocuments']->provide(\ILIAS\DataProtection|TermsOfService\Consumer::ID)->publicApi()`
and exposes the following methods:

```php
public function active(): bool;
public function agreed(ilObjUser $user): bool;
public function agreedToCurrentlyMatchingDocument(ilObjUser $user): bool;
public function everAgreed(ilObjUser $user): bool;
public function canAgree(ilObjUser $user): bool;
public function needsToAgree(ilObjUser $user): bool;
public function agreeDate(ilObjUser $user): ?DateTimeImmutable;
```