### PR TITLE
[FIX] incompatibly implementation of ArrayAccess

### DIFF
--- a/components/ILIAS/Component/src/Dependencies/NullDIC.php
+++ b/components/ILIAS/Component/src/Dependencies/NullDIC.php
@@ -30,12 +30,12 @@ class NullDIC implements \ArrayAccess
     {
     }
 
-    public function offsetGet($id): null
+    public function offsetGet($id): mixed
     {
         return null;
     }
 
-    public function offsetExists($id): false
+    public function offsetExists($id): bool
     {
         return false;
     }

--- a/components/ILIAS/Component/tests/Dependencies/RenamingDICTest.php
+++ b/components/ILIAS/Component/tests/Dependencies/RenamingDICTest.php
@@ -25,7 +25,7 @@ use ILIAS\Component\Dependencies\RenamingDIC;
 
 class RenamingDICTest extends TestCase
 {
-    public function testRenaming()
+    public function testRenaming(): void
     {
         $wrapped = new class () implements \ArrayAccess {
             public array $data = [];
@@ -35,10 +35,10 @@ class RenamingDICTest extends TestCase
                 $this->data[] = [$id, $value];
             }
 
-            public function offsetGet($id): null
+            public function offsetGet($id): mixed
             {
             }
-            public function offsetExists($id): false
+            public function offsetExists($id): bool
             {
             }
             public function offsetUnset($id): void


### PR DESCRIPTION
@klees I first thought about committing this directly as a trivial fix, but maybe there was a reason for this implementation? from my point of view this doesn't work, because on the one hand the ArrayAccess interface requires something else and also because null or false are not valid return types, right?