### PR TITLE
T&A/8: 34365 Cloze Question Import (QPL) from 5.4 to 7 moves text from Question to Cloze Text

### DIFF
--- a/Modules/TestQuestionPool/classes/import/qti12/class.assClozeTestImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assClozeTestImport.php
@@ -48,43 +48,32 @@ class assClozeTestImport extends assQuestionImport
         ilSession::clear('import_mob_xhtml');
         $presentation = $item->getPresentation();
 
-        $packageIliasVersion = $item->getIliasSourceVersion('ILIAS_VERSION');
-        $seperate_question_field = $item->getMetadataEntry("question");
+        $questiontext = $this->processNonAbstractedImageReferences(
+            $item->getMetadataEntry("question") ?? '&nbsp;',
+            $item->getIliasSourceNic()
+        );
 
-        $questiontext = '';
-        if (!$packageIliasVersion || version_compare($packageIliasVersion, '5.0.0', '<')) {
-            $questiontext = '&nbsp;';
-        } elseif ($seperate_question_field) {
-            $questiontext = $this->processNonAbstractedImageReferences(
-                $seperate_question_field,
-                $item->getIliasSourceNic()
-            );
-        }
-
-        $clozetext = array();
-        $shuffle = 0;
-        $now = getdate();
-        $created = sprintf("%04d%02d%02d%02d%02d%02d", $now['year'], $now['mon'], $now['mday'], $now['hours'], $now['minutes'], $now['seconds']);
-        $gaps = array();
+        $clozetext_array = [];
+        $gaps = [];
         foreach ($presentation->order as $entry) {
             switch ($entry["type"]) {
                 case "material":
 
-                    $materialString = $this->object->QTIMaterialToString(
+                    $material_string = $this->object->QTIMaterialToString(
                         $presentation->material[$entry["index"]]
                     );
 
                     if ($questiontext === '&nbsp;') {
-                        $questiontext = $materialString;
+                        $questiontext = $material_string;
                     } else {
-                        array_push($clozetext, $materialString);
+                        array_push($clozetext_array, $material_string);
                     }
 
                     break;
                 case "response":
                     $response = $presentation->response[$entry["index"]];
                     $rendertype = $response->getRenderType();
-                    array_push($clozetext, "<<" . $response->getIdent() . ">>");
+                    array_push($clozetext_array, "<<" . $response->getIdent() . ">>");
 
                     switch (strtolower(get_class($response->getRenderType()))) {
                         case "ilqtirenderfib":
@@ -292,7 +281,7 @@ class assClozeTestImport extends assQuestionImport
         }
 
         $this->object->setQuestion($questiontext);
-        $clozetext = join("", $clozetext);
+        $clozetext = join("", $clozetext_array);
 
         foreach ($gaptext as $idx => $val) {
             $clozetext = str_replace("<<" . $idx . ">>", $val, $clozetext);
@@ -323,8 +312,7 @@ class assClozeTestImport extends assQuestionImport
             $m = $this->object->QTIMaterialToString($material);
             $feedbacksgeneric[$correctness] = $m;
         }
-        $questiontext = $this->object->getQuestion();
-        $clozetext = $this->object->getClozeText();
+
         if (is_array(ilSession::get("import_mob_xhtml"))) {
             foreach (ilSession::get("import_mob_xhtml") as $mob) {
                 if ($tst_id > 0) {

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -234,12 +234,12 @@ class ilQTIParser extends ilSaxParser
     }
 
     /**
-    * set event handler
-    * should be overwritten by inherited class
-    * @access	private
-    *
-    * @param XMLParser|resource $a_xml_parser
-    */
+     * set event handler
+     * should be overwritten by inherited class
+     * @access    private
+     *
+     * @param XMLParser|resource $a_xml_parser
+     */
     public function setHandlers($a_xml_parser): void
     {
         xml_set_object($a_xml_parser, $this);
@@ -787,7 +787,7 @@ class ilQTIParser extends ilSaxParser
             case "material":
                 if ($this->material) {
                     $mat = $this->material->getMaterial(0);
-                    if(!is_array($mat)) {
+                    if (!is_array($mat)) {
                         $this->material = null;
                         break;
                     }
@@ -847,7 +847,7 @@ class ilQTIParser extends ilSaxParser
                 $this->matimage = null;
                 break;
 
-            // add support for matbreak element
+                // add support for matbreak element
             case "matbreak":
                 $this->mattext = new ilQTIMattext();
                 $this->mattext->setContent('<br />');
@@ -1253,7 +1253,7 @@ class ilQTIParser extends ilSaxParser
     {
         $matches = null;
 
-        if (preg_match('/^(\d+\.\d+\.\d+) .*$/', $versionDateString, $matches)) {
+        if (preg_match('/^(\d+\.\d+(?:\.\d+)?)(?: .*)?$/', $versionDateString, $matches)) {
             return $matches[1];
         }
 

--- a/Services/QTI/test/ilQTIParserTest.php
+++ b/Services/QTI/test/ilQTIParserTest.php
@@ -57,4 +57,28 @@ class ilQTIParserTest extends TestCase
     {
         unset($GLOBALS['DIC']);
     }
+
+    public function testSetGetIliasSourceVersionWithoutPatch(): void
+    {
+        $this->assertEquals('7.13', $this->fetchNumericVersionFromVersionDateString('7.13 2022-08-31'));
+    }
+
+    public function testSetGetIliasSourceVersionWithPatch(): void
+    {
+        $this->assertEquals('5.4.22', $this->fetchNumericVersionFromVersionDateString('5.4.22 2021-05-14'));
+    }
+
+    public function testSetGetIliasSourceVersionWithoutDate(): void
+    {
+        $this->assertEquals('8.14', $this->fetchNumericVersionFromVersionDateString('8.14'));
+    }
+
+    protected function fetchNumericVersionFromVersionDateString(string $version): string
+    {
+        $instance = new ilQTIParser('dummy xml file');
+        $reflection = new ReflectionClass($instance);
+        $method = $reflection->getMethod('fetchNumericVersionFromVersionDateString');
+        $method->setAccessible(true);
+        return $method->invoke($instance, $version);
+    }
 }


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=34365

The issue is caused by an error in the interpretation of the version number. The method is designed for the version scheme of Ilias 5 ('x.x.x -dd.mm.yyyy'), but since version 6 only ('x.x - dd.mm.yyyy') is used and since version 8 only ('x.x').

I found a similar bug reporting and used it as a reference:

- https://mantis.ilias.de/view.php?id=39073
- https://github.com/ILIAS-eLearning/ILIAS/commit/81bc7b15d7362ad5fae7a4fac10a0b7ba611a352#diff-8e45538b112fbd1b4a72c93852ae30bc2ae4d8f5e7935d7f54aaeb288229ef8c