### PR TITLE
Unit Tests: Show details for skipped tests

### DIFF
--- a/scripts/PHPUnit/phpunit.xml
+++ b/scripts/PHPUnit/phpunit.xml
@@ -13,6 +13,7 @@
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnSkippedTests="true"
          backupGlobals="true"
          executionOrder="random"
          cacheResultFile=".phpunit.cache/test-results">


### PR DESCRIPTION
This PR changes the "PHPUnit" configuration to display details about skipped tests. Having details about skipped tests is useful to determine the file/test class of the skipped tests (e.g. for CI reports at the ILIAS JourFixe).