### PR TITLE
UI: adjust SCSS Coding Guidelines for ILIAS 10. To compile the SCSS f…

### DIFF
--- a/templates/Guidelines_SCSS-Coding.md
+++ b/templates/Guidelines_SCSS-Coding.md
@@ -456,7 +456,7 @@ Division with a slash (e.g. "10px / 2") outside of calc() is deprecated and MUST
 CSS is obtained by using the latest Dart Sass compiler on delos.scss, e.g. like so:
 
 ```
-sass templates/default/delos.scss templates/default/delos.css
+./node_modules/sass/sass.js templates/default/delos.scss templates/default/delos.css
 ```
 
 Note that the output heavily depends on the used sass version. You MUST use the latest release version of Dart Sass: https://github.com/sass/dart-sass/releases

--- a/templates/Readme.md
+++ b/templates/Readme.md
@@ -99,13 +99,13 @@ up-to-date for fixes from the main repo.
 Do not froget to re-compile the scss-file after each change. Switch to the delos scss folder and execute:
 
 ```
-sass delos.scss mystyle.css
+./node_modules/sass/sass.js delos.scss mystyle.css
 ```
 
 or
 
 ```
-sass --style=compressed delos.scss mystyle.css
+./node_modules/sass/sass.js --style=compressed delos.scss mystyle.css
 ```
 
 for a minified CSS version.


### PR DESCRIPTION
…iles without running into conflicts the repo's sass.js (in './node_modules/sass/') has to be used instead of the 'sass' command.