### PR TITLE
[FIX] UI: remove for attribute of Field\Section component.

### DIFF
--- a/components/ILIAS/Test/tests/Scoring/Settings/ScoreSettingsTest.php
+++ b/components/ILIAS/Test/tests/Scoring/Settings/ScoreSettingsTest.php
@@ -216,7 +216,7 @@ class ScoreSettingsTest extends ilTestBaseTestCase
             'test_scoring',
             $i1 . $i2 . $i3,
             null,
-            'id_4',
+            '',
             ''
         );
         $this->assertHTMLEquals($expected, $this->brutallyTrimSignals($actual));
@@ -367,7 +367,7 @@ class ScoreSettingsTest extends ilTestBaseTestCase
             'test_results',
             $i1,
             null,
-            'id_8',
+            '',
             ''
         );
         $this->assertEquals($expected, $this->brutallyTrimSignals($actual));
@@ -416,7 +416,7 @@ class ScoreSettingsTest extends ilTestBaseTestCase
             'tst_results_details_options',
             $options,
             null,
-            'id_8',
+            '',
             ''
         );
         $this->assertEquals($expected, $this->brutallyTrimSignals($actual));
@@ -494,7 +494,7 @@ class ScoreSettingsTest extends ilTestBaseTestCase
             'tst_results_gamification',
             $group,
             null,
-            'id_10',
+            '',
             ''
         );
         $this->assertHTMLEquals($expected, $this->brutallyTrimSignals($actual));

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -749,7 +749,7 @@ class Renderer extends AbstractComponentRenderer
             $inputs_html .= $default_renderer->render($input);
         }
         $id = $this->bindJavaScript($section) ?? $this->createId();
-        return $this->wrapInFormContext($section, $section->getLabel(), $inputs_html, $id);
+        return $this->wrapInFormContext($section, $section->getLabel(), $inputs_html, $id, '', false);
     }
 
     protected function renderUrlField(F\Url $component, RendererInterface $default_renderer): string

--- a/components/ILIAS/UI/tests/Component/Input/Field/SectionInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SectionInputTest.php
@@ -67,7 +67,7 @@ class SectionInputTest extends ILIAS_UI_TestBase
             $label,
             $f1 . $f2,
             $byline,
-            'id_3'
+            ''
         );
         $this->assertEquals($expected, $this->render($section));
     }


### PR DESCRIPTION
Hi folks,

This addresses the issue I mentioned in #7524, which removes the `for` attribute of the `Field\Section` input, since it has no visible form control and must therefore not be used.

@kergomard could you sign off the code changes to the `ScoreSettingsTest`?

Thx and kind regards,
@thibsy 