### PR TITLE
Add NPM dependency linkify-element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dropzone": "^5.9.3",
         "jquery": "^3.6.0",
         "jstree": "^3.3.16",
+        "linkify-element": "^4.1.3",
         "linkifyjs": "^4.1.3",
         "moment": "^2.29.4",
         "tinymce": "^7.3.0"
@@ -4720,6 +4721,14 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/linkify-element": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkify-element/-/linkify-element-4.1.3.tgz",
+      "integrity": "sha512-oUoG7BWaR3Q6kAKdlLi8slsu5rkVRxbiDVVlkpoL7vtidY5THggLzRHIBtmcj+tvMpcAUQomJApDxg0ub0qpdA==",
+      "peerDependencies": {
+        "linkifyjs": "^4.0.0"
+      }
     },
     "node_modules/linkifyjs": {
       "version": "4.1.3",
@@ -9890,6 +9899,12 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "linkify-element": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkify-element/-/linkify-element-4.1.3.tgz",
+      "integrity": "sha512-oUoG7BWaR3Q6kAKdlLi8slsu5rkVRxbiDVVlkpoL7vtidY5THggLzRHIBtmcj+tvMpcAUQomJApDxg0ub0qpdA==",
+      "requires": {}
     },
     "linkifyjs": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dropzone": "^5.9.3",
     "jquery": "^3.6.0",
     "jstree": "^3.3.16",
+    "linkify-element": "^4.1.3",
     "linkifyjs": "^4.1.3",
     "moment": "^2.29.4",
     "tinymce": "^7.3.0",


### PR DESCRIPTION
This PR adds `linkify-element` as a NPM dependency (https://www.npmjs.com/package/linkify-element).

This PR is a follow up to PR #6893 (linkifyjs NPM dependency).

Usages:

- CoPage: Used in paragraphs
- LearningModule: Used for the export
- OnScreenChat: Used to make links in chat messages clickable.
  - See: components/ILIAS/OnScreenChat/js/onscreenchat.js

Wrapped by:

- ./components/ILIAS/Link/js/ilExtLink.js

Reasoning:

As of version 4.0.0 of the linkifyjs project, their features are split into multiple NPM packages instead of being shipped with the linkifyjs NPM package.
The linkifyjs core library itself provides functionality to extract and to parse URL's from strings but not to replace URL's in HTML strings or HTML elements (which is what the dependency is used for). This is now available in separate NPM packages.
The linkify-element package provides the functionality to replace all text links in a DOM element with DOM elements links.

Alternative packages and the reasoning why linkify-element is chosen instead, are:
- linkify-html: This package works on strings and not on DOM elements. With this package we would require to convert all places from node to string and back to node again.
- linkify-jquery: As we are moving away from jQuery, `linkify-element` is chosen over `linkify-jquery`.

Maintenance:

The repository is the same as the `linkifyjs` package. The distinction is only made in NPM.
As it is a part of the `linkifyjs` project it is maintained the same:

- `linkifyjs` is actively maintained, although it is feature-complete. In the last months a few bug fixes and improvements have been committed.

Links:

NPM: https://www.npmjs.com/package/linkify-element
GitHub: https://github.com/Hypercontext/linkifyjs/tree/main/packages/linkify-element
Documentation: https://linkify.js.org/docs/linkify-element.html