### PR TITLE
fix Mantis #40887: Update LTI paths

### DIFF
--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -1685,7 +1685,7 @@ class ilInitialisation
                 $_GET['offset'] = (int) $_GET['offset'];        // old code
             }
 
-            self::initGlobal("lti", "ilLTIViewGUI", "./components/ILIAS/LTI/classes/class.ilLTIViewGUI.php");
+            self::initGlobal("lti", "ilLTIViewGUI", "./components/ILIAS/LTIProvider/classes/class.ilLTIViewGUI.php");
             $GLOBALS["DIC"]["lti"]->init();
             self::initKioskMode($GLOBALS["DIC"]);
         }

--- a/components/ILIAS/LTIProvider/classes/Consumer/class.ilObjectConsumerTableGUI.php
+++ b/components/ILIAS/LTIProvider/classes/Consumer/class.ilObjectConsumerTableGUI.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * TableGUI class for LTI consumer listing
@@ -53,7 +54,7 @@ class ilObjectConsumerTableGUI extends ilTable2GUI
         $this->addColumn($DIC->language()->txt("actions"), "");
 
         $this->setFormAction($DIC->ctrl()->getFormAction($a_parent_obj));
-        $this->setRowTemplate("tpl.lti_consumer_list_row.html", "components/ILIAS/LTI");
+        $this->setRowTemplate("tpl.lti_consumer_list_row.html", "components/ILIAS/LTIProvider");
         $this->setDefaultOrderField("title");
 
         $this->getItems();

--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderReleasedObjectsTableGUI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderReleasedObjectsTableGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Description of class class
@@ -47,7 +47,7 @@ class ilLTIProviderReleasedObjectsTableGUI extends ilObjectTableGUI
         $this->addColumn($this->lng->txt('lti_consumer'), 'consumer', '30%');
 
         $this->setOrderColumn('title');
-        $this->setRowTemplate('tpl.lti_object_table_row.html', 'components/ILIAS/LTI');
+        $this->setRowTemplate('tpl.lti_object_table_row.html', 'components/ILIAS/LTIProvider');
     }
 
     /**

--- a/components/ILIAS/LTIProvider/classes/Screen/LtiViewLayoutProvider.php
+++ b/components/ILIAS/LTIProvider/classes/Screen/LtiViewLayoutProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\LTI\Screen;
 
@@ -55,7 +55,7 @@ class LtiViewLayoutProvider extends AbstractModificationProvider implements Modi
      */
     public function getPageBuilderDecorator(CalledContexts $screen_context_stack): ?PageBuilderModification
     {
-        $this->globalScreen()->layout()->meta()->addCss('./components/ILIAS/LTI/templates/default/lti.css');
+        $this->globalScreen()->layout()->meta()->addCss('./components/ILIAS/LTIProvider/templates/default/lti.css');
         $is_exit_mode = $this->isLTIExitMode($screen_context_stack);
         $external_css = ($is_exit_mode) ? '' : $this->dic["lti"]->getExternalCss();
         if ($external_css !== '') {

--- a/scripts/Rector/ilUtils/ilutil_rector.php
+++ b/scripts/Rector/ilUtils/ilutil_rector.php
@@ -15,7 +15,7 @@ return static function (RectorConfig $rectorConfig): void {
         // there a several classes which make Rector break (multiple classes
         // in one file, wrong declarations in inheritance, ...)
         "components/ILIAS/LTIConsumer",
-        "components/ILIAS/LTI",
+        "components/ILIAS/LTIProvider",
         "components/ILIAS/SOAPAuth/include"
     ]);
     $rectorConfig->parameters()->set(Option::DEBUG, false);


### PR DESCRIPTION
It looks like LTI has been renamed to LTIProvider, but some paths have been forgotten to be renamed as well. 
Please check if I have found them all or if I have changed too many.