### PR TITLE
LegalDocuments: Load ui factory and template later

### DIFF
--- a/Services/DataProtection/classes/class.ilObjDataProtectionGUI.php
+++ b/Services/DataProtection/classes/class.ilObjDataProtectionGUI.php
@@ -61,7 +61,7 @@ final class ilObjDataProtectionGUI extends ilObject2GUI
         $this->legal_documents = new ilLegalDocumentsAdministrationGUI(self::class, $config, $this->afterDocumentDeletion(...));
 
         $this->data_protection_settings = $this->createDataProtectionSettings();
-        $this->ui = new UI($this->getType(), $this->container->ui()->factory(), $this->container->ui()->mainTemplate(), $this->container->language());
+        $this->ui = new UI($this->getType(), $this->container->ui(), $this->container->language());
     }
 
     public function getType(): string

--- a/Services/LegalDocuments/classes/ConsumerToolbox/Blocks.php
+++ b/Services/LegalDocuments/classes/ConsumerToolbox/Blocks.php
@@ -108,7 +108,7 @@ class Blocks
 
     public function ui(): UI
     {
-        return new UI($this->id, $this->container->ui()->factory(), $this->container->ui()->mainTemplate(), $this->container->language());
+        return new UI($this->id, $this->container->ui(), $this->container->language());
     }
 
     public function user(Settings $global_settings, UserSettings $user_settings, ilObjUser $user): User

--- a/Services/LegalDocuments/classes/ConsumerToolbox/UI.php
+++ b/Services/LegalDocuments/classes/ConsumerToolbox/UI.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\LegalDocuments\ConsumerToolbox;
 
 use ILIAS\UI\Factory as UIFactory;
+use ILIAS\DI\UIServices;
 use ilGlobalTemplateInterface;
 use ilLanguage;
 use ilObjLegalDocumentsGUI;
@@ -29,20 +30,19 @@ class UI
 {
     public function __construct(
         private readonly string $id,
-        private readonly UIFactory $create,
-        private readonly ilGlobalTemplateInterface $main_template,
+        private readonly UIServices $services,
         private readonly ilLanguage $language
     ) {
     }
 
     public function create(): UIFactory
     {
-        return $this->create;
+        return $this->services->factory();
     }
 
     public function mainTemplate(): ilGlobalTemplateInterface
     {
-        return $this->main_template;
+        return $this->services->mainTemplate();
     }
 
     public function loadLanguageModule(string $module): void

--- a/Services/LegalDocuments/classes/DefaultMappings.php
+++ b/Services/LegalDocuments/classes/DefaultMappings.php
@@ -42,8 +42,7 @@ class DefaultMappings
     {
         $ui = new UI(
             $this->id,
-            $this->container->ui()->factory(),
-            $this->container->ui()->mainTemplate(),
+            $this->container->ui(),
             $this->container->language()
         );
 

--- a/Services/LegalDocuments/classes/Provide/ProvideDocument.php
+++ b/Services/LegalDocuments/classes/Provide/ProvideDocument.php
@@ -76,7 +76,7 @@ class ProvideDocument
         $t = new DocumentTable(
             fn($criterion) => $this->toCondition($criterion)->asComponent(),
             $this->document_repository,
-            new UI($this->id, $this->container->ui()->factory(), $this->container->ui()->mainTemplate(), $this->container->language()),
+            new UI($this->id, $this->container->ui(), $this->container->language()),
             new DocumentModal($this->container->ui(), $this->contentAsComponent(...))
         );
 

--- a/Services/LegalDocuments/classes/Provide/ProvideHistory.php
+++ b/Services/LegalDocuments/classes/Provide/ProvideHistory.php
@@ -54,7 +54,7 @@ class ProvideHistory
     public function table(object $gui, string $command, string $reset_command, string $auto_complete_command): Component
     {
         $auto_complete_link = $this->container->ctrl()->getLinkTarget($gui, $auto_complete_command, '', true);
-        $ui = new UI($this->id, $this->container->ui()->factory(), $this->container->ui()->mainTemplate(), $this->container->language());
+        $ui = new UI($this->id, $this->container->ui(), $this->container->language());
         $modal = new DocumentModal($this->container->ui(), $this->document->contentAsComponent(...));
         $create = fn(string $class, ...$args) => $class === ilObjUser::class && !ilObjUser::_lookupLogin($args[0], 'login') ?
                 null :

--- a/Services/LegalDocuments/classes/class.ilLegalDocumentsAdministrationGUI.php
+++ b/Services/LegalDocuments/classes/class.ilLegalDocumentsAdministrationGUI.php
@@ -53,8 +53,7 @@ class ilLegalDocumentsAdministrationGUI
         $this->container->language()->loadLanguageModule('ldoc');
         $this->ui = new UI(
             $this->config->legalDocuments()->id(),
-            $this->container->ui()->factory(),
-            $this->container->ui()->mainTemplate(),
+            $this->container->ui(),
             $this->container->language()
         );
         $this->admin = new Administration($this->config, $this->container, $this->ui);

--- a/Services/LegalDocuments/test/ConsumerToolbox/BlocksTest.php
+++ b/Services/LegalDocuments/test/ConsumerToolbox/BlocksTest.php
@@ -95,12 +95,7 @@ class BlocksTest extends TestCase
     public function testUi(): void
     {
         $container = $this->mock(Container::class);
-
-        $ui = $this->mock(UIServices::class);
-        $ui->expects(self::once())->method('factory')->willReturn($this->mock(UIFactory::class));
-        $ui->expects(self::once())->method('mainTemplate')->willReturn($this->mock(ilGlobalTemplateInterface::class));
-
-        $container->method('ui')->willReturn($ui);
+        $container->expects(self::once())->method('ui')->willReturn($this->mock(UIServices::class));
         $container->expects(self::once())->method('language')->willReturn($this->mock(ilLanguage::class));
 
         $instance = new Blocks(

--- a/Services/LegalDocuments/test/ConsumerToolbox/UITest.php
+++ b/Services/LegalDocuments/test/ConsumerToolbox/UITest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\LegalDocuments\test\ConsumerToolbox;
 
 use ILIAS\LegalDocuments\test\ContainerMock;
+use ILIAS\DI\UIServices;
 use ILIAS\UI\Factory as UIFactory;
 use PHPUnit\Framework\TestCase;
 use ILIAS\LegalDocuments\ConsumerToolbox\UI;
@@ -35,19 +36,19 @@ class UITest extends TestCase
 
     public function testConstruct(): void
     {
-        $this->assertInstanceOf(UI::class, new UI('foo', $this->mock(UIFactory::class), $this->mock(ilGlobalTemplateInterface::class), $this->mock(ilLanguage::class)));
+        $this->assertInstanceOf(UI::class, new UI('foo', $this->mock(UIServices::class), $this->mock(ilLanguage::class)));
     }
 
     public function testCreate(): void
     {
         $ui_factory = $this->mock(UIFactory::class);
-        $this->assertSame($ui_factory, (new UI('foo', $ui_factory, $this->mock(ilGlobalTemplateInterface::class), $this->mock(ilLanguage::class)))->create());
+        $this->assertSame($ui_factory, (new UI('foo', $this->mockTree(UIServices::class, ['factory' => $ui_factory]), $this->mock(ilLanguage::class)))->create());
     }
 
     public function testMainTemplate(): void
     {
         $template = $this->mock(ilGlobalTemplateInterface::class);
-        $this->assertSame($template, (new UI('foo', $this->mock(UIFactory::class), $template, $this->mock(ilLanguage::class)))->mainTemplate());
+        $this->assertSame($template, (new UI('foo', $this->mockTree(UIServices::class, ['mainTemplate' => $template]), $this->mock(ilLanguage::class)))->mainTemplate());
     }
 
     public function testTxt(): void
@@ -55,7 +56,7 @@ class UITest extends TestCase
         $language = $this->mockMethod(ilLanguage::class, 'txt', ['ldoc_foo'], 'baz');
         $language->expects(self::exactly(2))->method('exists')->withConsecutive(['bar_foo'], ['ldoc_foo'])->willReturnOnConsecutiveCalls(false, true);
 
-        $instance = new UI('bar', $this->mock(UIFactory::class), $this->mock(ilGlobalTemplateInterface::class), $language);
+        $instance = new UI('bar', $this->mock(UIServices::class), $language);
         $this->assertSame('baz', $instance->txt('foo'));
     }
 
@@ -64,7 +65,7 @@ class UITest extends TestCase
         $language = $this->mockMethod(ilLanguage::class, 'txt', ['foo'], 'baz');
         $language->expects(self::exactly(2))->method('exists')->withConsecutive(['bar_foo'], ['ldoc_foo'])->willReturn(false);
 
-        $instance = new UI('bar', $this->mock(UIFactory::class), $this->mock(ilGlobalTemplateInterface::class), $language);
+        $instance = new UI('bar', $this->mock(UIServices::class), $language);
         $this->assertSame('baz', $instance->txt('foo'));
     }
 }

--- a/Services/TermsOfService/classes/class.ilObjTermsOfServiceGUI.php
+++ b/Services/TermsOfService/classes/class.ilObjTermsOfServiceGUI.php
@@ -62,7 +62,7 @@ class ilObjTermsOfServiceGUI extends ilObject2GUI
         }
         $this->config = $config;
         $this->legal_documents = new ilLegalDocumentsAdministrationGUI(self::class, $this->config, $this->afterDocumentDeletion(...));
-        $this->ui = new UI(Consumer::ID, $this->dic->ui()->factory(), $this->dic->ui()->mainTemplate(), $this->dic->language());
+        $this->ui = new UI(Consumer::ID, $this->dic->ui(), $this->dic->language());
         $this->tos_settings = $this->createSettings();
     }
 


### PR DESCRIPTION
Fix Mantis Bug: https://mantis.ilias.de/view.php?id=42175

This PR ensures that the UI is loaded later in the LegalDocuments process and not in the initialization.