### PR TITLE
Contact: Add accessibility classes for `Community > Contacts` dropdowns

### DIFF
--- a/components/ILIAS/Contact/BuddySystem/classes/states/renderer/class.ilAbstractBuddySystemRelationStateButtonRenderer.php
+++ b/components/ILIAS/Contact/BuddySystem/classes/states/renderer/class.ilAbstractBuddySystemRelationStateButtonRenderer.php
@@ -38,6 +38,8 @@ abstract class ilAbstractBuddySystemRelationStateButtonRenderer implements ilBud
             'components/ILIAS/Contact/BuddySystem'
         );
 
+        $this->tpl->setVariable('MENU_ID', uniqid('buddy-system-menu'));
+
         $this->lng = $lng ?? $DIC['lng'];
     }
 

--- a/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_relation_table_row.html
+++ b/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_relation_table_row.html
@@ -1,11 +1,11 @@
 <tr class="{CSS_ROW} ilBuddySystemRelationRow" data-buddy-id="{VAL_USR_ID}">
 	<!-- BEGIN chb --><td class="std">{VAL_CHB}</td><!-- END chb -->
 	<td class="std">
-		<!-- BEGIN linked_name --><a href="{VAL_PROFILE_LINK}" title="{VAL_LINKED_PUBLIC_NAME}">{VAL_LINKED_PUBLIC_NAME}</a><!-- END linked_name -->
+		<!-- BEGIN linked_name --><a tabindex="0" href="{VAL_PROFILE_LINK}" title="{VAL_LINKED_PUBLIC_NAME}">{VAL_LINKED_PUBLIC_NAME}</a><!-- END linked_name -->
 		<!-- BEGIN unlinked_name -->{VAL_UNLINKED_PUBLIC_NAME}<!-- END unlinked_name -->
 	</td>
 	<td class="std">
-		<!-- BEGIN linked_login --><a href="{VAL_PROFILE_LINK_LOGIN}" title="{VAL_LINKED_LOGIN}">{VAL_LINKED_LOGIN}</a><!-- END linked_login -->
+		<!-- BEGIN linked_login --><a tabindex="0" href="{VAL_PROFILE_LINK_LOGIN}" title="{VAL_LINKED_LOGIN}">{VAL_LINKED_LOGIN}</a><!-- END linked_login -->
 		<!-- BEGIN unlinked_login -->{VAL_UNLINKED_LOGIN}<!-- END unlinked_login -->
 	</td>
 	<td class="std">

--- a/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_ignored_request.html
+++ b/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_ignored_request.html
@@ -1,10 +1,10 @@
 <div class="btn-group"><!-- BEGIN requester_container -->
-	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="true">{REQUESTER_BUTTON_TXT}<span class="caret"></span></button>
-	<ul class="dropdown-menu dropdown-menu__left" role="menu">
-		<li><a data-target-state="{REQUESTER_TARGET_STATE_UNLINKED}" data-action="{REQUESTER_TARGET_STATE_ACTION_UNLINKED}">{REQUESTER_TARGET_STATE_TXT_UNLINKED}</a></li>
+	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" aria-controls="{MENU_ID}">{REQUESTER_BUTTON_TXT}<span class="caret"></span></button>
+	<ul class="dropdown-menu" role="menu">
+		<li><a tabindex="0" data-target-state="{REQUESTER_TARGET_STATE_UNLINKED}" data-action="{REQUESTER_TARGET_STATE_ACTION_UNLINKED}">{REQUESTER_TARGET_STATE_TXT_UNLINKED}</a></li>
 	</ul><!-- END requester_container --><!-- BEGIN requestee_container -->
-	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="true">{REQUESTEE_BUTTON_TXT}<span class="caret"></span></button>
-	<ul class="dropdown-menu dropdown-menu__left" role="menu">
-		<li><a data-target-state="{REQUESTEE_TARGET_STATE_LINKED}" data-action="{REQUESTEE_TARGET_STATE_ACTION_LINKED}">{REQUESTEE_TARGET_STATE_TXT_LINKED}</a></li>
+	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" aria-controls="{MENU_ID}">{REQUESTEE_BUTTON_TXT}<span class="caret"></span></button>
+	<ul class="dropdown-menu" role="menu" id="{MENU_ID}">
+		<li><a tabindex="0" data-target-state="{REQUESTEE_TARGET_STATE_LINKED}" data-action="{REQUESTEE_TARGET_STATE_ACTION_LINKED}">{REQUESTEE_TARGET_STATE_TXT_LINKED}</a></li>
 	</ul><!-- END requestee_container -->
 </div>

--- a/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_linked.html
+++ b/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_linked.html
@@ -1,6 +1,6 @@
 <div class="btn-group">
-	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="true">{BUTTON_TXT}<span class="caret"></span></button>
-	<ul class="dropdown-menu dropdown-menu__left" role="menu">
-		<li><a data-target-state="{TARGET_STATE_UNLINKED}" data-action="{TARGET_STATE_ACTION_UNLINKED}">{TARGET_STATE_TXT_UNLINKED}</a></li>
+	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" aria-controls="{MENU_ID}">{BUTTON_TXT}<span class="caret"></span></button>
+	<ul class="dropdown-menu" role="menu" id="{MENU_ID}">
+		<li><a tabindex="0" data-target-state="{TARGET_STATE_UNLINKED}" data-action="{TARGET_STATE_ACTION_UNLINKED}">{TARGET_STATE_TXT_UNLINKED}</a></li>
 	</ul>
 </div>

--- a/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_requested.html
+++ b/components/ILIAS/Contact/BuddySystem/templates/default/tpl.buddy_system_state_requested.html
@@ -1,11 +1,11 @@
 <div class="btn-group"><!-- BEGIN requester_container -->
-	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="true">{REQUESTER_BUTTON_TXT}<span class="caret"></span></button>
-	<ul class="dropdown-menu dropdown-menu__left" role="menu">
-		<li><a data-target-state="{REQUESTER_TARGET_STATE_UNLINKED}" data-action="{REQUESTER_TARGET_STATE_ACTION_UNLINKED}">{REQUESTER_TARGET_STATE_TXT_UNLINKED}</a></li>
+	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" aria-controls="{MENU_ID}">{REQUESTER_BUTTON_TXT}<span class="caret"></span></button>
+	<ul class="dropdown-menu" role="menu" id="{MENU_ID}">
+		<li><a tabindex="0" data-target-state="{REQUESTER_TARGET_STATE_UNLINKED}" data-action="{REQUESTER_TARGET_STATE_ACTION_UNLINKED}">{REQUESTER_TARGET_STATE_TXT_UNLINKED}</a></li>
 	</ul><!-- END requester_container --><!-- BEGIN requestee_container -->
-	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="true">{REQUESTEE_BUTTON_TXT}<span class="caret"></span></button>
-	<ul class="dropdown-menu dropdown-menu__left" role="menu">
-		<li><a data-target-state="{REQUESTEE_TARGET_STATE_LINKED}" data-action="{REQUESTEE_TARGET_STATE_ACTION_LINKED}">{REQUESTEE_TARGET_STATE_TXT_LINKED}</a></li>
-		<li><a data-target-state="{REQUESTEE_TARGET_STATE_IGNORED_REQUEST}" data-action="{REQUESTEE_TARGET_STATE_ACTION_IGNORED_REQUEST}">{REQUESTEE_TARGET_STATE_TXT_IGNORED_REQUEST}</a></li>
+	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" aria-controls="{MENU_ID}">{REQUESTEE_BUTTON_TXT}<span class="caret"></span></button>
+	<ul class="dropdown-menu" role="menu" id="{MENU_ID}">
+		<li><a tabindex="0" data-target-state="{REQUESTEE_TARGET_STATE_LINKED}" data-action="{REQUESTEE_TARGET_STATE_ACTION_LINKED}">{REQUESTEE_TARGET_STATE_TXT_LINKED}</a></li>
+		<li><a tabindex="0" data-target-state="{REQUESTEE_TARGET_STATE_IGNORED_REQUEST}" data-action="{REQUESTEE_TARGET_STATE_ACTION_IGNORED_REQUEST}">{REQUESTEE_TARGET_STATE_TXT_IGNORED_REQUEST}</a></li>
 	</ul><!-- END requestee_container -->
 </div>

--- a/components/ILIAS/Contact/resources/buddy_system.js
+++ b/components/ILIAS/Contact/resources/buddy_system.js
@@ -147,9 +147,20 @@
 	};
 
 	$(document).ready(function() {
-		document.addEventListener('click', function(e){
+		const root = $('#buddy_system_tbl,.il-deck');
+		root.attr('aria-live', 'polite');
+		root.on('keydown', function(e){
+			if (e.key === 'Enter' && e.target.nodeName === 'A') {
+				e.target.click();
+			}
+		});
+		root.on('click', function(e){
 			if (e.target.classList.contains('dropdown-toggle')) {
 				e.target.parentNode.classList.toggle('open');
+				e.target.setAttribute('aria-expanded', String(e.target.parentNode.classList.contains('open')));
+				if (root.attr('id') === 'buddy_system_tbl') {
+					e.target.parentNode.querySelector(':scope > .dropdown-menu').classList.add('dropdown-menu__left');
+				}
 			}
 		});
 		$("#awareness_trigger").on("awrn:shown", function(event) {


### PR DESCRIPTION
Fix keyboard selection and accessibility classes for the `Community > Contacts` dropdowns.