### PR TITLE
Auth/CoPage: Remove `[list-language-selection]` placeholder support f…

### DIFF
--- a/Services/COPage/PC/Login/class.ilPCLoginPageElement.php
+++ b/Services/COPage/PC/Login/class.ilPCLoginPageElement.php
@@ -30,7 +30,6 @@ class ilPCLoginPageElement extends ilPageContent
         'shibboleth-login-form' => 'shib_login_form',
         'openid-connect-login' => 'openid_connect_login',
         'registration-link' => 'registration_link',
-        'language-selection' => 'language_selection',
         'user-agreement' => 'user_agreement_link',
         'dpro-agreement' => 'dpro_agreement_link',
         'saml-login' => 'saml_login'

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -1051,7 +1051,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
     {
         return str_replace(
             [
-                '[list-language-selection] ',
+                '[list-language-selection]',
                 '[list-registration-link]',
                 '[list-user-agreement]',
                 '[list-dpro-agreement]',


### PR DESCRIPTION
…or login page

See: https://mantis.ilias.de/view.php?id=32615

If approved, this has to be picked to `trunk` as well.