### PR TITLE
Forum: Fix misleading forum notification label

### DIFF
--- a/Modules/Forum/classes/class.ilObjForumAdministrationGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumAdministrationGUI.php
@@ -264,7 +264,7 @@ class ilObjForumAdministrationGUI extends ilObjectGUI
                 self::PROP_SECTION_NOTIFICATIONS => $section('frm_adm_sec_notifications', $disable_if_no_permission([
                     'forum_notification' => $checkbox_with_func(
                         'forum_notification',
-                        'cron_forum_notification',
+                        'forums_forum_notification',
                         fn($field) => (
                             $field
                             ->withDisabled($this->forumJobActive())

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -3784,7 +3784,6 @@ common#:#create_stylesheet#:#Style erstellen
 common#:#created#:#Erzeugt am
 common#:#cron_forum_notification#:#Foren-Benachrichtigungen via Cron-Job versenden
 common#:#cron_forum_notification_crob_desc#:#Wenn aktiviert, sendet ILIAS täglich Benachrichtigungen an die Benutzer, die bei ausgewählten Foren oder Foren-Themen über neue und geänderte Beiträge benachrichtigt werden wollen. Bitte beachten Sie: Wenn Sie diese Form der Foren-Benachrichtigungen aktivieren, werden keine direkten Benachrichtungen mehr verschickt (Administration / Foren / Foren-Benachrichtigungen versenden).
-common#:#cron_forum_notification_desc#:#Wenn aktiviert, sendet ILIAS Mails an die Benutzer, die bei ausgewählten Foren-Themen über neue Beiträge benachrichtigt werden wollen.
 common#:#cron_forum_notification_disabled#:#Kann nicht deaktiviert werden wenn der Cron Job aktiv ist.
 common#:#cron_jobs#:#Cron-Jobs
 common#:#cron_lucene_index#:#Lucene-Suchindex aktualisieren
@@ -9934,6 +9933,8 @@ forum#:#forums_download_attachment#:#Datei herunterladen
 forum#:#forums_edit_draft#:#Entwurf bearbeiten
 forum#:#forums_edit_post#:#Beitrag bearbeiten
 forum#:#forums_enable_notification#:#Benachrichtigung für dieses Thema starten
+forum#:#forums_forum_notification#:#Foren-Benachrichtigungen versenden
+forum#:#forums_forum_notification_desc#:#Wenn aktiviert, sendet ILIAS Mails an die Benutzer, die bei ausgewählten Foren-Themen über neue Beiträge benachrichtigt werden wollen.
 forum#:#forums_forum_notification_disabled#:#Sie werden nicht mehr über neue Beiträge in diesem Forum benachrichtigt.
 forum#:#forums_info_censor2_post#:#Sind Sie sicher, dass die Zensur für diesen Beitrag aufgehoben werden soll?
 forum#:#forums_info_censor_post#:#Geben Sie eine Begründung für die Zensur an.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -3784,7 +3784,6 @@ common#:#create_stylesheet#:#Create Style
 common#:#created#:#Creation Date
 common#:#cron_forum_notification#:#Send Forum Notifications via Cron Job
 common#:#cron_forum_notification_crob_desc#:#If enabled, all users who have enabled notifications for certain forums or forum threads will daily receive a notification mail about all new  or changed posts but no immediate notification for each submitted post.
-common#:#cron_forum_notification_desc#:#If enabled, all users, who want to be informed about new posts in specified forum threads, will get notifications by mail.
 common#:#cron_forum_notification_disabled#:#Can't be disabled when the Cron Job is active.
 common#:#cron_jobs#:#Cron Jobs
 common#:#cron_lucene_index#:#Update Lucene search index
@@ -9934,6 +9933,8 @@ forum#:#forums_download_attachment#:#Download file
 forum#:#forums_edit_draft#:#Edit Draft
 forum#:#forums_edit_post#:#Edit Post
 forum#:#forums_enable_notification#:#Enable Notification for this Thread
+forum#:#forums_forum_notification#:#Send Forum Notifications
+forum#:#forums_forum_notification_desc#:#If enabled, all users, who want to be informed about new posts in specified forum threads, will get notifications by mail.
 forum#:#forums_forum_notification_disabled#:#You will no longer be notified about new posts in this forum.
 forum#:#forums_info_censor2_post#:#Revoke Censorship?
 forum#:#forums_info_censor_post#:#Please provide a reason for hiding this post.


### PR DESCRIPTION
Fix Mantis Bug: https://mantis.ilias.de/view.php?id=42231

This PR changes the label of the notification setting in the forum administration form.