### PR TITLE
Export: renames ilObjectExporter to ilILIASObjectExporter to adjust to changes made by the component revision

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilILIASObjectExporter.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilILIASObjectExporter.php
@@ -25,7 +25,7 @@ declare(strict_types=1);
  *
  * @author Alex Killing <killing@leifos.de>
  */
-class ilObjectExporter extends ilXmlExporter
+class ilILIASObjectExporter extends ilXmlExporter
 {
     private ilObjectDataSet $ds;
 


### PR DESCRIPTION
Since the Object component was renamed to ILIASObject in the component revision the export currently fails because it can not find an `ilILIASObjectExporter`.

This PR simply renames the class.