### PR TITLE
[FEATURE] ILIASObject: remove `ilProgressBar` usage

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectCopyGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectCopyGUI.php
@@ -27,8 +27,10 @@ use ILIAS\Style\Content\Container\ContainerDBRepository;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Renderer as UIRenderer;
+use ILIAS\Data\Factory as DataFactory;
 use ILIAS\UI\Component\Input\Container\Form\Standard;
 use ILIAS\Object\ImplementsCreationCallback;
+use ILIAS\HTTP\GlobalHttpState;
 
 /**
  * GUI class for the workflow of copying objects
@@ -73,6 +75,7 @@ class ilObjectCopyGUI
     protected ServerRequestInterface $request;
     protected UIFactory $ui_factory;
     protected UIRenderer $ui_renderer;
+    protected GlobalHttpState $http;
 
     protected ContainerDBRepository $container_repo;
 
@@ -112,6 +115,7 @@ class ilObjectCopyGUI
         $this->ui_factory = $DIC['ui.factory'];
         $this->ui_renderer = $DIC['ui.renderer'];
         $this->retriever = new ilObjectRequestRetriever($DIC->http()->wrapper(), $this->refinery);
+        $this->http = $DIC->http();
 
         $this->container_repo = new ContainerDBRepository($DIC['ilDB']);
 
@@ -1007,6 +1011,9 @@ class ilObjectCopyGUI
         );
 
         $progress = new ilObjectCopyProgressTableGUI(
+            new DataFactory(),
+            $this->ui_renderer,
+            $this->ui_factory,
             $this,
             'showCopyProgress',
             $ref_id
@@ -1022,34 +1029,31 @@ class ilObjectCopyGUI
 
     protected function updateProgress(): void
     {
-        $json = new stdClass();
-        $json->percentage = null;
-        $json->performed_steps = null;
-
+        $max_steps = $this->retriever->getMaybeInt('_max_steps');
         $copy_id = $this->retriever->getMaybeInt('_copy_id');
         $options = ilCopyWizardOptions::_getInstance($copy_id);
-        $node = $options->fetchFirstNode();
-        $json->current_node_id = 0;
-        $json->current_node_title = "";
-        $json->in_dependencies = false;
-        if (is_array($node)) {
-            $json->current_node_id = $node['obj_id'];
-            $json->current_node_title = $node['title'];
+        $required_steps = $options->getRequiredSteps();
+
+        if ($required_steps === 0) {
+            $state = $this->ui_factory->progress()->state()->bar()->success($this->lng->txt('obj_copy_progress_success'));
+            $this->log->debug('Update copy progress: 100%');
         } else {
-            $node = $options->fetchFirstDependenciesNode();
-            if (is_array($node)) {
-                $json->current_node_id = $node['obj_id'];
-                $json->current_node_title = $node['title'];
-                $json->in_dependencies = true;
-            }
+            $completed_steps = $max_steps - $required_steps;
+            $percentage = floor(($completed_steps / $max_steps) * 100);
+            $percentage = (int) min($percentage, 99); // cap value to 99
+            $state = $this->ui_factory->progress()->state()->bar()->determinate($percentage);
+            $this->log->debug("Update copy progress: $percentage%");
         }
-        $json->required_steps = $options->getRequiredSteps();
-        $json->id = $copy_id;
 
-        $this->log->debug('Update copy progress: ' . json_encode($json));
+        $html = $this->ui_renderer->renderAsync($state);
 
-        echo json_encode($json);
-        exit;
+        $this->http->saveResponse(
+            $this->http->response()
+                       ->withHeader('Content-Type', 'text/html; charset=utf-8')
+                       ->withBody(\ILIAS\Filesystem\Stream\Streams::ofString($html))
+        );
+        $this->http->sendResponse();
+        $this->http->close();
     }
 
     protected function copyContainer(int $target_ref_id): array

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectCopyProgressTableGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectCopyProgressTableGUI.php
@@ -18,6 +18,10 @@
 
 declare(strict_types=1);
 
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\UI\Renderer as UIRenderer;
+use ILIAS\UI\Factory as UIFactory;
+
 /**
  * Table gui for copy progress
  *
@@ -27,8 +31,14 @@ class ilObjectCopyProgressTableGUI extends ilTable2GUI
 {
     protected array $objects = [];
 
-    public function __construct(ilObjectCopyGUI $parent_obj, string $parent_cmd, int $id)
-    {
+    public function __construct(
+        protected DataFactory $data_factory,
+        protected UIRenderer $ui_renderer,
+        protected UIFactory $ui_factory,
+        ilObjectCopyGUI $parent_obj,
+        string $parent_cmd,
+        int $id,
+    ) {
         $this->setId('obj_cp_prog_tbl_' . $id);
         parent::__construct($parent_obj, $parent_cmd);
     }
@@ -73,16 +83,11 @@ class ilObjectCopyProgressTableGUI extends ilTable2GUI
         $this->tpl->setVariable('TYPE_IMG', ilObject::_getIcon($set['obj_id'], "small", $set['type']));
         $this->tpl->setVariable('TYPE_STR', $this->lng->txt('obj_' . $set['type']));
 
-        $progress = ilProgressBar::getInstance();
-        $progress->setType(ilProgressBar::TYPE_SUCCESS);
-        $progress->setMin(0);
-        $progress->setMax($set['max_steps']);
-        $progress->setCurrent(0);
-        $progress->setAnimated(true);
-        $progress->setId((string) $set['copy_id']);
-
         $this->ctrl->setParameter($this->getParentObject(), '_copy_id', $set['copy_id']);
-        $progress->setAsyncStatusUrl(
+        $this->ctrl->setParameter($this->getParentObject(), '_max_steps', $set['max_steps']);
+
+        $progress_endpoint = $this->data_factory->uri(
+            ILIAS_HTTP_PATH . '/' .
             $this->ctrl->getLinkTarget(
                 $this->getParentObject(),
                 'updateProgress',
@@ -91,8 +96,20 @@ class ilObjectCopyProgressTableGUI extends ilTable2GUI
             )
         );
 
-        $progress->setAsynStatusTimeout(1);
-        $this->tpl->setVariable('PROGRESS_BAR', $progress->render());
+        $progress_bar = $this->ui_factory->progress()->bar(
+            sprintf($this->lng->txt('obj_copy_progress_to'), $set['title']),
+            $progress_endpoint,
+        );
+
+        $this->tpl->setVariable('PROGRESS_BAR', $this->ui_renderer->render($progress_bar));
+
+        // start pulling progress from $progress_endpoint once the page has loaded
+        $this->main_tpl->addOnLoadCode("
+            il.UI.Progress.Bar.indeterminate(
+                '{$progress_bar->getUpdateSignal()}',
+                '{$this->lng->txt('obj_copy_progress_estimate')}'
+            );
+        ");
     }
 
     public function parse(): void

--- a/components/ILIAS/ILIASObject/resources/ilCopyRedirection.js
+++ b/components/ILIAS/ILIASObject/resources/ilCopyRedirection.js
@@ -1,30 +1,41 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ */
+
 il.CopyRedirection = {
-	
-	url: "",
-	
-	setRedirectUrl: function(url) {
-		il.CopyRedirection.url = url;
-	},
-	checkDone: function() {
-		
-		var done = setInterval(function() {
-			
-			var completed = $('span[id^="progress_done_"]');
-			var allCompleted = true;
-			
-			for(i=0;i<completed.length;i++) {
-				if($('#' + completed[i].id).is(":visible") == false) {
-					allCompleted = false;
-				}
-				console.log(completed[i].id);
-			}
-			if(allCompleted == true && (completed.length > 0)) {
-				clearInterval(done);
-				setTimeout(function() {
-					$(location).attr('href', il.CopyRedirection.url);
-				},3000);
-			}
-			
-		},1000);
-	}
-}
+  url: '',
+
+  setRedirectUrl(url) {
+    il.CopyRedirection.url = url;
+  },
+
+  checkDone() {
+    const interval = setInterval(() => {
+      const progressBars = document.querySelectorAll('progress');
+      let allCompleted = true;
+
+      progressBars.forEach((progress) => {
+        allCompleted = allCompleted && (progress.value === progress.max);
+      });
+
+      if (allCompleted && progressBars.length > 0) {
+        clearInterval(interval);
+        setTimeout(() => {
+          window.location.href = il.CopyRedirection.url;
+        }, 3000);
+      }
+    }, 1000);
+  },
+};

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -12974,6 +12974,10 @@ obj#:#obj_base_lang#:#Basissprache
 obj#:#obj_conf_delete_lang#:#Wollen Sie die Anzeige von Titel und Beschreibung für diese Sprachen wirklich beenden?
 obj#:#obj_cont_transl_deactivated#:#Die Unterstützung für mehrsprachige Inhalte wurde deaktiviert.
 obj#:#obj_copy_progress#:#Fortschritt des Kopierens
+obj#:#obj_copy_progress_estimate#:#Dauer wird geschätzt...
+obj#:#obj_copy_progress_failure#:#Kopieren fehlgeschlagen.
+obj#:#obj_copy_progress_success#:#Erfolgreich kopiert.
+obj#:#obj_copy_progress_to#:#Kopieren nach %s
 obj#:#obj_deactivate_content_lang#:#Mehrsprachigkeit für die Bearbeitung deaktivieren
 obj#:#obj_deactivate_content_transl_conf#:# Wollen Sie die Unterstützung für mehrsprachige Inhalte im Seiteneditor wirklich deaktivieren? Nur die Inhalte der Standardsprache bleiben verfügbar.
 obj#:#obj_deactivate_multilang#:#Mehrsprachigkeit deaktivieren

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -12978,6 +12978,10 @@ obj#:#obj_base_lang#:#Master Language
 obj#:#obj_conf_delete_lang#:#Do you really want to stop the presentation of title and description in these languages?
 obj#:#obj_cont_transl_deactivated#:#Translation for page editing has been deactivated.
 obj#:#obj_copy_progress#:#Copy Progress
+obj#:#obj_copy_progress_estimate#:#Estimating duration...
+obj#:#obj_copy_progress_failure#:#Copying failed.
+obj#:#obj_copy_progress_success#:#Copied successfully.
+obj#:#obj_copy_progress_to#:#Copying to %s
 obj#:#obj_deactivate_content_lang#:#Deactivate Translation for Page Editing
 obj#:#obj_deactivate_content_transl_conf#:#Do you really want to deactivate translation for page editing? Only contents of the base language will be kept.
 obj#:#obj_deactivate_multilang#:#Deactivate Multilingualism


### PR DESCRIPTION
Hi @kergomard,

I have replaced the legacy `ilProgressBar` usage as fast and good as I could. I am not quite sure, if this code is actually reachable, because when copying multiple (nested) objects, the page simply loads without ever showing the `ilObjectCopyProgressTableGUI` table. Maybe you can try this out yourself?

Also note, I have replaced the legacy usage as is. I believe we should not render multiple progress bars on this page in the future, but instead use one progress bar to cover the progress of _all objects being copied_. I also needed to provide the `_max_steps` as an URL parameter, because there is (currently) no way to ping-pong the max-value of the progress bar.

Further note, this PR contains an additional commit which needs to be merged first. see #8268

Kind regards,
@thibsy 