### PR TITLE
LegalDocuments: Fix wrong Soap check

### DIFF
--- a/Services/DataProtection/classes/Consumer.php
+++ b/Services/DataProtection/classes/Consumer.php
@@ -89,7 +89,7 @@ final class Consumer implements ConsumerInterface
                          ->hasOnlineStatusFilter($blocks->slot()->onlineStatusFilter($this->usersWhoDidntAgree($this->container->database())))
                          ->hasUserManagementFields($blocks->userManagementAgreeDateField($build_user, 'dpro_agree_date', 'dpro'))
                          ->canReadInternalMails($blocks->slot()->canReadInternalMails($build_user))
-                         ->canUseSoapApi($constraint($public_api->agreed(...), 'Data Protection not agreed.'));
+                         ->canUseSoapApi($constraint(fn($u) => !$public_api->needsToAgree($u), 'Data Protection not agreed.'));
         }
 
         return $slot;

--- a/Services/LegalDocuments/classes/Conductor.php
+++ b/Services/LegalDocuments/classes/Conductor.php
@@ -40,6 +40,7 @@ use ILIAS\LegalDocuments\ConsumerToolbox\SelectSetting;
 use ILIAS\LegalDocuments\ConsumerToolbox\KeyValueStore\SessionStore;
 use ILIAS\LegalDocuments\ConsumerToolbox\Marshal;
 use ILIAS\LegalDocuments\ConsumerToolbox\Routing;
+use ILIAS\LegalDocuments\Value\Target;
 
 class Conductor
 {
@@ -158,6 +159,9 @@ class Conductor
         array_map(fn($proc) => $proc(), $this->internal->all('after-login'));
     }
 
+    /**
+     * @return Result<Target>
+     */
     public function findGotoLink(string $goto_target): Result
     {
         return $this->find(
@@ -244,7 +248,7 @@ class Conductor
     }
 
     /**
-     * @return Closure(Closure(string, string): Result<PageFragment>): string
+     * @return Closure(Closure(string, string): Result<PageFragment>): Result<string>
      */
     private function renderPageFragment(string $gui, string $cmd): Closure
     {

--- a/Services/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/PublicApi.php
+++ b/Services/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/PublicApi.php
@@ -70,7 +70,7 @@ class PublicApi implements PublicApiInterface
 
     public function needsToAgree(ilObjUser $user): bool
     {
-        return !$this->canAgree($user)
+        return $this->canAgree($user)
             && $this->user($user)->needsToAcceptNewDocument();
     }
 

--- a/Services/LegalDocuments/test/ConsumerToolbox/ConsumerSlots/PublicApiTest.php
+++ b/Services/LegalDocuments/test/ConsumerToolbox/ConsumerSlots/PublicApiTest.php
@@ -71,8 +71,8 @@ class PublicApiTest extends TestCase
     public function testNeedsToAgree(): void
     {
         $this->assertSameValues('needsToAgree', [
-            [true,  ['cannotAgree' => true, 'needsToAcceptNewDocument' => true]],
-            [false, ['cannotAgree' => false, 'needsToAcceptNewDocument' => true]],
+            [false,  ['cannotAgree' => true, 'needsToAcceptNewDocument' => true]],
+            [true, ['cannotAgree' => false, 'needsToAcceptNewDocument' => true]],
             [false, ['cannotAgree' => true, 'needsToAcceptNewDocument' => false]],
             [false, ['cannotAgree' => false, 'needsToAcceptNewDocument' => false]],
         ]);

--- a/Services/TermsOfService/classes/Consumer.php
+++ b/Services/TermsOfService/classes/Consumer.php
@@ -77,7 +77,7 @@ class Consumer implements ConsumerInterface
                     ->hasOnlineStatusFilter($blocks->slot()->onlineStatusFilter($this->usersWhoDidntAgree($this->container->database())))
                     ->hasUserManagementFields($blocks->userManagementAgreeDateField($build_user, 'tos_agree_date', 'tos'))
                     ->canReadInternalMails($blocks->slot()->canReadInternalMails($build_user))
-                    ->canUseSoapApi($constraint($public_api->agreed(...), 'TOS not accepted.'));
+                    ->canUseSoapApi($constraint(fn($u) => !$public_api->needsToAgree($u), 'TOS not accepted.'));
     }
 
     private function userHasWithdrawn(): void


### PR DESCRIPTION
This PR fixes Mantis Bug: https://mantis.ilias.de/view.php?id=42168
The boolean query to check if the ToS or Dpro need to be accepted via Soap is fixed.