### PR TITLE
Auth/RepoTree: Add "blocked auth." exception

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1759,6 +1759,14 @@ class ilInitialisation
             ilLoggerFactory::getLogger('auth')->debug('Blocked authentication for goto target: ' . $target);
             return true;
         }
+
+        if ($a_current_script === 'ilias.php' &&
+            $requestBaseClass === strtolower(ilRepositoryGUI::class) &&
+            $DIC->ctrl()->getCmd() === 'showRepTree') {
+            ilLoggerFactory::getLogger('auth')->debug('Blocked authentication for repository target: ' . $target);
+            return true;
+        }
+
         ilLoggerFactory::getLogger('auth')->debug('Authentication required');
         return false;
     }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=41601

This PR adds an exception within `\ilInitialisation::blockedAuthentication` for the context of the asynchronous repository tree explorer rendering.

`\ilInitialisation::blockedAuthentication` is from hell, IMO the different command handling endpoints need a way to communicate such exceptions to the "Init" component (maybe the mechanisms of the component revision will do the trick in future).

If approved, this has to be merged to all maintained branches.