### PR TITLE
DataCollection: Remove YUI and nodes JS

### DIFF
--- a/Modules/DataCollection/classes/class.ilObjDataCollectionGUI.php
+++ b/Modules/DataCollection/classes/class.ilObjDataCollectionGUI.php
@@ -106,12 +106,6 @@ class ilObjDataCollectionGUI extends ilObject2GUI
 
     private function addJavaScript(): void
     {
-        global $DIC;
-        $DIC->notes()->gui()->initJavascript();
-        ilYuiUtil::initConnection();
-        ilOverlayGUI::initJavascript();
-        // # see  https://mantis.ilias.de/view.php?id=26463
-        $this->dclUi->addJavaScriptFile("./Services/UIComponent/Modal/js/Modal.js");
         $this->dclUi->addJavaScriptFile("Modules/DataCollection/js/datacollection.js");
     }
 


### PR DESCRIPTION
Removes unused JS libaries:
- Yahoo YUI Libary
- Overlay
- Notes
- Modal (explicit call)