### PR TITLE
Fixes questions in question pool being saved on every cmd call regardless of cmd

### DIFF
--- a/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
+++ b/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
@@ -53,6 +53,9 @@ trait ilTestBaseTestCaseTrait
         if (!defined("ILIAS_LOG_FILE")) {
             define("ILIAS_LOG_FILE", '/var/log/ilias.log');
         }
+        if (!defined("IL_INST_ID")) {
+            define("IL_INST_ID", '0');
+        }
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -660,6 +660,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 
                 if (!in_array($cmd, ['save', 'saveReturn'])) {
                     $question_gui->$cmd();
+                    return;
                 }
 
                 if (!$question_gui->saveQuestion()) {


### PR DESCRIPTION
When trying to edit a question inside of a question pool, regardless of the cmd, the question is always saved. This leads to partially empty requests which reset the questions content such as title or answer possibilities (example Multiple Choice Single Answer Question).

I believe the fix is a missing return statement which would prevent the saving of the question if the cmd is not ment to do so.