### PR TITLE
CI/StyleToRepo: adjust workflow for 9 and (maybe) fail on git

### DIFF
--- a/.github/workflows/style-to-repo_trunk.yml
+++ b/.github/workflows/style-to-repo_trunk.yml
@@ -2,7 +2,7 @@ name: Build and deploy style files
 on:
   push:
     branches:
-      - "trunk"
+      - "release_9"
 
 jobs:
   style-to-repo:

--- a/CI/Style-To-Repo/README.md
+++ b/CI/Style-To-Repo/README.md
@@ -14,6 +14,8 @@ STYLE_REPO_NAME_SHORT="foo/style_test.git"
 
 ### Add a token for an user with admin access to style repository
 
+https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
+
 - open settings for the user on github
 - click 'Developer settings/Personal access tokens/Tokens (classic)'
 - click 'Generate new token (classic)'

--- a/CI/Style-To-Repo/deploy.sh
+++ b/CI/Style-To-Repo/deploy.sh
@@ -81,4 +81,10 @@ function deploy() {
     git -C ${DEPLOY_BASE_FOLDER} commit -m "Style changes from '${HASH}'" -m "Original message: '${MSG}'" -m "${URL}"
     git -C ${DEPLOY_BASE_FOLDER} push origin ${BRANCH}
   fi
+  if [ $? = 0 ] ; then
+    echo "[${NOW}] remote repo updated."
+  else
+    echo "[${NOW}] git commit/push failed."
+    exit $?
+  fi
 }


### PR DESCRIPTION
CI/Style-To-Repo no longer ran with release 9; also, the repo-token expired without anybody to notice.

https://mantis.ilias.de/view.php?id=41557