### PR TITLE
Fix usage of deprecated/removed ilCtrl::setCmd() for authentication component

### DIFF
--- a/components/ILIAS/Init/ROADMAP.md
+++ b/components/ILIAS/Init/ROADMAP.md
@@ -1,22 +1,35 @@
 # Roadmap
 
-## Long Term
+## Mid Term
 
-### Reduce endpoints located in the ilias root directory
+### Get rid of `ilStartupGUI::setForcedCommand` calls in *.php endpoint scripts
 
-In the future the amount of endpoints (.php classes) located in the ILIAS root directory   
-should be reduced and the existing code moved to the existing ilCtrl structure.  
-Just the ``index.php`` as the only endpoint may remain.
+In order to address the issues resulting from the application of
+[PR 6628](https://github.com/ILIAS-eLearning/ILIAS/pull/6628) (as a successor
+of [PR 5100](https://github.com/ILIAS-eLearning/ILIAS/pull/5100)), a new static
+method `ilStartupGUI::setForcedCommand` has been introduced as a bugfix
+(not supported with any/appropriate funding) to provide a new way to force `ilStartupGUI`
+to execute a specific command depending on the context of the requested
+PHP endpoint script, e.g. ...
 
-(With possible exceptions for things like **sso** or **cli**)
+* login.php
+* logout.php
+* confirmReg.php
+* pwassist.php
+* register.php
+* saml.php
+* openidconnect.php
+* sso/index.php
+* ...
 
-Examples: 
-- login.php
-- logout.php
-- error.php
-- register.php
-- ...
+. To solve the routing problems we also considered a different approach by looking a
+dozens and dozens of code references to these different PHP endpoints. Due to the sheer amount of
+of changes and conflicts with other mechanisms in the "Init/Authentication Process"
+(to name it: handling `cmd=force_login`, even if the forced command of these
+endpoints differs from "force_login"), we decided to go with
+the `ilStartupGUI::setForcedCommand` approach for now.
 
-Current Problems:
-- Current concepts like the redirecting to ``login.php?cmd=force_login`` have to be adjusted   
-  to no longer use the ilCtrl->getCmd() method and additionally check if the cmd is set to ``force_login`` in the POST var.
+Of course the endgame should be to get rid of these static calls in the PHP endpoint scripts,
+or even better, to get reduce the number of PHP endpoints generally.
+But all this will have impacts on other components (e.g. the "Routing") sooner or later and
+should be part of a dedicated project.

--- a/components/ILIAS/Init/ROADMAP.md
+++ b/components/ILIAS/Init/ROADMAP.md
@@ -1,0 +1,22 @@
+# Roadmap
+
+## Long Term
+
+### Reduce endpoints located in the ilias root directory
+
+In the future the amount of endpoints (.php classes) located in the ILIAS root directory   
+should be reduced and the existing code moved to the existing ilCtrl structure.  
+Just the ``index.php`` as the only endpoint may remain.
+
+(With possible exceptions for things like **sso** or **cli**)
+
+Examples: 
+- login.php
+- logout.php
+- error.php
+- register.php
+- ...
+
+Current Problems:
+- Current concepts like the redirecting to ``login.php?cmd=force_login`` have to be adjusted   
+  to no longer use the ilCtrl->getCmd() method and additionally check if the cmd is set to ``force_login`` in the POST var.

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -57,6 +57,8 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     private ILIAS\UI\Factory $ui_factory;
     private ILIAS\UI\Renderer $ui_renderer;
 
+    private static $forced_cmd = '';
+
     public function __construct(
         ilObjUser $user = null,
         ilGlobalTemplateInterface $mainTemplate = null,
@@ -86,6 +88,11 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         $this->ctrl->saveParameter($this, ['rep_ref_id', 'lang', 'target', 'client_id']);
         $this->user->setLanguage($this->lng->getLangKey());
         $this->help->setScreenIdComponent('init');
+    }
+
+    public static function setForcedCommand(string $cmd): void
+    {
+        self::$forced_cmd = $cmd;
     }
 
     private function mergeValuesTrafo(): ILIAS\Refinery\Transformation
@@ -127,6 +134,11 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     public function executeCommand(): void
     {
         $cmd = $this->ctrl->getCmd('processIndexPHP');
+        if (self::$forced_cmd) {
+            $cmd = self::$forced_cmd;
+            self::$forced_cmd = '';
+        }
+
         $next_class = $this->ctrl->getNextClass($this) ?? '';
 
         switch (strtolower($next_class)) {
@@ -165,18 +177,12 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
 
     private function jumpToRegistration(): void
     {
-        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-        // $this->ctrl->setCmdClass(ilAccountRegistrationGUI::class);
-        // $this->ctrl->setCmd('');
-        $this->executeCommand();
+        $this->ctrl->redirectByClass(ilAccountRegistrationGUI::class, '');
     }
 
     private function jumpToPasswordAssistance(): void
     {
-        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-        // $this->ctrl->setCmdClass(ilPasswordAssistanceGUI::class);
-        // $this->ctrl->setCmd('');
-        $this->executeCommand();
+        $this->ctrl->redirectByClass(ilPasswordAssistanceGUI::class, '');
     }
 
     private function showLoginPageOrStartupPage(): void

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -95,6 +95,15 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         self::$forced_cmd = $cmd;
     }
 
+    private function checkForcedCommand(string $cmd): string
+    {
+        if (self::$forced_cmd) {
+            $cmd = self::$forced_cmd;
+            self::$forced_cmd = '';
+        }
+        return $cmd;
+    }
+
     private function mergeValuesTrafo(): ILIAS\Refinery\Transformation
     {
         return $this->refinery->custom()->transformation(static function (array $values): array {
@@ -133,11 +142,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
 
     public function executeCommand(): void
     {
-        $cmd = $this->ctrl->getCmd('processIndexPHP');
-        if (self::$forced_cmd) {
-            $cmd = self::$forced_cmd;
-            self::$forced_cmd = '';
-        }
+        $cmd = $this->checkForcedCommand($this->ctrl->getCmd('processIndexPHP'));
 
         $next_class = $this->ctrl->getNextClass($this) ?? '';
 

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -101,6 +101,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             $cmd = self::$forced_cmd;
             self::$forced_cmd = '';
         }
+
         return $cmd;
     }
 

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -177,12 +177,12 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
 
     private function jumpToRegistration(): void
     {
-        $this->ctrl->redirectByClass(ilAccountRegistrationGUI::class, '');
+        $this->ctrl->redirectByClass(ilAccountRegistrationGUI::class);
     }
 
     private function jumpToPasswordAssistance(): void
     {
-        $this->ctrl->redirectByClass(ilPasswordAssistanceGUI::class, '');
+        $this->ctrl->redirectByClass(ilPasswordAssistanceGUI::class);
     }
 
     private function showLoginPageOrStartupPage(): void

--- a/components/ILIAS/Init/resources/login.php
+++ b/components/ILIAS/Init/resources/login.php
@@ -26,8 +26,7 @@ require_once '../vendor/composer/vendor/autoload.php';
 
 ilInitialisation::initILIAS();
 
-// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-// $ilCtrl->setCmd('showLoginPageOrStartupPage');
+ilStartUpGUI::setForcedCommand('showLoginPageOrStartupPage');
 $ilCtrl->callBaseClass(ilStartUpGUI::class);
 $ilBench->save();
 exit();

--- a/components/ILIAS/Init/resources/logout.php
+++ b/components/ILIAS/Init/resources/logout.php
@@ -26,8 +26,7 @@ require_once '../vendor/composer/vendor/autoload.php';
 
 ilInitialisation::initILIAS();
 
-// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-// $ilCtrl->setCmd('doLogout');
+ilStartUpGUI::setForcedCommand('doLogout');
 $ilCtrl->callBaseClass(ilStartUpGUI::class);
 $ilBench->save();
 exit();

--- a/components/ILIAS/Init/resources/pwassist.php
+++ b/components/ILIAS/Init/resources/pwassist.php
@@ -26,8 +26,7 @@ require_once '../vendor/composer/vendor/autoload.php';
 
 ilInitialisation::initILIAS();
 
-// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-// $ilCtrl->setCmd('jumpToPasswordAssistance');
+ilStartUpGUI::setForcedCommand('jumpToRegistration');
 $ilCtrl->callBaseClass(ilStartUpGUI::class);
 $ilBench->save();
 exit();

--- a/components/ILIAS/Init/resources/register.php
+++ b/components/ILIAS/Init/resources/register.php
@@ -26,8 +26,7 @@ require_once '../vendor/composer/vendor/autoload.php';
 
 ilInitialisation::initILIAS();
 
-// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-// $ilCtrl->setCmd("jumpToRegistration");
+ilStartUpGUI::setForcedCommand('jumpToRegistration');
 $ilCtrl->callBaseClass(ilStartUpGUI::class);
 $ilBench->save();
 exit();

--- a/components/ILIAS/Init/resources/sso/index.php
+++ b/components/ILIAS/Init/resources/sso/index.php
@@ -50,6 +50,5 @@ ilContext::init(ilContext::CONTEXT_APACHE_SSO);
 
 ilInitialisation::initILIAS();
 
-// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-// $ilCtrl->setCmd('doApacheAuthentication');
+ilStartUpGUI::setForcedCommand('doApacheAuthentication');
 $ilCtrl->callBaseClass(ilStartUpGUI::class);

--- a/components/ILIAS/OpenIdConnect/resources/openidconnect.php
+++ b/components/ILIAS/OpenIdConnect/resources/openidconnect.php
@@ -29,8 +29,7 @@ ilInitialisation::initILIAS();
 
 global $DIC;
 
-// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-// $DIC->ctrl()->setCmd('doOpenIdConnectAuthentication');
+ilStartUpGUI::setForcedCommand('doOpenIdConnectAuthentication');
 $DIC->ctrl()->setTargetScript('ilias.php');
 $DIC->ctrl()->callBaseClass(ilStartUpGUI::class);
 exit();

--- a/components/ILIAS/Registration/resources/confirmReg.php
+++ b/components/ILIAS/Registration/resources/confirmReg.php
@@ -27,8 +27,7 @@ require_once '../vendor/composer/vendor/autoload.php';
 ilInitialisation::initILIAS();
 
 /** @var ILIAS\DI\Container $DIC */
-// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-// $DIC->ctrl()->setCmd('confirmRegistration');
+ilStartUpGUI::setForcedCommand('confirmRegistration');
 $DIC->ctrl()->callBaseClass(ilStartUpGUI::class);
 $DIC->http()->close();
 exit();

--- a/components/ILIAS/Saml/resources/saml.php
+++ b/components/ILIAS/Saml/resources/saml.php
@@ -30,7 +30,6 @@ ilInitialisation::initILIAS();
 
 /** @var ILIAS\DI\Container $DIC */
 $DIC->ctrl()->setTargetScript('ilias.php');
-// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-// $DIC->ctrl()->setCmd('doSamlAuthentication');
+ilStartUpGUI::setForcedCommand('doSamlAuthentication');
 $DIC->ctrl()->callBaseClass(ilStartUpGUI::class);
 exit();


### PR DESCRIPTION
- (Temporarily) Fixes the usage of the deprecated/removed ``ilCtrl::setCmd()`` usage for authentication related endpoints   
  (login.php, register.php, logout.php, index.php, ...).
- Adds a ROADMAP for reducing the amount of endpoints (.php classes) in the ILIAS root dir in favor of the ilCtrl structure.