### PR TITLE
[ECS UI] Add language variable for consent modal button

### DIFF
--- a/components/ILIAS/WebServices/ECS/classes/Consent/class.ilECSUserConsentModalGUI.php
+++ b/components/ILIAS/WebServices/ECS/classes/Consent/class.ilECSUserConsentModalGUI.php
@@ -179,7 +179,7 @@ class ilECSUserConsentModalGUI
         $form = $this->initConsentForm();
         $form_id = 'form_' . $form->getId();
         $agree = $this->ui_factory->button()
-                                  ->primary('Agree and Proceed', '#')
+                                  ->primary($this->lng->txt('ecs_consent_modal_btn_accept'), '#')
                                   ->withOnLoadCode(
                                       function ($id) use ($form_id) {
                                           return "$('#$id').click(function() { $('#$form_id').submit(); return false; });";

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -8922,6 +8922,7 @@ ecs#:#ecs_cms_tree_synchronized#:#Der Baum wurde synchronisiert.
 ecs#:#ecs_communities#:#Teilnehmer
 ecs#:#ecs_confirm_delete_tree#:#Wollen Sie wirklich alle Zuweisungen zu diesem CMS-Baum löschen?
 ecs#:#ecs_connection_settings#:#Verbindungsdaten
+ecs#:#ecs_consent_modal_btn_accept#:#Zustimmen und fortfahren
 ecs#:#ecs_consent_modal_title#:#Einwilligung zur Datenübertragung
 ecs#:#ecs_consent_reset_confirm_title#:#Benutzerzustimmung für diesen Teilnehmer zurücksetzen
 ecs#:#ecs_cron_task_scheduler#:#ECS-Aufgaben ausführen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8922,6 +8922,7 @@ ecs#:#ecs_cms_tree_synchronized#:#The tree has been synchronized.
 ecs#:#ecs_communities#:#Participants
 ecs#:#ecs_confirm_delete_tree#:#Do you really want to delete all assignments for this campus management tree?
 ecs#:#ecs_connection_settings#:#Connection Settings
+ecs#:#ecs_consent_modal_btn_accept#:#Agree and Proceed
 ecs#:#ecs_consent_modal_title#:#Consent for data transfer
 ecs#:#ecs_consent_reset_confirm_title#:#Reset user consent for this participant
 ecs#:#ecs_cron_task_scheduler#:#ECS Task Scheduler


### PR DESCRIPTION
In the ECS user consent modal, “Agree and Proceed” is hard-coded on a button. Swapped with a language variable