### PR TITLE
Deletion of the legacy overlay in assQuestionGUI

### DIFF
--- a/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
+++ b/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
@@ -53,6 +53,9 @@ trait ilTestBaseTestCaseTrait
         if (!defined("ILIAS_LOG_FILE")) {
             define("ILIAS_LOG_FILE", '/var/log/ilias.log');
         }
+        if (!defined("IL_INST_ID")) {
+            define("IL_INST_ID", '0');
+        }
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -960,9 +960,6 @@ abstract class assQuestionGUI
     protected function populateTaxonomyFormSection(ilPropertyFormGUI $form): void
     {
         if ($this->getTaxonomyIds() !== []) {
-            // this is needed by ilTaxSelectInputGUI in some cases
-            ilOverlayGUI::initJavaScript();
-
             $sectHeader = new ilFormSectionHeaderGUI();
             $sectHeader->setTitle($this->lng->txt('qpl_qst_edit_form_taxonomy_section'));
             $form->addItem($sectHeader);


### PR DESCRIPTION
These changes are part of the [Legacy-UI refactoring](https://docu.ilias.de/go/wiki/wpage_7320_1357).
This PR deletes the unused legacy overlay. After testing, no differences in functionality could be identified.