### PR TITLE
LearningModule / T&A Feature: Disable ImageMap Question Answers after Solution provided

### DIFF
--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -1095,6 +1095,18 @@ ilias.questions.showCorrectAnswers =function(a_id) {
 					if(!jQuery('#canvas_' + a_id + '_' + i).attr('id')) {
 						mouseclick(null,document.getElementById(a_id+"_"+questions[a_id].answers[i].order));
 					}
+					// disbale answer options
+					document.querySelectorAll('area').forEach(function(area) {
+						area.addEventListener('mouseover', function(event) {
+							event.stopImmediatePropagation();
+						}, true);
+						area.addEventListener('mouseout', function(event) {
+							event.stopImmediatePropagation();
+						}, true);
+						area.addEventListener('click', function(event) {
+							event.stopImmediatePropagation();
+						}, true);
+					});
 				}
 				// remove incorrect
 				else {

--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -1,3 +1,19 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 var ilias = {}; //namespace
 var icount = 0; //interaction count
 ilias.UTILS={};


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=33539#c105407

Disabling answers in Learning Module after the solution has been selected or shown because of too many failed attempts. Hover and Click Event Listeners are being disabled on the ImageMapping Areas.