### PR TITLE
Deletion of the legacy overlay in TestRandomQuestionSetPoolDefinitionFormGUI

### DIFF
--- a/components/ILIAS/Test/classes/Forms/class.ilTestRandomQuestionSetPoolDefinitionFormGUI.php
+++ b/components/ILIAS/Test/classes/Forms/class.ilTestRandomQuestionSetPoolDefinitionFormGUI.php
@@ -113,8 +113,6 @@ class ilTestRandomQuestionSetPoolDefinitionFormGUI extends ilPropertyFormGUI
 
 
         if ($available_taxonomy_ids !== []) {
-            ilOverlayGUI::initJavaScript();
-
             $filter = $sourcePool->getOriginalTaxonomyFilter();
             foreach ($available_taxonomy_ids as $tax_id) {
                 $taxonomy = new ilObjTaxonomy($tax_id);


### PR DESCRIPTION
These changes are part of the [Legacy-UI refactoring](https://docu.ilias.de/go/wiki/wpage_7320_1357).
This PR deletes the unused legacy overlay. After testing, no differences in functionality could be identified.