### PR TITLE
CS Fixer: Prevent multiple filenames to be given as 1 argument

### DIFF
--- a/scripts/PHP-CS-Fixer/run_check.sh
+++ b/scripts/PHP-CS-Fixer/run_check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ -z ${GHRUN} ]]; then
+if [[ -z "${GHRUN}" ]]; then
   RUNCSFIXER=$(vendor/composer/vendor/bin/php-cs-fixer fix --using-cache=no --dry-run -vvv --config=./scripts/PHP-CS-Fixer/code-format.php_cs $@)
   RESULT=$?
   if [[ ${RESULT} -ne 0 ]]; then
@@ -11,11 +11,11 @@ else
   source scripts/Import/Functions.sh
 
   CHANGED_FILES=$(get_changed_files)
-  if [[ -z "${CHANGED_FILES[@]}" ]]; then
+  if [[ -z "${CHANGED_FILES}" ]]; then
       exit 0
   fi
 
-  vendor/composer/vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --config=./scripts/PHP-CS-Fixer/code-format.php_cs "${CHANGED_FILES[@]}"
+  echo "${CHANGED_FILES}" | xargs vendor/composer/vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --config=./scripts/PHP-CS-Fixer/code-format.php_cs
   RESULT=$?
   if [[ ${RESULT} -ne 0 ]]; then
     exit ${RESULT}


### PR DESCRIPTION
This PR changes the CS Fixer, so that if multiple files are to be checked, they are not given to the underlying CS Fixer command as one argument but as one argument for each file.