### PR TITLE
SOAP: Fix wrong authentication frontend

### DIFF
--- a/webservice/soap/classes/class.ilSoapUserAdministration.php
+++ b/webservice/soap/classes/class.ilSoapUserAdministration.php
@@ -62,7 +62,7 @@ class ilSoapUserAdministration extends ilSoapAdministration
 
         include_once './Services/Authentication/classes/Frontend/class.ilAuthFrontendFactory.php';
         $frontend_factory = new ilAuthFrontendFactory();
-        $frontend_factory->setContext(ilAuthFrontendFactory::CONTEXT_CLI);
+        $frontend_factory->setContext(ilAuthFrontendFactory::CONTEXT_WS);
         $frontend = $frontend_factory->getFrontend(
             $GLOBALS['DIC']['ilAuthSession'],
             $status,


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=41941

If approved, this MUST be picked to `release_9` and `trunk`.