### PR TITLE
Bugfix Authentication:0041779 add a session max idle set objective

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -23,6 +23,10 @@
 	XSendFile On
 </IfModule>
 
+<Files info.php>
+  Require ip 127.0.0.1
+</Files>
+
 AddType video/ogg .ogv
 AddType video/mp4 .mp4
 AddType video/webm .webm

--- a/Services/Authentication/classes/Setup/class.ilAuthenticationSetupAgent.php
+++ b/Services/Authentication/classes/Setup/class.ilAuthenticationSetupAgent.php
@@ -25,23 +25,45 @@ class ilAuthenticationSetupAgent implements Setup\Agent
 {
     use Setup\Agent\HasNoNamedObjective;
 
+    protected const DEFAULT_SESSION_EXPIRE = 30;
+
+    public function __construct(
+        protected Refinery\Factory $refinery
+    ) {
+    }
+
     public function hasConfig(): bool
     {
-        return false;
+        return true;
     }
 
     public function getArrayToConfigTransformation(): Refinery\Transformation
     {
-        throw new LogicException('Agent has no config.');
+        return $this->refinery->custom()->transformation(function ($data): \ilAuthenticationSetupConfig {
+            return new ilAuthenticationSetupConfig($data["session_max_idle"] ?? self::DEFAULT_SESSION_EXPIRE);
+        });
     }
 
     public function getInstallObjective(Setup\Config $config = null): Setup\Objective
     {
-        return new Setup\Objective\NullObjective();
+        if ($config !== null) {
+            return new ilSessionMaxIdleIsSetObjective($config);
+        }
+
+        return new ilSessionMaxIdleIsSetObjective(new ilAuthenticationSetupConfig(self::DEFAULT_SESSION_EXPIRE));
     }
 
     public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
     {
+        if ($config !== null) {
+            return new Setup\ObjectiveCollection('Setup Authentication and Sessions', true, ...[
+                new ilDatabaseUpdateStepsExecutedObjective(
+                    new ilAuthenticationDatabaseUpdateSteps8()
+                ),
+                new ilSessionMaxIdleIsSetObjective($config)
+            ]);
+        }
+
         return new ilDatabaseUpdateStepsExecutedObjective(
             new ilAuthenticationDatabaseUpdateSteps8()
         );

--- a/Services/Authentication/classes/Setup/class.ilAuthenticationSetupConfig.php
+++ b/Services/Authentication/classes/Setup/class.ilAuthenticationSetupConfig.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+
+class ilAuthenticationSetupConfig implements Setup\Config
+{
+    public function __construct(
+        protected int $session_max_idle
+    ) {
+    }
+
+    public function getSessionMaxIdle(): int
+    {
+        return $this->session_max_idle;
+    }
+}

--- a/Services/Authentication/classes/Setup/class.ilSessionMaxIdleIsSetObjective.php
+++ b/Services/Authentication/classes/Setup/class.ilSessionMaxIdleIsSetObjective.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+
+class ilSessionMaxIdleIsSetObjective implements Setup\Objective
+{
+    public function __construct(
+        protected ilAuthenticationSetupConfig $config
+    ) {
+    }
+
+    public function getHash(): string
+    {
+        return hash("sha256", self::class);
+    }
+
+    public function getLabel(): string
+    {
+        return "Ensures 'session_max_idle' is set properly";
+    }
+
+    public function isNotable(): bool
+    {
+        return false;
+    }
+
+    public function getPreconditions(Setup\Environment $environment): array
+    {
+        return [
+            new \ilIniFilesPopulatedObjective(),
+            new ilDatabaseInitializedObjective()
+        ];
+    }
+
+    public function achieve(Setup\Environment $environment): Setup\Environment
+    {
+        $client_ini = $environment->getResource(Setup\Environment::RESOURCE_CLIENT_INI);
+        $admin_interaction = $environment->getResource(Setup\Environment::RESOURCE_ADMIN_INTERACTION);
+
+        $session_max_idle = $this->config->getSessionMaxIdle();
+
+        $apache_php_ini_path = $this->getPHPIniPathForApache("localhost/info.php");
+        $apache_php_ini = parse_ini_file($apache_php_ini_path);
+
+        $cookie_lifetime = $apache_php_ini["session.cookie_lifetime"];
+        $gc_maxlifetime = $apache_php_ini["session.gc_maxlifetime"];
+
+        if ($cookie_lifetime != 0) {
+            $message =
+                "The value 'session.cookie_lifetime' in your php.ini does not correspond" . PHP_EOL .
+                "to the value '0' recommended by ILIAS. Do you want to continue anyway?";
+
+            if (!$admin_interaction->confirmOrDeny($message)) {
+                throw new Setup\NoConfirmationException($message);
+            }
+        }
+
+        if ($gc_maxlifetime <= $session_max_idle) {
+            $message =
+                "The value 'session.gc_maxlifetime' in your php.ini is smaller or equal than" . PHP_EOL .
+                "'session_max_idle' in your ILIAS-Config. ILIAS recommends a bigger value." . PHP_EOL .
+                "Do you want to continue anyway?";
+
+            if (!$admin_interaction->confirmOrDeny($message)) {
+                throw new Setup\NoConfirmationException($message);
+            }
+        }
+
+        $client_ini->setVariable("session", "expire", (string) $session_max_idle);
+
+        return $environment;
+    }
+
+    public function isApplicable(Setup\Environment $environment): bool
+    {
+        return true;
+    }
+
+    protected function getPHPIniPathForApache(string $url): string
+    {
+        return exec("wget -q -O - ${url} | grep 'Loaded Configuration File' | cut -d '<' -f5 | cut -d '>' -f2");
+    }
+}

--- a/docs/configuration/secure.md
+++ b/docs/configuration/secure.md
@@ -610,6 +610,27 @@ Nginx:
     }
 ```
 
+### Deny Access to file info.php
+
+The file info.php is necessary for the setup process. So it should only be delivered to localhost (127.0.0.1).
+
+Apache2 .htaccess (implemented per default):
+
+```
+    <Files info.php>
+        Require ip 127.0.0.1
+    </Files>
+```
+
+Nginx:
+
+```
+    location /info.php {
+        allow 127.0.0.1;
+        deny all;
+    }
+```
+
 ## Integrity check of ILIAS code in docroot
 
 Local changes of the code of ILIAS can indicate a potential intrusion.

--- a/info.php
+++ b/info.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+phpinfo();

--- a/setup/README.md
+++ b/setup/README.md
@@ -554,3 +554,10 @@ are printed bold**, all other fields might be omitted. A minimal example is
     * *deletion_unit* (type: string) possible values are `days`, `weeks`, `months`, `years`
     * *deletion_value* (type: string or number) depending on `deletion_unit` possible values are `days max 31`, `weeks max 52`, `months max 12`, `years no max`
     * *deletion_time* (type: string) with format `HH:MM e.g. 23:30`
+* *authentication* (type: object)
+  ```
+  "authentication" : {
+    "session_max_idle": 1500
+  }
+  ```
+  * *session_max_idle* (type: number) maximum session idle (in minutes)

--- a/tests/App/RootFolderTest.php
+++ b/tests/App/RootFolderTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
@@ -72,6 +72,7 @@ final class RootFolderTest extends TestCase
         'studip_referrer.php',
         'unzip_test_file.zip',
         'webdav.php',
+        'info.php',
         '.DS_Store',
         '.buildpath',
         '.project'


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41779

Hello everyone, this PR ensures that the PHP ini variable 'session_max_idle' is controlled via our setup. The current values ​​are obtained from a phpinfo file that has currently been added to the repo. This process could also be made dynamic by creating the file on the fly and deleting it again after reading it. This would also prevent the .htaccess file from being adjusted. Please let me know what you think about it.

Greetings Daniel