### PR TITLE
[BUGXFIX/Refactor] Refactor booking event listener to disable a lot of initialisation without use(?) (Undefined Constant in non web context)

### DIFF
--- a/Modules/BookingManager/classes/class.ilBookingManagerAppEventListener.php
+++ b/Modules/BookingManager/classes/class.ilBookingManagerAppEventListener.php
@@ -34,13 +34,11 @@ class ilBookingManagerAppEventListener
     ): void {
         global $DIC;
 
-        $user_event = $DIC->bookingManager()->internal()->domain()->userEvent();
-
         switch ($a_component) {
             case "Services/User":
                 switch ($a_event) {
                     case "deleteUser":
-                        $user_event->handleDeletion((int) $a_parameter["usr_id"]);
+                        $DIC->bookingManager()->internal()->domain()->userEvent()->handleDeletion((int) $a_parameter["usr_id"]);
                         break;
                 }
                 break;


### PR DESCRIPTION
Hello,

there is a somewhat bigger conceptional issue in the whole ILIAS code base. 
A lot of places are initialising GUI classes in non WEB context e.g. `ilContext::init(ilContext::CONTEXT_CRON);`

This now always results in errors when the stuff is reached in a CLI or Cron:

```
Error thrown with message "Undefined constant "ILIAS\Repository\Form\ILIAS_HTTP_PATH""

Stacktrace:
#10 Error in /var/www/ilias/Services/Repository/Service/Form/class.FormAdapterGUI.php:95
#9 ILIAS\Repository\Form\FormAdapterGUI:getOnLoadCode in /var/www/ilias/Services/Repository/Service/Form/class.FormAdapterGUI.php:111
#8 ILIAS\Repository\Form\FormAdapterGUI:initJavascript in /var/www/ilias/Services/Repository/Service/trait.GlobalDICGUIServices.php:50
#7 ILIAS\BookingManager\InternalGUIService:initGUIServices in /var/www/ilias/Modules/BookingManager/Service/class.InternalGUIService.php:43
#6 ILIAS\BookingManager\InternalGUIService:__construct in /var/www/ilias/Modules/BookingManager/Service/class.InternalService.php:49
#5 ILIAS\BookingManager\InternalService:__construct in /var/www/ilias/Modules/BookingManager/Service/class.Service.php:42
#4 ILIAS\BookingManager\Service:internal in /var/www/ilias/Modules/BookingManager/classes/class.ilBookingManagerAppEventListener.php:37
#3 ilBookingManagerAppEventListener:handleEvent in /var/www/ilias/Services/EventHandling/classes/class.ilAppEventHandler.php:143
#2 ilAppEventHandler:raise in /var/www/ilias/Services/User/classes/class.ilObjUser.php:549
#1 ilObjUser:update in /var/www/ilias/DefaultConfig.php:35
#0 changeRootPasword in /var/www/ilias/DefaultConfig.php:17
```

You cant call the update of an user anymore without setting constants on your own after the core ilias initialisation. There is even a deprecated "fix" in `ilCronManagerImpl` but the errors are getting more and more.

This is an bigger issue i cant fix so i propose another solution here for my usecase.

I read the code that calls the stuff and found this line of code that initialises a lot of stuff which is only used on delete Events of an user, but was called everytime. So i decided to move that line. Is that something we can do here? I dont think the code has to be called at all.

Greetings
Purhur

Mantis Issue: https://mantis.ilias.de/view.php?id=42242