### PR TITLE
T&A: BulkEdit Questions in Pool

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilBulkEditQuestionsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilBulkEditQuestionsGUI.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\UI\Factory as UIFactory;
+use ILIAS\UI\Renderer as UIRenderer;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Custom\Transformation;
+use Psr\Http\Message\ServerRequestInterface;
+use ILIAS\HTTP\Wrapper\RequestWrapper;
+use ILIAS\UI\Component\Input\Container\Form;
+use ILIAS\UI\Component\MessageBox\MessageBox;
+
+/**
+ * @ilCtrl_Calls ilBulkEditQuestionsGUI: ilFormPropertyDispatchGUI
+ */
+class ilBulkEditQuestionsGUI
+{
+    public const PARAM_IDS = 'qids';
+    public const CMD_EDITTAUTHOR = 'bulkedit_author';
+    public const CMD_SAVEAUTHOR = 'bulksave_author';
+    public const CMD_EDITLIFECYCLE = 'bulkedit_lifecycle';
+    public const CMD_SAVELIFECYCLE = 'bulksave_lifecycle';
+    public const CMD_EDITTAXONOMIES = 'bulkedit_taxonomies';
+    public const CMD_SAVETAXONOMIES = 'bulksave_taxonomies';
+
+    public function __construct(
+        protected ilGlobalTemplateInterface $tpl,
+        protected ilCtrl $ctrl,
+        protected ilLanguage $lng,
+        protected UIFactory $ui_factory,
+        protected UIRenderer $ui_renderer,
+        protected Refinery $refinery,
+        protected ServerRequestInterface $request,
+        protected RequestWrapper $request_wrapper,
+        protected int $qpl_obj_id,
+    ) {
+    }
+
+    protected array $question_ids = [];
+
+    public function executeCommand(): void
+    {
+        $cmd = $this->ctrl->getCmd();
+        $this->ctrl->saveParameter($this, self::PARAM_IDS);
+
+        $this->question_ids = $this->getQuestionIds();
+
+        $out = [];
+
+        if($this->question_ids === []) {
+            $out[] = $this->ui_factory->messageBox()->failure(
+                $this->lng->txt('qpl_bulkedit_no_ids')
+            );
+
+        } else {
+
+            switch ($cmd) {
+                case self::CMD_EDITTAUTHOR:
+                    $out[] = $this->getFormAuthor();
+                    break;
+                case self::CMD_SAVEAUTHOR:
+                    $out = array_merge($out, $this->store($this->getFormAuthor()));
+                    break;
+
+                case self::CMD_EDITLIFECYCLE:
+                    $out[] = $this->getFormLifecycle();
+                    break;
+                case self::CMD_SAVELIFECYCLE:
+                    $out = array_merge($out, $this->store($this->getFormLifecycle()));
+                    break;
+
+                case self::CMD_EDITTAXONOMIES:
+                    $out[] = $this->ui_factory->legacy($this->getFormTaxonomies()->getHTML());
+                    break;
+                case self::CMD_SAVETAXONOMIES:
+                    $out = array_merge($out, $this->storeTaxonomies($this->getFormTaxonomies()));
+                    break;
+
+                default:
+                    throw new \Exception("'$cmd'" . " not implemented");
+            }
+        }
+
+        $this->tpl->setContent($this->ui_renderer->render($out));
+    }
+
+    protected function getQuestionIds(): array
+    {
+        if (!$this->request_wrapper->has(self::PARAM_IDS)) {
+            return [];
+        }
+        $trafo = $this->refinery->custom()->transformation(
+            fn($v) => array_map('intval', explode(',', $v))
+        );
+        return $this->request_wrapper->retrieve(self::PARAM_IDS, $trafo);
+    }
+
+    protected function store(Form\Standard $form): array
+    {
+        $out = [];
+        $form = $form->withRequest($this->request);
+        if ($form->getData()) {
+            $out[] = $this->ui_factory->messageBox()->success($this->lng->txt('qpl_bulkedit_success'));
+        }
+        $out[] = $form;
+        return $out;
+    }
+
+    protected function getQuestions(): array
+    {
+        $questions = [];
+        foreach($this->question_ids as $qid) {
+            $questions[] = \assQuestion::instantiateQuestion($qid);
+        }
+        return $questions;
+    }
+
+    protected function getShiftTrafo(): Transformation
+    {
+        return $this->refinery->custom()->transformation(
+            fn(array $v) => array_shift($v)
+        );
+    }
+
+    protected function getFormAuthor(): Form\Standard
+    {
+        return $this->ui_factory->input()->container()->form()->standard(
+            $this->ctrl->getFormAction($this, self::CMD_SAVEAUTHOR),
+            [
+                $this->ui_factory->input()->field()
+                    ->text($this->lng->txt('author'))
+                    ->withRequired(true)
+            ]
+        )
+        ->withAdditionalTransformation($this->getShiftTrafo())
+        ->withAdditionalTransformation($this->getAuthorUpdater());
+    }
+
+    protected function getAuthorUpdater(): Transformation
+    {
+        $questions = $this->getQuestions();
+        return $this->refinery->custom()->transformation(
+            function (string $author) use ($questions) {
+                foreach($questions as $q) {
+                    $q->setAuthor($author);
+                    $q->saveQuestionDataToDb();
+                }
+                return true;
+            }
+        );
+    }
+
+    protected function getFormLifecycle(): Form\Standard
+    {
+        $lifecycle = \ilAssQuestionLifecycle::getDraftInstance();
+        $options = $lifecycle->getSelectOptions($this->lng);
+        return $this->ui_factory->input()->container()->form()->standard(
+            $this->ctrl->getFormAction($this, self::CMD_SAVELIFECYCLE),
+            [
+                $this->ui_factory->input()->field()
+                    ->select($this->lng->txt('qst_lifecycle'), $options)
+                    ->withRequired(true)
+            ]
+        )
+        ->withAdditionalTransformation($this->getShiftTrafo())
+        ->withAdditionalTransformation($this->getLifecycleUpdater());
+    }
+
+    protected function getLifecycleUpdater(): Transformation
+    {
+        $questions = $this->getQuestions();
+        return $this->refinery->custom()->transformation(
+            function (string $lifecycle) use ($questions) {
+                $lc = ilAssQuestionLifecycle::getInstance($lifecycle);
+                foreach($questions as $q) {
+                    $q->setLifecycle($lc);
+                    $q->saveToDb();
+                }
+                return true;
+            }
+        );
+    }
+
+    protected function getFormTaxonomies(): ilPropertyFormGUI
+    {
+        $form = new ilPropertyFormGUI();
+        $form->setFormAction($this->ctrl->getFormAction($this, self::CMD_SAVETAXONOMIES));
+        $taxonomy_ids = \ilObjTaxonomy::getUsageOfObject($this->qpl_obj_id);
+
+        //taken from assQuestionGUI::populateTaxonomyFormSection
+        foreach ($taxonomy_ids as $taxonomy_id) {
+            $taxonomy = new ilObjTaxonomy($taxonomy_id);
+            $label = sprintf($this->lng->txt('qpl_qst_edit_form_taxonomy'), $taxonomy->getTitle());
+            $postvar = "tax_node_assign_$taxonomy_id";
+            // selector not working due to failing modals, actually:
+            // $taxSelect = new ilTaxSelectInputGUI($taxonomy->getId(), $postvar, true);
+            $taxSelect = new ilTaxAssignInputGUI($taxonomy->getId(), true, $label, $postvar, true);
+            $taxSelect->setTitle($label);
+            $form->addItem($taxSelect);
+        }
+        $form->addCommandButton(self::CMD_SAVETAXONOMIES, $this->lng->txt("save"));
+        return $form;
+    }
+
+    protected function storeTaxonomies(ilPropertyFormGUI $form): array
+    {
+        $post = $this->request->getParsedBody();
+        $questions = $this->getQuestions();
+        $taxonomy_ids = \ilObjTaxonomy::getUsageOfObject($this->qpl_obj_id);
+        foreach ($taxonomy_ids as $taxonomy_id) {
+            $postvar = "tax_node_assign_$taxonomy_id";
+            $tax_node_assign = new ilTaxAssignInputGUI($taxonomy_id, true, '', $postvar);
+            foreach($questions as $q) {
+                $tax_node_assign->saveInput("qpl", $this->qpl_obj_id, "quest", $q->getId());
+            }
+        }
+        $out = [];
+        $out[] = $this->ui_factory->messageBox()->success($this->lng->txt('qpl_bulkedit_success'));
+        $form->setValuesByPost();
+        $out[] = $this->ui_factory->legacy($form->getHTML());
+        return $out;
+    }
+
+}

--- a/components/ILIAS/TestQuestionPool/classes/class.ilBulkEditQuestionsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilBulkEditQuestionsGUI.php
@@ -65,7 +65,7 @@ class ilBulkEditQuestionsGUI
 
         $out = [];
 
-        if($this->question_ids === []) {
+        if ($this->question_ids === []) {
             $out[] = $this->ui_factory->messageBox()->failure(
                 $this->lng->txt('qpl_bulkedit_no_ids')
             );
@@ -127,7 +127,8 @@ class ilBulkEditQuestionsGUI
         $data = $form->getData();
         $questions = $this->getQuestions();
         if ($data !== null && $update($questions, $data)) {
-            $out[] = $this->ui_factory->messageBox()->success($this->lng->txt('qpl_bulkedit_success'));
+            $this->tpl->setOnScreenMessage('success', $this->lng->txt('qpl_bulkedit_success'), true);
+            $this->ctrl->redirectByClass(ilObjQuestionPoolGUI::class, ilObjQuestionPoolGUI::DEFAULT_CMD);
         }
         $out[] = $form;
         return $out;
@@ -136,7 +137,7 @@ class ilBulkEditQuestionsGUI
     protected function getQuestions(): array
     {
         $questions = [];
-        foreach($this->question_ids as $qid) {
+        foreach ($this->question_ids as $qid) {
             $questions[] = \assQuestion::instantiateQuestion($qid);
         }
         return $questions;
@@ -165,7 +166,7 @@ class ilBulkEditQuestionsGUI
     protected function getAuthorUpdater(): \Closure
     {
         return function (array $questions, string $author) {
-            foreach($questions as $q) {
+            foreach ($questions as $q) {
                 $q->setAuthor($author);
                 $q->saveQuestionDataToDb();
             }
@@ -192,7 +193,7 @@ class ilBulkEditQuestionsGUI
     {
         return function (array $questions, string $lifecycle) {
             $lc = ilAssQuestionLifecycle::getInstance($lifecycle);
-            foreach($questions as $q) {
+            foreach ($questions as $q) {
                 $q->setLifecycle($lc);
                 $q->saveToDb();
             }
@@ -222,7 +223,7 @@ class ilBulkEditQuestionsGUI
         return $form;
     }
 
-    protected function storeTaxonomies(ilPropertyFormGUI $form): array
+    protected function storeTaxonomies(ilPropertyFormGUI $form): void
     {
         $questions = $this->getQuestions();
         $post = $this->request->getParsedBody();
@@ -232,7 +233,7 @@ class ilBulkEditQuestionsGUI
         $taxonomy_ids = \ilObjTaxonomy::getUsageOfObject($this->qpl_obj_id);
         foreach ($taxonomy_ids as $taxonomy_id) {
             $postvar = "tax_node_assign_$taxonomy_id";
-            foreach($questions as $q) {
+            foreach ($questions as $q) {
                 $assignments = new ilTaxNodeAssignment(ilObject::_lookupType($q->getObjId()), $q->getObjId(), 'quest', $taxonomy_id);
                 $assigned_nodes = $assignments->getAssignmentsOfItem($q->getId());
 
@@ -254,11 +255,8 @@ class ilBulkEditQuestionsGUI
                 }
             }
         }
-        $out = [];
-        $out[] = $this->ui_factory->messageBox()->success($this->lng->txt('qpl_bulkedit_success'));
-        $form->setValuesByPost();
-        $out[] = $this->ui_factory->legacy($form->getHTML());
-        return $out;
+        $this->tpl->setOnScreenMessage('success', $this->lng->txt('qpl_bulkedit_success'), true);
+        $this->ctrl->redirectByClass(ilObjQuestionPoolGUI::class, ilObjQuestionPoolGUI::DEFAULT_CMD);
     }
 
 }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -22,7 +22,6 @@ use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestDataCollector;
 use ILIAS\TestQuestionPool\Presentation\QuestionTable;
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
-
 use ILIAS\DI\RBACServices;
 use ILIAS\Taxonomy\Service;
 use Psr\Http\Message\ServerRequestInterface as HttpRequest;
@@ -1847,8 +1846,8 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             foreach (array_filter($filter_params) as $item => $value) {
                 switch ($item) {
                     case 'taxonomies':
-                        foreach($value as $tax_value) {
-                            if($tax_value === 'null') {
+                        foreach ($value as $tax_value) {
+                            if ($tax_value === 'null') {
                                 $table->addTaxonomyFilterNoTaxonomySet(true);
                             } else {
                                 $tax_nodes = explode('-', $tax_value);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -59,6 +59,7 @@ use ILIAS\HTTP\Services as HTTPServices;
  * @ilCtrl_Calls   ilObjQuestionPoolGUI: ilAssQuestionPreviewGUI
  * @ilCtrl_Calls   ilObjQuestionPoolGUI: assKprimChoiceGUI, assLongMenuGUI
  * @ilCtrl_Calls   ilObjQuestionPoolGUI: ilQuestionPoolSkillAdministrationGUI
+ * @ilCtrl_Calls   ilObjQuestionPoolGUI: ilBulkEditQuestionsGUI
  *
  * @ingroup components\ILIASTestQuestionPool
  *
@@ -516,9 +517,38 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 );
 
                 $this->ctrl->forwardCommand($gui);
-
                 break;
 
+            case 'ilbulkeditquestionsgui':
+                if (!$ilAccess->checkAccess('read', '', $this->object->getRefId())) {
+                    $this->redirectAfterMissingWrite();
+                }
+                $this->tabs_gui->setBackTarget(
+                    $this->lng->txt('backtocallingpool'),
+                    $this->ctrl->getLinkTargetByClass(self::class, self::DEFAULT_CMD)
+                );
+                $this->tabs_gui->addTarget(
+                    'edit_questions',
+                    '#',
+                    '',
+                    $this->ctrl->getCmdClass(),
+                    ''
+                );
+                $this->tabs_gui->setTabActive('edit_questions');
+
+                $gui = new \ilBulkEditQuestionsGUI(
+                    $this->tpl,
+                    $this->ctrl,
+                    $this->lng,
+                    $this->ui_factory,
+                    $this->ui_renderer,
+                    $this->refinery,
+                    $this->http_request,
+                    $this->request_wrapper,
+                    $this->object->getId(),
+                );
+                $this->ctrl->forwardCommand($gui);
+                break;
 
             case 'ilobjquestionpoolgui':
             case '':
@@ -605,6 +635,22 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                                 . '</script>'
                             ;
                             exit();
+
+                        case ilBulkEditQuestionsGUI::CMD_EDITTAUTHOR:
+                        case ilBulkEditQuestionsGUI::CMD_EDITLIFECYCLE:
+                        case ilBulkEditQuestionsGUI::CMD_EDITTAXONOMIES:
+                            $this->ctrl->clearParameters($this);
+                            $this->ctrl->setParameterByClass(
+                                ilBulkEditQuestionsGUI::class,
+                                ilBulkEditQuestionsGUI::PARAM_IDS,
+                                implode(',', $ids)
+                            );
+                            $url = $this->ctrl->getLinkTargetByClass(
+                                ilBulkEditQuestionsGUI::class,
+                                $action
+                            );
+                            $this->ctrl->redirectToURL($url);
+                            break;
 
                         default:
                             throw new \Exception("'$action'" . " not implemented");

--- a/components/ILIAS/TestQuestionPool/src/Presentation/QuestionTable.php
+++ b/components/ILIAS/TestQuestionPool/src/Presentation/QuestionTable.php
@@ -307,6 +307,9 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
             $this->buildAction('edit_page', 'single'),
             $this->buildAction('feedback', 'single'),
             $this->buildAction('hints', 'single'),
+            $this->buildAction(\ilBulkEditQuestionsGUI::CMD_EDITTAUTHOR, 'multi'),
+            $this->buildAction(\ilBulkEditQuestionsGUI::CMD_EDITLIFECYCLE, 'multi'),
+            $this->buildAction(\ilBulkEditQuestionsGUI::CMD_EDITTAXONOMIES, 'multi'),
             $this->showCommentAction() ? $this->buildAction('comments', 'single', true) : []
         );
     }

--- a/components/ILIAS/TestQuestionPool/src/Presentation/QuestionTable.php
+++ b/components/ILIAS/TestQuestionPool/src/Presentation/QuestionTable.php
@@ -110,7 +110,7 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
             $tax_filter_options = [
                 'null' => '<b>' . $this->lng->txt('tax_filter_notax') . '</b>'
             ];
-            foreach($taxs as $tax_entry) {
+            foreach ($taxs as $tax_entry) {
                 $tax = new \ilObjTaxonomy($tax_entry['tax_id']);
                 $children = array_filter(
                     $tax->getTree()->getFilteredSubTree($tax->getTree()->readRootId()),
@@ -122,7 +122,7 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
                 $tax_title = '<b>' . $tax_entry['title'] . '</b>';
                 $tax_filter_options[$tax_id] = $tax_title;
 
-                foreach($children as $subtax) {
+                foreach ($children as $subtax) {
                     $stax_id = $subtax['tax_id'] . '-' . $subtax['obj_id'];
                     $stax_title = str_repeat('&nbsp; ', ($subtax['depth'] - 2) * 2)
                         . ' &boxur;&HorizontalLine; '
@@ -181,7 +181,7 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
     private function treeify(&$pointer, $stack)
     {
         $hop = array_shift($stack);
-        if(!$hop) {
+        if (!$hop) {
             return;
         }
         if (! array_key_exists($hop, $pointer)) {

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1026,6 +1026,8 @@ assessment#:#previous_question_rows#:#← Fragen %d - %d von %d
 assessment#:#qpl_assessment_no_assessment_of_questions#:#Für die ausgewählte Frage ist keine statistische Auswertung vorhanden. Die Frage wurde bislang nie in einem Test verwendet.
 assessment#:#qpl_assessment_total_of_answers#:#Gesamtzahl der Antworten
 assessment#:#qpl_assessment_total_of_right_answers#:#Gesamtprozentsatz der richtigen Antworten
+assessment#:#qpl_bulk_save_add#:#Hinzufügen
+assessment#:#qpl_bulk_save_overwrite#:#Überschreiben
 assessment#:#qpl_bulkedit_success#:#Änderungen gespeichert.
 assessment#:#qpl_cancel_skill_assigns_update#:#Abbrechen
 assessment#:#qpl_confirm_delete_questions#:#Sind Sie sicher, dass Sie die folgenden Fragen entfernen wollen?

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -556,6 +556,9 @@ assessment#:#backtocallingpage#:#Zurück zur Fragenseite
 assessment#:#backtocallingpool#:#Zurück zum Fragenpool
 assessment#:#backtocallingtest#:#Zurück zum Test
 assessment#:#baseunit#:#Basiseinheit
+assessment#:#bulkedit_author#:#Autor ändern
+assessment#:#bulkedit_lifecycle#:#Lebenszyklus ändern
+assessment#:#bulkedit_taxonomies#:#Taxonomien ändern
 assessment#:#button_request_next_question_hint#:#Fordere nächsten Lösungshinweis an
 assessment#:#button_request_question_hint#:#Lösungshinweis anfordern
 assessment#:#by#:#nach
@@ -1023,6 +1026,7 @@ assessment#:#previous_question_rows#:#← Fragen %d - %d von %d
 assessment#:#qpl_assessment_no_assessment_of_questions#:#Für die ausgewählte Frage ist keine statistische Auswertung vorhanden. Die Frage wurde bislang nie in einem Test verwendet.
 assessment#:#qpl_assessment_total_of_answers#:#Gesamtzahl der Antworten
 assessment#:#qpl_assessment_total_of_right_answers#:#Gesamtprozentsatz der richtigen Antworten
+assessment#:#qpl_bulkedit_success#:#Änderungen gespeichert.
 assessment#:#qpl_cancel_skill_assigns_update#:#Abbrechen
 assessment#:#qpl_confirm_delete_questions#:#Sind Sie sicher, dass Sie die folgenden Fragen entfernen wollen?
 assessment#:#qpl_copy_insert_clipboard#:#Die ausgewählten Fragen wurden in die Zwischenablage kopiert

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1020,6 +1020,8 @@ assessment#:#previous_question_rows#:#<< Questions %d - %d of %d
 assessment#:#qpl_assessment_no_assessment_of_questions#:#There is no assessment of questions available for the selected question. The question has not yet been used in a test.
 assessment#:#qpl_assessment_total_of_answers#:#Total of Answers
 assessment#:#qpl_assessment_total_of_right_answers#:#Total Percentage of Correct Answers (percentage of maximum points)
+assessment#:#qpl_bulk_save_add#:#Add
+assessment#:#qpl_bulk_save_overwrite#:#Overwrite
 assessment#:#qpl_bulkedit_success#:#Modifications saved.
 assessment#:#qpl_cancel_skill_assigns_update#:#Cancel
 assessment#:#qpl_confirm_delete_questions#:#Are you sure you want to remove the following questions?

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -553,6 +553,9 @@ assessment#:#backtocallingpage#:#Back to the question page
 assessment#:#backtocallingpool#:#Back to the question pool
 assessment#:#backtocallingtest#:#Back to the test
 assessment#:#baseunit#:#Base Unit
+assessment#:#bulkedit_author#:#Set Author
+assessment#:#bulkedit_lifecycle#:#Set Lifecycle
+assessment#:#bulkedit_taxonomies#:#Set Taxonomies
 assessment#:#button_request_next_question_hint#:#Request Next Hint
 assessment#:#button_request_question_hint#:#Request Hint
 assessment#:#cancel_test#:#Suspend the Test
@@ -1017,6 +1020,7 @@ assessment#:#previous_question_rows#:#<< Questions %d - %d of %d
 assessment#:#qpl_assessment_no_assessment_of_questions#:#There is no assessment of questions available for the selected question. The question has not yet been used in a test.
 assessment#:#qpl_assessment_total_of_answers#:#Total of Answers
 assessment#:#qpl_assessment_total_of_right_answers#:#Total Percentage of Correct Answers (percentage of maximum points)
+assessment#:#qpl_bulkedit_success#:#Modifications saved.
 assessment#:#qpl_cancel_skill_assigns_update#:#Cancel
 assessment#:#qpl_confirm_delete_questions#:#Are you sure you want to remove the following questions?
 assessment#:#qpl_copy_insert_clipboard#:#The selected question(s) are copied to the clipboard


### PR DESCRIPTION
https://docu.ilias.de/go/wiki/wpage_8316_1357

adds bulk-editing for author, lifecycle and taxonomies to the question pool.
The Taxonomies are currently selected by ilTaxAssignInputGUIs, not the ilTaxSelectInputGUI, because the modals used in the selectors are not working.