### PR TITLE
10/UI/allow view controls in reporting panels

### DIFF
--- a/components/ILIAS/UI/src/Component/Panel/Factory.php
+++ b/components/ILIAS/UI/src/Component/Panel/Factory.php
@@ -109,9 +109,7 @@ interface Factory
      *         Report Panels SHOULD be used when user generated content of two sources (i.e results, guidelines in a template)
      *         is to be displayed alongside each other.
      *   composition:
-     *      1: Report Panels MAY contain a Mode View Control to change the current presentation of the content.
-     *      2: Report Panels MAY contain a Pagination View Control to display data in chunks.
-     *      3: Report Panels MAY contain a Sortation View Control to perform ordering actions to the presented data.
+     *      1: Report Panels MAY contain one or more View Controls.
      *   interaction:
      *      1: Links MAY open new views.
      *      2: Buttons MAY trigger actions or inline editing.

--- a/components/ILIAS/UI/src/Component/Panel/Factory.php
+++ b/components/ILIAS/UI/src/Component/Panel/Factory.php
@@ -108,6 +108,10 @@ interface Factory
      *      1: >
      *         Report Panels SHOULD be used when user generated content of two sources (i.e results, guidelines in a template)
      *         is to be displayed alongside each other.
+     *   composition:
+     *      1: Report Panels MAY contain a Mode View Control to change the current presentation of the content.
+     *      2: Report Panels MAY contain a Pagination View Control to display data in chunks.
+     *      3: Report Panels MAY contain a Sortation View Control to perform ordering actions to the presented data.
      *   interaction:
      *      1: Links MAY open new views.
      *      2: Buttons MAY trigger actions or inline editing.

--- a/components/ILIAS/UI/src/Component/Panel/Report.php
+++ b/components/ILIAS/UI/src/Component/Panel/Report.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Panel;
 

--- a/components/ILIAS/UI/src/Component/Panel/Report.php
+++ b/components/ILIAS/UI/src/Component/Panel/Report.php
@@ -20,9 +20,11 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Panel;
 
+use ILIAS\UI\Component\ViewControl\HasViewControls;
+
 /**
  * This describes how a Report could be modified during construction of UI.
  */
-interface Report extends Panel
+interface Report extends Panel, HasViewControls
 {
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Panel/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Panel/Renderer.php
@@ -23,6 +23,7 @@ namespace ILIAS\UI\Implementation\Component\Panel;
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
 use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\UI\Component;
+use ILIAS\UI\Implementation\Render\Template as Template;
 
 /**
  * Class Renderer
@@ -57,23 +58,7 @@ class Renderer extends AbstractComponentRenderer
     protected function renderStandard(Component\Panel\Standard $component, RendererInterface $default_renderer): string
     {
         $tpl = $this->getTemplate("tpl.standard.html", true, true);
-
-        $view_controls = $component->getViewControls();
-        if ($view_controls) {
-            foreach ($view_controls as $view_control) {
-                $tpl->setCurrentBlock("view_controls");
-                $tpl->setVariable("VIEW_CONTROL", $default_renderer->render($view_control));
-                $tpl->parseCurrentBlock();
-            }
-        }
-
-        // actions
-        $actions = $component->getActions();
-        if ($actions !== null) {
-            $tpl->setVariable("ACTIONS", $default_renderer->render($actions));
-        }
-
-        $tpl->setVariable("TITLE", $component->getTitle());
+        $tpl = $this->parseHeader($component, $default_renderer, $tpl);
         $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
         return $tpl->get();
     }
@@ -114,16 +99,32 @@ class Renderer extends AbstractComponentRenderer
     protected function renderReport(Component\Panel\Report $component, RendererInterface $default_renderer): string
     {
         $tpl = $this->getTemplate("tpl.report.html", true, true);
+        $tpl = $this->parseHeader($component, $default_renderer, $tpl);
+        $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
+        return $tpl->get();
+    }
+
+    protected function parseHeader(
+        Component\Panel\Standard|Component\Panel\Report $component,
+        RendererInterface $default_renderer,
+        Template $tpl
+    ): Template {
+        $view_controls = $component->getViewControls();
+        if ($view_controls) {
+            foreach ($view_controls as $view_control) {
+                $tpl->setCurrentBlock("view_controls");
+                $tpl->setVariable("VIEW_CONTROL", $default_renderer->render($view_control));
+                $tpl->parseCurrentBlock();
+            }
+        }
 
         $actions = $component->getActions();
-
-        $tpl->setVariable("TITLE", $component->getTitle());
-
         if ($actions !== null) {
             $tpl->setVariable("ACTIONS", $default_renderer->render($actions));
         }
 
-        $tpl->setVariable("BODY", $this->getContentAsString($component, $default_renderer));
-        return $tpl->get();
+        $tpl->setVariable("TITLE", $component->getTitle());
+
+        return $tpl;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Panel/Report.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Panel/Report.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Panel;
 

--- a/components/ILIAS/UI/src/Implementation/Component/Panel/Report.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Panel/Report.php
@@ -22,6 +22,7 @@ namespace ILIAS\UI\Implementation\Component\Panel;
 
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Implementation\Component\ViewControl\HasViewControls;
 
 /**
  * Class Panel
@@ -29,6 +30,7 @@ use ILIAS\UI\Implementation\Component\ComponentHelper;
  */
 class Report extends Panel implements C\Panel\Report
 {
+    use HasViewControls;
     use ComponentHelper;
 
     /**

--- a/components/ILIAS/UI/src/examples/Panel/Report/with_view_controls.php
+++ b/components/ILIAS/UI/src/examples/Panel/Report/with_view_controls.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Panel\Report;
+
+function with_view_controls(): string
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $refinery = $DIC->refinery();
+    $request_wrapper = $DIC->http()->wrapper()->query();
+
+    $url = $DIC->http()->request()->getRequestTarget();
+
+    $actions = $f->dropdown()->standard([
+        $f->button()->shy("ILIAS", "https://www.ilias.de"),
+        $f->button()->shy("GitHub", "https://www.github.com")
+    ]);
+    $current_presentation = 'simple';
+    if ($request_wrapper->has('mode')) {
+        $current_presentation = $request_wrapper->retrieve('mode', $refinery->kindlyTo()->string());
+    }
+    $presentation_options = [
+        'simple' => 'Simple',
+        'detailed' => 'Detailed'
+    ];
+    $modes = $f->viewControl()->mode(
+        array_reduce(
+            array_keys($presentation_options),
+            static function ($carry, $item) use ($presentation_options, $url) {
+                $carry[$presentation_options[$item]] = "$url&mode=$item";
+                return $carry;
+            },
+            []
+        ),
+        'Presentation Mode'
+    )->withActive($presentation_options[$current_presentation]);
+
+    $content = "Just some information.";
+    if ($current_presentation === 'detailed') {
+        $content = "This is clearly a lot more information!";
+    }
+
+    $sub1 = $f->panel()->sub("Sub Panel Title 1", $f->legacy($content))
+            ->withFurtherInformation($f->card()->standard("Card Heading")->withSections(array($f->legacy("Card Content"))));
+    $sub2 = $f->panel()->sub("Sub Panel Title 2", $f->legacy($content));
+
+    $block = $f->panel()->report("Report Title", [$sub1, $sub2])
+        ->withActions($actions)
+        ->withViewControls([$modes]);
+
+    return $renderer->render($block);
+}

--- a/components/ILIAS/UI/src/templates/default/Panel/tpl.report.html
+++ b/components/ILIAS/UI/src/templates/default/Panel/tpl.report.html
@@ -1,6 +1,9 @@
 <div class="panel panel-primary il-panel-report panel-flex">
 	<div class="panel-heading ilHeader">
-        <h2>{TITLE}</h2>
+        <div class="panel-title"><h2>{TITLE}</h2></div>
+        <!-- BEGIN vc_container -->
+		<div class="panel-viewcontrols l-bar__space-keeper"><!-- BEGIN view_controls -->{VIEW_CONTROL}<!-- END view_controls --></div>
+		<!-- END vc_container -->
         <div class="panel-controls">{ACTIONS}</div>
 	</div>
 	<div class="panel-body">{BODY}</div>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
@@ -349,7 +349,7 @@ EOT;
         $expected_html = <<<EOT
 <div class="panel panel-primary il-panel-report panel-flex">
     <div class="panel-heading ilHeader">
-        <h2>Title</h2>
+        <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-controls">
             <div class="dropdown" id="id_3"><button class="btn btn-default dropdown-toggle" type="button" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu"><span class="caret"></span></button>
                 <ul id="id_3_menu" class="dropdown-menu">
@@ -383,7 +383,7 @@ EOT;
         $this->assertHTMLEquals($this->brutallyTrimHTML($expected_html), $html);
     }
 
-    public function testWithViewControls(): void
+    public function testStandardWithViewControls(): void
     {
         $sort_options = [
             'a' => 'A',
@@ -396,6 +396,59 @@ EOT;
         ;
 
         $this->assertEquals($p->getViewControls(), [$sortation]);
+    }
+
+    public function testReportWithViewControls(): void
+    {
+        $sort_options = [
+            'a' => 'A',
+            'b' => 'B'
+        ];
+        $sortation = $this->getUIFactory()->viewControl()->sortation($sort_options);
+        $f = $this->getPanelFactory();
+        $p = $f->report("Title", [])
+            ->withViewControls([$sortation])
+        ;
+
+        $this->assertEquals($p->getViewControls(), [$sortation]);
+    }
+
+    public function testRenderReportWithMode(): void
+    {
+        $modes = [
+            'A' => 'a',
+            'B' => 'b'
+        ];
+        $mode = $this->getUIFactory()->viewControl()->mode($modes, 'Presentation Mode');
+
+        $f = $this->getPanelFactory();
+        $r = $this->getDefaultRenderer();
+
+
+        $p = $f->report("Title", [])
+            ->withViewControls([$mode]);
+
+        $html = $r->render($p);
+
+        $expected_html = <<<EOT
+<div class="panel panel-primary il-panel-report panel-flex">
+    <div class="panel-heading ilHeader">
+        <div class="panel-title"><h2>Title</h2></div>
+        <div class="panel-viewcontrols l-bar__space-keeper">
+            <div class="il-viewcontrol-mode l-bar__element" aria-label="Presentation Mode" role="group">
+                <button class="btn btn-default engaged" aria-label="A" aria-pressed="true" data-action="a" id="id_1">A</button>
+                <button class="btn btn-default" aria-label="B" aria-pressed="false" data-action="b" id="id_2">B</button>
+            </div>
+        </div>
+        <div class="panel-controls"></div>
+    </div>
+    <div class="panel-body"></div>
+</div>
+EOT;
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected_html),
+            $this->brutallyTrimHTML($html)
+        );
     }
 
     public function testRenderWithSortation(): void


### PR DESCRIPTION
Dear coordinators

This PR would introduce the possibility to add view controls to reporting panels. I built it on top of #7972 as this gave the opportunity to remove some code duplication, but please let me know, if you would prefere me to not do that and simply add the duplicate code.

I added the same constraints on view controls as we have in the standard panels and I think there are cases where all three types could be used reasonably. I don't think there is a justification for also adding the section view contro, though.

Thank you very much in advance and best,
@kergomard 

PS: The failing tests are from the copyright checker, I will fix them in one go.