### PR TITLE
[FIX] add scripts/PHPUnit/.phpunit.cache/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ virtual-data
 # cli
 captainhook.config.json
 captainhook.local.json
-.phpunit.result.cache
+scripts/PHPUnit/.phpunit.cache/
 .php-cs-fixer.cache
 phpstan.local.neon
 phpstan-baseline.neon


### PR DESCRIPTION
Hi folks,

I noticed when running PHP unit tests with `sh scripts/PHPUnit/run_tests.sh`, it creates the `.phpunit.cache` folder in a new location (`scripts/PHPUnit/` instead of root).

This PR changes the location accordingly in the `.gitignore` file.

Kind regards,
@thibsy 