### PR TITLE
Course/SOAP: Fix that title defaults to `dummy` when using `(add|update)Course`

### DIFF
--- a/webservice/soap/classes/class.ilSoapCourseAdministration.php
+++ b/webservice/soap/classes/class.ilSoapCourseAdministration.php
@@ -78,6 +78,7 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         include_once 'Modules/Course/classes/class.ilCourseXMLParser.php';
 
         $xml_parser = new ilCourseXMLParser($newObj);
+        $xml_parser->setMode(ilCourseXMLParser::MODE_SOAP);
         $xml_parser->setXMLContent($crs_xml);
         $xml_parser->startParsing();
         return $newObj->getRefId() ?: "0";

--- a/webservice/soap/classes/class.ilSoapCourseAdministration.php
+++ b/webservice/soap/classes/class.ilSoapCourseAdministration.php
@@ -398,6 +398,7 @@ class ilSoapCourseAdministration extends ilSoapAdministration
         include_once 'Modules/Course/classes/class.ilCourseXMLParser.php';
 
         $xml_parser = new ilCourseXMLParser($tmp_course);
+        $xml_parser->setMode(ilCourseXMLParser::MODE_SOAP);
         $xml_parser->setXMLContent($xml);
         $xml_parser->startParsing();
         $tmp_course->MDUpdateListener('General');


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42079

If approved, this must be picked to `trunk` as well.