### PR TITLE
Blog: introduce LOM, switch to LOM API

### DIFF
--- a/components/ILIAS/Blog/Export/class.ilBlogDataSet.php
+++ b/components/ILIAS/Blog/Export/class.ilBlogDataSet.php
@@ -387,6 +387,12 @@ class ilBlogDataSet extends ilDataSet
                 $this->reading_time->activate($newObj->getId(), (bool) ($a_rec["ReadingTime"] ?? false));
 
                 $a_mapping->addMapping("components/ILIAS/Blog", "blog", $a_rec["Id"], (string) $newObj->getId());
+                $a_mapping->addMapping(
+                    'components/ILIAS/MetaData',
+                    'md',
+                    $a_rec["Id"] . ':0:blog',
+                    $newObj->getId() . ':0:blog'
+                );
                 break;
 
             case "blog_posting":

--- a/components/ILIAS/Blog/Export/class.ilBlogExporter.php
+++ b/components/ILIAS/Blog/Export/class.ilBlogExporter.php
@@ -84,6 +84,18 @@ class ilBlogExporter extends ilXmlExporter
             "ids" => $a_ids
         );
 
+        $md_ids = [];
+        foreach ($a_ids as $id) {
+            $md_ids[] = $id . ':0:blog';
+        }
+        if (!empty($md_ids)) {
+            $res[] = [
+                'component' => 'components/ILIAS/MetaData',
+                'entity' => 'md',
+                'ids' => $md_ids,
+            ];
+        }
+
         return $res;
     }
 

--- a/components/ILIAS/Blog/LuceneObjectDefinition.xml
+++ b/components/ILIAS/Blog/LuceneObjectDefinition.xml
@@ -3,5 +3,6 @@
 	<Document type="default">
 		<xi:include href="../../Services/Object/LuceneDataSource.xml" />
 		<xi:include href="../../Services/Tagging/LuceneDataSource.xml" />
+		<xi:include href="../../../components/ILIAS/MetaData/LuceneDataSource.xml" />
 	</Document>
 </ObjectDefinition>

--- a/components/ILIAS/Blog/PRIVACY.md
+++ b/components/ILIAS/Blog/PRIVACY.md
@@ -15,6 +15,7 @@ or contribute a fix via [Pull Request](../../docs/development/contributing.md#pu
     - The **Mail/Contacts** service implements a user search for finding users to share blogs with.
     - [AccessControl](../AccessControl/PRIVACY.md)
     - [Info Screen Service](../InfoScreen/PRIVACY.md)
+    - [Learning Object Metadata](../../../components/ILIAS/MetaData/Privacy.md)
 
 ## General Information
 

--- a/components/ILIAS/Blog/Posting/class.ilBlogPosting.php
+++ b/components/ILIAS/Blog/Posting/class.ilBlogPosting.php
@@ -252,19 +252,14 @@ class ilBlogPosting extends ilPageObject
         global $DIC;
 
         $ilDB = $DIC->database();
+        $lom_services = $DIC->learningObjectMetadata();
 
         $query = "SELECT * FROM il_blog_posting" .
             " WHERE blog_id = " . $ilDB->quote($a_blog_id, "integer");
         $set = $ilDB->query($query);
         while ($rec = $ilDB->fetchAssoc($set)) {
-            // delete all md keywords
-            $md_obj = new ilMD($a_blog_id, $rec["id"], "blp");
-            if (is_object($md_section = $md_obj->getGeneral())) {
-                foreach ($md_section->getKeywordIds() as $id) {
-                    $md_key = $md_section->getKeyword($id);
-                    $md_key->delete();
-                }
-            }
+            // delete lom
+            $lom_services->deleteAll($a_blog_id, $rec["id"], "blp");
 
             $post = new ilBlogPosting($rec["id"]);
             $post->delete();
@@ -410,36 +405,33 @@ class ilBlogPosting extends ilPageObject
 
 
     // keywords
-
-    public function getMDSection(): ?ilMDGeneral
-    {
-        // general section available?
-        $md_obj = new ilMD($this->getBlogId(), $this->getId(), "blp");
-        if (!is_object($md_section = $md_obj->getGeneral())) {
-            $md_section = $md_obj->addGeneral();
-            $md_section->save();
-            return $md_section;
-        }
-        return $md_section;
-    }
-
     public function updateKeywords(
         array $keywords
     ): void {
-        $ilUser = $this->user;
-
-        // language is not "used" anywhere
-        $ulang = $ilUser->getLanguage();
-        $keywords = array($ulang => $keywords);
-
-        ilMDKeyword::updateKeywords($this->getMDSection(), $keywords);
+        $this->lom_services->manipulate($this->getBlogId(), $this->getId(), "blp")
+                           ->prepareDelete($this->lom_services->paths()->keywords())
+                           ->prepareCreateOrUpdate($this->lom_services->paths()->keywords(), ...$keywords)
+                           ->execute();
     }
 
     public static function getKeywords(
         int $a_obj_id,
         int $a_posting_id
     ): array {
-        return ilMDKeyword::lookupKeywords($a_obj_id, $a_posting_id);
+        global $DIC;
+
+        $lom_services = $DIC->learningObjectMetadata();
+
+        $result = [];
+        $keywords = $lom_services->read($a_obj_id, $a_posting_id, "blp")
+                                 ->allData($lom_services->paths()->keywords());
+        foreach ($keywords as $keyword) {
+            if ($keyword->value() !== "") {
+                $result[] = $keyword->value();
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/components/ILIAS/Blog/Posting/class.ilBlogPosting.php
+++ b/components/ILIAS/Blog/Posting/class.ilBlogPosting.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilBlogPosting

--- a/components/ILIAS/Blog/classes/class.ilObjBlog.php
+++ b/components/ILIAS/Blog/classes/class.ilObjBlog.php
@@ -116,6 +116,8 @@ class ilObjBlog extends ilObject2
     {
         $ilDB = $this->db;
 
+        $this->createMetaData();
+
         $ilDB->manipulate("INSERT INTO il_blog (id,ppic,rss_active,approval" .
             ",abs_shorten,abs_shorten_len,abs_image,abs_img_width,abs_img_height" .
             ",keywords,authors,nav_mode,nav_list_mon_with_post,ov_post) VALUES (" .
@@ -143,6 +145,8 @@ class ilObjBlog extends ilObject2
     {
         $ilDB = $this->db;
 
+        $this->deleteMetaData();
+
         ilBlogPosting::deleteAllBlogPostings($this->id);
 
         // remove all notifications
@@ -155,6 +159,8 @@ class ilObjBlog extends ilObject2
     protected function doUpdate(): void
     {
         $ilDB = $this->db;
+
+        $this->updateMetaData();
 
         if ($this->id) {
             $ilDB->manipulate("UPDATE il_blog" .
@@ -204,6 +210,8 @@ class ilObjBlog extends ilObject2
 
         // set/copy stylesheet
         $this->content_style_domain->styleForObjId($this->getId())->cloneTo($new_obj->getId());
+
+        $this->cloneMetaData($new_obj);
     }
 
     public function getNotesStatus(): bool

--- a/components/ILIAS/Blog/classes/class.ilObjBlogGUI.php
+++ b/components/ILIAS/Blog/classes/class.ilObjBlogGUI.php
@@ -28,6 +28,7 @@ use ILIAS\Blog\StandardGUIRequest;
  * @ilCtrl_Calls ilObjBlogGUI: ilInfoScreenGUI, ilNoteGUI, ilCommonActionDispatcherGUI
  * @ilCtrl_Calls ilObjBlogGUI: ilPermissionGUI, ilObjectCopyGUI, ilRepositorySearchGUI
  * @ilCtrl_Calls ilObjBlogGUI: ilExportGUI, ilObjectContentStyleSettingsGUI, ilBlogExerciseGUI, ilObjNotificationSettingsGUI
+ * @ilCtrl_Calls ilObjBlogGUI: ilObjectMetaDataGUI
  */
 class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
 {
@@ -506,6 +507,15 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
             }
 
             if ($this->id_type === self::REPOSITORY_NODE_ID) {
+                $mdgui = new ilObjectMetaDataGUI($this->object, null, null, $this->call_by_reference);
+                $mdtab = $mdgui->getTab();
+                if ($mdtab) {
+                    $this->tabs_gui->addTab(
+                        "meta_data",
+                        $this->lng->txt("meta_data"),
+                        $mdtab
+                    );
+                }
                 $this->tabs_gui->addTab(
                     "export",
                     $lng->txt("export"),
@@ -780,6 +790,14 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
                 $ilTabs->activateTab("settings");
                 $this->setSettingsSubTabs("notifications");
                 $gui = new ilObjNotificationSettingsGUI($this->object->getRefId());
+                $this->ctrl->forwardCommand($gui);
+                break;
+
+            case strtolower(ilObjectMetaDataGUI::class):
+                $this->checkPermission("write");
+                $this->prepareOutput();
+                $ilTabs->activateTab("meta_data");
+                $gui = new ilObjectMetaDataGUI($this->object, null, null, $this->call_by_reference);
                 $this->ctrl->forwardCommand($gui);
                 break;
 

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectMetaDataGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectMetaDataGUI.php
@@ -294,6 +294,7 @@ class ilObjectMetaDataGUI
         return (
             ($this->obj_id || !$this->obj_type) &&
             in_array($type, [
+                'blog',
                 "crs",
                 'grp',
                 "file",


### PR DESCRIPTION
This PR introduces LOM for `Blog` as described in [Learning Object Metadata for Mediacast, Mediapool, and Blog](https://docu.ilias.de/go/wiki/wpage_8217_1357), including a small addendum to the PRIVACY.md. For details on what else this entails, see the [documentation](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/enabling_lom.md).

Further, it replaces all usages of the old `MetaData` classes with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Cheers, @schmitz-ilias