### PR TITLE
Calendar: fix css of recurrence inputs (42329)

### DIFF
--- a/Services/Calendar/templates/default/tpl.recurrence_input.html
+++ b/Services/Calendar/templates/default/tpl.recurrence_input.html
@@ -1,4 +1,4 @@
-<div class="form-inline">
+<div class="form-inline calrecurrenceinput">
 	{FREQUENCE}
 	<!-- BEGIN daily_block -->
 	<div id="sub_DAILY_1" style="padding-left: 40px;">
@@ -21,8 +21,8 @@
 		<label class="control-label" for="count_WEEKLY">{TXT_EVERY}</label>
 		<input type="text"
 			   class="form-control"
-				name="count_WEEKLY" 
-				value="{COUNT_WEEKLY_VAL}" 
+				name="count_WEEKLY"
+				value="{COUNT_WEEKLY_VAL}"
 				size="2"
 				maxlength="3"
 				style="text-align:right" />
@@ -46,10 +46,10 @@
 	<div id="sub_MONTHLY_1" style="padding-left: 40px;">
 		<hr/>
 		<label class="control-label" for="count_MONTHLY">{TXT_EVERY}</label>
-		<input	type="text" 
+		<input	type="text"
 				class="form-control ilRight"
-				name="count_MONTHLY" 
-				value="{COUNT_MONTHLY_VAL}" 
+				name="count_MONTHLY"
+				value="{COUNT_MONTHLY_VAL}"
 				size="2"
 				maxlength="3" />
 		{TXT_MONTHLY_FREQ_UNIT}
@@ -75,7 +75,7 @@
 					value="2" /> {TXT_ON_THE}</label>
 		{SELECT_BYMONTHDAY}
 		{TXT_SUFFIX}
-		<hr/>	
+		<hr/>
 	</div>
 	<!-- END monthly_block -->
 	<!-- BEGIN yearly_block -->
@@ -83,9 +83,9 @@
 		<hr/>
 		<label class="control-label" for="count_YEARLY">{TXT_EVERY}</label>
 		<input	type="text"
-				class="form-control ilRight" 
-				name="count_YEARLY" 
-				value="{COUNT_YEARLY_VAL}" 
+				class="form-control ilRight"
+				name="count_YEARLY"
+				value="{COUNT_YEARLY_VAL}"
 				size="2"
 				maxlength="3" />
 		{TXT_YEARLY_FREQ_UNIT}
@@ -116,7 +116,7 @@
 		<hr/>
 	</div>
 	<!-- END yearly_block -->
-	
+
 	<!--  BEGIN until_selection_unlimited -->
 	<div id="sub_UNTIL_1" style="padding-left: 40px;">
 			<label class="control-label">

--- a/templates/default/070-components/legacy/Services/_component_calendar.scss
+++ b/templates/default/070-components/legacy/Services/_component_calendar.scss
@@ -488,3 +488,14 @@ span.ilIcalIcon .btn {
 		padding-right: 4px;
 	}
 }
+
+// Hacky solution to make legacy recurrence inputs look okay, #42329
+
+.calrecurrenceinput.form-inline label {
+	padding-right: unset;
+	vertical-align: unset;
+}
+
+.calrecurrenceinput.form-inline .form-control {
+	vertical-align: middle;
+}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -13840,6 +13840,15 @@ span.ilIcalIcon .btn {
   padding-right: 4px;
 }
 
+.calrecurrenceinput.form-inline label {
+  padding-right: unset;
+  vertical-align: unset;
+}
+
+.calrecurrenceinput.form-inline .form-control {
+  vertical-align: middle;
+}
+
 /* Services/Chart */
 td.legendColorBox, td.legendLabel {
   padding: 3px;


### PR DESCRIPTION
This PR fixes [42329](https://mantis.ilias.de/view.php?id=42329) by introducing a new css class for the recurrence input, such that the changes to legacy forms can be reverted 'locally'.

Are there any requirements on css style in legacy UI (naming conventions, etc.)?