### PR TITLE
T&A: Participant Table Revision Adjustments

### DIFF
--- a/components/ILIAS/Test/src/Participants/ParticipantRepository.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantRepository.php
@@ -22,7 +22,6 @@ namespace ILIAS\Test\Participants;
 
 use ILIAS\Data\Order;
 use ILIAS\Data\Range;
-use ILIAS\Test\Results\Data\StatusOfAttempt;
 
 class ParticipantRepository
 {
@@ -171,6 +170,18 @@ class ParticipantRepository
     {
         $this->database->manipulate(
             "DELETE FROM tst_invited_user WHERE test_fi = {$selected_participants[0]->getTestId()} AND "
+                . $this->database->in(
+                    'user_fi',
+                    array_map(
+                        fn(Participant $participant): int => $participant->getUserId(),
+                        $selected_participants
+                    ),
+                    false,
+                    \ilDBConstants::T_INTEGER
+                )
+        );
+        $this->database->manipulate(
+            "DELETE FROM tst_addtime WHERE test_fi = {$selected_participants[0]->getTestId()} AND "
                 . $this->database->in(
                     'user_fi',
                     array_map(

--- a/components/ILIAS/Test/src/Participants/ParticipantTableActions.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableActions.php
@@ -140,10 +140,13 @@ class ParticipantTableActions
         );
 
         if ($selected_participants === []) {
+            $error_message = method_exists($action, 'getSelectionErrorMessage')
+                ? $action->getSelectionErrorMessage()
+                : $this->lng->txt('no_valid_participant_selection');
             $this->test_response->sendAsync(
                 $this->ui_renderer->renderAsync(
                     $this->ui_factory->messageBox()->failure(
-                        $this->lng->txt('no_valid_participant_selection')
+                        $error_message
                     )
                 )
             );

--- a/components/ILIAS/Test/src/Participants/ParticipantTableActions.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableActions.php
@@ -140,9 +140,7 @@ class ParticipantTableActions
         );
 
         if ($selected_participants === []) {
-            $error_message = method_exists($action, 'getSelectionErrorMessage')
-                ? $action->getSelectionErrorMessage()
-                : $this->lng->txt('no_valid_participant_selection');
+            $error_message = $action->getSelectionErrorMessage() ?? $this->lng->txt('no_valid_participant_selection');
             $this->test_response->sendAsync(
                 $this->ui_renderer->renderAsync(
                     $this->ui_factory->messageBox()->failure(

--- a/components/ILIAS/Test/src/Participants/ParticipantTableDeleteParticipantAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableDeleteParticipantAction.php
@@ -118,4 +118,9 @@ class ParticipantTableDeleteParticipantAction implements TableAction
     {
         return $record->getActiveId() === null;
     }
+
+    public function getSelectionErrorMessage(): string
+    {
+        return $this->lng->txt('delete_participants_no_valid_participants_selected');
+    }
 }

--- a/components/ILIAS/Test/src/Participants/ParticipantTableDeleteParticipantAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableDeleteParticipantAction.php
@@ -119,7 +119,7 @@ class ParticipantTableDeleteParticipantAction implements TableAction
         return $record->getActiveId() === null;
     }
 
-    public function getSelectionErrorMessage(): string
+    public function getSelectionErrorMessage(): ?string
     {
         return $this->lng->txt('delete_participants_no_valid_participants_selected');
     }

--- a/components/ILIAS/Test/src/Participants/ParticipantTableDeleteResultsAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableDeleteResultsAction.php
@@ -140,4 +140,9 @@ class ParticipantTableDeleteResultsAction implements TableAction
 
         return $this->lng->txt('delete_selected_user_data_confirmation');
     }
+
+    public function getSelectionErrorMessage(): string
+    {
+        return $this->lng->txt('delete_result_no_valid_participants_selected');
+    }
 }

--- a/components/ILIAS/Test/src/Participants/ParticipantTableDeleteResultsAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableDeleteResultsAction.php
@@ -141,7 +141,7 @@ class ParticipantTableDeleteResultsAction implements TableAction
         return $this->lng->txt('delete_selected_user_data_confirmation');
     }
 
-    public function getSelectionErrorMessage(): string
+    public function getSelectionErrorMessage(): ?string
     {
         return $this->lng->txt('delete_result_no_valid_participants_selected');
     }

--- a/components/ILIAS/Test/src/Participants/ParticipantTableExtraTimeAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableExtraTimeAction.php
@@ -203,4 +203,9 @@ class ParticipantTableExtraTimeAction implements TableAction
             );
         }
     }
+
+    public function getSelectionErrorMessage(): ?string
+    {
+        return null;
+    }
 }

--- a/components/ILIAS/Test/src/Participants/ParticipantTableFinishTestAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableFinishTestAction.php
@@ -178,4 +178,9 @@ class ParticipantTableFinishTestAction implements TableAction
 
         return $this->lng->txt('finish_test_multiple');
     }
+
+    public function getSelectionErrorMessage(): string
+    {
+        return $this->lng->txt('finish_test_no_valid_participants_selected');
+    }
 }

--- a/components/ILIAS/Test/src/Participants/ParticipantTableFinishTestAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableFinishTestAction.php
@@ -179,7 +179,7 @@ class ParticipantTableFinishTestAction implements TableAction
         return $this->lng->txt('finish_test_multiple');
     }
 
-    public function getSelectionErrorMessage(): string
+    public function getSelectionErrorMessage(): ?string
     {
         return $this->lng->txt('finish_test_no_valid_participants_selected');
     }

--- a/components/ILIAS/Test/src/Participants/ParticipantTableIpRangeAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableIpRangeAction.php
@@ -227,4 +227,9 @@ class ParticipantTableIpRangeAction implements TableAction
         }
         return false;
     }
+
+    public function getSelectionErrorMessage(): ?string
+    {
+        return null;
+    }
 }

--- a/components/ILIAS/Test/src/Participants/ParticipantTableIpRangeAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableIpRangeAction.php
@@ -29,10 +29,6 @@ use ILIAS\UI\URLBuilderToken;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\Refinery\Factory as Refinery;
 
-use function array_map;
-use function array_unique;
-use function count;
-
 class ParticipantTableIpRangeAction implements TableAction
 {
     public const ACTION_ID = 'client_ip_range';
@@ -82,6 +78,30 @@ class ParticipantTableIpRangeAction implements TableAction
                 || filter_var($ip, FILTER_VALIDATE_IP) !== false,
             $this->lng->txt('invalid_ip')
         );
+        $validate_order = $this->refinery->custom()->constraint(
+            function (?array $vs): bool {
+                if ($vs === null) {
+                    return true;
+                }
+                return $this->checkIpRangeValidity(
+                    $vs['from'],
+                    $vs['to']
+                );
+            },
+            sprintf($this->lng->txt('not_greater_than'), $this->lng->txt('max_ip_label'), $this->lng->txt('min_ip_label'))
+        );
+        $ip_range_group_trafo = $this->refinery->custom()->transformation(
+            static function (?array $vs): array {
+                if ($vs === null) {
+                    $vs = [
+                        'from' => null,
+                        'to' => null
+                    ];
+                }
+                return $vs;
+            }
+        );
+
 
         $participant_rows = array_map(
             fn(Participant $participant) => sprintf(
@@ -91,8 +111,6 @@ class ParticipantTableIpRangeAction implements TableAction
             ),
             $selected_participants
         );
-
-        $is_unique_ip_range = $this->isUniqueClientIp($selected_participants);
 
         return $this->ui_factory->modal()->roundtrip(
             $this->lng->txt('client_ip_range'),
@@ -111,22 +129,21 @@ class ParticipantTableIpRangeAction implements TableAction
                 'ip_range' => $this->ui_factory->input()->field()->group([
                     'from' => $this->ui_factory->input()->field()->text(
                         $this->lng->txt('min_ip_label')
-                    )->withAdditionalTransformation($valid_ip_constraint)
-                        ->withValue(
-                            $is_unique_ip_range ?
-                            $selected_participants[0]->getClientIpFrom() ?? '' :
-                            ''
-                        ),
+                    )->withAdditionalTransformation($valid_ip_constraint),
                     'to' => $this->ui_factory->input()->field()->text(
                         $this->lng->txt('max_ip_label'),
                         $this->lng->txt('ip_range_byline')
-                    )->withAdditionalTransformation($valid_ip_constraint)
-                        ->withValue(
-                            $is_unique_ip_range ?
-                            $selected_participants[0]->getClientIpTo() ?? '' :
-                            ''
-                        ),
-                ])
+                    )->withAdditionalTransformation($valid_ip_constraint),
+                ])->withValue(
+                    $this->isUniqueClientIp($selected_participants) ?
+                        [
+                            'from' => $selected_participants[0]->getClientIpFrom() ?? '',
+                            'to' => $selected_participants[0]->getClientIpTo() ?? ''
+                        ] :
+                        null
+                )
+                    ->withAdditionalTransformation($ip_range_group_trafo)
+                    ->withAdditionalTransformation($validate_order)
             ],
             $url_builder->buildURI()->__toString()
         )->withSubmitLabel($this->lng->txt('change'));
@@ -195,5 +212,19 @@ class ParticipantTableIpRangeAction implements TableAction
                 fn(Participant $participant) => $participant->getClientIpFrom() . '-' . $participant->getClientIpTo(),
                 $selected_participants
             ))) === 1;
+    }
+
+    private function checkIpRangeValidity(string $start, string $end): bool
+    {
+        if (filter_var($start, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false
+            && filter_var($end, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            return ip2long($start) <= ip2long($end);
+        }
+
+        if (filter_var($start, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false
+            && filter_var($end, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            return bin2hex(inet_pton($start)) <= bin2hex(inet_pton($end));
+        }
+        return false;
     }
 }

--- a/components/ILIAS/Test/src/Participants/ParticipantTableShowResultsAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableShowResultsAction.php
@@ -120,4 +120,9 @@ class ParticipantTableShowResultsAction implements TableAction
             $this->test_obj->getTestId()
         );
     }
+
+    public function getSelectionErrorMessage(): ?string
+    {
+        return null;
+    }
 }

--- a/components/ILIAS/Test/src/Participants/TableAction.php
+++ b/components/ILIAS/Test/src/Participants/TableAction.php
@@ -54,4 +54,5 @@ interface TableAction
         bool $all_participants_selected
     ): ?Modal;
     public function allowActionForRecord(Participant $record): bool;
+    public function getSelectionErrorMessage(): ?string;
 }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -573,7 +573,7 @@ assessment#:#checkbox_unchecked#:#Nicht ausgewählt
 assessment#:#circle#:#Kreis
 assessment#:#circle_click_center#:#Bitte klicken Sie auf den Mittelpunkt der gewünschten Region
 assessment#:#circle_click_circle#:#Bitte klicken Sie auf einen Punkt auf dem Umkreis der gewünschten Region
-assessment#:#client_ip_range#:#Client IP Range
+assessment#:#client_ip_range#:#Client IP Bereich
 assessment#:#clientip#:#Client IP
 assessment#:#close_text_hint#:#Um eine Lücke in den Text einzufügen, setzen Sie den Cursor an die entsprechende Position und nutzen Sie die Schaltfläche "Textlücke". Anschließend stehen weiter unten entsprechende Bearbeitungsbereiche zur Verfügung. Ebenso können Sie die Lücken zur Bearbeitung im Lückentext direkt anklicken.
 assessment#:#cloze_answer_text_info#:#Vorangestellte oder nachfolgende Leerzeichen werden beim Speichern aus der Antwort gelöscht.
@@ -610,6 +610,8 @@ assessment#:#deleteSuggestedSolution#:#Inhalte zur Wiederholung entfernen
 assessment#:#delete_all_user_data_confirmation#:#Wollen Sie wirklich die Testergebnisse aller Teilnehmer löschen?
 assessment#:#delete_image_header#:#Bild entfernen
 assessment#:#delete_image_question#:#Möchten Sie das Bild wirklich entfernen?
+assessment#:#delete_participant_no_valid_participants_selected#:#Für die gewählten Teilnehmer liegen bereits Testergebnisse vor und können deshalb nicht entfernt werden.
+assessment#:#delete_result_no_valid_participants_selected#:#Für die gewählten Teilnehmer liegen keine Testergebnisse vor und können deshalb nicht entfernt werden.
 assessment#:#delete_selected_user_data_confirmation#:#Sind Sie sicher, dass Sie alle Testdaten der ausgewählten Teilnehmenden entfernen wollen?
 assessment#:#delete_user_data#:#Testergebnisse entfernen
 assessment#:#description_maxchars#:#Wenn nichts eingegeben wird, ist die maximale Anzahl von Zeichen für diese Textantwort unbegrenzt.
@@ -744,6 +746,7 @@ assessment#:#finish_pass_for_user_in_processing_time#:#WARNUNG: die Bearbeitungs
 assessment#:#finish_test#:#Test beenden
 assessment#:#finish_test_all#:#Sind Sie sicher, dass die den Testdurchlauf für alle Teilnehmer beenden möchten?
 assessment#:#finish_test_multiple#:#Sind Sie sicher, dass Sie den Testdurchlauf für folgende Teilnehmer beenden möchten?
+assessment#:#finish_test_no_valid_participants_selected#:#Für die gewählten Teilnehmer gibt es keine aktiven Testdurchläufe und können daher nicht beendet werden.
 assessment#:#finish_test_single#:#Sind Sie sicher, dass Sie den Testdurchlauf für den Teilnehmer "%s" beenden möchten?
 assessment#:#finish_unfinished_passes#:#Beendet noch offene Testdurchläufe
 assessment#:#finish_unfinished_passes_desc#:#Noch nicht beendete Testdurchläufe werden automatisch beendet – vorausgesetzt, es wurde für diese Tests ein Endzeitpunkt festgelegt oder Teilnehmende haben die maximale Bearbeitungsdauer überschritten.
@@ -788,10 +791,10 @@ assessment#:#internal_links#:#Interne Verweise
 assessment#:#intprecision#:#Teilbar durch
 assessment#:#intprecision_info#:#"Teilbar durch" hat nur Auswirkungen auf die Variablenerzeugung, wenn der Wert für die Präzision 0 beträgt. In diesem Fall legt "Teilbar durch" fest, durch welche ganze Zahl die erzeugte Variable teilbar sein muss. Ein Wert von 10 erzeugt also nur ganze Zahlen, die durch 10 teilbar sind, ein Wert von 5 erzeugt ganze Zahlen, die durch 5 teilbar sind usw. Bei einer Präzision von 0 ist "Teilbar durch" ein Pflichtfeld und muss eine positive, ganze Zahl enthalten. Voreingestellt ist der Wert 1 für beliebige ganze Zahlen.
 assessment#:#invalid_ip#:#Ungültige IP
-assessment#:#ip_range_byline#:#Nur IP Adressen die innerhalb der IP Range liegen, können den Test starten. Sie können entweder IPv4 ODER IPv6 verwenden.
-assessment#:#ip_range_for_all_participants#:#Sie bearbeiten die IP Range für alle Teilnehmer.
-assessment#:#ip_range_for_selected_participants#:#Sie bearbeiten die IP Range für die folgende Teilnehmer:
-assessment#:#ip_range_for_single_participant#:#Sie bearbeiten die IP Range für folgenden Teilnehmer:
+assessment#:#ip_range_byline#:#Nur IP Adressen die innerhalb der IP Bereich liegen, können den Test starten. Sie können entweder IPv4 ODER IPv6 verwenden.
+assessment#:#ip_range_for_all_participants#:#Sie bearbeiten die IP Bereich für alle Teilnehmer.
+assessment#:#ip_range_for_selected_participants#:#Sie bearbeiten die IP Bereich für die folgende Teilnehmer:
+assessment#:#ip_range_for_single_participant#:#Sie bearbeiten die IP Bereich für folgenden Teilnehmer:
 assessment#:#ip_range_info#:#Nur Geräte mit einer IP aus der festgelegten Spanne können den Test starten.
 assessment#:#ip_range_label#:#Beschränkung auf IPs
 assessment#:#ip_range_updated#:#Die IP-Rang wurde für die gewählten Teilnehmer aktualisiert.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -610,6 +610,8 @@ assessment#:#deleteSuggestedSolution#:#Remove this content for recapitulation
 assessment#:#delete_all_user_data_confirmation#:#Are you sure you want to delete the test results of all of the participants of this test?
 assessment#:#delete_image_header#:#Remove image
 assessment#:#delete_image_question#:#Do you really want to remove the image?
+assessment#:#delete_participant_no_valid_participants_selected#:#Test results already exist for the selected participants, so they cannot be removed.
+assessment#:#delete_result_no_valid_participants_selected#:#There are no test results for the selected participants, so they cannot be removed.
 assessment#:#delete_selected_user_data_confirmation#:#Are you sure you want to remove the test data of the selected users?
 assessment#:#delete_user_data#:#Remove Result(s)
 assessment#:#description_maxchars#:#If nothing entered the maximum number of characters for this text answer is unlimited.
@@ -744,6 +746,7 @@ assessment#:#finish_pass_for_user_in_processing_time#:#WARNING: the processing t
 assessment#:#finish_test#:#Finish Test
 assessment#:#finish_test_all#:#Are you sure you want to finish the test attempts for all users?
 assessment#:#finish_test_multiple#:#Are you sure you want to finish the test attempts for the following participants?
+assessment#:#finish_test_no_valid_participants_selected#:#There are no active test runs for the selected participants, so they cannot be completed.
 assessment#:#finish_test_single#:#Are you sure you want to finish the test attempt for the participant "%s"?
 assessment#:#finish_unfinished_passes#:#Finish Uncompleted Attempts
 assessment#:#finish_unfinished_passes_desc#:#Test attempts which have a set finishing time or a time limit will be closed by this cron job.


### PR DESCRIPTION
This PR introduces the following updates:

- **Client-IP Range Validation**: Ensures that the lower IP is less than or equal to the higher IP in the range.
- **German Translation Update**: Adjusts the translation for "Client-IP-Range."
- **Error Message Improvements**: Clarifies error messages for invalid participant selection on actions such as "Finish Test Attempt," "Delete Participant," and "Delete Results."
