### PR TITLE
10/UnitTests: remove ASSERT_WARNING constant

### DIFF
--- a/components/ILIAS/UI/tests/Base.php
+++ b/components/ILIAS/UI/tests/Base.php
@@ -326,16 +326,6 @@ abstract class ILIAS_UI_TestBase extends TestCase
 
 trait BaseUITestTrait
 {
-    public function setUp(): void
-    {
-        assert_options(ASSERT_WARNING, 0);
-    }
-
-    public function tearDown(): void
-    {
-        assert_options(ASSERT_WARNING, 1);
-    }
-
     public function getUIFactory(): NoUIFactory
     {
         return new NoUIFactory();


### PR DESCRIPTION
UnitTests for PHP8.3 pass more happily.