### PR TITLE
Filter uploaded files from hasUploads if ERR_NO_FILE detected

### DIFF
--- a/src/FileUpload/FileUploadImpl.php
+++ b/src/FileUpload/FileUploadImpl.php
@@ -358,6 +358,10 @@ final class FileUploadImpl implements FileUpload
         }
 
         $uploadedFiles = $this->flattenUploadedFiles($this->globalHttpState->request()->getUploadedFiles());
+        $uploadedFiles = array_filter(
+            $uploadedFiles,
+            fn (UploadedFileInterface $uploadedFile) => $uploadedFile->getError() !== UPLOAD_ERR_NO_FILE
+        );
 
         return ($uploadedFiles !== []);
     }

--- a/tests/FileUpload/FileUploadImplTest.php
+++ b/tests/FileUpload/FileUploadImplTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\FileUpload;
 
 require_once('./libs/composer/vendor/autoload.php');
@@ -190,6 +206,9 @@ class FileUploadImplTest extends TestCase
     public function testHasUploadsWithSingleUploadedFile()
     {
         $uploadedFile = Mockery::mock(UploadedFileInterface::class);
+        $uploadedFile->shouldReceive('getError')
+            ->once()
+            ->andReturn(0);
 
         $this->globalHttpStateMock->shouldReceive('request->getUploadedFiles')
                                   ->once()
@@ -206,7 +225,11 @@ class FileUploadImplTest extends TestCase
     {
         $files = [];
         for ($i = 0; $i < 10; $i++) {
-            $files[] = Mockery::mock(UploadedFileInterface::class);
+            $mock = Mockery::mock(UploadedFileInterface::class);
+            $mock->shouldReceive('getError')
+                ->once()
+                ->andReturn(0);
+            $files[] = $mock;
         }
 
         $this->globalHttpStateMock->shouldReceive('request->getUploadedFiles')


### PR DESCRIPTION
As outlined in https://mantis.ilias.de/view.php?id=42106, we encountered an issue with file upload handling in the assFileUpload component. Specifically, when a form with a file upload field is submitted without selecting a file, it results in an empty UploadedFile object. Below is a sample dump illustrating the issue:

![file upload dump](https://github.com/user-attachments/assets/d54cae48-4704-4bba-b145-6f0bbea0e656)

The problem arises because the hasUploads method still returns true, as it counts any available entries from the HTTP request, regardless of whether a file was actually uploaded.

We modified the hasUploads method to filter out files with the error "ERR_NO_FILE", ensuring that they are not counted as valid uploads.

If this change is likely to introduce side effects—for example, if the method is expected to return all files, regardless of their error state—an alternative solution could be to implement a custom hasValidUploads method. This would specifically count only successfully uploaded files.