### PR TITLE
Fix assFileUpload to prevent error message if files are deleted

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -1177,11 +1177,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
      */
     protected function isFileUploadAvailable(): bool
     {
-        if (!isset($_FILES['upload'])) {
-            return false;
-        }
-
-        if (!isset($_FILES['upload']['tmp_name'])) {
+        if (!$this->file_upload->hasUploads()) {
             return false;
         }
 
@@ -1189,6 +1185,6 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
             $this->file_upload->process();
         }
 
-        return strlen($_FILES['upload']['tmp_name']) > 0;
+        return true;
     }
 }


### PR DESCRIPTION
As outlined in https://mantis.ilias.de/view.php?id=42106, a false-positive error message appears when deleting already uploaded files in an assFileUpload question.

This PR modifies the file upload handling logic in the assFileUpload component to prevent the error message from being displayed when files are deleted.

This PR requires #8085 to be merged beforehand.