### PR TITLE
MediaPool: introduce LOM, switch to LOM API

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectMetaDataGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectMetaDataGUI.php
@@ -316,6 +316,7 @@ class ilObjectMetaDataGUI
                 'exc',
                 'lti',
                 'cmix',
+                'mep',
                 'mep:mpg'
             ])
         );

--- a/components/ILIAS/MediaPool/LuceneObjectDefinition.xml
+++ b/components/ILIAS/MediaPool/LuceneObjectDefinition.xml
@@ -3,6 +3,7 @@
 	<Document type="default">
 		<xi:include href="../../Services/Object/LuceneDataSource.xml" />
 		<xi:include href="../../Services/Tagging/LuceneDataSource.xml" />
+		<xi:include href="../../../components/ILIAS/MetaData/LuceneDataSource.xml" />
 	</Document>
 	<Document type="subItem">
 		<DataSource type="JDBC" action="create">

--- a/components/ILIAS/MediaPool/MediaPool/MediaPoolManager.php
+++ b/components/ILIAS/MediaPool/MediaPool/MediaPoolManager.php
@@ -160,8 +160,14 @@ class MediaPoolManager
                 $target_child_id
             );
 
-            $md = new \ilMD($source_pool_id, $source_child_id, "mpg");
-            $new_md = $md->cloneMD($target_pool_id, $target_child_id, "mpg");
+            $this->domain->metadata()->cloneLOM(
+                $source_pool_id,
+                $source_child_id,
+                "mpg",
+                $target_pool_id,
+                $target_child_id,
+                "mpg"
+            );
         }
     }
 

--- a/components/ILIAS/MediaPool/Metadata/class.MetadataManager.php
+++ b/components/ILIAS/MediaPool/Metadata/class.MetadataManager.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\MediaPool\Metadata;
+
+use ILIAS\MetaData\Services\ServicesInterface as LOMServices;
+
+class MetadataManager
+{
+    protected LOMServices $lom_services;
+
+    public function __construct(LOMServices $lom_services)
+    {
+        $this->lom_services = $lom_services;
+    }
+
+    public function cloneLOM(
+        int $source_obj_id,
+        int $source_sub_id,
+        string $source_type,
+        int $target_obj_id,
+        int $target_sub_id,
+        string $target_type
+    ): void {
+        $this->lom_services->derive()
+                           ->fromObject($source_obj_id, $source_sub_id, $source_type)
+                           ->forObject($source_obj_id, $source_sub_id, $source_type);
+    }
+}

--- a/components/ILIAS/MediaPool/Service/class.InternalDomainService.php
+++ b/components/ILIAS/MediaPool/Service/class.InternalDomainService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,12 +16,15 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\MediaPool;
 
 use ILIAS\DI\Container;
 use ILIAS\Repository\GlobalDICDomainServices;
 use ILIAS\MediaPool\Clipboard;
 use ILIAS\MediaPool\Tree\MediaPoolTree;
+use ILIAS\MediaPool\Metadata\MetadataManager;
 
 /**
  * @author Alexander Killing <killing@leifos.de>
@@ -76,4 +77,8 @@ class InternalDomainService
         return new MediaPoolTree($mep_obj_id);
     }
 
+    public function metadata(): MetadataManager
+    {
+        return new MetadataManager($this->learningObjectMetadata());
+    }
 }

--- a/components/ILIAS/MediaPool/classes/class.ilMediaPoolDataSet.php
+++ b/components/ILIAS/MediaPool/classes/class.ilMediaPoolDataSet.php
@@ -274,6 +274,12 @@ class ilMediaPoolDataSet extends ilDataSet
                 $this->current_obj = $newObj;
                 $a_mapping->addMapping("components/ILIAS/MediaPool", "mep", $a_rec["Id"], $newObj->getId());
                 $a_mapping->addMapping("components/ILIAS/Object", "obj", $a_rec["Id"], $newObj->getId());
+                $a_mapping->addMapping(
+                    "components/ILIAS/MetaData",
+                    "md",
+                    $a_rec["Id"] . ":0:mep",
+                    $newObj->getId() . ":0:mep"
+                );
                 break;
 
             case "mep_tree":

--- a/components/ILIAS/MediaPool/classes/class.ilMediaPoolExporter.php
+++ b/components/ILIAS/MediaPool/classes/class.ilMediaPoolExporter.php
@@ -102,6 +102,18 @@ class ilMediaPoolExporter extends ilXmlExporter
             "entity" => "tile",
             "ids" => $a_ids);
 
+        $md_ids = [];
+        foreach ($a_ids as $id) {
+            $md_ids[] = $id . ':0:mep';
+        }
+        if (!empty($md_ids)) {
+            $deps[] = [
+                'component' => 'components/ILIAS/MetaData',
+                'entity' => 'md',
+                'ids' => $md_ids,
+            ];
+        }
+
         return $deps;
     }
 

--- a/components/ILIAS/MediaPool/classes/class.ilObjMediaPool.php
+++ b/components/ILIAS/MediaPool/classes/class.ilObjMediaPool.php
@@ -122,6 +122,8 @@ class ilObjMediaPool extends ilObject implements ilAdvancedMetaDataSubItems
 
         $id = parent::create();
 
+        $this->createMetaData();
+
         $ilDB->manipulate("INSERT INTO mep_data " .
             "(id, default_width, default_height, for_translation) VALUES (" .
             $ilDB->quote($this->getId(), "integer") . ", " .
@@ -156,6 +158,8 @@ class ilObjMediaPool extends ilObject implements ilAdvancedMetaDataSubItems
             return false;
         }
 
+        $this->updateMetaData();
+
         // put here object specific stuff
         $ilDB->manipulate(
             "UPDATE mep_data SET " .
@@ -175,6 +179,8 @@ class ilObjMediaPool extends ilObject implements ilAdvancedMetaDataSubItems
         if (!parent::delete()) {
             return false;
         }
+
+        $this->deleteMetaData();
 
         // get childs
         $childs = $this->mep_tree->getSubTree($this->mep_tree->getNodeData($this->mep_tree->readRootId()));
@@ -445,6 +451,8 @@ class ilObjMediaPool extends ilObject implements ilAdvancedMetaDataSubItems
             $new_obj->getTree()->readRootId(),
             $this->getTree()->readRootId()
         );
+
+        $this->cloneMetaData($new_obj);
 
         return $new_obj;
     }

--- a/components/ILIAS/MediaPool/classes/class.ilObjMediaPoolGUI.php
+++ b/components/ILIAS/MediaPool/classes/class.ilObjMediaPoolGUI.php
@@ -33,6 +33,7 @@ use ILIAS\FileUpload\Handler\HandlerResult;
  * @ilCtrl_Calls ilObjMediaPoolGUI: ilObjMediaObjectGUI, ilObjFolderGUI, ilEditClipboardGUI, ilPermissionGUI
  * @ilCtrl_Calls ilObjMediaPoolGUI: ilInfoScreenGUI, ilMediaPoolPageGUI, ilExportGUI
  * @ilCtrl_Calls ilObjMediaPoolGUI: ilCommonActionDispatcherGUI, ilObjectCopyGUI, ilObjectTranslationGUI, ilMediaPoolImportGUI
+ * @ilCtrl_Calls ilObjMediaPoolGUI: ilObjectMetaDataGUI
  * @ilCtrl_Calls ilObjMediaPoolGUI: ilMobMultiSrtUploadGUI, ilObjectMetaDataGUI, ilRepoStandardUploadHandlerGUI, ilMediaCreationGUI
  */
 class ilObjMediaPoolGUI extends ilObject2GUI
@@ -427,6 +428,14 @@ class ilObjMediaPoolGUI extends ilObject2GUI
                 $this->tpl->printToStdout();
                 break;
 
+            case strtolower(ilObjectMetaDataGUI::class):
+                $this->checkPermission("write");
+                $this->prepareOutput();
+                $this->addHeaderAction();
+                $ilTabs->activateTab("meta_data");
+                $gui = new ilObjectMetaDataGUI($this->object);
+                $this->ctrl->forwardCommand($gui);
+                break;
 
             default:
                 $this->prepareOutput();


### PR DESCRIPTION
This PR introduces LOM for `MediaPool` as described in [Learning Object Metadata for Mediacast, Mediapool, and Blog](https://docu.ilias.de/go/wiki/wpage_8217_1357). For details on what else this entails, see the [documentation](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/enabling_lom.md).

Further, it replaces all usages of the old `MetaData` classes with the new [LOM API](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/MetaData/docs/api.md).

Cheers, @schmitz-ilias