### PR TITLE
Data: Add @template type annotations for `ILIAS\Data\Result`

### DIFF
--- a/components/ILIAS/Data/src/Result.php
+++ b/components/ILIAS/Data/src/Result.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/* Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+declare(strict_types=1);
 
 namespace ILIAS\Data;
 
@@ -10,6 +24,8 @@ namespace ILIAS\Data;
  * A result encapsulates a value or an error and simplifies the handling of those.
  *
  * To be implemented as immutable object.
+ *
+ * @template-covariant A
  */
 interface Result
 {
@@ -21,7 +37,7 @@ interface Result
     /**
      * Get the encapsulated value.
      *
-     * @return mixed
+     * @return A
      * @throws \Exception    if !isOK, will either throw the contained exception or
      *                      a NotOKException if a string is contained as error.
      */
@@ -43,8 +59,10 @@ interface Result
     /**
      * Get the encapsulated value or the supplied default if result is an error.
      *
-     * @param mixed $default
-     * @return mixed
+     * @template B
+     *
+     * @param B $default
+     * @return A|B
      */
     public function valueOr($default);
 
@@ -53,7 +71,10 @@ interface Result
      *
      * Does nothing if !isOK.
      *
-     * @param callable $f mixed -> mixed
+     * @template B
+     *
+     * @param callable(A): B $f
+     * @return Result<B>
      */
     public function map(callable $f): Result;
 
@@ -64,7 +85,10 @@ interface Result
      *
      * Does nothing if !isOK. This is monadic bind.
      *
-     * @param callable $f mixed -> Result|null
+     * @template B
+     *
+     * @param callable(A): ?Result<B> $f
+     * @return Result<A>|Result<B>
      * @throws    \UnexpectedValueException    If callable returns no instance of Result
      */
     public function then(callable $f): Result;
@@ -77,7 +101,10 @@ interface Result
      *
      * Does nothing if !isError.
      *
-     * @param callable $f string|\Exception -> Result|null
+     * @template B
+     *
+     * @param callable(string|\Exception): ?Result<B> $f
+     * @return Result<A>|Result<B>
      * @throws    \UnexpectedValueException    If callable returns no instance of Result
      */
     public function except(callable $f): Result;

--- a/components/ILIAS/Data/src/Result/Error.php
+++ b/components/ILIAS/Data/src/Result/Error.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+declare(strict_types=1);
 
 namespace ILIAS\Data\Result;
 
@@ -13,6 +27,9 @@ use ILIAS\Data\Result;
  * A result encapsulates a value or an error and simplifies the handling of those.
  *
  * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
+ *
+ * @template-covariant A
+ * @implements Result<A>
  */
 class Error implements Data\Result
 {

--- a/components/ILIAS/Data/src/Result/Ok.php
+++ b/components/ILIAS/Data/src/Result/Ok.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/* Copyright (c) 2017 Stefan Hecken <stefan.hecken@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+declare(strict_types=1);
 
 namespace ILIAS\Data\Result;
 
@@ -12,14 +26,20 @@ use ILIAS\Data\Result;
  * A result encapsulates a value or an error and simplifies the handling of those.
  *
  * @author Stefan Hecken <stefan.hecken@concepts-and-training.de>
+ *
+ * @template-covariant A
+ * @implements Result<A>
  */
 class Ok implements Result
 {
     /**
-     * @var mixed
+     * @var A
      */
     protected $value;
 
+    /**
+     * @param A $value
+     */
     public function __construct($value)
     {
         $this->value = $value;


### PR DESCRIPTION
This PR adds type annotations for the `ILIAS\Data\Result` inteface as well as it's implementors `ILIAS\Data\Result\Ok` and `ILIAS\Data\Result\Error` to support a generic type. These type annotations are understood by phpstan (https://phpstan.org/blog/generics-in-php-using-phpdocs) and phpstorm.

With this change the following can be checked via static analysis:
```php
/**
 * @param Result<Baz> $bar
 */
function foo(Result $bar): void
{
    // ...
}
```