### PR TITLE
Add jstree as dependency

### DIFF
--- a/components/ILIAS/UIComponent/UIComponent.php
+++ b/components/ILIAS/UIComponent/UIComponent.php
@@ -35,6 +35,8 @@ class UIComponent implements Component\Component
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "Explorer2.js");
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
+        new Component\Resource\NodeModule("jstree/dist/jstree.js");
+        $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "ilOverlay.js");
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "LegacyModal.js");

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "chart.js": "^4.4.1",
         "dropzone": "^5.9.3",
         "jquery": "^3.6.0",
+        "jstree": "^3.3.16",
         "linkifyjs": "^4.1.3",
         "moment": "^2.29.4",
         "tinymce": "^6.8.4"
@@ -4465,6 +4466,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jstree": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/jstree/-/jstree-3.3.17.tgz",
+      "integrity": "sha512-V0Pl1B6BIaxHUQMiWkol37QlhlBKoZA9RUeUmm95+UnV2QeZsj2QP1sOQl/m2EIOyZXOOxOHvR0SYZLSDC7EFw==",
+      "license": "MIT",
+      "dependencies": {
+        "jquery": "^3.5.0"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "jquery": "^3.6.0",
     "linkifyjs": "^4.1.3",
     "moment": "^2.29.4",
-    "tinymce": "^6.8.4"
+    "tinymce": "^6.8.4",
+    "jstree": "^3.3.16"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.1.0",


### PR DESCRIPTION
Larger trees like the repository or org unit tree must load subtrees asynchronously due to performance reasons. The KS tree component currently does not support this. Thus we still need the legacy implementation for ILIAS 10 which uses the js tree lib.

github: https://github.com/vakata/jstree

Latest version is two weeks old. 74 contributors.

Wrapped by UIComponent.