### PR TITLE
SOAP: Fix extracting NULL when parsing XML

### DIFF
--- a/webservice/soap/classes/class.ilObjectXMLParser.php
+++ b/webservice/soap/classes/class.ilObjectXMLParser.php
@@ -58,7 +58,7 @@ class ilObjectXMLParser extends ilSaxParser
                 $this->addProperty(
                     'obj_id',
                     is_numeric($a_attribs['obj_id']) ? (int) $a_attribs["obj_id"] : ilUtil::__extractId(
-                        $a_attribs["obj_id"],
+                        $a_attribs["obj_id"] ?? '',
                         IL_INST_ID
                     )
                 );


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42056

If approved, this has to be picked to `release_9` and `trunk` as well.