### PR TITLE
Display public key in LTI provider form

### DIFF
--- a/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/Modules/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -532,6 +532,7 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
         $publicKey = new ilTextAreaInputGUI($lng->txt('lti_con_key_type_rsa_public_key'), 'public_key');
         $publicKey->setRows(6);
         $publicKey->setRequired(true);
+        $publicKey->setValue($this->provider->getPublicKey());
         $publicKey->setInfo($lng->txt('lti_con_key_type_rsa_public_key_info'));
         $keyRsa->addSubItem($publicKey);
         //JWK


### PR DESCRIPTION
The form didn't display the RSA public key material, leaving the user in the dark about whether their key material was actually saved. With this change, the stored key gets displayed.