### PR TITLE
UI: 39326 Allow empty cell in data table by providiung a null value

### DIFF
--- a/components/ILIAS/UI/src/Component/Table/Column/Column.php
+++ b/components/ILIAS/UI/src/Component/Table/Column/Column.php
@@ -39,6 +39,11 @@ interface Column extends \ILIAS\UI\Component\Component
         string $desc_label = null
     ): self;
 
+    /**
+     * you may specify a placeholder to be displayed if the value is empty
+     */
+    public function withEmptyPlaceholder(string $empty_placeholder): self;
+
     public function withIsOptional(bool $is_optional, bool $is_initially_visible = true): self;
     public function isOptional(): bool;
     public function isInitiallyVisible(): bool;

--- a/components/ILIAS/UI/src/Component/Table/EmptyCell.php
+++ b/components/ILIAS/UI/src/Component/Table/EmptyCell.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Component\Table;
+
+/**
+ * A EmptyCell represents the content in a table cell when the cell is empty. It is used to display a placeholder
+ * in the cell.
+ */
+interface EmptyCell extends \ILIAS\UI\Component\Component
+{
+    public function getEmptyPlaceholder(): string;
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Boolean.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Boolean.php
@@ -24,7 +24,7 @@ use ILIAS\UI\Component\Table\Column as C;
 use ILIAS\UI\Component\Symbol\Icon\Icon;
 use ILIAS\UI\Component\Symbol\Glyph\Glyph;
 use ILIAS\UI\Component\Symbol\Symbol;
-use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Table\EmptyCell;
 use ILIAS\Language\Language;
 
 class Boolean extends Column implements C\Boolean
@@ -47,8 +47,11 @@ class Boolean extends Column implements C\Boolean
         }
     }
 
-    public function format($value): string|Icon|Glyph
+    public function format($value): string|Icon|Glyph|EmptyCell
     {
+        if($value === null) {
+            return $this->asEmptyCell();
+        }
         $this->checkBoolArg('value', $value);
         return $value ? $this->true_option : $this->false_option;
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Column.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Column.php
@@ -24,6 +24,7 @@ use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\UI\Component\Table\Column as C;
 use ILIAS\UI\Component\Component;
 use ILIAS\Language\Language;
+use ILIAS\UI\Implementation\Component\Table\EmptyCell;
 
 abstract class Column implements C\Column
 {
@@ -38,6 +39,7 @@ abstract class Column implements C\Column
     protected int $index;
     protected ?string $asc_label = null;
     protected ?string $desc_label = null;
+    protected ?string $empty_placeholder = null;
 
     public function __construct(
         protected Language $lng,
@@ -132,8 +134,23 @@ abstract class Column implements C\Column
         return $this->highlighted;
     }
 
+    public function withEmptyPlaceholder(string $empty_placeholder): self
+    {
+        $clone = clone $this;
+        $clone->empty_placeholder = $empty_placeholder;
+        return $clone;
+    }
+
+    protected function asEmptyCell(): EmptyCell
+    {
+        return new EmptyCell($this->empty_placeholder ?? '');
+    }
+
     public function format($value): string|Component
     {
+        if(empty($value)) {
+            return $this->asEmptyCell();
+        }
         return (string) $value;
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Date.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Date.php
@@ -23,6 +23,7 @@ namespace ILIAS\UI\Implementation\Component\Table\Column;
 use ILIAS\UI\Component\Table\Column as C;
 use ILIAS\Data\DateFormat\DateFormat;
 use ILIAS\Language\Language;
+use ILIAS\UI\Component\Table\EmptyCell;
 
 class Date extends Column implements C\Date
 {
@@ -39,8 +40,11 @@ class Date extends Column implements C\Date
         return $this->format;
     }
 
-    public function format($value): string
+    public function format($value): string|EmptyCell
     {
+        if(empty($value)) {
+            return $this->asEmptyCell();
+        }
         $this->checkArgInstanceOf('value', $value, \DateTimeImmutable::class);
         return $value->format($this->getFormat()->toString());
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Link.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Link.php
@@ -28,6 +28,9 @@ class Link extends Column implements C\Link
 {
     public function format($value): string|Component
     {
+        if(empty($value)) {
+            return $this->asEmptyCell();
+        }
         $this->checkArgInstanceOf('value', $value, Standard::class);
         return $value;
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/LinkListing.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/LinkListing.php
@@ -30,6 +30,10 @@ class LinkListing extends Column implements C\LinkListing
 {
     public function format($value): string|Component
     {
+        if(empty($value)) {
+            return $this->asEmptyCell();
+        }
+
         $listing = $this->toArray($value);
         $this->checkArgListElements("value", $listing, [Ordered::class, Unordered::class]);
         $listing_items = $value->getItems();

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Number.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Number.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Table\Column;
 
 use ILIAS\UI\Component\Table\Column as C;
+use ILIAS\UI\Component\Table\EmptyCell;
 
 class Number extends Column implements C\Number
 {
@@ -63,8 +64,12 @@ class Number extends Column implements C\Number
         return $clone;
     }
 
-    public function format($value): string
+    public function format($value): string|EmptyCell
     {
+        if ($value === null) {
+            return $this->asEmptyCell();
+        }
+
         $value = number_format(
             $value,
             $this->decimals,

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/StatusIcon.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/StatusIcon.php
@@ -21,12 +21,16 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Table\Column;
 
 use ILIAS\UI\Component\Table\Column as C;
+use ILIAS\UI\Component\Table\EmptyCell;
 use ILIAS\UI\Component\Symbol\Icon\Icon;
 
 class StatusIcon extends Column implements C\StatusIcon
 {
-    public function format($value): Icon
+    public function format($value): Icon|EmptyCell
     {
+        if(empty($value)) {
+            return $this->asEmptyCell();
+        }
         $this->checkArgInstanceOf('value', $value, Icon::class);
         return $value;
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/TimeSpan.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/TimeSpan.php
@@ -23,6 +23,7 @@ namespace ILIAS\UI\Implementation\Component\Table\Column;
 use ILIAS\UI\Component\Table\Column as C;
 use ILIAS\Data\DateFormat\DateFormat;
 use ILIAS\Language\Language;
+use ILIAS\UI\Component\Table\EmptyCell;
 
 class TimeSpan extends Column implements C\TimeSpan
 {
@@ -39,8 +40,12 @@ class TimeSpan extends Column implements C\TimeSpan
         return $this->format;
     }
 
-    public function format($value): string
+    public function format($value): string|EmptyCell
     {
+        if(empty($value)) {
+            return $this->asEmptyCell();
+        }
+
         $this->checkArgListElements('value', $value, [\DateTimeImmutable::class]);
         return
             $value[0]->format($this->getFormat()->toString())

--- a/components/ILIAS/UI/src/Implementation/Component/Table/EmptyCell.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/EmptyCell.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Table;
+
+use ILIAS\UI\Component\Table as T;
+use ILIAS\UI\Implementation\Component\ComponentHelper;
+
+class EmptyCell implements T\EmptyCell
+{
+    use ComponentHelper;
+
+    public function __construct(
+        protected string $empty_placeholder
+    ) {
+    }
+
+    public function getEmptyPlaceholder(): string
+    {
+        return $this->empty_placeholder;
+    }
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -58,6 +58,9 @@ class Renderer extends AbstractComponentRenderer
         if ($component instanceof Component\Table\OrderingRow) {
             return $this->renderOrderingRow($component, $default_renderer);
         }
+        if($component instanceof Component\Table\EmptyCell) {
+            return $this->renderEmptyCell($component, $default_renderer);
+        }
         $this->cannotHandleComponent($component);
     }
 
@@ -704,5 +707,13 @@ class Renderer extends AbstractComponentRenderer
             "$(document).on('$close', function() { il.UI.table.presentation.get('$table_id').collapseRow('$id'); return false; });" .
             "$(document).on('$toggle', function() { il.UI.table.presentation.get('$table_id').toggleRow('$id'); return false; });"
         );
+    }
+
+    public function renderEmptyCell(EmptyCell $component, RendererInterface $default_renderer): string
+    {
+        $tpl = $this->getTemplate("tpl.emptycell.html", true, true);
+        $tpl->setCurrentBlock('cell_content');
+        $tpl->setVariable('CELL_CONTENT', $component->getEmptyPlaceholder());
+        return $tpl->get();
     }
 }

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.emptycell.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.emptycell.html
@@ -1,0 +1,3 @@
+<!-- BEGIN cell_content -->
+<i class="c-table-data__cell__empty">{CELL_CONTENT}</i>
+<!-- END cell_content -->


### PR DESCRIPTION
This PR extends the `Column` class with the `withEmptyPlaceholder` method and introduces a new `ExmptyCell` component. The idea is that data tables can now handle null values instead of throwing an error due to an incorrect parameter (see https://mantis.ilias.de/view.php?id=39326).

- A placeholder can now be specified for each column, which is displayed if the value of the column is empty. If no placeholder is defined, the cell remains without any content. 
- A new component has been defined for empty cells. In this implementation, the message is displayed in italics. In the future, the component will make it possible to adapt the display via style sheets (e.g. to define the `text-align`).
- A cell is treated as empty if the format method of the respective column returns an `EmptyCell` component. Depending on the type of column, values are recognized differently as empty:
   - an empty string, zero numeric values, false, null and empty arrays are considered empty by default (see [empty()](https://www.php.net/manual/en/function.empty.php)) 
   - in columns `Boolean` and `Number` only null values are considered empty