### PR TITLE
FileServices: correct service locator check

### DIFF
--- a/Services/FileServices/classes/class.ilFileServicesSettings.php
+++ b/Services/FileServices/classes/class.ilFileServicesSettings.php
@@ -62,6 +62,7 @@ class ilFileServicesSettings
     {
         global $DIC;
         return $DIC->isDependencyAvailable('rbac')
+            && isset($DIC["rbacsystem"])
             && $DIC->rbac()->system()->checkAccess(
                 'upload_blacklisted_files',
                 $this->file_admin_ref_id


### PR DESCRIPTION
Hi @chfsx,

this is something we discovered in our own code when using `FileUpload` functionality, so I have no mantis ticket to reproduce. There seem to be paths through `ilInit::initILIAS` that indeed initialize `RBACServices` but not `$DIC["rbacsystem"]`, so this throws an error when using file upload functionality in these circumstances.

The check indicates that this should indeed be able to work when RBAC does not exist in the service locator, but it actually checks an insufficient condition, as `RBACServices` (behind `rbac()`) reaches into the service locator _again_ at the index `rbacsystem`. The existence of `RBACServices` does not imply the existence of `rbacsystem`, though. We could get rid of the first check by checking and using what is actually required here (`$DIC["rbacsystem"]`).

Kind regards!