### PR TITLE
User/Auth: Increase field size of `login_attempts` (ILIAS 10)

### DIFF
--- a/components/ILIAS/PrivacySecurity/classes/class.ilSecuritySettings.php
+++ b/components/ILIAS/PrivacySecurity/classes/class.ilSecuritySettings.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
- */
+ *
+ *********************************************************************/
 
+declare(strict_types=1);
 
 /**
  * Singleton class that stores all security settings
@@ -50,6 +53,7 @@ class ilSecuritySettings
     public const DEFAULT_PASSWORD_MAX_LENGTH = 0;
     public const DEFAULT_PASSWORD_MAX_AGE = 90;
     public const DEFAULT_LOGIN_MAX_ATTEMPTS = 5;
+    public const MAX_LOGIN_ATTEMPTS = 99;
 
     public const DEFAULT_PASSWORD_CHANGE_ON_FIRST_LOGIN_ENABLED = false;
     public const DEFAULT_PREVENT_SIMULTANEOUS_LOGINS = false;

--- a/components/ILIAS/User/classes/class.ilObjUserFolderGUI.php
+++ b/components/ILIAS/User/classes/class.ilObjUserFolderGUI.php
@@ -2137,6 +2137,9 @@ class ilObjUserFolderGUI extends ilObjectGUI
             'login_max_attempts'
         );
         $text->setInfo($this->lng->txt('ps_login_max_attempts_info'));
+        $text->allowDecimals(false);
+        $text->setMinValue(1);
+        $text->setMaxValue(ilSecuritySettings::MAX_LOGIN_ATTEMPTS);
         $text->setSize(1);
         $text->setMaxLength(2);
         $this->form->addItem($text);

--- a/components/ILIAS/User/src/Setup/DBUpdateSteps10.php
+++ b/components/ILIAS/User/src/Setup/DBUpdateSteps10.php
@@ -117,4 +117,28 @@ class DBUpdateSteps10 implements \ilDatabaseUpdateSteps
             ['session_reminder_enabled']
         );
     }
+
+    public function step_4(): void
+    {
+        $query = 'SELECT value FROM settings WHERE module = %s AND keyword = %s';
+        $res = $this->db->queryF(
+            $query,
+            [\ilDBConstants::T_TEXT, \ilDBConstants::T_TEXT],
+            ['common', 'ps_login_max_attempts']
+        );
+
+        // We should adjust the usr_data values, even if the "Max. Login Attempts" are currently not set
+        $max_login_attempts = min(
+            (int) ($this->db->fetchAssoc($res)['value'] ?? \ilSecuritySettings::MAX_LOGIN_ATTEMPTS),
+            \ilSecuritySettings::MAX_LOGIN_ATTEMPTS
+        );
+
+        $max_login_attempts_exceeded = $max_login_attempts + 1;
+
+        $this->db->manipulateF(
+            'UPDATE usr_data SET login_attempts = %s WHERE login_attempts > %s',
+            [\ilDBConstants::T_INTEGER, \ilDBConstants::T_INTEGER],
+            [$max_login_attempts_exceeded, $max_login_attempts_exceeded]
+        );
+    }
 }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42516

If approved, this schema change should be picked to `trunk` as well.

Depens on: https://github.com/ILIAS-eLearning/ILIAS/pull/8357 (for ILIAS >= 10.x)