### PR TITLE
mantis #41510 plugin type is ignored, when no plugins installed

### DIFF
--- a/Modules/DataCollection/classes/Fields/class.ilDclFieldEditGUI.php
+++ b/Modules/DataCollection/classes/Fields/class.ilDclFieldEditGUI.php
@@ -266,6 +266,15 @@ class ilDclFieldEditGUI
             foreach (ilDclDatatype::getAllDatatype() as $datatype) {
                 $model = new ilDclBaseFieldModel();
                 $model->setDatatypeId($datatype->getId());
+                //check plugin field type for validity (no plugins - the type must not be displayed)
+                if ($model->getDatatypeId() === ilDclDatatype::INPUTFORMAT_PLUGIN) {
+                    $ilPluginAdmin = $DIC['ilPluginAdmin'];
+                    $pluginIterator = $ilPluginAdmin->getComponentRepository()->getPluginSlotById("dclfth")->getPlugins();
+                    if (iterator_count($pluginIterator) === 0) {
+                        $this->main_tpl->setOnScreenMessage('info', "no plugins installed - field type 'Plugin' is not available", true);
+                        continue;
+                    }
+                }
                 $field_representation = ilDclFieldFactory::getFieldRepresentationInstance($model);
                 $field_representation->addFieldCreationForm($edit_datatype, $this->getDataCollectionObject());
             }

--- a/Modules/DataCollection/classes/Fields/class.ilDclFieldEditGUI.php
+++ b/Modules/DataCollection/classes/Fields/class.ilDclFieldEditGUI.php
@@ -251,6 +251,14 @@ class ilDclFieldEditGUI
         $edit_datatype = new ilRadioGroupInputGUI($lng->txt('dcl_datatype'), 'datatype');
 
         if ($a_mode === 'edit') {
+            //check plugin field type for validity
+            if ($this->field_obj->getDatatypeId() === ilDclDatatype::INPUTFORMAT_PLUGIN) {
+                $ilPluginAdmin = $DIC['ilPluginAdmin'];
+                $pluginIterator = $ilPluginAdmin->getComponentRepository()->getPluginSlotById("dclfth")->getPlugins();
+                if (iterator_count($pluginIterator) === 0) {
+                    $this->main_tpl->setOnScreenMessage('info', "no plugins installed - field '" . $this->field_obj->getTitle() . "' cannot be edited", true);
+                }
+            }
             $field_representation = ilDclFieldFactory::getFieldRepresentationInstance($this->field_obj);
             $field_representation->addFieldCreationForm($edit_datatype, $this->getDataCollectionObject(), $a_mode);
             $edit_datatype->setDisabled(true);

--- a/Modules/DataCollection/classes/TableView/class.ilDclTableView.php
+++ b/Modules/DataCollection/classes/TableView/class.ilDclTableView.php
@@ -227,10 +227,10 @@ class ilDclTableView extends ActiveRecord
      */
     public function getVisibleFields(): array
     {
-       global $DIC;
-       $this->main_tpl = $DIC->ui()->mainTemplate();
+        global $DIC;
+        $this->main_tpl = $DIC->ui()->mainTemplate();
 
-       if (!$this->visible_fields_cache) {
+        if (!$this->visible_fields_cache) {
             $visible = ilDclTableViewFieldSetting::where(
                 [
                     "tableview_id" => $this->id,

--- a/Services/Component/classes/class.ilPluginAdmin.php
+++ b/Services/Component/classes/class.ilPluginAdmin.php
@@ -40,7 +40,7 @@ class ilPluginAdmin
     /**
      * @return ilComponentRepository
      */
-    public function getComponentRepository() : ilComponentRepository
+    public function getComponentRepository(): ilComponentRepository
     {
         return $this->component_repository;
     }

--- a/Services/Component/classes/class.ilPluginAdmin.php
+++ b/Services/Component/classes/class.ilPluginAdmin.php
@@ -37,6 +37,14 @@ class ilPluginAdmin
         $this->component_repository = $component_repository;
     }
 
+    /**
+     * @return ilComponentRepository
+     */
+    public function getComponentRepository() : ilComponentRepository
+    {
+        return $this->component_repository;
+    }
+
     protected function getPluginInfo($a_ctype, $a_cname, $a_slot_id, $a_pname): \ilPluginInfo
     {
         return $this->component_repository


### PR DESCRIPTION
three functionalities are affected:

when no plugins are installed
- ignore plugin field in existing table (with warning)
- for an already existing field of type plugin: choosing a plugin is disabled
- for an additional field the type 'plugin' is not offered