### PR TITLE
Replacement of the legacy modal in assClozeTestGUI

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -79,6 +79,8 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     });
 JS;
 
+    private const DEFAULT_MODAL_ID = 'ilGapModal';
+
     /**
     * A temporary variable to store gap indexes of ilCtrl commands in the getCommand method
     */
@@ -341,13 +343,25 @@ JS;
         }
 
         if (!$checkonly) {
-            $modal = ilModalGUI::getInstance();
-            $modal->setHeading($this->lng->txt(''));
-            $modal->setId('ilGapModal');
-            $modal->setBody('');
-            $this->renderEditForm($form, $modal->getHTML());
+            $modal_id = self::DEFAULT_MODAL_ID;
+            $modal_html = $this->getModalHtml($modal_id);
+            $this->tpl->setVariable('MY_MODAL', $modal_html);
+            $this->tpl->addOnLoadCode('gap_modal_id = "' . $modal_id . '";');
+
+            $this->renderEditForm($form, $modal_html);
         }
         return $errors;
+    }
+
+    private function getModalHtml(string &$modal_id): string
+    {
+        $modal = $this->ui_factory->modal()->interruptive('', '', '');
+        $doc = new DOMDocument();
+        @$doc->loadHTML($this->ui_renderer->render($modal));
+        $divs = $doc->getElementsByTagName('div');
+        $divs->item($divs->count() - 1)->nodeValue = '';
+        $modal_id = $divs->item(0)->attributes->getNamedItem('id')->nodeValue ?? self::DEFAULT_MODAL_ID;
+        return $doc->saveHTML();
     }
 
     private function hasErrorInGapCombinationPoints(array $gap_combinations): bool

--- a/components/ILIAS/TestQuestionPool/resources/clozeQuestionGapBuilder.js
+++ b/components/ILIAS/TestQuestionPool/resources/clozeQuestionGapBuilder.js
@@ -41,6 +41,9 @@ const ClozeGlobals = {
   gap_restore: true,
 };
 
+// Can't be a constant because it is dynamically evaluated in assClozeTestGUI.
+var gap_modal_id = 'ilGapModal';
+
 let ClozeSettings = {};
 
 const ClozeQuestionGapBuilder = (function () {
@@ -119,12 +122,12 @@ const ClozeQuestionGapBuilder = (function () {
 
   pro.closeModalWithOkButton = function () {
     ClozeGlobals.gap_restore = false;
-    $('#ilGapModal').modal('hide');
+    $('#' + gap_modal_id).modal('hide');
   };
 
   pro.closeModalWithCancelButton = function () {
     pro.restoreSavedGap();
-    $('#ilGapModal').modal('hide');
+    $('#' + gap_modal_id).modal('hide');
   };
 
   pro.restoreSavedGap = function () {
@@ -1036,16 +1039,16 @@ const ClozeQuestionGapBuilder = (function () {
   pro.focusOnFormular = function (pos) {
     pro.cloneFormPart(pos[0]);
     // ToDo: fix fokus
-    $('#ilGapModal').modal('show');
+    const modal = $('#' + gap_modal_id);
+    modal.modal('show');
     ClozeGlobals.gap_restore = true;
     const gap = parseInt(pos[0], 10) - 1;
-    const lightBoxInner = $('#ilGapModal');
     $('#cloze_text').focus();
-    lightBoxInner.find(`#gap_${gap}\\[answer\\]\\[0\\]`).focus();
-    lightBoxInner.find(`#gap_${gap}_numeric`).focus();
+    modal.find(`#gap_${gap}\\[answer\\]\\[0\\]`).focus();
+    modal.find(`#gap_${gap}_numeric`).focus();
 
-    $('#ilGapModal').off('hidden.bs.modal');
-    $('#ilGapModal').on('hidden.bs.modal', () => {
+    modal.off('hidden.bs.modal');
+    modal.on('hidden.bs.modal', () => {
       pro.restoreSavedGap();
       pro.checkForm();
     });
@@ -1194,8 +1197,8 @@ const ClozeQuestionGapBuilder = (function () {
         ClozeSettings.gaps_php[0].splice(position[2], 1);
         pro.removeFromTextarea(position[2]);
         pub.paintGaps();
-        if (whereAmI == 'modal-body') {
-          $('#ilGapModal').modal('hide');
+        if (whereAmI == 'modal-body' || whereAmI == 'modal-content') {
+          $('#' + gap_modal_id).modal('hide');
         }
       }
     });


### PR DESCRIPTION
These changes are part of the [Legacy-UI refactoring](https://docu.ilias.de/go/wiki/wpage_7320_1357).
I replaced the legacy ilModalGUI with the newer Kitchen Sink interruptive Modal.