### PR TITLE
Forum: export option

### DIFF
--- a/components/ILIAS/Forum/classes/class.ilForumExportOptionHTML.php
+++ b/components/ILIAS/Forum/classes/class.ilForumExportOptionHTML.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Export\ExportHandler\Consumer\ExportOption\BasicHandler as ilBasicExportOption;
+use ILIAS\Export\ExportHandler\I\Consumer\Context\HandlerInterface as ilExportHandlerConsumerContextInterface;
+use ILIAS\DI\Container;
+use ILIAS\Data\ObjectId;
+
+class ilForumExportOptionHTML extends ilBasicExportOption
+{
+    protected ilLanguage $lng;
+    protected ilCtrlInterface $ctrl;
+
+    public function init(Container $DIC): void
+    {
+        $this->lng = $DIC->language();
+        $this->ctrl = $DIC->ctrl();
+    }
+
+    public function getExportType(): string
+    {
+        return 'html';
+    }
+
+    public function getExportOptionId(): string
+    {
+        return 'frm_exp_option_html';
+    }
+
+    public function getSupportedRepositoryObjectTypes(): array
+    {
+        return ['frm'];
+    }
+
+    public function getLabel(): string
+    {
+        $this->lng->loadLanguageModule('exp');
+        return $this->lng->txt('exp_html');
+    }
+
+    public function onExportOptionSelected(ilExportHandlerConsumerContextInterface $context): void
+    {
+        $fex_gui = new ilForumExportGUI();
+        $fex_gui->exportHTML();
+        $this->ctrl->redirectByClass(ilObjForumGUI::class, 'export');
+    }
+
+    public function onDeleteFiles(
+        ilExportHandlerConsumerContextInterface $context,
+        \ILIAS\Export\ExportHandler\I\Consumer\File\Identifier\CollectionInterface $file_identifiers
+    ): void {
+        # Direct download on export creation, no local files
+    }
+
+    public function onDownloadFiles(
+        ilExportHandlerConsumerContextInterface $context,
+        \ILIAS\Export\ExportHandler\I\Consumer\File\Identifier\CollectionInterface $file_identifiers
+    ): void {
+        # Direct download on export creation, no local files
+    }
+
+    public function onDownloadWithLink(
+        \ILIAS\Data\ReferenceId $reference_id,
+        \ILIAS\Export\ExportHandler\I\Consumer\File\Identifier\HandlerInterface $file_identifier
+    ): void {
+        # Direct download on export creation, no local files
+    }
+
+    public function getFiles(
+        ilExportHandlerConsumerContextInterface $context
+    ): \ILIAS\Export\ExportHandler\I\Info\File\CollectionInterface {
+        # Direct download on export creation, no local files
+        return $context->fileCollectionBuilder()->collection();
+    }
+
+    public function getFileSelection(
+        ilExportHandlerConsumerContextInterface $context,
+        \ILIAS\Export\ExportHandler\I\Consumer\File\Identifier\CollectionInterface $file_identifiers
+    ): \ILIAS\Export\ExportHandler\I\Info\File\CollectionInterface {
+        # Direct download on export creation, no local files
+        return $context->fileCollectionBuilder()->collection();
+    }
+}

--- a/components/ILIAS/Forum/classes/class.ilObjForumGUI.php
+++ b/components/ILIAS/Forum/classes/class.ilObjForumGUI.php
@@ -483,17 +483,6 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
             case strtolower(ilExportGUI::class):
                 $this->tabs_gui->activateTab('export');
                 $exp = new ilExportGUI($this);
-                $exp->addFormat('html');
-                $exp->addFormat('xml');
-                if ($cmd === 'createExportFile') {
-                    if ($this->http->wrapper()->post()->has('format')) {
-                        $format = $this->http->wrapper()->post()->retrieve('format', $this->refinery->kindlyTo()->string());
-                        if ($format === 'html') {
-                            $fex_gui = new ilForumExportGUI();
-                            $fex_gui->exportHTML();
-                        }
-                    }
-                }
                 $this->ctrl->forwardCommand($exp);
                 break;
 
@@ -805,14 +794,14 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
         }
 
         $found_threads = false;
-        if(count($top_group) > 0) {
+        if (count($top_group) > 0) {
             $top_threads = $this->factory->item()->group($this->lng->txt('top_thema'), $top_group);
             $found_threads = true;
         } else {
             $top_threads = $this->factory->item()->group('', $top_group);
         }
 
-        if(count($thread_group) > 0) {
+        if (count($thread_group) > 0) {
             $normal_threads = $this->factory->item()->group($this->lng->txt('thema'), $thread_group);
             $found_threads = true;
         } else {


### PR DESCRIPTION
This PR reimplements the non standard export option of Forum to conform with the new export infrastructure. This also includes changes to the `ilObjForumGUI`. For details see [the documentation](https://github.com/ILIAS-eLearning/ILIAS/blob/trunk/components/ILIAS/Export/README-CustomExportOptions.md).

The export option is "HTML". The implementation of the option is fairly trivial because no files are stored on the server. They are only offered as a direct download.
