### PR TITLE
UI: 41308, adjust rendering of symbols in breadcrumbs.

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Breadcrumbs/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Breadcrumbs/Renderer.php
@@ -42,6 +42,10 @@ class Renderer extends AbstractComponentRenderer
         foreach ($component->getItems() as $crumb) {
             $tpl->setCurrentBlock("crumbs");
             $tpl->setVariable("CRUMB", $default_renderer->render($crumb));
+            if (!preg_match('/[a-zA-Z0-9\ ]$/', $crumb->getLabel())) {
+                $tpl->setCurrentBlock("lrmmark");
+                $tpl->setVariable("LRMMARK", htmlspecialchars_decode("&lrm;", ENT_HTML5));
+            }
             $tpl->parseCurrentBlock();
         }
         return $tpl->get();

--- a/components/ILIAS/UI/src/templates/default/Breadcrumbs/tpl.breadcrumbs.html
+++ b/components/ILIAS/UI/src/templates/default/Breadcrumbs/tpl.breadcrumbs.html
@@ -3,6 +3,9 @@
 		<!-- BEGIN crumbs -->
 		<span class="crumb">
 			{CRUMB}
+			<!-- BEGIN lrmmark -->
+			{LRMMARK}
+			<!-- END lrmmark -->
 		</span>
 		<!-- END crumbs -->
 	</div>

--- a/components/ILIAS/UI/tests/Component/Breadcrumbs/BreadcrumbsTest.php
+++ b/components/ILIAS/UI/tests/Component/Breadcrumbs/BreadcrumbsTest.php
@@ -97,4 +97,34 @@ class BreadcrumbsTest extends ILIAS_UI_TestBase
 
         $this->assertHTMLEquals($expected, $html);
     }
+
+    public function testRenderingWithSpecialCharacters(): void
+    {
+        $f = $this->getFactory();
+        $r = $this->getDefaultRenderer();
+
+        $label = "label without special characters";
+        $label2 = "label with special characters + –...+}*@ç%#&/($";
+
+        $crumbs = [
+            new I\Component\Link\Standard($label, '#'),
+            new I\Component\Link\Standard($label2, '#')
+        ];
+        $c = $f->Breadcrumbs($crumbs);
+
+        $html = $this->brutallyTrimHTML($r->render($c));
+        $expected = '<nav aria-label="breadcrumbs_aria_label" class="breadcrumb_wrapper">'
+            . '	<div class="breadcrumb">'
+            . '		    <span class="crumb">'
+            . '			    <a href="#">label without special characters</a>'
+            . '		    </span>'
+            . '		    <span class="crumb">'
+            . '			    <a href="#">label with special characters + –...+}*@ç%#&/($</a>'
+            . '&lrm;'
+            . '		    </span>'
+            . '	</div>'
+            . '</nav>';
+
+        $this->assertEquals($this->brutallyTrimHTML($expected), $html);
+    }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41308

As 'direction: rtl;' is used to shorten the breadcrumbs from right to left we cannot use 'dir/direction ltr;' in spans or bdo/bdi tags as it will destroy the purpose of shortening inputs that are too long in regard to the screen size. It also will change the sortation of the single breadcrumbs (e.g.: repository will be rendered at last instead at first) in case of using '<span dir:'ltr'>'.

Therefore adding a left-to-right html character into the breadcrumb template was necessary.