### PR TITLE
OSC: Move HTML escaping from DB to frontend

### DIFF
--- a/components/ILIAS/Chatroom/chat/SocketTasks/ConversationMessage.js
+++ b/components/ILIAS/Chatroom/chat/SocketTasks/ConversationMessage.js
@@ -1,5 +1,20 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 var Container  = require('../AppContainer');
-var HTMLEscape = require('../Helper/HTMLEscape');
 var UUID = require('node-uuid');
 
 module.exports = function(conversationId, userId, message) {
@@ -31,7 +46,7 @@ module.exports = function(conversationId, userId, message) {
 			var messageObj = {
 				conversationId: conversationId,
 				userId: userId,
-				message: HTMLEscape.escape(message),
+				message: message,
 				timestamp: (new Date).getTime(),
 				id: UUID.v4()
 			};

--- a/components/ILIAS/OnScreenChat/classes/Setup/Agent.php
+++ b/components/ILIAS/OnScreenChat/classes/Setup/Agent.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\OnScreenChat\Setup;
+
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Setup\Objective;
+use ILIAS\Setup\Config;
+use ILIAS\Setup\Metrics\Storage;
+use ILIAS\Setup\Objective\NullObjective;
+use ILIAS\Setup\Agent as AgentInterface;
+use ilDatabaseUpdateStepsExecutedObjective;
+use ilDatabaseUpdateStepsMetricsCollectedObjective;
+
+class Agent implements AgentInterface
+{
+    public function __construct(private readonly Refinery $refinery)
+    {
+    }
+
+    public function hasConfig(): bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation(): Transformation
+    {
+        return $this->refinery->identity();
+    }
+
+    public function getInstallObjective(Config $config = null): Objective
+    {
+        return new NullObjective();
+    }
+
+    public function getUpdateObjective(Config $config = null): Objective
+    {
+        return new ilDatabaseUpdateStepsExecutedObjective(new UpdateSteps());
+    }
+
+    public function getBuildObjective(): Objective
+    {
+        return new NullObjective();
+    }
+
+    public function getStatusObjective(Storage $storage): Objective
+    {
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new UpdateSteps());
+    }
+
+    public function getMigrations(): array
+    {
+        return [];
+    }
+
+    public function getNamedObjectives(?Config $config = null): array
+    {
+        return [];
+    }
+}

--- a/components/ILIAS/OnScreenChat/classes/Setup/UpdateSteps.php
+++ b/components/ILIAS/OnScreenChat/classes/Setup/UpdateSteps.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\OnScreenChat\Setup;
+
+use ilDatabaseUpdateSteps;
+use ilDBInterface;
+use ilDBConstants;
+
+class UpdateSteps implements ilDatabaseUpdateSteps
+{
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $replace = [
+            '&lt;' => '<',
+            '&gt;' => '>',
+            '&amp;' => '&',
+            '&quot;' => '"',
+        ];
+
+        $replaced_message = 'message';
+        foreach ($replace as $from => $to) {
+            $replaced_message = sprintf(
+                'REPLACE(%s, %s, %s)',
+                $replaced_message,
+                $this->db->quote($from, ilDBConstants::T_TEXT),
+                $this->db->quote($to, ilDBConstants::T_TEXT)
+            );
+        }
+
+        $this->db->manipulate('UPDATE osc_messages SET message = ' . $replaced_message);
+    }
+}

--- a/components/ILIAS/OnScreenChat/resources/onscreenchat.js
+++ b/components/ILIAS/OnScreenChat/resources/onscreenchat.js
@@ -1,3 +1,19 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 (function($, $scope, $chat, dateTimeFormatter){
 	'use strict';
 
@@ -1022,15 +1038,22 @@
 
 			let messageDate = new Date();
 			messageDate.setTime(messageObject.timestamp);
+			const placeholderClass = 'm' + new Date().getTime();
+			const placeholder = '<span class="' + n + '"></span>';
 
 			template = template.replace(/\[\[username\]\]/g, findUsernameInConversationByMessage(messageObject));
 			template = template.replace(/\[\[time_raw\]\]/g, messageObject.timestamp);
 			template = template.replace(/\[\[time\]\]/g, dateTimeFormatter.fromNowToTime(messageObject.timestamp));
 			template = template.replace(/\[\[time_only\]\]/g, dateTimeFormatter.format(messageObject.timestamp, 'LT'));
-			template = template.replace(/\[\[message]\]/g, message);
+			template = template.replace(/\[\[message]\]/g, placeholder);
 			template = template.replace(/\[\[avatar\]\]/g, getProfileImage(messageObject.userId));
 			template = template.replace(/\[\[userId\]\]/g, messageObject.userId);
 			template = template.replace(/\[\[position\]\]/g, position);
+
+			template = $(template);
+			template.find('.' + placeholderClass).each(function(){
+				this.textContent = message;
+			});
 
 			let $firstHeader = chatBody.find("li.header").first(),
 				$messages = chatBody.find("li.message"),


### PR DESCRIPTION
This PR changes that messages aren't escaped when writing them to the database but are saved unescaped in the database and are escaped when outputting them in HTML instead.