### PR TITLE
Plugins: for 10, move plugins to public/Customizing/

### DIFF
--- a/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
+++ b/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
+++ b/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
@@ -19,7 +19,7 @@ use ILIAS\Setup;
 
 class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactObjective
 {
-    protected const BASE_PATH = "./Customizing/global/plugins/";
+    protected const BASE_PATH = "./public/Customizing/plugins/";
     protected const PLUGIN_PHP = "plugin.php";
     protected const PLUGIN_CLASS_FILE = "classes/class.il%sPlugin.php";
 
@@ -33,30 +33,36 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
     public function build(): Setup\Artifact
     {
         $data = [];
-        foreach (["components/ILIAS"] as $type) {
-            $components = $this->scanDir(static::BASE_PATH . $type);
-            foreach ($components as $component) {
-                if ($this->isDotFile($component)
-                    || ! $this->isDir(static::BASE_PATH . "$type/$component")) continue;
-                $slots = $this->scanDir(static::BASE_PATH . "$type/$component");
-                foreach ($slots as $slot) {
-                    if ($this->isDotFile($slot)
-                        || ! $this->isDir(static::BASE_PATH . "$type/$component/$slot")) continue;
-                    $plugins = $this->scanDir(static::BASE_PATH . "$type/$component/$slot");
-                    foreach ($plugins as $plugin) {
-                        if ($this->isDotFile($plugin)
-                            || ! $this->isDir(static::BASE_PATH . "$type/$component/$slot/$plugin")) continue;
-                        $this->addPlugin($data, $type, $component, $slot, $plugin);
+
+        $components = $this->scanDir(static::BASE_PATH);
+        foreach ($components as $component) {
+            if ($this->isDotFile($component)
+                || ! $this->isDir(static::BASE_PATH . "$component")) {
+                continue;
+            }
+            $slots = $this->scanDir(static::BASE_PATH . "$component");
+            foreach ($slots as $slot) {
+                if ($this->isDotFile($slot)
+                    || ! $this->isDir(static::BASE_PATH . "$component/$slot")) {
+                    continue;
+                }
+                $plugins = $this->scanDir(static::BASE_PATH . "$component/$slot");
+                foreach ($plugins as $plugin) {
+                    if ($this->isDotFile($plugin)
+                        || ! $this->isDir(static::BASE_PATH . "$component/$slot/$plugin")) {
+                        continue;
                     }
+                    $this->addPlugin($data, $component, $slot, $plugin);
                 }
             }
         }
+
         return new Setup\Artifact\ArrayArtifact($data);
     }
 
-    protected function addPlugin(array &$data, string $type, string $component, string $slot, string $plugin): void
+    protected function addPlugin(array &$data, string $component, string $slot, string $plugin): void
     {
-        $plugin_path = $this->buildPluginPath($type, $component, $slot, $plugin);
+        $plugin_path = $this->buildPluginPath($component, $slot, $plugin);
         $plugin_php = $plugin_path . static::PLUGIN_PHP;
         if (!$this->fileExists($plugin_php)) {
             throw new \RuntimeException(
@@ -92,7 +98,7 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
         }
 
         $data[$id] = [
-            $type,
+            \ilComponentInfo::TYPES[0],
             $component,
             $slot,
             $plugin,
@@ -131,11 +137,11 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
 
     protected function isDotFile(string $file): bool
     {
-        return ( substr($file, 0, 1) === '.' );
+        return (substr($file, 0, 1) === '.');
     }
 
-    protected function buildPluginPath(string $type, string $component, string $slot, string $plugin): string
+    protected function buildPluginPath(string $component, string $slot, string $plugin): string
     {
-        return static::BASE_PATH . "$type/$component/$slot/$plugin/";
+        return static::BASE_PATH . "$component/$slot/$plugin/";
     }
 }

--- a/components/ILIAS/Component/classes/class.ilComponentRepository.php
+++ b/components/ILIAS/Component/classes/class.ilComponentRepository.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
  */
 interface ilComponentRepository
 {
-    public const PLUGIN_BASE_PATH = "Customizing/global/plugins";
+    public const PLUGIN_BASE_PATH = "public/Customizing/plugins";
 
     /**
      * Check if a component exists.

--- a/components/ILIAS/Component/tests/Setup/ilComponentBuildPluginInfoObjectiveTest.php
+++ b/components/ILIAS/Component/tests/Setup/ilComponentBuildPluginInfoObjectiveTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -34,7 +35,7 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
         $this->files = [];
         $this->added = [];
         $this->builder = new class ($this) extends ilComponentBuildPluginInfoObjective {
-            protected const BASE_PATH = "";
+            protected const BASE_PATH = "plugins/";
             protected ilComponentBuildPluginInfoObjectiveTest $test;
             public function __construct($test)
             {
@@ -61,22 +62,22 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
             {
                 return parent::isDotFile($file);
             }
-            protected function buildPluginPath(string $type, string $component, string $slot, string $plugin): string
+            protected function buildPluginPath(string $component, string $slot, string $plugin): string
             {
-                return $this->test->files[parent::buildPluginPath($type, $component, $slot, $plugin)];
+                return $this->test->files[parent::buildPluginPath($component, $slot, $plugin)];
             }
 
-            public function _buildPluginPath(string $type, string $component, string $slot, string $plugin): string
+            public function _buildPluginPath(string $component, string $slot, string $plugin): string
             {
-                return parent::buildPluginPath($type, $component, $slot, $plugin);
+                return parent::buildPluginPath($component, $slot, $plugin);
             }
-            protected function addPlugin(array &$data, string $type, string $component, string $slot, string $plugin): void
+            protected function addPlugin(array &$data, string $component, string $slot, string $plugin): void
             {
-                $this->test->added[] = "$type/$component/$slot/$plugin";
+                $this->test->added[] = "$component/$slot/$plugin";
             }
-            public function _addPlugin(array &$data, string $type, string $component, string $slot, string $plugin): void
+            public function _addPlugin(array &$data, string $component, string $slot, string $plugin): void
             {
-                parent::addPlugin($data, $type, $component, $slot, $plugin);
+                parent::addPlugin($data, $component, $slot, $plugin);
             }
         };
     }
@@ -85,7 +86,7 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     {
         $this->builder->build();
 
-        $expected = ["components/ILIAS"];
+        $expected = ["plugins/"];
         sort($expected);
         sort($this->scanned);
         $this->assertEquals($expected, $this->scanned);
@@ -94,15 +95,15 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     public function testScanningComplete(): void
     {
         $this->dirs = [
-            "components/ILIAS" => ["Module1", "Module2"],
-            "components/ILIAS/Module1" => ["Slot1", "Slot2"],
-            "components/ILIAS/Module2" => []
+            "plugins/" => ["Module1", "Module2"],
+            "plugins/Module1" => ["Slot1", "Slot2"],
+            "plugins/Module2" => []
         ];
 
         $this->builder->build();
 
-        $expected = ["components/ILIAS", "components/ILIAS/Module1", "components/ILIAS/Module2",
-            "components/ILIAS/Module1/Slot1", "components/ILIAS/Module1/Slot2"];
+        $expected = ["plugins/", "plugins/Module1", "plugins/Module2",
+            "plugins/Module1/Slot1", "plugins/Module1/Slot2"];
         sort($expected);
         sort($this->scanned);
         $this->assertEquals($expected, $this->scanned);
@@ -111,16 +112,16 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     public function testPluginsAdded(): void
     {
         $this->dirs = [
-            "components/ILIAS" => ["Module1"],
-            "components/ILIAS/Module1" => ["Slot1"],
-            "components/ILIAS/Module1/Slot1" => ["Plugin1", "Plugin2"]
+            "plugins/" => ["Module1"],
+            "plugins/Module1" => ["Slot1"],
+            "plugins/Module1/Slot1" => ["Plugin1", "Plugin2"]
         ];
 
         $this->builder->build();
 
         $expected = [
-            "components/ILIAS/Module1/Slot1/Plugin1",
-            "components/ILIAS/Module1/Slot1/Plugin2"
+            "Module1/Slot1/Plugin1",
+            "Module1/Slot1/Plugin2"
         ];
         sort($expected);
         sort($this->added);
@@ -158,8 +159,8 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     public function testAddPlugins(): void
     {
         $data = [];
-        $this->files["components/ILIAS/Module1/Slot1/Plugin1/"] = __DIR__ . "/";
-        $this->builder->_addPlugin($data, "components/ILIAS", "Module1", "Slot1", "Plugin1");
+        $this->files["plugins/Module1/Slot1/Plugin1/"] = __DIR__ . "/";
+        $this->builder->_addPlugin($data, "Module1", "Slot1", "Plugin1");
 
         $expected = [
             "tstplg" => [
@@ -182,6 +183,6 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
 
     public function testBuildPluginPath(): void
     {
-        $this->assertEquals("TYPE/COMPONENT/SLOT/PLUGIN/", $this->builder->_buildPluginPath("TYPE", "COMPONENT", "SLOT", "PLUGIN"));
+        $this->assertEquals("plugins/COMPONENT/SLOT/PLUGIN/", $this->builder->_buildPluginPath("COMPONENT", "SLOT", "PLUGIN"));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
 			"@php cli/build_bootstrap.php components/ILIAS/Setup/resources/dependency_resolution.php setup",
 			"@php cli/setup.php build --yes"
 		],
+		"pre-install-cmd": [
+			"mkdir -p public/Customizing/plugins"
+		],
 		"post-install-cmd": [
 			"@php vendor/composer/rmdirs.php"
 		],

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
 			"ILIAS\\Scripts\\" : "./scripts"
 		},
 		"classmap": [
-			"./Customizing/global/plugins",
+			"./public/Customizing/plugins",
 			"./components/ILIAS",
 			"./vendor/ilias",
 			"./components/ILIAS/soap",
@@ -92,6 +92,7 @@
 			"./components/ILIAS/Migration",
 			"./*/*/lib",
 			"./Customizing/**/vendor",
+			"./public/Customizing/**/vendor",
 			"./components/ILIAS/setup_/sql",
 			"./cli/setup.php",
 			"./components/ILIAS/setup_/client.master.ini.php",

--- a/docs/development/components-and-directories-process.md
+++ b/docs/development/components-and-directories-process.md
@@ -5,7 +5,7 @@ This document describes the implementation of the new Components and Directories
 1. [Creation of root directories](#1-creation-of-root-directories)
 2. [dicto](#2-dicto)
 3. [Modules and Services](#3-modules-and-services)
-4. [Customizing > global > plugin](#4-customizingglobalplugin)
+4. [public > Customizing > plugins](#4-publiccustomizingplugins)
 5. [include](#5-include)
 6. [CI](#6-ci)
 7. [sso](#7-sso)
@@ -237,9 +237,9 @@ The following new structure won't implemented in the first PR / process step:
 
 -----------
 
-## 4. ./Customizing/global/plugin
+## 4. ./public/Customizing/plugins
 
-The plugin directory stays at `Customizing/global/plugin` for now and will later on moved to
+The plugin directory stays at `public/Customizing/plugins` for now and will later on moved to
 `components/{SERVICE_PROVIDER}`.
 The name {SERVICE_PROVIDER} will be a placeholder for unique provider, who will create their own plugins.
 


### PR DESCRIPTION
This moves the plugin directory to /public/Customizing/plugins; 
'Services' and 'Modules' are removed from the path.

so, e.g., the TestPageComponent will now reside in 
`/public/Customizing/plugins/COPage/PageComponent/TestPageComponent/`


- [ ] docs still have to be updated