### PR TITLE
DataCollection: prevent error on old imports

### DIFF
--- a/Modules/DataCollection/classes/class.ilDataCollectionDataSet.php
+++ b/Modules/DataCollection/classes/class.ilDataCollectionDataSet.php
@@ -200,9 +200,9 @@ class ilDataCollectionDataSet extends ilDataSet
                 $new_table_id = $a_mapping->getMapping('Modules/DataCollection', 'il_dcl_table', $a_rec['table_id']);
                 if ($new_table_id) {
                     $datatype_id = $a_rec['datatype_id'];
-                    $datatype = $a_rec['datatype_title'];
+                    $datatype = $a_rec['datatype_title'] ?? null;
                     $datatypes = ilDclDatatype::getAllDatatype();
-                    if (ilDclFieldTypePlugin::isPluginDatatype($datatype)) {
+                    if ($datatype !== null && ilDclFieldTypePlugin::isPluginDatatype($datatype)) {
                         $datatype_id = null;
                         foreach ($datatypes as $dt) {
                             if ($dt->getTitle() === $datatype) {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42527

This prevents an error on old imports.
Be aware that this does not fix the import of older datacollection exports regarding plugin data.
Se the [Release Notes](https://docu.ilias.de/go/pg/185362_35) for more information.