### PR TITLE
MediaCast: introduce LOM

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectMetaDataGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectMetaDataGUI.php
@@ -303,6 +303,7 @@ class ilObjectMetaDataGUI
                 "tst",
                 "qpl",
                 ":mob",
+                'mcst',
                 "webr",
                 "htlm",
                 "lm",

--- a/components/ILIAS/MediaCast/LuceneObjectDefinition.xml
+++ b/components/ILIAS/MediaCast/LuceneObjectDefinition.xml
@@ -3,6 +3,7 @@
 	<Document type="default">
 		<xi:include href="../../Services/Object/LuceneDataSource.xml" />
 		<xi:include href="../../Services/Tagging/LuceneDataSource.xml" />
+		<xi:include href="../../../components/ILIAS/MetaData/LuceneDataSource.xml" />
 		<DataSource type="JDBC" action="append">
 			<Query>
 				SELECT 1 as offline FROM il_media_cast_data

--- a/components/ILIAS/MediaCast/PRIVACY.md
+++ b/components/ILIAS/MediaCast/PRIVACY.md
@@ -14,6 +14,7 @@ or contribute a fix via [Pull Request](../../../docs/development/contributing.md
     - [AccessControl](../../ILIAS/AccessControl/PRIVACY.md)
     - [Info Screen Service](../../ILIAS/InfoScreen/PRIVACY.md)
     - [News Service](../../ILIAS/News/PRIVACY.md)
+    - [Learning Object Metadata](../../../components/ILIAS/MetaData/Privacy.md)
 
 ## General Information
 

--- a/components/ILIAS/MediaCast/classes/class.ilMediaCastDataSet.php
+++ b/components/ILIAS/MediaCast/classes/class.ilMediaCastDataSet.php
@@ -237,6 +237,12 @@ class ilMediaCastDataSet extends ilDataSet
                     $a_rec["Id"] . ":mcst:0:",
                     $newObj->getId() . ":mcst:0:"
                 );
+                $a_mapping->addMapping(
+                    "components/ILIAS/MetaData",
+                    "md",
+                    $a_rec["Id"] . ":0:mcst",
+                    $newObj->getId() . ":0:mcst"
+                );
                 break;
         }
     }

--- a/components/ILIAS/MediaCast/classes/class.ilMediaCastExporter.php
+++ b/components/ILIAS/MediaCast/classes/class.ilMediaCastExporter.php
@@ -60,6 +60,18 @@ class ilMediaCastExporter extends ilXmlExporter
             "entity" => "common",
             "ids" => $a_ids);
 
+        $md_ids = [];
+        foreach ($a_ids as $id) {
+            $md_ids[] = $id . ':0:mcst';
+        }
+        if (!empty($md_ids)) {
+            $deps[] = [
+                'component' => 'components/ILIAS/MetaData',
+                'entity' => 'md',
+                'ids' => $md_ids,
+            ];
+        }
+
         return $deps;
     }
 

--- a/components/ILIAS/MediaCast/classes/class.ilObjMediaCast.php
+++ b/components/ILIAS/MediaCast/classes/class.ilObjMediaCast.php
@@ -229,6 +229,8 @@ class ilObjMediaCast extends ilObject
 
         $id = parent::create();
 
+        $this->createMetaData();
+
         $query = "INSERT INTO il_media_cast_data (" .
             " id" .
             ", is_online" .
@@ -263,6 +265,8 @@ class ilObjMediaCast extends ilObject
         if (!parent::update()) {
             return false;
         }
+
+        $this->updateMetaData();
 
         // update media cast data
         $query = "UPDATE il_media_cast_data SET " .
@@ -318,6 +322,8 @@ class ilObjMediaCast extends ilObject
         if (!parent::delete()) {
             return false;
         }
+
+        $this->deleteMetaData();
 
         // delete all items
         $med_items = $this->getItemsArray();
@@ -458,6 +464,8 @@ class ilObjMediaCast extends ilObject
         if ($collection) {
             $collection->cloneCollection($new_obj->getRefId(), $cp_options->getCopyId());
         }
+
+        $this->cloneMetaData($new_obj);
 
         return $new_obj;
     }

--- a/components/ILIAS/MediaCast/classes/class.ilObjMediaCastGUI.php
+++ b/components/ILIAS/MediaCast/classes/class.ilObjMediaCastGUI.php
@@ -28,6 +28,7 @@ use ILIAS\Filesystem\Util\LegacyPathHelper;
  * @ilCtrl_Calls ilObjMediaCastGUI: ilPermissionGUI, ilInfoScreenGUI, ilExportGUI
  * @ilCtrl_Calls ilObjMediaCastGUI: ilCommonActionDispatcherGUI, ilMediaCreationGUI
  * @ilCtrl_Calls ilObjMediaCastGUI: ilLearningProgressGUI, ilObjectCopyGUI, McstImageGalleryGUI, McstPodcastGUI, ilCommentGUI
+ * @ilCtrl_Calls ilObjMediaCastGUI: ilObjectMetaDataGUI
  * @ilCtrl_IsCalledBy ilObjMediaCastGUI: ilRepositoryGUI, ilAdministrationGUI
  */
 class ilObjMediaCastGUI extends ilObjectGUI
@@ -189,6 +190,13 @@ class ilObjMediaCastGUI extends ilObjectGUI
 
             case strtolower(ilCommentGUI::class):
                 $this->ctrl->forwardCommand($this->getCommentGUI());
+                break;
+
+            case strtolower(ilObjectMetaDataGUI::class):
+                $this->checkPermission("write");
+                $ilTabs->activateTab("meta_data");
+                $gui = new ilObjectMetaDataGUI($this->object);
+                $this->ctrl->forwardCommand($gui);
                 break;
 
             default:
@@ -1011,6 +1019,7 @@ EOT;
 
         $info = new ilInfoScreenGUI($this);
 
+        $info->addMetaDataSections($this->object->getId(), 0, $this->object->getType());
         $info->enablePrivateNotes();
 
         // general information
@@ -1079,6 +1088,18 @@ EOT;
                 $lng->txt('learning_progress'),
                 $this->ctrl->getLinkTargetByClass(array(__CLASS__, 'illearningprogressgui'), '')
             );
+        }
+
+        if ($ilAccess->checkAccess("write", "", $this->object->getRefId())) {
+            $mdgui = new ilObjectMetaDataGUI($this->object);
+            $mdtab = $mdgui->getTab();
+            if ($mdtab) {
+                $this->tabs_gui->addTab(
+                    "meta_data",
+                    $this->lng->txt("meta_data"),
+                    $mdtab
+                );
+            }
         }
 
         // export


### PR DESCRIPTION
This PR introduces LOM for `MediaCast` as described in [Learning Object Metadata for Mediacast, Mediapool, and Blog](https://docu.ilias.de/go/wiki/wpage_8217_1357), including a small addendum to the PRIVACY.md. For details on what else this entails, see the [documentation](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/enabling_lom.md).

Cheers, @schmitz-ilias