### PR TITLE
ilServer: Handle `null` sections when parsing INI file

### DIFF
--- a/Services/WebServices/RPC/lib/src/main/java/de/ilias/services/settings/LogConfigManager.java
+++ b/Services/WebServices/RPC/lib/src/main/java/de/ilias/services/settings/LogConfigManager.java
@@ -80,7 +80,7 @@ public class LogConfigManager {
 		try (FileReader fileReader = new FileReader(path)) {
 			ini.read(fileReader);
 			for (String section : ini.getSections()) {
-				if (section.equals("Server")) {
+				if (section != null && section.equals("Server")) {
 					SubnodeConfiguration sectionConfig = ini.getSection(section);
 					if (sectionConfig.containsKey("LogLevel")) {
 						setLogLevel(purgeString(sectionConfig.getProperty("LogLevel").toString()));


### PR DESCRIPTION
This PR fixes a possible `NullPointerException` when parsing the INI file. According to the source files of the `configuration2` Apache-package such `null`-sections are possible.

```java
    public Set<String> getSections() {
        return syncRead(() -> {
            final Set<String> sections = new LinkedHashSet<>();
            boolean globalSection = false;
            boolean inSection = false;
            for (final ImmutableNode node : getModel().getNodeHandler().getRootNode().getChildren()) {
                if (isSectionNode(node)) {
                    inSection = true;
                    sections.add(node.getNodeName());
                } else if (!inSection && !globalSection) {
                    globalSection = true;
                    sections.add(null);
                }
            }
            return sections;
        }, false);
    }
```

See: https://github.com/apache/commons-configuration/blob/master/src/main/java/org/apache/commons/configuration2/INIConfiguration.java#L674 

```bash
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "section" is null
        at de.ilias.services.settings.LogConfigManager.parse(LogConfigManager.java:83)
        at de.ilias.ilServer.handleRequest(ilServer.java:78)
        at de.ilias.ilServer.main(ilServer.java:63)
```

If approved, please pick this to all relevant branches.