### PR TITLE
8/UI/learning-sequence-kiosk footer-position 42025

### DIFF
--- a/Modules/LearningSequence/templates/default/tpl.kioskpage.html
+++ b/Modules/LearningSequence/templates/default/tpl.kioskpage.html
@@ -1,4 +1,4 @@
-<div id="mainspacekeeper" class="col-sm-12">
+<div id="mainspacekeeper" class="container-fluid">
 
 	<div class="ilLSOKioskModeObjectHeader">
 		<div class="media il_HeaderInner">


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42025

# Issue

Odd placement of footer on learning sequence kiosk content pages.

![image](https://github.com/user-attachments/assets/d35ca8f7-d0df-4754-a2c1-5ee306f4278f)

# Changes

Learning Sequence html template now uses mainspacekeeper with container-fluid like most other mainspacekeepers.
 instead of col-sm-12 for padding and width.

![image](https://github.com/user-attachments/assets/5c652a3f-0935-45f9-a1bc-6dd0a2aa8514)