### PR TITLE
Implement ability to use styles for login & logout page editor

### DIFF
--- a/components/ILIAS/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
@@ -135,7 +135,7 @@ class ilAuthLoginPageEditorGUI
 
         $this->tpl->addCss(ilObjStyleSheet::getContentStylePath(0));
         $this->tpl->addCss(ilObjStyleSheet::getSyntaxStylePath());
-        $this->content_style_gui->addCss($this->tpl,  $this->ref_id);
+        $this->content_style_gui->addCss($this->tpl, $this->ref_id);
 
         $this->ctrl->setReturnByClass(ilLoginPageGUI::class, 'edit');
         $page_gui = new ilLoginPageGUI($this->key);

--- a/components/ILIAS/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilAuthLoginPageEditorGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Style\Content\GUIService;
+
 /**
  * @ilCtrl_isCalledBy ilAuthLoginPageEditorGUI: ilObjAuthSettingsGUI
  * @ilCtrl_Calls      ilAuthLoginPageEditorGUI: ilLoginPageGUI
@@ -35,6 +37,8 @@ class ilAuthLoginPageEditorGUI
     private \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
     private ?string $redirect_source = null;
     private ?int $key = null;
+    private GUIService $content_style_gui;
+    private int $ref_id;
 
     public function __construct(int $a_ref_id)
     {
@@ -53,9 +57,13 @@ class ilAuthLoginPageEditorGUI
 
         $this->lng->loadLanguageModule('auth');
 
-        $this->content_style_domain = $DIC->contentStyle()
-                                          ->domain()
-                                          ->styleForRefId($a_ref_id);
+        $this->ref_id = $a_ref_id;
+
+        $content_style = $DIC->contentStyle();
+        $this->content_style_domain = $content_style
+            ->domain()
+            ->styleForRefId($a_ref_id);
+        $this->content_style_gui = $content_style->gui();
 
         $query_wrapper = $DIC->http()->wrapper()->query();
         $post_wrapper = $DIC->http()->wrapper()->post();
@@ -127,6 +135,7 @@ class ilAuthLoginPageEditorGUI
 
         $this->tpl->addCss(ilObjStyleSheet::getContentStylePath(0));
         $this->tpl->addCss(ilObjStyleSheet::getSyntaxStylePath());
+        $this->content_style_gui->addCss($this->tpl,  $this->ref_id);
 
         $this->ctrl->setReturnByClass(ilLoginPageGUI::class, 'edit');
         $page_gui = new ilLoginPageGUI($this->key);

--- a/components/ILIAS/Authentication/classes/class.ilAuthLogoutPageEditorGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilAuthLogoutPageEditorGUI.php
@@ -149,7 +149,7 @@ class ilAuthLogoutPageEditorGUI
 
         $this->tpl->addCss(ilObjStyleSheet::getContentStylePath(0));
         $this->tpl->addCss(ilObjStyleSheet::getSyntaxStylePath());
-        $this->content_style_gui->addCss($this->tpl,  $this->ref_id);
+        $this->content_style_gui->addCss($this->tpl, $this->ref_id);
 
         $this->ctrl->setReturnByClass(ilLogoutPageGUI::class, 'edit');
         $page_gui = new ilLogoutPageGUI($this->key);

--- a/components/ILIAS/Authentication/classes/class.ilAuthLogoutPageEditorGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilAuthLogoutPageEditorGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Style\Content\GUIService;
+
 /**
  * @ilCtrl_isCalledBy ilAuthLogoutPageEditorGUI: ilObjAuthSettingsGUI
  * @ilCtrl_Calls      ilAuthLogoutPageEditorGUI: ilLogoutPageGUI
@@ -42,6 +44,7 @@ class ilAuthLogoutPageEditorGUI
     private \ILIAS\Style\Content\Object\ObjectFacade $content_style_domain;
     private ?string $redirect_source = null;
     private ?int $key = null;
+    private GUIService $content_style_gui;
 
     public function __construct(int $a_ref_id)
     {
@@ -65,9 +68,12 @@ class ilAuthLogoutPageEditorGUI
         $this->ref_id = $a_ref_id;
 
         $this->settings = ilAuthLogoutPageEditorSettings::getInstance();
-        $this->content_style_domain = $DIC->contentStyle()
-                                          ->domain()
-                                          ->styleForRefId($a_ref_id);
+
+        $content_style = $DIC->contentStyle();
+        $this->content_style_domain = $content_style
+            ->domain()
+            ->styleForRefId($a_ref_id);
+        $this->content_style_gui = $content_style->gui();
 
         $query_wrapper = $DIC->http()->wrapper()->query();
         $post_wrapper = $DIC->http()->wrapper()->post();
@@ -143,6 +149,7 @@ class ilAuthLogoutPageEditorGUI
 
         $this->tpl->addCss(ilObjStyleSheet::getContentStylePath(0));
         $this->tpl->addCss(ilObjStyleSheet::getSyntaxStylePath());
+        $this->content_style_gui->addCss($this->tpl,  $this->ref_id);
 
         $this->ctrl->setReturnByClass(ilLogoutPageGUI::class, 'edit');
         $page_gui = new ilLogoutPageGUI($this->key);

--- a/components/ILIAS/Authentication/classes/class.ilObjAuthSettings.php
+++ b/components/ILIAS/Authentication/classes/class.ilObjAuthSettings.php
@@ -72,4 +72,12 @@ class ilObjAuthSettings extends ilObject
 
         return true;
     }
+
+    public static function getAuthSettingsRefId(): int
+    {
+        $auth_settings_objects = ilObject::_getObjectsByType('auth');
+        $auth_settings_obj_id = (int) reset($auth_settings_objects)['obj_id'];
+        $auth_settings_ref_ids = ilObject::_getAllReferences($auth_settings_obj_id);
+        return (int) reset($auth_settings_ref_ids);
+    }
 }

--- a/components/ILIAS/Authentication/classes/class.ilObjAuthSettings.php
+++ b/components/ILIAS/Authentication/classes/class.ilObjAuthSettings.php
@@ -78,6 +78,7 @@ class ilObjAuthSettings extends ilObject
         $auth_settings_objects = ilObject::_getObjectsByType('auth');
         $auth_settings_obj_id = (int) reset($auth_settings_objects)['obj_id'];
         $auth_settings_ref_ids = ilObject::_getAllReferences($auth_settings_obj_id);
+
         return (int) reset($auth_settings_ref_ids);
     }
 }

--- a/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -865,12 +865,13 @@ class ilObjAuthSettingsGUI extends ilObjectGUI implements ilContentPageObjectCon
                 $lpe = new ilAuthLogoutPageEditorGUI($this->object->getRefId());
                 $this->ctrl->forwardCommand($lpe);
                 break;
+
             case strtolower(ilObjectContentStyleSettingsGUI::class):
-                $this->checkPermission("write");
+                $this->checkPermission('write');
                 $this->setTitleAndDescription();
-                $this->setSubTabs("authSettings");
+                $this->setSubTabs('authSettings');
                 $this->tabs_gui->activateTab('authentication_settings');
-                $this->tabs_gui->activateSubTab("style");
+                $this->tabs_gui->activateSubTab('style');
                 $settings_gui = $this->content_style_gui
                     ->objectSettingsGUIForRefId(
                         null,
@@ -878,6 +879,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI implements ilContentPageObjectCon
                     );
                 $this->ctrl->forwardCommand($settings_gui);
                 break;
+
             default:
                 if (!$cmd) {
                     $cmd = 'authSettings';
@@ -1009,7 +1011,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI implements ilContentPageObjectCon
                 $this->tabs_gui->addSubTab(
                     self::UI_TAB_ID_STYLE,
                     $this->lng->txt('cont_style'),
-                    $this->ctrl->getLinkTargetByClass(ilObjectContentStyleSettingsGUI::class, "")
+                    $this->ctrl->getLinkTargetByClass(ilObjectContentStyleSettingsGUI::class)
                 );
             }
         }

--- a/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -1009,7 +1009,7 @@ class ilObjAuthSettingsGUI extends ilObjectGUI implements ilContentPageObjectCon
 
             if ($this->access->checkAccess('write', '', $this->object->getRefId())) {
                 $this->tabs_gui->addSubTab(
-                    self::UI_TAB_ID_STYLE,
+                    'style',
                     $this->lng->txt('cont_style'),
                     $this->ctrl->getLinkTargetByClass(ilObjectContentStyleSettingsGUI::class)
                 );

--- a/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsGUI.php
@@ -28,7 +28,7 @@ use ILIAS\Style\Content\GUIService;
  * @ilCtrl_Calls ilObjAuthSettingsGUI: ilSamlSettingsGUI, ilOpenIdConnectSettingsGUI
  * @ilCtrl_Calls ilObjAuthSettingsGUI: ilObjectContentStyleSettingsGUI
  */
-class ilObjAuthSettingsGUI extends ilObjectGUI implements ilContentPageObjectConstants
+class ilObjAuthSettingsGUI extends ilObjectGUI
 {
     private ilLogger $logger;
     private ILIAS\UI\Factory $ui;

--- a/components/ILIAS/Authentication/classes/class.ilSessionStatisticsGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilSessionStatisticsGUI.php
@@ -772,7 +772,7 @@ class ilSessionStatisticsGUI
                     break;
             }
         }
-        foreach ($meta as  $caption => $value) {
+        foreach ($meta as $caption => $value) {
             $csv->addColumn(strip_tags((string) $caption));
             $csv->addColumn(strip_tags((string) $value));
             $csv->addRow();

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -951,14 +951,12 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             return '';
         }
 
-        $auth_settings_ref_id = (int) $this->dic->database()->fetchAssoc(
-            $this->dic->database()->queryF(
-                "SELECT ref_id FROM object_reference WHERE obj_id = (SELECT obj_id FROM object_data WHERE type = %s)",
-                [ilDBConstants::T_TEXT],
-                ['auth']
-            )
-        )['ref_id'];
-        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $this->getAuthSettingsRefId());
+        $auth_settings_objects = ilObject::_getObjectsByType('auth');
+        $auth_settings_obj_id = (int) reset($auth_settings_objects)['obj_id'];
+        $auth_settings_ref_ids = ilObject::_getAllReferences($auth_settings_obj_id);
+        $auth_settings_ref_id = (int) reset($auth_settings_ref_ids);
+        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $auth_settings_ref_id);
+
         $page_gui = new ilLoginPageGUI(ilLanguage::lookupId($active_lang));
 
         $page_gui->setStyleId(0);
@@ -983,14 +981,10 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             return '';
         }
 
-        $auth_settings_ref_id = (int) $this->dic->database()->fetchAssoc(
-            $this->dic->database()->queryF(
-                "SELECT ref_id FROM object_reference WHERE obj_id = (SELECT obj_id FROM object_data WHERE type = %s)",
-                [ilDBConstants::T_TEXT],
-                ['auth']
-            )
-        )['ref_id'];
-
+        $auth_settings_objects = ilObject::_getObjectsByType('auth');
+        $auth_settings_obj_id = (int) reset($auth_settings_objects)['obj_id'];
+        $auth_settings_ref_ids = ilObject::_getAllReferences($auth_settings_obj_id);
+        $auth_settings_ref_id = (int) reset($auth_settings_ref_ids);
         $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $auth_settings_ref_id);
 
         $page_gui = new ilLogoutPageGUI(ilLanguage::lookupId($active_lang));

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -951,7 +951,14 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             return '';
         }
 
-        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $this->getAuthSettingsRefId());
+        $auth_settings_ref_id = (int) $this->dic->database()->fetchAssoc(
+            $this->dic->database()->queryF(
+                "SELECT ref_id FROM object_reference WHERE obj_id = (SELECT obj_id FROM object_data WHERE type = %s)",
+                [ilDBConstants::T_TEXT],
+                ['auth']
+            )
+        )['ref_id'];
+        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $auth_settings_ref_id);
         //$this->mainTemplate->setCurrentBlock('SyntaxStyle');
         //$this->mainTemplate->setVariable('LOCATION_SYNTAX_STYLESHEET', ilObjStyleSheet::getSyntaxStylePath());
         //$this->mainTemplate->parseCurrentBlock();
@@ -981,7 +988,15 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             return '';
         }
 
-        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $this->getAuthSettingsRefId());
+        $auth_settings_ref_id = (int) $this->dic->database()->fetchAssoc(
+            $this->dic->database()->queryF(
+                "SELECT ref_id FROM object_reference WHERE obj_id = (SELECT obj_id FROM object_data WHERE type = %s)",
+                [ilDBConstants::T_TEXT],
+                ['auth']
+            )
+        )['ref_id'];
+
+        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $auth_settings_ref_id);
 
         $page_gui = new ilLogoutPageGUI(ilLanguage::lookupId($active_lang));
 
@@ -992,19 +1007,6 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         $page_gui->setHeader('');
 
         return $page_gui->showPage();
-    }
-
-    private function getAuthSettingsRefId(): int
-    {
-        $auth_settings_obj_data = $this->dic->database()->fetchAssoc(
-            $this->dic->database()->queryF(
-                "SELECT ref_id FROM object_reference WHERE obj_id = (SELECT obj_id FROM object_data WHERE type = %s)",
-                [ilDBConstants::T_TEXT],
-                ['auth']
-            )
-        );
-
-        return (int) $auth_settings_obj_data['ref_id'];
     }
 
     private function showRegistrationLinks(string $page_editor_html): string

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -951,6 +951,11 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             return '';
         }
 
+        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $this->getAuthSettingsRefId());
+        //$this->mainTemplate->setCurrentBlock('SyntaxStyle');
+        //$this->mainTemplate->setVariable('LOCATION_SYNTAX_STYLESHEET', ilObjStyleSheet::getSyntaxStylePath());
+        //$this->mainTemplate->parseCurrentBlock();
+
         // get page object
         $page_gui = new ilLoginPageGUI(ilLanguage::lookupId($active_lang));
 
@@ -976,6 +981,8 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             return '';
         }
 
+        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $this->getAuthSettingsRefId());
+
         $page_gui = new ilLogoutPageGUI(ilLanguage::lookupId($active_lang));
 
         $page_gui->setStyleId(0);
@@ -985,6 +992,19 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         $page_gui->setHeader('');
 
         return $page_gui->showPage();
+    }
+
+    private function getAuthSettingsRefId(): int
+    {
+        $auth_settings_obj_data = $this->dic->database()->fetchAssoc(
+            $this->dic->database()->queryF(
+                "SELECT ref_id FROM object_reference WHERE obj_id = (SELECT obj_id FROM object_data WHERE type = %s)",
+                [ilDBConstants::T_TEXT],
+                ['auth']
+            )
+        );
+
+        return (int) $auth_settings_obj_data['ref_id'];
     }
 
     private function showRegistrationLinks(string $page_editor_html): string

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -952,11 +952,6 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         }
 
         $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $this->getAuthSettingsRefId());
-        //$this->mainTemplate->setCurrentBlock('SyntaxStyle');
-        //$this->mainTemplate->setVariable('LOCATION_SYNTAX_STYLESHEET', ilObjStyleSheet::getSyntaxStylePath());
-        //$this->mainTemplate->parseCurrentBlock();
-
-        // get page object
         $page_gui = new ilLoginPageGUI(ilLanguage::lookupId($active_lang));
 
         $page_gui->setStyleId(0);

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -951,11 +951,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             return '';
         }
 
-        $auth_settings_objects = ilObject::_getObjectsByType('auth');
-        $auth_settings_obj_id = (int) reset($auth_settings_objects)['obj_id'];
-        $auth_settings_ref_ids = ilObject::_getAllReferences($auth_settings_obj_id);
-        $auth_settings_ref_id = (int) reset($auth_settings_ref_ids);
-        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $auth_settings_ref_id);
+        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, ilObjAuthSettings::getAuthSettingsRefId());
 
         $page_gui = new ilLoginPageGUI(ilLanguage::lookupId($active_lang));
 
@@ -981,11 +977,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             return '';
         }
 
-        $auth_settings_objects = ilObject::_getObjectsByType('auth');
-        $auth_settings_obj_id = (int) reset($auth_settings_objects)['obj_id'];
-        $auth_settings_ref_ids = ilObject::_getAllReferences($auth_settings_obj_id);
-        $auth_settings_ref_id = (int) reset($auth_settings_ref_ids);
-        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, $auth_settings_ref_id);
+        $this->dic->contentStyle()->gui()->addCss($this->mainTemplate, ilObjAuthSettings::getAuthSettingsRefId());
 
         $page_gui = new ilLogoutPageGUI(ilLanguage::lookupId($active_lang));
 


### PR DESCRIPTION
This PR introduces content styles for the login/logout-page `IPE` content.

See:
- https://docu.ilias.de/go/wiki/wpage_8269_1357
- https://docu.ilias.de/go/wiki/wpage_7330_1357