### PR TITLE
User/WelcomeMail: Fix `pre_replace` in welcome mail migration

### DIFF
--- a/Services/User/classes/Setup/Migration/class.ilUpdateNewAccountMailTemplatesForMustache.php
+++ b/Services/User/classes/Setup/Migration/class.ilUpdateNewAccountMailTemplatesForMustache.php
@@ -141,7 +141,7 @@ class ilUpdateNewAccountMailTemplatesForMustache implements Migration
                 '/\[([A-Z_\/]+?)\]/',
                 '{{$1}}'
             );
-            $body = preg_replace(
+            $body = $this->replaceInText(
                 $row['body'],
                 '/\[([A-Z_\/]+?)\]/',
                 '{{$1}}'


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42139