### PR TITLE
Fixes uri input throwing error when left empty but not required

### DIFF
--- a/Services/Form/classes/class.ilUriInputGUI.php
+++ b/Services/Form/classes/class.ilUriInputGUI.php
@@ -45,16 +45,19 @@ class ilUriInputGUI extends ilTextInputGUI
     {
         $lng = $this->lng;
 
+        $uri_string = trim($this->getInput());
+
         // check required
-        if ($this->getRequired() && trim($this->str($this->getPostVar())) == "") {
-            $this->setAlert($lng->txt("msg_input_is_required"));
-            return false;
+        if ($uri_string === "") {
+            if ($this->getRequired()) {
+                $this->setAlert($lng->txt("msg_input_is_required"));
+                return false;
+            }
+            return true;
         }
 
-        $url = $this->getInput();
-
         try {
-            new URI($url);
+            new URI($uri_string);
         } catch (Throwable $e) {
             $this->setAlert($lng->txt("form_invalid_uri"));
             return false;


### PR DESCRIPTION
When using a URI input and setting it to not required you can not leave it empty because you get an error stating that "" is not a valid URI. This would be true but setting the input to not required should probably allow me to leave it empty so no validity checks are performered in that case.

I believe this a viable fix for the issue mentioned.

https://mantis.ilias.de/view.php?id=42077