### PR TITLE
[FIX] 0042349: UI Tooltips (via Topics) won't shown on slate-triggerers in MainBar

### DIFF
--- a/components/ILIAS/UI/src/Component/MainControls/Slate/Slate.php
+++ b/components/ILIAS/UI/src/Component/MainControls/Slate/Slate.php
@@ -25,11 +25,12 @@ use ILIAS\UI\Component\JavaScriptBindable;
 use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Component\Symbol\Symbol;
 use ILIAS\UI\Component\Triggerer;
+use ILIAS\UI\Component\HasHelpTopics;
 
 /**
  * This describes a Slate
  */
-interface Slate extends Component, JavaScriptBindable, Triggerer
+interface Slate extends Component, JavaScriptBindable, Triggerer, HasHelpTopics
 {
     /**
      * Get the name of this slate

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
@@ -139,7 +139,8 @@ class Renderer extends AbstractComponentRenderer
                 $trigger_signal = $component->getTriggerSignal($mb_id, $component::ENTRY_ACTION_TRIGGER);
                 $this->trigger_signals[] = $trigger_signal;
                 $button = $f->button()->bulky($entry->getSymbol(), $entry->getName(), '#')
-                    ->withOnClick($trigger_signal);
+                    ->withOnClick($trigger_signal)
+                    ->withHelpTopics(...$entry->getHelpTopics());
             } else {
                 //add Links/Buttons as toplevel entries
                 $pos = array_search($k, array_keys($entries));
@@ -358,7 +359,8 @@ class Renderer extends AbstractComponentRenderer
                     ->withEngagedState($engaged)
                     ->withOnClick($entry_signal)
                     ->appendOnClick($secondary_signal)
-                    ->withAriaRole(IBulky::MENUITEM);
+                    ->withAriaRole(IBulky::MENUITEM)
+                    ->withHelpTopics(...$entry->getHelpTopics());
 
                 $slate = $entry;
             } elseif ($entry instanceof IBulky) {

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Renderer.php
@@ -60,7 +60,9 @@ class Renderer extends AbstractComponentRenderer
             if ($entry instanceof ISlate\Slate && !$entry instanceof ISlate\Notification) {
                 $trigger_signal = $entry->getToggleSignal();
                 $triggerer = $f->button()->bulky($entry->getSymbol(), $entry->getName(), '#')
-                    ->withOnClick($trigger_signal);
+                    ->withOnClick($trigger_signal)
+                    ->withHelpTopics(...$entry->getHelpTopics())
+                ;
 
                 $mb_id = $entry->getMainBarTreePosition();
                 if ($mb_id) {

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Slate.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Slate/Slate.php
@@ -29,12 +29,14 @@ use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Implementation\Component\ReplaceSignal as ReplaceSignalImplementation;
 use ILIAS\UI\Implementation\Component\Triggerer;
+use ILIAS\UI\Implementation\Component\HasHelpTopics;
 
 abstract class Slate implements ISlate\Slate
 {
     use ComponentHelper;
     use JavaScriptBindable;
     use Triggerer;
+    use HasHelpTopics;
 
     // allowed ARIA roles
     public const MENU = 'menu';


### PR DESCRIPTION
as mentioned in https://mantis.ilias.de/view.php?id=42349, Slates currently are unable to receive UI-Topics which are needed for e.g. the Tooltips of the Help-Package to be rendered correctly (@alex40724 this might be of interest for you).

I implemented the HasHelpTopics interface in Slates with this PR. Please be aware that this might break some layouts when using Topcis, but as far as I can see the e.g. Buttons inside a CombinedSlate inside the MetaBar are broken anyway (look strange since some time)., I sure it will be easier for people which are fitter than me in (S)CSS to takle this in one step.

A central question is, of course, which component receives the tooltip in the case of a slate (the same question probably arises for all components that internally use another component, for example, as a trigger, i.e. something like Modals). From this point of view, tooltips can be said to be at the triggerer. For further use cases (such as extensive explanatory texts), further `Purposes` should be implemented for the `Topics`, which then also allow a different form of presentation in a component.

Is there anything needed beside this?