### PR TITLE
[FIX] 0042161: Uploads via “Evaluation for many Participants” lead to…

### DIFF
--- a/Modules/Exercise/IRSS/CollectionWrapper.php
+++ b/Modules/Exercise/IRSS/CollectionWrapper.php
@@ -284,15 +284,18 @@ class CollectionWrapper
         ResourceStakeholder $target_stakeholder
     ) {
         $entry_parts = explode("/", $entry);
-        $zip = new \ZipArchive();
-        if ($zip->open($this->stream($rid)->getMetadata()['uri'], \ZipArchive::RDONLY)) {
-            $feedback_rid = $this->irss->manage()->stream(
-                Streams::ofResource($zip->getStream($entry)),
-                $target_stakeholder,
-                $entry_parts[2]
-            );
-            $target_collection->add($feedback_rid);
-            $this->irss->collection()->store($target_collection);
-        }
+        $zip_path = $this->stream($rid)->getMetadata("uri");
+
+        $stream = Streams::ofFileInsideZIP(
+            $zip_path,
+            $entry
+        );
+        $feedback_rid = $this->irss->manage()->stream(
+            $stream,
+            $target_stakeholder,
+            $entry_parts[2]
+        );
+        $target_collection->add($feedback_rid);
+        $this->irss->collection()->store($target_collection);
     }
 }


### PR DESCRIPTION
… empty files (IRSS stores stream from zip archive with 0 byte content)

This fixes https://mantis.ilias.de/view.php?id=42161, please note that it needed the change from https://github.com/ILIAS-eLearning/ILIAS/commit/021ef3476cb4e402f4321284e503624f4f44f1c9 / https://mantis.ilias.de/view.php?id=42062