### PR TITLE
OrgUnit: export options

### DIFF
--- a/components/ILIAS/OrgUnit/classes/class.ilOrgUnitExportGUI.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilOrgUnitExportGUI.php
@@ -46,11 +46,19 @@ class ilOrgUnitExportGUI extends ilExportGUI
         $this->ui_factory = $DIC['ui.factory'];
 
         $this->ilObjOrgUnit = $a_parent_gui->getObject();
+    }
 
-        if ($this->ilObjOrgUnit->getRefId() === ilObjOrgUnit::getRootOrgRefId()) {
-            //Simple XML and Simple XLS Export should only be available in the root orgunit folder as it always exports the whole tree
-            $this->extendExportGUI();
+    public function executeCommand(): void
+    {
+        $cmd = $this->ctrl->getCmd();
+        if (
+            $cmd === "simpleExport" ||
+            $cmd === "simpleExportExcel"
+        ) {
+            $this->$cmd();
+            return;
         }
+        parent::executeCommand();
     }
 
     public function listExportFiles(): void
@@ -58,22 +66,6 @@ class ilOrgUnitExportGUI extends ilExportGUI
         if ($this->ilObjOrgUnit->getRefId() != ilObjOrgUnit::getRootOrgRefId()) {
             parent::listExportFiles();
         }
-    }
-
-    private function extendExportGUI(): void
-    {
-        $this->toolbar->addComponent(
-            $this->ui_factory->link()->standard(
-                $this->lng->txt('simple_xml'),
-                $this->ctrl->getLinkTarget($this, "simpleExport")
-            )
-        );
-        $this->toolbar->addComponent(
-            $this->ui_factory->link()->standard(
-                $this->lng->txt('simple_xls'),
-                $this->ctrl->getLinkTarget($this, "simpleExportExcel")
-            )
-        );
     }
 
     public function simpleExport(): void

--- a/components/ILIAS/OrgUnit/classes/class.ilOrgUnitExportOptionXLS.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilOrgUnitExportOptionXLS.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Data\ObjectId;
+use ILIAS\Data\ReferenceId;
+use ILIAS\Export\ExportHandler\Consumer\ExportOption\BasicHandler as ilBasicExportOption;
+use ILIAS\Export\ExportHandler\I\Consumer\Context\HandlerInterface as ilExportHandlerConsumerContextInterface;
+use ILIAS\DI\Container;
+use ILIAS\Export\ExportHandler\I\Info\File\CollectionInterface as ilExportHandlerFileInfoCollectionInterface;
+use ILIAS\Export\ExportHandler\I\Consumer\File\Identifier\CollectionInterface as ilExportHandlerConsumerFileIdentifierCollectionInterface;
+use ILIAS\Export\ExportHandler\I\Consumer\File\Identifier\HandlerInterface as ilExportHandlerConsumerFileIdentifierInterface;
+
+class ilOrgUnitExportOptionXLS extends ilBasicExportOption
+{
+    protected ilLanguage $lng;
+    protected ilCtrlInterface $ctrl;
+
+    public function init(Container $DIC): void
+    {
+        $this->lng = $DIC->language();
+        $this->ctrl = $DIC->ctrl();
+    }
+
+    public function getExportType(): string
+    {
+        return "simple xls";
+    }
+
+    public function getExportOptionId(): string
+    {
+        return "orgu_exp_option_simple_xls";
+    }
+
+    public function getSupportedRepositoryObjectTypes(): array
+    {
+        return ["orgu"];
+    }
+
+    public function getLabel(): string
+    {
+        return $this->lng->txt('simple_xls');
+    }
+
+    public function isObjectSupported(ObjectId $object_id): bool
+    {
+        //Simple XML and Simple XLS Export should only be available in the root orgunit folder as it always exports the whole tree
+        return $object_id->toInt() === ilObjOrgUnit::getRootOrgId();
+    }
+
+    public function onExportOptionSelected(ilExportHandlerConsumerContextInterface $context): void
+    {
+        $this->ctrl->redirect($context->exportGUIObject(), "simpleExportExcel");
+    }
+
+    public function onDeleteFiles(
+        ilExportHandlerConsumerContextInterface $context,
+        ilExportHandlerConsumerFileIdentifierCollectionInterface $file_identifiers
+    ): void {
+        # Direct download on export creation, no local files
+    }
+
+    public function onDownloadFiles(
+        ilExportHandlerConsumerContextInterface $context,
+        ilExportHandlerConsumerFileIdentifierCollectionInterface $file_identifiers
+    ): void {
+        # Direct download on export creation, no local files
+    }
+
+    public function onDownloadWithLink(
+        ReferenceId $reference_id,
+        ilExportHandlerConsumerFileIdentifierInterface $file_identifier
+    ): void {
+        # Direct download on export creation, no local files
+    }
+
+    public function getFiles(
+        ilExportHandlerConsumerContextInterface $context
+    ): ilExportHandlerFileInfoCollectionInterface {
+        # Direct download on export creation, no local files
+        return $context->fileCollectionBuilder()->collection();
+    }
+
+    public function getFileSelection(
+        ilExportHandlerConsumerContextInterface $context,
+        ilExportHandlerConsumerFileIdentifierCollectionInterface $file_identifiers
+    ): ilExportHandlerFileInfoCollectionInterface {
+        # Direct download on export creation, no local files
+        return $context->fileCollectionBuilder()->collection();
+    }
+}

--- a/components/ILIAS/OrgUnit/classes/class.ilOrgUnitExportOptionXML.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilOrgUnitExportOptionXML.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Data\ObjectId;
+use ILIAS\Data\ReferenceId;
+use ILIAS\Export\ExportHandler\Consumer\ExportOption\BasicHandler as ilBasicExportOption;
+use ILIAS\Export\ExportHandler\I\Consumer\Context\HandlerInterface as ilExportHandlerConsumerContextInterface;
+use ILIAS\DI\Container;
+use ILIAS\Export\ExportHandler\I\Info\File\CollectionInterface as ilExportHandlerFileInfoCollectionInterface;
+use ILIAS\Export\ExportHandler\I\Consumer\File\Identifier\CollectionInterface as ilExportHandlerConsumerFileIdentifierCollectionInterface;
+use ILIAS\Export\ExportHandler\I\Consumer\File\Identifier\HandlerInterface as ilExportHandlerConsumerFileIdentifierInterface;
+
+class ilOrgUnitExportOptionXML extends ilBasicExportOption
+{
+    protected ilLanguage $lng;
+    protected ilCtrlInterface $ctrl;
+
+    public function init(Container $DIC): void
+    {
+        $this->lng = $DIC->language();
+        $this->ctrl = $DIC->ctrl();
+    }
+
+    public function getExportType(): string
+    {
+        return "simple xml";
+    }
+
+    public function getExportOptionId(): string
+    {
+        return "orgu_exp_option_simple_xml";
+    }
+
+    public function getSupportedRepositoryObjectTypes(): array
+    {
+        return ["orgu"];
+    }
+
+    public function isObjectSupported(ObjectId $object_id): bool
+    {
+        //Simple XML and Simple XLS Export should only be available in the root orgunit folder as it always exports the whole tree
+        return $object_id->toInt() === ilObjOrgUnit::getRootOrgId();
+    }
+
+    public function getLabel(): string
+    {
+        return $this->lng->txt('simple_xml');
+    }
+
+    public function onExportOptionSelected(ilExportHandlerConsumerContextInterface $context): void
+    {
+        $this->ctrl->redirect($context->exportGUIObject(), "simpleExport");
+    }
+
+    public function onDeleteFiles(
+        ilExportHandlerConsumerContextInterface $context,
+        ilExportHandlerConsumerFileIdentifierCollectionInterface $file_identifiers
+    ): void {
+        # Direct download on export creation, no local files
+    }
+
+    public function onDownloadFiles(
+        ilExportHandlerConsumerContextInterface $context,
+        ilExportHandlerConsumerFileIdentifierCollectionInterface $file_identifiers
+    ): void {
+        # Direct download on export creation, no local files
+    }
+
+    public function onDownloadWithLink(
+        ReferenceId $reference_id,
+        ilExportHandlerConsumerFileIdentifierInterface $file_identifier
+    ): void {
+        # Direct download on export creation, no local files
+    }
+
+    public function getFiles(
+        ilExportHandlerConsumerContextInterface $context
+    ): ilExportHandlerFileInfoCollectionInterface {
+        # Direct download on export creation, no local files
+        return $context->fileCollectionBuilder()->collection();
+    }
+
+    public function getFileSelection(
+        ilExportHandlerConsumerContextInterface $context,
+        ilExportHandlerConsumerFileIdentifierCollectionInterface $file_identifiers
+    ): ilExportHandlerFileInfoCollectionInterface {
+        # Direct download on export creation, no local files
+        return $context->fileCollectionBuilder()->collection();
+    }
+}


### PR DESCRIPTION
This PR reimplements the non standard export options of OrgUnit to conform with the new export infrastructure. This also includes changes to the `ilOrgUnitExportGUI`. For details see [the documentation](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/Export/README-CustomExportOptions.md).

The export options are  "Simple XML" and "Simple XLS". The implementation of the options is fairly trivial because no files are stored on the server. They are only offered as a direct download.