### PR TITLE
T&A 41680: Fix sql data too long error by validating input parameter

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
@@ -286,7 +286,6 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         $kprimAnswers = new ilKprimChoiceWizardInputGUI($this->lng->txt('answers'), 'kprim_answers');
         $kprimAnswers->setInfo($this->lng->txt('kprim_answers_info'));
         $kprimAnswers->setSize(64);
-        $kprimAnswers->setMaxLength(1000);
         $kprimAnswers->setRequired(true);
         $kprimAnswers->setAllowMove(true);
         $kprimAnswers->setQuestionObject($this->object);

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -812,7 +812,6 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         if ($this->object->getSelfAssessmentEditingMode()) {
             $choices->setSize(40);
         }
-        $choices->setMaxLength(800);
         if ($this->object->getAnswerCount() == 0) {
             $this->object->addAnswer("", 0, 0, 0);
         }

--- a/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -692,7 +692,6 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         if ($this->object->getSelfAssessmentEditingMode()) {
             $choices->setSize(40);
         }
-        $choices->setMaxLength(800);
         if ($this->object->getAnswerCount() == 0) {
             $this->object->addAnswer("", 0, 0);
         }

--- a/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -297,7 +297,7 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
 
         $solution = '';
         $autosaved_solution = $this->object->getLatestAutosaveContent($active_id, $pass);
-        if(!is_null($autosaved_solution)) {
+        if (!is_null($autosaved_solution)) {
             if ($show_autosave_title) {
                 $template->setCurrentBlock('autosave_title');
                 $template->setVariable('AUTOSAVE_TITLE', $this->lng->txt('autosavecontent'));
@@ -731,6 +731,7 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         //$allKeyword->setQuestionObject($this->object);
         //$allKeyword->setSingleline(TRUE);
         $allKeyword->setValues(self::buildAnswerTextOnlyArray($this->object->getAnswers()));
+        $allKeyword->setMaxLength($anyKeyword->getMaxLength());
         $scoringOptionAllKeyword->addSubItem($allKeyword);
         $allKeywordPoints = new ilNumberInputGUI($this->lng->txt("points"), "all_keyword_points");
         $allKeywordPoints->allowDecimals(true);
@@ -747,6 +748,7 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         //$oneKeyword->setQuestionObject($this->object);
         //$oneKeyword->setSingleline(TRUE);
         $oneKeyword->setValues(self::buildAnswerTextOnlyArray($this->object->getAnswers()));
+        $oneKeyword->setMaxLength($anyKeyword->getMaxLength());
         $scoringOptionOneKeyword->addSubItem($oneKeyword);
         $oneKeywordPoints = new ilNumberInputGUI($this->lng->txt("points"), "one_keyword_points");
         $oneKeywordPoints->allowDecimals(true);

--- a/Modules/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
@@ -70,6 +70,11 @@ class ilEssayKeywordWizardInputGUI extends ilSingleChoiceWizardInputGUI
                         $this->setAlert($lng->txt("msg_input_is_required"));
                         return false;
                     }
+
+                    if (mb_strlen($answervalue) > $this->getMaxLength()) {
+                        $this->setAlert($lng->txt("msg_input_char_limit_max"));
+                        return false;
+                    }
                 }
             }
             // check points

--- a/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -137,6 +137,11 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                         $this->setAlert($lng->txt("msg_input_is_required"));
                         return false;
                     }
+
+                    if (mb_strlen($answervalue) > $this->getMaxLength()) {
+                        $this->setAlert($lng->txt("msg_input_char_limit_max"));
+                        return false;
+                    }
                 }
             }
 
@@ -227,6 +232,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                 $tpl->setVariable("MULTILINE_ID", $this->getPostVar() . "[answer][{$value->getPosition()}]");
                 $tpl->setVariable("MULTILINE_ROW_NUMBER", $value->getPosition());
                 $tpl->setVariable("MULTILINE_POST_VAR", $this->getPostVar());
+                $tpl->setVariable("MAXLENGTH", $this->getMaxLength());
                 if ($this->getDisabled()) {
                     $tpl->setVariable("DISABLED_MULTILINE", " disabled=\"disabled\"");
                 }

--- a/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -76,7 +76,7 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                         return false;
                     }
 
-                    if (strlen($answervalue) > $this->getMaxLength()) {
+                    if (mb_strlen($answervalue) > $this->getMaxLength()) {
                         $this->setAlert($lng->txt("msg_input_char_limit_max"));
                         return false;
                     }

--- a/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -75,6 +75,11 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                         $this->setAlert($lng->txt("msg_input_is_required"));
                         return false;
                     }
+
+                    if (strlen($answervalue) > $this->getMaxLength()) {
+                        $this->setAlert($lng->txt("msg_input_char_limit_max"));
+                        return false;
+                    }
                 }
             }
             // check points
@@ -303,6 +308,7 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                 $tpl->setVariable("MULTILINE_ID", $this->getPostVar() . "[answer][$i]");
                 $tpl->setVariable("MULTILINE_ROW_NUMBER", $i);
                 $tpl->setVariable("MULTILINE_POST_VAR", $this->getPostVar());
+                $tpl->setVariable("MAXLENGTH", $this->getMaxLength());
                 if ($this->getDisabled()) {
                     $tpl->setVariable("DISABLED_MULTILINE", " disabled=\"disabled\"");
                 }

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -47,6 +47,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         parent::__construct($a_title, $a_postvar);
         $this->setSuffixes(['jpg', 'jpeg', 'png', 'gif']);
         $this->setSize('25');
+        $this->setMaxLength(1000);
         $this->validationRegexp = '';
         global $DIC;
         $this->post_wrapper = $DIC->http()->wrapper()->post();
@@ -239,6 +240,11 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                 foreach ($foundvalues['answer'] as $aidx => $answervalue) {
                     if (((strlen($answervalue)) == 0) && (!isset($foundvalues['imagename'][$aidx]) || strlen($foundvalues['imagename'][$aidx]) == 0)) {
                         $this->setAlert($lng->txt("msg_input_is_required"));
+                        return false;
+                    }
+
+                    if (mb_strlen($answervalue) > $this->getMaxLength()) {
+                        $this->setAlert($lng->txt("msg_input_char_limit_max"));
                         return false;
                     }
                 }
@@ -451,6 +457,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                 $tpl->setVariable("MULTILINE_ID", $this->getPostVar() . "[answer][$i]");
                 $tpl->setVariable("MULTILINE_ROW_NUMBER", $i);
                 $tpl->setVariable("MULTILINE_POST_VAR", $this->getPostVar());
+                $tpl->setVariable("MAXLENGTH", $this->getMaxLength());
                 if ($this->getDisabled()) {
                     $tpl->setVariable("DISABLED_MULTILINE", " disabled=\"disabled\"");
                 }

--- a/Modules/TestQuestionPool/templates/default/tpl.prop_kprimchoicewizardinput.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.prop_kprimchoicewizardinput.html
@@ -44,7 +44,7 @@
 					<!-- END addimage -->
 				<!-- END singleline -->
 				<!-- BEGIN multiline -->
-					<textarea cols="60" rows="4" name="{MULTILINE_POST_VAR}[answer][{MULTILINE_ROW_NUMBER}]" id="{MULTILINE_ID}"{DISABLED_MULTILINE}>{PROPERTY_VALUE}</textarea>
+					<textarea cols="60" rows="4" name="{MULTILINE_POST_VAR}[answer][{MULTILINE_ROW_NUMBER}]" maxlength="{MAXLENGTH}" id="{MULTILINE_ID}"{DISABLED_MULTILINE}>{PROPERTY_VALUE}</textarea>
 				<!-- END multiline -->
 			</td>
 			<td class="correctness">

--- a/Modules/TestQuestionPool/templates/default/tpl.prop_multiplechoicewizardinput.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.prop_multiplechoicewizardinput.html
@@ -27,7 +27,7 @@
 					<input class="form-control" type="text" size="{SIZE}" id="{SINGLELINE_ID}" maxlength="{MAXLENGTH}" name="{SINGLELINE_POST_VAR}[answer][{SINGLELINE_ROW_NUMBER}]" <!-- BEGIN prop_text_propval -->value="{PROPERTY_VALUE}" <!-- END prop_text_propval -->{DISABLED_SINGLELINE}/>
 <!-- END singleline -->
 <!-- BEGIN multiline -->
-					<textarea class="form-control" cols="60" rows="4" name="{MULTILINE_POST_VAR}[answer][{MULTILINE_ROW_NUMBER}]" id="{MULTILINE_ID}"{DISABLED_MULTILINE}>{PROPERTY_VALUE}</textarea>
+					<textarea class="form-control" cols="60" rows="4" maxlength="{MAXLENGTH}" name="{MULTILINE_POST_VAR}[answer][{MULTILINE_ROW_NUMBER}]" id="{MULTILINE_ID}"{DISABLED_MULTILINE}>{PROPERTY_VALUE}</textarea>
 <!-- END multiline -->
 				</td>
 				<td class="imagecolumn">

--- a/Modules/TestQuestionPool/templates/default/tpl.prop_singlechoicewizardinput.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.prop_singlechoicewizardinput.html
@@ -18,7 +18,7 @@
 					<input class="form-control" type="text" size="{SIZE}" id="{SINGLELINE_ID}" maxlength="{MAXLENGTH}" name="{SINGLELINE_POST_VAR}[answer][{SINGLELINE_ROW_NUMBER}]" <!-- BEGIN prop_text_propval -->value="{PROPERTY_VALUE}" <!-- END prop_text_propval -->{DISABLED_SINGLELINE}/>
 <!-- END singleline -->
 <!-- BEGIN multiline -->
-					<textarea class="form-control" cols="60" rows="4" name="{MULTILINE_POST_VAR}[answer][{MULTILINE_ROW_NUMBER}]" id="{MULTILINE_ID}"{DISABLED_MULTILINE}>{PROPERTY_VALUE}</textarea>
+					<textarea class="form-control" cols="60" rows="4" maxlength="{MAXLENGTH}" name="{MULTILINE_POST_VAR}[answer][{MULTILINE_ROW_NUMBER}]" id="{MULTILINE_ID}"{DISABLED_MULTILINE}>{PROPERTY_VALUE}</textarea>
 <!-- END multiline -->
 				</td>
 				<td class="imagecolumn">

--- a/Services/Form/classes/class.ilTextWizardInputGUI.php
+++ b/Services/Form/classes/class.ilTextWizardInputGUI.php
@@ -84,6 +84,9 @@ class ilTextWizardInputGUI extends ilTextInputGUI
                         $this->setAlert($lng->txt("msg_wrong_format"));
                         return false;
                     }
+                } elseif ($this->getMaxLength() && mb_strlen($value) > $this->getMaxLength()) {
+                    $this->setAlert($lng->txt("msg_input_char_limit_max"));
+                    return false;
                 }
             }
         } elseif ($this->getRequired()) {


### PR DESCRIPTION
Hi everyone,

This PR addresses an error including data loss when an answer text exceeds the length of the corresponding table column. 

See: https://mantis.ilias.de/view.php?id=41680
> I have implemented a fix that checks that the text does not exceed the maximum length before saving, so that no data is lost due to the error. However, this does not solve the problem that you cannot save the answer text. Therefore, the question here would be whether a limit of 1000 characters makes sense at this point?

This could also be cherry-picked to `release_9`, `release_10` and `trunk`

Thanks for the review and feedback in advance,
@lukas-heinrich