### PR TITLE
DataCollection: Fix ref property type

### DIFF
--- a/Modules/DataCollection/classes/Fields/Reference/class.ilDclReferenceFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Reference/class.ilDclReferenceFieldModel.php
@@ -43,7 +43,7 @@ class ilDclReferenceFieldModel extends ilDclBaseFieldModel
             return null;
         }
 
-        $ref_field = ilDclCache::getFieldCache($this->getProperty(self::PROP_REFERENCE));
+        $ref_field = ilDclCache::getFieldCache((int) $this->getProperty(self::PROP_REFERENCE));
 
         $select_str = "stloc_{$this->getId()}_joined.value AS field_{$this->getId()},";
         $join_str = "LEFT JOIN il_dcl_record_field AS record_field_{$this->getId()} ON (record_field_{$this->getId()}.record_id = record.id AND record_field_{$this->getId()}.field_id = "


### PR DESCRIPTION
This is not required, since the default configuration of PHP 8.0 would not catch that error.
However, if PHP is false configured, this restores at least the visibility of the DataCollection.