### PR TITLE
UI/OrderingTable: 42306, move modal (with form) out of table-surrounding form

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
@@ -53,7 +53,6 @@
 							<!-- BEGIN multi_action -->
 							<div class="l-bar__element">
 								<div class="c-table-data__multiaction-triggerer">{MULTI_ACTION_TRIGGERER}</div>
-								{MULTI_ACTION_ALL_MODAL}
 								<!-- END multi_action -->
 							</div>
 							<div class="l-bar__element">
@@ -68,6 +67,7 @@
 		</table>
 	</form>
 
+	{MULTI_ACTION_ALL_MODAL}
 
 	<div class="c-table-data__async_modal_container"></div>
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42306