### PR TITLE
[FIX] use `\ILIAS\Language\Language` instead of `\ilLanguage`

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Duration.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Duration.php
@@ -29,7 +29,7 @@ use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use DateTimeImmutable;
 use Closure;
-use ilLanguage;
+use ILIAS\Language\Language;
 
 /**
  * This implements the duration input group.
@@ -49,7 +49,7 @@ class Duration extends Group implements C\Input\Field\Duration
     public function __construct(
         DataFactory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
-        ilLanguage $lng,
+        Language $lng,
         Factory $field_factory,
         string $label,
         ?string $byline

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
@@ -26,7 +26,7 @@ use ILIAS\UI\Component\Input\Container\Form\FormInput;
 use ILIAS\UI\Component\Input\Field as I;
 use ILIAS\UI\Component\Input\Field\UploadHandler;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
-use ilLanguage;
+use ILIAS\Language\Language;
 
 /**
  * Class Factory
@@ -39,14 +39,14 @@ class Factory implements I\Factory
     protected Data\Factory $data_factory;
     protected SignalGeneratorInterface $signal_generator;
     private \ILIAS\Refinery\Factory $refinery;
-    protected ilLanguage $lng;
+    protected Language $lng;
 
     public function __construct(
         UploadLimitResolver $upload_limit_resolver,
         SignalGeneratorInterface $signal_generator,
         Data\Factory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
-        ilLanguage $lng
+        Language $lng,
     ) {
         $this->upload_limit_resolver = $upload_limit_resolver;
         $this->signal_generator = $signal_generator;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
@@ -28,7 +28,7 @@ use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Component as C;
 use ILIAS\Refinery\Constraint;
 use Closure;
-use ilLanguage;
+use ILIAS\Language\Language;
 
 /**
  * Class File
@@ -50,7 +50,7 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
     protected int $max_file_size_in_bytes;
 
     public function __construct(
-        ilLanguage $language,
+        Language $language,
         DataFactory $data_factory,
         Refinery $refinery,
         UploadLimitResolver $upload_limit_resolver,

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Group.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Group.php
@@ -27,7 +27,7 @@ use ILIAS\UI\Implementation\Component\Input\GroupInternal;
 use ILIAS\UI\Implementation\Component\Input\Group as GroupInternals;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\Data\Factory as DataFactory;
-use ilLanguage;
+use ILIAS\Language\Language;
 use ILIAS\Refinery\Constraint;
 use Closure;
 use ILIAS\Data\Result\Ok;
@@ -47,7 +47,7 @@ class Group extends FormInput implements C\Input\Field\Group, GroupInternal
     public function __construct(
         DataFactory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
-        protected ilLanguage $lng,
+        protected Language $lng,
         array $inputs,
         string $label,
         ?string $byline = null
@@ -142,7 +142,7 @@ class Group extends FormInput implements C\Input\Field\Group, GroupInternal
         $this->error = $error;
     }
 
-    protected function getLanguage(): \ilLanguage
+    protected function getLanguage(): Language
     {
         return $this->lng;
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/HasDynamicInputsBase.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/HasDynamicInputsBase.php
@@ -30,7 +30,7 @@ use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
 use InvalidArgumentException;
 use LogicException;
-use ilLanguage;
+use ILIAS\Language\Language;
 
 /**
  * @author Thibeau Fuhrer <thf@studer-raimann.ch>
@@ -46,10 +46,10 @@ abstract class HasDynamicInputsBase extends FormInput implements HasDynamicInput
      */
     protected array $dynamic_inputs = [];
     protected FormInputInterface $dynamic_input_template;
-    protected ilLanguage $language;
+    protected Language $language;
 
     public function __construct(
-        ilLanguage $language,
+        Language $language,
         DataFactory $data_factory,
         Refinery $refinery,
         string $label,

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Link.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Link.php
@@ -23,7 +23,7 @@ use ILIAS\UI\Component as C;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\URI;
 use ILIAS\Refinery\Constraint;
-use ilLanguage;
+use ILIAS\Language\Language;
 
 /**
  * This implements the link input group.
@@ -33,7 +33,7 @@ class Link extends Group implements C\Input\Field\Link
     public function __construct(
         DataFactory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
-        ilLanguage $lng,
+        Language $lng,
         Factory $field_factory,
         string $label,
         ?string $byline
@@ -51,7 +51,7 @@ class Link extends Group implements C\Input\Field\Link
     protected function addValidation(): void
     {
         $txt_id = 'label_cannot_be_empty_if_url_is_set';
-        $error = fn (callable $txt, $value) => $txt($txt_id, $value);
+        $error = fn(callable $txt, $value) => $txt($txt_id, $value);
         $is_ok = function ($v) {
             list($label, $url) = $v;
             return (

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -26,7 +26,7 @@ use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Implementation\Component\Triggerer;
 use ILIAS\UI\Implementation\Component\Input\InputData;
 use ILIAS\UI\Component\Input\Field as I;
-use ilLanguage;
+use ILIAS\Language\Language;
 use LogicException;
 use InvalidArgumentException;
 
@@ -44,7 +44,7 @@ class SwitchableGroup extends Group implements I\SwitchableGroup
     public function __construct(
         DataFactory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
-        ilLanguage $lng,
+        Language $lng,
         array $inputs,
         string $label,
         ?string $byline = null

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Group.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Group.php
@@ -25,6 +25,7 @@ use ILIAS\Refinery\Constraint;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\Result;
 use ILIAS\Data\Result\Ok;
+use ILIAS\Language\Language;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
@@ -172,7 +173,7 @@ trait Group
      */
     abstract protected function setError(string $error): void;
 
-    abstract protected function getLanguage(): \ilLanguage;
+    abstract protected function getLanguage(): Language;
 
     abstract protected function getDataFactory(): DataFactory;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Factory.php
@@ -25,6 +25,7 @@ use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Implementation\Component\Input\Field\Factory as FieldFactory;
+use ILIAS\Language\Language;
 
 /**
  * Factory for View Controls
@@ -36,7 +37,7 @@ class Factory implements VCInterface\Factory
         protected DataFactory $data_factory,
         protected Refinery $refinery,
         protected SignalGeneratorInterface $signal_generator,
-        protected \ilLanguage $language,
+        protected Language $language,
     ) {
     }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Group.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Group.php
@@ -25,6 +25,7 @@ use ILIAS\UI\Implementation\Component\Input\GroupInternal;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
 use ILIAS\UI\Implementation\Component\Input\Input;
 use ILIAS\UI\Implementation\Component\Input\Group as GroupInternals;
+use ILIAS\Language\Language;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\Result\Ok;
@@ -41,7 +42,7 @@ class Group extends ViewControlInput implements ViewControlGroupInterface, Group
     public function __construct(
         DataFactory $data_factory,
         Refinery $refinery,
-        protected \ilLanguage $language,
+        protected Language $language,
         array $inputs,
     ) {
         parent::__construct($data_factory, $refinery);
@@ -86,7 +87,7 @@ class Group extends ViewControlInput implements ViewControlGroupInterface, Group
         $this->error = $error;
     }
 
-    protected function getLanguage(): \ilLanguage
+    protected function getLanguage(): Language
     {
         return $this->language;
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Boolean.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Boolean.php
@@ -25,11 +25,12 @@ use ILIAS\UI\Component\Symbol\Icon\Icon;
 use ILIAS\UI\Component\Symbol\Glyph\Glyph;
 use ILIAS\UI\Component\Symbol\Symbol;
 use ILIAS\UI\Component\Component;
+use ILIAS\Language\Language;
 
 class Boolean extends Column implements C\Boolean
 {
     public function __construct(
-        protected \ilLanguage $lng,
+        protected Language $lng,
         string $title,
         protected string|Icon|Glyph $true_option,
         protected string|Icon|Glyph $false_option

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Column.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Column.php
@@ -23,6 +23,7 @@ namespace ILIAS\UI\Implementation\Component\Table\Column;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\UI\Component\Table\Column as C;
 use ILIAS\UI\Component\Component;
+use ILIAS\Language\Language;
 
 abstract class Column implements C\Column
 {
@@ -39,7 +40,7 @@ abstract class Column implements C\Column
     protected ?string $desc_label = null;
 
     public function __construct(
-        protected \ilLanguage $lng,
+        protected Language $lng,
         protected string $title
     ) {
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Date.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Date.php
@@ -22,11 +22,12 @@ namespace ILIAS\UI\Implementation\Component\Table\Column;
 
 use ILIAS\UI\Component\Table\Column as C;
 use ILIAS\Data\DateFormat\DateFormat;
+use ILIAS\Language\Language;
 
 class Date extends Column implements C\Date
 {
     public function __construct(
-        \ilLanguage $lng,
+        Language $lng,
         string $title,
         protected DateFormat $format
     ) {

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Factory.php
@@ -23,11 +23,12 @@ namespace ILIAS\UI\Implementation\Component\Table\Column;
 use ILIAS\UI\Component\Table\Column as I;
 use ILIAS\UI\Component\Symbol\Icon\Icon;
 use ILIAS\UI\Component\Symbol\Glyph\Glyph;
+use ILIAS\Language\Language;
 
 class Factory implements I\Factory
 {
     public function __construct(
-        protected \ilLanguage $lng
+        protected Language $lng
     ) {
     }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/TimeSpan.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/TimeSpan.php
@@ -22,11 +22,12 @@ namespace ILIAS\UI\Implementation\Component\Table\Column;
 
 use ILIAS\UI\Component\Table\Column as C;
 use ILIAS\Data\DateFormat\DateFormat;
+use ILIAS\Language\Language;
 
 class TimeSpan extends Column implements C\TimeSpan
 {
     public function __construct(
-        \ilLanguage $lng,
+        Language $lng,
         string $title,
         protected DateFormat $format
     ) {

--- a/components/ILIAS/UI/src/Implementation/Render/AbstractComponentRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Render/AbstractComponentRenderer.php
@@ -27,7 +27,7 @@ use ILIAS\UI\Component\Triggerer;
 use ILIAS\UI\Factory;
 use ILIAS\UI\HelpTextRetriever;
 use ILIAS\UI\Help;
-use ilLanguage;
+use ILIAS\Language\Language;
 use InvalidArgumentException;
 use LogicException;
 use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
@@ -46,7 +46,7 @@ abstract class AbstractComponentRenderer implements ComponentRenderer, HelpTextR
     final public function __construct(
         private Factory $ui_factory,
         private TemplateFactory $tpl_factory,
-        private ilLanguage $lng,
+        private Language $lng,
         private JavaScriptBinding $js_binding,
         private ImagePathResolver $image_path_resolver,
         private DataFactory $data_factory,

--- a/components/ILIAS/UI/src/Implementation/Render/DefaultRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Render/DefaultRendererFactory.php
@@ -25,7 +25,7 @@ use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Factory as RootFactory;
 use ILIAS\UI\HelpTextRetriever;
-use ilLanguage;
+use ILIAS\Language\Language;
 use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 class DefaultRendererFactory implements RendererFactory
@@ -33,7 +33,7 @@ class DefaultRendererFactory implements RendererFactory
     public function __construct(
         protected RootFactory $ui_factory,
         protected TemplateFactory $tpl_factory,
-        protected ilLanguage $lng,
+        protected Language $lng,
         protected JavaScriptBinding $js_binding,
         protected ImagePathResolver $image_path_resolver,
         protected DataFactory $data_factory,

--- a/components/ILIAS/UI/tests/Base.php
+++ b/components/ILIAS/UI/tests/Base.php
@@ -160,7 +160,7 @@ class LoggingRegistry implements ResourceRegistry
     }
 }
 
-class ilLanguageMock extends ilLanguage
+class LanguageMock extends ilLanguage
 {
     public array $requested = array();
 
@@ -346,9 +346,9 @@ trait BaseUITestTrait
         return new LoggingRegistry();
     }
 
-    public function getLanguage(): ilLanguageMock
+    public function getLanguage(): LanguageMock
     {
-        return new ilLanguageMock();
+        return new LanguageMock();
     }
 
     public function getJavaScriptBinding(): LoggingJavaScriptBinding

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterFactoryTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterFactoryTest.php
@@ -39,7 +39,7 @@ class FilterFactoryTest extends AbstractFactoryTestCase
     final public function buildFactory(): Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new Factory(
             new SignalGenerator(),
             new \ILIAS\UI\Implementation\Component\Input\Field\Factory(

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
@@ -74,7 +74,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
     protected function buildInputFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new I\SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterTest.php
@@ -101,10 +101,10 @@ class ConcreteFilter extends Filter
     }
 
     // TODO: DW perhaps, this can be removed
-//    public function _getInput(ServerRequestInterface $request)
-//    {
-//        return $this->getInput($request);
-//    }
+    //    public function _getInput(ServerRequestInterface $request)
+    //    {
+    //        return $this->getInput($request);
+    //    }
 }
 
 /**
@@ -123,7 +123,7 @@ class FilterTest extends ILIAS_UI_TestBase
     protected function buildInputFactory(): Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new ILIAS\UI\Implementation\Component\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/StandardFilterTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/StandardFilterTest.php
@@ -90,7 +90,7 @@ class StandardFilterTest extends ILIAS_UI_TestBase
     protected function buildInputFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new I\SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/FormFactoryTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/FormFactoryTest.php
@@ -39,7 +39,7 @@ class FormFactoryTest extends AbstractFactoryTestCase
     final public function buildFactory(): I\Container\Form\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Container\Form\Factory(
             new I\Field\Factory(
                 $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/FormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/FormTest.php
@@ -85,7 +85,7 @@ class ConcreteForm extends Form
 class FormTest extends ILIAS_UI_TestBase
 {
     /**
-     * @var ilLanguage|mixed|MockObject
+     * @var ILIAS\Language\Language|mixed|MockObject
      */
     protected $language;
     protected array $inputs;
@@ -98,7 +98,7 @@ class FormTest extends ILIAS_UI_TestBase
     protected function buildInputFactory(): Input\Field\Factory
     {
         $df = new Data\Factory();
-        $this->language = $this->createMock(ilLanguage::class);
+        $this->language = $this->createMock(ILIAS\Language\Language::class);
         return new Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
@@ -116,7 +116,7 @@ class FormTest extends ILIAS_UI_TestBase
     protected function buildTransformation(Closure $trafo): Transformation
     {
         $dataFactory = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         $refinery = new Refinery($dataFactory, $language);
 
         return $refinery->custom()->transformation($trafo);

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/NoSubmitFormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/NoSubmitFormTest.php
@@ -25,6 +25,7 @@ use ILIAS\UI\Component\Input\Container\Form\Factory as FormFactory;
 use ILIAS\UI\Component\Input\Field\Factory as InputFactory;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Language\Language;
 use Psr\Http\Message\ServerRequestInterface;
 
 require_once(__DIR__ . "/../../../../Base.php");
@@ -58,7 +59,7 @@ class NoSubmitFormTest extends \ILIAS_UI_TestBase
     protected SignalGenerator $signal_generator;
     protected NameSource $namesource;
     protected Refinery $refinery;
-    protected \ilLanguageMock $language;
+    protected Language $language;
 
     public function setUp(): void
     {

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/StandardFormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/StandardFormTest.php
@@ -79,7 +79,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
     protected function buildInputFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),
@@ -230,7 +230,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
     {
         $r = $this->getDefaultRenderer();
         $df = new Data\Factory();
-        $language = $this->createMock(\ilLanguage::class);
+        $language = $this->createMock(\ILIAS\Language\Language::class);
         $language
             ->expects($this->once())
             ->method("txt")
@@ -296,7 +296,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
     {
         $r = $this->getDefaultRenderer();
         $df = new Data\Factory();
-        $language = $this->createMock(\ilLanguage::class);
+        $language = $this->createMock(\ILIAS\Language\Language::class);
         $refinery = new \ILIAS\Refinery\Factory($df, $language);
 
         $if = new ILIAS\UI\Implementation\Component\Input\Field\Factory(

--- a/components/ILIAS/UI/tests/Component/Input/Container/ViewControl/ViewControlContainerTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/ViewControl/ViewControlContainerTest.php
@@ -42,7 +42,7 @@ class ViewControlContainerTest extends ILIAS_UI_TestBase
     {
         return new Refinery(
             $this->buildDataFactory(),
-            $this->createMock(ilLanguage::class)
+            $this->createMock(ILIAS\Language\Language::class)
         );
     }
     protected function buildContainerFactory(): VC\Factory

--- a/components/ILIAS/UI/tests/Component/Input/Field/CheckboxInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/CheckboxInputTest.php
@@ -37,13 +37,13 @@ class CheckboxInputTest extends ILIAS_UI_TestBase
     public function setUp(): void
     {
         $this->name_source = new DefNamesource();
-        $this->refinery = new Refinery($this->createMock(Data\Factory::class), $this->createMock(ilLanguage::class));
+        $this->refinery = new Refinery($this->createMock(Data\Factory::class), $this->createMock(ILIAS\Language\Language::class));
     }
 
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Field/DateTimeInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/DateTimeInputTest.php
@@ -55,9 +55,9 @@ class DateTimeInputTest extends ILIAS_UI_TestBase
         };
     }
 
-    public function getLanguage(): ilLanguageMock
+    public function getLanguage(): LanguageMock
     {
-        return new class () extends ilLanguageMock {
+        return new class () extends LanguageMock {
             public function getLangKey(): string
             {
                 return 'en';
@@ -68,7 +68,7 @@ class DateTimeInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
 
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),

--- a/components/ILIAS/UI/tests/Component/Input/Field/DurationInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/DurationInputTest.php
@@ -27,13 +27,14 @@ use ILIAS\UI\Component as C;
 use ILIAS\Data;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Implementation\Component\Symbol as S;
+use ILIAS\Language\Language;
 
 class DurationInputTest extends ILIAS_UI_TestBase
 {
     protected DefNamesource $name_source;
     protected Data\Factory $data_factory;
     protected I\Input\Field\Factory $factory;
-    protected ilLanguage $lng;
+    protected Language $lng;
 
     public function setUp(): void
     {
@@ -42,9 +43,9 @@ class DurationInputTest extends ILIAS_UI_TestBase
         $this->factory = $this->buildFactory();
     }
 
-    protected function buildLanguage(): ilLanguage
+    protected function buildLanguage(): Language
     {
-        $this->lng = $this->createMock(ilLanguage::class);
+        $this->lng = $this->createMock(Language::class);
         $this->lng->method("txt")
             ->will($this->returnArgument(0));
 

--- a/components/ILIAS/UI/tests/Component/Input/Field/FieldFactoryTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/FieldFactoryTest.php
@@ -70,7 +70,7 @@ class FieldFactoryTest extends AbstractFactoryTestCase
     final public function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Field/FileInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/FileInputTest.php
@@ -70,7 +70,7 @@ class FileInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
 
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),

--- a/components/ILIAS/UI/tests/Component/Input/Field/GroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/GroupInputTest.php
@@ -54,7 +54,7 @@ class GroupInputTest extends ILIAS_UI_TestBase
     protected Data\Factory $data_factory;
 
     /**
-     * @var ilLanguage|mixed|MockObject
+     * @var ILIAS\Language\Language|mixed|MockObject
      */
     protected $language;
     protected Refinery $refinery;
@@ -65,7 +65,7 @@ class GroupInputTest extends ILIAS_UI_TestBase
         $this->child1 = $this->createMock(Input1::class);
         $this->child2 = $this->createMock(Input2::class);
         $this->data_factory = new Data\Factory();
-        $this->language = $this->createMock(ilLanguage::class);
+        $this->language = $this->createMock(ILIAS\Language\Language::class);
         $this->refinery = new Refinery($this->data_factory, $this->language);
 
         $this->group = new Group(

--- a/components/ILIAS/UI/tests/Component/Input/Field/HasDynamicInputsBaseTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/HasDynamicInputsBaseTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\Constraint;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data\Factory as DataFactory;
-use ilLanguage;
+use ILIAS\Language\Language;
 use Closure;
 
 /**
@@ -36,13 +36,13 @@ class HasDynamicInputsBaseTest extends TestCase
 {
     protected HasDynamicInputsBase $input;
     protected DataFactory $data_factory;
-    protected ilLanguage $language;
+    protected Language $language;
     protected Refinery $refinery;
 
     public function setUp(): void
     {
         $this->data_factory = $this->createMock(DataFactory::class);
-        $this->language = $this->createMock(ilLanguage::class);
+        $this->language = $this->createMock(Language::class);
         $this->refinery = $this->createMock(Refinery::class);
         $this->input = new class ($this->language, $this->data_factory, $this->refinery, 'test_input_name', $this->getTestInputTemplate(), 'test_byline') extends HasDynamicInputsBase {
             public function getUpdateOnLoadCode(): Closure

--- a/components/ILIAS/UI/tests/Component/Input/Field/HiddenInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/HiddenInputTest.php
@@ -38,7 +38,7 @@ class HiddenInputTest extends ILIAS_UI_TestBase
             new Data\Factory(),
             new Refinery(
                 new Data\Factory(),
-                $this->createMock(ilLanguage::class)
+                $this->createMock(ILIAS\Language\Language::class)
             )
         );
     }

--- a/components/ILIAS/UI/tests/Component/Input/Field/InputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/InputTest.php
@@ -132,7 +132,7 @@ class InputTest extends ILIAS_UI_TestBase
     public function setUp(): void
     {
         $this->data_factory = new DataFactory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         $this->refinery = new Refinery($this->data_factory, $language);
         $this->input = new DefInput(
             $this->data_factory,

--- a/components/ILIAS/UI/tests/Component/Input/Field/LinkInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/LinkInputTest.php
@@ -41,7 +41,7 @@ class LinkInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): Factory
     {
         $data_factory = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         $language->method("txt")
             ->will($this->returnArgument(0));
 

--- a/components/ILIAS/UI/tests/Component/Input/Field/MultiSelectInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/MultiSelectInputTest.php
@@ -41,7 +41,7 @@ class MultiSelectInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Field/OptionalGroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/OptionalGroupInputTest.php
@@ -51,7 +51,7 @@ class OptionalGroupInputTest extends ILIAS_UI_TestBase
     protected Data\Factory $data_factory;
 
     /**
-     * @var ilLanguage|mixed|MockObject
+     * @var ILIAS\Language\Language|mixed|MockObject
      */
     protected $language;
 
@@ -64,7 +64,7 @@ class OptionalGroupInputTest extends ILIAS_UI_TestBase
         $this->child1 = $this->createMock(Input11::class);
         $this->child2 = $this->createMock(Input12::class);
         $this->data_factory = new Data\Factory();
-        $this->language = $this->createMock(ilLanguage::class);
+        $this->language = $this->createMock(ILIAS\Language\Language::class);
         $this->refinery = new ILIAS\Refinery\Factory($this->data_factory, $this->language);
 
         $this->child1

--- a/components/ILIAS/UI/tests/Component/Input/Field/PasswordInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/PasswordInputTest.php
@@ -69,7 +69,7 @@ class PasswordInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Field/RadioInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/RadioInputTest.php
@@ -39,7 +39,7 @@ class RadioInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(\ilLanguage::class);
+        $language = $this->createMock(\ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Field/RatingInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/RatingInputTest.php
@@ -40,7 +40,7 @@ class RatingInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new DataFactory();
-        $language = $this->createMock(\ilLanguage::class);
+        $language = $this->createMock(\ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Field/SelectInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SelectInputTest.php
@@ -46,7 +46,7 @@ class SelectInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
@@ -58,7 +58,7 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
     protected $nested_child;
 
     /**
-     * @var ilLanguage|mixed|MockObject
+     * @var ILIAS\Language\Language|mixed|MockObject
      */
     protected $lng;
 
@@ -73,8 +73,8 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
         $this->child1 = $this->createMock(Group1::class);
         $this->child2 = $this->createMock(Group2::class);
         $this->data_factory = new Data\Factory();
-        $this->refinery = new Refinery($this->data_factory, $this->createMock(ilLanguage::class));
-        $this->lng = $this->createMock(ilLanguage::class);
+        $this->refinery = new Refinery($this->data_factory, $this->createMock(ILIAS\Language\Language::class));
+        $this->lng = $this->createMock(ILIAS\Language\Language::class);
 
         $this->nested_child
             ->method("withNameFrom")

--- a/components/ILIAS/UI/tests/Component/Input/Field/TagInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TagInputTest.php
@@ -44,7 +44,7 @@ class TagInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Field/TextInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TextInputTest.php
@@ -40,7 +40,7 @@ class TextInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Field/TextareaTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TextareaTest.php
@@ -40,7 +40,7 @@ class TextareaTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/Field/UrlInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/UrlInputTest.php
@@ -40,7 +40,7 @@ class UrlInputTest extends ILIAS_UI_TestBase
     protected function buildFactory(): I\Input\Field\Factory
     {
         $data_factory = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
+        $language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class),
             new SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlTestBase.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlTestBase.php
@@ -52,7 +52,7 @@ abstract class ViewControlTestBase extends ILIAS_UI_TestBase
     {
         return new Refinery(
             $this->buildDataFactory(),
-            $this->createMock(ilLanguage::class)
+            $this->createMock(ILIAS\Language\Language::class)
         );
     }
 

--- a/components/ILIAS/UI/tests/Component/Launcher/LauncherInlineTest.php
+++ b/components/ILIAS/UI/tests/Component/Launcher/LauncherInlineTest.php
@@ -29,7 +29,7 @@ use ILIAS\Refinery\Factory as Refinery;
 class LauncherInlineTest extends ILIAS_UI_TestBase
 {
     protected ILIAS\Data\Factory $df;
-    protected ilLanguage $language;
+    protected ILIAS\Language\Language $language;
 
     public function setUp(): void
     {
@@ -38,7 +38,7 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
 
     protected function getInputFactory(): I\Input\Field\Factory
     {
-        $this->language = $this->createMock(ilLanguage::class);
+        $this->language = $this->createMock(ILIAS\Language\Language::class);
         return new I\Input\Field\Factory(
             $this->createMock(I\Input\UploadLimitResolver::class),
             new I\SignalGenerator(),

--- a/components/ILIAS/UI/tests/Component/MainControls/Slate/DrilldownSlateTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/Slate/DrilldownSlateTest.php
@@ -42,7 +42,6 @@ class DrilldownSlateTest extends ILIAS_UI_TestBase
             {
                 return new I\Menu\Factory(
                     $this->getSigGen(),
-                    new ilLanguageMock()
                 );
             }
 

--- a/components/ILIAS/UI/tests/Component/Menu/Drilldown/DrilldownTest.php
+++ b/components/ILIAS/UI/tests/Component/Menu/Drilldown/DrilldownTest.php
@@ -43,7 +43,6 @@ class DrilldownTest extends ILIAS_UI_TestBase
             {
                 return new Menu\Factory(
                     new I\SignalGenerator(),
-                    new ilLanguageMock()
                 );
             }
             public function button(): C\Button\Factory

--- a/components/ILIAS/UI/tests/Component/Table/Column/ColumnFactoryTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/Column/ColumnFactoryTest.php
@@ -42,7 +42,7 @@ class ColumnFactoryTest extends AbstractFactoryTestCase
 
     protected function buildColumnFactory()
     {
-        $lng = $this->getMockBuilder(\ilLanguage::class)
+        $lng = $this->getMockBuilder(\ILIAS\Language\Language::class)
             ->disableOriginalConstructor()
             ->getMock();
         $lng->method('txt')->willReturnCallback(fn($v) => $v);

--- a/components/ILIAS/UI/tests/Component/Table/Column/ColumnTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/Column/ColumnTest.php
@@ -36,7 +36,7 @@ class ColumnTest extends ILIAS_UI_TestBase
 {
     public function setUp(): void
     {
-        $lng = $this->getMockBuilder(\ilLanguage::class)
+        $lng = $this->getMockBuilder(\ILIAS\Language\Language::class)
             ->disableOriginalConstructor()
             ->getMock();
         $lng->method('txt')->willReturnCallback(fn($v) => $v);

--- a/components/ILIAS/UI/tests/Component/Table/TableTestBase.php
+++ b/components/ILIAS/UI/tests/Component/Table/TableTestBase.php
@@ -48,7 +48,7 @@ abstract class TableTestBase extends ILIAS_UI_TestBase
     {
         return new Refinery(
             new \ILIAS\Data\Factory(),
-            $this->createMock(ilLanguage::class)
+            $this->createMock(ILIAS\Language\Language::class)
         );
     }
 

--- a/components/ILIAS/UI/tests/Renderer/AbstractRendererTest.php
+++ b/components/ILIAS/UI/tests/Renderer/AbstractRendererTest.php
@@ -108,6 +108,7 @@ namespace {
     use ILIAS\UI\Implementation\Component\Counter\CounterNonAbstractRenderer;
     use ILIAS\UI\Implementation\Component\Symbol\Glyph\GlyphNonAbstractRendererWithJS;
     use ILIAS\UI\Implementation\Component\Symbol\Glyph\Glyph;
+    use ILIAS\Language\Language;
 
     class NullTemplate implements Template
     {
@@ -173,7 +174,7 @@ namespace {
     {
         protected TemplateFactoryMock $tpl_factory;
         protected NoUIFactory $ui_factory;
-        protected ilLanguageMock $lng;
+        protected Language $lng;
         protected LoggingJavaScriptBinding $js_binding;
         /**
          * @var ImagePathResolver|mixed|MockObject
@@ -186,7 +187,7 @@ namespace {
             parent::setUp();
             $this->tpl_factory = new TemplateFactoryMock();
             $this->ui_factory = $this->getUIFactory(); //new NoUIFactory();
-            $this->lng = new ilLanguageMock();
+            $this->lng = new LanguageMock();
             $this->js_binding = new LoggingJavaScriptBinding();
             $this->image_path_resolver = $this->getMockBuilder(ILIAS\UI\Implementation\Render\ImagePathResolver::class)
                                               ->getMock();

--- a/components/ILIAS/UI/tests/Renderer/ComponentRendererFSLoaderTest.php
+++ b/components/ILIAS/UI/tests/Renderer/ComponentRendererFSLoaderTest.php
@@ -43,7 +43,7 @@ class ComponentRendererFSLoaderTest extends TestCase
     {
         $ui_factory = $this->getMockBuilder(ILIAS\UI\Factory::class)->getMock();
         $tpl_factory = $this->getMockBuilder(I\Render\TemplateFactory::class)->getMock();
-        $lng = $this->getMockBuilder(ilLanguage::class)->disableOriginalConstructor()->getMock();
+        $lng = $this->getMockBuilder(ILIAS\Language\Language::class)->disableOriginalConstructor()->getMock();
         $js_binding = $this->getMockBuilder(I\Render\JavaScriptBinding::class)->getMock();
         $image_path_resolver = $this->getMockBuilder(ILIAS\UI\Implementation\Render\ImagePathResolver::class)
                 ->getMock();

--- a/components/ILIAS/UI/tests/Renderer/TestComponent.php
+++ b/components/ILIAS/UI/tests/Renderer/TestComponent.php
@@ -59,10 +59,10 @@ class Renderer implements ComponentRenderer
 {
     public Factory $ui_factory;
     public TemplateFactory $tpl_factory;
-    public \ilLanguage $lng;
+    public \ILIAS\Language\Language $lng;
     public JavaScriptBinding $js_binding;
 
-    final public function __construct(Factory $ui_factory, TemplateFactory $tpl_factory, \ilLanguage $lng, JavaScriptBinding $js_binding)
+    final public function __construct(Factory $ui_factory, TemplateFactory $tpl_factory, \ILIAS\Language\Language $lng, JavaScriptBinding $js_binding)
     {
         $this->ui_factory = $ui_factory;
         $this->tpl_factory = $tpl_factory;

--- a/components/ILIAS/UI/tests/UITestHelper.php
+++ b/components/ILIAS/UI/tests/UITestHelper.php
@@ -46,7 +46,7 @@ class UITestHelper
 
         $tpl_fac = new ilIndependentTemplateFactory();
         $this->dic["tpl"] = $tpl_fac->getTemplate("tpl.main.html", false, false);
-        $this->dic["lng"] = new ilLanguageMock();
+        $this->dic["lng"] = new LanguageMock();
         $data_factory = new DataFactory();
         $this->dic["refinery"] = new RefinaryFactory($data_factory, $this->dic["lng"]);
         (new InitUIFramework())->init($this->dic);


### PR DESCRIPTION
Hi all,

This PR simply replaces all `ilLanguage` usages with the new interface definition `ILIAS\Language\Language`.

Kind regards,
@thibsy 