### PR TITLE
Saml: Fix wrong baseurlpath in Saml README.md

### DIFF
--- a/Services/Saml/README.md
+++ b/Services/Saml/README.md
@@ -103,7 +103,7 @@ The key `debug` is now not a boolean but an array value instead. New installatio
 The key `baseurlpath` must be changed to the following. New installations will have this value as default.
 ```diff
 - 'baseurlpath' => 'simplesaml/',
-+ 'baseurlpath' => 'Services/saml/lib/',
++ 'baseurlpath' => 'Services/Saml/lib/',
 ```
 
 If it does not already exist the key `module.enable` must be added with the following content. New installations will have this value as default.

--- a/Services/Saml/lib/config.php.dist
+++ b/Services/Saml/lib/config.php.dist
@@ -31,7 +31,7 @@ $config = array(
      * external url, no matter where you come from (direct access or via the
      * reverse proxy).
      */
-    'baseurlpath'           => 'Services/saml/lib/',
+    'baseurlpath'           => 'Services/Saml/lib/',
     'certdir' => 'cert/',
     'loggingdir'            => '[[LOG_DIRECTORY]]',
     'datadir' => 'data/',


### PR DESCRIPTION
This PR fixes a typo in the README and config.php.dist of the Saml Service.