### PR TITLE
Object: Remove Usages of initCreationForms

### DIFF
--- a/components/ILIAS/Blog/classes/class.ilObjBlogGUI.php
+++ b/components/ILIAS/Blog/classes/class.ilObjBlogGUI.php
@@ -182,18 +182,6 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
         return $this->items;
     }
 
-
-    protected function initCreationForms(string $new_type): array
-    {
-        $forms = parent::initCreationForms($new_type);
-
-        if ($this->id_type === self::WORKSPACE_NODE_ID) {
-            unset($forms[self::CFORM_IMPORT], $forms[self::CFORM_CLONE]);
-        }
-
-        return $forms;
-    }
-
     protected function afterSave(ilObject $new_object): void
     {
         $ilCtrl = $this->ctrl;

--- a/components/ILIAS/BookingManager/classes/class.ilObjBookingPoolGUI.php
+++ b/components/ILIAS/BookingManager/classes/class.ilObjBookingPoolGUI.php
@@ -242,14 +242,6 @@ class ilObjBookingPoolGUI extends ilObjectGUI
         $this->addHeaderAction();
     }
 
-    protected function initCreationForms(string $new_type): array
-    {
-        $forms = parent::initCreationForms($new_type);
-        unset($forms[self::CFORM_IMPORT]);
-
-        return $forms;
-    }
-
     protected function afterSave(ilObject $new_object): void
     {
         $new_object->setOffline(true);

--- a/components/ILIAS/Category/classes/class.ilObjCategoryGUI.php
+++ b/components/ILIAS/Category/classes/class.ilObjCategoryGUI.php
@@ -585,13 +585,6 @@ class ilObjCategoryGUI extends ilContainerGUI implements \ILIAS\Taxonomy\Setting
         $this->renderObject();
     }
 
-    protected function initCreationForms(string $new_type): array
-    {
-        $forms = parent::initCreationForms($new_type);
-        //unset($forms[self::CFORM_IMPORT]);
-        return $forms;
-    }
-
     protected function afterSave(ilObject $new_object): void
     {
         $tree = $this->tree;

--- a/components/ILIAS/EmployeeTalk/classes/TalkSeries/class.ilObjEmployeeTalkSeriesGUI.php
+++ b/components/ILIAS/EmployeeTalk/classes/TalkSeries/class.ilObjEmployeeTalkSeriesGUI.php
@@ -306,13 +306,6 @@ final class ilObjEmployeeTalkSeriesGUI extends ilContainerGUI
         return $form;
     }
 
-    protected function initCreationForms($new_type): array
-    {
-        return [
-            self::CFORM_NEW => $this->initCreateForm($new_type)
-        ];
-    }
-
     public function viewObject(): void
     {
         self::_goto((string) $this->ref_id);

--- a/components/ILIAS/EmployeeTalk/classes/class.ilObjTalkTemplateGUI.php
+++ b/components/ILIAS/EmployeeTalk/classes/class.ilObjTalkTemplateGUI.php
@@ -171,13 +171,6 @@ final class ilObjTalkTemplateGUI extends ilContainerGUI
         }
     }
 
-    protected function initCreationForms(string $new_type): array
-    {
-        return [
-            self::CFORM_NEW => $this->initCreateForm($new_type)
-        ];
-    }
-
     public function getAdminTabs(): void
     {
         $this->getTabs();

--- a/components/ILIAS/EmployeeTalk/classes/class.ilObjTalkTemplateGUI.php
+++ b/components/ILIAS/EmployeeTalk/classes/class.ilObjTalkTemplateGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\EmployeeTalk\UI\ControlFlowCommand;
 use ILIAS\EmployeeTalk\Metadata\MetadataHandlerInterface;

--- a/components/ILIAS/HTMLLearningModule/classes/class.ilObjFileBasedLMGUI.php
+++ b/components/ILIAS/HTMLLearningModule/classes/class.ilObjFileBasedLMGUI.php
@@ -196,14 +196,6 @@ class ilObjFileBasedLMGUI extends ilObjectGUI
         $this->addHeaderAction();
     }
 
-    protected function initCreationForms(string $new_type): array
-    {
-        return [
-            self::CFORM_NEW => $this->initCreateForm($new_type),
-            self::CFORM_IMPORT => $this->initImportForm($new_type)
-        ];
-    }
-
     final public function cancelCreationObject(): void
     {
         $this->ctrl->redirectByClass("ilrepositorygui", "frameset");

--- a/components/ILIAS/ILIASObject/classes/class.ilObject2GUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject2GUI.php
@@ -632,23 +632,6 @@ abstract class ilObject2GUI extends ilObjectGUI
     }
 
     /**
-     * Init creation forms.
-     * This will create the default creation forms: new, import, clone
-     * @return \ilPropertyFormGUI[]
-     */
-    protected function initCreationForms(string $new_type): array
-    {
-        $forms = parent::initCreationForms($new_type);
-
-        // cloning doesn't work in workspace yet
-        if ($this->id_type == self::WORKSPACE_NODE_ID) {
-            unset($forms[self::CFORM_CLONE]);
-        }
-
-        return $forms;
-    }
-
-    /**
      * Add object to tree at given position
      */
     public function putObjectInTree(ilObject $obj, int $parent_node_id = null): void

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
@@ -659,25 +659,21 @@ class ilObjectGUI implements ImplementsCreationCallback
     {
         $title = $this->getCreationFormTitle();
 
+        if (is_array($form)) {
+            throw new Exception('We do not deal with arrays here.');
+        }
+
         $content = $form;
         if ($form instanceof ilPropertyFormGUI) {
             $form->setTitle('');
             $form->setTitleIcon('');
             $form->setTableWidth('100%');
             $content = $this->ui_factory->legacy($form->getHTML());
-        } elseif (is_array($form)) {
-            $content = $this->ui_factory->legacy(
-                array_reduce(
-                    $form,
-                    fn(string $c, ilPropertyFormGUI $v) => $c . $v->getHTML(),
-                    ''
-                )
-            );
         }
 
-        $panel = $this->ui_factory->panel()->standard($title, $content);
-
-        return $this->ui_renderer->render($panel);
+        return $this->ui_renderer->render(
+            $this->ui_factory->panel()->standard($title, $content)
+        );
     }
 
     protected function getCreationFormTitle(): string

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectGUI.php
@@ -652,7 +652,10 @@ class ilObjectGUI implements ImplementsCreationCallback
         $this->tpl->setContent($this->getCreationFormsHTML($create_form));
     }
 
-    protected function getCreationFormsHTML(StandardForm|ilPropertyFormGUI $form): string
+    /**
+     * @param StandardForm|ilPropertyFormGUI|array<ilPropertyFormGUI> $form
+     */
+    protected function getCreationFormsHTML(StandardForm|ilPropertyFormGUI|array $form): string
     {
         $title = $this->getCreationFormTitle();
 
@@ -660,8 +663,16 @@ class ilObjectGUI implements ImplementsCreationCallback
         if ($form instanceof ilPropertyFormGUI) {
             $form->setTitle('');
             $form->setTitleIcon('');
-            $form->setTableWidth("100%");
+            $form->setTableWidth('100%');
             $content = $this->ui_factory->legacy($form->getHTML());
+        } elseif (is_array($form)) {
+            $content = $this->ui_factory->legacy(
+                array_reduce(
+                    $form,
+                    fn(string $c, ilPropertyFormGUI $v) => $c . $v->getHTML(),
+                    ''
+                )
+            );
         }
 
         $panel = $this->ui_factory->panel()->standard($title, $content);
@@ -674,7 +685,7 @@ class ilObjectGUI implements ImplementsCreationCallback
         return $this->lng->txt($this->requested_new_type . '_new');
     }
 
-    protected function initCreateForm(string $new_type): StandardForm|ilPropertyFormGUI
+    protected function initCreateForm(string $new_type): StandardForm|ilPropertyFormGUI|array
     {
         $form_fields['title_and_description'] = (new ilObject())->getObjectProperties()->getPropertyTitleAndDescription()->toForm(
             $this->lng,

--- a/components/ILIAS/ItemGroup/classes/class.ilObjItemGroupGUI.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilObjItemGroupGUI.php
@@ -121,13 +121,6 @@ class ilObjItemGroupGUI extends ilObject2GUI
         }
     }
 
-    protected function initCreationForms(string $new_type): array
-    {
-        $forms = array(self::CFORM_NEW => $this->initCreateForm($new_type));
-
-        return $forms;
-    }
-
     protected function initEditCustomForm(ilPropertyFormGUI $form): void
     {
         $form->removeItemByPostVar("desc");

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderList.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderList.php
@@ -342,9 +342,9 @@ class ilLTIConsumeProviderList implements Iterator
 			ON oref.obj_id = oset.obj_id
 			AND oref.deleted IS NULL
 			GROUP BY oset.provider_id
-			
+
 			UNION
-			
+
 			SELECT 'trashed' query, oset.provider_id, COUNT(oset.obj_id) cnt
 			FROM lti_consumer_settings oset
 			INNER JOIN object_reference oref
@@ -473,7 +473,7 @@ class ilLTIConsumeProviderList implements Iterator
     /**
      * @return false|ilLTIConsumeProvider|mixed
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->providers);
     }

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilObjLTIConsumerGUI

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\UI\Component\Input\Container\Form\Standard as StandardForm;
+
 /**
  * Class ilObjLTIConsumerGUI
  * @author       Uwe Kohnle <kohnle@internetlehrer-gmbh.de>
@@ -78,7 +80,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
     }
 
     /**
-     * @return \ilPropertyFormGUI[]|null[]
+     * @return array<ilPropertyFormGUI>
      */
     protected function initCreateForm(string $a_new_type): array
     {
@@ -92,6 +94,27 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         }
 
         return $forms;
+    }
+
+    protected function getCreationFormsHTML(StandardForm|ilPropertyFormGUI|array $forms): string
+    {
+        if (!is_array($forms)) {
+            throw new Exception('We only deal with arrays here.');
+        }
+
+        $acc = new ilAccordionGUI();
+        $acc->setBehaviour(ilAccordionGUI::FIRST_OPEN);
+        array_walk(
+            $forms,
+            function (ilPropertyFormGUI $v, string $k) use ($acc): void {
+                $acc->addItem(
+                    $v->getTitle(),
+                    $v->getHTML()
+                );
+            }
+        );
+
+        return $acc->getHTML();
     }
 
     protected function initNewForm(string $a_new_type): \ilLTIConsumerProviderSelectionFormTableGUI

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -80,10 +80,10 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
     /**
      * @return \ilPropertyFormGUI[]|null[]
      */
-    protected function initCreationForms(string $a_new_type): array
+    protected function initCreateForm(string $a_new_type): array
     {
         $forms = array(
-            self::CFORM_NEW => $this->initCreateForm($a_new_type)
+            self::CFORM_NEW => $this->initNewForm($a_new_type)
         );
 
         if (ilLTIConsumerAccess::hasCustomProviderCreationAccess()) {
@@ -94,7 +94,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         return $forms;
     }
 
-    protected function initCreateForm(string $a_new_type): \ilLTIConsumerProviderSelectionFormTableGUI
+    protected function initNewForm(string $a_new_type): \ilLTIConsumerProviderSelectionFormTableGUI
     {
         global $DIC;
         /* @var \ILIAS\DI\Container $DIC */
@@ -343,7 +343,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         $provider_id = $this->getRequestValue("provider_id");
         $DIC->ctrl()->setParameter($this, "provider_id", $provider_id);
         $DIC->language()->loadLanguageModule($new_type);
-        $form = $this->initShowToolConfig($new_type, (int)$provider_id);
+        $form = $this->initShowToolConfig($new_type, (int) $provider_id);
         $DIC->ui()->mainTemplate()->setContent($form->getHTML());
     }
 
@@ -360,7 +360,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         $DIC->language()->loadLanguageModule($new_type);
         ilSession::clear('lti_dynamic_registration_client_id');
         ilSession::clear('lti_dynamic_registration_custom_params');
-        $form = $this->initShowToolConfig($new_type, (int)$provider_id);
+        $form = $this->initShowToolConfig($new_type, (int) $provider_id);
         $form->setValuesByPost();
         if ($form->checkInput()) { // update only overridable fields
             $provider = $form->getProvider();
@@ -821,7 +821,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         $newType = $this->getRequestValue('new_type');
         $refId = $this->getRequestValue('ref_id');
         if ($providerId !== null && $newType == 'lti' && $refId != null) {
-            $provider = new ilLTIConsumeProvider((int)$providerId);
+            $provider = new ilLTIConsumeProvider((int) $providerId);
             // check if post variables from contentSelectionResponse
             if ($DIC->http()->wrapper()->post()->has('JWT')) {
                 // ToDo:

--- a/components/ILIAS/MediaCast/classes/class.ilObjMediaCastGUI.php
+++ b/components/ILIAS/MediaCast/classes/class.ilObjMediaCastGUI.php
@@ -216,14 +216,6 @@ class ilObjMediaCastGUI extends ilObjectGUI
         $this->addHeaderAction();
     }
 
-    protected function initCreationForms(string $new_type): array
-    {
-        $forms = array(self::CFORM_NEW => $this->initCreateForm($new_type),
-                self::CFORM_IMPORT => $this->initImportForm($new_type));
-
-        return $forms;
-    }
-
     protected function afterSave(ilObject $new_object): void
     {
         // always send a message

--- a/components/ILIAS/MediaPool/classes/class.ilObjMediaPoolGUI.php
+++ b/components/ILIAS/MediaPool/classes/class.ilObjMediaPoolGUI.php
@@ -473,14 +473,6 @@ class ilObjMediaPoolGUI extends ilObject2GUI
         $this->ctrl->redirectByClass("ilobjmediaobjectgui", "create");
     }
 
-    protected function initCreationForms(string $new_type): array
-    {
-        $forms = array(self::CFORM_NEW => $this->initCreateForm($new_type),
-            self::CFORM_IMPORT => $this->initImportForm($new_type));
-
-        return $forms;
-    }
-
     protected function afterSave(ilObject $new_object): void
     {
         // always send a message

--- a/components/ILIAS/OrgUnit/classes/class.ilObjOrgUnitGUI.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilObjOrgUnitGUI.php
@@ -222,7 +222,7 @@ class ilObjOrgUnitGUI extends ilContainerGUI
                 );
                 if (!ilObjOrgUnitAccess::_checkAccessToUserLearningProgress(
                     $this->object->getRefid(),
-                    (int)$_GET['obj_id']
+                    (int) $_GET['obj_id']
                 )) {
                     $this->tpl->setOnScreenMessage('failure', $this->lng->txt("permission_denied"), true);
                     $this->ctrl->redirectByClass("ilOrgUnitUserAssignmentGUI", "index");
@@ -232,7 +232,7 @@ class ilObjOrgUnitGUI extends ilContainerGUI
                 $new_gui = new ilLearningProgressGUI(
                     ilLearningProgressGUI::LP_CONTEXT_ORG_UNIT,
                     $this->ref_id,
-                    (int)$_GET['obj_id']
+                    (int) $_GET['obj_id']
                 );
                 $this->ctrl->forwardCommand($new_gui);
                 break;
@@ -406,21 +406,6 @@ class ilObjOrgUnitGUI extends ilContainerGUI
         $this->tabs_gui->activateTab(self::TAB_VIEW_CONTENT);
         $this->tabs_gui->removeSubTab("page_editor");
         $this->tabs_gui->removeSubTab("ordering"); // Mantis 0014728
-    }
-
-    /**
-     * initCreationForms
-     * We override the method of class.ilObjectGUI because we have no copy functionality
-     * at the moment
-     */
-    protected function initCreationForms(string $new_type): array
-    {
-        $forms = array(
-            self::CFORM_NEW => $this->initCreateForm($new_type),
-            self::CFORM_IMPORT => $this->initImportForm($new_type),
-        );
-
-        return $forms;
     }
 
     public function showPossibleSubObjects(): void

--- a/components/ILIAS/Portfolio/classes/class.ilObjPortfolioGUI.php
+++ b/components/ILIAS/Portfolio/classes/class.ilObjPortfolioGUI.php
@@ -339,12 +339,6 @@ class ilObjPortfolioGUI extends ilObjPortfolioBaseGUI
         return $message;
     }
 
-
-    protected function initCreationForms(string $new_type): array
-    {
-        return array(self::CFORM_NEW => $this->initCreateForm($new_type));
-    }
-
     protected function initCreateForm(string $new_type): ilPropertyFormGUI
     {
         $ilSetting = $this->settings;

--- a/components/ILIAS/Repository/PluginSlot/class.ilObjectPluginGUI.php
+++ b/components/ILIAS/Repository/PluginSlot/class.ilObjectPluginGUI.php
@@ -219,22 +219,6 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
     }
 
     /**
-     * Init creation forms
-     * this will create the default creation forms: new, import, clone
-     */
-    protected function initCreationForms(string $new_type): array
-    {
-        $forms = [];
-        $forms[self::CFORM_NEW] = $this->initCreateForm($new_type);
-
-        if ($this->supportsExport()) {
-            $forms[self::CFORM_IMPORT] = $this->initImportForm($new_type);
-        }
-
-        return $forms;
-    }
-
-    /**
      * @return bool returns true if this plugin object supports cloning
      */
     protected function supportsCloning(): bool

--- a/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
@@ -511,14 +511,6 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI
     }
 
     /**
-     * Overwritten from ilObjectGUI since copy and import are not implemented.
-     */
-    protected function initCreationForms($new_type): array
-    {
-        return array(self::CFORM_NEW => $this->initCreateForm($new_type));
-    }
-
-    /**
      * Method for implementing async windows-output
      * Should be moved into core to enable async requests on creation-form
      */
@@ -526,8 +518,9 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI
     {
         $asyncForm = new ilAsyncPropertyFormGUI($this->request_wrapper);
 
-        $tmp_forms = $this->initCreationForms('prg');
-        $asyncForm->cloneForm($tmp_forms[self::CFORM_NEW]);
+        $asyncForm->cloneForm(
+            $this->initCreateForm('prg')
+        );
         $asyncForm->setAsync(true);
 
         return $asyncForm;

--- a/components/ILIAS/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPoolGUI.php
+++ b/components/ILIAS/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPoolGUI.php
@@ -600,16 +600,6 @@ class ilObjSurveyQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassI
         $this->ctrl->redirect($this, "export");
     }
 
-    protected function initCreationForms(string $new_type): array
-    {
-        $form = $this->initImportForm($new_type);
-
-        $forms = array(self::CFORM_NEW => $this->initCreateForm($new_type),
-            self::CFORM_IMPORT => $form);
-
-        return $forms;
-    }
-
     protected function importFile(string $file_to_import, string $path_to_uploaded_file_in_temp_dir): void
     {
         $tpl = $this->tpl;

--- a/components/ILIAS/Taxonomy/classes/class.ilObjTaxonomyGUI.php
+++ b/components/ILIAS/Taxonomy/classes/class.ilObjTaxonomyGUI.php
@@ -154,17 +154,6 @@ class ilObjTaxonomyGUI extends ilObject2GUI
         $this->$cmd();
     }
 
-    /**
-     * Init creation forms
-     */
-    protected function initCreationForms(string $a_new_type): array
-    {
-        return array(
-            self::CFORM_NEW => $this->initCreateForm("tax")
-        );
-    }
-
-
     ////
     //// Features that work on the base of an assigned object (AO)
     ////

--- a/components/ILIAS/WorkspaceFolder/classes/class.ilObjWorkspaceFolderGUI.php
+++ b/components/ILIAS/WorkspaceFolder/classes/class.ilObjWorkspaceFolderGUI.php
@@ -198,15 +198,6 @@ class ilObjWorkspaceFolderGUI extends ilObject2GUI
         }
     }
 
-    protected function initCreationForms($a_new_type): array
-    {
-        $forms = array(
-            self::CFORM_NEW => $this->initCreateForm($a_new_type)
-            );
-
-        return $forms;
-    }
-
     public function render(): void
     {
         $tpl = $this->tpl;


### PR DESCRIPTION
Hi all

When changing the file creation dialogs, somewhere in the process the removal of `ilObjectGUI::initCrtaionForms()` got lost. Thanks to @mjansenDatabay for pointing this out to me. I now removed the code and it mostly just is a removal as the function was used to remove one or the other options that where there previously ('create', 'import', or 'clone' an object). Now there are two special cases though:
- `ilObjBibliographicGUI` added a file object here. I just moved the corresponding code to `initCreateForm` and copied the `saveObject()`-function for the legacy form here, so that it would still save. With these changes (and requiring the missing LibRIS-library) things work again. Please have a look at the changes @alex40724 .
- The second problem child is `ilObjLTIConsumerGUI`. There additional forms are added. I made room for that, but will deprecate support for these "hacks" with ILIAS 11. @Uwe-Kohnle this should be moved to the new forms and a switchable group. I could not really test this, as things go sideways for independent reasons. Please have a look at these changes @Uwe-Kohnle .

Then corresponding issue is here: https://mantis.ilias.de/view.php?id=41943

Thanks and best,
@kergomard 