### PR TITLE
Tutorial Support: Remove deprecated property

### DIFF
--- a/components/ILIAS/Course/classes/class.ilTutorialSupportBlockGUI.php
+++ b/components/ILIAS/Course/classes/class.ilTutorialSupportBlockGUI.php
@@ -48,7 +48,6 @@ class ilTutorialSupportBlockGUI extends ilBlockGUI
     {
         global $DIC;
         parent::__construct();
-        $this->new_rendering = true;
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
         $this->ilias_settings = $DIC['ilSetting'];


### PR DESCRIPTION
Due to the changes made in https://github.com/ILIAS-eLearning/ILIAS/pull/6936

this property is no longer used, since all renderings are now "new renderings". This might throw an error depending on the PHP Version due to the deprecation of dynamic properties.

(I recommend removing this in ILIAS 10, too)