### PR TITLE
Badge: Update the last time the badge list has been seen correctly

### DIFF
--- a/Services/Badge/classes/class.ilBadgeProfileGUI.php
+++ b/Services/Badge/classes/class.ilBadgeProfileGUI.php
@@ -114,6 +114,7 @@ class ilBadgeProfileGUI
     protected function listBadges(): void
     {
         $this->tpl->setContent($this->renderDeck($this->tile_view->show()));
+        $this->noti_repo->updateLastCheckedTimestamp();
     }
 
     private function renderDeck(string $deck): string


### PR DESCRIPTION
Fix Mantis Bug: https://mantis.ilias.de/view.php?id=42194

This PR updates the time a user has last seen the badge list.