### PR TITLE
[FIX] Auth: pass arguments as correct data-type.

### DIFF
--- a/Services/Authentication/classes/Provider/class.ilAuthProviderFactory.php
+++ b/Services/Authentication/classes/Provider/class.ilAuthProviderFactory.php
@@ -46,7 +46,7 @@ class ilAuthProviderFactory
 
         $providers = [];
         foreach ($sequence as $position => $authmode) {
-            $provider = $this->getProviderByAuthMode($credentials, $authmode);
+            $provider = $this->getProviderByAuthMode($credentials, (string) $authmode);
             if ($provider instanceof ilAuthProviderInterface) {
                 $providers[] = $provider;
             }

--- a/Services/Authentication/classes/class.ilAuthModeDetermination.php
+++ b/Services/Authentication/classes/class.ilAuthModeDetermination.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
 * @author Stefan Meyer <meyer@leifos.com>
@@ -213,7 +213,7 @@ class ilAuthModeDetermination
 
                     default:
                         foreach (ilAuthUtils::getAuthPlugins() as $pl) {
-                            if ($pl->isAuthActive($auth_mode)) {
+                            if ($pl->isAuthActive((int) $auth_mode)) {
                                 $this->position[] = $auth_mode;
                             }
                         }


### PR DESCRIPTION
Hi @pascalseeland,

I have noticed there are some missing type-casts, which lead to a fatal error on login requests.

Kind regards,
@thibsy 