### PR TITLE
Search: do not show relevance in search results (41910)

### DIFF
--- a/components/ILIAS/Forum/classes/class.ilObjForumSearchResultTableGUI.php
+++ b/components/ILIAS/Forum/classes/class.ilObjForumSearchResultTableGUI.php
@@ -39,7 +39,6 @@ class ilObjForumSearchResultTableGUI extends ilRepositoryObjectSearchResultTable
             $DIC->ctrl()->setParameterByClass(ilObjForumGUI::class, 'thr_pk', $result_set['item_id']);
             $row['link'] = $DIC->ctrl()->getLinkTargetByClass(ilObjForumGUI::class, 'viewThread');
 
-            $row['relevance'] = (float) ($result_set['relevance'] ?? 0.0);
             $row['content'] = (string) ($result_set['content'] ?? '');
 
             $rows[] = $row;
@@ -52,10 +51,6 @@ class ilObjForumSearchResultTableGUI extends ilRepositoryObjectSearchResultTable
     {
         $this->tpl->setVariable('HREF_ITEM', $a_set['link']);
         $this->tpl->setVariable('TXT_ITEM_TITLE', $a_set['title']);
-
-        if ($this->getSettings()->enabledLucene()) {
-            $this->tpl->setVariable('RELEVANCE', $this->getRelevanceHTML($a_set['relevance']));
-        }
 
         if ($a_set['content'] !== '') {
             $this->tpl->setVariable('HIGHLIGHT_CONTENT', $a_set['content']);

--- a/components/ILIAS/Search/classes/class.ilRepositoryObjectSearchGUI.php
+++ b/components/ILIAS/Search/classes/class.ilRepositoryObjectSearchGUI.php
@@ -1,7 +1,22 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory;
@@ -153,10 +168,9 @@ class ilRepositoryObjectSearchGUI
     public function getResultTableInstance(): ?object
     {
         $class = $this->obj_definition->getClassName($this->getObject()->getType());
-        $location = $this->obj_definition->getLocation($this->getObject()->getType());
         $full_class = "ilObj" . $class . "SearchResultTableGUI";
 
-        if (include_once($location . "/class." . $full_class . ".php")) {
+        if (class_exists($full_class)) {
             return new $full_class(
                 $this,
                 'performSearch',

--- a/components/ILIAS/Search/classes/class.ilRepositoryObjectSearchResultTableGUI.php
+++ b/components/ILIAS/Search/classes/class.ilRepositoryObjectSearchResultTableGUI.php
@@ -16,7 +16,6 @@
  *
  *********************************************************************/
 
-
 declare(strict_types=1);
 
 abstract class ilRepositoryObjectSearchResultTableGUI extends ilTable2GUI
@@ -77,13 +76,7 @@ abstract class ilRepositoryObjectSearchResultTableGUI extends ilTable2GUI
 
     protected function initColumns(): void
     {
-        if ($this->getSettings()->enabledLucene()) {
-            $this->lng->loadLanguageModule('search');
-            $this->addColumn($this->lng->txt("title"), "", "80%");
-            $this->addColumn($this->lng->txt("lucene_relevance_short"), "", "20%");
-        } else {
-            $this->addColumn($this->lng->txt("title"), "", "100%");
-        }
+        $this->addColumn($this->lng->txt("title"), "", "100%");
     }
 
     protected function initRowTemplate(): void
@@ -93,19 +86,4 @@ abstract class ilRepositoryObjectSearchResultTableGUI extends ilTable2GUI
 
 
     abstract public function parse();
-
-
-    public function getRelevanceHTML(float $a_rel): string
-    {
-        $tpl = new ilTemplate('tpl.lucene_relevance.html', true, true, 'components/ILIAS/Search');
-
-        $pbar = ilProgressBar::getInstance();
-        $pbar->setCurrent($a_rel);
-
-        $tpl->setCurrentBlock('relevance');
-        $tpl->setVariable('REL_PBAR', $pbar->render());
-        $tpl->parseCurrentBlock();
-
-        return $tpl->get();
-    }
 }

--- a/components/ILIAS/Search/classes/class.ilSearchResultPresentation.php
+++ b/components/ILIAS/Search/classes/class.ilSearchResultPresentation.php
@@ -1,10 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
-use ILIAS\HTTP\GlobalHttpState;
-use ILIAS\Refinery\Factory;
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -20,6 +15,11 @@ use ILIAS\Refinery\Factory;
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\HTTP\GlobalHttpState;
+use ILIAS\Refinery\Factory;
 
 /**
 * Presentation of search results using object list gui
@@ -276,7 +276,7 @@ class ilSearchResultPresentation
         $result_table = new ilSearchResultTableGUI($this->container, "showSavedResults", $this);
         $result_table->setCustomPreviousNext($this->prev, $this->next);
 
-        $result_table->setData($set);
+        $result_table->setDataAndApplySortation($set);
         $this->thtml = $result_table->getHTML();
         return true;
     }

--- a/components/ILIAS/Search/classes/trait.ilSearchResultTableHelper.php
+++ b/components/ILIAS/Search/classes/trait.ilSearchResultTableHelper.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\UI\Component\ViewControl\Sortation as SortationViewControl;
+
+trait ilSearchResultTableHelper
+{
+    protected string $current_sortation;
+
+    /**
+     * Returns key => label
+     */
+    abstract protected function getPossibleSortations(): array;
+
+    abstract protected function getDefaultSortation(): string;
+
+    protected function getCurrentSortation(): string
+    {
+        if (isset($this->current_sortation)) {
+            return $this->current_sortation;
+        }
+
+        $sortation = $this->getDefaultSortation();
+        if ($this->http->wrapper()->query()->has('sortation')) {
+            $sortation = $this->http->wrapper()->query()->retrieve(
+                'sortation',
+                $this->refinery->kindlyTo()->string()
+            );
+        }
+        if (!array_key_exists($sortation, $this->getPossibleSortations())) {
+            $sortation = $this->getDefaultSortation();
+        }
+        return $this->current_sortation = $sortation;
+    }
+
+    protected function buildSortationViewControl(): SortationViewControl
+    {
+        $options = $this->getPossibleSortations();
+        $label = sprintf(
+            $options[$this->getCurrentSortation()] ?? '',
+            $this->lng->txt('search_sort_by')
+        );
+        $options[$this->getCurrentSortation()] ?? '';
+
+        return $this->ui->factory()->viewControl()
+                        ->sortation($options)
+                        ->withLabel($label)
+                        ->withTargetURL(
+                            $this->ctrl->getLinkTarget($this->parent_obj, $this->parent_cmd),
+                            'sortation'
+                        );
+    }
+}

--- a/components/ILIAS/Search/templates/default/tpl.global_search_usr_result_row.html
+++ b/components/ILIAS/Search/templates/default/tpl.global_search_usr_result_row.html
@@ -14,9 +14,6 @@
 		{VAL_CUST}
 	</td>
 	<!-- END custom_fields -->
-	<td class="std">
-		{SEARCH_RELEVANCE}
-	</td>
 	<!-- BEGIN contact_actions -->
 	<td class="std">
 		<div class="pull-right">{CONTACT_ACTIONS}</div>

--- a/components/ILIAS/Search/templates/default/tpl.lucene_relevance.html
+++ b/components/ILIAS/Search/templates/default/tpl.lucene_relevance.html
@@ -1,5 +1,0 @@
-<!-- BEGIN relevance -->
-<div style="width:100px">
-	{REL_PBAR}
-</div>
-<!-- END relevance -->

--- a/components/ILIAS/Search/templates/default/tpl.lucene_sub_relevance.html
+++ b/components/ILIAS/Search/templates/default/tpl.lucene_sub_relevance.html
@@ -1,5 +1,0 @@
-<!-- BEGIN relevance -->
-<div style="width:100px;">
-	{REL_PBAR}
-</div>
-<!-- END relevance -->

--- a/components/ILIAS/Search/templates/default/tpl.repository_object_search_result_row.html
+++ b/components/ILIAS/Search/templates/default/tpl.repository_object_search_result_row.html
@@ -5,9 +5,4 @@
 		<div class="il_SearchFragment ilPreventBreakOut">{HIGHLIGHT_CONTENT}</div>
 		<!-- END highlight -->
 	</td>
-	<!-- BEGIN rel -->
-	<td class="std">
-        {RELEVANCE}
-	</td>
-	<!-- END rel -->
 </tr>

--- a/components/ILIAS/Search/templates/default/tpl.search_result_row.html
+++ b/components/ILIAS/Search/templates/default/tpl.search_result_row.html
@@ -10,11 +10,6 @@
 		{CREATION_DATE}
 	</td>
 	<!-- END creation -->
-	<!-- BEGIN relev -->
-	<td class="std" style="vertical-align: top; padding-top: 18px;">		
-		{REL_PBAR}
-	</td>
-	<!-- END relev -->
 	<td class="std" style="vertical-align: top; padding: 18px;">
 		<div style="float:right">{ACTION_HTML}</div>
 	</td>

--- a/components/ILIAS/Wiki/classes/class.ilObjWikiSearchResultTableGUI.php
+++ b/components/ILIAS/Wiki/classes/class.ilObjWikiSearchResultTableGUI.php
@@ -40,7 +40,6 @@ class ilObjWikiSearchResultTableGUI extends ilRepositoryObjectSearchResultTableG
                 );
                 $row['link'] = $ilCtrl->getLinkTargetByClass('ilwikipagegui', 'preview');
 
-                $row['relevance'] = (float) ($result_set['relevance'] ?? 0);
                 $row['content'] = $result_set['content'] ?? "";
 
                 $rows[] = $row;
@@ -54,10 +53,6 @@ class ilObjWikiSearchResultTableGUI extends ilRepositoryObjectSearchResultTableG
     {
         $this->tpl->setVariable('HREF_ITEM', $a_set['link']);
         $this->tpl->setVariable('TXT_ITEM_TITLE', $a_set['title']);
-
-        if ($this->getSettings()->enabledLucene()) {
-            $this->tpl->setVariable('RELEVANCE', $this->getRelevanceHTML($a_set['relevance']));
-        }
 
         if ($a_set['content'] !== '') {
             $this->tpl->setVariable('HIGHLIGHT_CONTENT', $a_set['content']);

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -15179,7 +15179,6 @@ search#:#lucene_port#:#Port
 search#:#lucene_prefix_wildcard#:#Platzhalter am Wortbeginn
 search#:#lucene_prefix_wildcard_info#:#Erlaubt die Nutzung von Platzhaltern auch am Beginn eines Suchbegriffes: "*LIAS" findet "ILIAS"
 search#:#lucene_relevance#:#Relevanz der Suchergebnisse
-search#:#lucene_relevance_short#:#Relevanz
 search#:#lucene_settings_tab#:#Lucene
 search#:#lucene_settings_title#:#Einstellungen zur Lucene-Suche
 search#:#lucene_show_relevance#:#Relevanz anzeigen
@@ -15251,6 +15250,14 @@ search#:#search_show_inactive_user#:#Inaktive Benutzer anzeigen
 search#:#search_show_inactive_user_info#:#In der Benutzersuche werden auch Benutzer angezeigt, deren Konto nicht aktiv ist.
 search#:#search_show_limited_user#:#Zeitlich begrenzte Benutzer anzeigen
 search#:#search_show_limited_user_info#:#In der Benutzersuche werden auch Benutzer mit zeitlichem begrenztem Zugang angezeigt, die entweder noch nicht oder nicht mehr auf ILIAS zugreifen können.
+search#:#search_sort_by#:#Sortierung: %s
+search#:#search_sort_creation_date_asc#:#Ältestes
+search#:#search_sort_creation_date_desc#:#Neuestes
+search#:#search_sort_generic_asc#:#%s, aufst.
+search#:#search_sort_generic_desc#:#%s, abst.
+search#:#search_sort_relevance#:#Nach Relevanz
+search#:#search_sort_title_asc#:#Alphabetisch: A-Z
+search#:#search_sort_title_desc#:#Alphabetisch: Z-A
 search#:#search_term_combination#:#Kombination
 search#:#search_title_description#:#Titel / Beschreibung
 search#:#search_tst_svy#:#Tests/Umfragen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -15232,7 +15232,7 @@ search#:#search_sort_creation_date_asc#:#Oldest
 search#:#search_sort_creation_date_desc#:#Latest
 search#:#search_sort_generic_asc#:#%s, asc.
 search#:#search_sort_generic_desc#:#%s, desc.
-search#:#search_sort_relevance#:#by Relevance
+search#:#search_sort_relevance#:#By Relevance
 search#:#search_sort_title_asc#:#Alphabetically: A-Z
 search#:#search_sort_title_desc#:#Alphabetically: Z-A
 search#:#search_term_combination#:#Combination

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -15156,7 +15156,6 @@ search#:#lucene_port#:#Port
 search#:#lucene_prefix_wildcard#:#Prefix Wildcard Queries
 search#:#lucene_prefix_wildcard_info#:#Supports prefix wildcard queries: ‘*LIAS’ finds ‘ILIAS’
 search#:#lucene_relevance#:#Relevance of Search Results
-search#:#lucene_relevance_short#:#Relevance
 search#:#lucene_settings_tab#:#Lucene
 search#:#lucene_settings_title#:#Lucene Settings
 search#:#lucene_show_relevance#:#Show Relevance
@@ -15228,6 +15227,14 @@ search#:#search_show_inactive_user#:#Show Inactive Users
 search#:#search_show_inactive_user_info#:#If enabled, the user search will show inactive users, too.
 search#:#search_show_limited_user#:#Show Users with Limited Access
 search#:#search_show_limited_user_info#:#If enabled, the user search will also show users with limited access outside their allowed time period.
+search#:#search_sort_by#:#Sortation: %s
+search#:#search_sort_creation_date_asc#:#Oldest
+search#:#search_sort_creation_date_desc#:#Latest
+search#:#search_sort_generic_asc#:#%s, asc.
+search#:#search_sort_generic_desc#:#%s, desc.
+search#:#search_sort_relevance#:#by Relevance
+search#:#search_sort_title_asc#:#Alphabetically: A-Z
+search#:#search_sort_title_desc#:#Alphabetically: Z-A
 search#:#search_term_combination#:#Combination
 search#:#search_title_description#:#Title / Description
 search#:#search_tst_svy#:#Tests/Surveys


### PR DESCRIPTION
As already accepted by the JF with [41910](https://mantis.ilias.de/view.php?id=41910), this PR removes ilProgressBar from Search by not showing relevance in search results anymore, and introducing a sortation view control such that one can still order the results by relevance:
![object_search_results](https://github.com/user-attachments/assets/66eec7b8-bd05-4b74-b643-cf8922dc6728)

What was not discussed with [41910](https://mantis.ilias.de/view.php?id=41910) is that relevance is not only shown when searching for objects, but also when searching for users and in Wikis and Forums.

The latter are simple enough. When searching in Wikis and Forums, the results are anyways always ordered by relevance, reordering is not possible. This PR then simply removes the column 'Relevance' (in the screenshot in a Forum, analogously for Wikis):
![forum_search_results](https://github.com/user-attachments/assets/60bf5dfd-a6f4-44da-8792-34f08a1d2dec)

In user searches however, the solution accepted for object searches can only be applied somewhat inelegantly. Since in user search results, all user fields (including custom ones) can be displayed, the sortation view control has to accommodate an effectively arbitrary number of fields:
![user_search_results](https://github.com/user-attachments/assets/3177fcea-e41d-4229-afb9-963b3ac60d2b)

We still believe this to be an acceptable solution, since it is self-imposed by users. When a reasonable number of columns is made visible, the view control is also in a manageable state, the issue only presents itself when a lot of columns are selected.
