### PR TITLE
Notes fix of #41936

### DIFF
--- a/Services/Notes/Settings/class.NoteSettingsDBRepository.php
+++ b/Services/Notes/Settings/class.NoteSettingsDBRepository.php
@@ -44,12 +44,13 @@ class NoteSettingsDBRepository
     ): bool {
         $db = $this->db;
         $set = $db->query(
-            "SELECT rep_obj_id FROM note_settings " .
+            "SELECT activated FROM note_settings " .
             " WHERE rep_obj_id = " . $db->quote($obj_id, "integer") .
-            " AND activated = " . $db->quote(1, "integer")
+            " ORDER BY obj_type ASC"
         );
+
         if ($db->fetchAssoc($set)) {
-            return true;
+            return (bool)$db->fetchAssoc($set)["activated"];
         }
         return false;
     }
@@ -93,7 +94,7 @@ class NoteSettingsDBRepository
             [
            "rep_obj_id" => ["integer", $obj_id],
            "obj_id" => ["integer", $sub_obj_id],
-           "obj_type" => ["integer", $obj_type],
+           "obj_type" => ["string", $obj_type],
         ],
             [
                 "activated" => ["integer", (int) $a_activate]


### PR DESCRIPTION
Fix for #https://mantis.ilias.de/view.php?id=41936

Note that the issue is the wrong primary type (was integer, should be string). This leads to duplicate entries in the db, such as:
<img width="274" alt="image" src="https://github.com/user-attachments/assets/90f53b43-3f54-438d-9b6e-a720ac47c994">

Since only the first is read and the other is written, comments in migrated objects can not be activated/deactivated.

Note that this PR is not without issues. This does not remove wrong entries, it just fixed the wrong type and then always sticks to reading the one with a type if available. 

The Proper way to fix this would be to remove the wrongly generated entries and copying their values to the right ones as well as adding the obj_type for all new entries generated since the update. 