### PR TITLE
Auth/Registration/LDAP/Init/ApacheAuth/OIDC: Fix license headers

### DIFF
--- a/components/ILIAS/AuthApache/classes/class.ilAuthProviderApache.php
+++ b/components/ILIAS/AuthApache/classes/class.ilAuthProviderApache.php
@@ -1,20 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Apache auth provider

--- a/components/ILIAS/AuthApache/classes/class.ilWhiteListUrlValidator.php
+++ b/components/ILIAS/AuthApache/classes/class.ilWhiteListUrlValidator.php
@@ -1,20 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilWhiteListUrlValidator

--- a/components/ILIAS/AuthApache/classes/custom_username_func.php
+++ b/components/ILIAS/AuthApache/classes/custom_username_func.php
@@ -1,20 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+declare(strict_types=1);
 
 final class ApacheCustom
 {

--- a/components/ILIAS/AuthApache/tests/bootstrap.php
+++ b/components/ILIAS/AuthApache/tests/bootstrap.php
@@ -1,19 +1,21 @@
 <?php
 
-declare(strict_types=1);
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../../../vendor/composer/vendor/autoload.php';

--- a/components/ILIAS/Authentication/classes/Cookie/class.ilCookie.php
+++ b/components/ILIAS/Authentication/classes/Cookie/class.ilCookie.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Representation of an HTTP cookie

--- a/components/ILIAS/Authentication/classes/External/UserAttributeMapping/class.ilExternalAuthUserAttributeMapping.php
+++ b/components/ILIAS/Authentication/classes/External/UserAttributeMapping/class.ilExternalAuthUserAttributeMapping.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilExternalAuthUserAttributeMapping

--- a/components/ILIAS/Authentication/classes/External/UserAttributeMapping/class.ilExternalAuthUserAttributeMappingRule.php
+++ b/components/ILIAS/Authentication/classes/External/UserAttributeMapping/class.ilExternalAuthUserAttributeMappingRule.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilExternalAuthUserAttributeMappingRule

--- a/components/ILIAS/Authentication/classes/External/UserAttributeMapping/class.ilExternalAuthUserCreationAttributeMappingFilter.php
+++ b/components/ILIAS/Authentication/classes/External/UserAttributeMapping/class.ilExternalAuthUserCreationAttributeMappingFilter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilExternalAuthUserCreationAttributeMappingFilter

--- a/components/ILIAS/Authentication/classes/External/UserAttributeMapping/class.ilExternalAuthUserUpdateAttributeMappingFilter.php
+++ b/components/ILIAS/Authentication/classes/External/UserAttributeMapping/class.ilExternalAuthUserUpdateAttributeMappingFilter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilExternalAuthUserUpdateAttributeMappingFilter

--- a/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendCredentials.php
+++ b/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendCredentials.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Stefan Meyer <smeyer.ilias@gmx.de>

--- a/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsHTTP.php
+++ b/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendCredentialsHTTP.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * HTTP auth credentials

--- a/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendFactory.php
+++ b/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Factory for auth frontend classes.

--- a/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendHTTP.php
+++ b/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendHTTP.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Stefan Meyer <smeyer.ilias@gmx.de>

--- a/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendWS.php
+++ b/components/ILIAS/Authentication/classes/Frontend/class.ilAuthFrontendWS.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Stefan Meyer <smeyer.ilias@gmx.de>

--- a/components/ILIAS/Authentication/classes/Frontend/class.ilAuthStandardFormFrontend.php
+++ b/components/ILIAS/Authentication/classes/Frontend/class.ilAuthStandardFormFrontend.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Auth class for form based authentication

--- a/components/ILIAS/Authentication/classes/Password/class.ilLocalUserPasswordSettingsGUI.php
+++ b/components/ILIAS/Authentication/classes/Password/class.ilLocalUserPasswordSettingsGUI.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
  *

--- a/components/ILIAS/Authentication/classes/Provider/class.ilAuthProvider.php
+++ b/components/ILIAS/Authentication/classes/Provider/class.ilAuthProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Base class for authentication providers (ldap, apache, ...)

--- a/components/ILIAS/Authentication/classes/class.ilAuthFactory.php
+++ b/components/ILIAS/Authentication/classes/class.ilAuthFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Authentication frontend factory

--- a/components/ILIAS/Authentication/classes/class.ilAuthModeDetermination.php
+++ b/components/ILIAS/Authentication/classes/class.ilAuthModeDetermination.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
 * @author Stefan Meyer <meyer@leifos.com>

--- a/components/ILIAS/Authentication/classes/class.ilAuthPlugin.php
+++ b/components/ILIAS/Authentication/classes/class.ilAuthPlugin.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +16,7 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
 /**
  * Authentication plugin
  *

--- a/components/ILIAS/Authentication/classes/class.ilAuthStatus.php
+++ b/components/ILIAS/Authentication/classes/class.ilAuthStatus.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Auth status implementation

--- a/components/ILIAS/Authentication/classes/class.ilLoginPage.php
+++ b/components/ILIAS/Authentication/classes/class.ilLoginPage.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Login page object

--- a/components/ILIAS/Authentication/classes/class.ilLoginPageConfig.php
+++ b/components/ILIAS/Authentication/classes/class.ilLoginPageConfig.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Login page configuration

--- a/components/ILIAS/Authentication/classes/class.ilLoginPageGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilLoginPageGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Login page GUI class

--- a/components/ILIAS/Authentication/classes/class.ilObjAuthSettings.php
+++ b/components/ILIAS/Authentication/classes/class.ilObjAuthSettings.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
 * @author Sascha Hofmann <saschahofmann@gmx.de>

--- a/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsAccess.php
+++ b/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsAccess.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Alex Killing <alex.killing@gmx.de>

--- a/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsListGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilObjAuthSettingsListGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 class ilObjAuthSettingsListGUI extends ilObjectListGUI
 {

--- a/components/ILIAS/Authentication/classes/class.ilSessionControl.php
+++ b/components/ILIAS/Authentication/classes/class.ilSessionControl.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Bjoern Heyser <bheyser@databay.de>

--- a/components/ILIAS/Authentication/classes/class.ilSessionIStorage.php
+++ b/components/ILIAS/Authentication/classes/class.ilSessionIStorage.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Session based immediate storage.

--- a/components/ILIAS/Authentication/classes/class.ilSessionReminder.php
+++ b/components/ILIAS/Authentication/classes/class.ilSessionReminder.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\Clock\ClockInterface;

--- a/components/ILIAS/Authentication/classes/class.ilSessionReminderCheck.php
+++ b/components/ILIAS/Authentication/classes/class.ilSessionReminderCheck.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Data\Clock\ClockInterface;
 use ILIAS\Filesystem\Stream\Streams;

--- a/components/ILIAS/Authentication/classes/class.ilSessionReminderGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilSessionReminderGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 class ilSessionReminderGUI
 {

--- a/components/ILIAS/Authentication/classes/class.ilSessionStatistics.php
+++ b/components/ILIAS/Authentication/classes/class.ilSessionStatistics.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
 * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>

--- a/components/ILIAS/Authentication/classes/class.ilSessionStatisticsGUI.php
+++ b/components/ILIAS/Authentication/classes/class.ilSessionStatisticsGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Jörg Lützenkirchen <luetzenkirchen@leifos.com>

--- a/components/ILIAS/Authentication/interfaces/interface.ilAuthCredentials.php
+++ b/components/ILIAS/Authentication/interfaces/interface.ilAuthCredentials.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Interface of auth credentials

--- a/components/ILIAS/Authentication/interfaces/interface.ilAuthDefinition.php
+++ b/components/ILIAS/Authentication/interfaces/interface.ilAuthDefinition.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Stefan Meyer <smeyer.ilias@gmx.de>

--- a/components/ILIAS/Authentication/interfaces/interface.ilAuthFrontendInterface.php
+++ b/components/ILIAS/Authentication/interfaces/interface.ilAuthFrontendInterface.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Interface for auth methods (web form, http, ...)

--- a/components/ILIAS/Authentication/interfaces/interface.ilAuthProviderAccountMigrationInterface.php
+++ b/components/ILIAS/Authentication/interfaces/interface.ilAuthProviderAccountMigrationInterface.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  *

--- a/components/ILIAS/Authentication/interfaces/interface.ilAuthProviderInterface.php
+++ b/components/ILIAS/Authentication/interfaces/interface.ilAuthProviderInterface.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Standard interface for auth provider implementations

--- a/components/ILIAS/Init/classes/Provider/StartUpModificationProvider.php
+++ b/components/ILIAS/Init/classes/Provider/StartUpModificationProvider.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\Init\Provider;
 
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;

--- a/components/ILIAS/Init/classes/StartupSequence/StartUpSequenceStep.php
+++ b/components/ILIAS/Init/classes/StartupSequence/StartUpSequenceStep.php
@@ -1,7 +1,22 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 namespace ILIAS\Init\StartupSequence;
 

--- a/components/ILIAS/Init/classes/class.ilIniFile.php
+++ b/components/ILIAS/Init/classes/class.ilIniFile.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * INIFile Parser

--- a/components/ILIAS/Init/classes/class.ilPublicSectionSettings.php
+++ b/components/ILIAS/Init/classes/class.ilPublicSectionSettings.php
@@ -1,6 +1,20 @@
 <?php
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Description of class class

--- a/components/ILIAS/Init/classes/class.ilias.php
+++ b/components/ILIAS/Init/classes/class.ilias.php
@@ -1,6 +1,20 @@
 <?php
 
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * ILIAS base class

--- a/components/ILIAS/Init/tests/InitCtrlServiceTest.php
+++ b/components/ILIAS/Init/tests/InitCtrlServiceTest.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/* Copyright (c) 2021 Thibeau Fuhrer <thf@studer-raimann.ch> Extended GPL, see docs/LICENSE */
+declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;

--- a/components/ILIAS/Init/tests/InitHttpServicesTest.php
+++ b/components/ILIAS/Init/tests/InitHttpServicesTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 require_once("vendor/composer/vendor/autoload.php");
 
 use PHPUnit\Framework\TestCase;

--- a/components/ILIAS/Init/tests/InitUIFrameworkTest.php
+++ b/components/ILIAS/Init/tests/InitUIFrameworkTest.php
@@ -1,8 +1,23 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 require_once("vendor/composer/vendor/autoload.php");
 
-use ILIAS\Refinery\Factory;
 use PHPUnit\Framework\TestCase;
 
 class InitUIFrameworkTest extends TestCase

--- a/components/ILIAS/LDAP/exceptions/class.ilLDAPAccountMigrationRequiredException.php
+++ b/components/ILIAS/LDAP/exceptions/class.ilLDAPAccountMigrationRequiredException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Stefan Meyer <meyer@leifos.com>

--- a/components/ILIAS/LDAP/exceptions/class.ilLDAPConnectTimeOutException.php
+++ b/components/ILIAS/LDAP/exceptions/class.ilLDAPConnectTimeOutException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Stefan Meyer <meyer@leifos.com>

--- a/components/ILIAS/LDAP/exceptions/class.ilLDAPPagingException.php
+++ b/components/ILIAS/LDAP/exceptions/class.ilLDAPPagingException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Fabian Wolf <wolf@ilias.de>

--- a/components/ILIAS/LDAP/exceptions/class.ilLDAPSynchronisationFailedException.php
+++ b/components/ILIAS/LDAP/exceptions/class.ilLDAPSynchronisationFailedException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Thrown in case of failed synchronisation settings

--- a/components/ILIAS/LDAP/exceptions/class.ilLDAPSynchronisationForbiddenException.php
+++ b/components/ILIAS/LDAP/exceptions/class.ilLDAPSynchronisationForbiddenException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Stefan Meyer <meyer@leifos.com>

--- a/components/ILIAS/LDAP/exceptions/class.ilLDAPUndefinedScopeException.php
+++ b/components/ILIAS/LDAP/exceptions/class.ilLDAPUndefinedScopeException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Per Pascal Seeland <pascal.seeland@tik.uni-stuttgart.de>

--- a/components/ILIAS/LDAP/interfaces/interface.ilLDAPRoleAssignmentPlugin.php
+++ b/components/ILIAS/LDAP/interfaces/interface.ilLDAPRoleAssignmentPlugin.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
 * Interface for ldap role assignment plugins

--- a/components/ILIAS/LDAP/tests/ilLDAPServerTest.php
+++ b/components/ILIAS/LDAP/tests/ilLDAPServerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,9 +16,9 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\DI\Container;
-use ILIAS\UI\Component\Legacy\Legacy;
-use ILIAS\UI\Factory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/components/ILIAS/OpenIdConnect/classes/class.ilAuthFrontendCredentialsOpenIdConnect.php
+++ b/components/ILIAS/OpenIdConnect/classes/class.ilAuthFrontendCredentialsOpenIdConnect.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * @author Stefan Meyer <smeyer.ilias@gmx.de>

--- a/components/ILIAS/OpenIdConnect/classes/class.ilOpenIdConnectAppEventListener.php
+++ b/components/ILIAS/OpenIdConnect/classes/class.ilOpenIdConnectAppEventListener.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * event listener

--- a/components/ILIAS/OpenIdConnect/classes/class.ilOpenIdConnectSettings.php
+++ b/components/ILIAS/OpenIdConnect/classes/class.ilOpenIdConnectSettings.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,10 +16,11 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 /**
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  */
-
 use ILIAS\Filesystem\Filesystem;
 
 class ilOpenIdConnectSettings

--- a/components/ILIAS/OpenIdConnect/exceptions/class.ilOpenIdConnectSyncForbiddenException.php
+++ b/components/ILIAS/OpenIdConnect/exceptions/class.ilOpenIdConnectSyncForbiddenException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilOpenIdConnectSettingsGUI


### PR DESCRIPTION
This PR fixes the license header for PHP files in all auth. related components.#

The changes have been automatically applied with the help of (the ILIAS 9.x) `rector`.