### PR TITLE
DataCollection: Fix cloned field porperties from older ILIAS

### DIFF
--- a/Modules/DataCollection/classes/Setup/class.ilDataCollectionDBUpdateSteps80.php
+++ b/Modules/DataCollection/classes/Setup/class.ilDataCollectionDBUpdateSteps80.php
@@ -140,4 +140,9 @@ class ilDataCollectionDBUpdateSteps implements \ilDatabaseUpdateSteps
             [ilDclDatatype::INPUTFORMAT_TEXT]
         );
     }
+
+    public function step_10(): void
+    {
+        $this->db->manipulate('UPDATE il_dcl_field_prop SET value = "" WHERE value IS NULL');
+    }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41804

This fixes an issue that occurred when a datacollection was copied which had actively deselected properties on fields.
Since the cause was already fixed for ILIAS 8+ this just cleans up the database