### PR TITLE
UI 42336: Fixes being unable to sort table records by columns that are not show…

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
@@ -125,8 +125,8 @@ class Data extends AbstractTable implements T\Data
         $view_controls = $this->getViewControls($total_count);
 
         if ($request = $this->getRequest()) {
-            $view_controls = $this->applyValuesToViewcontrols($view_controls, $request);
-            $data = $view_controls->getData();
+            # This retrieves container data from the request
+            $data = $this->applyValuesToViewcontrols($view_controls, $request)->getData();
             $range = $data[self::VIEWCONTROL_KEY_PAGINATION];
             $range = ($range instanceof Range) ? $range->croppedTo($total_count ?? PHP_INT_MAX) : null;
             $order = $data[self::VIEWCONTROL_KEY_ORDERING];
@@ -136,6 +136,8 @@ class Data extends AbstractTable implements T\Data
                 ->withRange($range)
                 ->withOrder($order)
                 ->withSelectedOptionalColumns($data[self::VIEWCONTROL_KEY_FIELDSELECTION] ?? null);
+            # This retrieves the view controls that should be displayed
+            $view_controls = $table->applyValuesToViewcontrols($table->getViewControls($total_count), $request);
         }
 
         return [


### PR DESCRIPTION
When trying to sort the entries of a table using the viewcontrols you get only shown the columns that are visible by default. Even when enabling optional columns you are unable to sort by them because the according entries in the dropdown menu are missing. This applies to the new KS tables.

I believe this could be a possible fix.

[Mantis](https://mantis.ilias.de/view.php?id=42336)