### PR TITLE
LearningModule: switch to LOM API

### DIFF
--- a/components/ILIAS/LearningModule/classes/class.ilLMPageObject.php
+++ b/components/ILIAS/LearningModule/classes/class.ilLMPageObject.php
@@ -113,8 +113,9 @@ class ilLMPageObject extends ilLMObject
         }
 
         // copy meta data
-        $md = new ilMD($this->getLMId(), $this->getId(), $this->getType());
-        $new_md = $md->cloneMD($a_target_lm->getId(), $lm_page->getId(), $this->getType());
+        $this->lom_services->derive()
+                           ->fromObject($this->getLMId(), $this->getId(), $this->getType())
+                           ->forObject($a_target_lm->getId(), $lm_page->getId(), $this->getType());
 
         // check whether export id already exists in the target lm
         if ($del_exp_id) {
@@ -157,8 +158,9 @@ class ilLMPageObject extends ilLMObject
         $a_copied_nodes[$this->getId()] = $lm_page->getId();
 
         // copy meta data
-        $md = new ilMD($this->getLMId(), $this->getId(), $this->getType());
-        $new_md = $md->cloneMD($a_cont_obj->getId(), $lm_page->getId(), $this->getType());
+        $this->lom_services->derive()
+                           ->fromObject($this->getLMId(), $this->getId(), $this->getType())
+                           ->forObject($a_cont_obj->getId(), $lm_page->getId(), $this->getType());
 
         // copy page content
         $page = $lm_page->getPageObject();
@@ -385,10 +387,17 @@ class ilLMPageObject extends ilLMObject
     public function exportXMLMetaData(
         ilXmlWriter $a_xml_writer
     ): void {
-        $md2xml = new ilMD2XML($this->getLMId(), $this->getId(), $this->getType());
+        /*
+         * As far as I can tell, this is unused.
+         *
+         * I traced usages of this method up to ilObjContentObjectGUI::export and
+         * ilObjMediaPoolGUI::export (both via ilObjContentObject::exportXML), which have
+         * both been made redundant by the usual export mechanisms.
+         */
+        /*$md2xml = new ilMD2XML($this->getLMId(), $this->getId(), $this->getType());
         $md2xml->setExportMode(true);
         $md2xml->startExport();
-        $a_xml_writer->appendXML($md2xml->getXML());
+        $a_xml_writer->appendXML($md2xml->getXML());*/
     }
 
     public function modifyExportIdentifier(

--- a/components/ILIAS/LearningModule/classes/class.ilStructureObject.php
+++ b/components/ILIAS/LearningModule/classes/class.ilStructureObject.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
 /**
  * Handles StructureObjects of ILIAS Learning Modules (see ILIAS DTD)
  *
@@ -24,6 +26,7 @@
 class ilStructureObject extends ilLMObject
 {
     protected \ILIAS\Help\Map\MapManager $help_map;
+    protected LOMServices $lom_services;
     public string $origin_id;
     public ilLMTree $tree;
 
@@ -37,6 +40,7 @@ class ilStructureObject extends ilLMObject
         parent::__construct($a_content_obj, $a_id);
         $this->tree = new ilLMTree($this->getLMId());
         $this->help_map = $DIC->help()->internal()->domain()->map();
+        $this->lom_services = $DIC->learningObjectMetadata();
     }
 
     public function delete(bool $a_delete_meta_data = true): void
@@ -90,8 +94,9 @@ class ilStructureObject extends ilLMObject
         $a_copied_nodes[$this->getId()] = $chap->getId();
 
         // copy meta data
-        $md = new ilMD($this->getLMId(), $this->getId(), $this->getType());
-        $new_md = $md->cloneMD($a_target_lm->getId(), $chap->getId(), $this->getType());
+        $this->lom_services->derive()
+                           ->fromObject($this->getLMId(), $this->getId(), $this->getType())
+                           ->forObject($a_target_lm->getId(), $chap->getId(), $this->getType());
 
         // copy translations
         ilLMObjTranslation::copy($this->getId(), $chap->getId());
@@ -124,10 +129,17 @@ class ilStructureObject extends ilLMObject
     public function exportXMLMetaData(
         ilXmlWriter $a_xml_writer
     ): void {
-        $md2xml = new ilMD2XML($this->getLMId(), $this->getId(), $this->getType());
+        /*
+         * As far as I can tell, this is unused.
+         *
+         * I traced usages of this method up to ilObjContentObjectGUI::export and
+         * ilObjMediaPoolGUI::export (both via ilObjContentObject::exportXML), which have
+         * both been made redundant by the usual export mechanisms.
+         */
+        /*$md2xml = new ilMD2XML($this->getLMId(), $this->getId(), $this->getType());
         $md2xml->setExportMode(true);
         $md2xml->startExport();
-        $a_xml_writer->appendXML($md2xml->getXML());
+        $a_xml_writer->appendXML($md2xml->getXML());*/
     }
 
     public function modifyExportIdentifier(


### PR DESCRIPTION
This PR replaces the leftover usages of the old `MetaData` classes in `LearningModule` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

As far as I can tell, the usages of `ilMD2XML` all lead to dead ends, so I commented them out. I did not remove them outright, since they lead to a whole network of unused export-related methods. Those should all be looked at carefully, and ripped out all at once.

Note that because of the current state of the trunk, I was not able to test everything related to export IDs.

Let me know if you want anything done differently.

Cheers, @schmitz-ilias