### PR TITLE
UI/DataTable: initialize with Order and Range

### DIFF
--- a/components/ILIAS/ResourceStorage/classes/Collections/View/RequestToDataTable.php
+++ b/components/ILIAS/ResourceStorage/classes/Collections/View/RequestToDataTable.php
@@ -100,8 +100,8 @@ class RequestToDataTable implements RequestToComponents, DataRetrieval
             $this->http->request()
         )->withActions(
             $this->action_builder->getActions()
-        )->withNumberOfRows(
-            $this->request->getItemsPerPage()
+        )->withRange(
+            new Range(0, $this->request->getItemsPerPage())
         );
     }
 

--- a/components/ILIAS/ResourceStorage/classes/Container/View/RequestToDataTable.php
+++ b/components/ILIAS/ResourceStorage/classes/Container/View/RequestToDataTable.php
@@ -45,7 +45,7 @@ class RequestToDataTable implements RequestToComponents, DataRetrieval
     public const F_TYPE = 'type';
     public const F_MODIFICATION_DATE = 'create_date';
     public const FIELD_TITLE = 'title';
-    const HOME = 'HOME';
+    public const HOME = 'HOME';
     private \ILIAS\Data\Factory $data_factory;
     private \ILIAS\ResourceStorage\Services $irss;
     private \ILIAS\UI\Renderer $ui_renderer;
@@ -127,9 +127,9 @@ class RequestToDataTable implements RequestToComponents, DataRetrieval
 
             foreach ($directories as $i => $directory) {
                 $path_inside_zip = rtrim(
-                        implode('/', array_slice($directories, 0, $i + 1)),
-                        '/'
-                    ) . '/';
+                    implode('/', array_slice($directories, 0, $i + 1)),
+                    '/'
+                ) . '/';
                 $links[] = $this->ui_factory->link()->standard(
                     $directory,
                     $get_action($path_inside_zip)

--- a/components/ILIAS/ResourceStorage/classes/Container/View/RequestToDataTable.php
+++ b/components/ILIAS/ResourceStorage/classes/Container/View/RequestToDataTable.php
@@ -184,8 +184,8 @@ class RequestToDataTable implements RequestToComponents, DataRetrieval
             $this->http->request()
         )->withActions(
             $this->action_builder->getActions()
-        )->withNumberOfRows(
-            $this->request->getItemsPerPage()
+        )->withRange(
+            new Range(0, $this->request->getItemsPerPage())
         );
     }
 

--- a/components/ILIAS/UI/src/Component/Table/Data.php
+++ b/components/ILIAS/UI/src/Component/Table/Data.php
@@ -44,11 +44,6 @@ interface Data extends Table
     public function withRequest(ServerRequestInterface $request): static;
 
     /**
-     * Number of Rows is the amount of rows shown per page
-     */
-    public function withNumberOfRows(int $number_of_rows): self;
-
-    /**
      * Not all columns are neccessarily visible; "selected optional" is the
      * positive list of shown columns (the non-optional columns are always shown
      * and are not included here)

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
@@ -34,6 +34,7 @@ use ILIAS\Data\Factory as DataFactory;
 use ILIAS\UI\Component\Input\ViewControl;
 use ILIAS\UI\Component\Input\Container\ViewControl as ViewControlContainer;
 use ILIAS\Data\Range;
+use ILIAS\Data\Order;
 
 class Data extends AbstractTable implements T\Data
 {
@@ -130,9 +131,11 @@ class Data extends AbstractTable implements T\Data
             $data = $view_controls->getData();
             $range = $data[self::VIEWCONTROL_KEY_PAGINATION];
             $range = ($range instanceof Range) ? $range->croppedTo($total_count ?? PHP_INT_MAX) : null;
+            $order = $data[self::VIEWCONTROL_KEY_ORDERING];
+            $order = ($order instanceof Order) ? $order : null;
             $table = $table
                 ->withRange($range)
-                ->withOrder($data[self::VIEWCONTROL_KEY_ORDERING] ?? null)
+                ->withOrder($order)
                 ->withSelectedOptionalColumns($data[self::VIEWCONTROL_KEY_FIELDSELECTION] ?? null);
         }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
@@ -29,8 +29,6 @@ use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Component\JavaScriptBindable as JSBindable;
 use ILIAS\Data\Factory as DataFactory;
-
-
 use ILIAS\UI\Component\Input\ViewControl;
 use ILIAS\UI\Component\Input\Container\ViewControl as ViewControlContainer;
 use ILIAS\Data\Range;
@@ -133,6 +131,7 @@ class Data extends AbstractTable implements T\Data
             $range = ($range instanceof Range) ? $range->croppedTo($total_count ?? PHP_INT_MAX) : null;
             $order = $data[self::VIEWCONTROL_KEY_ORDERING];
             $order = ($order instanceof Order) ? $order : null;
+
             $table = $table
                 ->withRange($range)
                 ->withOrder($order)

--- a/components/ILIAS/UI/src/Implementation/Component/Table/TableViewControlOrdering.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/TableViewControlOrdering.php
@@ -31,7 +31,7 @@ trait TableViewControlOrdering
 
     protected function initViewControlOrdering(): void
     {
-        $this->order = $this->data_factory->order($this->initialOrder(), Order::ASC);
+        $this->order = $this->getOrder();
     }
 
     private function initialOrder(): string
@@ -74,7 +74,10 @@ trait TableViewControlOrdering
             $sort_options[$labels[0]] = $order_asc;
             $sort_options[$labels[1]] = $order_desc;
         }
-        return $this->view_control_factory->sortation($sort_options);
+
+        $value = $this->getOrder()->join('', fn($ret, $key, $value) => [$key, $value]);
+        return $this->view_control_factory->sortation($sort_options)
+            ->withValue($value);
     }
 
     public function withOrder(?Order $order): self

--- a/components/ILIAS/UI/src/Implementation/Component/Table/TableViewControlOrdering.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/TableViewControlOrdering.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Table;
 
 use ILIAS\UI\Component\Input\ViewControl\Sortation;
-use ILIAS\UI\Component\Input\ViewControl\NullControl;
+use ILIAS\UI\Implementation\Component\Input\ViewControl;
 use ILIAS\UI\Component\Table\Column\Column;
 use ILIAS\Data\Order;
 
@@ -47,7 +47,7 @@ trait TableViewControlOrdering
         return array_key_first($sortable_visible_cols);
     }
 
-    protected function getViewControlOrdering(int|null $total_count): Sortation|NullControl
+    protected function getViewControlOrdering(int|null $total_count): Sortation|ViewControl\Group
     {
 
         $sortable_visible_cols = array_filter(
@@ -58,7 +58,10 @@ trait TableViewControlOrdering
         if ($sortable_visible_cols === [] ||
             ($total_count !== null && $total_count < 2)
         ) {
-            return $this->view_control_factory->nullControl();
+            return $this->view_control_factory->group([
+                $this->view_control_factory->nullControl(),
+                $this->view_control_factory->nullControl()
+            ]);
         }
 
         $sort_options = [];

--- a/components/ILIAS/UI/src/Implementation/Component/Table/TableViewControlPagination.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/TableViewControlPagination.php
@@ -31,7 +31,7 @@ trait TableViewControlPagination
 
     protected function initViewControlpagination(): void
     {
-        $this->range = $this->data_factory->range(0, $this->number_of_rows);
+        $this->range = $this->getRange();
     }
 
     protected function getViewControlPagination(?int $total_count = null): ViewControl\Pagination|ViewControl\Group
@@ -51,18 +51,6 @@ trait TableViewControlPagination
             $this->view_control_factory->nullControl(),
             $this->view_control_factory->nullControl()
         ]);
-    }
-
-    public function withNumberOfRows(int $number_of_rows): self
-    {
-        $clone = clone $this;
-        $clone->number_of_rows = $number_of_rows;
-        return $clone;
-    }
-
-    public function getNumberOfRows(): int
-    {
-        return $this->number_of_rows;
     }
 
     public function withRange(?Range $range): self

--- a/components/ILIAS/UI/src/examples/Table/Data/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Data/base.php
@@ -157,10 +157,10 @@ function base()
                     $this->ui_factory->symbol()->icon()->custom('assets/images/standard/icon_x.svg', '', 'small'),
                 ];
                 $icon = $icons[2];
-                if($record['achieve'] > 80) {
+                if ($record['achieve'] > 80) {
                     $icon = $icons[0];
                 }
-                if($record['achieve'] < 30) {
+                if ($record['achieve'] < 30) {
                     $icon = $icons[1];
                 }
                 $record['achieve'] = $icon;
@@ -227,6 +227,12 @@ function base()
             ->data('a data table', $columns, $data_retrieval)
             ->withId('example_base')
             ->withActions($actions)
+
+            //these are initial settings that apply if the according view control
+            //has not been operated, yet
+            ->withRange(new Range(0, 2))
+            ->withOrder(new Order('achieve', Order::DESC))
+
             ->withRequest($request);
 
     /**

--- a/components/ILIAS/UI/tests/Component/Table/DataTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/DataTest.php
@@ -73,7 +73,6 @@ class DataTest extends TableTestBase
         $data = $this->getDataRetrieval();
         $cols = ['f0' => $this->getTableFactory()->column()->text("col1")];
         $table = $this->getTableFactory()->data('title', $cols, $data);
-        $this->assertEquals(800, $table->getNumberOfRows());
         $this->assertInstanceOf(Order::class, $table->getOrder());
         $this->assertInstanceOf(Range::class, $table->getRange());
         $this->assertInstanceOf(I\Signal::class, $table->getAsyncActionSignal());
@@ -152,13 +151,6 @@ class DataTest extends TableTestBase
         $table = $this->getTable();
         $request = $this->createMock(ServerRequestInterface::class);
         $this->assertEquals($request, $table->withRequest($request)->getRequest());
-    }
-
-    public function testDataTableWithNumberOfRows(): void
-    {
-        $table = $this->getTable();
-        $nor = 12;
-        $this->assertEquals($nor, $table->withNumberOfRows($nor)->getNumberOfRows());
     }
 
     public function testDataTableWithOrder(): void

--- a/components/ILIAS/UI/tests/Component/Table/DataViewControlsTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/DataViewControlsTest.php
@@ -145,7 +145,7 @@ class DataViewControlsTest extends TableTestBase
             array_keys($inputs)
         );
         $this->assertInstanceOf(
-            I\Input\ViewControl\NullControl::class,
+            I\Input\ViewControl\Group::class,
             $inputs[C\Table\Data::VIEWCONTROL_KEY_ORDERING]
         );
     }
@@ -173,7 +173,7 @@ class DataViewControlsTest extends TableTestBase
             array_keys($inputs)
         );
         $this->assertInstanceOf(
-            I\Input\ViewControl\NullControl::class,
+            I\Input\ViewControl\Group::class,
             $inputs[C\Table\Data::VIEWCONTROL_KEY_ORDERING]
         );
     }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41328

Optionally initialize a DataTable with Range and/or Order.

This includes the fix from https://github.com/ILIAS-eLearning/ILIAS/pull/8083
Also, I removed withNumberOfRows/getNumberOfRows from the interface in favour of (allready existing) get-/withRange.

