### PR TITLE
Auth: Init global user for "blocked authentication" state (fix for `$DIC->user()->getId() === 0`)

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1407,7 +1407,7 @@ class ilInitialisation
         }
 
         if (
-            !$DIC['ilAuthSession']->isAuthenticated() or
+            !$DIC['ilAuthSession']->isAuthenticated() ||
             $DIC['ilAuthSession']->isExpired()
         ) {
             if ($GLOBALS['DIC']['ilAuthSession']->isExpired()) {
@@ -1417,6 +1417,7 @@ class ilInitialisation
             $current_script = substr(strrchr($_SERVER["PHP_SELF"], "/"), 1);
             if (self::blockedAuthentication($current_script)) {
                 ilLoggerFactory::getLogger('init')->debug('Authentication is started in current script.');
+                self::initUserAccount();
                 // nothing todo: authentication is done in current script
                 return;
             }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=41601

If approved, this MUST be picked to all maintained branches.

This will init/set the global user object in case `\ilInitialisation::blockedAuthentication` returns `true`, so the user id of a non-logged-in user will be `13` and not `0` for these cases.