### PR TITLE
Mail: Remove deprecated property

### DIFF
--- a/components/ILIAS/Mail/classes/class.ilPDMailBlockGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilPDMailBlockGUI.php
@@ -51,7 +51,6 @@ class ilPDMailBlockGUI extends ilBlockGUI
         $this->rbacsystem = $DIC->rbac()->system();
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
-        $this->new_rendering = true;
 
         parent::__construct();
 


### PR DESCRIPTION
Due to the changes made in https://github.com/ILIAS-eLearning/ILIAS/pull/6936

this property is no longer used, since all renderings are now "new renderings". This might throw an error depending on the PHP Version due to the deprecation of dynamic properties.

(I recommend removing this in ILIAS 10, too)