### PR TITLE
Course: Fix default value in LO course

### DIFF
--- a/Modules/Course/classes/Objectives/class.ilLOEditorGUI.php
+++ b/Modules/Course/classes/Objectives/class.ilLOEditorGUI.php
@@ -437,7 +437,9 @@ class ilLOEditorGUI
         $type_qa->addSubItem($start_q);
 
         $passed_mode = new ilRadioGroupInputGUI($this->lng->txt('crs_loc_settings_passed_mode'), 'passed_mode');
-        $passed_mode->setValue((string) $this->getSettings()->getPassedObjectiveMode());
+        $passed_mode->setValue(
+            (string) ($this->getSettings()->getPassedObjectiveMode() ?: ilLOSettings::HIDE_PASSED_OBJECTIVE_QST)
+        );
 
         $passed_mode->addOption(
             new ilRadioOption(


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=41738

If approved, this must be picked to `release_9` and `trunk` as well.