### PR TITLE
File: fix creation of metadata (42065)

### DIFF
--- a/components/ILIAS/File/classes/trait.ilObjFileMetadata.php
+++ b/components/ILIAS/File/classes/trait.ilObjFileMetadata.php
@@ -96,11 +96,14 @@ trait ilObjFileMetadata
         global $DIC;
 
         // add file size and format to LOM
-        $DIC->learningObjectMetadata()->manipulate($this->getId(), 0, $this->getType())
-                                      ->prepareCreateOrUpdate($this->getPathToSize(), (string) $this->getFileSize())
-//                                      ->prepareCreateOrUpdate($this->getPathToFirstFormat(), $this->getFileType()) // TIDI thwors exception
-                                      ->prepareCreateOrUpdate($this->getPathToVersion(), (string) $this->getVersion())
-                                      ->execute();
+        $manipulator = $DIC->learningObjectMetadata()
+                           ->manipulate($this->getId(), 0, $this->getType())
+                           ->prepareCreateOrUpdate($this->getPathToSize(), (string) $this->getFileSize())
+                           ->prepareCreateOrUpdate($this->getPathToVersion(), (string) $this->getVersion());
+        if ($this->getFileType() !== '') {
+            $manipulator = $manipulator->prepareCreateOrUpdate($this->getPathToFirstFormat(), $this->getFileType());
+        }
+        $manipulator->execute();
     }
 
     protected function beforeMDUpdateListener(string $a_element): bool


### PR DESCRIPTION
Hi @chfsx,

this PR is a possible fix for [42065](https://mantis.ilias.de/view.php?id=42065). The underlying issue is that the file type that `ilObjFileMetadata` tries to write into the LOM is an empty string, which the LOM API does not accept.

At the end of the creation process, files do have a non-empty file type in their LOM, so somewhere along the line an `updateObject` or something similar is probably called, and at that point the file type is accessible to `ilObjFileMetadata`. Looks like something is getting initiated later than expected?

Long story short: depending on whether it is expected for Files to have an empty file type on creation, this PR is more workaround than proper fix. The alternative would be to dig through the Gordian knot that is the object creation process.

Cheers, @schmitz-ilias 