### PR TITLE
Deps: add webui-popover (npm)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "linkify-element": "^4.1.3",
         "linkifyjs": "^4.1.3",
         "moment": "^2.29.4",
-        "tinymce": "^7.3.0"
+        "tinymce": "^7.3.0",
+        "webui-popover": "^1.2.18"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.3.0",
@@ -6412,6 +6413,11 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/webui-popover": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/webui-popover/-/webui-popover-1.2.18.tgz",
+      "integrity": "sha512-JIpcJnXXjtjg1/VKIEzLRC8ZEutpMZNY9/uBV8ztZ8Hh2IF7Op31Y55krARiTr9CLqXSyBghr9jPAG0dZFL2cA=="
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11240,6 +11246,11 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "webui-popover": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/webui-popover/-/webui-popover-1.2.18.tgz",
+      "integrity": "sha512-JIpcJnXXjtjg1/VKIEzLRC8ZEutpMZNY9/uBV8ztZ8Hh2IF7Op31Y55krARiTr9CLqXSyBghr9jPAG0dZFL2cA=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "linkifyjs": "^4.1.3",
     "moment": "^2.29.4",
     "tinymce": "^7.3.0",
-    "jstree": "^3.3.16"
+    "webui-popover": "^1.2.18"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.3.0",


### PR DESCRIPTION
This commit adds webui-popover v. 1.2.18 as npm dependency to ILIAS 10.

**Usage**

ILIAS/UI

**Reasoning**

The library is used to create popovers in the UI-framework. This applies to the initial Popover component, as well as to other components, such as Filters, that use the Popover component.

**Maintenance**

There are 26 contributors to the library. The last commit to the library is 8 years old, as well as the last released version. Last opem issue is from Oct '21, as well as the last closed issue. Last closed PR is from 2023. The open issues seem to be either feature requests or rather specific bugs.

It seems as if the development of the library has stopped, be it because its feature complete, be it because interest vanished.

**Links**

NPM: https://www.npmjs.com/package/webui-popover
GitHub: https://github.com/sandywalker/webui-popover
Documentation: https://www.npmjs.com/package/webui-popover?activeTab=readme

**Alternatives**

There are plenty of alternatives to this library in the JS library space. Also, the HTML standard itself has gotten facilities to create popovers, although they are not enough to replace this library.

**Assessment**

The library has served us well for quite some time now. We most probably would not add it as a new library now, due to the state of its maintenance. It still seems to be reasonable to accept it for ILIAS 10 now, so we can move on with the release and testing. We should definitly look for alternatives for ILIAS 11, most probably a custom implementation for vanilla HTML/JS. Dependending on the complexity of the new solution and the state of the ILIAS 10 release, we could then decide to replace the library.