### PR TITLE
Changes function signature ilDataset::setExportDirectories(string, string) to ilDataset::initByExporter(ilXMLExporter)

### DIFF
--- a/components/ILIAS/Bibliographic/classes/class.ilBibliographicExporter.php
+++ b/components/ILIAS/Bibliographic/classes/class.ilBibliographicExporter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/Bibliographic/classes/class.ilBibliographicExporter.php
+++ b/components/ILIAS/Bibliographic/classes/class.ilBibliographicExporter.php
@@ -60,7 +60,7 @@ class ilBibliographicExporter extends ilXmlExporter
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
         ilFileUtils::makeDirParents($this->getAbsoluteExportDirectory());
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->exportLibraryFile($a_id);
 
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], '', true, true);

--- a/components/ILIAS/Blog/Export/class.ilBlogExporter.php
+++ b/components/ILIAS/Blog/Export/class.ilBlogExporter.php
@@ -104,7 +104,7 @@ class ilBlogExporter extends ilXmlExporter
         string $a_schema_version,
         string $a_id
     ): string {
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 

--- a/components/ILIAS/COPage/classes/class.ilCOPageExporter.php
+++ b/components/ILIAS/COPage/classes/class.ilCOPageExporter.php
@@ -52,7 +52,7 @@ class ilCOPageExporter extends ilXmlExporter
         $component_repository = $DIC["component.repository"];
 
         $this->ds = new ilCOPageDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
         $this->config = $this->getExport()->getConfig("components/ILIAS/COPage");
         if ($this->config->getMasterLanguageOnly()) {

--- a/components/ILIAS/Calendar/classes/class.ilCalendarExporter.php
+++ b/components/ILIAS/Calendar/classes/class.ilCalendarExporter.php
@@ -19,7 +19,7 @@ class ilCalendarExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilCalendarDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 
@@ -28,7 +28,7 @@ class ilCalendarExporter extends ilXmlExporter
      */
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 

--- a/components/ILIAS/Calendar/classes/class.ilCalendarExporter.php
+++ b/components/ILIAS/Calendar/classes/class.ilCalendarExporter.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 /* Copyright (c) 1998-2012 ILIAS open source, Extended GPL, see docs/LICENSE */
 

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiExporter.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiExporter.php
@@ -39,7 +39,7 @@ class ilCmiXapiExporter extends ilXmlExporter
     {
         parent::__construct();
         $this->_dataset = new ilCmiXapiDataSet();
-        $this->_dataset->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->_dataset->initByExporter($this);
         $this->_dataset->setDSPrefix("ds");
 
         /*

--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiExporter.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiExporter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilCmiXapiExporter

--- a/components/ILIAS/ContentPage/classes/class.ilContentPageExporter.php
+++ b/components/ILIAS/ContentPage/classes/class.ilContentPageExporter.php
@@ -38,7 +38,7 @@ class ilContentPageExporter extends ilXmlExporter implements ilContentPageObject
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
         ilFileUtils::makeDirParents($this->getAbsoluteExportDirectory());
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
 
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], '', true, true);
     }

--- a/components/ILIAS/DataCollection/classes/class.ilDataCollectionExporter.php
+++ b/components/ILIAS/DataCollection/classes/class.ilDataCollectionExporter.php
@@ -59,7 +59,7 @@ class ilDataCollectionExporter extends ilXmlExporter
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
         ilFileUtils::makeDirParents($this->getAbsoluteExportDirectory());
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
 
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], '', true, true);
     }

--- a/components/ILIAS/DataSet/classes/class.ilDataSet.php
+++ b/components/ILIAS/DataSet/classes/class.ilDataSet.php
@@ -114,10 +114,10 @@ abstract class ilDataSet
         array $a_ids
     ): void;
 
-    public function setExportDirectories(string $a_relative, string $a_absolute): void
+    public function initByExporter(ilXmlExporter $xml_exporter): void
     {
-        $this->relative_export_dir = $a_relative;
-        $this->absolute_export_dir = $a_absolute;
+        $this->relative_export_dir = $xml_exporter->getRelativeExportDirectory();
+        $this->absolute_export_dir = $xml_exporter->getAbsoluteExportDirectory();
     }
 
     public function setImportDirectory(string $a_val): void

--- a/components/ILIAS/Exercise/classes/class.ilExerciseExporter.php
+++ b/components/ILIAS/Exercise/classes/class.ilExerciseExporter.php
@@ -28,7 +28,7 @@ class ilExerciseExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilExerciseDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 
@@ -41,7 +41,7 @@ class ilExerciseExporter extends ilXmlExporter
      */
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 

--- a/components/ILIAS/Glossary/Export/class.ilGlossaryExporter.php
+++ b/components/ILIAS/Glossary/Export/class.ilGlossaryExporter.php
@@ -31,7 +31,7 @@ class ilGlossaryExporter extends ilXmlExporter
         global $DIC;
 
         $this->ds = new ilGlossaryDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
         $this->metadata = $DIC->glossary()->internal()->domain()->metadata();
     }

--- a/components/ILIAS/HTMLLearningModule/classes/class.ilHTMLLearningModuleExporter.php
+++ b/components/ILIAS/HTMLLearningModule/classes/class.ilHTMLLearningModuleExporter.php
@@ -27,7 +27,7 @@ class ilHTMLLearningModuleExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilHTMLLearningModuleDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 
@@ -57,7 +57,7 @@ class ilHTMLLearningModuleExporter extends ilXmlExporter
 
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 

--- a/components/ILIAS/Help/Export/class.ilHelpExporter.php
+++ b/components/ILIAS/Help/Export/class.ilHelpExporter.php
@@ -28,7 +28,7 @@ class ilHelpExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilHelpDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectExporter.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectExporter.php
@@ -32,7 +32,7 @@ class ilObjectExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilObjectDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 
@@ -47,7 +47,7 @@ class ilObjectExporter extends ilXmlExporter
 
     public function getXmlRepresentation(string $entity, string $schema_version, string $id): string
     {
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($entity, $schema_version, [$id], "", true, true);
     }
 

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectExporter.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectExporter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Exporter class for object related data (please note that title and description

--- a/components/ILIAS/IndividualAssessment/classes/class.ilIndividualAssessmentExporter.php
+++ b/components/ILIAS/IndividualAssessment/classes/class.ilIndividualAssessmentExporter.php
@@ -40,7 +40,7 @@ class ilIndividualAssessmentExporter extends ilXmlExporter
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
         ilFileUtils::makeDirParents($this->getAbsoluteExportDirectory());
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
 
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], '', true, true);
     }

--- a/components/ILIAS/ItemGroup/classes/class.ilItemGroupExporter.php
+++ b/components/ILIAS/ItemGroup/classes/class.ilItemGroupExporter.php
@@ -28,7 +28,7 @@ class ilItemGroupExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilItemGroupDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 

--- a/components/ILIAS/LearningModule/classes/class.ilLearningModuleExporter.php
+++ b/components/ILIAS/LearningModule/classes/class.ilLearningModuleExporter.php
@@ -32,7 +32,7 @@ class ilLearningModuleExporter extends ilXmlExporter
         global $DIC;
 
         $this->ds = new ilLearningModuleDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
         $this->config = $this->getExport()->getConfig("components/ILIAS/LearningModule");
         if ($this->config->getMasterLanguageOnly()) {

--- a/components/ILIAS/MediaCast/classes/class.ilMediaCastExporter.php
+++ b/components/ILIAS/MediaCast/classes/class.ilMediaCastExporter.php
@@ -28,7 +28,7 @@ class ilMediaCastExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilMediaCastDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 

--- a/components/ILIAS/MediaObjects/classes/class.ilMediaObjectsExporter.php
+++ b/components/ILIAS/MediaObjects/classes/class.ilMediaObjectsExporter.php
@@ -55,7 +55,7 @@ class ilMediaObjectsExporter extends ilXmlExporter
         string $a_id
     ): string {
         ilFileUtils::makeDirParents($this->getAbsoluteExportDirectory());
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 

--- a/components/ILIAS/MediaPool/classes/class.ilMediaPoolExporter.php
+++ b/components/ILIAS/MediaPool/classes/class.ilMediaPoolExporter.php
@@ -29,7 +29,7 @@ class ilMediaPoolExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilMediaPoolDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
         $this->config = $this->getExport()->getConfig("components/ILIAS/MediaPool");
         if ($this->config->getMasterLanguageOnly()) {

--- a/components/ILIAS/News/classes/class.ilNewsExporter.php
+++ b/components/ILIAS/News/classes/class.ilNewsExporter.php
@@ -28,7 +28,7 @@ class ilNewsExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilNewsDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 

--- a/components/ILIAS/Notes/Export/class.ilNotesExporter.php
+++ b/components/ILIAS/Notes/Export/class.ilNotesExporter.php
@@ -32,7 +32,7 @@ class ilNotesExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilNotesDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 
@@ -41,7 +41,7 @@ class ilNotesExporter extends ilXmlExporter
         string $a_schema_version,
         string $a_id
     ): string {
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 

--- a/components/ILIAS/Poll/classes/class.ilPollExporter.php
+++ b/components/ILIAS/Poll/classes/class.ilPollExporter.php
@@ -36,7 +36,7 @@ class ilPollExporter extends ilXmlExporter
 
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 

--- a/components/ILIAS/Portfolio/Export/class.ilPortfolioExporter.php
+++ b/components/ILIAS/Portfolio/Export/class.ilPortfolioExporter.php
@@ -74,7 +74,7 @@ class ilPortfolioExporter extends ilXmlExporter
         string $a_schema_version,
         string $a_id
     ): string {
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 

--- a/components/ILIAS/Rating/classes/class.ilRatingExporter.php
+++ b/components/ILIAS/Rating/classes/class.ilRatingExporter.php
@@ -31,7 +31,7 @@ class ilRatingExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilRatingDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 

--- a/components/ILIAS/ScormAicc/classes/class.ilScormAiccExporter.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilScormAiccExporter.php
@@ -32,7 +32,7 @@ class ilScormAiccExporter extends ilXmlExporter
 
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
-        $this->dataset->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->dataset->initByExporter($this);
         //using own getXmlRepresentation function in ilScormAiccDataSet
         return $this->dataset->getExtendedXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", false, true);
     }

--- a/components/ILIAS/ScormAicc/classes/class.ilScormAiccExporter.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilScormAiccExporter.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 class ilScormAiccExporter extends ilXmlExporter
 {

--- a/components/ILIAS/Session/classes/class.ilSessionExporter.php
+++ b/components/ILIAS/Session/classes/class.ilSessionExporter.php
@@ -33,7 +33,7 @@ class ilSessionExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilSessionDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 

--- a/components/ILIAS/Session/classes/class.ilSessionExporter.php
+++ b/components/ILIAS/Session/classes/class.ilSessionExporter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  ********************************************************************
  */
+
+declare(strict_types=1);
 
 /**
  * Exporter class for sessions

--- a/components/ILIAS/Skill/Export/class.ilSkillExporter.php
+++ b/components/ILIAS/Skill/Export/class.ilSkillExporter.php
@@ -33,7 +33,7 @@ class ilSkillExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilSkillDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
         $this->config = $this->getExport()->getConfig("components/ILIAS/Skill");
         $this->ds->setSelectedNodes($this->config->getSelectedNodes());

--- a/components/ILIAS/Skill/Export/class.ilSkillExporter.php
+++ b/components/ILIAS/Skill/Export/class.ilSkillExporter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -19,6 +17,7 @@ declare(strict_types=1);
  ********************************************************************
  */
 
+declare(strict_types=1);
 
 /**
  * Exporter class for skills

--- a/components/ILIAS/Style/classes/class.ilStyleExporter.php
+++ b/components/ILIAS/Style/classes/class.ilStyleExporter.php
@@ -28,14 +28,14 @@ class ilStyleExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilStyleDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
         ilFileUtils::makeDirParents($this->getAbsoluteExportDirectory());
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 

--- a/components/ILIAS/Survey/Export/class.ilSurveyExporter.php
+++ b/components/ILIAS/Survey/Export/class.ilSurveyExporter.php
@@ -34,7 +34,7 @@ class ilSurveyExporter extends ilXmlExporter
 
         $this->domain = $DIC->survey()->internal()->domain();
         $this->ds = new ilSurveyDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 

--- a/components/ILIAS/Taxonomy/classes/class.ilTaxonomyExporter.php
+++ b/components/ILIAS/Taxonomy/classes/class.ilTaxonomyExporter.php
@@ -30,7 +30,7 @@ class ilTaxonomyExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilTaxonomyDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 

--- a/components/ILIAS/User/classes/class.ilUserExporter.php
+++ b/components/ILIAS/User/classes/class.ilUserExporter.php
@@ -30,7 +30,7 @@ class ilUserExporter extends ilXmlExporter
     public function init(): void
     {
         $this->ds = new ilUserDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
     }
 
@@ -73,7 +73,7 @@ class ilUserExporter extends ilXmlExporter
 
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         return $this->ds->getXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", true, true);
     }
 

--- a/components/ILIAS/Wiki/classes/class.ilWikiExporter.php
+++ b/components/ILIAS/Wiki/classes/class.ilWikiExporter.php
@@ -34,7 +34,7 @@ class ilWikiExporter extends ilXmlExporter
 
         $repo = $DIC->wiki()->internal()->repo();
         $this->ds = new ilWikiDataSet();
-        $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
+        $this->ds->initByExporter($this);
         $this->ds->setDSPrefix("ds");
         $this->wiki_log = ilLoggerFactory::getLogger('wiki');
         $this->content_style_domain = $DIC->contentStyle()


### PR DESCRIPTION
This PR makes changes to the method ilDataset::setExportDirectories: it is renamed to ilDataset::initByExporter, and instead of accepting the export directories directly as strings, it now takes an ilXMLExporter (from which the export directories can then be obtained).

The changes by themselves do not affect functionality in any way, they basically just shift around some responsibility from consuming components to Export/Dataset. This is necessary for the forthcoming rework of [Export to use IRSS](https://docu.ilias.de/go/wiki/wpage_7758_1357): the more explicit interface between Export and consumers via Dataset requires a more explicit dependency between the two, facilitated by this signature change.

Since the changes affect ~30 components and are largely trivial, we would like to merge them directly without waiting for approval of every single involved authority.