### PR TITLE
[FIX - 42249] fixed display issue in detailed results view of cloze questions

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -1435,7 +1435,7 @@ JS;
      */
     private function populateSolutiontextToGapTpl($gaptemplate, $gap, $solutiontext): void
     {
-        if ($this->renderPurposeSupportsFormHtml() || $this->isRenderPurposePrintPdf()) {
+        if ($this->isRenderPurposePrintPdf()) {
             $gaptemplate->setCurrentBlock('gap_span');
             $gaptemplate->setVariable('SPAN_SOLUTION', $solutiontext);
         } elseif ($gap->getType() == CLOZE_SELECT) {


### PR DESCRIPTION
This pull request contains a code change provided by a customer of ours to solve the presentation issue of cloze question fields being too wide in the results view.

This issue has been reported in the following mantis ticket:
https://mantis.ilias.de/view.php?id=42249