### PR TITLE
Auth/OpenIDConnect: Use `id_token` for claims

### DIFF
--- a/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
+++ b/Services/OpenIdConnect/classes/class.ilAuthProviderOpenIdConnect.php
@@ -96,7 +96,7 @@ class ilAuthProviderOpenIdConnect extends ilAuthProvider
             $oidc->authenticate();
             // user is authenticated, otherwise redirected to authorization endpoint or exception
 
-            $claims = $oidc->requestUserInfo();
+            $claims = $oidc->getVerifiedClaims();
             $this->logger->dump($claims, ilLogLevel::DEBUG);
             $status = $this->handleUpdate($status, $claims);
 


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=39471

This PR reverts a significant OpenID Connect change (at least for Microsoft providers) of PR #6306 .

The problem is: At least with Microsoft providers, not all claims are correctly provided in the response of the `UserInfo` endpoint. For instance we noticed that lists of values (e.g. role strings in a custom "roles" claim) are JSON-encoded **twice**.

Example `UserInfo` JSON Response:

```
{..., "roles":"[\\"Mitarbeitende\\"]", ...}
```

```php
var_dump(json_decode('{"roles":"[\\"Mitarbeitende\\"]"}'));
```

A JSON-decoded object of the response string looks like this:

```
object(stdClass)#1 (1) {
  ["roles"]=>
  string(17) "["Mitarbeitende"]"
}
```
The result has to be decoded **again** to finally retrieve the list of roles. This is **unexpected** and **not specified**.

```php
var_dump(json_decode(json_decode('{"roles":"[\\"Mitarbeitende\\"]"}')->roles));
```

```
array(1) {
  [0]=>
  string(13) "Mitarbeitende"
}
````
It seems this cannot be changed in Microsoft providers. Therefore I hereby propose to use the `id_token` like it was the case before the change applied with PR #6306 .

If approved, this should be picked to all maintained branches.

See also:

* https://learn.microsoft.com/en-us/entra/identity-platform/userinfo#consider-using-an-id-token-instead