### PR TITLE
Fixes roundtrip modal issue with multiple overlaping forms

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.roundtrip.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.roundtrip.html
@@ -2,7 +2,7 @@
 	<div class="modal-dialog" role="document" data-replace-marker="component">
 		<div class="modal-content">
 			<div class="modal-header">
-				<form><button formmethod="dialog" class="close" aria-label="{CLOSE_LABEL}"><span aria-hidden="true">&times;</span></button></form>
+				<button formmethod="dialog" class="close" aria-label="{CLOSE_LABEL}"><span aria-hidden="true">&times;</span></button>
 				<h1 class="modal-title">{TITLE}</h1>
 			</div>
 			<div class="modal-body">
@@ -14,15 +14,13 @@
 				<!-- END with_form -->
 			</div>
 			<div class="modal-footer">
-				<form>
-					<!-- BEGIN with_buttons -->
-					{BUTTON}
-					<!-- END with_buttons -->
-					<!-- BEGIN with_submit -->
-					{SUBMIT_BUTTON}
-					<!-- END with_submit -->
-					<button formmethod="dialog" class="btn btn-default" data-dismiss="modal">{CANCEL_BUTTON_LABEL}</button>
-				</form>
+				<!-- BEGIN with_buttons -->
+				{BUTTON}
+				<!-- END with_buttons -->
+				<!-- BEGIN with_submit -->
+				{SUBMIT_BUTTON}
+				<!-- END with_submit -->
+				<button formmethod="dialog" class="btn btn-default" data-dismiss="modal">{CANCEL_BUTTON_LABEL}</button>
 			</div>
 		</div>
 	</div>

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
@@ -46,7 +46,7 @@
 					{CELLS}
 				</tr>
 				<!-- END row -->
-				
+
 				<tr>
 					<td class="c-table-data__cell c-table-data__cell--multiaction" colspan="{COLUMN_COUNT}">
 						<div class="l-bar__space-keeper">
@@ -54,8 +54,8 @@
 							<div class="l-bar__element">
 								<div class="c-table-data__multiaction-triggerer">{MULTI_ACTION_TRIGGERER}</div>
 								{MULTI_ACTION_ALL_MODAL}
-								<!-- END multi_action -->
 							</div>
+							<!-- END multi_action -->
 							<div class="l-bar__element">
 							{FORM_BUTTONS}
 							</div>

--- a/components/ILIAS/UI/tests/Component/Dropzone/File/StandardTest.php
+++ b/components/ILIAS/UI/tests/Component/Dropzone/File/StandardTest.php
@@ -45,11 +45,11 @@ class StandardTest extends FileTestBase
     <dialog class="c-modal il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
 		<div class="modal-dialog" role="document" data-replace-marker="component">
 			<div class="modal-content">
-				<div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>
+				<div class="modal-header"><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button><h1 class="modal-title">' . $expected_title . ' </h1></div>
 				<div class="modal-body">
 					<form id="id_2" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">' . $this->input->getCanonicalName() . '</form>
 				</div>
-				<div class="modal-footer"><form><button class="btn btn-default" id="id_3">save</button><button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button></form></div>
+				<div class="modal-footer"><button class="btn btn-default" id="id_3">save</button><button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button></div>
 			</div>
 		</div>
 	</dialog>
@@ -114,11 +114,11 @@ class StandardTest extends FileTestBase
 	<dialog class="c-modal il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
 		<div class="modal-dialog" role="document" data-replace-marker="component">
 			<div class="modal-content">
-				<div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>
+				<div class="modal-header"><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button><h1 class="modal-title">' . $expected_title . ' </h1></div>
 				<div class="modal-body">
 					<form id="id_2" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">' . $this->input->getCanonicalName() . '</form>
 				</div>
-				<div class="modal-footer"><form><button class="btn btn-default" id="id_3">save</button><button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button></form></div>
+				<div class="modal-footer"><button class="btn btn-default" id="id_3">save</button><button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button></div>
 			</div>
 		</div>
 	</dialog>

--- a/components/ILIAS/UI/tests/Component/Dropzone/File/WrapperTest.php
+++ b/components/ILIAS/UI/tests/Component/Dropzone/File/WrapperTest.php
@@ -41,11 +41,11 @@ class WrapperTest extends FileTestBase
     <dialog class="c-modal il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
         <div class="modal-dialog" role="document" data-replace-marker="component">
             <div class="modal-content">
-                <div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>
+                <div class="modal-header"><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button><h1 class="modal-title">' . $expected_title . ' </h1></div>
                 <div class="modal-body">
                     <form id="id_2" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">File Field Input</form>
                 </div>
-                <div class="modal-footer"><form><button class="btn btn-default" id="id_3">save</button><button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button></form></div>
+                <div class="modal-footer"><button class="btn btn-default" id="id_3">save</button><button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button></div>
             </div>
         </div>
     </dialog>

--- a/components/ILIAS/UI/tests/Component/Launcher/LauncherInlineTest.php
+++ b/components/ILIAS/UI/tests/Component/Launcher/LauncherInlineTest.php
@@ -225,7 +225,7 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
             <div class="modal-dialog" role="document" data-replace-marker="component">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form>
+                        <button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button>
                         <h1 class="modal-title">different label</h1>
                     </div>
                     <div class="modal-body">$msg_html
@@ -240,10 +240,8 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
                         </form>
                     </div>
                     <div class="modal-footer">
-                        <form>
-                            <button class="btn btn-default" id="id_4">some submit label</button>
-                            <button formmethod="dialog" class="btn btn-default" data-dismiss="modal">some cancel label</button>
-                        </form>
+                        <button class="btn btn-default" id="id_4">some submit label</button>
+                        <button formmethod="dialog" class="btn btn-default" data-dismiss="modal">some cancel label</button>
                     </div>
                 </div>
             </div>

--- a/components/ILIAS/UI/tests/Component/MainControls/FooterTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/FooterTest.php
@@ -276,18 +276,14 @@ EOT;
                     <div class="modal-dialog" role="document" data-replace-marker="component">
                         <div class="modal-content">
                             <div class="modal-header">
-                                <form>
-                                    <button formmethod="dialog" class="close" aria-label="close">
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
-                                </form>
+                                <button formmethod="dialog" class="close" aria-label="close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
                                 <h1 class="modal-title">Modal1</h1>
                             </div>
                             <div class="modal-body">PhpUnit</div>
                             <div class="modal-footer">
-                                <form>
-                                    <button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button>
-                                </form>
+                                <button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button>
                             </div>
                         </div>
                     </div>
@@ -296,18 +292,14 @@ EOT;
                     <div class="modal-dialog" role="document" data-replace-marker="component">
                         <div class="modal-content">
                             <div class="modal-header">
-                                <form>
-                                    <button formmethod="dialog" class="close" aria-label="close">
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
-                                </form>
+                                <button formmethod="dialog" class="close" aria-label="close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
                                 <h1 class="modal-title">Modal2</h1>
                             </div>
                             <div class="modal-body">PhpUnit</div>
                             <div class="modal-footer">
-                                <form>
-                                    <button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button>
-                                </form>
+                                <button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button>
                             </div>
                         </div>
                     </div>

--- a/components/ILIAS/UI/tests/Component/Modal/RoundTripTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/RoundTripTest.php
@@ -86,16 +86,14 @@ class RoundTripTest extends ModalBase
    <div class="modal-dialog" role="document" data-replace-marker="component">
       <div class="modal-content">
          <div class="modal-header">
-            <form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form>
+            <button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button>
             <h1 class="modal-title">Title</h1>
          </div>
          <div class="modal-body">Content</div>
          <div class="modal-footer">
-            <form>
-                <button class="btn btn-default btn-primary" data-action="">Action 1</button>
-                <button class="btn btn-default" data-action="">Action 2</button>
-                <button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button>
-            </form>
+            <button class="btn btn-default btn-primary" data-action="">Action 1</button>
+            <button class="btn btn-default" data-action="">Action 2</button>
+            <button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button>
          </div>
       </div>
    </div>


### PR DESCRIPTION
This PR regards the following Mantis Ticket: https://mantis.ilias.de/view.php?id=42306

In my opinion this is a viable fix for issue. The issue was a few redundant HTML forms, that caused HTML restructuring when loaded by the browser, trying to clean up the HTML.