### PR TITLE
UIComponent: replace legacy modal in repository picker (41921)

### DIFF
--- a/components/ILIAS/Form/classes/class.ilRepositorySelector2InputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilRepositorySelector2InputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Select repository nodes

--- a/components/ILIAS/Form/classes/class.ilRepositorySelector2InputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilRepositorySelector2InputGUI.php
@@ -99,7 +99,7 @@ class ilRepositorySelector2InputGUI extends ilExplorerSelectInputGUI
     public function getOnloadCode(): array
     {
         return [
-            "il.Explorer2.initSelect('" . $this->getFieldId() . "');"
+            $this->getInitializationOnLoadCode()
         ];
     }
 

--- a/components/ILIAS/JavaScript/resources/Basic.js
+++ b/components/ILIAS/JavaScript/resources/Basic.js
@@ -619,47 +619,7 @@ il.UICore = {
         il.Util.fixPosition(this);
       });
     });
-  },
-
-  showRightPanel() {
-    this.right_panel = il.Modal.dialogue({
-      id: 'il_right_panel',
-      show: true,
-      body: "<div id='ilRightPanel'></div>",
-      buttons: {
-      },
-    });
-  },
-
-  setRightPanelContent(c) {
-    $('div#ilRightPanel').html(c);
-  },
-
-  // load content from wrapper element into right panel
-  loadWrapperToRightPanel(wrapper_id) {
-    this.right_panel_wrapper = wrapper_id;
-    $(`#${wrapper_id}`).children().appendTo('#ilRightPanel');
-  },
-
-  // move the right panel content back to wrapper
-  unloadWrapperFromRightPanel() {
-    if (this.right_panel_wrapper != '') {
-      $('#ilRightPanel').children().appendTo(`#${this.right_panel_wrapper}`);
-    }
-    this.right_panel_wrapper = '';
-  },
-
-  hideRightPanel() {
-    il.UICore.unloadWrapperFromRightPanel();
-
-    if (this.right_panel) {
-      this.right_panel.hide();
-    }
-    return;
-
-    il.Overlay.hide(null, 'ilRightPanel');
-  },
-
+  }
 };
 
 $(document).on('visibilitychange', () => {

--- a/components/ILIAS/UIComponent/resources/Explorer2.js
+++ b/components/ILIAS/UIComponent/resources/Explorer2.js
@@ -147,11 +147,12 @@ il.Explorer2 = {
   //
 
   // init select input
-  initSelect(id) {
+  initSelect(id, renderedModal, showSignal, closeSignal) {
+    this.insertModalIntoDocument(renderedModal);
+
     $(`#${id}_select`).on('click', (ev) => {
-      il.UICore.unloadWrapperFromRightPanel();
-      il.UICore.showRightPanel();
-      il.UICore.loadWrapperToRightPanel(`${id}_expl_wrapper`);
+      $(`#${id}_expl_wrapper`).children().appendTo(`#${id}_expl_marker`);
+      this.triggerSignal($(`#${id}_select`), showSignal, ev);
       return false;
     });
     $(`#${id}_reset`).on('click', (ev) => {
@@ -169,7 +170,7 @@ il.Explorer2 = {
       $(`#${id}_hid`).empty();
       $(`#${id}_cont_txt`).empty();
       $(`#${id}_expl_content input[type="checkbox"]`).each(function () {
-        const n = `${this.name.substr(0, this.name.length - 6)}[]`;
+        const n = this.name;
         const ni = `<input type='hidden' name='${n}' value='${this.value}' />`;
         if (this.checked) {
           t = t + sep + $(this).parent().find('span.ilExp2NodeContent').html();
@@ -178,7 +179,7 @@ il.Explorer2 = {
         }
       });
       $(`#${id}_expl_content input[type="radio"]`).each(function () {
-        const n = this.name.substr(0, this.name.length - 4);
+        const n = this.name;
         const ni = `<input type='hidden' name='${n}' value='${this.value}' />`;
         if (this.checked) {
           t = t + sep + $(this).parent().find('span.ilExp2NodeContent').html();
@@ -187,13 +188,27 @@ il.Explorer2 = {
         }
       });
       $(`#${id}_cont_txt`).html(t);
-      il.UICore.hideRightPanel();
-
+      this.triggerSignal($(`#${id}_expl_content a.ilExplSelectInputButS`), closeSignal, ev);
       return false;
     });
     $(`#${id}_expl_content a.ilExplSelectInputButC`).on('click', (ev) => {
-      il.UICore.hideRightPanel();
+      this.triggerSignal($(`#${id}_expl_content a.ilExplSelectInputButC`), closeSignal, ev);
       return false;
+    });
+  },
+
+  insertModalIntoDocument(renderedModal) {
+    const modal = $.parseHTML(renderedModal)[0];
+    $(modal).find('.modal-header').remove();
+    $(modal).find('.modal-footer').remove();
+    $('body').append(modal);
+  },
+
+  triggerSignal(triggerer, signal, event) {
+    triggerer.trigger(signal, {
+      'id': signal,
+      'event': event,
+      'triggerer': triggerer
     });
   },
 


### PR DESCRIPTION
This PR fixes [41921](https://mantis.ilias.de/view.php?id=41921) by replacing all usages of legacy modals in the repository picker with KS modals, and removes some code from Basic.js of which the repository picker was the only remaining consumer.