### PR TITLE
T&A 41683/41684: remove superglobal access in question actions

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -91,6 +91,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
 
     protected array $ui;
 
+    protected const INSERT_MODE_BEFORE = 0;
+    protected const INSERT_MODE_AFTER = 1;
+
     /**
      * Constructor
      * @access public
@@ -1885,14 +1888,12 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
     */
     public function moveQuestionsObject()
     {
-        $selected_questions = null;
-        $selected_questions = $_POST['q_id'];
-        if ($selected_questions === null && is_numeric($_GET['q_id'])) {
-            $selected_questions = [$_GET['q_id']];
-        }
-        if (is_array($selected_questions)) {
+        $selected_questions = $this->testrequest->getQuestionIds()
+            ? $this->testrequest->getQuestionIds()
+            : [$this->testrequest->getQuestionId()];
+        if (count($selected_questions) > 0) {
             ilSession::set('tst_qst_move_' . $this->object->getTestId(), $selected_questions);
-            $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_selected_for_move"), true);
+            $this->tpl->setOnScreenMessage('success', $this->lng->txt('msg_selected_for_move'), true);
         } else {
             $this->tpl->setOnScreenMessage('failure', $this->lng->txt('no_selection_for_move'), true);
         }
@@ -1904,22 +1905,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
     */
     public function insertQuestionsBeforeObject()
     {
-        // get all questions to move
-        $move_questions = ilSession::get('tst_qst_move_' . $this->object->getTestId());
-
-        if (!is_array($_POST['q_id']) || 0 === count($_POST['q_id'])) {
-            $this->tpl->setOnScreenMessage('failure', $this->lng->txt("no_target_selected_for_move"), true);
-            $this->ctrl->redirect($this, 'questions');
-        }
-        if (count($_POST['q_id']) > 1) {
-            $this->tpl->setOnScreenMessage('failure', $this->lng->txt("too_many_targets_selected_for_move"), true);
-            $this->ctrl->redirect($this, 'questions');
-        }
-        $insert_mode = 0;
-        $this->object->moveQuestions(ilSession::get('tst_qst_move_' . $this->object->getTestId()), $_POST['q_id'][0], $insert_mode);
-        $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_questions_moved"), true);
-        ilSession::clear('tst_qst_move_' . $this->object->getTestId());
-        $this->ctrl->redirect($this, "questions");
+        $this->insertQuestionsBeforeOrAfter(self::INSERT_MODE_BEFORE);
     }
 
     /**
@@ -1927,21 +1913,30 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
     */
     public function insertQuestionsAfterObject()
     {
-        // get all questions to move
-        $move_questions = ilSession::get('tst_qst_move_' . $this->object->getTestId());
-        if (!is_array($_POST['q_id']) || 0 === count($_POST['q_id'])) {
-            $this->tpl->setOnScreenMessage('failure', $this->lng->txt("no_target_selected_for_move"), true);
+        $this->insertQuestionsBeforeOrAfter(self::INSERT_MODE_AFTER);
+    }
+
+    /**
+     * @param integer $insert_mode 0, if insert before the target position, 1 if insert after the target position
+     */
+    protected function insertQuestionsBeforeOrAfter(int $insert_mode)
+    {
+        $target_questions = $this->testrequest->getQuestionIds()
+            ? $this->testrequest->getQuestionIds()
+            : [$this->testrequest->getQuestionId()];
+
+        if (count($target_questions) === 0) {
+            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('no_target_selected_for_move'), true);
+            $this->ctrl->redirect($this, 'questions');
+        } elseif (count($target_questions) > 1) {
+            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('too_many_targets_selected_for_move'), true);
             $this->ctrl->redirect($this, 'questions');
         }
-        if (count($_POST['q_id']) > 1) {
-            $this->tpl->setOnScreenMessage('failure', $this->lng->txt("too_many_targets_selected_for_move"), true);
-            $this->ctrl->redirect($this, 'questions');
-        }
-        $insert_mode = 1;
-        $this->object->moveQuestions(ilSession::get('tst_qst_move_' . $this->object->getTestId()), $_POST['q_id'][0], $insert_mode);
-        $this->tpl->setOnScreenMessage('success', $this->lng->txt("msg_questions_moved"), true);
+
+        $this->object->moveQuestions(ilSession::get('tst_qst_move_' . $this->object->getTestId()), $target_questions[0], $insert_mode);
+        $this->tpl->setOnScreenMessage('success', $this->lng->txt('msg_questions_moved'), true);
         ilSession::clear('tst_qst_move_' . $this->object->getTestId());
-        $this->ctrl->redirect($this, "questions");
+        $this->ctrl->redirect($this, 'questions');
     }
 
     /**
@@ -1951,27 +1946,28 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
     */
     public function insertQuestionsObject()
     {
-        $selected_array = (is_array($_POST['q_id'])) ? $_POST['q_id'] : array();
-        if (!count($selected_array)) {
-            $this->tpl->setOnScreenMessage('info', $this->lng->txt("tst_insert_missing_question"), true);
-            $this->ctrl->redirect($this, "browseForQuestions");
-        } else {
-            $manscoring = false;
-            foreach ($selected_array as $key => $value) {
-                $this->object->insertQuestion($this->testQuestionSetConfigFactory->getQuestionSetConfig(), $value);
-                if (!$manscoring) {
-                    $manscoring = $manscoring | assQuestion::_needsManualScoring($value);
-                }
-            }
-            $this->object->saveCompleteStatus($this->testQuestionSetConfigFactory->getQuestionSetConfig());
-            if ($manscoring) {
-                $this->tpl->setOnScreenMessage('info', $this->lng->txt("manscoring_hint"), true);
-            } else {
-                $this->tpl->setOnScreenMessage('success', $this->lng->txt("tst_questions_inserted"), true);
-            }
-            $this->ctrl->redirect($this, "questions");
-            return;
+        $selected_questions = $this->testrequest->getQuestionIds()
+            ? $this->testrequest->getQuestionIds()
+            : [$this->testrequest->getQuestionId()];
+
+        if (count($selected_questions) === 0) {
+            $this->tpl->setOnScreenMessage('info', $this->lng->txt('tst_insert_missing_question'), true);
+            $this->ctrl->redirect($this, 'browseForQuestions');
         }
+
+        $man_scoring = false;
+        foreach ($selected_questions as $key => $value) {
+            $this->object->insertQuestion($this->testQuestionSetConfigFactory->getQuestionSetConfig(), $value);
+            $man_scoring = $man_scoring || assQuestion::_needsManualScoring($value);
+        }
+
+        $this->object->saveCompleteStatus($this->testQuestionSetConfigFactory->getQuestionSetConfig());
+        if ($man_scoring) {
+            $this->tpl->setOnScreenMessage('info', $this->lng->txt('manscoring_hint'), true);
+        } else {
+            $this->tpl->setOnScreenMessage('success', $this->lng->txt('tst_questions_inserted'), true);
+        }
+        $this->ctrl->redirect($this, 'questions');
     }
 
     public function addQuestionObject()


### PR DESCRIPTION
This PR addresses an 'undefined array key' problem caused by accessing the Superglobal variables `$_GET` and `$_POST` directly. 

See: https://mantis.ilias.de/view.php?id=41683, https://mantis.ilias.de/view.php?id=41684

### Problem

The error occurs when the [Drop-In-Replacements for Superglobals](https://github.com/ILIAS-eLearning/ILIAS/blob/release_8/src/HTTP/README.md#dropinreplacements) is deactivated. In this case, the arrays are accessed directly, which leads to an error message, as the IDs are not always in `$_POST`, but sometimes also in `$_GET`. If Drop-In-Replacement is activated (default behavior), the issue does not occur because the wrapper class intercepts this error.

### Reproduction

To reproduce the behavior as described in the ticket, Drop-In-Replacements must be deactivated explicitly:

```ini
# client.ini.php

[server]
prevent_super_global_replacement = "1"
```

### Fix

I have fixed the issue by completely removing access to the request arrays in the relevant methods. Instead, I use the request object (`InternalRequestService`) which is already available in the class. This object provides methods for querying the required parameters, which already select the correct request array and safely access the array index. In addition, typecasting already takes place there.

I also refactored the methods for inserting, as there was a lot of duplicate code here.