### PR TITLE
UI/UnitTests: Remove deprecated usage of `ASSERT_WARNING`

### DIFF
--- a/components/ILIAS/UI/tests/Base.php
+++ b/components/ILIAS/UI/tests/Base.php
@@ -326,16 +326,6 @@ abstract class ILIAS_UI_TestBase extends TestCase
 
 trait BaseUITestTrait
 {
-    public function setUp(): void
-    {
-        assert_options(ASSERT_WARNING, 0);
-    }
-
-    public function tearDown(): void
-    {
-        assert_options(ASSERT_WARNING, 1);
-    }
-
     public function getUIFactory(): NoUIFactory
     {
         return new NoUIFactory();


### PR DESCRIPTION
This PR fixes the following issue when running the unit tests with PHP 8.3:

```
...
655 tests triggered 4 PHP deprecations:

1) /var/www/ilias/trunk/components/ILIAS/UI/tests/Base.php:336
Constant ASSERT_WARNING is deprecated
...
```
See: https://www.php.net/manual/en/migration83.deprecated.php#migration83.deprecated.standard