### PR TITLE
Saml: Fix table. Fix config paths

### DIFF
--- a/components/ILIAS/Saml/classes/class.ilSamlIdpTableGUI.php
+++ b/components/ILIAS/Saml/classes/class.ilSamlIdpTableGUI.php
@@ -162,12 +162,10 @@ final class ilSamlIdpTableGUI implements \ILIAS\UI\Component\Table\DataRetrieval
         foreach ($this->getRecords($range, $order) as $item) {
             $record = [
                 'title' => $item->getEntityId(),
-                'active' => $this->ui_renderer->render(
-                    $this->ui_factory->symbol()->icon()->custom(
-                        ilUtil::getImagePath($item->isActive() ? 'standard/icon_ok.svg' : 'standard/icon_not_ok.svg'),
-                        $item->isActive() ? $this->lng->txt('active') : $this->lng->txt('inactive')
-                    )
-                )
+                'active' => $this->ui_factory->symbol()->icon()->custom(
+                    ilUtil::getImagePath($item->isActive() ? 'standard/icon_ok.svg' : 'standard/icon_not_ok.svg'),
+                    $item->isActive() ? $this->lng->txt('active') : $this->lng->txt('inactive')
+                ),
             ];
 
             yield $row_builder

--- a/components/ILIAS/Saml/classes/class.ilSimpleSAMLphpWrapper.php
+++ b/components/ILIAS/Saml/classes/class.ilSimpleSAMLphpWrapper.php
@@ -50,7 +50,7 @@ final class ilSimpleSAMLphpWrapper implements ilSamlAuth
         global $DIC;
 
         $templateHandler = new ilSimpleSAMLphpConfigTemplateHandler($DIC->filesystem()->storage());
-        $templateHandler->copy('./components/ILIAS/Saml/lib/config.php.dist', 'auth/saml/config/config.php', [
+        $templateHandler->copy('../components/ILIAS/Saml/resources/config.php.dist', 'auth/saml/config/config.php', [
             'DB_PATH' => rtrim($configurationPath, '/') . '/ssphp.sq3',
             'SQL_INITIAL_PASSWORD' => static function (): string {
                 return substr(str_replace('+', '.', base64_encode(ilPasswordUtils::getBytes(20))), 0, 10);
@@ -58,7 +58,7 @@ final class ilSimpleSAMLphpWrapper implements ilSamlAuth
             'COOKIE_PATH' => IL_COOKIE_PATH,
             'LOG_DIRECTORY' => ilLoggingDBSettings::getInstance()->getLogDir()
         ]);
-        $templateHandler->copy('./components/ILIAS/Saml/lib/authsources.php.dist', 'auth/saml/config/authsources.php', [
+        $templateHandler->copy('../components/ILIAS/Saml/resources/authsources.php.dist', 'auth/saml/config/authsources.php', [
             'RELAY_STATE' => rtrim(ILIAS_HTTP_PATH, '/') . '/saml.php',
             'SP_ENTITY_ID' => rtrim(ILIAS_HTTP_PATH, '/') . '/metadata.php'
         ]);


### PR DESCRIPTION
This PR fixes the table on the SAML Administration page and the paths when copying the config files for the first time.