### PR TITLE
Display public key in LTI provider form

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -535,6 +535,7 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
         $publicKey = new ilTextAreaInputGUI($lng->txt('lti_con_key_type_rsa_public_key'), 'public_key');
         $publicKey->setRows(6);
         $publicKey->setRequired(true);
+        $publicKey->setValue($this->provider->getPublicKey());
         $publicKey->setInfo($lng->txt('lti_con_key_type_rsa_public_key_info'));
         $keyRsa->addSubItem($publicKey);
         //JWK

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilLTIConsumeProviderFormGUI


### PR DESCRIPTION
The form didn't display the RSA public key material, leaving the user in the dark about whether their key material was actually saved. With this change, the stored key gets displayed.