### PR TITLE
HTTP: Fix sending `Set-Cookie` HTTP header

### DIFF
--- a/src/HTTP/Response/Sender/DefaultResponseSenderStrategy.php
+++ b/src/HTTP/Response/Sender/DefaultResponseSenderStrategy.php
@@ -46,7 +46,14 @@ class DefaultResponseSenderStrategy implements ResponseSenderStrategy
 
         //render all headers
         foreach (array_keys($response->getHeaders()) as $key) {
-            header("$key: " . $response->getHeaderLine($key));
+            // See Mantis #37385.
+            if (strtolower($key) === 'set-cookie') {
+                foreach ($response->getHeader($key) as $header) {
+                    header("$key: " . $header, false);
+                }
+            } else {
+                header("$key: " . $response->getHeaderLine($key));
+            }
         }
 
         //rewind body stream


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=41226

If approved, this MUST be picked to `release_9` and `trunk`.