### PR TITLE
TOS & DPRO: Enable soap api check

### DIFF
--- a/components/ILIAS/DataProtection/tests/ConsumerTest.php
+++ b/components/ILIAS/DataProtection/tests/ConsumerTest.php
@@ -135,6 +135,7 @@ class ConsumerTest extends TestCase
         $slot->expects(self::once())->method('hasUserManagementFields')->willReturn($slot);
         $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
         $slot->expects(self::once())->method('canReadInternalMails')->willReturn($slot);
+        $slot->expects(self::once())->method('canUseSoapApi')->willReturn($slot);
 
         $instance = new Consumer($container);
 

--- a/components/ILIAS/TermsOfService/tests/ConsumerTest.php
+++ b/components/ILIAS/TermsOfService/tests/ConsumerTest.php
@@ -91,9 +91,11 @@ class ConsumerTest extends TestCase
         $slot->expects(self::once())->method('hasOnlineStatusFilter')->willReturn($slot);
         $slot->expects(self::once())->method('hasUserManagementFields')->willReturn($slot);
         $slot->expects(self::once())->method('hasPublicApi')->willReturn($slot);
+        $slot->expects(self::once())->method('canReadInternalMails')->willReturn($slot);
+        $slot->expects(self::once())->method('canUseSoapApi')->willReturn($slot);
 
         $instance = new Consumer($container);
 
-        $instance->uses($slot, $this->mock(LazyProvide::class));
+        $this->assertSame($slot, $instance->uses($slot, $this->mock(LazyProvide::class)));
     }
 }


### PR DESCRIPTION
This PR enables the check if a user accepted the tos & dpro when using the SOAP API.