### PR TITLE
Soap: Add Options to improve server to server requests

### DIFF
--- a/components/ILIAS/WebServices/classes/Setup/class.ilWebServicesConfigStoredObjective.php
+++ b/components/ILIAS/WebServices/classes/Setup/class.ilWebServicesConfigStoredObjective.php
@@ -11,9 +11,9 @@ use ILIAS\Setup;
  */
 class ilWebServicesConfigStoredObjective implements Setup\Objective
 {
-    protected Setup\Config $config;
+    protected ilWebServicesSetupConfig $config;
 
-    public function __construct(Setup\Config $config)
+    public function __construct(ilWebServicesSetupConfig $config)
     {
         $this->config = $config;
     }
@@ -54,6 +54,11 @@ class ilWebServicesConfigStoredObjective implements Setup\Objective
         $settings->set("soap_response_timeout", (string) $this->config->getSoapResponseTimeout());
         $settings->set("rpc_server_host", $this->config->getRPCServerHost());
         $settings->set("rpc_server_port", (string) $this->config->getRPCServerPort());
+
+        $settings->set('soap_internal_wsdl_path', (string) $this->config->getSoapInternalWsdlPath());
+        $settings->set('soap_internal_wsdl_verify_peer', (string) $this->config->getSoapInternalWsdlVerifyPeer());
+        $settings->set('soap_internal_wsdl_verify_peer_name', (string) $this->config->getSoapInternalWsdlVerifyPeerName());
+        $settings->set('soap_internal_wsdl_allow_self_signed', (string) $this->config->getSoapInternalWsdlAllowSelfSigned());
 
         return $environment;
     }

--- a/components/ILIAS/WebServices/classes/Setup/class.ilWebServicesSetupAgent.php
+++ b/components/ILIAS/WebServices/classes/Setup/class.ilWebServicesSetupAgent.php
@@ -62,6 +62,10 @@ class ilWebServicesSetupAgent implements Setup\Agent
                 (int) ($data["soap_response_timeout"] ?? ilSoapClient::DEFAULT_RESPONSE_TIMEOUT),
                 $data["rpc_server_host"] ?? "",
                 (int) ($data["rpc_server_port"] ?? 0),
+                (string) ($data['soap_internal_wsdl_path'] ?? ''),
+                (bool) ($data['soap_internal_wsdl_verify_peer'] ?? true),
+                (bool) ($data['soap_internal_wsdl_verify_peer_name'] ?? true),
+                (bool) ($data['soap_internal_wsdl_allow_self_signed'] ?? false),
             );
         });
     }

--- a/components/ILIAS/WebServices/classes/Setup/class.ilWebServicesSetupConfig.php
+++ b/components/ILIAS/WebServices/classes/Setup/class.ilWebServicesSetupConfig.php
@@ -14,6 +14,11 @@ class ilWebServicesSetupConfig implements Setup\Config
     protected string $rpc_server_host;
     protected int $rpc_server_port;
 
+    protected string $soap_internal_wsdl_path;
+    protected bool $soap_internal_wsdl_verify_peer;
+    protected bool $soap_internal_wsdl_verify_peer_name;
+    protected bool $soap_internal_wsdl_allow_self_signed;
+
     /**
      * @var int
      */
@@ -25,7 +30,11 @@ class ilWebServicesSetupConfig implements Setup\Config
         int $soap_connect_timeout,
         int $soap_response_timeout,
         string $rpc_server_host,
-        int $rpc_server_port
+        int $rpc_server_port,
+        string $soap_internal_wsdl_path,
+        bool $soap_internal_wsdl_verify_peer,
+        bool $soap_internal_wsdl_verify_peer_name,
+        bool $soap_internal_wsdl_allow_self_signed,
     ) {
         $this->soap_user_administration = $soap_user_administration;
         $this->soap_wsdl_path = $soap_wsdl_path;
@@ -33,6 +42,11 @@ class ilWebServicesSetupConfig implements Setup\Config
         $this->rpc_server_host = $rpc_server_host;
         $this->rpc_server_port = $rpc_server_port;
         $this->soap_response_timeout = $soap_response_timeout;
+
+        $this->soap_internal_wsdl_path = $soap_internal_wsdl_path;
+        $this->soap_internal_wsdl_verify_peer = $soap_internal_wsdl_verify_peer;
+        $this->soap_internal_wsdl_verify_peer_name = $soap_internal_wsdl_verify_peer_name;
+        $this->soap_internal_wsdl_allow_self_signed = $soap_internal_wsdl_allow_self_signed;
     }
 
     public function isSOAPUserAdministration(): bool
@@ -63,5 +77,25 @@ class ilWebServicesSetupConfig implements Setup\Config
     public function getSoapResponseTimeout(): int
     {
         return $this->soap_response_timeout;
+    }
+
+    public function getSoapInternalWsdlPath(): string
+    {
+        return $this->soap_internal_wsdl_path;
+    }
+
+    public function getSoapInternalWsdlVerifyPeer(): bool
+    {
+        return $this->soap_internal_wsdl_verify_peer;
+    }
+
+    public function getSoapInternalWsdlVerifyPeerName(): bool
+    {
+        return $this->soap_internal_wsdl_verify_peer_name;
+    }
+
+    public function getSoapInternalWsdlAllowSelfSigned(): bool
+    {
+        return $this->soap_internal_wsdl_allow_self_signed;
     }
 }

--- a/components/ILIAS/setup_/README.md
+++ b/components/ILIAS/setup_/README.md
@@ -508,7 +508,11 @@ are printed bold**, all other fields might be omitted. A minimal example is
 		"soap_wsdl_path" : "https://test7.ilias.de/public/soap/server.php?wsdl",
 		"soap_connect_timeout" : 30,
 		"rpc_server_host" : "192.168.47.13",
-		"rpc_server_port" : "11112"
+		"rpc_server_port" : "11112",
+		"soap_internal_wsdl_path": "https://localhost/public/soap/server.php?wsdl",
+		"soap_internal_wsdl_verify_peer": false,
+		"soap_internal_wsdl_verify_peer_name": false,
+		"soap_internal_wsdl_allow_self_signed": false
 	},
     ```
   * *soap_user_administration* (type: boolean) enable administration per soap, defaults to `false`
@@ -516,6 +520,10 @@ are printed bold**, all other fields might be omitted. A minimal example is
   * *soap_connect_timeout* (type: number) maximum time in seconds until a connection attempt to the SOAP-Webservice is interrupted, defaults to `10`
   * *rpc_server_host* (type: string) Java-Server host (must be set too, if *rpc_server_port* is set)
   * *rpc_server_port* (type: string or number) Java-Server port (must be set too, if *rpc_server_host* is set)
+  * *soap_internal_wsdl_path* (type: string) path to the ilias wsdl file for internal usage (for calls from ilias to ilias itself), default is *soap_wsdl_path*
+  * *soap_internal_wsdl_verify_peer* (type: bool) verify peer for calls from ilias to ilias itself (see https://www.php.net/manual/en/context.ssl.php for more information)
+  * *soap_internal_wsdl_verify_peer_name* (type: bool) verify peer name for calls from ilias to ilias itself (see https://www.php.net/manual/en/context.ssl.php)
+  * *soap_internal_wsdl_allow_self_signed* (type: bool) allow self signed certificates for calls from ilias to ilias itself (see https://www.php.net/manual/en/context.ssl.php)
 * *chatroom* (type: object) see also [Chat Server Setup](/components/ILIAS/Chatroom/README.md), eg.:
     ```
 	"chatroom" : {

--- a/components/ILIAS/soap/classes/class.ilNusoapUserAdministrationAdapter.php
+++ b/components/ILIAS/soap/classes/class.ilNusoapUserAdministrationAdapter.php
@@ -54,7 +54,8 @@ class ilNusoapUserAdministrationAdapter
         $this->server->class = "ilSoapFunctions";
 
         if ($a_use_wsdl) {
-            $this->enableWSDL();
+            global $DIC;
+            $this->enableWSDL($DIC->settings());
         }
 
         $this->registerMethods();
@@ -67,9 +68,13 @@ class ilNusoapUserAdministrationAdapter
         exit();
     }
 
-    private function enableWSDL(): void
+    private function enableWSDL(ilSetting $setting): void
     {
         $this->server->configureWSDL(SERVICE_NAME, SERVICE_NAMESPACE);
+        $internal_path = $setting->get('soap_internal_wsdl_path', '');
+        if ($internal_path) {
+            $this->server->addInternalPort(SERVICE_NAME, $internal_path);
+        }
     }
 
     private function registerMethods(): void

--- a/components/ILIAS/soap/resources/soap/server.php
+++ b/components/ILIAS/soap/resources/soap/server.php
@@ -61,5 +61,6 @@ if (strcasecmp($_SERVER['REQUEST_METHOD'], 'post') === 0) {
     $soapServer->handle();
 } else {
     // This is a request to display the available SOAP methods or WSDL...
+    ilInitialisation::initILIAS();
     require './components/ILIAS/soap/nusoapserver.php';
 }


### PR DESCRIPTION
This PR adds new options for the soap setup config to improve the performance for calls from ILIAS to the same ILIAS instance via SOAP (e.g. when copying an object).

The new options are:
- soap_internal_wsdl_path
- soap_internal_wsdl_verify_peer
- soap_internal_wsdl_verify_peer_name
- soap_internal_wsdl_allow_self_signed

and are documented in `components/ILIAS/setup_/README.md` accordingly.

Feature Request: https://docu.ilias.de/go/wiki/wpage_8363_1357