### PR TITLE
10/UI/Input error-message accessibility

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Renderer.php
@@ -116,7 +116,13 @@ class Renderer extends AbstractComponentRenderer
     {
         if (null !== ($error = $component->getError())) {
             $tpl->setCurrentBlock("error");
+            $error_id = $this->createId();
             $tpl->setVariable("ERROR", $error);
+            $tpl->setVariable("ERROR_ID", $error_id);
+            $tpl->setVariable("ERROR_LABEL", $this->txt("ui_error"));
+            $tpl->parseCurrentBlock();
+            $tpl->setCurrentBlock("reference_error");
+            $tpl->setVariable("ERROR_ID", $error_id);
             $tpl->parseCurrentBlock();
         }
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -199,13 +199,13 @@ class Renderer extends AbstractComponentRenderer
 
         $error = $component->getError();
         if ($error) {
+            $error_id = $this->createId();
+            $tpl->setVariable("ERROR_LABEL", $this->txt("ui_error"));
+            $tpl->setVariable("ERROR_ID", $error_id);
             $tpl->setVariable("ERROR", $error);
-            if ($id_pointing_to_input) {
-                $tpl->setVariable("ERROR_FOR_ID", $id_pointing_to_input);
-            }
         }
 
-        if($dependant_group_html !== '') {
+        if ($dependant_group_html !== '') {
             $tpl->setVariable("DEPENDANT_GROUP", $dependant_group_html);
         }
         return $tpl->get();
@@ -470,7 +470,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable("HIDDEN", "hidden");
         }
 
-        if(!($value && $component->isRequired())) {
+        if (!($value && $component->isRequired())) {
             $tpl->setVariable("VALUE", null);
             $tpl->setVariable("VALUE_STR", $component->isRequired() ? $this->txt('ui_select_dropdown_label') : '-');
             $tpl->parseCurrentBlock();
@@ -1057,7 +1057,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->parseCurrentBlock();
         }
 
-        if(!$component->isRequired()) {
+        if (!$component->isRequired()) {
             $tpl->setVariable('NEUTRAL_ID', $id . '-0');
             $tpl->setVariable('NEUTRAL_NAME', $component->getName());
             $tpl->setVariable('NEUTRAL_LABEL', $this->txt('reset_stars'));

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.context_form.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.context_form.html
@@ -1,4 +1,4 @@
-<fieldset class="c-input" data-il-ui-component="{UI_COMPONENT}" data-il-ui-input-name="{INPUT_NAME}" {DISABLED}>
+<fieldset class="c-input" data-il-ui-component="{UI_COMPONENT}" data-il-ui-input-name="{INPUT_NAME}"<!-- BEGIN described --> aria-describedby="{ERROR_ID}"<!-- END described --> {DISABLED}>
 
 	<label <!-- BEGIN for -->for="{ID}" <!-- END for -->>{LABEL}<!-- BEGIN required --><span class="asterisk">*</span><!-- END required --></label>
 
@@ -7,7 +7,7 @@
 	</div>
 
 	<!-- BEGIN error -->
-	<div class="c-input__error-msg alert alert-danger"<!-- BEGIN described --> aria-describedby="{ERROR_FOR_ID}"<!-- END described --> role="alert">{ERROR}</div>
+	<div class="c-input__error-msg alert alert-danger" id="{ERROR_ID}"><span class="sr-only">{ERROR_LABEL}: </span>{ERROR}</div>
 	<!-- END error -->
 
 	<!-- BEGIN byline -->

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.no_submit.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.no_submit.html
@@ -1,6 +1,6 @@
-<form id="{ID}" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post" novalidate="novalidate">
+<form id="{ID}" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data"<!-- BEGIN reference_error --> describedby="{ERROR_ID}"<!-- END reference_error --> {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post" novalidate="novalidate">
 	<!-- BEGIN error -->
-	<div class="c-form__error-msg alert alert-danger" role="alert">
+	<div id="{ERROR_ID}" class="c-form__error-msg alert alert-danger">
 		{ERROR}
 	</div>
 	<!-- END error -->

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.standard.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.standard.html
@@ -1,4 +1,4 @@
-<form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post" novalidate="novalidate">
+<form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data"<!-- BEGIN reference_error --> describedby="{ERROR_ID}"<!-- END reference_error --> {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post" novalidate="novalidate">
 	<div class="c-form__header">
 		<div class="c-form__actions">{BUTTONS_TOP}</div>
 		<!-- BEGIN required_text_top -->
@@ -8,9 +8,7 @@
 		<!-- END required_text_top -->
 	</div>
 	<!-- BEGIN error -->
-	<div class="c-form__error-msg alert alert-danger" role="alert">
-		{ERROR}
-	</div>
+	<div class="c-form__error-msg alert alert-danger" id="{ERROR_ID}"><span class="sr-only">{ERROR_LABEL}: </span>{ERROR}</div>
 	<!-- END error -->
 	{INPUTS}
 	<div class="c-form__footer">

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/NoSubmitFormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/NoSubmitFormTest.php
@@ -163,8 +163,8 @@ class NoSubmitFormTest extends \ILIAS_UI_TestBase
         $data = $form->getData();
 
         $expected_html =
-            "<form id=\"id_1\" role=\"form\" class=\"c-form c-form--horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\" novalidate=\"novalidate\">" .
-            "<div class=\"c-form__error-msg alert alert-danger\" role=\"alert\">$error_lang_var</div>" .
+            "<form id=\"id_2\" role=\"form\" class=\"c-form c-form--horizontal\" enctype=\"multipart/form-data\" describedby=\"id_1\" action=\"$post_url\" method=\"post\" novalidate=\"novalidate\">" .
+            "<div id=\"id_1\" class=\"c-form__error-msg alert alert-danger\">$error_lang_var</div>" .
             $dummy_input->getCanonicalName() .
             "</form>";
 

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/StandardFormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/StandardFormTest.php
@@ -256,26 +256,31 @@ class StandardFormTest extends ILIAS_UI_TestBase
 
         $html = $this->brutallyTrimHTML($r->render($form));
         $expected = $this->brutallyTrimHTML('
-            <form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" method="post" novalidate="novalidate">
-            <div class="c-form__header">
-                <div class="c-form__actions">
-                    <button class="btn btn-default" data-action="">save</button>
-                </div>
-            </div>
-            <div class="c-form__error-msg alert alert-danger" role="alert">testing error message</div>
-            <fieldset class="c-input" data-il-ui-component="text-field-input" data-il-ui-input-name="form_0/input_1"><label
-                    for="id_1">label</label>
-                <div class="c-input__field"><input id="id_1" type="text" name="form_0/input_1" class="c-field-text" /></div>
-                <div class="c-input__error-msg alert alert-danger" aria-describedby="id_1" role="alert">This is invalid...</div>
-                <div class="c-input__help-byline">byline</div>
-            </fieldset>
-            <div class="c-form__footer">
-                <div class="c-form__actions">
-                    <button class="btn btn-default" data-action="">save</button>
-                </div>
-            </div>
-        </form>
-        ');
+<form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" describedby="id_1" method="post"
+      novalidate="novalidate">
+    <div class="c-form__header">
+        <div class="c-form__actions">
+            <button class="btn btn-default" data-action="">save</button>
+        </div>
+    </div>
+    <div class="c-form__error-msg alert alert-danger" id="id_1"><span class="sr-only">ui_error:</span>testing error
+        message
+    </div>
+    <fieldset class="c-input" data-il-ui-component="text-field-input" data-il-ui-input-name="form_0/input_1"
+              aria-describedby="id_3"><label for="id_2">label</label>
+        <div class="c-input__field"><input id="id_2" type="text" name="form_0/input_1" class="c-field-text" /></div>
+        <div class="c-input__error-msg alert alert-danger" id="id_3"><span class="sr-only">ui_error:</span>This is
+            invalid...
+        </div>
+        <div class="c-input__help-byline">byline</div>
+    </fieldset>
+    <div class="c-form__footer">
+        <div class="c-form__actions">
+            <button class="btn btn-default" data-action="">save</button>
+        </div>
+    </div>
+</form>
+');
         $this->assertEquals($expected, $html);
         $this->assertHTMLEquals($expected, $html);
     }
@@ -319,19 +324,19 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $field_html = $this->getFormWrappedHtml(
             'text-field-input',
             'label',
-            '<input id="id_1" type="text" name="form_0/input_1" class="c-field-text" />',
+            '<input id="id_2" type="text" name="form_0/input_1" class="c-field-text"/>',
             'byline',
-            'id_1',
+            'id_2',
             'form_0/input_1'
         );
 
         $html = $this->brutallyTrimHTML($r->render($form));
         $expected = $this->brutallyTrimHTML('
-            <form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" method="post" novalidate="novalidate">
+            <form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" describedby="id_1" method="post" novalidate="novalidate">
                 <div class="c-form__header">
                     <div class="c-form__actions"><button class="btn btn-default" data-action="">save</button></div>
                 </div>
-                <div class="c-form__error-msg alert alert-danger" role="alert">This is a fail on form.</div>
+                <div class="c-form__error-msg alert alert-danger" id="id_1"><span class="sr-only">ui_error:</span>This is a fail on form.</div>
                 ' . $field_html . '
                 <div class="c-form__footer">
                     <div class="c-form__actions"><button class="btn btn-default" data-action="">save</button></div>

--- a/components/ILIAS/UI/tests/Component/Input/Field/CommonFieldRendering.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/CommonFieldRendering.php
@@ -51,7 +51,7 @@ trait CommonFieldRendering
     {
         $error = "an_error";
         $expected = '<div class="c-input__error-msg alert alert-danger"';
-        $expected2 = '" role="alert">' . $error . '</div>';
+        $expected2 = 'ui_error:</span>' . $error . '</div>';
         $html = $this->render($component->withError($error));
         $this->assertStringContainsString($expected, $html);
         $this->assertStringContainsString($expected2, $html);
@@ -92,7 +92,7 @@ trait CommonFieldRendering
         $html .= $payload_field;
         $html .= '
             </div>';
-        if($byline) {
+        if ($byline) {
             $html .= '
             <div class="c-input__help-byline">' . $byline . '</div>';
         }

--- a/components/ILIAS/UI/tests/Component/Input/Field/MarkdownTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/MarkdownTest.php
@@ -418,45 +418,9 @@ class MarkdownTest extends ILIAS_UI_TestBase
         )->withError($error)->withNameFrom($this->name_source);
 
         $expected = $this->brutallyTrimHTML(
-            "
-            <fieldset class=\"c-input\" data-il-ui-component=\"markdown-field-input\" data-il-ui-input-name=\"name_0\">
-                <label for=\"id_1\">$label</label>
-                <div class=\"c-input__field\">
-
-                        <div class=\"c-field-markdown\">
-                            <div class=\"c-field-markdown__controls\">
-                                view_control_mode
-                                <div class=\"c-field-markdown__actions\">
-                                    <span data-action=\"insert-heading\">
-                                        <button class=\"btn btn-default\" data-action=\"#\" id=\"id_2\">header</button>
-                                    </span>
-                                    <span data-action=\"insert-link\">
-                                        <button class=\"btn btn-default\" data-action=\"#\" id=\"id_3\">link</button>
-                                    </span>
-                                    <span data-action=\"insert-bold\">
-                                        <button class=\"btn btn-default\" data-action=\"#\" id=\"id_4\">bold</button>
-                                    </span>
-                                    <span data-action=\"insert-italic\">
-                                        <button class=\"btn btn-default\" data-action=\"#\" id=\"id_5\">italic</button>
-                                    </span>
-                                    <span data-action=\"insert-bullet-points\">
-                                        <button class=\"btn btn-default\" data-action=\"#\" id=\"id_7\">bulletpoint</button>
-                                    </span>
-                                    <span data-action=\"insert-enumeration\">
-                                        <button class=\"btn btn-default\" data-action=\"#\" id=\"id_6\">numberedlist</button>
-                                    </span>
-                                </div>
-                            </div>
-                                 <textarea id=\"id_1\" class=\"c-field-textarea\" name=\"name_0\"></textarea>
-                        <div class=\"c-field-markdown__preview hidden\">
-                        </div>
-                    </div>
-
-                </div>
-                <div class=\"c-input__error-msg alert alert-danger\" aria-describedby=\"id_1\" role=\"alert\">$error</div>
-                <div class=\"c-input__help-byline\">$byline</div>
-            </fieldset>
-            "
+            html: <<<EOF
+        <fieldset class="c-input" data-il-ui-component="markdown-field-input" data-il-ui-input-name="name_0" aria-describedby="id_8"><label for="id_1">test_label</label><div class="c-input__field"><div class="c-field-markdown"><div class="c-field-markdown__controls"> view_control_mode<div class="c-field-markdown__actions"><span data-action="insert-heading"><button class="btn btn-default" data-action="#" id="id_2">header</button></span><span data-action="insert-link"><button class="btn btn-default" data-action="#" id="id_3">link</button></span><span data-action="insert-bold"><button class="btn btn-default" data-action="#" id="id_4">bold</button></span><span data-action="insert-italic"><button class="btn btn-default" data-action="#" id="id_5">italic</button></span><span data-action="insert-bullet-points"><button class="btn btn-default" data-action="#" id="id_7">bulletpoint</button></span><span data-action="insert-enumeration"><button class="btn btn-default" data-action="#" id="id_6">numberedlist</button></span></div></div><textarea id="id_1" class="c-field-textarea" name="name_0"></textarea><div class="c-field-markdown__preview hidden"></div></div></div><div class="c-input__error-msg alert alert-danger" id="id_8"><span class="sr-only">ui_error:</span>test_error</div><div class="c-input__help-byline">test_byline</div></fieldset>
+        EOF
         );
 
         $html = $this->brutallyTrimHTML($this->getRendererWithStubs()->render($input));

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -6071,7 +6071,7 @@ cont#:#cont_tile_size_3#:#sehr groß (bis zu zwei Kacheln in einer Zeile)
 cont#:#cont_tile_size_4#:#volle Breite (eine Kachel in einer Zeile)
 cont#:#cont_tile_view#:#Kacheln
 cont#:#cont_tile_view_info#:#Untergeordnete Objekte als Kacheln anzeigen. Bilder für diese Kacheln können in den Einstellungen jedes einzelnen Objekts hochgeladen werden.
-cont#:#cont_trash_general_usage#:#Um größere Mengen alter, gelöschter Objekte aus dem System zu entfernen, ist es empfehlenswert zunächst die Nicht-Container (etwa Dateien, Glossare, Tests, ..) und so alle Objekte aus den Container-Objekten (Kategorien, Kurse, Gruppen, Lernsequenzen,..) zu entfernen. Die Filter "Typ" und "Gelöscht am" unterstützen den Vorgang. Abschließend löschen Sie dann die Container. 
+cont#:#cont_trash_general_usage#:#Um größere Mengen alter, gelöschter Objekte aus dem System zu entfernen, ist es empfehlenswert zunächst die Nicht-Container (etwa Dateien, Glossare, Tests, ..) und so alle Objekte aus den Container-Objekten (Kategorien, Kurse, Gruppen, Lernsequenzen,..) zu entfernen. Die Filter "Typ" und "Gelöscht am" unterstützen den Vorgang. Abschließend löschen Sie dann die Container.
 contact#:#contact_awrn_ap_contacts#:#Bestätigte Kontakte
 contact#:#contact_awrn_ap_contacts_info#:#Alle bestätigten Kontakte eines Benutzers werden aufgelistet.
 contact#:#contact_awrn_req_contacts#:#Kontaktanfragen
@@ -17076,6 +17076,7 @@ ui#:#table_posinput_col_title#:#Position
 ui#:#ui_chars_max#:#Maximum:
 ui#:#ui_chars_min#:#Minimum:
 ui#:#ui_chars_remaining#:#Verbleibende Buchstaben
+ui#:#ui_error#:#Fehler
 ui#:#ui_error_in_group#:#Es gibt einen Fehler in diesem Bereich.
 ui#:#ui_error_switchable_group_required#:#Bitte treffen Sie eine Auswahl.
 ui#:#ui_file_input_general_error#:#Es ist ein Fehler aufgetreten. Sie können in der JavaSkript-Konsole Ihres Browser nachschauen, ob es weitere Informationen zu diesem Fehler gibt, und/oder die Administration Ihrer ILIAS-Installation über den Vorfall informieren.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -14630,7 +14630,7 @@ registration#:#reg_direct_info#:#New user registration requests are automaticall
 registration#:#reg_disabled#:#No Registration Possible
 registration#:#reg_domain#:#Domain
 registration#:#reg_domain_already_assigned_p#:#The domains '%s' were already entered for another role.
-registration#:#reg_domain_already_assigned_s#:#The domain '%s' was already entered for another role. 
+registration#:#reg_domain_already_assigned_s#:#The domain '%s' was already entered for another role.
 registration#:#reg_email#:#Automatic Role Assignment
 registration#:#reg_email_domains#:#The following e-mail address domains are valid: %s
 registration#:#reg_email_domains_code#:#With a registration code any E-Mail-Address is valid.
@@ -17053,6 +17053,7 @@ ui#:#table_posinput_col_title#:#Position
 ui#:#ui_chars_max#:#Maximum:
 ui#:#ui_chars_min#:#Minimum:
 ui#:#ui_chars_remaining#:#Characters remaining:
+ui#:#ui_error#:#Error
 ui#:#ui_error_in_group#:#There is some error in this part.
 ui#:#ui_error_switchable_group_required#:#Please select an option.
 ui#:#ui_file_input_general_error#:#An error occurred! You can check the JavaScript console of your browser for more information and/or contact your ILIAS system administration about this incident.


### PR DESCRIPTION
# Issue

The form and input fields don't point to corresponding error messages with aria-describedby but the other way around. This leads to screen reader not reading out the error messages when it is expected by the user.

# Changes

Adjusted the html templates so both field and form error messages are referred to with aria-describedby by the parent.

Added an "Error:" label only visible to screen readers before error text as done in other very accessible ui frameworks.

![image](https://github.com/user-attachments/assets/c492286a-864e-417a-aa90-6993d93b270c)