### PR TITLE
42321: Save standard search page number (release_8)

### DIFF
--- a/Services/Search/classes/class.ilSearchGUI.php
+++ b/Services/Search/classes/class.ilSearchGUI.php
@@ -418,6 +418,8 @@ class ilSearchGUI extends ilSearchBaseGUI
             $this->search_cache->deleteCachedEntries();
         }
 
+        $this->search_cache->setResultPageNumber($page_number);
+
         if ($this->getType() == ilSearchBaseGUI::SEARCH_DETAILS and !$this->getDetails()) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('search_choose_object_type'));
             $this->showSearch();


### PR DESCRIPTION
The page number is saved in Lucene search, but not in standard (direct) search.