### PR TITLE
T&A Fix ilAssQuestion list duplicated join

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -484,18 +484,9 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         }
 
         if ($this->getParentObjectType() === 'tst'
-            && $this->getQuestionInstanceTypeFilter() === self::QUESTION_INSTANCE_TYPE_ALL) {
-            $tableJoin .= "
-            						INNER JOIN	tst_test_question tstquest
-			ON			tstquest.question_fi = qpl_questions.question_id
-			";
-        }
-
-        if (
-            $this->getParentObjectType() === 'tst'
             && $this->getQuestionInstanceTypeFilter() === self::QUESTION_INSTANCE_TYPE_ALL
         ) {
-            $tableJoin .= " INNER JOIN tst_test_question ON tst_test_question.question_fi = qpl_questions.question_id ";
+            $tableJoin .= "INNER JOIN tst_test_question tstquest ON tstquest.question_fi = qpl_questions.question_id";
         }
 
         $tableJoin = $this->handleFeedbackJoin($tableJoin);


### PR DESCRIPTION
This PR is related to Mantis https://mantis.ilias.de/view.php?id=42475.
During code review, i detected a duplicated code snippet in the `ilAssQuestionList`.
The duplicated join was likely introduced during previous rebasing and merging.
Removing this redundancy may increase performance.