### PR TITLE
BackgroundTasks: Use "Fire & Forget" approach when starting workers as…

### DIFF
--- a/components/ILIAS/BackgroundTasks/src/Implementation/TaskManager/AsyncTaskManager.php
+++ b/components/ILIAS/BackgroundTasks/src/Implementation/TaskManager/AsyncTaskManager.php
@@ -44,7 +44,7 @@ class AsyncTaskManager extends BasicTaskManager
 
         // Call SOAP-Server
         $soap_client = new \ilSoapClient();
-        $soap_client->setResponseTimeout(1);
+        $soap_client->setResponseTimeout(0);
         $soap_client->enableWSDL(true);
         $soap_client->init();
         $session_id = session_id();

--- a/components/ILIAS/BackgroundTasks_/classes/class.ilSoapBackgroundTasksAdministration.php
+++ b/components/ILIAS/BackgroundTasks_/classes/class.ilSoapBackgroundTasksAdministration.php
@@ -34,6 +34,8 @@ class ilSoapBackgroundTasksAdministration extends ilSoapAdministration
      */
     public function runAsync(string $sid)
     {
+        ignore_user_abort(true);
+
         $this->initAuth($sid);
         $this->initIlias();
 


### PR DESCRIPTION
…ynchronously

This PR suggests making the start of asynchronous workers for background tasks really asynchronous to ensure a "Fire & Forget" approach. This is done by setting the "Response Timeout" to `0` and by adding a `ignore_user_abort(true);`) on the server-side (SOAP).