### PR TITLE
Feature: New taxonomy filters to use taxonomies in the question selection for fixed tests (2)

### DIFF
--- a/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
@@ -64,7 +64,6 @@ class ilTestQuestionBrowserTableGUI
         private readonly ilUIService $ui_service,
         private readonly DataFactory $data_factory,
         private readonly TaxonomyService $taxonomy,
-        private readonly \Closure $questionPoolLinkBuilder
     ) {
     }
 
@@ -138,7 +137,6 @@ class ilTestQuestionBrowserTableGUI
             $this->tree,
             $this->testrequest,
             $this->taxonomy,
-            $this->questionPoolLinkBuilder,
             $parent_title
         );
     }

--- a/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
@@ -18,41 +18,31 @@
 
 declare(strict_types=1);
 
-use ILIAS\Test\Utilities\TitleColumnsBuilder;
-use ILIAS\Test\RequestDataCollector;
-use ILIAS\Test\Logging\TestLogger;
-use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
+use ILIAS\Data\Factory as DataFactory;
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Taxonomy\DomainService as TaxonomyService;
+use ILIAS\Test\Logging\TestLogger;
+use ILIAS\Test\Questions\QuestionsBrowserFilter;
+use ILIAS\Test\Questions\QuestionsBrowserTable;
+use ILIAS\Test\RequestDataCollector;
+use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
+use ILIAS\UI\Component\Input\Container\Filter\Filter;
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Renderer as UIRenderer;
-use ILIAS\UI\Component\Link\Standard as StandardLink;
 
 /**
- * @author Helmut Schottmüller <ilias@aurealis.de>
  * @ilCtrl_Calls ilTestQuestionBrowserTableGUI: ilFormPropertyDispatchGUI
  */
-class ilTestQuestionBrowserTableGUI extends ilTable2GUI
+class ilTestQuestionBrowserTableGUI
 {
-    private const REPOSITORY_ROOT_NODE_ID = 1;
-
-    public const CONTEXT_PARAMETER = 'question_browse_context';
-    public const CONTEXT_PAGE_VIEW = 'contextPageView';
-    public const CONTEXT_LIST_VIEW = 'contextListView';
-
+    public const REPOSITORY_ROOT_NODE_ID = 1;
     public const MODE_PARAMETER = 'question_browse_mode';
     public const MODE_BROWSE_POOLS = 'modeBrowsePools';
     public const MODE_BROWSE_TESTS = 'modeBrowseTests';
 
     public const CMD_BROWSE_QUESTIONS = 'browseQuestions';
-    public const CMD_APPLY_FILTER = 'applyFilter';
-    public const CMD_RESET_FILTER = 'resetFilter';
     public const CMD_INSERT_QUESTIONS = 'insertQuestions';
-
-    private bool $writeAccess = false;
-
-    /** @var array<string, mixed> */
-    private array $filter = [];
 
     public function __construct(
         private readonly ilTabsGUI $tabs,
@@ -67,168 +57,126 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
         private readonly UIFactory $ui_factory,
         private readonly UIRenderer $ui_renderer,
         private readonly RequestDataCollector $testrequest,
-        private readonly TitleColumnsBuilder $title_builder,
-        private readonly GeneralQuestionPropertiesRepository $questionrepository
+        private readonly GeneralQuestionPropertiesRepository $questionrepository,
+        private readonly ilLanguage $lng,
+        private readonly ilCtrl $ctrl,
+        private readonly ilGlobalTemplateInterface $main_tpl,
+        private readonly ilUIService $ui_service,
+        private readonly DataFactory $data_factory,
+        private readonly TaxonomyService $taxonomy,
+        private readonly \Closure $questionPoolLinkBuilder
     ) {
-        $this->setId('qpl_brows_tabl_' . $this->test_obj->getId());
-
-        parent::__construct($this, self::CMD_BROWSE_QUESTIONS);
-        $this->setFilterCommand(self::CMD_APPLY_FILTER);
-        $this->setResetCommand(self::CMD_RESET_FILTER);
-
-        $this->setFormName('questionbrowser');
-        $this->setStyle('table', 'fullwidth');
-        $this->addColumn('', '', '1%', true);
-        $this->addColumn($this->lng->txt("tst_question_title"), 'title', '');
-        $this->addColumn($this->lng->txt("description"), 'description', '');
-        $this->addColumn($this->lng->txt("tst_question_type"), 'ttype', '');
-        $this->addColumn($this->lng->txt("author"), 'author', '');
-        $this->addColumn($this->lng->txt('qst_lifecycle'), 'lifecycle', '');
-        $this->addColumn($this->lng->txt("create_date"), 'created', '');
-        $this->addColumn(
-            $this->lng->txt("last_update"),
-            'tstamp',
-            ''
-        );  // name of col is proper "updated" but in data array the key is "tstamp"
-        $this->addColumn($this->getParentObjectLabel(), 'parent_title', '');
-        $this->setSelectAllCheckbox('q_id');
-        $this->setRowTemplate("tpl.il_as_tst_question_browser_row.html", "components/ILIAS/Test");
-
-        $this->setFormAction($this->ctrl->getFormAction($this->getParentObject(), $this->getParentCmd()));
-        $this->setDefaultOrderField("title");
-        $this->setDefaultOrderDirection("asc");
-
-        $this->enable('sort');
-        $this->enable('select_all');
-        $this->initFilter();
-        $this->setDisableFilterHiding(true);
-    }
-
-    public function setWriteAccess(bool $value): void
-    {
-        $this->writeAccess = $value;
-    }
-
-    public function hasWriteAccess(): bool
-    {
-        return $this->writeAccess;
-    }
-
-    public function init(): void
-    {
-        if ($this->hasWriteAccess()) {
-            $this->addMultiCommand(self::CMD_INSERT_QUESTIONS, $this->lng->txt('insert'));
-        }
     }
 
     public function executeCommand(): bool
     {
-        $this->handleParameters();
+        $this->handleWriteAccess();
         $this->handleTabs();
 
         switch (strtolower((string) $this->ctrl->getNextClass($this))) {
-            case strtolower(__CLASS__):
+            case strtolower(self::class):
             case '':
                 $cmd = $this->ctrl->getCmd() . 'Cmd';
                 return $this->$cmd();
 
             default:
                 $this->ctrl->setReturn($this, self::CMD_BROWSE_QUESTIONS);
-                return parent::executeCommand();
+                return $this->browseQuestionsCmd();
+        }
+    }
+
+    private function handleWriteAccess(): void
+    {
+        if (!$this->access->checkAccess('write', '', $this->test_obj->getRefId())) {
+            $this->ctrl->redirectByClass(ilObjTestGUI::class, ilObjTestGUI::SHOW_QUESTIONS_CMD);
         }
     }
 
     private function browseQuestionsCmd(): bool
     {
-        $this->setData($this->getQuestionsData());
+        $this->ctrl->setParameter($this, self::MODE_PARAMETER, $this->testrequest->raw(self::MODE_PARAMETER));
+        $action = $this->ctrl->getLinkTarget($this, self::CMD_BROWSE_QUESTIONS);
 
-        $this->main_tpl->setContent($this->ctrl->getHTML($this));
+        $mode = $this->ctrl->getParameterArrayByClass(self::class)[self::MODE_PARAMETER];
+        $parent_title = ($mode === self::MODE_BROWSE_TESTS ? 'test_title' : 'tst_source_question_pool');
+
+        $filter = $this->getQuestionsBrowserFilterComponent($parent_title, $action);
+        $question_browser_table = $this->getQuestionsBrowserTable($parent_title);
+
+        $this->main_tpl->setContent(
+            $this->ui_renderer->render([
+                $filter,
+                $question_browser_table->getComponent($this->http_state->request(), $this->ui_service->filter()->getData($filter))
+            ])
+        );
+
         return true;
     }
 
-    private function applyFilterCmd(): void
+    private function getQuestionsBrowserFilterComponent(string $parent_title = '', string $action = ''): Filter
     {
-        $this->writeFilterToSession();
-        $this->ctrl->redirect($this, self::CMD_BROWSE_QUESTIONS);
+        return (new QuestionsBrowserFilter(
+            $this->ui_service,
+            $this->lng,
+            $this->ui_factory,
+            'question_browser_filter',
+            $parent_title
+        ))->getComponent($action, $this->http_state->request());
     }
 
-    private function resetFilterCmd(): void
+    private function getQuestionsBrowserTable(string $parent_title = ''): QuestionsBrowserTable
     {
-        $this->resetFilter();
-        $this->ctrl->redirect($this, self::CMD_BROWSE_QUESTIONS);
+        return new QuestionsBrowserTable(
+            (string) $this->test_obj->getId(),
+            $this->ui_factory,
+            $this->ui_renderer,
+            $this->lng,
+            $this->ctrl,
+            $this->data_factory,
+            new ilAssQuestionList($this->db, $this->lng, $this->refinery, $this->component_repository),
+            $this->test_obj,
+            $this->tree,
+            $this->testrequest,
+            $this->taxonomy,
+            $this->questionPoolLinkBuilder,
+            $parent_title
+        );
     }
 
     private function insertQuestionsCmd(): void
     {
-        $selected_array = [];
-        if ($this->http_state->wrapper()->post()->has('q_id')) {
-            $selected_array = $this->http_state->wrapper()->post()->retrieve(
-                'q_id',
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int())
-            );
-        }
+        $selected_array = $this->http_state->wrapper()->query()->retrieve(
+            'qlist_q_id',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([])
+            ])
+        );
 
         if ($selected_array === []) {
-            $this->main_tpl->setOnScreenMessage('info', $this->lng->txt("tst_insert_missing_question"), true);
+            $this->main_tpl->setOnScreenMessage('info', $this->lng->txt('tst_insert_missing_question'), true);
             $this->ctrl->redirect($this, self::CMD_BROWSE_QUESTIONS);
         }
 
-        $test_question_set_config = $this->buildTestQuestionSetConfig();
+        if (in_array('ALL_OBJECTS', $selected_array, true)) {
+            $selected_array = array_keys(
+                $this->getQuestionsBrowserTable()->loadRecords(
+                    $this->ui_service->filter()->getData($this->getQuestionsBrowserFilterComponent())
+                )
+            );
+        }
+
         array_map(
             fn(int $v): int => $this->test_obj->insertQuestion($v),
             $selected_array
         );
 
-        $this->test_obj->saveCompleteStatus($test_question_set_config);
+        $this->test_obj->saveCompleteStatus($this->buildTestQuestionSetConfig());
 
         $this->main_tpl->setOnScreenMessage('success', $this->lng->txt('tst_questions_inserted'), true);
 
-        $this->ctrl->redirectByClass($this->getBackTargetCmdClass(), $this->getBackTargetCommand());
-    }
-
-    private function handleParameters(): void
-    {
-        if ($this->testrequest->isset(self::CONTEXT_PARAMETER)) {
-            $this->ctrl->setParameterByClass(
-                self::class,
-                self::CONTEXT_PARAMETER,
-                $this->testrequest->raw(self::CONTEXT_PARAMETER)
-            );
-            $this->addHiddenInput(self::CONTEXT_PARAMETER, $this->testrequest->raw(self::CONTEXT_PARAMETER));
-        }
-
-        if ($this->testrequest->isset(self::MODE_PARAMETER)) {
-            $this->ctrl->setParameterByClass(
-                self::class,
-                self::MODE_PARAMETER,
-                $this->testrequest->raw(self::MODE_PARAMETER)
-            );
-            $this->addHiddenInput(self::MODE_PARAMETER, $this->testrequest->raw(self::MODE_PARAMETER));
-        }
-    }
-
-    /**
-     * @return mixed|null
-     */
-    private function fetchContextParameter()
-    {
-        if ($this->testrequest->isset(self::CONTEXT_PARAMETER)) {
-            return $this->testrequest->raw(self::CONTEXT_PARAMETER);
-        }
-
-        return null;
-    }
-
-    /**
-     * @return mixed|null
-     */
-    private function fetchModeParameter()
-    {
-        if ($this->testrequest->isset(self::MODE_PARAMETER)) {
-            return $this->testrequest->raw(self::MODE_PARAMETER);
-        }
-
-        return null;
+        $this->ctrl->redirectByClass(ilObjTestGUI::class, ilObjTestGUI::SHOW_QUESTIONS_CMD);
     }
 
     private function handleTabs(): void
@@ -237,218 +185,27 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
         $this->tabs->clearSubTabs();
 
         $this->tabs->setBackTarget(
-            $this->getBackTargetLabel(),
-            $this->getBackTargetUrl()
+            $this->lng->txt('backtocallingtest'),
+            $this->ctrl->getLinkTargetByClass(ilObjTestGUI::class, ilObjTestGUI::SHOW_QUESTIONS_CMD)
         );
 
+        $browseQuestionsTabLabel = match ($this->testrequest->raw(self::MODE_PARAMETER)) {
+            self::MODE_BROWSE_POOLS => $this->lng->txt('tst_browse_for_qpl_questions'),
+            self::MODE_BROWSE_TESTS => $this->lng->txt('tst_browse_for_tst_questions'),
+            default => ''
+        };
+
         $this->tabs->addTab(
-            'browseQuestions',
-            $this->getBrowseQuestionsTabLabel(),
-            $this->getBrowseQuestionsTabUrl()
+            self::CMD_BROWSE_QUESTIONS,
+            $browseQuestionsTabLabel,
+            $this->ctrl->getLinkTarget($this, self::CMD_BROWSE_QUESTIONS)
         );
         $this->tabs->activateTab('browseQuestions');
     }
 
-    private function getBackTargetLabel(): string
-    {
-        return $this->lng->txt('backtocallingtest');
-    }
-
-    private function getBackTargetUrl(): string
-    {
-        return $this->ctrl->getLinkTargetByClass(
-            $this->getBackTargetCmdClass(),
-            $this->getBackTargetCommand()
-        );
-    }
-
-    private function getBackTargetCmdClass(): string
-    {
-        switch ($this->fetchContextParameter()) {
-            case self::CONTEXT_PAGE_VIEW:
-
-                return 'ilTestExpressPageObjectGUI';
-            case self::CONTEXT_LIST_VIEW:
-            default:
-                return 'ilObjTestGUI';
-        }
-    }
-
-    private function getBackTargetCommand(): string
-    {
-        switch ($this->fetchContextParameter()) {
-            case self::CONTEXT_LIST_VIEW:
-                return ilObjTestGUI::SHOW_QUESTIONS_CMD;
-
-            case self::CONTEXT_PAGE_VIEW:
-                return 'showPage';
-        }
-
-        return '';
-    }
-
-    private function getBrowseQuestionsTabLabel(): string
-    {
-        switch ($this->fetchModeParameter()) {
-            case self::MODE_BROWSE_POOLS:
-
-                return $this->lng->txt('tst_browse_for_qpl_questions');
-
-            case self::MODE_BROWSE_TESTS:
-
-                return $this->lng->txt('tst_browse_for_tst_questions');
-        }
-
-        return '';
-    }
-
-    private function getBrowseQuestionsTabUrl(): string
-    {
-        return $this->ctrl->getLinkTarget($this, self::CMD_BROWSE_QUESTIONS);
-    }
-
-    public function initFilter(): void
-    {
-        $ti = new ilTextInputGUI($this->lng->txt("tst_qbt_filter_question_title"), "title");
-        $ti->setMaxLength(64);
-        $ti->setSize(20);
-        $ti->setValidationRegexp('/(^[^%]+$)|(^$)/is');
-        $this->addFilterItem($ti);
-        $ti->readFromSession();
-        $this->filter["title"] = $ti->getValue();
-
-        $ti = new ilTextInputGUI($this->lng->txt("description"), "description");
-        $ti->setMaxLength(64);
-        $ti->setSize(20);
-        $ti->setValidationRegexp('/(^[^%]+$)|(^$)/is');
-        $this->addFilterItem($ti);
-        $ti->readFromSession();
-        $this->filter["description"] = $ti->getValue();
-
-        $ti = new ilTextInputGUI($this->lng->txt("author"), "author");
-        $ti->setMaxLength(64);
-        $ti->setSize(20);
-        $this->addFilterItem($ti);
-        $ti->setValidationRegexp('/(^[^%]+$)|(^$)/is');
-        $ti->readFromSession();
-        $this->filter["author"] = $ti->getValue();
-
-        $lifecycleOptions = array_merge(
-            ['' => $this->lng->txt('qst_lifecycle_filter_all')],
-            ilAssQuestionLifecycle::getDraftInstance()->getSelectOptions($this->lng)
-        );
-        $lifecycleInp = new ilSelectInputGUI($this->lng->txt('qst_lifecycle'), 'lifecycle');
-        $lifecycleInp->setOptions($lifecycleOptions);
-        $this->addFilterItem($lifecycleInp);
-        $lifecycleInp->readFromSession();
-        $this->filter['lifecycle'] = $lifecycleInp->getValue();
-
-        $types = ilObjQuestionPool::_getQuestionTypes();
-        $options = [];
-        $options[""] = $this->lng->txt('filter_all_question_types');
-        foreach ($types as $translation => $row) {
-            $options[$row['type_tag']] = $translation;
-        }
-
-        $si = new ilSelectInputGUI($this->lng->txt("question_type"), "type");
-        $si->setOptions($options);
-        $this->addFilterItem($si);
-        $si->readFromSession();
-        $this->filter["type"] = $si->getValue();
-
-        $ti = new ilTextInputGUI($this->getParentObjectLabel(), 'parent_title');
-        $ti->setMaxLength(64);
-        $ti->setSize(20);
-        $ti->setValidationRegexp('/(^[^%]+$)|(^$)/is');
-        $this->addFilterItem($ti);
-        $ti->readFromSession();
-        $this->filter['parent_title'] = $ti->getValue();
-
-        $ri = new ilRepositorySelectorInputGUI($this->lng->txt('repository'), 'repository_root_node');
-        $ri->setHeaderMessage($this->lng->txt('question_browse_area_info'));
-        if ($this->fetchModeParameter() === self::MODE_BROWSE_TESTS) {
-            $ri->setClickableTypes(['tst']);
-        } else {
-            $ri->setClickableTypes(['qpl']);
-        }
-        $this->addFilterItem($ri);
-        $ri->readFromSession();
-        $this->filter['repository_root_node'] = $ri->getValue();
-    }
-
-    private function getParentObjectLabel(): string
-    {
-        switch ($this->fetchModeParameter()) {
-            case self::MODE_BROWSE_POOLS:
-
-                return $this->lng->txt('qpl');
-
-            case self::MODE_BROWSE_TESTS:
-
-                return $this->lng->txt('tst');
-        }
-
-        return '';
-    }
-
-    protected function getTranslatedLifecycle(?string $lifecycle): string
-    {
-        try {
-            return ilAssQuestionLifecycle::getInstance($lifecycle)->getTranslation($this->lng);
-        } catch (ilTestQuestionPoolInvalidArgumentException $e) {
-            return '';
-        }
-    }
-
-    public function fillRow(array $a_set): void
-    {
-        $this->tpl->setVariable('QUESTION_ID', $a_set['question_id']);
-        $this->tpl->setVariable('QUESTION_TITLE', $a_set['title']);
-        $this->tpl->setVariable('QUESTION_COMMENT', $a_set['description']);
-        $this->tpl->setVariable('QUESTION_TYPE', $this->questionrepository->getForQuestionId($a_set['question_id'])->getTypeName($this->lng));
-        $this->tpl->setVariable('QUESTION_AUTHOR', $a_set['author']);
-        $this->tpl->setVariable('QUESTION_LIFECYCLE', $this->getTranslatedLifecycle($a_set['lifecycle']));
-        $this->tpl->setVariable(
-            'QUESTION_CREATED',
-            ilDatePresentation::formatDate(new ilDate($a_set['created'], IL_CAL_UNIX))
-        );
-        $this->tpl->setVariable(
-            'QUESTION_UPDATED',
-            ilDatePresentation::formatDate(new ilDate($a_set['tstamp'], IL_CAL_UNIX))
-        );
-        $this->tpl->setVariable(
-            'QUESTION_POOL_OR_TEST_TITLE',
-            $this->ui_renderer->render(
-                $this->buildPossiblyLinkedQuestonPoolOrTestTitle(
-                    (int) $a_set['obj_fi'],
-                    $a_set['parent_title']
-                )
-            )
-        );
-    }
-
-    private function buildPossiblyLinkedQuestonPoolOrTestTitle(int $obj_id, string $parent_title): StandardLink
-    {
-        switch ($this->fetchModeParameter()) {
-            case self::MODE_BROWSE_POOLS:
-                return $this->title_builder->buildAccessCheckedQuestionpoolTitleAsLink(
-                    $obj_id,
-                    $parent_title
-                );
-
-            case self::MODE_BROWSE_TESTS:
-                return $this->title_builder->buildAccessCheckedTestTitleAsLinkForObjId(
-                    $obj_id,
-                    $parent_title
-                );
-        }
-
-        return '';
-    }
-
     private function buildTestQuestionSetConfig(): ilTestQuestionSetConfig
     {
-        $testQuestionSetConfigFactory = new ilTestQuestionSetConfigFactory(
+        return (new ilTestQuestionSetConfigFactory(
             $this->tree,
             $this->db,
             $this->lng,
@@ -456,107 +213,6 @@ class ilTestQuestionBrowserTableGUI extends ilTable2GUI
             $this->component_repository,
             $this->test_obj,
             $this->questionrepository
-        );
-
-        return $testQuestionSetConfigFactory->getQuestionSetConfig();
-    }
-
-    private function getQuestionsData(): array
-    {
-        $question_list = new ilAssQuestionList($this->db, $this->lng, $this->refinery, $this->component_repository);
-        $question_list->setQuestionInstanceTypeFilter($this->getQuestionInstanceTypeFilter());
-        $question_list->setExcludeQuestionIdsFilter($this->test_obj->getExistingQuestions());
-
-        $repository_root_node = self::REPOSITORY_ROOT_NODE_ID;
-
-        foreach ($this->getFilterItems() as $item) {
-            if (!in_array($item->getValue(), [false, null, ''], true)) {
-                switch ($item->getPostVar()) {
-                    case 'title':
-                    case 'description':
-                    case 'author':
-                    case 'lifecycle':
-                    case 'type':
-                    case 'parent_title':
-                        $question_list->addFieldFilter($item->getPostVar(), $item->getValue());
-                        break;
-
-                    case 'repository_root_node':
-                        $repository_root_node = (int) $item->getValue();
-                }
-            }
-        }
-        if ($repository_root_node < 1) {
-            $repository_root_node = self::REPOSITORY_ROOT_NODE_ID;
-        }
-
-        $parent_object_ids = $this->getQuestionParentObjIds($repository_root_node);
-        if ($parent_object_ids === []) {
-            return [];
-        }
-
-        $question_list->setParentObjIdsFilter($parent_object_ids);
-        $question_list->setParentObjectType($this->getQuestionParentObjectType());
-
-        $question_list->load();
-
-        return $question_list->getQuestionDataArray();
-    }
-
-    private function getQuestionInstanceTypeFilter(): string
-    {
-        if ($this->fetchModeParameter() === self::MODE_BROWSE_TESTS) {
-            return ilAssQuestionList::QUESTION_INSTANCE_TYPE_ALL;
-        }
-
-        return ilAssQuestionList::QUESTION_INSTANCE_TYPE_ORIGINALS;
-    }
-
-    /**
-     * @param int $repositoryRootNode
-     * @return int[]
-     */
-    private function getQuestionParentObjIds(int $repositoryRootNode): array
-    {
-        $parents = $this->tree->getSubTree(
-            $this->tree->getNodeData($repositoryRootNode),
-            true,
-            [$this->getQuestionParentObjectType()]
-        );
-
-        $parentIds = [];
-
-        foreach ($parents as $nodeData) {
-            if ((int) $nodeData['obj_id'] === $this->test_obj->getId()) {
-                continue;
-            }
-
-            $parentIds[$nodeData['obj_id']] = $nodeData['obj_id'];
-        }
-
-        $parentIds = array_map('intval', array_values($parentIds));
-
-        if ($this->fetchModeParameter() === self::MODE_BROWSE_POOLS) {
-            $available_pools = array_map('intval', array_keys(ilObjQuestionPool::_getAvailableQuestionpools(true)));
-            return array_intersect($parentIds, $available_pools);
-        } elseif ($this->fetchModeParameter() === self::MODE_BROWSE_TESTS) {
-            return array_filter($parentIds, function ($obj_id): bool {
-                $refIds = ilObject::_getAllReferences($obj_id);
-                $refId = current($refIds);
-                return $this->access->checkAccess('write', '', $refId);
-            });
-        }
-
-        // Return no parent ids if the user wants to hack...
-        return [];
-    }
-
-    private function getQuestionParentObjectType(): string
-    {
-        if ($this->fetchModeParameter() === self::MODE_BROWSE_TESTS) {
-            return 'tst';
-        }
-
-        return 'qpl';
+        ))->getQuestionSetConfig();
     }
 }

--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -659,7 +659,6 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                     $this->obj_data_cache,
                     $test_process_locker_factory,
                     $this->testrequest,
-                    $this->title_builder,
                     $this->questionrepository
                 );
                 $this->ctrl->forwardCommand($gui);
@@ -691,7 +690,6 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                     $this->ui_service,
                     $this->data_factory,
                     $this->taxonomy,
-                    static fn() => ''
                 );
                 $this->ctrl->forwardCommand($gui);
                 break;

--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsTableActions.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsTableActions.php
@@ -66,7 +66,8 @@ class QuestionsTableActions
         private readonly \ilObjTest $test_obj,
         private readonly bool $is_adjusting_questions_with_results_allowed,
         private readonly bool $is_in_test_with_results,
-        private readonly bool $is_in_test_with_random_question_set
+        private readonly bool $is_in_test_with_random_question_set,
+        private readonly \ilTestQuestionSetConfigFactory $test_question_set_config_factory
     ) {
         $this->table_id = (string) $test_obj->getId();
     }

--- a/components/ILIAS/Test/src/Questions/QuestionsBrowserFilter.php
+++ b/components/ILIAS/Test/src/Questions/QuestionsBrowserFilter.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Test\Questions;
+
+use ilAssQuestionLifecycle;
+use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
+use ILIAS\UI\Component\Input\Input;
+use ILIAS\UI\Factory as UIFactory;
+use ILIAS\UI\Component\Input\Container\Filter\Filter;
+use ilLanguage;
+use ilObjQuestionPool;
+use ilUIService;
+use Psr\Http\Message\ServerRequestInterface;
+
+class QuestionsBrowserFilter
+{
+    public function __construct(
+        private readonly ilUIService $ui_service,
+        private readonly ilLanguage $lng,
+        private readonly UIFactory $ui_factory,
+        private readonly string $filter_id,
+        private readonly string $parent_title
+    ) {
+    }
+
+    public function getComponent(string $action, ServerRequestInterface $request): Filter
+    {
+        $filter_inputs = [];
+        $is_input_initially_rendered = [];
+        $field_factory = $this->ui_factory->input()->field();
+
+        foreach ($this->getFields($field_factory) as $filter_id => $filter) {
+            [$filter_inputs[$filter_id], $is_input_initially_rendered[$filter_id]] = $filter;
+        }
+
+        $component = $this->ui_service->filter()->standard(
+            $this->filter_id,
+            $action,
+            $filter_inputs,
+            $is_input_initially_rendered,
+            true,
+            true
+        );
+
+        return $request->getMethod() === 'POST' ? $component->withRequest($request) : $component;
+    }
+
+    /**
+     * @param FieldFactory $input
+     *
+     * @return array<string, array<Input, bool>>
+     */
+    private function getFields(FieldFactory $input): array
+    {
+        $lifecycle_options = array_merge(
+            ['' => $this->lng->txt('qst_lifecycle_filter_all')],
+            ilAssQuestionLifecycle::getDraftInstance()->getSelectOptions($this->lng)
+        );
+        $yes_no_all_options = [
+            '' => $this->lng->txt('resulttable_all'),
+            'true' => $this->lng->txt('yes'),
+            'false' => $this->lng->txt('no')
+        ];
+
+        return [
+            'title' => [$input->text($this->lng->txt('tst_question_title')), true],
+            'description' => [$input->text($this->lng->txt('description')), false],
+            'type' => [$input->select($this->lng->txt('tst_question_type'), $this->resolveQuestionTypeFilterOptions()), true],
+            'author' => [$input->text($this->lng->txt('author')), false],
+            'lifecycle' => [$input->select($this->lng->txt('qst_lifecycle'), $lifecycle_options), false],
+            'parent_title' => [$input->text($this->lng->txt($this->parent_title)), true],
+            'taxonomy_title' => [$input->text($this->lng->txt('taxonomy_title')), true],
+            'taxonomy_node_title' => [$input->text($this->lng->txt('taxonomy_node_title')), true],
+            'feedback' => [$input->select($this->lng->txt('feedback'), $yes_no_all_options), false],
+            'hints' => [$input->select($this->lng->txt('hints'), $yes_no_all_options), false]
+        ];
+    }
+
+    private function resolveQuestionTypeFilterOptions(): array
+    {
+        $question_type_options = ['' => $this->lng->txt('filter_all_question_types')];
+
+        foreach (ilObjQuestionPool::_getQuestionTypes() as $translation => $row) {
+            $question_type_options[$row['type_tag']] = $translation;
+        }
+        return $question_type_options;
+    }
+}

--- a/components/ILIAS/Test/src/Questions/QuestionsBrowserTable.php
+++ b/components/ILIAS/Test/src/Questions/QuestionsBrowserTable.php
@@ -26,6 +26,7 @@ use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\Order;
 use ILIAS\Data\Range;
 use ILIAS\Test\RequestDataCollector;
+use ILIAS\Test\Utilities\TitleColumnsBuilder;
 use ILIAS\UI\Component\Table\Action\Standard as TableAction;
 use ILIAS\UI\Component\Table\Column\Column;
 use ILIAS\UI\Component\Table\DataRetrieval;
@@ -55,7 +56,6 @@ class QuestionsBrowserTable implements DataRetrieval
         protected \ilTree $tree,
         protected RequestDataCollector $testrequest,
         protected TaxonomyService $taxonomy,
-        protected \Closure $getQuestionPoolLink,
         protected string $parent_title
     ) {
     }
@@ -166,7 +166,6 @@ class QuestionsBrowserTable implements DataRetrieval
             $record['type_tag'] = $this->lng->txt($record['type_tag']);
             $record['complete'] = (bool) $record['complete'];
             $record['lifecycle'] = \ilAssQuestionLifecycle::getInstance($record['lifecycle'])->getTranslation($this->lng) ?? '';
-            $record['qpl'] = call_user_func($this->getQuestionPoolLink, $record['orig_obj_fi'] ?? null);
 
             $record['created'] = (new \DateTimeImmutable())->setTimestamp($record['created']);
             $record['tstamp'] = (new \DateTimeImmutable())->setTimestamp($record['tstamp']);

--- a/components/ILIAS/Test/src/Questions/QuestionsBrowserTable.php
+++ b/components/ILIAS/Test/src/Questions/QuestionsBrowserTable.php
@@ -1,0 +1,380 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Test\Questions;
+
+use ILIAS\Taxonomy\DomainService as TaxonomyService;
+use GuzzleHttp\Psr7\ServerRequest;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Data\Order;
+use ILIAS\Data\Range;
+use ILIAS\Test\RequestDataCollector;
+use ILIAS\UI\Component\Table\Action\Standard as TableAction;
+use ILIAS\UI\Component\Table\Column\Column;
+use ILIAS\UI\Component\Table\DataRetrieval;
+use ILIAS\UI\Component\Table\DataRowBuilder;
+use ILIAS\UI\Factory as UIFactory;
+use ILIAS\UI\Renderer as UIRenderer;
+use ILIAS\UI\URLBuilder;
+use ilTestQuestionBrowserTableGUI;
+use Psr\Http\Message\ServerRequestInterface;
+use ILIAS\UI\Component\Table\Data;
+
+class QuestionsBrowserTable implements DataRetrieval
+{
+    public const ACTION_INSERT = 'insert';
+
+    private ?array $records = null;
+
+    public function __construct(
+        protected readonly string $table_id,
+        protected UIFactory $ui_factory,
+        protected UIRenderer $ui_renderer,
+        protected \ilLanguage $lng,
+        protected \ilCtrl $ctrl,
+        protected DataFactory $data_factory,
+        protected \ilAssQuestionList $question_list,
+        protected \ilObjTest $test_obj,
+        protected \ilTree $tree,
+        protected RequestDataCollector $testrequest,
+        protected TaxonomyService $taxonomy,
+        protected \Closure $getQuestionPoolLink,
+        protected string $parent_title
+    ) {
+    }
+
+    public function getComponent(ServerRequestInterface $request, ?array $filter): Data
+    {
+        return $this->ui_factory->table()->data(
+            $this->lng->txt('list_of_questions'),
+            $this->getColumns(),
+            $this
+        )
+            ->withId($this->table_id)
+            ->withActions($this->getActions())
+            ->withRequest($request)
+            ->withFilter($filter);
+    }
+
+    public function getColumns(): array
+    {
+        $column_factory = $this->ui_factory->table()->column();
+        $icon_factory = $this->ui_factory->symbol()->icon();
+        $iconYes = $icon_factory->custom('assets/images/standard/icon_checked.svg', 'yes');
+        $iconNo = $icon_factory->custom('assets/images/standard/icon_unchecked.svg', 'no');
+        $dateFormat = $this->data_factory->dateFormat()->withTime24($this->data_factory->dateFormat()->germanShort());
+
+        $columns = [
+            'title' => $column_factory->text(
+                $this->lng->txt('tst_question_title')
+            )->withIsOptional(false, true),
+            'description' => $column_factory->text(
+                $this->lng->txt('description')
+            )->withIsOptional(true, true),
+            'type_tag' => $column_factory->text(
+                $this->lng->txt('tst_question_type')
+            )->withIsOptional(false, true),
+            'points' => $column_factory->number(
+                $this->lng->txt('points')
+            )->withIsOptional(false, true),
+            'author' => $column_factory->text(
+                $this->lng->txt('author')
+            )->withIsOptional(true, false),
+            'lifecycle' => $column_factory->text(
+                $this->lng->txt('qst_lifecycle')
+            )->withIsOptional(true, false),
+            'parent_title' => $column_factory->text(
+                $this->lng->txt($this->parent_title)
+            )->withIsOptional(false, true),
+            'taxonomies' => $column_factory->text(
+                $this->lng->txt('qpl_settings_subtab_taxonomies')
+            )->withIsOptional(false, true),
+            'feedback' => $column_factory->boolean(
+                $this->lng->txt('feedback'),
+                $iconYes,
+                $iconNo
+            )->withIsOptional(true, false),
+            'hints' => $column_factory->boolean(
+                $this->lng->txt('hints'),
+                $iconYes,
+                $iconNo
+            )->withIsOptional(true, false),
+            'created' => $column_factory->date(
+                $this->lng->txt('created'),
+                $dateFormat
+            )->withIsOptional(true, false),
+            'tstamp' => $column_factory->date(
+                $this->lng->txt('updated'),
+                $dateFormat
+            )->withIsOptional(true, false)
+        ];
+
+        return array_map(static fn(Column $column): Column => $column->withIsSortable(true), $columns);
+    }
+
+    public function getActions(): array
+    {
+        return [self::ACTION_INSERT => $this->getInsertAction()];
+    }
+
+    private function getInsertAction(): TableAction
+    {
+        $url_builder = new URLBuilder($this->data_factory->uri(
+            ServerRequest::getUriFromGlobals() . $this->ctrl->getLinkTargetByClass(
+                ilTestQuestionBrowserTableGUI::class,
+                ilTestQuestionBrowserTableGUI::CMD_INSERT_QUESTIONS
+            )
+        ));
+
+        [$url_builder, $row_id_token] = $url_builder->acquireParameters(['qlist'], 'q_id');
+
+        return $this->ui_factory->table()->action()->standard(
+            $this->lng->txt('tst_insert_in_test'),
+            $url_builder,
+            $row_id_token
+        );
+    }
+
+    public function getRows(
+        DataRowBuilder $row_builder,
+        array $visible_column_ids,
+        Range $range,
+        Order $order,
+        ?array $filter_data,
+        ?array $additional_parameters
+    ): \Generator {
+        foreach ($this->getViewControlledRecords($filter_data, $range, $order) as $record) {
+            $question_id = $record['question_id'];
+
+            $record['type_tag'] = $this->lng->txt($record['type_tag']);
+            $record['complete'] = (bool) $record['complete'];
+            $record['lifecycle'] = \ilAssQuestionLifecycle::getInstance($record['lifecycle'])->getTranslation($this->lng) ?? '';
+            $record['qpl'] = call_user_func($this->getQuestionPoolLink, $record['orig_obj_fi'] ?? null);
+
+            $record['created'] = (new \DateTimeImmutable())->setTimestamp($record['created']);
+            $record['tstamp'] = (new \DateTimeImmutable())->setTimestamp($record['tstamp']);
+            $record['taxonomies'] = $this->resolveTaxonomiesRowData($record['obj_fi'], $question_id);
+
+            yield $row_builder->buildDataRow((string) $question_id, $record);
+        }
+    }
+
+    public function getTotalRowCount(?array $filter_data, ?array $additional_parameters): int
+    {
+        return count($this->loadRecords($filter_data));
+    }
+
+    private function getViewControlledRecords(?array $filter_data, Range $range, Order $order): array
+    {
+        return $this->limitRecords($this->sortRecords($this->loadRecords($filter_data), $order), $range);
+    }
+
+    public function loadRecords(?array $filter): array
+    {
+        $filter ??= [];
+        if ($this->records !== null) {
+            return $this->records;
+        }
+
+        if ($this->testrequest->raw(ilTestQuestionBrowserTableGUI::MODE_PARAMETER) === ilTestQuestionBrowserTableGUI::MODE_BROWSE_TESTS) {
+            $this->question_list->setParentObjectType('tst');
+            $this->question_list->setQuestionInstanceTypeFilter(\ilAssQuestionList::QUESTION_INSTANCE_TYPE_ALL);
+            $this->question_list->setExcludeQuestionIdsFilter($this->test_obj->getQuestions());
+        } else {
+            $this->question_list->setParentObjIdsFilter($this->getQuestionParentObjIds(ilTestQuestionBrowserTableGUI::REPOSITORY_ROOT_NODE_ID));
+            $this->question_list->setQuestionInstanceTypeFilter(\ilAssQuestionList::QUESTION_INSTANCE_TYPE_ORIGINALS);
+            $this->question_list->setExcludeQuestionIdsFilter($this->test_obj->getExistingQuestions());
+        }
+
+        foreach (array_filter($filter) as $item => $value) {
+            switch ($item) {
+                case 'title':
+                case 'description':
+                case 'type':
+                case 'author':
+                case 'lifecycle':
+                case 'parent_title':
+                case 'taxonomy_title':
+                case 'taxonomy_node_title':
+                    if ($value !== '') {
+                        $this->question_list->addFieldFilter($item, $value);
+                    }
+                    break;
+                case 'commented':
+                    if ($value !== '') {
+                        $this->question_list->setCommentFilter((int) $value);
+                    }
+                    break;
+                case 'taxonomies':
+                    if ($value === '') {
+                        $this->question_list->addTaxonomyFilterNoTaxonomySet(true);
+                        break;
+                    }
+
+                    $tax_nodes = explode('-', $value);
+                    $this->question_list->addTaxonomyFilter(
+                        array_shift($tax_nodes),
+                        $tax_nodes,
+                        $this->test_obj->getId(),
+                        $this->test_obj->getType()
+                    );
+                    break;
+                default:
+                    $this->question_list->addFieldFilter($item, $value);
+            }
+        }
+
+        $this->question_list->load();
+        $records = $this->filterRecordsByTaxonomyOrNodeTitle(
+            $this->question_list->getQuestionDataArray(),
+            $filter['taxonomy_title'] ?? '',
+            $filter['taxonomy_node_title'] ?? ''
+        );
+
+        return $this->records = $records;
+    }
+
+    private function filterRecordsByTaxonomyOrNodeTitle(array $records, string $taxonomyTitle = '', string $taxonomyNodeTitle = ''): array
+    {
+        if (empty($taxonomyTitle) && empty($taxonomyNodeTitle)) {
+            return $records;
+        }
+
+        foreach ($records as $key => $record) {
+            $obj_fi = $record['obj_fi'];
+            $data = $this->loadTaxonomyAssignmentData($obj_fi, $key, $this->taxonomy->getUsageOfObject($obj_fi));
+            $safe = false;
+
+            foreach ($data as $taxonomyId => $taxData) {
+                $titleCheck = empty($taxonomyTitle) || is_int(mb_stripos(\ilObject::_lookupTitle($taxonomyId), $taxonomyTitle));
+
+                if ($titleCheck) {
+                    foreach ($taxData as $node) {
+                        if (empty($taxonomyNodeTitle) || is_int(mb_stripos(\ilTaxonomyNode::_lookupTitle($node['node_id']), $taxonomyNodeTitle))) {
+                            $safe = true;
+                            break 2;
+                        }
+                    }
+                }
+            }
+
+            if (!$safe) {
+                unset($records[$key]);
+            }
+        }
+
+        return $records;
+    }
+
+    private function getQuestionParentObjIds(int $repositoryRootNode): array
+    {
+        $parents = $this->tree->getSubTree(
+            $this->tree->getNodeData($repositoryRootNode),
+            true,
+            ['qpl']
+        );
+
+        $parentIds = [];
+
+        foreach ($parents as $nodeData) {
+            if ((int) $nodeData['obj_id'] === $this->test_obj->getId()) {
+                continue;
+            }
+
+            $parentIds[$nodeData['obj_id']] = $nodeData['obj_id'];
+        }
+
+        $parentIds = array_map('intval', array_values($parentIds));
+        $available_pools = array_map('intval', array_keys(\ilObjQuestionPool::_getAvailableQuestionpools(true)));
+        return array_intersect($parentIds, $available_pools);
+    }
+
+    private function resolveTaxonomiesRowData(int $obj_fi, int $questionId): string
+    {
+        $available_taxonomy_ids = $this->taxonomy->getUsageOfObject($obj_fi);
+        $data = $this->loadTaxonomyAssignmentData($obj_fi, $questionId, $available_taxonomy_ids);
+
+        $taxonomies = [];
+
+        foreach ($data as $taxonomyId => $taxData) {
+            $taxonomies[] = \ilObject::_lookupTitle($taxonomyId);
+            $taxonomies[] = $this->ui_renderer->render(
+                $this->ui_factory->listing()->unordered(
+                    array_map(static function ($node) {
+                        return \ilTaxonomyNode::_lookupTitle($node['node_id']);
+                    }, $taxData)
+                )
+            );
+        }
+
+        return implode('', $taxonomies);
+    }
+
+    private function loadTaxonomyAssignmentData(int $parentObjId, int $questionId, array $available_taxonomy_ids): array
+    {
+        $taxonomyAssignmentData = [];
+
+        foreach ($available_taxonomy_ids as $taxId) {
+            $taxTree = new \ilTaxonomyTree($taxId);
+            $assignments = (new \ilTaxNodeAssignment(
+                'qpl',
+                $parentObjId,
+                'quest',
+                $taxId
+            ))->getAssignmentsOfItem($questionId);
+
+            foreach ($assignments as $assData) {
+                $taxId = $assData['tax_id'];
+                if (!isset($taxonomyAssignmentData[$taxId])) {
+                    $taxonomyAssignmentData[$taxId] = [];
+                }
+
+                $nodeId = $assData['node_id'];
+                $assData['node_lft'] = $taxTree->getNodeData($nodeId)['lft'];
+                $taxonomyAssignmentData[$taxId][$nodeId] = $assData;
+            }
+        }
+
+        return $taxonomyAssignmentData;
+    }
+
+    private function sortRecords(array $records, Order $order): array
+    {
+        [$order_field, $order_direction] = $order->join(
+            '',
+            fn(string $index, string $key, string $value): array => [$key, $value]
+        );
+
+        usort($records, static function (array $a, array $b) use ($order_field): int {
+            if (is_numeric($a[$order_field]) || is_bool($a[$order_field]) || is_array($a[$order_field])) {
+                return $a[$order_field] <=> $b[$order_field];
+            }
+
+            return strcmp($a[$order_field] ?? '', $b[$order_field] ?? '');
+        });
+
+        return $order_direction === $order::DESC ? array_reverse($records) : $records;
+    }
+
+    private function limitRecords(array $records, Range $range): array
+    {
+        return \array_slice($records, $range->getStart(), $range->getLength());
+    }
+}

--- a/components/ILIAS/Test/tests/tables/ilTestQuestionBrowserTableGUITest.php
+++ b/components/ILIAS/Test/tests/tables/ilTestQuestionBrowserTableGUITest.php
@@ -82,21 +82,19 @@ class ilTestQuestionBrowserTableGUITest extends ilTestBaseTestCase
             $this->createMock(ILIAS\UI\Factory::class),
             $this->createMock(ILIAS\UI\Renderer::class),
             $this->createMock(ILIAS\Test\RequestDataCollector::class),
-            $this->createMock(ILIAS\Test\Utilities\TitleColumnsBuilder::class),
-            $this->createMock(ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository::class)
+            $this->createMock(ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository::class),
+            $lng_mock,
+            $ctrl_mock,
+            $mainTpl_mock,
+            $this->createMock(ilUIService::class),
+            $this->createMock(ILIAS\Data\Factory::class),
+            $this->createMock(ILIAS\Taxonomy\DomainService::class),
+            fn(int $questionPoolId) => 'testLink'
         );
     }
 
     public function test_instantiateObject_shouldReturnInstance(): void
     {
         $this->assertInstanceOf(ilTestQuestionBrowserTableGUI::class, $this->tableGui);
-    }
-
-    public function testWriteAccess(): void
-    {
-        $this->tableGui->setWriteAccess(false);
-        $this->assertFalse($this->tableGui->hasWriteAccess());
-        $this->tableGui->setWriteAccess(true);
-        $this->assertTrue($this->tableGui->hasWriteAccess());
     }
 }

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
@@ -1769,7 +1769,7 @@ abstract class assQuestion implements Question
         $ilDB = $DIC['ilDB'];
         $lng = $DIC['lng'];
         $questionrepository = QuestionPoolDIC::dic()['question.general_properties.repository'];
-        $question_type = $questionrepository->getForQuestionId($question_id)->getClassName();
+        $question_type = $questionrepository->getForQuestionId($question_id)?->getClassName() ?? '';
         if ($question_type === '') {
             throw new InvalidArgumentException('No question with ID ' . $question_id . ' exists');
         }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -598,6 +598,7 @@ assessment#:#correct_answers#:#Richtige Antworten
 assessment#:#counter#:#Zähler
 assessment#:#create_gaps#:#Lücken erzeugen und aktualisieren
 assessment#:#create_new#:#Erstelle neue
+assessment#:#created#:#Erstellt
 assessment#:#customstyle#:#Eigenes Stylesheet
 assessment#:#dashboard_tab#:#Teilnehmer
 assessment#:#date_time#:#Datum und Uhrzeit
@@ -1269,6 +1270,8 @@ assessment#:#ta_resulttable_vc_mode_aria#:#Anzeigeoptionen für Fragen
 assessment#:#tab_nest_answers#:#Einrückung
 assessment#:#tax_filter#:#Taxonomie
 assessment#:#tax_filter_notax#:#Fragen ohne zugeordnete Taxonomie
+assessment#:#taxonomy_node_title#:#Taxonomie Knoten Titel
+assessment#:#taxonomy_title#:#Taxonomie Titel
 assessment#:#term#:#Term
 assessment#:#term_image#:#Bild
 assessment#:#term_text#:#Text
@@ -1293,6 +1296,7 @@ assessment#:#test_question_set_type_random_info#:#Jedem Teilnehmenden werden unt
 assessment#:#test_results#:#Bekanntgabe des Testergebnisses
 assessment#:#test_scoring#:#Bewertung des Tests
 assessment#:#test_template_reset#:#Die Vorlage wurde entfernt.
+assessment#:#test_title#:#Test Titel
 assessment#:#test_using_template#:#Dieser Test verwendet die Vorlage %s. Wenn Sie keine Vorlage und alle Einstellungen verwenden wollen, klicken Sie bitte hier: %s.
 assessment#:#test_using_template_link#:#Vorlage nicht mehr verwenden
 assessment#:#text_correct#:#Korrekter Text
@@ -2038,6 +2042,8 @@ assessment#:#unit_placeholder#:#** Neue Einheit **
 assessment#:#units#:#Einheiten
 assessment#:#unlimited#:#unbegrenzt
 assessment#:#unlock#:#Entsperren
+assessment#:#updated#:#Aktualisiert
+assessment#:#updated#:#Aktualisiert
 assessment#:#uploaded_material#:#Hochgeladene Materialien
 assessment#:#use_previous_solution#:#Verwende vorherige Lösung
 assessment#:#use_previous_solution_advice#:#Die angezeigte Lösung wurde vormals von Ihnen abgegeben. Sie müssen die Übernahme dieser Lösung unterhalb der Frage bestätigen, falls Sie die Lösung ohne Änderungen übernehmen wollen.

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2043,7 +2043,6 @@ assessment#:#units#:#Einheiten
 assessment#:#unlimited#:#unbegrenzt
 assessment#:#unlock#:#Entsperren
 assessment#:#updated#:#Aktualisiert
-assessment#:#updated#:#Aktualisiert
 assessment#:#uploaded_material#:#Hochgeladene Materialien
 assessment#:#use_previous_solution#:#Verwende vorherige Lösung
 assessment#:#use_previous_solution_advice#:#Die angezeigte Lösung wurde vormals von Ihnen abgegeben. Sie müssen die Übernahme dieser Lösung unterhalb der Frage bestätigen, falls Sie die Lösung ohne Änderungen übernehmen wollen.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -598,6 +598,7 @@ assessment#:#correct_answers#:#Correct Answers
 assessment#:#counter#:#Counter
 assessment#:#create_gaps#:#Create and Refresh Gaps
 assessment#:#create_new#:#Create New
+assessment#:#created#:#Created
 assessment#:#customstyle#:#Custom Style
 assessment#:#dashboard_tab#:#Participants
 assessment#:#date_time#:#Date and Time
@@ -1269,6 +1270,8 @@ assessment#:#ta_resulttable_vc_mode_aria#:#switch question mode
 assessment#:#tab_nest_answers#:#Nesting
 assessment#:#tax_filter#:#Taxonomy
 assessment#:#tax_filter_notax#:#Questions without assigned Taxonomy
+assessment#:#taxonomy_node_title#:#Taxonomy Node Title
+assessment#:#taxonomy_title#:#Taxonomy Title
 assessment#:#term#:#Term
 assessment#:#term_image#:#Term Image
 assessment#:#term_text#:#Term Text
@@ -1293,6 +1296,7 @@ assessment#:#test_question_set_type_random_info#:#Each test participant will see
 assessment#:#test_results#:#Summary Test Results
 assessment#:#test_scoring#:#Scoring Options
 assessment#:#test_template_reset#:#The template has been removed.
+assessment#:#test_title#:#Test Title
 assessment#:#test_using_template#:#This test uses the template %s. If you do not want to use a template and have access to all settings, please click here: %s.
 assessment#:#test_using_template_link#:#Do not use template anymore
 assessment#:#text_correct#:#Correct Text
@@ -1544,6 +1548,7 @@ assessment#:#tst_input_dynamic_question_set_question_ordering_by_date#:#Order Qu
 assessment#:#tst_input_dynamic_question_set_question_ordering_by_tax#:#Order Questions by Taxonomy
 assessment#:#tst_input_dynamic_question_set_source_questionpool#:#Source Question Pool
 assessment#:#tst_input_dynamic_question_set_taxonomie_filter_enabled#:#Provide Taxonomy Filter
+assessment#:#tst_insert_in_test#:#Insert in Test
 assessment#:#tst_insert_missing_question#:#Please select at least one question to insert it into the test!
 assessment#:#tst_insert_questions#:#Are you sure you want to insert the following question(s) to the test?
 assessment#:#tst_instant_feedback#:#Instant Feedback
@@ -2038,6 +2043,7 @@ assessment#:#unit_placeholder#:#** New Unit **
 assessment#:#units#:#Units
 assessment#:#unlimited#:#unlimited
 assessment#:#unlock#:#Unlock
+assessment#:#updated#:#Updated
 assessment#:#uploaded_material#:#Uploaded Material
 assessment#:#use_previous_solution#:#Use Previous Solution
 assessment#:#use_previous_solution_advice#:#The shown solution for the question is your previously given one. You have to confirm the adoption of the solution, if you like to use it without any change.


### PR DESCRIPTION
This is the implentation of the Feature Wiki entry [New taxonomy filters to use taxonomies in the question selection for fixed tests](https://docu.ilias.de/go/wiki/wpage_8158_1357).

I believe all the requested features are implemented according to the Request.

PR 2!