### PR TITLE
Background Tasks: Async background tasks fail silently if soap client return false

### DIFF
--- a/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
+++ b/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
@@ -37,6 +37,14 @@ class AsyncTaskManager extends BasicTaskManager
     {
         global $DIC;
 
+        // check this before saving the bucket state to prevent an orphaned entry with 0%
+        if (!$DIC->settings()->get('soap_user_administration')) {
+            $DIC->logger()->bgtk()->warning("SOAP not enabled, fallback to sync version");
+            $sync_manager = new SyncTaskManager($this->persistence);
+            $sync_manager->run($bucket);
+            return;
+        }
+
         $bucket->setState(State::SCHEDULED);
         $bucket->setCurrentTask($bucket->getTask());
         $DIC->backgroundTasks()->persistence()->saveBucketAndItsTasks($bucket);

--- a/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
+++ b/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
@@ -55,9 +55,14 @@ class AsyncTaskManager extends BasicTaskManager
             )
             : '';
         try {
-            $soap_client->call(self::CMD_START_WORKER, array(
+            $result = $soap_client->call(self::CMD_START_WORKER, array(
                 $session_id . '::' . $client_id,
             ));
+            if ($result === false) {
+                $DIC->logger()->root()->info("[BT] Calling Webserver returned false, fallback to sync version");
+                $sync_manager = new SyncTaskManager($this->persistence);
+                $sync_manager->run($bucket);
+            }
         } catch (\Throwable $t) {
             $DIC->logger()->root()->info("[BT] Calling Webserver failed, fallback to sync version");
             $sync_manager = new SyncTaskManager($this->persistence);

--- a/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
+++ b/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
@@ -64,12 +64,9 @@ class AsyncTaskManager extends BasicTaskManager
             )
             : '';
         try {
-            $result = $soap_client->call(self::CMD_START_WORKER, array(
+            $soap_client->call(self::CMD_START_WORKER, array(
                 $session_id . '::' . $client_id,
             ));
-            if ($result === false) {
-                throw new ilException("SOAP call returned false");
-            }
         } catch (\Throwable $t) {
             $DIC->logger()->bgtk()->warning($t->getMessage());
             $DIC->logger()->bgtk()->warning("Calling webserver failed, fallback to sync version");


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=42183

This PR ads a fallback to SyncTaskManager if the soap client returns false.