### PR TITLE
Data/LanguageTag/UnitTests: Fix test provider

### DIFF
--- a/components/ILIAS/Data/tests/LanguageTagTest.php
+++ b/components/ILIAS/Data/tests/LanguageTagTest.php
@@ -52,6 +52,10 @@ class LanguageTagTest extends TestCase
         $this->testParse($input, $isOk);
     }
 
+    /**
+     * @return list<array{0: string, 1: bool}>
+     */
+
     public static function saveToRun(): array
     {
         return [
@@ -139,10 +143,13 @@ class LanguageTagTest extends TestCase
         ];
     }
 
+    /**
+     * @return list<array{0: string, 1: bool}>
+     */
     public static function risky(): array
     {
         if (function_exists('xdebug_info') && ((int) ini_get('xdebug.max_nesting_level')) < 780) {
-            $this->markTestSkipped(sprintf(
+            self::markTestSkipped(sprintf(
                 'You are running under Xdebug. To be able to run all tests xdebug.max_nesting_level must be at least 780 (Currently %d).',
                 (int) ini_get('xdebug.max_nesting_level')
             ));


### PR DESCRIPTION
This PR fixes the following error with PHP 8.3:

```
There was 1 PHPUnit error:

1) ILIAS\Tests\Data\LanguageTagTest::testRisky
The data provider specified for ILIAS\Tests\Data\LanguageTagTest::testRisky is invalid
Using $this when not in object context
```