### PR TITLE
Init/PasswordAssistance: Fix `auth_mode` equals `12_[id]` (Saml)

### DIFF
--- a/Services/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/Services/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -281,7 +281,8 @@ class ilPasswordAssistanceGUI implements ilCtrlSecurityInterface
                     $user->getAuthMode(true) != ilAuthUtils::AUTH_LOCAL ||
                     ($user->getAuthMode(true) == $defaultAuth && $defaultAuth != ilAuthUtils::AUTH_LOCAL)
                 ) && !(
-                    $user->getAuthMode(true) == ilAuthUtils::AUTH_SAML
+                    (int) $user->getAuthMode(true) === ilAuthUtils::AUTH_SAML &&
+                    \ilAuthUtils::isLocalPasswordEnabledForAuthMode($user->getAuthMode(true))
                 )
             ) {
                 \ilLoggerFactory::getLogger('usr')->info(sprintf(


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42327

If approved, this has to be picked to `relase_9` and `trunk`.