### PR TITLE
Repository/PluginSlot: Add ability to use next_class in the derived class

### DIFF
--- a/components/ILIAS/Component/classes/class.ilPluginConfigGUI.php
+++ b/components/ILIAS/Component/classes/class.ilPluginConfigGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -13,8 +14,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 /**
  * Parent class for all plugin config gui classes
@@ -85,8 +85,23 @@ abstract class ilPluginConfigGUI
             );
         }
 
+        $this->addTabs($ilTabs);
+
+        $next_class = $ilCtrl->getNextClass();
+        if ($next_class && $this->performNextClass($next_class)) {
+            return;
+        }
         $this->performCommand($ilCtrl->getCmd("configure"));
     }
 
     abstract public function performCommand(string $cmd): void;
+
+    protected function performNextClass(string $next_class): bool
+    {
+        return false;
+    }
+
+    protected function addTabs(ilTabsGUI $tabs): void
+    {
+    }
 }

--- a/components/ILIAS/Repository/PluginSlot/class.ilObjectPluginGUI.php
+++ b/components/ILIAS/Repository/PluginSlot/class.ilObjectPluginGUI.php
@@ -159,6 +159,10 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
                 $this->ctrl->forwardCommand($gui);
                 break;
             default:
+                if ($next_class && $this->performNextClass($next_class)) {
+                    break;
+                }
+
                 if ($cmd === "save" || $this->getCreationMode()) {
                     $this->$cmd();
                     return;
@@ -463,5 +467,10 @@ abstract class ilObjectPluginGUI extends ilObject2GUI
         return ilObject::_lookupTitle(ilObject::_lookupObjId(
             $this->slot_request->getRefId()
         ));
+    }
+
+    protected function performNextClass(string $next_class): bool
+    {
+        return false;
     }
 }


### PR DESCRIPTION
There is no way for plugins to route from their GUI to another one via the next_class system. The only chance so far is to read the next_class from the control structure again in the performCommand() and then use it. But that is not the purpose of this function. That is why I would like to add a performNextClass() that gives the plugins an option to react to the value in next_class.

The advantage is that you no longer have to write everything in the plugin's GUI and you get a clearer code.