### PR TITLE
[Bugfix - 42248]Add lang var for creation of ecs categories

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -8981,6 +8981,7 @@ ecs#:#ecs_protocol#:#Protokoll
 ecs#:#ecs_publish_as#:#Veröffentlichen unter:
 ecs#:#ecs_publish_for#:#Freigabe für:
 ecs#:#ecs_published_for#:#Freigegeben für:
+ecs#:#ecs_rcat_created_body_a#:#Eine neue ECS-Kategorie wurde angelegt:
 ecs#:#ecs_rcrs_created_body_a#:#Ein neuer ECS-Kurs wurde angelegt:
 ecs#:#ecs_read_remote_links#:#Kursinformationen aktualisieren
 ecs#:#ecs_refresh_participants#:#ECS-Teilnehmer aktualisieren

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8981,6 +8981,7 @@ ecs#:#ecs_protocol#:#Protocol
 ecs#:#ecs_publish_as#:#Publish as:
 ecs#:#ecs_publish_for#:#Release for:
 ecs#:#ecs_published_for#:#Published for:
+ecs#:#ecs_rcat_created_body_a#:#A new ECS Category has been created:
 ecs#:#ecs_rcrs_created_body_a#:#A new ECS Course has been created:
 ecs#:#ecs_read_remote_links#:#Update ECS Courses
 ecs#:#ecs_refresh_participants#:#Refresh ECS-Participants


### PR DESCRIPTION
the lang var is missing in ILIAS 8 / ILIAS 9 and Trunk(ILIAS 10)

Issue: https://mantis.ilias.de/view.php?id=42248