### PR TITLE
Certificate Bugfix #0042529: Certificate Standard Icon signWAC Error

### DIFF
--- a/components/ILIAS/Certificate/classes/User/class.ilUserCertificateGUI.php
+++ b/components/ILIAS/Certificate/classes/User/class.ilUserCertificateGUI.php
@@ -181,7 +181,7 @@ class ilUserCertificateGUI
                 }
 
                 if ($imagePath === '') {
-                    $imagePath = ilWACSignedPath::signFile(ilUtil::getImagePath('standard/icon_cert.svg'));
+                    $imagePath = ilUtil::getImagePath('standard/icon_cert.svg');
                 }
 
                 $cardImage = $this->uiFactory->image()->standard(


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42529

cherry-pick to 10 as well

since icon_cert.svg is located outside of public/data/root in public/assets it cannot be signed