### PR TITLE
UI: 42318 Fixes date column output in user timezone

### DIFF
--- a/components/ILIAS/UI/UI.php
+++ b/components/ILIAS/UI/UI.php
@@ -36,6 +36,7 @@ class UI implements Component\Component
         $define[] = UI\Renderer::class;
         $define[] = UI\HelpTextRetriever::class;
         $define[] = UI\Storage::class;
+        $define[] = UI\UserTimezone::class;
         $define[] = UI\Component\Progress\AsyncRefreshInterval::class;
         $define[] = UI\Component\Input\Field\PhpUploadLimit::class;
         $define[] = UI\Component\Input\Field\GlobalUploadLimit::class;
@@ -380,6 +381,7 @@ class UI implements Component\Component
         $internal[UI\Implementation\Component\Table\Column\Factory::class] = static fn() =>
             new UI\Implementation\Component\Table\Column\Factory(
                 $use[\ILIAS\Language\Language::class],
+                $use[UI\UserTimezone::class],
             );
         $internal[UI\Implementation\Component\Table\Action\Factory::class] = static fn() =>
             new UI\Implementation\Component\Table\Action\Factory();

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Date.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Date.php
@@ -29,7 +29,8 @@ class Date extends Column implements C\Date
     public function __construct(
         Language $lng,
         string $title,
-        protected DateFormat $format
+        protected DateFormat $format,
+        protected \DateTimeZone $timezone
     ) {
         parent::__construct($lng, $title);
     }
@@ -39,10 +40,22 @@ class Date extends Column implements C\Date
         return $this->format;
     }
 
+    public function withTimeZone(\DateTimeZone $timezone): C\Date
+    {
+        $clone = clone $this;
+        $clone->timezone = $timezone;
+        return $clone;
+    }
+
+    public function getTimeZone(): \DateTimeZone
+    {
+        return $this->timezone;
+    }
+
     public function format($value): string
     {
         $this->checkArgInstanceOf('value', $value, \DateTimeImmutable::class);
-        return $value->format($this->getFormat()->toString());
+        return $value->setTimezone($this->getTimeZone())->format($this->getFormat()->toString());
     }
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Factory.php
@@ -24,11 +24,13 @@ use ILIAS\UI\Component\Table\Column as I;
 use ILIAS\UI\Component\Symbol\Icon\Icon;
 use ILIAS\UI\Component\Symbol\Glyph\Glyph;
 use ILIAS\Language\Language;
+use ILIAS\UI\UserTimezone;
 
 class Factory implements I\Factory
 {
     public function __construct(
-        protected Language $lng
+        protected Language $lng,
+        protected UserTimezone $user_timezone,
     ) {
     }
 
@@ -45,7 +47,7 @@ class Factory implements I\Factory
 
     public function date(string $title, \ILIAS\Data\DateFormat\DateFormat $format): Date
     {
-        return new Date($this->lng, $title, $format);
+        return new Date($this->lng, $title, $format, $this->user_timezone->getTimezone());
     }
 
     public function status(string $title): Status

--- a/components/ILIAS/UI/src/UserTimezone.php
+++ b/components/ILIAS/UI/src/UserTimezone.php
@@ -16,18 +16,9 @@
  *
  *********************************************************************/
 
-declare(strict_types=1);
+namespace ILIAS\UI;
 
-namespace ILIAS\UI\Component\Table\Column;
-
-use ILIAS\Data\DateFormat\DateFormat;
-
-interface Date extends Column
+interface UserTimezone
 {
-    public function getFormat(): DateFormat;
-
-    /**
-     * You may want to specify a timezone for the date to be formatted in. By default, the user's timezone is used.
-     */
-    public function withTimeZone(\DateTimeZone $timezone): Date;
+    public function getTimezone(): \DateTimeZone;
 }

--- a/components/ILIAS/UI/tests/Component/Table/Column/ColumnFactoryTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/Column/ColumnFactoryTest.php
@@ -48,7 +48,14 @@ class ColumnFactoryTest extends AbstractFactoryTestCase
             ->getMock();
         $lng->method('txt')->willReturnCallback(fn($v) => $v);
 
-        return new \ILIAS\UI\Implementation\Component\Table\Column\Factory($lng);
+        $user_tz = new class implements \ILIAS\UI\UserTimezone {
+            public function getTimezone(): \DateTimeZone
+            {
+                return new \DateTimeZone(date_default_timezone_get());
+            }
+        };
+
+        return new \ILIAS\UI\Implementation\Component\Table\Column\Factory($lng, $user_tz);
     }
 
     public static function getColumnTypeProvider(): array

--- a/components/ILIAS/UI/tests/Component/Table/Column/ColumnTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/Column/ColumnTest.php
@@ -36,6 +36,7 @@ use ILIAS\Language\Language;
 class ColumnTest extends ILIAS_UI_TestBase
 {
     protected Language $lng;
+    protected \DateTimeZone $timezone;
 
     public function setUp(): void
     {
@@ -44,6 +45,8 @@ class ColumnTest extends ILIAS_UI_TestBase
             ->getMock();
         $lng->method('txt')->willReturnCallback(fn($v) => $v);
         $this->lng = $lng;
+
+        $this->timezone = new \DateTimeZone(date_default_timezone_get());
     }
 
     public function testDataTableColumnsAttributes(): void
@@ -104,8 +107,22 @@ class ColumnTest extends ILIAS_UI_TestBase
         $df = new \ILIAS\Data\Factory();
         $format = $df->dateFormat()->germanShort();
         $dat = new \DateTimeImmutable();
-        $col = new Column\Date($this->lng, 'col', $format);
+        $tz = $dat->getTimezone();
+        $col = new Column\Date($this->lng, 'col', $format, $tz);
         $this->assertEquals($dat->format($format->toString()), $col->format($dat));
+    }
+
+    public function testDataTableColumnDateFormatWithTZ(): void
+    {
+        $df = new \ILIAS\Data\Factory();
+        $format = $df->dateFormat()->germanShort();
+        $dat = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        $tz = new \DateTimeZone('Europe/Berlin');
+        $expected = $dat->setTimezone($tz)->format($format->toString());
+
+        $col = new Column\Date($this->lng, 'col', $format, $tz);
+        $this->assertEquals($expected, $col->format($dat));
     }
 
     public function testDataTableColumnTimespanFormat(): void

--- a/components/ILIAS/UI/tests/Component/Table/TableRendererTestBase.php
+++ b/components/ILIAS/UI/tests/Component/Table/TableRendererTestBase.php
@@ -39,7 +39,8 @@ class TableRendererTestBase extends TableTestBase
     protected function getColumnFactory()
     {
         return new I\Table\Column\Factory(
-            $this->getLanguage()
+            $this->getLanguage(),
+            $this->getMockUserTimezone()
         );
     }
 

--- a/components/ILIAS/UI/tests/Component/Table/TableTestBase.php
+++ b/components/ILIAS/UI/tests/Component/Table/TableTestBase.php
@@ -27,6 +27,7 @@ use ILIAS\UI\Implementation\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Implementation\Component\Input\Container\ViewControl as ViewControlContainer;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
+use ILIAS\UI\UserTimezone;
 
 /**
  * Basic Tests for all Tables.
@@ -79,7 +80,7 @@ abstract class TableTestBase extends ILIAS_UI_TestBase
             $this->getViewControlFactory(),
             $this->getViewControlContainerFactory(),
             new \ILIAS\Data\Factory(),
-            new C\Table\Column\Factory($this->getLanguage()),
+            new C\Table\Column\Factory($this->getLanguage(), $this->getMockUserTimezone()),
             new C\Table\Action\Factory(),
             $this->getMockStorage(),
             new C\Table\DataRowBuilder(),
@@ -109,6 +110,16 @@ abstract class TableTestBase extends ILIAS_UI_TestBase
             public function offsetUnset(mixed $offset): void
             {
                 unset($this->data[$offset]);
+            }
+        };
+    }
+
+    protected function getMockUserTimezone(): UserTimezone
+    {
+        return new class () implements UserTimezone {
+            public function getTimezone(): \DateTimeZone
+            {
+                return new \DateTimeZone(date_default_timezone_get());
             }
         };
     }

--- a/components/ILIAS/UI/tests/InitUIFramework.php
+++ b/components/ILIAS/UI/tests/InitUIFramework.php
@@ -193,7 +193,13 @@ class InitUIFramework
         };
         $c["ui.factory.table.column"] = function ($c) {
             return new ILIAS\UI\Implementation\Component\Table\Column\Factory(
-                $c["lng"]
+                $c["lng"],
+                new class () implements \ILIAS\UI\UserTimezone {
+                    public function getTimezone(): \DateTimeZone
+                    {
+                        return new DateTimeZone(date_default_timezone_get());
+                    }
+                }
             );
         };
         $c["ui.factory.table.action"] = function ($c) {

--- a/components/ILIAS/User/User.php
+++ b/components/ILIAS/User/User.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS;
 
+use ILIAS\UI\UserTimezone;
+use ILIAS\User\Settings\User\UserTimezoneProvider;
 use ILIAS\User\Setup\Agent;
 use ILIAS\User\Settings\UserSettings;
 use ILIAS\User\Settings\User\Settings as SettingsOfUser;
@@ -56,5 +58,7 @@ class User implements Component\Component
             new CustomTypeTextArea();
         $contribute[CustomProfileFieldType::class] = fn() =>
             new CustomTypeSelect();
+
+        $implement[UserTimezone::class] = fn() => new UserTimezoneProvider();
     }
 }

--- a/components/ILIAS/User/src/Settings/User/UserTimezoneProvider.php
+++ b/components/ILIAS/User/src/Settings/User/UserTimezoneProvider.php
@@ -18,16 +18,16 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\UI\Component\Table\Column;
+namespace ILIAS\User\Settings\User;
 
-use ILIAS\Data\DateFormat\DateFormat;
+use ILIAS\UI\UserTimezone;
 
-interface Date extends Column
+class UserTimezoneProvider implements UserTimezone
 {
-    public function getFormat(): DateFormat;
+    public function getTimezone(): \DateTimeZone
+    {
+        global $DIC;
 
-    /**
-     * You may want to specify a timezone for the date to be formatted in. By default, the user's timezone is used.
-     */
-    public function withTimeZone(\DateTimeZone $timezone): Date;
+        return new \DateTimeZone($DIC->user()->getTimezone());
+    }
 }


### PR DESCRIPTION
This PR addresses the problem that a date in a DataTable is not displayed in the user's time zone. The problem is solved here by adding a method for defining the time zone to be displayed. If the time zone is not explicitly defined, the date is displayed in the user's time zone.

See: https://mantis.ilias.de/view.php?id=42318