### PR TITLE
Replacement of the legacy modals in ilTestPlayerConfirmationModal

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2964,13 +2964,15 @@ JS;
         $this->tpl->setVariable($this->getContentBlockName(), $content_html);
     }
 
-    protected function populateModals()
+    /**
+     * @throws ilTemplateException
+     */
+    protected function populateModals(): void
     {
         $this->populateDiscardSolutionModal();
 
         if ($this->object->isFollowupQuestionAnswerFixationEnabled()) {
             $this->populateNextLocksChangedModal();
-
             $this->populateNextLocksUnchangedModal();
         }
     }
@@ -3017,48 +3019,43 @@ JS;
         $this->tpl->parseCurrentBlock();
     }
 
-    protected function populateNextLocksUnchangedModal()
+    /**
+     * @throws ilTemplateException
+     */
+    protected function populateNextLocksUnchangedModal(): void
     {
-        $modal = new ilTestPlayerConfirmationModal($this->ui_renderer);
-        $modal->setModalId('tst_next_locks_unchanged_modal');
-
-        $modal->setHeaderText($this->lng->txt('tst_nav_next_locks_empty_answer_header'));
-        $modal->setConfirmationText($this->lng->txt('tst_nav_next_locks_empty_answer_confirm'));
-
-        $button = $this->ui_factory->button()->standard($this->lng->txt('tst_proceed'), '#');
-        $modal->addButton($button);
-
-        $button = $this->ui_factory->button()->primary($this->lng->txt('cancel'), '#');
-        $modal->addButton($button);
+        $modal = (new ilTestPlayerConfirmationModal($this->ui_renderer, $this->ui_factory))
+            ->setActionButtonLabel($this->lng->txt('tst_proceed'))
+            ->setHeaderText($this->lng->txt('tst_nav_next_locks_empty_answer_header'))
+            ->setConfirmationText($this->lng->txt('tst_nav_next_locks_empty_answer_confirm'));
 
         $this->tpl->setCurrentBlock('next_locks_unchanged_modal');
-        $this->tpl->setVariable('NEXT_LOCKS_UNCHANGED_MODAL', $modal->getHTML());
+        $modal_id = 'tst_next_locks_unchanged_modal';
+        $this->tpl->setVariable('NEXT_LOCKS_UNCHANGED_MODAL', $modal->getHTML($modal_id));
+        $this->tpl->addOnLoadCode('unchanged_modal_id = "' . $modal_id . '";');
         $this->tpl->parseCurrentBlock();
     }
 
-    protected function populateNextLocksChangedModal()
+    /**
+     * @throws ilTemplateException
+     */
+    protected function populateNextLocksChangedModal(): void
     {
         if ($this->isFollowUpQuestionLocksConfirmationPrevented()) {
             return;
         }
 
-        $modal = new ilTestPlayerConfirmationModal($this->ui_renderer);
-        $modal->setModalId('tst_next_locks_changed_modal');
-
-        $modal->setHeaderText($this->lng->txt('tst_nav_next_locks_current_answer_header'));
-        $modal->setConfirmationText($this->lng->txt('tst_nav_next_locks_current_answer_confirm'));
-
-        $modal->setConfirmationCheckboxName(self::FOLLOWUP_QST_LOCKS_PREVENT_CONFIRMATION_PARAM);
-        $modal->setConfirmationCheckboxLabel($this->lng->txt('tst_dont_show_msg_again_in_current_session'));
-
-        $button = $this->ui_factory->button()->primary($this->lng->txt('tst_save_and_proceed'), '#');
-        $modal->addButton($button);
-
-        $button = $this->ui_factory->button()->standard($this->lng->txt('cancel'), '#');
-        $modal->addButton($button);
+        $modal = (new ilTestPlayerConfirmationModal($this->ui_renderer, $this->ui_factory))
+            ->setActionButtonLabel($this->lng->txt('tst_save_and_proceed'))
+            ->setHeaderText($this->lng->txt('tst_nav_next_locks_current_answer_header'))
+            ->setConfirmationText($this->lng->txt('tst_nav_next_locks_current_answer_confirm'))
+            ->setConfirmationCheckboxName(self::FOLLOWUP_QST_LOCKS_PREVENT_CONFIRMATION_PARAM)
+            ->setConfirmationCheckboxLabel($this->lng->txt('tst_dont_show_msg_again_in_current_session'));
 
         $this->tpl->setCurrentBlock('next_locks_changed_modal');
-        $this->tpl->setVariable('NEXT_LOCKS_CHANGED_MODAL', $modal->getHTML());
+        $modal_id = 'tst_next_locks_changed_modal';
+        $this->tpl->setVariable('NEXT_LOCKS_CHANGED_MODAL', $modal->getHTML($modal_id));
+        $this->tpl->addOnLoadCode('changed_modal_id = "' . $modal_id . '";');
         $this->tpl->parseCurrentBlock();
     }
 

--- a/components/ILIAS/Test/resources/ilTestPlayerQuestionEditControl.js
+++ b/components/ILIAS/Test/resources/ilTestPlayerQuestionEditControl.js
@@ -16,6 +16,10 @@
 
 /* fau: testNav - new script for test player control of editable questions. */
 
+// Can't be constants because they are dynamically evaluated in ilTestPlayerAbstractGUI.
+var changed_modal_id = 'tst_next_locks_changed_modal';
+var unchanged_modal_id = 'tst_next_locks_unchanged_modal';
+
 /**
  * Test Player Control for Editable Questions
  * added and initialized by ilTestPlayerAbstractGUI::populateQuestionEditControl()
@@ -167,21 +171,21 @@ il.TestPlayerQuestionEditControl = new function() {
 
         if (config.nextQuestionLocks) {
           // handle the buttons in next locks current answer confirmation modal
-          let first_child_changed = document.querySelector('#tst_next_locks_changed_modal .tstModalConfirmationButtons :nth-child(1)');
+          let first_child_changed = document.querySelector('#' + changed_modal_id + ' .modal-footer :nth-child(1)');
           if (first_child_changed !== null) {
               first_child_changed.addEventListener('click', saveWithNavigation);
           }
-          let second_child_changed = document.querySelector('#tst_next_locks_changed_modal .tstModalConfirmationButtons :nth-child(2)');
+          let second_child_changed = document.querySelector('#' + changed_modal_id + ' .modal-footer :nth-child(2)');
           if (second_child_changed !== null) {
             second_child_changed.addEventListener('click', hideFollowupQuestionLocksCurrentAnswerModal);
           }
 
           // handle the buttons in next locks empty answer confirmation modal
-          let first_child_unchanged = document.querySelector('#tst_next_locks_unchanged_modal .tstModalConfirmationButtons :nth-child(1)');
+          let first_child_unchanged = document.querySelector('#' + unchanged_modal_id + ' .modal-footer :nth-child(1)');
           if (first_child_unchanged !== null) {
             first_child_unchanged.addEventListener('click', saveWithNavigationEmptyAnswer);
           }
-          let second_child_unchanged = document.querySelector('#tst_next_locks_unchanged_modal .tstModalConfirmationButtons :nth-child(2)');
+          let second_child_unchanged = document.querySelector('#' + unchanged_modal_id + ' .modal-footer :nth-child(2)');
           if (second_child_unchanged !== null) {
             second_child_unchanged.addEventListener('click', hideFollowupQuestionLocksEmptyAnswerModal);
           }
@@ -450,7 +454,7 @@ il.TestPlayerQuestionEditControl = new function() {
 
             if (!answerChanged && !answered) {
                 showFollowupQuestionLocksEmptyAnswerModal();
-            } else if( $('#tst_next_locks_changed_modal').length > 0 ) {
+            } else if($('#' + changed_modal_id).length > 0 ) {
                 showFollowupQuestionLocksCurrentAnswerModal();
             } else {
                 saveWithNavigation();
@@ -518,23 +522,25 @@ il.TestPlayerQuestionEditControl = new function() {
 
     function showFollowupQuestionLocksCurrentAnswerModal()
     {
-        $('#tst_next_locks_changed_modal').modal('show');
+        $('#' + changed_modal_id).modal('show');
         $('#followup_qst_locks_prevent_confirmation').attr('checked',false);
     }
 
     function hideFollowupQuestionLocksCurrentAnswerModal()
     {
-        $('#tst_next_locks_changed_modal').modal('hide');
+        e.preventDefault();
+        $('#' + changed_modal_id).modal('hide');
     }
 
     function showFollowupQuestionLocksEmptyAnswerModal()
     {
-        $('#tst_next_locks_unchanged_modal').modal('show');
+        $('#' + unchanged_modal_id).modal('show');
     }
 
     function hideFollowupQuestionLocksEmptyAnswerModal()
     {
-        $('#tst_next_locks_unchanged_modal').modal('hide');
+        e.preventDefault();
+        $('#' + unchanged_modal_id).modal('hide');
     }
 
     /**

--- a/components/ILIAS/Test/tests/ilTestPlayerConfirmationModalTest.php
+++ b/components/ILIAS/Test/tests/ilTestPlayerConfirmationModalTest.php
@@ -28,64 +28,61 @@ class ilTestPlayerConfirmationModalTest extends ilTestBaseTestCase
 
     protected function setUp(): void
     {
-        global $DIC;
         parent::setUp();
+        global $DIC;
+        $ui = $DIC->ui();
 
-        $this->testObj = new ilTestPlayerConfirmationModal($DIC['ui.renderer']);
+        $this->testObj = new ilTestPlayerConfirmationModal($ui->renderer(), $ui->factory());
     }
 
-    public function test_instantiateObject_shouldReturnInstance(): void
+    public function testConstruct(): void
     {
         $this->assertInstanceOf(ilTestPlayerConfirmationModal::class, $this->testObj);
     }
 
-    public function testModalId(): void
+    public function testSetAndGetHeaderText(): void
     {
-        $modalId = '12345';
-        $this->testObj->setModalId($modalId);
-        $this->assertEquals($modalId, $this->testObj->getModalId());
+        $header_text = 'testString';
+        $this->assertEquals($this->testObj, $this->testObj->setHeaderText($header_text));
+        $this->assertEquals($header_text, $this->testObj->getHeaderText());
     }
 
-    public function testHeaderText(): void
+    public function testSetAndGetConfirmationText(): void
     {
-        $headerText = 'testString';
-        $this->testObj->setHeaderText($headerText);
-        $this->assertEquals($headerText, $this->testObj->getHeaderText());
+        $confirmation_text = 'testString';
+        $this->assertEquals($this->testObj, $this->testObj->setConfirmationText($confirmation_text));
+        $this->assertEquals($confirmation_text, $this->testObj->getConfirmationText());
     }
 
-    public function testConfirmationText(): void
+    public function testSetAndGetConfirmationCheckboxName(): void
     {
-        $confirmationText = 'testString';
-        $this->testObj->setConfirmationText($confirmationText);
-        $this->assertEquals($confirmationText, $this->testObj->getConfirmationText());
+        $confirmation_checkbox_name = 'testString';
+        $this->assertEquals($this->testObj, $this->testObj->setConfirmationCheckboxName($confirmation_checkbox_name));
+        $this->assertEquals($confirmation_checkbox_name, $this->testObj->getConfirmationCheckboxName());
     }
 
-    public function testConfirmationCheckboxName(): void
+    public function testSetAndGetConfirmationCheckboxLabel(): void
     {
-        $confirmationCheckboxName = 'testString';
-        $this->testObj->setConfirmationCheckboxName($confirmationCheckboxName);
-        $this->assertEquals($confirmationCheckboxName, $this->testObj->getConfirmationCheckboxName());
+        $confirmation_checkbox_label = 'testString';
+        $this->assertEquals($this->testObj, $this->testObj->setConfirmationCheckboxLabel($confirmation_checkbox_label));
+        $this->assertEquals($confirmation_checkbox_label, $this->testObj->getConfirmationCheckboxLabel());
     }
 
-    public function testConfirmationCheckboxLabel(): void
+    public function testSetAndGetActionButtonLabel(): void
     {
-        $confirmationCheckboxLabel = 'testString';
-        $this->testObj->setConfirmationCheckboxLabel($confirmationCheckboxLabel);
-        $this->assertEquals($confirmationCheckboxLabel, $this->testObj->getConfirmationCheckboxLabel());
+        $action_button_label = 'testString';
+        $this->assertEquals($this->testObj, $this->testObj->setActionButtonLabel($action_button_label));
+        $this->assertEquals($action_button_label, $this->testObj->getActionButtonLabel());
     }
 
-    public function testAddParameter(): void
+    public function testAddAndGetParameters(): void
     {
         $this->addGlobal_ilCtrl();
-
         $this->addGlobal_lng();
 
         foreach ([51, 291, 15, 681] as $id) {
             $hiddenInput = new ilHiddenInputGUI('postVar_' . $id);
             $expected[] = $hiddenInput;
-        }
-
-        foreach ($expected ?? [] as $hiddenInput) {
             $this->testObj->addParameter($hiddenInput);
         }
 
@@ -96,8 +93,8 @@ class ilTestPlayerConfirmationModalTest extends ilTestBaseTestCase
     {
         $this->assertFalse($this->testObj->isConfirmationCheckboxRequired());
 
-        $this->testObj->setConfirmationCheckboxName('testName');
-        $this->testObj->setConfirmationCheckboxLabel('testLabel');
+        $this->assertEquals($this->testObj, $this->testObj->setConfirmationCheckboxName('testName'));
+        $this->assertEquals($this->testObj, $this->testObj->setConfirmationCheckboxLabel('testLabel'));
         $this->assertTrue($this->testObj->isConfirmationCheckboxRequired());
     }
 }


### PR DESCRIPTION
These changes are part of the [Legacy-UI refactoring](https://docu.ilias.de/go/wiki/wpage_7320_1357).
I replaced the legacy ilModalGUI with the newer Kitchen Sink interruptive Modal.