### PR TITLE
[FIX] Fixed ReferenceError renderILQuestion is not defined

### DIFF
--- a/Services/COPage/classes/class.ilPCQuestion.php
+++ b/Services/COPage/classes/class.ilPCQuestion.php
@@ -312,12 +312,17 @@ class ilPCQuestion extends ilPageContent
 
         $code = array();
 
+        $q_ids = $this->getPage()->getQuestionIds();
         if ($this->getPage()->getPageConfig()->getEnableSelfAssessment()) {
             if (!$this->getPage()->getPageConfig()->getEnableSelfAssessmentScorm() && $a_mode != ilPageObjectGUI::PREVIEW
                 && $a_mode != "offline" && $a_mode !== "edit") {
                 $ilCtrl->setParameterByClass(strtolower(get_class($this->getPage())) . "gui", "page_id", $this->getPage()->getId());
                 $url = $ilCtrl->getLinkTargetByClass(strtolower(get_class($this->getPage())) . "gui", "processAnswer", "", true, false);
                 $code[] = "ilCOPageQuestionHandler.initCallback('" . $url . "');";
+                // call renderers
+                foreach ($q_ids as $q_id) {
+                    $code[] = "renderILQuestion$q_id();";
+                }
             }
 
             if ($this->getPage()->getPageConfig()->getDisableDefaultQuestionFeedback()) {
@@ -325,13 +330,6 @@ class ilPCQuestion extends ilPageContent
             }
 
             $code[] = self::getJSTextInitCode($this->getPage()->getPageConfig()->getLocalizationLanguage()) . ' il.COPagePres.updateQuestionOverviews();';
-        }
-
-        $q_ids = $this->getPage()->getQuestionIds();
-
-        // call renderers
-        foreach ($q_ids as $q_id) {
-            $code[] = "renderILQuestion$q_id();";
         }
 
         // init answer status


### PR DESCRIPTION
This pull request contains code changes provided by a customer of ours to fix a JS error which is thrown in the detailed results view of cloze questions.

This issue has been reported in the following mantis ticket:
https://mantis.ilias.de/view.php?id=42250 