### PR TITLE
[FIX] start only one PHP-CS-Fixer run in GitHub actions

### DIFF
--- a/scripts/PHP-CS-Fixer/run_check.sh
+++ b/scripts/PHP-CS-Fixer/run_check.sh
@@ -1,31 +1,25 @@
 #!/bin/bash
 
-if [[ -z ${GHRUN} ]]
-then
+if [[ -z ${GHRUN} ]]; then
   RUNCSFIXER=$(vendor/composer/vendor/bin/php-cs-fixer fix --using-cache=no --dry-run -vvv --config=./scripts/PHP-CS-Fixer/code-format.php_cs $@)
   RESULT=$?
-  if [[ ${RESULT} -ne 0 ]]
-  then
+  if [[ ${RESULT} -ne 0 ]]; then
     exit ${RESULT}
   fi
-  exit 0
 else
   # run at github actions
   source scripts/Import/Functions.sh
 
   CHANGED_FILES=$(get_changed_files)
-  for FILE in ${CHANGED_FILES}
-  do
-  	if [ -f ${FILE} ]
-  	then
-	  	echo "Check file: ${FILE}"
-	  	RUNCSFIXER=$(vendor/composer/vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --config=./scripts/PHP-CS-Fixer/code-format.php_cs ${FILE})
-	  	RESULT=$?
-	  	if [[ ${RESULT} -ne 0 ]]
-	  	then
-	  		exit ${RESULT}
-	    fi
-	  fi
-  done
-  exit 0
+  if [[ -z "${CHANGED_FILES[@]}" ]]; then
+      exit 0
+  fi
+
+  vendor/composer/vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --config=./scripts/PHP-CS-Fixer/code-format.php_cs "${CHANGED_FILES[@]}"
+  RESULT=$?
+  if [[ ${RESULT} -ne 0 ]]; then
+    exit ${RESULT}
+  fi
 fi
+
+exit 0


### PR DESCRIPTION
Hi all,

This PR improves the PHP-CS-Fixer GitHub action, so **all** changed files will be checked in **one** run. 

Until now a separate run has been started for every file - which is unnecessary - and did not display what file is invalid. Using one PHP-CS-Fixer run will output the invalid files nicely now.

Kind regards,
@thibsy 