### PR TITLE
9/UI/settings icon-font-path to settings layer

### DIFF
--- a/templates/default/010-settings/_settings_media.scss
+++ b/templates/default/010-settings/_settings_media.scss
@@ -1,2 +1,4 @@
 //** if left unchanged, you have to copy all the background images to your skin/images folder. To use the delos background images in your skin, please change this value (in custom less data or in variables.scss of your custom skin) to "../../../../templates/default/images/"
 $il-background-images-path: "./images/" !default;
+//** this should point to bootstrap's glyphicon-halfling font
+$il-icon-font-path: "./fonts/bootstrap/" !default;

--- a/templates/default/010-settings/legacy-settings/_legacy-settings_symbol.scss
+++ b/templates/default/010-settings/legacy-settings/_legacy-settings_symbol.scss
@@ -10,4 +10,3 @@ $il-icon-size-medium: 35px;
 $il-icon-size-large: 45px;
 //** Path for standard icons in ILIAS
 $il-standard-icon-path: $il-background-images-path;
-

--- a/templates/default/070-components/UI-framework/Symbol/_ui-component_glyph.scss
+++ b/templates/default/070-components/UI-framework/Symbol/_ui-component_glyph.scss
@@ -1,7 +1,6 @@
 @use "../../../010-settings/" as *;
 @use "../../../050-layout/basics" as *;
 
-$il-icon-font-path: "./fonts/bootstrap/";
 $il-glyph-color: $il-link-color;
 $il-glyph-hover-color: $il-link-hover-color;
 $il-glyph-highlighted-color: $il-warning-color;
@@ -40,7 +39,7 @@ $icon-font-svg-id:        "glyphicons_halflingsregular" !default;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
   }
-  
+
   // Individual icons
   .glyphicon-asterisk               { &:before { content: "\002a"; } }
   .glyphicon-plus                   { &:before { content: "\002b"; } }


### PR DESCRIPTION
# Issue

Icon font path for glyphs cannot be set from a custom system style's entry point as it's part of the symbol component and not a general setting.

# Change

Moved $il-icon-font-path to settings layer and exposed it to entry point re-definition with !default. 