### PR TITLE
Chatroom: Remove unused dependency node-mysql

### DIFF
--- a/components/ILIAS/Chatroom/chat/package-lock.json
+++ b/components/ILIAS/Chatroom/chat/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "async": "3.2",
         "mysql": "^2.18.1",
-        "node-mysql": "^0.4.2",
         "node-schedule": "^2.1.0",
         "node-uuid": "^1.4.8",
         "socket.io": "^4.6.1",
@@ -91,11 +90,6 @@
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
-    },
-    "node_modules/better-js-class": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/better-js-class/-/better-js-class-0.1.3.tgz",
-      "integrity": "sha512-EMgtYym2RSQ75pUfOqKmCDL5EKur62Ec83aggzkJ942RM/mwskb6QDLaJJz93EwSK1dsfkPUFe+nlmxEbtBKDQ=="
     },
     "node_modules/bignumber.js": {
       "version": "9.0.0",
@@ -179,11 +173,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/cps": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cps/-/cps-1.0.2.tgz",
-      "integrity": "sha512-kFE6vY9PBrN1sogxTxWa8ktnmfcKeR2I7+8tQgxqWndSgToerwITuprBs4FeQWEeMf+IGxo+ILixT/RK0wcIPQ=="
     },
     "node_modules/cron-parser": {
       "version": "3.5.0",
@@ -529,17 +518,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-mysql": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/node-mysql/-/node-mysql-0.4.2.tgz",
-      "integrity": "sha512-V/AVfW/d47Wsb2c8AfEu9Q8PiHUG7/3SbDJ03HFycMMrlKSXj5bNItnHgjSSA6N60/1JXmhoJYXJESSS5BYV9A==",
-      "dependencies": {
-        "better-js-class": "*",
-        "cps": "*",
-        "mysql": "*",
-        "underscore": "*"
-      }
-    },
     "node_modules/node-schedule": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.0.tgz",
@@ -734,11 +712,6 @@
       "engines": {
         "node": ">= 14.0.0"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/components/ILIAS/Chatroom/chat/package.json
+++ b/components/ILIAS/Chatroom/chat/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "async": "3.2",
     "mysql": "^2.18.1",
-    "node-mysql": "^0.4.2",
     "node-schedule": "^2.1.0",
     "node-uuid": "^1.4.8",
     "socket.io": "^4.6.1",


### PR DESCRIPTION
This PR removes the unused node dependency `node-mysql` from the dependency list of the Chatroom.