### PR TITLE
Legacy Form: fix date range comparison for combination inputs

### DIFF
--- a/Services/Form/classes/class.ilDateTimeInputGUI.php
+++ b/Services/Form/classes/class.ilDateTimeInputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * This class represents a date/time property in a property form.
@@ -327,7 +327,7 @@ class ilDateTimeInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableF
 
     public function getPostValueForComparison(): string
     {
-        return trim($this->str($this->getPostVar()));
+        return $this->serializeData();
     }
 
     public function getToolbarHTML(): string


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42053

This PR resolves an issue within the date range comparison of legacy forms.

##  Initial Problem
Within date range fields (combination fields of datetime with comparison mode) the comparison value of such datetime fields is not formatted correctly, causing the comparison to fail.
- e.g. `25.10.2024` is defined greater than `24.11.2036` since `25 > 24.`

The dates should be formatted into timestamps to be compared semantically correctly.

## Solution
The comparison provider method should use the serialized data since this is already transformed into a timestamp.
The solution must be provided for ILIAS 9+ as well.