### PR TITLE
T&A 42182 Fix scoring datetime handling by using the default server timezone

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -1337,7 +1337,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
             $this->setTestId($data->test_id);
 
             if ($data->author) {
-                if(strlen($this->getAuthor()) == 0) {
+                if (strlen($this->getAuthor()) == 0) {
                     $this->saveAuthorToMetadata($data->author);
                 }
                 $this->setAuthor($data->author);
@@ -1978,17 +1978,14 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     /**
     * Gets the reporting date of the ilObjTest object
     *
-    * @return string The reporting date of the test of an empty string (=FALSE) if no reporting date is set
+    * @return DateTimeImmutable|null The reporting date of the test or null (=FALSE) if no reporting date is set
     * @access public
     * @see $reporting_date
+    * @depracated Use Score Settings instead
     */
-    public function getReportingDate(): ?string
+    public function getReportingDate(): ?DateTimeImmutable
     {
-        $date = $this->getScoreSettings()->getResultSummarySettings()->getReportingDate();
-        if ($date) {
-            $date = $date->format('YmdHis'); //legacy-reasons ;(
-        }
-        return $date;
+        return $this->getScoreSettings()->getResultSummarySettings()->getReportingDate();
     }
 
     /**
@@ -6121,14 +6118,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware, ilEctsGradesEnabl
     {
         $total = $this->evalTotalPersons();
         if ($total > 0) {
-            if ($this->getReportingDate()) {
-                if (preg_match("/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/", $this->getReportingDate(), $matches)) {
-                    $epoch_time = mktime($matches[4], $matches[5], $matches[6], $matches[2], $matches[3], $matches[1]);
-                    $now = time();
-                    if ($now < $epoch_time) {
-                        return true;
-                    }
-                }
+            $reporting_date = $this->getScoreSettings()->getResultSummarySettings()->getReportingDate();
+            if ($reporting_date !== null) {
+                return $reporting_date <= new DateTimeImmutable('now', new DateTimeZone('UTC'));
             }
             return false;
         } else {

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -2814,9 +2814,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
                 $info->addProperty(
                     $this->lng->txt('tst_score_reporting_date'),
                     ilDatePresentation::formatDate(new ilDateTime(
-                        $reporting_date
-                            ->setTimezone(new DateTimeZone($this->user->getTimeZone()))
-                            ->format('YmdHis'),
+                        $reporting_date->format('YmdHis'),
                         IL_CAL_TIMESTAMP,
                         $reporting_date->getTimezone()->getName()
                     ))

--- a/Modules/Test/classes/class.ilObjTestSettingsScoringResultsGUI.php
+++ b/Modules/Test/classes/class.ilObjTestSettingsScoringResultsGUI.php
@@ -106,7 +106,7 @@ class ilObjTestSettingsScoringResultsGUI extends ilTestSettingsGUI
 
         if ($templateId) {
             $this->settingsTemplate = new ilSettingsTemplate(
-                (int)$templateId,
+                (int) $templateId,
                 ilObjAssessmentFolderGUI::getSettingsTemplateConfig()
             );
         }
@@ -279,11 +279,10 @@ class ilObjTestSettingsScoringResultsGUI extends ilTestSettingsGUI
             return false;
         }
 
-        if (
-            $this->testOBJ->getScoreReporting() == ilObjTest::SCORE_REPORTING_DATE
-            && $this->testOBJ->getReportingDate() > time()
-        ) {
-            return false;
+        if ($this->testOBJ->getScoreReporting() == ilObjTest::SCORE_REPORTING_DATE) {
+            /** @var DateTimeImmutable $reporting_date */
+            $reporting_date = $this->testOBJ->getScoreSettings()->getResultSummarySettings()->getReportingDate();
+            return $reporting_date <= new DateTimeImmutable('now', new DateTimeZone('UTC'));
         }
 
         return true;

--- a/Modules/Test/classes/class.ilTestPassesSelector.php
+++ b/Modules/Test/classes/class.ilTestPassesSelector.php
@@ -259,19 +259,8 @@ class ilTestPassesSelector
 
     private function isReportingDateReached(): bool
     {
-        $reg = '/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/';
-        $date = $this->testOBJ->getReportingDate();
-        $matches = [];
-
-        if (!preg_match($reg, $date, $matches)) {
-            return false;
-        }
-
-        $matches = array_map('intval', $matches);
-
-        $repTS = mktime($matches[4], $matches[5], $matches[6], $matches[2], $matches[3], $matches[1]);
-
-        return time() >= $repTS;
+        $reporting_date = $this->testOBJ->getScoreSettings()->getResultSummarySettings()->getReportingDate();
+        return $reporting_date <= new DateTimeImmutable('now', new DateTimeZone('UTC'));
     }
 
     private function isProcessingTimeReached($pass): bool
@@ -300,7 +289,7 @@ class ilTestPassesSelector
         }
 
         $passes = $this->getLazyLoadedPasses();
-        if(!isset($passes[$last_finished_pass])) {
+        if (!isset($passes[$last_finished_pass])) {
             return null;
         }
         return $passes[$last_finished_pass]['tstamp'];

--- a/Modules/Test/classes/class.ilTestResultsGUI.php
+++ b/Modules/Test/classes/class.ilTestResultsGUI.php
@@ -346,20 +346,24 @@ class ilTestResultsGUI
                 break;
 
             case ilObjTest::SCORE_REPORTING_DATE:
-
-                $date = new ilDateTime($this->testObj->getReportingDate(), IL_CAL_TIMESTAMP);
+                $reporting_date = $this->testObj->getScoreSettings()->getResultSummarySettings()->getReportingDate();
+                $reporting_date = new ilDateTime(
+                    $reporting_date->format('YmdHis'),
+                    IL_CAL_TIMESTAMP,
+                    $reporting_date->getTimezone()->getName() //date is provided in UTC, formatDate prints it in user timezone
+                );
 
                 if (!$this->testObj->hasAnyTestResult($this->getTestSession())) {
                     $message = sprintf(
                         $DIC->language()->txt('tst_res_tab_msg_res_after_date_no_res'),
-                        ilDatePresentation::formatDate($date)
+                        ilDatePresentation::formatDate($reporting_date)
                     );
                     break;
                 }
 
                 $message = sprintf(
                     $DIC->language()->txt('tst_res_tab_msg_res_after_date'),
-                    ilDatePresentation::formatDate($date)
+                    ilDatePresentation::formatDate($reporting_date)
                 );
                 break;
 


### PR DESCRIPTION
This PR adresses a bug where a UTC DateTime is written into the database but needs to be handled as same as configured server timezone


 This is related to mantis issue: https://mantis.ilias.de/view.php?id=42182

