### PR TITLE
Export: separates component and container export in export gui, fixes export table action 'Actions for Entire Table'

### DIFF
--- a/components/ILIAS/Export/README-technical.md
+++ b/components/ILIAS/Export/README-technical.md
@@ -18,7 +18,6 @@ The export tab should be placed accoring to the [tabs guidelines](https://docu.i
 // in execute command:
 ...
 $exp_gui = new ilExportGUI($this); // $this is the ilObj...GUI class of the resource
-$exp_gui->addFormat("xml");
 $ret = $this->ctrl->forwardCommand($exp_gui);
 ...
 // in set/get tabs:
@@ -31,22 +30,7 @@ if ($ilAccess->checkAccess("write", "", $this->object->getRefId()))
 ...
 ```
 
-The simple example above can be found in `ILIAS/Exercise/classes/class.ilObjExerciseGUI.php`. A more complex usage can be found in learning modules, class `ILIAS/LearningModule/classes/class.ilObjContentObjectGUI.php`. This uses the `addFormat()` method to add multiple formats and custom columns and multi commands:
-
-```php
-// in executeCommand()
-...
-$exp_gui = new ilExportGUI($this);
-$exp_gui->addFormat("xml", "", $this, "export");
-$exp_gui->addFormat("html", "", $this, "exportHTML");
-$exp_gui->addFormat("scorm", "", $this, "exportSCORM");
-$exp_gui->addCustomColumn($this->lng->txt("cont_public_access"),
-    $this, "getPublicAccessColValue");
-$exp_gui->addCustomMultiCommand($this->lng->txt("cont_public_access"),
-    $this, "publishExportFile");
-$ret = $this->ctrl->forwardCommand($exp_gui);
-...
-```
+The simple example above can be found in `ILIAS/Exercise/classes/class.ilObjExerciseGUI.php`. A more complex usage can be found in learning modules, class `ILIAS/LearningModule/classes/class.ilObjContentObjectGUI.php`.
 
 ### Class il<Component>Exporter
 For the XML export the export user interface class calls a generic export method ilExport->exportObject (ILIAS/Export). To use this generic export, you need to implement an il\<Module\>Exporter class that is derived from `ilXmlExporter`.

--- a/components/ILIAS/Export/classes/class.ilExportGUI.php
+++ b/components/ILIAS/Export/classes/class.ilExportGUI.php
@@ -131,22 +131,6 @@ class ilExportGUI
 
     }
 
-    /**
-     * @depricated
-     */
-    public function addCustomColumn(): void
-    {
-
-    }
-
-    /**
-     * @depricated
-     */
-    public function addCustomMultiCommand(): void
-    {
-
-    }
-
     public function listExportFiles(): void
     {
         $this->displayExportFiles();
@@ -238,7 +222,7 @@ class ilExportGUI
 
     final protected function createXMLExportFile(): void
     {
-        if ($this->parent_gui instanceof  ilContainerGUI) {
+        if ($this->parent_gui instanceof ilContainerGUI) {
             $this->showItemSelection();
             return;
         }
@@ -279,12 +263,26 @@ class ilExportGUI
             return;
         }
         // create export
-        $this->createXMLExport();
+        $this->createXMLContainerExport();
         $this->tpl->setOnScreenMessage('success', $this->lng->txt('export_created'), true);
         $this->ctrl->redirect($this, self::CMD_LIST_EXPORT_FILES);
     }
 
     final protected function createXMLExport()
+    {
+        $manager = $this->export_handler->manager()->handler();
+        $export_info = $manager->getExportInfo(
+            $this->data_factory->objId($this->obj->getId()),
+            time()
+        );
+        $element = $manager->createExport(
+            $this->il_user->getId(),
+            $export_info,
+            ""
+        );
+    }
+
+    final protected function createXMLContainerExport()
     {
         $tree_nodes = $this->tree->getSubTree($this->tree->getNodeData($this->parent_gui->getObject()->getRefId()));
         $post_export_options = $this->initExportOptionsFromPost();
@@ -297,7 +295,6 @@ class ilExportGUI
             $tree_nodes,
             $post_export_options
         );
-
         $ref_ids_export = [$this->parent_gui->getObject()->getRefId()];
         $ref_ids_all = [$this->parent_gui->getObject()->getRefId()];
         $tree_ref_ids = array_map(function ($node) { return (int) $node['ref_id']; }, $tree_nodes);
@@ -351,7 +348,6 @@ class ilExportGUI
             );
             $element = $manager->createContainerExport($this->il_user->getId(), $container_export_info);
         }
-
         $eo->delete();
     }
 }


### PR DESCRIPTION
Also removes outdated information from README-technical.md.

Link: https://mantis.ilias.de/view.php?id=42500