### PR TITLE
InfoPage: switch to LOM API

### DIFF
--- a/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
+++ b/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
@@ -326,6 +326,7 @@ class ilInfoScreenGUI
         $md_reader = $this->metadata->read($a_rep_obj_id, $a_obj_id, $a_type);
         $md_paths = $this->metadata->paths();
         $md_data_helper = $this->metadata->dataHelper();
+        $md_cp_helper = $this->metadata->copyrightHelper();
 
         // general
         $description = $md_reader->firstData($md_paths->descriptions())->value();
@@ -341,11 +342,12 @@ class ilInfoScreenGUI
         $author = $md_data_helper->makePresentableAsList(', ', ...$author_data);
 
         // copyright
-        $copyright_description = $md_reader->firstData($md_paths->copyright())->value();
-        if ($copyright_description) {
-            $copyright = ilMDUtils::_parseCopyright($copyright_description);
+        if ($md_cp_helper->hasPresetCopyright($md_reader)) {
+            $copyright = $this->ui->renderer()->render(
+                $md_cp_helper->readPresetCopyright($md_reader)->presentAsUIComponents()
+            );
         } else {
-            $copyright = ilMDUtils::_getDefaultCopyright();
+            $copyright = $md_cp_helper->readCustomCopyright($md_reader);
         }
 
         // learning time

--- a/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
+++ b/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\InfoScreen\StandardGUIRequest;
 use ILIAS\MetaData\Services\Services as Metadata;

--- a/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
+++ b/components/ILIAS/InfoScreen/classes/class.ilInfoScreenGUI.php
@@ -19,7 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\InfoScreen\StandardGUIRequest;
-use ILIAS\MetaData\Services\Services as Metadata;
+use ILIAS\MetaData\Services\ServicesInterface as Metadata;
 
 /**
  * Class ilInfoScreenGUI


### PR DESCRIPTION
This PR replaces the leftover usages of the old `MetaData` classes in `InfoPage` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Let me know if you want anything done differently.

Cheers, @schmitz-ilias 