### PR TITLE
Search: Fix PHP type when calling `ilSearchAutoComplete::checkObjectP…

### DIFF
--- a/Services/Search/classes/class.ilSearchAutoComplete.php
+++ b/Services/Search/classes/class.ilSearchAutoComplete.php
@@ -114,7 +114,7 @@ class ilSearchAutoComplete
                 $rec["keyword"] = '"' . $rec["keyword"] . '"';
             }
             if (!in_array($rec["keyword"], $list) && !in_array($rec["rbac_id"], $checked)) {
-                if (ilSearchAutoComplete::checkObjectPermission($rec["rbac_id"])) {
+                if (ilSearchAutoComplete::checkObjectPermission((int) $rec["rbac_id"])) {
                     $list[] = $lim . $rec["keyword"];
                     $cnt++;
                 }


### PR DESCRIPTION
…ermission`

Mantis Issue: https://mantis.ilias.de/view.php?id=42071

If approved, this MUST be picked to all relevant/maintained releaes.