### PR TITLE
Integrate league oauth2 client for openid connect

### DIFF
--- a/components/ILIAS/OpenIdConnect/classes/class.ilOpenIdConnectSettings.php
+++ b/components/ILIAS/OpenIdConnect/classes/class.ilOpenIdConnectSettings.php
@@ -90,6 +90,7 @@ class ilOpenIdConnectSettings
     private ?string $custom_discovery_url = null;
     private ilLanguage $lng;
     private ilUserDefinedFields $udf;
+    private string $scope_separator = ' ';
 
     private function __construct()
     {
@@ -447,6 +448,8 @@ class ilOpenIdConnectSettings
         } else {
             $this->storage->delete('custom_discovery_url');
         }
+
+        $this->storage->set('scope_separator', $this->getScopeSeparator());
     }
 
     protected function load(): void
@@ -491,6 +494,7 @@ class ilOpenIdConnectSettings
         if (self::URL_VALIDATION_CUSTOM === $this->getValidateScopes()) {
             $this->setCustomDiscoveryUrl($this->storage->get('custom_discovery_url'));
         }
+        $this->setScopeSeparator($this->storage->get('scope_separator') ?? ' ');
     }
 
     public function getProfileMappingFieldValue(string $field): string
@@ -555,5 +559,15 @@ class ilOpenIdConnectSettings
         }
 
         return $mapping_fields;
+    }
+
+    public function getScopeSeparator(): string
+    {
+        return $this->scope_separator;
+    }
+
+    public function setScopeSeparator(string $scope_separator): void
+    {
+        $this->scope_separator = $scope_separator;
     }
 }

--- a/components/ILIAS/OpenIdConnect/src/Authentication/Authenticator.php
+++ b/components/ILIAS/OpenIdConnect/src/Authentication/Authenticator.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\OpenIdConnect\Authentication;
+
+use ILIAS\Data\Factory;
+use IlIAS\HTTP\Services as HttpService;
+use ILIAS\OpenIdConnect\Exceptions\AuthenticationException;
+use ILIAS\Refinery\Factory as Refinery;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Token\AccessTokenInterface;
+
+class Authenticator
+{
+    public const SESSION_KEY_STATE = 'oauth2state';
+    public const SESSION_KEY_CODE = 'oauth2pkceCode';
+
+    public function __construct(
+        private readonly Refinery $refinery,
+        private readonly HttpService $http_service,
+        private readonly \ilCtrlInterface $ctrl
+    ) {
+    }
+
+    public function authenticate(OpenIdConnectProvider $provider, array $auth_params = []): ?AccessTokenInterface
+    {
+        $request = $this->http_service->wrapper();
+
+        if ($request->query()->has('error') || $request->query()->has('error_description')) {
+            $error_description = $request->query()->retrieve(
+                'error_description',
+                $this->refinery->byTrying([
+                    $this->refinery->kindlyTo()->string(),
+                    $this->refinery->always(
+                        $request->query()->retrieve(
+                            'error',
+                            $this->refinery->kindlyTo()->string()
+                        )
+                    )
+                ])
+            );
+
+            throw new AuthenticationException($error_description);
+        }
+
+        $code = $request->query()->retrieve(
+            'code',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always(null)
+            ])
+        );
+
+        if (!$code) {
+            $auth_url = $provider->getAuthorizationUrl($auth_params);
+
+            \ilSession::set(self::SESSION_KEY_STATE, $provider->getState());
+            \ilSession::set(self::SESSION_KEY_CODE, $provider->getPkceCode());
+
+            $this->ctrl->redirectToURL($auth_url);
+            return null;
+        }
+
+        $state = $request->query()->retrieve(
+            'state',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always(null)
+            ])
+        );
+
+        if (!$state || !\ilSession::has(self::SESSION_KEY_STATE) || $state !== \ilSession::get(self::SESSION_KEY_STATE)) {
+            \ilSession::clear(self::SESSION_KEY_STATE);
+            \ilSession::clear(self::SESSION_KEY_CODE);
+
+            throw new AuthenticationException('Invalid State');
+        }
+
+        try {
+            $provider->setPkceCode(\ilSession::get(self::SESSION_KEY_CODE));
+
+            return $provider->getAccessToken('authorization_code', [
+                'code' => $code
+            ]);
+        } catch (IdentityProviderException $e) {
+            throw new AuthenticationException(
+                $e->getMessage(),
+                $e->getCode()
+            );
+        }
+    }
+
+    public function logout(OpenIdConnectProvider $provider, string $id_token): void
+    {
+        $end_session_url = (new Factory())->uri($provider->getEndSessionUrl());
+        $end_session_url = $end_session_url
+            ->withParameters([
+                'id_token_hint' => $id_token,
+                'post_logout_redirect_uri' => ILIAS_HTTP_PATH . '/' . \ilStartUpGUI::logoutUrl()
+            ]);
+
+        $this->ctrl->redirectToURL((string) $end_session_url);
+    }
+}

--- a/components/ILIAS/OpenIdConnect/src/Authentication/OpenIdConnectProvider.php
+++ b/components/ILIAS/OpenIdConnect/src/Authentication/OpenIdConnectProvider.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\OpenIdConnect\Authentication;
+
+use ILIAS\Cache\Config;
+use ILIAS\Cache\Container\ActiveContainer;
+use ILIAS\Cache\Container\BaseRequest;
+use ILIAS\Cache\Container\Container;
+use ILIAS\Cache\Container\VoidContainer;
+use ILIAS\OpenIdConnect\Exceptions\AuthenticationException;
+use ILIAS\OpenIdConnect\Exceptions\OpenIdConnectException;
+use League\OAuth2\Client\Provider\GenericProvider;
+use League\OAuth2\Client\Token\AccessToken;
+use ILIAS\Cache\Services as CacheFactory;
+use ILIAS\Refinery\Factory as Refinery;
+
+class OpenIdConnectProvider extends GenericProvider
+{
+    private array $config = [];
+    private ?CacheFactory $cache = null;
+
+    protected string $url_provider;
+    protected string $scope_separator = ' ';
+
+    public function __construct(
+        private readonly Refinery $refinery,
+        array $options = [],
+        array $collaborators = []
+    ) {
+        $options['pkceMethod'] = self::PKCE_METHOD_S256;
+
+        parent::__construct($options, $collaborators);
+    }
+
+    public function withCache(CacheFactory $cache): self
+    {
+        $clone = clone $this;
+        $clone->cache = $cache;
+        return $clone;
+    }
+
+    protected function getConfigurableOptions(): array
+    {
+        return array_merge(parent::getConfigurableOptions(), [
+            'proxy',
+            'timeout',
+            'verify',
+            'scope_separator'
+        ]);
+    }
+
+    protected function getRequiredOptions(): array
+    {
+        return [
+            'url_provider',
+        ];
+    }
+
+    public function getBaseAuthorizationUrl(): string
+    {
+        return $this->getProviderUrl(WellKnownEndpoints::AUTHORIZATION);
+    }
+
+    public function getBaseAccessTokenUrl(array $params): string
+    {
+        return $this->getProviderUrl(WellKnownEndpoints::TOKEN);
+    }
+
+    public function getResourceOwnerDetailsUrl(AccessToken $token): string
+    {
+        return $this->getProviderUrl(WellKnownEndpoints::USERINFO);
+    }
+
+    public function getEndSessionUrl(): string
+    {
+        return $this->getProviderUrl(WellKnownEndpoints::END_SESSION);
+    }
+
+    public function getIdToken(AccessToken $token): string
+    {
+        $values = $token->getValues();
+
+        if (!isset($values['id_token'])) {
+            throw new AuthenticationException('Authenticated without openid scope');
+        }
+
+        return $values['id_token'];
+    }
+
+    public function getIdTokenPayload(AccessToken $access_token): array
+    {
+        $id_token = $this->getIdToken($access_token);
+        $parts = explode('.', $id_token);
+        return [
+            'header' => json_decode(base64_decode($parts[0] ?? ''), true),
+            'body' => json_decode(base64_decode($parts[1] ?? ''), true)
+        ];
+    }
+
+    private function getProviderUrl(WellKnownEndpoints $type): string
+    {
+        if (!$this->isCached($type) && !$this->isInMemory($type)) {
+            $this->loadWellKnownConfig();
+        }
+
+        return $this->isCacheEnable()
+            ? $this->readFromCache($type)
+            : $this->config[$type->value];
+    }
+
+    private function loadWellKnownConfig(): void
+    {
+        $response = $this->getHttpClient()->request('GET', $this->url_provider . '/.well-known/openid-configuration');
+        if (200 !== $response->getStatusCode()) {
+            throw new OpenIdConnectException('Cannot access OpenID configuration resource.');
+        }
+
+        try {
+            $content = $response->getBody()->getContents();
+        } catch (\RuntimeException $e) {
+            throw new OpenIdConnectException('Cannot read OpenID configuration content.');
+        }
+
+        if (null === $json = json_decode($content, true)) {
+            throw new OpenIdConnectException('Cannot decode OpenID configuration file.');
+        }
+
+        $this->config = $json;
+
+        if ($this->isCacheEnable()) {
+            $this->writeToCache($json);
+        }
+    }
+
+    private function isInMemory(WellKnownEndpoints $type): bool
+    {
+        return isset($this->config[$type->value]);
+    }
+
+    private function isCached(WellKnownEndpoints $type): bool
+    {
+        if (!$this->isCacheEnable()) {
+            return false;
+        }
+
+        return $this->getCacheContainer()->has($type->value);
+    }
+
+    private function readFromCache(WellKnownEndpoints $type): ?string
+    {
+        return $this->getCacheContainer()
+            ->get(
+                $type->value,
+                $this->refinery->to()->string()
+            );
+    }
+
+    private function writeToCache(array $config): void
+    {
+        $cache_container = $this->getCacheContainer();
+
+        foreach ($config as $key => $value) {
+            $cache_container->set($key, $value);
+        }
+    }
+
+    private function getCacheContainer(): Container
+    {
+        return $this->cache->get(new BaseRequest('auth_oidc_config', true));
+    }
+
+    protected function getScopeSeparator(): string
+    {
+        return $this->scope_separator;
+    }
+
+
+    private function isCacheEnable(): bool
+    {
+        return $this->cache && !$this->cache instanceof VoidContainer;
+    }
+
+}

--- a/components/ILIAS/OpenIdConnect/src/Authentication/WellKnownEndpoints.php
+++ b/components/ILIAS/OpenIdConnect/src/Authentication/WellKnownEndpoints.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\OpenIdConnect\Authentication;
+
+enum WellKnownEndpoints: string
+{
+    case AUTHORIZATION = 'authorization_endpoint';
+    case TOKEN = 'token_endpoint';
+    case USERINFO = 'userinfo_endpoint';
+    case END_SESSION = 'end_session_endpoint';
+}

--- a/components/ILIAS/OpenIdConnect/src/Exceptions/AuthenticationException.php
+++ b/components/ILIAS/OpenIdConnect/src/Exceptions/AuthenticationException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\OpenIdConnect\Exceptions;
+
+class AuthenticationException extends \ilException
+{
+}

--- a/components/ILIAS/OpenIdConnect/src/Exceptions/OpenIdConnectException.php
+++ b/components/ILIAS/OpenIdConnect/src/Exceptions/OpenIdConnectException.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\OpenIdConnect\Exceptions;
+
+use ilException;
+
+class OpenIdConnectException extends ilException
+{
+}

--- a/components/ILIAS/OpenIdConnect/tests/Authentication/AuthenticatorTest.php
+++ b/components/ILIAS/OpenIdConnect/tests/Authentication/AuthenticatorTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace ILIAS\OpenIdConnect\Tests\Authentication;
+
+use ilCtrlInterface;
+use ILIAS\DI\Container;
+use ILIAS\HTTP\Services as HttpService;
+use ILIAS\HTTP\Wrapper\ArrayBasedRequestWrapper;
+use ILIAS\HTTP\Wrapper\WrapperFactory;
+use ILIAS\OpenIdConnect\Authentication\Authenticator;
+use ILIAS\OpenIdConnect\Authentication\OpenIdConnectProvider;
+use ILIAS\OpenIdConnect\Exceptions\AuthenticationException;
+use ILIAS\Refinery\Factory;
+use ilObjUser;
+use ilSession;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+use function define;
+use function defined;
+use function str_starts_with;
+
+class AuthenticatorTest extends TestCase
+{
+    private const TEST_CODE = 'test_code_1234';
+    private const TEST_STATE = 'test_state_5678';
+    private const TEST_PKCE_CODE = 'test_pkce_code';
+    private const TEST_ID_TOKEN = 'test_id_token';
+
+    /**
+     * @var MockObject<ilCtrlInterface>
+     */
+    protected MockObject $ctrl;
+    /**
+     * @var MockObject<OpenIdConnectProvider>
+     */
+    protected MockObject $provider;
+    /**
+     * @var MockObject<HttpService>
+     */
+    protected MockObject $http;
+    /**
+     * @var MockObject<ArrayBasedRequestWrapper>
+     */
+    protected MockObject $query;
+
+    protected Authenticator $authenticator;
+
+    protected function setUp(): void
+    {
+        if (!defined('ILIAS_HTTP_PATH')) {
+            define('ILIAS_HTTP_PATH', 'http://ilias.example.com');
+        }
+
+        $this->ctrl = $this->createMock(ilCtrlInterface::class);
+        $this->provider = $this->createMock(OpenIdConnectProvider::class);
+        [$this->http, $this->query] = $this->createHttpMocks();
+        $this->authenticator = new Authenticator(
+            $this->createMock(Factory::class),
+            $this->http,
+            $this->ctrl
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        ilSession::clear(Authenticator::SESSION_KEY_STATE);
+        ilSession::clear(Authenticator::SESSION_KEY_CODE);
+    }
+
+    public function testAuthenticateWithoutCode()
+    {
+        $this->provider
+            ->expects($this->once())
+            ->method('getAuthorizationUrl')
+            ->willReturn('http://auth.example.com/login');
+
+        $this->ctrl
+            ->expects($this->once())
+            ->method('redirectToURL')
+            ->with($this->callback(
+                fn($url) => str_starts_with($url, 'http://auth.example.com/login')
+            ));
+        $this->authenticator->authenticate($this->provider, []);
+    }
+
+    public function testAuthenticateWithInvalidStateQuery()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid State');
+
+        $this->query->method('retrieve')
+            ->willReturnCallback(function ($name) {
+                return match($name) {
+                    'code' => self::TEST_CODE,
+                    'state' => null
+                };
+            });
+
+        ilSession::set(Authenticator::SESSION_KEY_STATE, self::TEST_STATE);
+
+        $this->authenticator->authenticate($this->provider, []);
+    }
+
+    public function testAuthenticateWithInvalidStateSession()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid State');
+
+        $this->query->method('retrieve')
+            ->willReturnCallback(function ($name) {
+                return match($name) {
+                    'code' => self::TEST_CODE,
+                    'state' => self::TEST_STATE
+                };
+            });
+
+        $this->authenticator->authenticate($this->provider, []);
+    }
+
+    public function testAuthenticateWithCode()
+    {
+        $this->provider
+            ->expects($this->never())
+            ->method('getAuthorizationUrl')
+            ->willReturn('http://auth.example.com');
+
+        $this->query->method('retrieve')
+            ->willReturnCallback(function ($name) {
+                return match($name) {
+                    'code' => self::TEST_CODE,
+                    'state' => self::TEST_STATE
+                };
+            });
+
+        \ilSession::set(Authenticator::SESSION_KEY_STATE, self::TEST_STATE);
+        \ilSession::set(Authenticator::SESSION_KEY_CODE, self::TEST_PKCE_CODE);
+
+        $this->provider
+            ->expects($this->once())
+            ->method('setPkceCode')
+            ->with($this->equalTo(self::TEST_PKCE_CODE));
+        $this->provider
+            ->expects($this->once())
+            ->method('getAccessToken')
+            ->with(
+                $this->equalTo('authorization_code'),
+                $this->equalTo(['code' => self::TEST_CODE])
+            )->willReturn($this->createMock(AccessToken::class));
+
+        $access_token = $this->authenticator->authenticate($this->provider, []);
+        $this->assertInstanceOf(AccessToken::class, $access_token);
+    }
+
+
+    public function testAuthenticateException()
+    {
+        $this->expectException(AuthenticationException::class);
+
+        $this->provider
+            ->expects($this->never())
+            ->method('getAuthorizationUrl')
+            ->willReturn('http://auth.example.com');
+
+        $this->query->method('retrieve')
+            ->willReturnCallback(function ($name) {
+                return match($name) {
+                    'code' => self::TEST_CODE,
+                    'state' => self::TEST_STATE
+                };
+            });
+
+        \ilSession::set(Authenticator::SESSION_KEY_STATE, self::TEST_STATE);
+        \ilSession::set(Authenticator::SESSION_KEY_CODE, self::TEST_PKCE_CODE);
+
+        $this->provider
+            ->expects($this->once())
+            ->method('getAccessToken')
+            ->willThrowException($this->createMock(IdentityProviderException::class));
+
+        $this->authenticator->authenticate($this->provider, []);
+    }
+
+    public function testAuthenticateWithError()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid Scopes a b c');
+        $this->query->method('has')
+            ->willReturnCallback(function ($name) {
+                return match($name) {
+                    'error' => true,
+                    'error_description' => true,
+                    default => false
+                };
+            });
+        $this->query->method('retrieve')
+            ->willReturnCallback(function ($name) {
+                return match($name) {
+                    'error' => 'Invalid Scopes',
+                    'error_description' => 'Invalid Scopes a b c',
+                    default => null
+                };
+            });
+
+        $this->authenticator->authenticate($this->provider, []);
+    }
+
+    public function testLogout()
+    {
+        global $DIC;
+
+        $DIC = $this->createMock(Container::class);
+        $DIC->method('user')->willReturn($this->createMock(ilObjUser::class));
+
+        $this->provider
+            ->expects($this->once())
+            ->method('getEndSessionUrl')
+            ->willReturn('http://auth.example.com/logout');
+
+        $this->ctrl
+            ->expects($this->once())
+            ->method('redirectToURL')
+            ->with($this->callback(
+                fn(string $url) => str_starts_with($url, 'http://auth.example.com/logout')
+            ));
+
+        $this->authenticator->logout($this->provider, self::TEST_ID_TOKEN);
+    }
+
+    /**
+     * @return array{0: MockObject<HttpService>, 1: MockObject<ArrayBasedRequestWrapper>}
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    protected function createHttpMocks(): array
+    {
+        $query_mock = $this->createMock(ArrayBasedRequestWrapper::class);
+        $http_wrapper_mock = $this->createMock(WrapperFactory::class);
+        $http_mock = $this->createMock(HttpService::class);
+
+        $http_mock->method('wrapper')->willReturn($http_wrapper_mock);
+        $http_wrapper_mock->method('query')->willReturn($query_mock);
+
+        return [$http_mock, $query_mock];
+    }
+}

--- a/components/ILIAS/OpenIdConnect/tests/Authentication/OpenIdConnectProviderTest.php
+++ b/components/ILIAS/OpenIdConnect/tests/Authentication/OpenIdConnectProviderTest.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace ILIAS\OpenIdConnect\Tests\Authentication;
+
+use GuzzleHttp\ClientInterface;
+use ILIAS\Cache\Container\Container;
+use ILIAS\Cache\Services as CacheService;
+use ILIAS\OpenIdConnect\Authentication\OpenIdConnectProvider;
+use ILIAS\OpenIdConnect\Authentication\WellKnownEndpoints;
+use ILIAS\OpenIdConnect\Exceptions\AuthenticationException;
+use ILIAS\OpenIdConnect\Exceptions\OpenIdConnectException;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\To\Group;
+use ILIAS\Refinery\To\Transformation\StringTransformation;
+use ILIAS\Refinery\Transformation;
+use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+
+use function base64_encode;
+use function json_encode;
+
+class OpenIdConnectProviderTest extends TestCase
+{
+    private const TEST_URL_PROVIDER = 'http://auth.example.com';
+    /**
+     * @var MockObject<CacheService>
+     */
+    protected MockObject $cache;
+    /**
+     * @var MockObject<ClientInterface>
+     */
+    private MockObject $http_client;
+
+    protected OpenIdConnectProvider $provider;
+
+    protected function setUp(): void
+    {
+        $refinery = $this->createMock(Refinery::class);
+
+        $this->http_client = $this->createMock(ClientInterface::class);
+        $this->cache = $this->mockCache();
+        $this->provider = new OpenIdConnectProvider(
+            $refinery,
+            [
+                'url_provider' => self::TEST_URL_PROVIDER,
+                'scopes' => ['openid', 'email']
+            ],
+            [
+                'httpClient' => $this->http_client
+            ]
+        );
+    }
+
+    public function testWithCache()
+    {
+        $providerWithCache = $this->provider->withCache($this->cache);
+
+        $this->assertInstanceOf(OpenIdConnectProvider::class, $providerWithCache);
+        $this->assertNotSame($providerWithCache, $this->provider);
+    }
+
+    public function testLoadUrlWithInvalidStatusCode()
+    {
+        $this->expectException(OpenIdConnectException::class);
+        $this->expectExceptionMessage('Cannot access OpenID configuration resource.');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(400);
+
+        $this->http_client
+            ->expects($this->once())
+            ->method('request')
+            ->with(
+                $this->equalTo('GET'),
+                $this->equalTo(self::TEST_URL_PROVIDER . '/.well-known/openid-configuration')
+            )->willReturn($response);
+
+        $this->provider->getBaseAuthorizationUrl();
+    }
+
+    public function testLoadUrlWithInvalidResponse()
+    {
+        $this->expectException(OpenIdConnectException::class);
+        $this->expectExceptionMessage('Cannot read OpenID configuration content.');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $response
+            ->expects($this->once())
+            ->method('getBody')
+            ->willThrowException(new \RuntimeException("Connection failed"));
+
+        $this->http_client
+            ->expects($this->once())
+            ->method('request')
+            ->with(
+                $this->equalTo('GET'),
+                $this->equalTo(self::TEST_URL_PROVIDER . '/.well-known/openid-configuration')
+            )->willReturn($response);
+
+        $this->provider->getBaseAuthorizationUrl();
+    }
+
+
+    public function testLoadUrlWithInvalidJson()
+    {
+        $this->expectException(OpenIdConnectException::class);
+        $this->expectExceptionMessage('Cannot decode OpenID configuration file.');
+
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->expects($this->once())
+            ->method('getContents')
+            ->willReturn("");
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(200);
+        $response
+            ->expects($this->once())
+            ->method('getBody')
+            ->willReturn($stream);
+
+        $this->http_client
+            ->expects($this->once())
+            ->method('request')
+            ->with(
+                $this->equalTo('GET'),
+                $this->equalTo(self::TEST_URL_PROVIDER . '/.well-known/openid-configuration')
+            )->willReturn($response);
+
+        $this->provider->getBaseAuthorizationUrl();
+    }
+
+    /**
+     * @dataProvider provideEnableCache
+     */
+    public function testGetUrls(bool $enable_cache): void
+    {
+        $provider = $this->provider;
+        if ($enable_cache) {
+            $provider = $provider->withCache($this->cache);
+        }
+
+        $dummy_urls = $this->getDummyUrls();
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->expects($this->once())
+            ->method('getContents')
+            ->willReturn(json_encode($dummy_urls));
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(200);
+        $response
+            ->expects($this->once())
+            ->method('getBody')
+            ->willReturn($stream);
+
+        $this->http_client
+            ->expects($this->once())
+            ->method('request')
+            ->with(
+                $this->equalTo('GET'),
+                $this->equalTo(self::TEST_URL_PROVIDER . '/.well-known/openid-configuration')
+            )->willReturn($response);
+
+        $authorization_url = $provider->getBaseAuthorizationUrl();
+        $access_token_url = $provider->getBaseAccessTokenUrl([]);
+        $resource_owner_url = $provider->getResourceOwnerDetailsUrl($this->createMock(AccessToken::class));
+        $end_session_url = $provider->getEndSessionUrl();
+
+        $this->assertContains($authorization_url, $dummy_urls);
+        $this->assertContains($access_token_url, $dummy_urls);
+        $this->assertContains($resource_owner_url, $dummy_urls);
+        $this->assertContains($end_session_url, $dummy_urls);
+    }
+
+    public function testIdTokenMissing(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Authenticated without openid scope');
+
+        $access_token = $this->createMock(AccessToken::class);
+        $access_token
+            ->expects($this->once())
+            ->method('getValues')
+            ->willReturn([]);
+
+        $this->provider->getIdToken($access_token);
+    }
+
+
+    public function testIdToken(): void
+    {
+        $id_token = $this->getDummyIdToken();
+        $access_token = $this->createMock(AccessToken::class);
+        $access_token
+            ->expects($this->once())
+            ->method('getValues')
+            ->willReturn([
+                'id_token' => $id_token
+            ]);
+
+        $this->assertEquals(
+            $id_token,
+            $this->provider->getIdToken($access_token)
+        );
+    }
+
+    public function testIdTokenPayload(): void
+    {
+        $id_token = $this->getDummyIdToken();
+        $access_token = $this->createMock(AccessToken::class);
+        $access_token
+            ->expects($this->once())
+            ->method('getValues')
+            ->willReturn([
+                'id_token' => $id_token
+            ]);
+
+        $this->assertEquals(
+            [
+                'header' => ['head' => 'value'],
+                'body' => ['email' => 'user@example.com']
+            ],
+            $this->provider->getIdTokenPayload($access_token)
+        );
+    }
+
+    public function provideEnableCache(): array
+    {
+        return [
+            'without cache' => [false],
+            'with cache' => [true]
+        ];
+    }
+
+    private function getDummyUrls(): array
+    {
+        return [
+            WellKnownEndpoints::AUTHORIZATION->value => self::TEST_URL_PROVIDER . '/auth',
+            WellKnownEndpoints::TOKEN->value => self::TEST_URL_PROVIDER . '/token',
+            WellKnownEndpoints::USERINFO->value => self::TEST_URL_PROVIDER . '/userinfo',
+            WellKnownEndpoints::END_SESSION->value => self::TEST_URL_PROVIDER . '/endsession'
+        ];
+    }
+
+    private function getDummyIdToken(): string
+    {
+        return sprintf(
+            '%s.%s',
+            base64_encode(json_encode(['head' => 'value'])),
+            base64_encode(json_encode(['email' => 'user@example.com']))
+        );
+    }
+
+    private function mockCache(): CacheService
+    {
+        $fake_cache = [];
+
+        $cacheContainer = $this->createMock(Container::class);
+        $cacheContainer
+            ->method('has')
+            ->willReturnCallback(function (string $key) use (&$fake_cache) {
+                return isset($fake_cache[$key]);
+            });
+        $cacheContainer
+            ->method('get')
+            ->willReturnCallback(function (string $key) use (&$fake_cache) {
+                return $fake_cache[$key];
+            });
+        $cacheContainer
+            ->method('set')
+            ->willReturnCallback(function (string $key, mixed $value) use (&$fake_cache) {
+                $fake_cache[$key] = $value;
+            });
+
+        $cache = $this->createMock(CacheService::class);
+        $cache
+            ->method('get')
+            ->willReturn($cacheContainer);
+
+        return $cache;
+    }
+}

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2133,6 +2133,10 @@ auth#:#auth_oidc_settings_logout_scope_global_info#:#Wenn aktiviert, wird beim A
 auth#:#auth_oidc_settings_logout_scope_local#:#nur bei ILIAS abmelden
 auth#:#auth_oidc_settings_logout_scope_local_info#:#Wenn aktiviert, wird beim Abmelden nur die ILIAS-Sitzung beendet.
 auth#:#auth_oidc_settings_provider#:#Provider-URL
+auth#:#auth_oidc_settings_scope_separator#:#Scope Trennzeichen
+auth#:#auth_oidc_settings_scope_separator_comma#:#Komma (",")
+auth#:#auth_oidc_settings_scope_separator_info#:#Diese Zeichen wird dazu verwendet, die Scopes in der Authenfizierungs-URL zu einem String zuverbinden.
+auth#:#auth_oidc_settings_scope_separator_space#:#Leerzeichen (" ")
 auth#:#auth_oidc_settings_secret#:#Client-Schlüssel
 auth#:#auth_oidc_settings_section_user_sync#:#Einstellungen zur Benutzersynchronisierung
 auth#:#auth_oidc_settings_session_duration#:#Dauer

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2133,6 +2133,10 @@ auth#:#auth_oidc_settings_logout_scope_global_info#:#When a users logs out, they
 auth#:#auth_oidc_settings_logout_scope_local#:#Log Out of ILIAS ONLY
 auth#:#auth_oidc_settings_logout_scope_local_info#:#When a user logs out, they only end their session in  ILIAS, not their OpenID Connect session.
 auth#:#auth_oidc_settings_provider#:#Provider URL
+auth#:#auth_oidc_settings_scope_separator#:#Scope Trennzeichen
+auth#:#auth_oidc_settings_scope_separator_comma#:#Komma (",")
+auth#:#auth_oidc_settings_scope_separator_info#:#Diese Zeichen wird dazu verwendet, die Scopes in der Authenfizierungs-URL zu einem String zuverbinden.
+auth#:#auth_oidc_settings_scope_separator_space#:#Leerzeichen (" ")
 auth#:#auth_oidc_settings_secret#:#Client Key
 auth#:#auth_oidc_settings_section_user_sync#:#User Synchronisation Settings
 auth#:#auth_oidc_settings_session_duration#:#Duration


### PR DESCRIPTION
This PR addresses (https://mantis.ilias.de/view.php?id=42623).

Due to security concerns (see #6766), the previous dependency was removed. This PR introduces a secure alternative by implementing league/oauth2-client, which will be added as a dependency with #8375.

Summary of Changes
* Commit 1: Focuses on minimal changes, updating only the necessary code to integrate the new dependency while keeping most of the existing structure intact.

* Commit 2: Enhances the scopes configuration UI by removing an unnecessary nested group. It also adds a new configuration option, scope_separator, to allow flexible joining of scopes as a string in the Authentication request, accommodating variations across providers.

Feedback and suggestions are welcome.

Best regards,
@thojou