### PR TITLE
Contact: Fix broken buddy system relationship dropdowns (prev with bs)

### DIFF
--- a/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_relation_table_listener.html
+++ b/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_relation_table_listener.html
@@ -8,10 +8,10 @@ document.addEventListener("DOMContentLoaded", function() {
         const stateChangedListener = function (event, usr_id, is_state, was_state) {
             if ((is_state == "ilBuddySystemUnlinkedRelationState") ||
                 (filter_val != "" && is_state != filter_val)) {
-                var num_cells = table.find("tr[data-buddy-id=" + usr_id + "]").find("td").size();
+                var num_cells = table.find("tr[data-buddy-id=" + usr_id + "]").find("td").length;
                 table.find("tr[data-buddy-id=" + usr_id + "]").remove();
 
-                if (!table.find('.ilBuddySystemRelationRow').size()) {
+                if (!table.find('.ilBuddySystemRelationRow').length) {
                     var tform = table.closest('form');
 
                     table.find('tbody').append('<tr class="tblrow1"><td class="ilCenter" colspan="' + num_cells + '">' + no_entries_txt + '</td></tr>');
@@ -19,7 +19,7 @@ document.addEventListener("DOMContentLoaded", function() {
                     tform.find('.ilTableSelectAll').remove();
                     tform.find('.ilTableCommandRowTop').remove();
                     tform.find('.ilTableCommandRow').remove();
-                    if (!tform.find('.ilTableNav label').size()) {
+                    if (!tform.find('.ilTableNav label').length) {
                         tform.find('.ilTableNav').remove();
                     }
                 }

--- a/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_ignored_request.html
+++ b/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_ignored_request.html
@@ -1,10 +1,10 @@
 <div class="btn-group"><!-- BEGIN requester_container -->
 	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="true">{REQUESTER_BUTTON_TXT}<span class="caret"></span></button>
-	<ul class="dropdown-menu" role="menu">
+	<ul class="dropdown-menu dropdown-menu__left" role="menu">
 		<li><a data-target-state="{REQUESTER_TARGET_STATE_UNLINKED}" data-action="{REQUESTER_TARGET_STATE_ACTION_UNLINKED}">{REQUESTER_TARGET_STATE_TXT_UNLINKED}</a></li>
 	</ul><!-- END requester_container --><!-- BEGIN requestee_container -->
 	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="true">{REQUESTEE_BUTTON_TXT}<span class="caret"></span></button>
-	<ul class="dropdown-menu" role="menu">
+	<ul class="dropdown-menu dropdown-menu__left" role="menu">
 		<li><a data-target-state="{REQUESTEE_TARGET_STATE_LINKED}" data-action="{REQUESTEE_TARGET_STATE_ACTION_LINKED}">{REQUESTEE_TARGET_STATE_TXT_LINKED}</a></li>
 	</ul><!-- END requestee_container -->
 </div>

--- a/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_linked.html
+++ b/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_linked.html
@@ -1,6 +1,6 @@
 <div class="btn-group">
 	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="true">{BUTTON_TXT}<span class="caret"></span></button>
-	<ul class="dropdown-menu" role="menu">
+	<ul class="dropdown-menu dropdown-menu__left" role="menu">
 		<li><a data-target-state="{TARGET_STATE_UNLINKED}" data-action="{TARGET_STATE_ACTION_UNLINKED}">{TARGET_STATE_TXT_UNLINKED}</a></li>
 	</ul>
 </div>

--- a/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_requested.html
+++ b/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_requested.html
@@ -1,10 +1,10 @@
 <div class="btn-group"><!-- BEGIN requester_container -->
 	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="true">{REQUESTER_BUTTON_TXT}<span class="caret"></span></button>
-	<ul class="dropdown-menu" role="menu">
+	<ul class="dropdown-menu dropdown-menu__left" role="menu">
 		<li><a data-target-state="{REQUESTER_TARGET_STATE_UNLINKED}" data-action="{REQUESTER_TARGET_STATE_ACTION_UNLINKED}">{REQUESTER_TARGET_STATE_TXT_UNLINKED}</a></li>
 	</ul><!-- END requester_container --><!-- BEGIN requestee_container -->
 	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="true">{REQUESTEE_BUTTON_TXT}<span class="caret"></span></button>
-	<ul class="dropdown-menu" role="menu">
+	<ul class="dropdown-menu dropdown-menu__left" role="menu">
 		<li><a data-target-state="{REQUESTEE_TARGET_STATE_LINKED}" data-action="{REQUESTEE_TARGET_STATE_ACTION_LINKED}">{REQUESTEE_TARGET_STATE_TXT_LINKED}</a></li>
 		<li><a data-target-state="{REQUESTEE_TARGET_STATE_IGNORED_REQUEST}" data-action="{REQUESTEE_TARGET_STATE_ACTION_IGNORED_REQUEST}">{REQUESTEE_TARGET_STATE_TXT_IGNORED_REQUEST}</a></li>
 	</ul><!-- END requestee_container -->

--- a/components/ILIAS/Contact/resources/buddy_system.js
+++ b/components/ILIAS/Contact/resources/buddy_system.js
@@ -1,3 +1,19 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 (function($, $scope) {
 	$scope.il.BuddySystem = {
 		config: {},
@@ -131,6 +147,11 @@
 	};
 
 	$(document).ready(function() {
+		document.addEventListener('click', function(e){
+			if (e.target.classList.contains('dropdown-toggle')) {
+				e.target.parentNode.classList.toggle('open');
+			}
+		});
 		$("#awareness_trigger").on("awrn:shown", function(event) {
 			$("#awareness-content").find("a[data-target-state]").off("click").on("click", function(e) {
 				let bs = $scope.il.BuddySystem,


### PR DESCRIPTION
This PR fixes the dropdowns in the `Communication > Contacts`. This is a replacement for the bootstrap dropdowns that where used previously for this (and are no longer available).