### PR TITLE
File: switch to LOM API

### DIFF
--- a/components/ILIAS/File/classes/Versions/class.ilFileVersionsGUI.php
+++ b/components/ILIAS/File/classes/Versions/class.ilFileVersionsGUI.php
@@ -650,13 +650,13 @@ class ilFileVersionsGUI
         );
 
         // return form at this point if copyright selection is not enabled
-        if (!$this->getLOM()->copyrightHelper()->isCopyrightSelectionActive()) {
+        if (!$this->lom_services->copyrightHelper()->isCopyrightSelectionActive()) {
             return $this->ui->factory()->input()->container()->form()->standard($form_action, $inputs);
         }
 
         // add the option for letting all unzipped files inherit the copyright of their parent zip (if a copyright has been set for the zip)
-        $lom_reader = $this->getLOM()->read($this->file->getId(), 0, $this->file->getType());
-        $lom_cp_helper = $this->getLOM()->copyrightHelper();
+        $lom_reader = $this->lom_services->read($this->file->getId(), 0, $this->file->getType());
+        $lom_cp_helper = $this->lom_services->copyrightHelper();
 
         if ($lom_cp_helper->hasPresetCopyright($lom_reader)) {
             $zip_copyright = $lom_cp_helper->readPresetCopyright($lom_reader);
@@ -761,10 +761,5 @@ class ilFileVersionsGUI
     protected function getLanguage(): \ilLanguage
     {
         return $this->lng;
-    }
-
-    protected function getLOM(): LOMServices
-    {
-        return $this->lom_services;
     }
 }

--- a/components/ILIAS/File/classes/Versions/class.ilFileVersionsGUI.php
+++ b/components/ILIAS/File/classes/Versions/class.ilFileVersionsGUI.php
@@ -30,6 +30,7 @@ use ILIAS\Data\URI;
 use ILIAS\UI\Component\Modal\Modal;
 use ILIAS\components\WOPI\Discovery\ActionTarget;
 use ILIAS\FileUpload\MimeType;
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
@@ -84,6 +85,7 @@ class ilFileVersionsGUI
     protected ilTree $tree;
     protected int $parent_id;
     protected Refinery $refinery;
+    protected LOMServices $lom_services;
 
     /**
      * ilFileVersionsGUI constructor.
@@ -105,6 +107,7 @@ class ilFileVersionsGUI
         $this->tree = $this->isWorkspaceContext() ? new ilWorkspaceTree($DIC->user()->getId()) : $DIC->repositoryTree();
         $this->file_component_builder = new ilObjFileComponentBuilder($this->lng, $this->ui);
         $this->refinery = $DIC->refinery();
+        $this->lom_services = $DIC->learningObjectMetadata();
 
         $this->parent_id = $this->tree->getParentId($this->file->getRefId()) ?? $this->getParentIdType();
         $this->wsp_access = new ilWorkspaceAccessHandler($this->tree);
@@ -647,25 +650,31 @@ class ilFileVersionsGUI
         );
 
         // return form at this point if copyright selection is not enabled
-        if (!ilMDSettings::_getInstance()->isCopyrightSelectionActive()) {
+        if (!$this->getLOM()->copyrightHelper()->isCopyrightSelectionActive()) {
             return $this->ui->factory()->input()->container()->form()->standard($form_action, $inputs);
         }
 
         // add the option for letting all unzipped files inherit the copyright of their parent zip (if a copyright has been set for the zip)
-        $zip_md = new ilMD($this->file->getId(), 0, $this->file->getType());
-        $rights = $zip_md->getRights();
-        if ($rights !== null) {
-            $zip_copyright_description = $zip_md->getRights()->getDescription();
-            $zip_copyright_id = ilMDCopyrightSelectionEntry::_extractEntryId($zip_copyright_description);
+        $lom_reader = $this->getLOM()->read($this->file->getId(), 0, $this->file->getType());
+        $lom_cp_helper = $this->getLOM()->copyrightHelper();
+
+        if ($lom_cp_helper->hasPresetCopyright($lom_reader)) {
+            $zip_copyright = $lom_cp_helper->readPresetCopyright($lom_reader);
+            $zip_copyright_id = $zip_copyright->identifier();
+            $zip_copyright_title = $zip_copyright->title();
+        } else {
+            $zip_copyright_id = $zip_copyright_title = $lom_cp_helper->readCustomCopyright($lom_reader);
+        }
+        if ($zip_copyright_id !== '') {
             $copyright_inheritance_input = $this->ui->factory()->input()->field()->hidden()->withValue(
-                (string) $zip_copyright_id
+                $zip_copyright_id
             );
             $copyright_options[self::KEY_INHERIT_COPYRIGHT] = $this->ui->factory()->input()->field()->group(
                 [self::KEY_COPYRIGHT_ID => $copyright_inheritance_input],
                 $this->lng->txt("copyright_inherited"),
                 sprintf(
                     $this->lng->txt("copyright_inherited_info"),
-                    ilMDCopyrightSelectionEntry::lookupCopyyrightTitle($zip_copyright_description)
+                    $zip_copyright_title
                 )
             );
         }
@@ -752,5 +761,10 @@ class ilFileVersionsGUI
     protected function getLanguage(): \ilLanguage
     {
         return $this->lng;
+    }
+
+    protected function getLOM(): LOMServices
+    {
+        return $this->lom_services;
     }
 }

--- a/components/ILIAS/File/classes/class.ilObjFileGUI.php
+++ b/components/ILIAS/File/classes/class.ilObjFileGUI.php
@@ -31,6 +31,7 @@ use ILIAS\components\WOPI\Discovery\ActionDBRepository;
 use ILIAS\components\WOPI\Embed\EmbeddedApplication;
 use ILIAS\Data\URI;
 use ILIAS\components\WOPI\Discovery\ActionTarget;
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 
 /**
  * GUI class for file objects.
@@ -86,6 +87,7 @@ class ilObjFileGUI extends ilObject2GUI
     protected \Psr\Http\Message\ServerRequestInterface $request;
     protected \ILIAS\Data\Factory $data_factory;
     private ActionDBRepository $action_repo;
+    protected LOMServices $lom_services;
 
     /**
      * Constructor
@@ -115,6 +117,7 @@ class ilObjFileGUI extends ilObject2GUI
         $this->request = $DIC->http()->request();
         $this->data_factory = new Factory();
         $this->action_repo = new ActionDBRepository($DIC->database());
+        $this->lom_services = $DIC->learningObjectMetadata();
     }
 
     public function getType(): string
@@ -409,7 +412,7 @@ class ilObjFileGUI extends ilObject2GUI
         )->withRequired(true);
 
         // add input for copyright selection if enabled in the metadata settings
-        if (ilMDSettings::_getInstance()->isCopyrightSelectionActive()) {
+        if ($this->getLOM()->copyrightHelper()->isCopyrightSelectionActive()) {
             $inputs[self::PARAM_COPYRIGHT_ID] = $this->getCopyrightSelectionInput('set_license_for_all_files');
         }
 
@@ -1145,5 +1148,10 @@ class ilObjFileGUI extends ilObject2GUI
     protected function getUser(): ilObjUser
     {
         return $this->user;
+    }
+
+    protected function getLOM(): LOMServices
+    {
+        return $this->lom_services;
     }
 }

--- a/components/ILIAS/File/classes/class.ilObjFileGUI.php
+++ b/components/ILIAS/File/classes/class.ilObjFileGUI.php
@@ -412,7 +412,7 @@ class ilObjFileGUI extends ilObject2GUI
         )->withRequired(true);
 
         // add input for copyright selection if enabled in the metadata settings
-        if ($this->getLOM()->copyrightHelper()->isCopyrightSelectionActive()) {
+        if ($this->lom_services->copyrightHelper()->isCopyrightSelectionActive()) {
             $inputs[self::PARAM_COPYRIGHT_ID] = $this->getCopyrightSelectionInput('set_license_for_all_files');
         }
 
@@ -1148,10 +1148,5 @@ class ilObjFileGUI extends ilObject2GUI
     protected function getUser(): ilObjUser
     {
         return $this->user;
-    }
-
-    protected function getLOM(): LOMServices
-    {
-        return $this->lom_services;
     }
 }

--- a/components/ILIAS/File/classes/class.ilObjFileUploadDropzone.php
+++ b/components/ILIAS/File/classes/class.ilObjFileUploadDropzone.php
@@ -65,7 +65,7 @@ class ilObjFileUploadDropzone
     {
         static $active;
         if ($active === null) {
-            $active = $this->getLOM()->copyrightHelper()->isCopyrightSelectionActive();
+            $active = $this->lom_services->copyrightHelper()->isCopyrightSelectionActive();
         }
         return $active;
     }
@@ -163,10 +163,5 @@ class ilObjFileUploadDropzone
     protected function getRefinery(): \ILIAS\Refinery\Factory
     {
         return $this->refinery;
-    }
-
-    protected function getLOM(): LOMServices
-    {
-        return $this->lom_services;
     }
 }

--- a/components/ILIAS/File/classes/class.ilObjFileUploadDropzone.php
+++ b/components/ILIAS/File/classes/class.ilObjFileUploadDropzone.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\UI\Component\Dropzone\File\File as FileDropzone;
 use ILIAS\UI\Component\Input\Field\UploadHandler;
 use ILIAS\DI\UIServices;
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
@@ -37,6 +38,7 @@ class ilObjFileUploadDropzone
     protected ilAccess $access;
     protected UIServices $ui;
     protected \ILIAS\Refinery\Factory $refinery;
+    protected LOMServices $lom_services;
 
     protected int $target_ref_id;
     protected ?string $content;
@@ -52,6 +54,7 @@ class ilObjFileUploadDropzone
         $this->ctrl = $DIC->ctrl();
         $this->ui = $DIC->ui();
         $this->refinery = $DIC->refinery();
+        $this->lom_services = $DIC->learningObjectMetadata();
 
         $this->upload_handler = new ilObjFileUploadHandlerGUI();
         $this->target_ref_id = $target_ref_id;
@@ -62,7 +65,7 @@ class ilObjFileUploadDropzone
     {
         static $active;
         if ($active === null) {
-            $active = ilMDSettings::_getInstance()->isCopyrightSelectionActive();
+            $active = $this->getLOM()->copyrightHelper()->isCopyrightSelectionActive();
         }
         return $active;
     }
@@ -160,5 +163,10 @@ class ilObjFileUploadDropzone
     protected function getRefinery(): \ILIAS\Refinery\Factory
     {
         return $this->refinery;
+    }
+
+    protected function getLOM(): LOMServices
+    {
+        return $this->lom_services;
     }
 }

--- a/components/ILIAS/File/classes/trait.ilObjFileCopyrightInput.php
+++ b/components/ILIAS/File/classes/trait.ilObjFileCopyrightInput.php
@@ -36,7 +36,7 @@ trait ilObjFileCopyrightInput
         }
 
         $copyright_input = $this->getUIFactory()->input()->field()->radio($this->getLanguage()->txt($lang_var_title));
-        foreach ($this->getLOM()->copyrightHelper()->getNonOutdatedCopyrightPresets() as $copyright_option) {
+        foreach ($this->lom_services->copyrightHelper()->getNonOutdatedCopyrightPresets() as $copyright_option) {
             $copyright_input = $copyright_input->withOption(
                 $copyright_option->identifier(),
                 $copyright_option->title(),
@@ -49,8 +49,6 @@ trait ilObjFileCopyrightInput
 
         return $copyright_input;
     }
-
-    abstract protected function getLOM(): LOMServices;
 
     abstract protected function getUIFactory(): Factory;
 

--- a/components/ILIAS/File/classes/trait.ilObjFileCopyrightInput.php
+++ b/components/ILIAS/File/classes/trait.ilObjFileCopyrightInput.php
@@ -17,8 +17,9 @@
  *********************************************************************/
 
 declare(strict_types=1);
-use ILIAS\UI\Factory;
 
+use ILIAS\UI\Factory;
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
 use ILIAS\UI\Implementation\Component\Input\Field\Radio;
 
 /**
@@ -35,22 +36,21 @@ trait ilObjFileCopyrightInput
         }
 
         $copyright_input = $this->getUIFactory()->input()->field()->radio($this->getLanguage()->txt($lang_var_title));
-        $copyright_options = ilMDCopyrightSelectionEntry::_getEntries();
-        $default_entry_id = ilMDCopyrightSelectionEntry::getDefault();
-        foreach ($copyright_options as $copyright_option) {
-            $entry_id = $copyright_option->getEntryId();
+        foreach ($this->getLOM()->copyrightHelper()->getNonOutdatedCopyrightPresets() as $copyright_option) {
             $copyright_input = $copyright_input->withOption(
-                (string) $entry_id,
-                $copyright_option->getTitle(),
-                $copyright_option->getDescription()
+                $copyright_option->identifier(),
+                $copyright_option->title(),
+                $copyright_option->description()
             );
-            if ($entry_id === $default_entry_id) {
-                $copyright_input = $copyright_input->withValue($entry_id);
+            if ($copyright_option->isDefault()) {
+                $copyright_input = $copyright_input->withValue($copyright_option->identifier());
             }
         }
 
         return $copyright_input;
     }
+
+    abstract protected function getLOM(): LOMServices;
 
     abstract protected function getUIFactory(): Factory;
 


### PR DESCRIPTION
This PR replaces all usages of the old `MetaData` classes in `File` with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Due to the current state of the trunk I was only able to test that the copyright selection input on file creation is generated properly. For what it's worth, that seems to be working fine.

Let me know if there is anything you want done differently.

Cheers, @schmitz-ilias 