### PR TITLE
UI: Fix Typo in StandardPanel Rules

### DIFF
--- a/components/ILIAS/UI/src/Component/Panel/Factory.php
+++ b/components/ILIAS/UI/src/Component/Panel/Factory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Panel;
 

--- a/components/ILIAS/UI/src/Component/Panel/Factory.php
+++ b/components/ILIAS/UI/src/Component/Panel/Factory.php
@@ -47,7 +47,7 @@ interface Factory
      *      2: Standard Panels SHOULD be used in the center content as primary Container for grouping content of varying content.
      *
      *   composition:
-     *      1: Standard Panels MAY contain a Section View Control to change the current presentation of the content.
+     *      1: Standard Panels MAY contain a Mode View Control to change the current presentation of the content.
      *      2: Standard Panels MAY contain a Pagination View Control to display data in chunks.
      *      3: Standard Panels MAY have a Sortation View Control to perform ordering actions to the presented data.
      * ---

--- a/components/ILIAS/UI/src/Component/Panel/Factory.php
+++ b/components/ILIAS/UI/src/Component/Panel/Factory.php
@@ -47,9 +47,7 @@ interface Factory
      *      2: Standard Panels SHOULD be used in the center content as primary Container for grouping content of varying content.
      *
      *   composition:
-     *      1: Standard Panels MAY contain a Mode View Control to change the current presentation of the content.
-     *      2: Standard Panels MAY contain a Pagination View Control to display data in chunks.
-     *      3: Standard Panels MAY have a Sortation View Control to perform ordering actions to the presented data.
+     *      1: Standard Panels MAY contain one or more View Controls.
      * ---
      * @param string $title
      * @param Component[]|Component

--- a/components/ILIAS/UI/src/examples/Panel/Standard/with_view_controls.php
+++ b/components/ILIAS/UI/src/examples/Panel/Standard/with_view_controls.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Panel\Standard;
 
-function with_all_view_controls(): string
+function with_view_controls(): string
 {
     global $DIC;
     $f = $DIC->ui()->factory();


### PR DESCRIPTION
Dear ui-coordinators

Looking at the examples and usages, this looks like a small typo in the rules of the standard panels. Maybe we also want to allow both, I'm not sure though.

Best,
@kergomard 