### PR TITLE
11/UI: Sequence Navigation

### DIFF
--- a/components/ILIAS/Init/Init.php
+++ b/components/ILIAS/Init/Init.php
@@ -122,6 +122,7 @@ class Init implements Component\Component
                 $pull[\ILIAS\UI\Implementation\Component\Progress\State\Bar\Factory::class],
                 $pull[\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class],
                 $use[\ILIAS\Setup\AgentFinder::class],
+                $pull[\ILIAS\UI\Implementation\Component\Navigation\Factory::class],
             );
     }
 }

--- a/components/ILIAS/Init/src/AllModernComponents.php
+++ b/components/ILIAS/Init/src/AllModernComponents.php
@@ -94,6 +94,7 @@ class AllModernComponents implements \ILIAS\Component\EntryPoint
         protected \ILIAS\UI\Implementation\Component\Progress\State\Bar\Factory $ui_progress_state_bar_factory,
         protected \ILIAS\UI\Implementation\Component\Input\UploadLimitResolver $ui_upload_limit_resolver,
         protected \ILIAS\Setup\AgentFinder $setup_agent_finder,
+        protected \ILIAS\UI\Implementation\Component\Navigation\Factory $ui_factory_navigation,
     ) {
     }
 
@@ -170,6 +171,7 @@ class AllModernComponents implements \ILIAS\Component\EntryPoint
         $DIC['ui.factory'] = fn() => $this->ui_factory;
         $DIC['ui.renderer'] = fn() => $this->ui_renderer;
         $DIC['setup.agentfinder'] = fn() => $this->setup_agent_finder;
+        $DIC['ui.factory.navigation'] = fn() => $this->ui_factory_input_field;
     }
 
     public function getName(): string

--- a/components/ILIAS/UI/UI.php
+++ b/components/ILIAS/UI/UI.php
@@ -169,6 +169,9 @@ class UI implements Component\Component
             $internal[UI\Implementation\Component\Prompt\State\Factory::class];
         $provide[UI\Implementation\Component\Input\UploadLimitResolver::class] = static fn() =>
             $internal[UI\Implementation\Component\Input\UploadLimitResolver::class];
+        $provide[UI\Implementation\Component\Navigation\Factory::class] = static fn() =>
+            $internal[UI\Implementation\Component\Navigation\Factory::class];
+
         // =================================================================================
 
         $internal[UI\Implementation\Factory::class] = static fn() =>
@@ -203,6 +206,7 @@ class UI implements Component\Component
                 $internal[UI\Implementation\Component\Launcher\Factory::class],
                 $internal[UI\Implementation\Component\Entity\Factory::class],
                 $internal[UI\Implementation\Component\Prompt\Factory::class],
+                $internal[UI\Implementation\Component\Navigation\Factory::class],
             );
 
         $internal[UI\Implementation\Component\Counter\Factory::class] = static fn() =>
@@ -461,6 +465,13 @@ class UI implements Component\Component
             );
         $internal[UI\Implementation\Component\Prompt\State\Factory::class] = static fn() =>
             new UI\Implementation\Component\Prompt\State\Factory();
+
+        $internal[UI\Implementation\Component\Navigation\Factory::class] = static fn() =>
+            new UI\Implementation\Component\Navigation\Factory(
+                $pull[Data\Factory::class],
+                $pull[Refinery\Factory::class],
+                $use[UI\Storage::class],
+            );
 
         $internal[UI\Implementation\DefaultRenderer::class] = static fn() =>
             new UI\Implementation\DefaultRenderer(

--- a/components/ILIAS/UI/docs/ROADMAP.md
+++ b/components/ILIAS/UI/docs/ROADMAP.md
@@ -283,6 +283,15 @@ as "close" sign for modals. This character is not suitable for expressing this i
 we are actually using a "multiplication" sign. We should search for a better alternative and
 streamline these usages in order to avoid any A11y implications.
 
+### Move Components into Navigation (beginner, 2h)
+The top sections "breadcrumbs" and "menu" should both be moved into navigation.
+
+### Trait for usage of ILIAS\UI\Storage in Table and Sequence Navigation
+Storage of paramters in DataTable and SequenceNavigation look very much alike;
+in favor of those and further/future components the implementation should be
+realized as a trait to be used by several components.
+
+
 ## Long Term
 
 ### Mark Some Components as Internal

--- a/components/ILIAS/UI/src/Component/Legacy/Factory.php
+++ b/components/ILIAS/UI/src/Component/Legacy/Factory.php
@@ -72,4 +72,28 @@ interface Factory
      */
     public function latexContent(string $content): LatexContent;
 
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     The legacy segment is used as container for visible content in
+     *     the context of sequence navigations.
+     *     We currently lack quite a lot of UI components for describing the
+     *     actual contents of the page, e.g. questions, combinations of text/table/form, etc.
+     *     Until these components exist an enable us to better describe the
+     *     correlations to navigations, the legacy segment is used to contain
+     *     rendered HTML.
+     *   composition: >
+     *     The legacy segment contains html (or any other content) as string;
+     *     it also has a title.
+     *
+     * context:
+     *   - A segment is the content affected by operating the sequence navigation.
+     * ---
+     * @param string $title the title of the legacy segment
+     * @param string $content the content of the legacy segment
+     * @return \ILIAS\UI\Component\Legacy\Segment
+     */
+    public function segment(string $title, string $content): Segment;
+
 }

--- a/components/ILIAS/UI/src/Component/Legacy/Segment.php
+++ b/components/ILIAS/UI/src/Component/Legacy/Segment.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Component\Legacy;
+
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Navigation\Sequence\Segment as NavigationSegment;
+use ILIAS\UI\Component\Button;
+
+interface Segment extends Component, NavigationSegment
+{
+    /**
+     * Segments MAY add actions to the sequence.
+     * Those actions MUST target the actually displayed contents rather
+     * than changing context entirely (i.e. breaking the sequence).
+     */
+    public function withSegmentActions(Button\Standard ...$actions): static;
+}

--- a/components/ILIAS/UI/src/Component/Navigation/Factory.php
+++ b/components/ILIAS/UI/src/Component/Navigation/Factory.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Component\Navigation;
+
+interface Factory
+{
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      The Sequence Navigation is used to move through a series of
+     *      content segments in a particular order.
+     *      Segments (or the amount of) may change during navigation, however,
+     *      they will remain in a consecutive order.
+     *   composition: >
+     *      Sequence Navigation consists of several groups of buttons, mainly.
+     *      First of all, there is the primary navigation of back- and next buttons
+     *      to navigate through the parts of the sequence; a part is called a "Segment".
+     *      While every Segment of a sequence is part of a bigger process (i.e.
+     *      the perception of the entire sequence), there might be additional buttons
+     *      for actions targeting outer context, or terminating the browsing
+     *      of the sequence.
+     *      Every shown segement may also add buttons with actions regarding the
+     *      current segement.
+     *      Finally, there may be view controls and filters to change the amount of
+     *      and manner in which the segments are displayed,
+     *   effect: >
+     *      By pressing the forward and backward navigation buttons, users can
+     *      switch between the segments of a sequence.
+     *      Other buttons will trigger their respective actions.
+     *      Operating view controls and filters will alter the sequence itself or
+     *      the way its segments are rendered.
+     *   rivals:
+     *      pagination: >
+     *          Paginations are to display a section of uniform data; segments may vary.
+     *          Also, a pagination does not enforce linear browsing of its elements - sequences do.
+     *
+     * rules:
+     *   usage:
+     *     1: >
+     *       Use a sequence when the order of presentation is crucial or the
+     *       sequencial presentation aids focus. The sequence is not of an
+     *       explorative nature but rather instructional.
+     *     2: >
+     *       Sequence MUST be called "withRequest", i.e. the current ServerRequest
+     *       MUST be provided before rendering.
+     *   interaction:
+     *     1: >
+     *       Any actions included/provided by (parts of) a segment MUST NOT leave
+     *       the context of the sequence.
+     * ---
+     * @return \ILIAS\UI\Component\Navigation\Sequence\Sequence
+     */
+    public function sequence(
+        Sequence\SegmentRetrieval $segment_retrieval
+    ): Sequence\Sequence;
+}

--- a/components/ILIAS/UI/src/Component/Navigation/Sequence/Segment.php
+++ b/components/ILIAS/UI/src/Component/Navigation/Sequence/Segment.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Component\Navigation\Sequence;
+
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Button;
+
+/**
+ * A segment is the content resulting from operating a sequence.
+ */
+interface Segment extends Component
+{
+}

--- a/components/ILIAS/UI/src/Component/Navigation/Sequence/SegmentRetrieval.php
+++ b/components/ILIAS/UI/src/Component/Navigation/Sequence/SegmentRetrieval.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Component\Navigation\Sequence;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * The SegmentRetrieval defines available stops for the sequence and builds
+ * it's segments.
+ */
+interface SegmentRetrieval
+{
+    /**
+     * Provides available positions as an iterable list of (sets of) information
+     * necessary to identify and factor a segment.
+     * Data provided by a position for a certain index is relayed to getSegment.
+     */
+    public function getAllPositions(
+        ServerRequestInterface $request,
+        mixed $viewcontrol_values,
+        mixed $filter_values
+    ): array;
+
+    /**
+     * Receives position data (provided by getAllPositions) and builds a segment.
+     */
+    public function getSegment(
+        ServerRequestInterface $request,
+        mixed $position_data,
+        mixed $viewcontrol_values,
+        mixed $filter_values
+    ): Segment;
+}

--- a/components/ILIAS/UI/src/Component/Navigation/Sequence/Sequence.php
+++ b/components/ILIAS/UI/src/Component/Navigation/Sequence/Sequence.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Component\Navigation\Sequence;
+
+use ILIAS\UI\Component\Component;
+use Psr\Http\Message\ServerRequestInterface;
+use ILIAS\UI\Component\Input\Container\ViewControl\ViewControl as ViewControlContainer;
+use ILIAS\UI\Component\Button\Standard as StdButton;
+
+interface Sequence extends Component
+{
+    /**
+     * Rendering the sequence must be done using the current request:
+     * it (the request) will carry parameters determining e.g. the sequence's
+     * position and other 'moving' parts
+     */
+    public function withRequest(ServerRequestInterface $request): static;
+
+    /**
+     * You may add view controls to the sequences's player that alter the way, order
+     * or focus in which the segements are presented.
+     * You probably SHOULD NOT use a pagination here, though.
+     */
+    public function withViewControls(ViewControlContainer $viewcontrols): static;
+
+    /**
+     * Add additional actions to the Sequence. These actions should target global/outer context,
+     * or be available regardless of the currently displayd segment.
+     * See Segment::withActions, too.
+     */
+    public function withActions(StdButton ...$actions): static;
+
+    /**
+     * The Sequence comes with a storage to keep ViewControl-settings throughout requests.
+     * Set an Id to enable the storage and identify the distinct sequence.
+     */
+    public function withId(string $id): static;
+}

--- a/components/ILIAS/UI/src/Factory.php
+++ b/components/ILIAS/UI/src/Factory.php
@@ -1073,7 +1073,6 @@ interface Factory
      */
     public function entity(): C\Entity\Factory;
 
-
     /**
      * ---
      * description:
@@ -1125,4 +1124,19 @@ interface Factory
      * @return \ILIAS\UI\Component\Prompt\Factory
      */
     public function prompt(): C\Prompt\Factory;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *     Navigation refers to the actions and mechanisms that allow users to move
+     *     from one part of the system to another.
+     *     While this is basically true for links already, a navigational concept's
+     *     purpose is to shape and organize possible interaction into a structure
+     *     providing easy access, orientation and guidance.
+     * ---
+     * @return \ILIAS\UI\Component\Navigation\Factory
+     */
+    public function navigation(): C\Navigation\Factory;
+
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Legacy/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Legacy/Factory.php
@@ -22,6 +22,7 @@ namespace ILIAS\UI\Implementation\Component\Legacy;
 
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component as I;
 
 class Factory implements C\Legacy\Factory
 {
@@ -40,5 +41,10 @@ class Factory implements C\Legacy\Factory
     public function latexContent(string $content): LatexContent
     {
         return new LatexContent($content, $this->signal_generator);
+    }
+
+    public function segment(string $title, string $content): I\Legacy\Segment
+    {
+        return new Segment($title, $content);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Legacy/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Legacy/Renderer.php
@@ -23,6 +23,7 @@ namespace ILIAS\UI\Implementation\Component\Legacy;
 use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
 use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\UI\Component;
+use ILIAS\UI\Implementation\Component as I;
 use ILIAS\UI\Implementation\Render\ResourceRegistry;
 
 /**
@@ -36,10 +37,20 @@ class Renderer extends AbstractComponentRenderer
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        if (!$component instanceof Component\Legacy\Content) {
-            $this->cannotHandleComponent($component);
+
+        if ($component instanceof I\Legacy\Content) {
+            return $this->renderContent($component, $default_renderer);
+        }
+        if ($component instanceof I\Legacy\Segment) {
+            return $this->renderSegment($component, $default_renderer);
         }
 
+        $this->cannotHandleComponent($component);
+
+    }
+
+    protected function renderContent(Content $component, RendererInterface $default_renderer): string
+    {
         $component = $this->registerSignals($component);
         $this->bindJavaScript($component);
 
@@ -77,5 +88,10 @@ class Renderer extends AbstractComponentRenderer
         parent::registerResources($registry);
         $registry->register('assets/js/mathjax_config.js');
         $registry->register('node_modules/mathjax/es5/tex-chtml-full.js');
+    }
+
+    protected function renderSegment(Segment $component, RendererInterface $default_renderer): string
+    {
+        return $component->getSegmentContent();
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Legacy/Segment.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Legacy/Segment.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Legacy;
+
+use ILIAS\UI\Component\Legacy\Segment as LegacySegment;
+use ILIAS\UI\Implementation\Component\Navigation\Sequence\Segment as SequenceSegment;
+use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Component\Button;
+
+class Segment implements SequenceSegment, LegacySegment
+{
+    use ComponentHelper;
+
+    protected ?array $actions = null;
+
+
+    public function __construct(
+        protected string $title,
+        protected string $content
+    ) {
+    }
+
+    public function getSegmentTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getSegmentContent(): string
+    {
+        return $this->content;
+    }
+
+    public function withSegmentActions(Button\Standard ...$actions): static
+    {
+        $clone = clone $this;
+        $clone->actions = $actions;
+        return $clone;
+    }
+
+    public function getSegmentActions(): array
+    {
+        return $this->actions ?? [];
+    }
+
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Navigation/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Navigation/Factory.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Navigation;
+
+use ILIAS\UI\Component\Navigation as INavigation;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\UI\Storage;
+
+class Factory implements INavigation\Factory
+{
+    public function __construct(
+        protected DataFactory $data_factory,
+        protected Refinery $refinery,
+        protected Storage $storage,
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function sequence(
+        INavigation\Sequence\SegmentRetrieval $segment_retrieval
+    ): Sequence\Sequence {
+        return new Sequence\Sequence(
+            $this->data_factory,
+            $this->refinery,
+            $this->storage,
+            $segment_retrieval
+        );
+    }
+
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Navigation/Sequence/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Navigation/Sequence/Renderer.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Navigation\Sequence;
+
+use ILIAS\UI\Implementation\Render\AbstractComponentRenderer;
+use ILIAS\UI\Implementation\Render\ResourceRegistry;
+use ILIAS\UI\Renderer as RendererInterface;
+use ILIAS\UI\Component;
+use ILIAS\UI\Implementation\Component as I;
+
+class Renderer extends AbstractComponentRenderer
+{
+    /**
+     * @inheritdoc
+     */
+    public function render(Component\Component $component, RendererInterface $default_renderer): string
+    {
+        if ($component instanceof I\Navigation\Sequence\Sequence) {
+            return $this->renderSequence($component, $default_renderer);
+        }
+
+        $this->cannotHandleComponent($component);
+    }
+
+    protected function renderSequence(
+        Sequence $component,
+        RendererInterface $default_renderer
+    ): string {
+        $tpl = $this->getTemplate("tpl.sequence.html", true, true);
+
+        $binding = $component->getSegmentRetrieval();
+        $request = $component->getRequest();
+        $vc_data = $component->getViewControls()?->getData() ?? [];
+        $filter_data = [];
+        $positions = $binding->getAllPositions(
+            $request,
+            $vc_data,
+            $filter_data
+        );
+
+        $position = $component->getCurrentPosition();
+        if ($position >= count($positions) || $position < 0) {
+            $position = 0;
+            $component = $component->withCurrentPosition($position);
+        }
+
+        $segment = $binding->getSegment(
+            $request,
+            $positions[$position],
+            $vc_data,
+            $filter_data
+        );
+
+        $ui_factory = $this->getUIFactory();
+        $back = $ui_factory->button()->standard($this->txt('back'), $component->getNext(-1)->__toString())
+            ->withSymbol($ui_factory->symbol()->glyph()->back())
+            ->withUnavailableAction($position - 1 < 0);
+
+        $next = $ui_factory->button()->standard($this->txt('next'), $component->getNext(1)->__toString())
+            ->withSymbol($ui_factory->symbol()->glyph()->next())
+            ->withUnavailableAction($position + 1 === count($positions));
+
+        $tpl->setVariable('BACK', $default_renderer->render($back));
+        $tpl->setVariable('NEXT', $default_renderer->render($next));
+
+        if ($viewcontrols = $component->getViewControls()) {
+            $tpl->setVariable('VIEWCONTROLS', $default_renderer->render($viewcontrols));
+        }
+
+        if ($actions = $component->getActions()) {
+            $tpl->setVariable('ACTIONS_GLOBAL', $default_renderer->render($actions));
+        }
+
+        if ($actions = $segment->getSegmentActions()) {
+            $tpl->setVariable('ACTIONS_SEGMENT', $default_renderer->render($actions));
+        }
+
+        $tpl->setVariable('SEGMENT_TITLE', $segment->getSegmentTitle());
+        $tpl->setVariable('SEGMENT_CONTENTS', $default_renderer->render($segment));
+
+        $content_region_id = $this->createId();
+        $tpl->setVariable('CONTENT_REGION_ID', $content_region_id);
+
+        $headline_id = $this->createId();
+        $tpl->setVariable('HEADLINE_ID', $headline_id);
+
+        $navigation_id = $this->createId();
+        $tpl->setVariable('NAVIGATION_ID', $navigation_id);
+
+        $navigation_description_id = $this->createId();
+        $tpl->setVariable('NAVIGATION_DESCRIPTION_ID', $navigation_description_id);
+
+        $nav_label = $this->txt("ui_nav_sequence_control_label");
+        $tpl->setVariable('NAVIGATION_LABEL', $nav_label);
+
+        $nav_description = $this->txt("ui_nav_sequence_description");
+        $tpl->setVariable('NAVIGATION_DESCRIPTION', $nav_description);
+
+        return $tpl->get();
+    }
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Navigation/Sequence/Segment.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Navigation/Sequence/Segment.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Navigation\Sequence;
+
+use ILIAS\UI\Component\Navigation\Sequence\Segment as SegmentInterface;
+use ILIAS\UI\Component\Button;
+
+interface Segment extends SegmentInterface
+{
+    /**
+     * A segment MUST provide a title
+     */
+    public function getSegmentTitle(): string;
+
+    /**
+     * Segments MAY add actions to the sequence.
+     * Those actions MUST target the actually displayed contents rather
+     * than changing context entirely (i.e. breaking the sequence).
+     * @return Button\Standard[]
+     */
+    public function getSegmentActions(): array;
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Navigation/Sequence/Sequence.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Navigation/Sequence/Sequence.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Navigation\Sequence;
+
+use ILIAS\UI\Component\Navigation\Sequence as ISequence;
+use ILIAS\UI\Implementation\Component\ComponentHelper;
+use Psr\Http\Message\ServerRequestInterface;
+use ILIAS\UI\URLBuilder;
+use ILIAS\UI\URLBuilderToken;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\URI;
+use ILIAS\UI\Component\Input\Container\ViewControl\ViewControl as ViewControlContainer;
+use ILIAS\UI\Implementation\Component\Input\ArrayInputData;
+use ILIAS\UI\Storage;
+
+class Sequence implements ISequence\Sequence
+{
+    use ComponentHelper;
+
+    private const PARAM_POSITION = 'p';
+    public const STORAGE_ID_PREFIX = self::class . '_';
+
+    protected ?ServerRequestInterface $request = null;
+    protected ?URLBuilder $url_builder = null;
+    protected ?URLBuilderToken $token_position = null;
+    protected ?ViewControlContainer $viewcontrols = null;
+    protected ?array $actions = null;
+    protected int $position = 0;
+    protected ?string $id = null;
+
+    public function __construct(
+        protected DataFactory $data_factory,
+        protected Refinery $refinery,
+        protected Storage $storage,
+        protected ISequence\SegmentRetrieval $segment_retrieval
+    ) {
+    }
+
+    public function getSegmentRetrieval(): ISequence\SegmentRetrieval
+    {
+        return $this->segment_retrieval;
+    }
+
+    public function getCurrentPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function withCurrentPosition(int $position): static
+    {
+        $clone = clone $this;
+        $clone->position = $position;
+        return $clone;
+    }
+
+    public function withViewControls(ViewControlContainer $viewcontrols): static
+    {
+        $clone = clone $this;
+        $clone->viewcontrols = $viewcontrols;
+        return $clone;
+    }
+
+    public function getViewControls(): ?ViewControlContainer
+    {
+        return $this->viewcontrols;
+    }
+
+    public function withActions(...$actions): static
+    {
+        $clone = clone $this;
+        $clone->actions = $actions;
+        return $clone;
+    }
+
+    public function getActions(): ?array
+    {
+        return $this->actions;
+    }
+
+    protected function checkRequest(): void
+    {
+        if (! $this->request) {
+            throw new \LogicException('no request was set on the sequence');
+        }
+    }
+
+    public function withRequest(ServerRequestInterface $request): static
+    {
+        $clone = clone $this;
+        $clone->request = $request;
+        $clone->initFromRequest();
+        return $clone;
+    }
+
+    public function getRequest(): ServerRequestInterface
+    {
+        $this->checkRequest();
+        return $this->request;
+    }
+
+    protected function initFromRequest(): void
+    {
+        $base_uri = $this->data_factory->uri($this->request->getUri()->__toString());
+        $namespace = ['sequence_' . $this->getId() ?? ''];
+        $url_builder = new URLBuilder($base_uri);
+        list(
+            $this->url_builder,
+            $this->token_position
+        ) = $url_builder->acquireParameters(
+            $namespace,
+            self::PARAM_POSITION
+        );
+
+        $query = new \ILIAS\HTTP\Wrapper\ArrayBasedRequestWrapper($this->request->getQueryParams());
+        $this->position = $query->retrieve(
+            $this->token_position->getName(),
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->int(),
+                $this->refinery->always(0)
+            ])
+        );
+
+        if ($this->viewcontrols) {
+            $this->viewcontrols = $this->applyValuesToViewcontrols(
+                $this->viewcontrols,
+                $this->request
+            );
+        }
+    }
+
+    public function getNext(int $direction): URI
+    {
+        $this->checkRequest();
+        return $this->url_builder
+            ->withParameter($this->token_position, (string) ($this->position + $direction))
+            ->buildURI();
+    }
+
+    protected function getStorageData(): ?array
+    {
+        if (null !== ($storage_id = $this->getStorageId())) {
+            return $this->storage[$storage_id] ?? null;
+        }
+        return null;
+    }
+
+    protected function setStorageData(array $data): void
+    {
+        if (null !== ($storage_id = $this->getStorageId())) {
+            $this->storage[$storage_id] = $data;
+        }
+    }
+
+    protected function getStorageId(): ?string
+    {
+        if (null !== ($id = $this->getId())) {
+            return static::STORAGE_ID_PREFIX . $id;
+        }
+        return null;
+    }
+
+    public function withId(string $id): static
+    {
+        $clone = clone $this;
+        $clone->id = $id;
+        return $clone;
+    }
+
+    protected function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    protected function applyValuesToViewcontrols(
+        ViewControlContainer $view_controls,
+        ServerRequestInterface $request
+    ): ViewControlContainer {
+        $stored_values = new ArrayInputData($this->getStorageData() ?? []);
+        $view_controls = $view_controls
+            ->withStoredInput($stored_values)
+            ->withRequest($request);
+        $this->setStorageData($view_controls->getComponentInternalValues());
+        return $view_controls;
+    }
+
+}

--- a/components/ILIAS/UI/src/Implementation/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Factory.php
@@ -57,6 +57,7 @@ class Factory implements FactoryInternal
         protected I\launcher\Factory $launcher_factory,
         protected I\Entity\Factory $entity_factory,
         protected I\Prompt\Factory $prompt_factory,
+        protected I\Navigation\Factory $navigation_factory,
     ) {
     }
 
@@ -227,4 +228,10 @@ class Factory implements FactoryInternal
     {
         return $this->prompt_factory;
     }
+
+    public function navigation(): I\Navigation\Factory
+    {
+        return $this->navigation_factory;
+    }
+
 }

--- a/components/ILIAS/UI/src/Implementation/FactoryInternal.php
+++ b/components/ILIAS/UI/src/Implementation/FactoryInternal.php
@@ -87,4 +87,6 @@ interface FactoryInternal extends \ILIAS\UI\Factory
     public function entity(): I\Entity\Factory;
 
     public function prompt(): I\Prompt\Factory;
+
+    public function navigation(): I\Navigation\Factory;
 }

--- a/components/ILIAS/UI/src/examples/Legacy/Segment/base.php
+++ b/components/ILIAS/UI/src/examples/Legacy/Segment/base.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Legacy\Segment;
+
+/**
+ * ---
+ * description: >
+ *   Example for rendering a legacy segment.
+ *
+ * expected output: >
+ *   ILIAS shows the word "content".
+ * ---
+ */
+function base()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $legacy = $f->legacy()->segment('title', 'content');
+    return $renderer->render($legacy);
+}

--- a/components/ILIAS/UI/src/examples/Navigation/Sequence/base.php
+++ b/components/ILIAS/UI/src/examples/Navigation/Sequence/base.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Navigation\Sequence;
+
+use ILIAS\UI\Factory as UIFactory;
+use ILIAS\UI\Renderer as UIRenderer;
+use ILIAS\UI\Component\Navigation\Sequence\SegmentRetrieval;
+use ILIAS\UI\Component\Navigation\Sequence\SegmentBuilder;
+use ILIAS\UI\Component\Navigation\Sequence\Segment;
+use ILIAS\UI\URLBuilder;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * ---
+ * description: >
+ *   Base example for rendering a sequence navigation.
+ *
+ * expected output: >
+ *   ILIAS shows a group of buttons and different placeholders for the segment.
+ *   The navigation buttons are "back" and "next". At first, the "back" button is
+ *   inactive until the next button was clicked. On the last segment, the "next"
+ *   button will be inactive.
+ *   A view control allows the user to select chunks of data, and an additional
+ *   button (without real function) is labeled "a global action".
+ *   On some segments there is an additional button labeled "a segment action
+ *   for pos x". In this example, these buttons don't trigger a function.
+ * ---
+ */
+function base()
+{
+    global $DIC;
+    $f = $DIC['ui.factory'];
+    $r = $DIC['ui.renderer'];
+    $df = new \ILIAS\Data\Factory();
+    $refinery = $DIC['refinery'];
+    $request = $DIC->http()->request();
+
+    $binding = new class ($f, $r) implements SegmentRetrieval {
+        private array $seq_data;
+
+        public function __construct(
+            protected UIFactory $f,
+            protected UIRenderer $r
+        ) {
+            $this->seq_data = [
+                ['c0', 'pos 1', '<div style="width: 100%;
+                                            height: 500px;
+                                            background-color: #b8d7ea;
+                                            display: flex;
+                                            align-items: center;
+                                            justify-content: center;">
+                                            placeholder for the segment at position 1</div>'],
+                ['c0', 'pos 2', '<div style="width: 100%;
+                                            height: 700px;
+                                            background-color: #f6d9a1;
+                                            display: flex;
+                                            align-items: center;
+                                            justify-content: center;">
+                                            placeholder for the segment at position 2</div>'],
+                ['c1', 'pos 3', 'the segment at position 3'],
+                ['c2', 'pos 4', 'the segment at position 4'],
+                ['c1', 'pos 5', 'the segment at position 5'],
+            ];
+        }
+
+        public function getAllPositions(
+            ServerRequestInterface $request,
+            mixed $viewcontrol_values,
+            mixed $filter_values,
+        ): array {
+            $chunks = $viewcontrol_values['chunks'] ?? [];
+            $chunks[] = 'c0';
+            return array_values(
+                array_filter(
+                    $this->seq_data,
+                    fn($posdata) => in_array($posdata[0], $chunks)
+                )
+            );
+        }
+
+        public function getSegment(
+            ServerRequestInterface $request,
+            mixed $position_data,
+            mixed $viewcontrol_values,
+            mixed $filter_values,
+        ): Segment {
+            list($chunk, $title, $data) = $position_data;
+
+            $segment = $this->f->legacy()->segment($title, $data);
+
+            if ($chunk === 'c0') {
+                $segment = $segment->withSegmentActions(
+                    $this->f->button()->standard('a segment action for ' . $title, '#')
+                );
+            }
+            return $segment;
+        }
+    };
+
+    $viewcontrols = $f->input()->container()->viewControl()->standard([
+        $f->input()->viewControl()->fieldSelection(
+            [
+                'c1' => 'chunk 1',
+                'c2' => 'chunk 2',
+            ],
+            'shown chunks',
+            'apply'
+        )
+        ->withAdditionalTransformation($refinery->custom()->transformation(
+            fn($v) => ['chunks' => $v]
+        ))
+    ])
+    ->withAdditionalTransformation(
+        $refinery->custom()->transformation(fn($v) => array_shift($v))
+    );
+
+    $global_actions = [
+        $f->button()->standard('a global action', '#')
+    ];
+
+    $sequence = $f->navigation()->sequence($binding)
+        ->withViewControls($viewcontrols)
+        ->withId('example')
+        ->withActions($global_actions)
+        ->withRequest($request);
+
+    $out = [];
+    $out[] = $sequence;
+
+    return $r->render($out);
+}

--- a/components/ILIAS/UI/src/templates/default/Navigation/tpl.sequence.html
+++ b/components/ILIAS/UI/src/templates/default/Navigation/tpl.sequence.html
@@ -1,0 +1,42 @@
+<div class="c-sequence c-sequence--linear"<!-- BEGIN id --> id="{ID}"<!-- END id -->>
+    <div class="c-sequence__header">
+        <div  id="{NAVIGATION_ID}" class="c-sequence__navigation">
+            <div class="c-sequence__navigation--back">
+                {BACK}
+            </div>
+            <!-- BEGIN viewcontrols -->
+            <div class="c-sequence__navigation--viewcontrols">
+                {VIEWCONTROLS}
+            </div>
+            <!-- END viewcontrols -->
+            <div class="c-sequence__navigation--next">
+                {NEXT}
+            </div>
+        </div>
+        <!-- BEGIN globalactions -->
+        <div class="c-sequence__global-actions">
+            <div class="c-sequence__navigation--actions_external">
+                {ACTIONS_GLOBAL}
+            </div>
+        </div>
+        <!-- END globalactions -->
+        <div class="c-sequence__header__segment">
+            <div class="c-sequence__header__segment__title">
+                <div id="{HEADLINE_ID}">{SEGMENT_TITLE}</div>
+            </div>
+            <!-- BEGIN segmentactions -->
+            <div class="c-sequence__header__segment__actions">
+                {ACTIONS_SEGMENT}
+            </div>
+            <!-- END segmentactions -->
+        </div>
+    </div>
+    <div class="c-sequence__segment">
+        <div id="{CONTENT_REGION_ID}" class="c-sequence__segment__contents">
+            {SEGMENT_CONTENTS}
+        </div>
+    </div>
+
+
+
+</div>

--- a/components/ILIAS/UI/tests/Base.php
+++ b/components/ILIAS/UI/tests/Base.php
@@ -156,6 +156,9 @@ class NoUIFactory implements FactoryInternal
     public function prompt(): I\Prompt\Factory
     {
     }
+    public function navigation(): I\Navigation\Factory
+    {
+    }
 }
 
 class LoggingRegistry implements ResourceRegistry

--- a/components/ILIAS/UI/tests/Component/Navigation/NavigationTest.php
+++ b/components/ILIAS/UI/tests/Component/Navigation/NavigationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+require_once(__DIR__ . "/../../../../../../vendor/composer/vendor/autoload.php");
+require_once(__DIR__ . "/../../Base.php");
+
+use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component\Navigation;
+
+class NavigationTest extends ILIAS_UI_TestBase
+{
+    public function testImplementsFactoryInterface()
+    {
+        $f = new Navigation\Factory(
+            $this->getDataFactory(),
+            $this->getRefinery(),
+            $this->createMock(ILIAS\UI\Storage::class)
+        );
+
+        $this->assertInstanceOf("ILIAS\\UI\\Component\\Navigation\\Factory", $f);
+
+        $sequence = $f->sequence(
+            $this->createMock(C\Navigation\Sequence\SegmentRetrieval::class)
+        );
+        $this->assertInstanceOf("ILIAS\\UI\\Component\\Navigation\\Sequence\\Sequence", $sequence);
+    }
+
+}

--- a/components/ILIAS/UI/tests/Component/Navigation/Sequence/SequenceTest.php
+++ b/components/ILIAS/UI/tests/Component/Navigation/Sequence/SequenceTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+require_once(__DIR__ . "/../../../../../../../vendor/composer/vendor/autoload.php");
+require_once(__DIR__ . "/../../../Base.php");
+
+use ILIAS\UI\Component as C;
+use ILIAS\UI\Implementation\Component as I;
+use ILIAS\UI\Implementation\Component\Navigation;
+use Psr\Http\Message\ServerRequestInterface;
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Factory as Refinery;
+
+class SequenceTest extends ILIAS_UI_TestBase
+{
+    protected I\Button\Factory $button_factory;
+    protected I\Button\Standard $button_stub;
+    protected string $button_html;
+    protected I\Symbol\Factory $symbol_factory;
+    protected Refinery $refinery;
+    protected DataFactory $data_factory;
+    protected ServerRequestInterface $request;
+
+    public function setUp(): void
+    {
+        $this->button_stub = $this->createMock(I\Button\Standard::class);
+        $this->button_html = sha1(I\Button\Standard::class);
+        $this->button_stub->method('getCanonicalName')->willReturn($this->button_html);
+        $this->button_stub->method('withSymbol')->willReturn($this->button_stub);
+        $this->button_stub->method('withUnavailableAction')->willReturn($this->button_stub);
+
+        $this->button_factory = $this->createMock(I\Button\Factory::class);
+        $this->button_factory->method('standard')->willReturn($this->button_stub);
+
+        $this->symbol_factory = $this->createMock(I\Symbol\Factory::class);
+
+        $lang = $this->getLanguage();
+        $this->data_factory = new DataFactory();
+        $this->refinery = new Refinery($this->data_factory, $lang);
+
+        $this->request = $this->createMock(ServerRequestInterface::class);
+        $this->request->method("getUri")
+            ->willReturn(new \GuzzleHttp\Psr7\Uri('http://localhost:80/doil'));
+
+        parent::setUp();
+    }
+
+    public function getUIFactory(): NoUIFactory
+    {
+        return new class (
+            $this->button_factory,
+            $this->symbol_factory,
+        ) extends NoUIFactory {
+            public function __construct(
+                protected I\Button\Factory $button_factory,
+                protected I\Symbol\Factory $symbol_factory,
+            ) {
+            }
+
+            public function button(): I\Button\Factory
+            {
+                return $this->button_factory;
+            }
+            public function symbol(): I\Symbol\Factory
+            {
+                return $this->symbol_factory;
+            }
+
+        };
+    }
+
+    protected function getNavigationFactory(): Navigation\Factory
+    {
+        return new Navigation\Factory(
+            $this->data_factory,
+            $this->refinery,
+            $this->createMock(ILIAS\UI\Storage::class)
+        );
+    }
+
+    public function testSequenceNavigationBasics(): void
+    {
+        $sequence = $this->getNavigationFactory()->sequence(
+            $this->createMock(C\Navigation\Sequence\SegmentRetrieval::class)
+        );
+
+        $id = 'some_id';
+        $view_controls = $this->createMock(I\Input\Container\ViewControl\ViewControl::class);
+        $actions = [
+            $this->createMock(I\Button\Standard::class),
+            $this->createMock(I\Button\Standard::class),
+        ];
+
+        $this->assertEquals($view_controls, $sequence->withViewControls($view_controls)->getViewControls());
+        $this->assertEquals($actions, $sequence->withActions(...$actions)->getActions());
+        $this->assertEquals($this->request, $sequence->withRequest($this->request)->getRequest());
+        $this->assertStringContainsString(
+            'sequence_' . $id . '_p=1',
+            $sequence->withId($id)->withRequest($this->request)->getNext(1)->__toString()
+        );
+    }
+
+    public function testSequenceNavigationRendering(): void
+    {
+        $binding = new class () implements C\Navigation\Sequence\SegmentRetrieval {
+            public function getAllPositions(
+                ServerRequestInterface $request,
+                mixed $viewcontrol_values,
+                mixed $filter_values,
+            ): array {
+                return [
+                    ['pos 1', 'content 1'],
+                    ['pos 2', 'content 2'],
+                ];
+            }
+            public function getSegment(
+                ServerRequestInterface $request,
+                mixed $position_data,
+                mixed $viewcontrol_values,
+                mixed $filter_values,
+            ): I\Legacy\Segment {
+                return new I\Legacy\Segment('title', 'content');
+            }
+        };
+
+        $sequence = $this->getNavigationFactory()->sequence($binding)->withRequest($this->request);
+        $actual_html = $this->getDefaultRenderer(null, [$this->button_stub])
+            ->render($sequence);
+
+        $expected_html = <<<EOT
+            <div class="c-sequence c-sequence--linear">
+                <div class="c-sequence__header">
+
+                    <div  id="id_3" class="c-sequence__navigation">
+                        <div class="c-sequence__navigation--back">
+                            {$this->button_html}
+                        </div>
+                        <div class="c-sequence__navigation--next">
+                            {$this->button_html}
+                        </div>
+                    </div>
+
+                    <div class="c-sequence__header__segment">
+                        <div class="c-sequence__header__segment__title">
+                            <div id="id_2">title</div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <div class="c-sequence__segment">
+                    <div id="id_1" class="c-sequence__segment__contents">
+                        content
+                    </div>
+                </div>
+
+            </div>
+        EOT;
+
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected_html),
+            $this->brutallyTrimHTML($actual_html)
+        );
+    }
+
+    public function testSequenceNavigationPositionsFromQuery(): void
+    {
+        $request = $this->request;
+        $request
+            ->method('getQueryParams')
+            ->willReturn(['sequence__p' => 12]);
+        $sequence = $this->getNavigationFactory()->sequence(
+            $this->createMock(C\Navigation\Sequence\SegmentRetrieval::class)
+        )->withRequest($request);
+
+        $this->assertEquals(12, $sequence->getCurrentPosition());
+        $this->assertStringContainsString('_p=11', $sequence->getNext(-1)->__toString());
+    }
+}

--- a/components/ILIAS/UI/tests/InitUIFramework.php
+++ b/components/ILIAS/UI/tests/InitUIFramework.php
@@ -62,6 +62,7 @@ class InitUIFramework
                 $c["ui.factory.launcher"],
                 $c["ui.factory.entity"],
                 $c["ui.factory.prompt"],
+                $c["ui.factory.navigation"],
             );
         };
         $c["ui.upload_limit_resolver"] = function ($c) {
@@ -420,10 +421,18 @@ class InitUIFramework
             return new ILIAS\UI\Implementation\Component\Prompt\Factory($c["ui.signal_generator"]);
         };
 
+        $c["ui.factory.navigation"] = function ($c) {
+            return new ILIAS\UI\Implementation\Component\Navigation\Factory(
+                $c["ui.data_factory"],
+                $c["refinery"],
+                $c["ui.storage"],
+            );
+        };
+
         // currently this is will be a session storage because we cannot store
         // data on the client, see https://mantis.ilias.de/view.php?id=38503.
-        $c["ui.storage"] = function ($c): ArrayAccess {
-            return new class () implements ArrayAccess {
+        $c["ui.storage"] = function ($c): ILIAS\UI\Storage {
+            return new class () implements ILIAS\UI\Storage {
                 public function offsetExists(mixed $offset): bool
                 {
                     return ilSession::has($offset);

--- a/components/ILIAS/UI/tests/MainFactoryTest.php
+++ b/components/ILIAS/UI/tests/MainFactoryTest.php
@@ -36,7 +36,8 @@ class MainFactoryTest extends AbstractFactoryTestCase
         "layout" => ["rules" => false],
         "menu" => ["rules" => false],
         "symbol" => ["rules" => false],
-        "entity" => ["context" => true]
+        "entity" => ["context" => true],
+        "navigation" => ["rules" => false],
     ];
 
     public static string $factory_title = 'ILIAS\\UI\\Factory';

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -17278,6 +17278,8 @@ ui#:#ui_link_label#:#Label
 ui#:#ui_link_url#:#URL
 ui#:#ui_md_input_edit#:#Bearbeiten
 ui#:#ui_md_input_view#:#Vorschau
+ui#:#ui_nav_sequence_control_label#:#Steuerung der nachfolgenden Sequenz von Inhalten
+ui#:#ui_nav_sequence_description#:#Wird genutzt, um durch Inhalte zu navigieren oder um Aktionen und Filter auszulösen, welche die gesamte Sequenz betreffen.
 ui#:#ui_pagination_unlimited#:#Unbegrenzt
 ui#:#ui_select_dropdown_label#:#Bitte auswählen
 ui#:#ui_table_no_records#:#Keine Einträge

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -17285,6 +17285,8 @@ ui#:#ui_link_label#:#Label
 ui#:#ui_link_url#:#URL
 ui#:#ui_md_input_edit#:#Edit
 ui#:#ui_md_input_view#:#View
+ui#:#ui_nav_sequence_control_label#:#Sequence control for contents below
+ui#:#ui_nav_sequence_description#:#Used to navigate through this content or trigger actions and filters on the entire sequence.
 ui#:#ui_pagination_unlimited#:#Unlimited
 ui#:#ui_select_dropdown_label#:#Please select
 ui#:#ui_table_no_records#:#No records

--- a/templates/default/030-tools/_tool_screen-reader-only.scss
+++ b/templates/default/030-tools/_tool_screen-reader-only.scss
@@ -11,14 +11,15 @@
     padding: 0;
     margin: -1px;
     overflow: hidden;
+    white-space: nowrap;
     clip: rect(0, 0, 0, 0);
     border: 0;
   }
-  
+
   // Use in conjunction with .sr-only to only display content when it's focused.
   // Useful for "Skip to main content" links; see https://www.w3.org/TR/2013/NOTE-WCAG20-TECHS-20130905/G1
   // Credit: HTML5 Boilerplate
-  
+
   @mixin sr-only-focusable() {
     &:active,
     &:focus {

--- a/templates/default/050-layout/_layout_element-bar.scss
+++ b/templates/default/050-layout/_layout_element-bar.scss
@@ -17,7 +17,7 @@ $l-bar__element__margin-bottom: $il-margin-xlarge-vertical; // this margin separ
 
 .l-bar__space-keeper,
 .l-bar__group {
-    // you MUST NOT add padding or margin and SHOULD NOT add any styling (e.g. background-color) in consumer code 
+    // you MUST NOT add padding or margin and SHOULD NOT add any styling (e.g. background-color) in consumer code
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -34,7 +34,7 @@ $l-bar__element__margin-bottom: $il-margin-xlarge-vertical; // this margin separ
 .l-bar__space-keeper > .l-bar__element,
 .l-bar__group > .l-bar__element {
     margin-bottom: var(--l-bar__element__margin-bottom);
-    &:last-child {
+    &:last-of-type {
         margin-right: 0;
     }
 }

--- a/templates/default/070-components/UI-framework/Button/_ui-component_button.scss
+++ b/templates/default/070-components/UI-framework/Button/_ui-component_button.scss
@@ -129,6 +129,11 @@ input.btn {
   }
 }
 
+.c-sequence__navigation--back > .btn-default,
+.c-sequence__navigation--next > .btn-default {
+  @extend .btn-ctrl;
+}
+
 // ILIAS doesn't use btn-success, btn-info, btn-warning, btn-danger
 
 // Link buttons

--- a/templates/default/070-components/UI-framework/Navigation/_ui-component_sequence.scss
+++ b/templates/default/070-components/UI-framework/Navigation/_ui-component_sequence.scss
@@ -1,0 +1,89 @@
+@use "../../../010-settings" as s;
+@use "../../../050-layout/basics" as l;
+@use "../../../050-layout/standardpage/layout_standardpage" as lstp;
+@use "../../../050-layout/layout_breakpoints" as lbrk;
+
+$c-sequence__shadow--down: 0 6px 3px -3px rgba(0, 0, 0, 0.15);
+
+.c-sequence {
+  position: relative;
+  border: s.$il-main-border;
+  border-radius: s.$il-border-radius-secondary-large;
+  background-color: s.$il-main-bg;
+  padding: 0 l.$il-margin-xlarge-horizontal;
+
+  &__header {
+    position: sticky;
+    top: 0;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: l.$il-margin-xxlarge-horizontal;
+    padding-top: l.$il-padding-xlarge-vertical;
+    background-color: s.$il-main-bg;
+    box-shadow: $c-sequence__shadow--down;
+    z-index: 2;
+
+    .c-sequence__navigation {
+      display: grid;
+      grid-template-columns: max-content max-content max-content;
+      grid-template-areas: "back viewctrl next";
+      gap: l.$il-margin-large-horizontal;
+      align-items: center;
+      justify-content: center;
+      width: max-content;
+
+      &--back {
+        grid-area: back;
+      }
+
+      &--viewcontrols {
+        grid-area: viewctrl;
+
+        .l-bar__space-keeper {
+          justify-content: center;
+        }
+      }
+
+      &--next {
+        grid-area: next;
+      }
+
+      @include lbrk.on-screen-size(small) {
+        width: 100%;
+      }
+    }
+
+    &__segment {
+      display:grid;
+      width: 100%;
+      padding: l.$il-padding-xxlarge-vertical l.$il-margin-xlarge-horizontal;
+      grid-template-areas: "title actions";
+      grid-template-columns: 1fr max-content;
+      &__title {
+        grid-area: title;
+      }
+
+      &__actions {
+        grid-area: actions;
+      }
+    }
+  }
+  &__segment__contents {
+    margin: 0 l.$il-margin-xlarge-horizontal;
+  }
+  &__global-actions {
+    @include lbrk.on-screen-size(small) {
+      width: 100%;
+    }
+  }
+}
+
+.il-layout-page-content:has(> .breadcrumbs) {
+  .c-sequence__header {
+    top: lstp.$il-standard-page-breadcrumbs-height;
+  }
+}
+

--- a/templates/default/070-components/_index.scss
+++ b/templates/default/070-components/_index.scss
@@ -34,6 +34,7 @@
 @use "./UI-framework/Input/_ui-component_input.scss";
 @use "./UI-framework/MessageBox/_ui-component_messagebox.scss";
 @use "./UI-framework/Modal/_ui-component_modal.scss";
+@use "./UI-framework/Navigation/ui-component_sequence";
 @use "./UI-framework/Panel/_ui-component_panel.scss";
 @use "./UI-framework/Player/_ui-component_player.scss";
 @use "./UI-framework/Popover/_ui-component_popover.scss";

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -99,6 +99,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Increment Hours";
@@ -110,6 +111,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Increment Minutes";
@@ -121,6 +123,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Decrement Hours";
@@ -132,6 +135,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Decrement Minutes";
@@ -143,6 +147,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Show Hours";
@@ -154,6 +159,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Show Minutes";
@@ -165,6 +171,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Toggle AM/PM";
@@ -176,6 +183,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Clear the picker";
@@ -187,6 +195,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Set the date to today";
@@ -201,6 +210,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Toggle Date and Time Screens";
@@ -245,6 +255,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Previous Month";
@@ -256,6 +267,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
   content: "Next Month";
@@ -264,7 +276,7 @@
   cursor: pointer;
 }
 .bootstrap-datetimepicker-widget table thead tr:first-child th:hover {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: black;
 }
 .bootstrap-datetimepicker-widget table td {
@@ -284,7 +296,7 @@
   width: 20px;
 }
 .bootstrap-datetimepicker-widget table td.day:hover, .bootstrap-datetimepicker-widget table td.hour:hover, .bootstrap-datetimepicker-widget table td.minute:hover, .bootstrap-datetimepicker-widget table td.second:hover {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: black;
   cursor: pointer;
 }
@@ -299,14 +311,14 @@
   display: inline-block;
   border: solid transparent;
   border-width: 0 0 7px 7px;
-  border-bottom-color: #557b2e;
+  border-bottom-color: rgb(84.5, 122.9090909091, 46.0909090909);
   border-top-color: rgba(0, 0, 0, 0.2);
   position: absolute;
   bottom: 4px;
   right: 4px;
 }
 .bootstrap-datetimepicker-widget table td.active, .bootstrap-datetimepicker-widget table td.active:hover {
-  background-color: #557b2e;
+  background-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: white;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
@@ -328,11 +340,11 @@
   border-radius: 0px;
 }
 .bootstrap-datetimepicker-widget table td span:hover {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: black;
 }
 .bootstrap-datetimepicker-widget table td span.active {
-  background-color: #557b2e;
+  background-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: white;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
@@ -539,7 +551,7 @@
 .dropdown-menu li .btn-link:hover,
 .dropdown-menu li .btn-link:focus {
   color: black;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   text-decoration: none;
 }
 .dropdown-menu li a[disabled],
@@ -608,7 +620,7 @@
   background-color: transparent;
 }
 .ui-menu .ui-menu-item > *:hover, .ui-menu .ui-menu-item > *.ui-state-hover, .ui-menu .ui-menu-item > *.ui-state-active {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #161616;
 }
 .ui-menu .ui-menu-item a {
@@ -1798,8 +1810,8 @@ th {
 .l-bar__group > .l-bar__element {
   margin-bottom: var(--l-bar__element__margin-bottom);
 }
-.l-bar__space-keeper > .l-bar__element:last-child,
-.l-bar__group > .l-bar__element:last-child {
+.l-bar__space-keeper > .l-bar__element:last-of-type,
+.l-bar__group > .l-bar__element:last-of-type {
   margin-right: 0;
 }
 
@@ -2357,7 +2369,7 @@ a {
   /* END WebDAV: Enable links with AnchorClick behavior for Internet Explorer. */
 }
 a:hover, a:focus {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   text-decoration: underline;
 }
 a:focus-visible {
@@ -2483,15 +2495,15 @@ strong, b {
 code {
   font-family: Pragmata, Menlo, "DejaVu LGC Sans Mono", "DejaVu Sans Mono", Consolas, "Everson Mono", "Lucida Console", "Andale Mono", "Nimbus Mono L", "Liberation Mono", FreeMono, "Osaka Monospaced", Courier, "New Courier", monospace;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 ::selection {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 ::-moz-selection {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 @media print {
@@ -2598,7 +2610,7 @@ code {
   color: #4c6586;
 }
 .breadcrumb_wrapper .breadcrumb span.crumb a:hover {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .breadcrumb_wrapper .breadcrumb span.crumb a:focus {
   border: inherit;
@@ -2691,8 +2703,8 @@ ol.breadcrumb > li + li:before {
 .il-drilldown .c-drilldown .c-drilldown__menulevel--trigger + .menulevel,
 .c-drilldown .il-drilldown .c-drilldown__menulevel--trigger + .menulevel,
 .il-drilldown .il-link.link-bulky + .menulevel,
-.il-drilldown .menulevel + .menulevel, .navbar-form > a + .btn, .c-input-tree_select.navbar-form > a + input[type=button], .c-drilldown .navbar-form > a + .c-drilldown__menulevel--trigger, .navbar-form > a + .il-link.link-bulky,
-.il-drilldown .navbar-form > a + .menulevel, .navbar-form > .btn + a, .c-input-tree_select.navbar-form > input[type=button] + a, .c-drilldown .navbar-form > .c-drilldown__menulevel--trigger + a, .navbar-form > .il-link.link-bulky + a,
+.il-drilldown .menulevel + .menulevel, .navbar-form > a + .btn, .navbar-form.c-input-tree_select > a + input[type=button], .c-drilldown .navbar-form > a + .c-drilldown__menulevel--trigger, .navbar-form > a + .il-link.link-bulky,
+.il-drilldown .navbar-form > a + .menulevel, .navbar-form > .btn + a, .navbar-form.c-input-tree_select > input[type=button] + a, .c-drilldown .navbar-form > .c-drilldown__menulevel--trigger + a, .navbar-form > .il-link.link-bulky + a,
 .il-drilldown .navbar-form > .menulevel + a, .navbar-form > a + a {
   margin-left: 3px;
 }
@@ -2745,19 +2757,19 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 }
 .btn-default:hover, .navbar-form > a:hover {
   text-decoration: none;
-  background-color: #3a4c65;
+  background-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3a4c65;
+  border-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .btn-default:active, .navbar-form > a:active {
   transform: none;
-  background-color: #273445;
+  background-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #273445;
+  border-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
 }
 .btn-default:focus, .navbar-form > a:focus {
   color: white;
@@ -2788,28 +2800,28 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
   font-size: 0.75rem;
   padding: 3px 6px;
   gap: 6px;
-  background-color: #557b2e;
+  background-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   border-radius: 0px;
 }
 .btn-primary:hover {
   text-decoration: none;
-  background-color: #3b5620;
+  background-color: rgb(59, 85.8181818182, 32.1818181818);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3b5620;
+  border-color: rgb(59, 85.8181818182, 32.1818181818);
 }
 .btn-primary:active {
   transform: none;
-  background-color: #223112;
+  background-color: rgb(33.5, 48.7272727273, 18.2727272727);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #223112;
+  border-color: rgb(33.5, 48.7272727273, 18.2727272727);
 }
 .btn-primary:focus {
   color: white;
@@ -2829,7 +2841,7 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
   background-color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: #161616;
 }
 
@@ -2851,9 +2863,11 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-mode > .btn-default,
 .il-viewcontrol-mode > .btn-link, .il-viewcontrol-sortation > .btn-default.btn,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button],
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn, .c-sequence__navigation--back > .btn-default, .c-sequence__navigation--back.navbar-form > a,
+.c-sequence__navigation--next > .btn-default,
+.c-sequence__navigation--next.navbar-form > a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button],
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
   align-items: center;
@@ -2872,11 +2886,11 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
   font-size: 0.75rem;
   padding: 3px 6px;
   gap: 6px;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #4c6586;
   border-width: 1px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-radius: 10px;
 }
 .btn-ctrl + .btn-ctrl, .il-viewcontrol-sortation > .btn-default + .btn-ctrl, .il-viewcontrol-sortation > .btn-link + .btn-ctrl,
@@ -2898,204 +2912,270 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-mode > .btn-link + .btn-ctrl,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn + .btn-ctrl,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn + .btn-ctrl, .il-viewcontrol-sortation > .btn-ctrl + .btn-default, .il-viewcontrol-sortation > .btn-default + .btn-default, .il-viewcontrol-sortation > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default.btn + .btn-default, .il-viewcontrol-sortation > .btn-ctrl + .btn-link, .il-viewcontrol-sortation > .btn-default + .btn-link, .il-viewcontrol-sortation > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default.btn + .btn-default, .il-viewcontrol-sortation > .btn-ctrl + .btn-link, .il-viewcontrol-sortation > .btn-default + .btn-link, .il-viewcontrol-sortation > .btn-link + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default.btn + .btn-link,
 .il-viewcontrol-section > .btn-ctrl + .btn-default,
 .il-viewcontrol-section > .btn-default + .btn-default,
 .il-viewcontrol-section > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-default.btn + .btn-default,
 .il-viewcontrol-section > .btn-ctrl + .btn-link,
 .il-viewcontrol-section > .btn-default + .btn-link,
 .il-viewcontrol-section > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-default.btn + .btn-link,
 .il-viewcontrol-section .btn-group > .btn-ctrl + .btn-default,
 .il-viewcontrol-section .btn-group > .btn-default + .btn-default,
 .il-viewcontrol-section .btn-group > .btn-link + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default.btn + .btn-default,
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default.btn + .btn-default,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default.btn + .btn-default,
 .il-viewcontrol-section .btn-group > .btn-ctrl + .btn-link,
 .il-viewcontrol-section .btn-group > .btn-default + .btn-link,
 .il-viewcontrol-section .btn-group > .btn-link + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default.btn + .btn-link,
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default.btn + .btn-link,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-ctrl + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn + .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-ctrl + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-ctrl + .btn-default,
 .il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default,
 .il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-default.btn + .btn-default,
 .il-viewcontrol-pagination__num-of-items > .btn-ctrl + .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination > .btn-ctrl + .btn-default,
 .il-viewcontrol-pagination > .btn-default + .btn-default,
 .il-viewcontrol-pagination > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-default.btn + .btn-default,
 .il-viewcontrol-pagination > .btn-ctrl + .btn-link,
 .il-viewcontrol-pagination > .btn-default + .btn-link,
 .il-viewcontrol-pagination > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination .dropdown > .btn-ctrl + .btn-default,
 .il-viewcontrol-pagination .dropdown > .btn-default + .btn-default,
 .il-viewcontrol-pagination .dropdown > .btn-link + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-default.btn + .btn-default,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn + .btn-default,
 .il-viewcontrol-pagination .dropdown > .btn-ctrl + .btn-link,
 .il-viewcontrol-pagination .dropdown > .btn-default + .btn-link,
 .il-viewcontrol-pagination .dropdown > .btn-link + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-default.btn + .btn-link,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn + .btn-link,
 .il-viewcontrol-pagination .last > .btn-ctrl + .btn-default,
 .il-viewcontrol-pagination .last > .btn-default + .btn-default,
 .il-viewcontrol-pagination .last > .btn-link + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-default.btn + .btn-default,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-default.btn + .btn-default,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-default.btn + .btn-default,
 .il-viewcontrol-pagination .last > .btn-ctrl + .btn-link,
 .il-viewcontrol-pagination .last > .btn-default + .btn-link,
 .il-viewcontrol-pagination .last > .btn-link + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-default.btn + .btn-link,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-default.btn + .btn-link,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-default.btn + .btn-link,
 .il-viewcontrol-mode > .btn-ctrl + .btn-default,
 .il-viewcontrol-mode > .btn-default + .btn-default,
 .il-viewcontrol-mode > .btn-link + .btn-default,
-.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-default.btn + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-default.btn + .btn-default,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-default.btn + .btn-default,
 .il-viewcontrol-mode > .btn-ctrl + .btn-link,
 .il-viewcontrol-mode > .btn-default + .btn-link,
 .il-viewcontrol-mode > .btn-link + .btn-link,
-.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-default.btn + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-default.btn + .btn-link,
+.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-default.btn + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-default.btn + .btn-link,
 .il-viewcontrol-sortation .dropdown > .btn-ctrl + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-link + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-link + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-default + .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-link + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-default + .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-link + .btn-default.btn,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn + .btn-default.btn,
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-ctrl + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-link + .btn-default.btn,
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default + .btn-default.btn,
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-link + .btn-default.btn,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-default + .btn-default.btn,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-link + .btn-default.btn,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-default + .btn-default.btn,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-default + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn + .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button] + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.btn-group > .btn-link + .btn-default, .ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.c-input-tree_select.btn-group > input[type=button] + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.c-input-tree_select.btn-group > input[type=button] + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-link + .btn-default.btn,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default + .btn-default.btn,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-link + .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-default + .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn + .btn-default.btn, .c-sequence__navigation--back > .btn-default + .btn-ctrl,
+.il-viewcontrol-sortation .c-sequence__navigation--back.dropdown > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .c-sequence__navigation--back.l-bar__element > .btn-default + .btn-default.btn, .c-sequence__navigation--back.navbar-form > a + .btn-ctrl, .c-sequence__navigation--back.navbar-form.il-viewcontrol-sortation > a + .btn-link,
+.c-sequence__navigation--back.navbar-form.il-viewcontrol-section > a + .btn-link,
+.il-viewcontrol-section .c-sequence__navigation--back.navbar-form.btn-group > a + .btn-link,
+.c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-link,
+.c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination__num-of-items > a + .btn-link,
+.c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination > a + .btn-link,
+.il-viewcontrol-pagination .c-sequence__navigation--back.navbar-form.dropdown > a + .btn-link,
+.il-viewcontrol-pagination .c-sequence__navigation--back.navbar-form.last > a + .btn-link,
+.c-sequence__navigation--back.navbar-form.il-viewcontrol-mode > a + .btn-link,
+.il-viewcontrol-sortation .c-sequence__navigation--back.navbar-form.dropdown > a + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .c-sequence__navigation--back.navbar-form.l-bar__element > a + .btn-default.btn,
+.c-sequence__navigation--next > .btn-default + .btn-ctrl,
+.il-viewcontrol-sortation .c-sequence__navigation--next.dropdown > .btn-default + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .c-sequence__navigation--next.l-bar__element > .btn-default + .btn-default.btn,
+.c-sequence__navigation--next.navbar-form > a + .btn-ctrl,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-sortation > a + .btn-link,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-section > a + .btn-link,
+.il-viewcontrol-section .c-sequence__navigation--next.navbar-form.btn-group > a + .btn-link,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-link,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination__num-of-items > a + .btn-link,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination > a + .btn-link,
+.il-viewcontrol-pagination .c-sequence__navigation--next.navbar-form.dropdown > a + .btn-link,
+.il-viewcontrol-pagination .c-sequence__navigation--next.navbar-form.last > a + .btn-link,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-mode > a + .btn-link,
+.il-viewcontrol-sortation .c-sequence__navigation--next.navbar-form.dropdown > a + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .c-sequence__navigation--next.navbar-form.l-bar__element > a + .btn-default.btn, .c-sequence__navigation--back > .btn-ctrl + .btn-default,
+.il-viewcontrol-sortation .c-sequence__navigation--back.dropdown > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .c-sequence__navigation--back.l-bar__element > .btn-default.btn + .btn-default, .c-sequence__navigation--back > .btn-default + .btn-default, .c-sequence__navigation--back.navbar-form > a + .btn-default, .c-sequence__navigation--back.navbar-form > .btn-ctrl + a, .c-sequence__navigation--back.navbar-form.il-viewcontrol-sortation > .btn-link + a,
+.c-sequence__navigation--back.navbar-form.il-viewcontrol-section > .btn-link + a,
+.il-viewcontrol-section .c-sequence__navigation--back.navbar-form.btn-group > .btn-link + a,
+.c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-link + a,
+.c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination__num-of-items > .btn-link + a,
+.c-sequence__navigation--back.navbar-form.il-viewcontrol-pagination > .btn-link + a,
+.il-viewcontrol-pagination .c-sequence__navigation--back.navbar-form.dropdown > .btn-link + a,
+.il-viewcontrol-pagination .c-sequence__navigation--back.navbar-form.last > .btn-link + a,
+.c-sequence__navigation--back.navbar-form.il-viewcontrol-mode > .btn-link + a,
+.il-viewcontrol-sortation .c-sequence__navigation--back.navbar-form.dropdown > .btn-default.btn + a,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .c-sequence__navigation--back.navbar-form.l-bar__element > .btn-default.btn + a, .c-sequence__navigation--back.navbar-form > .btn-default + a, .c-sequence__navigation--back.navbar-form > a + a,
+.c-sequence__navigation--next > .btn-ctrl + .btn-default,
+.il-viewcontrol-sortation .c-sequence__navigation--next.dropdown > .btn-default.btn + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .c-sequence__navigation--next.l-bar__element > .btn-default.btn + .btn-default,
+.c-sequence__navigation--next > .btn-default + .btn-default,
+.c-sequence__navigation--next.navbar-form > a + .btn-default,
+.c-sequence__navigation--next.navbar-form > .btn-ctrl + a,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-sortation > .btn-link + a,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-section > .btn-link + a,
+.il-viewcontrol-section .c-sequence__navigation--next.navbar-form.btn-group > .btn-link + a,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-link + a,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination__num-of-items > .btn-link + a,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-pagination > .btn-link + a,
+.il-viewcontrol-pagination .c-sequence__navigation--next.navbar-form.dropdown > .btn-link + a,
+.il-viewcontrol-pagination .c-sequence__navigation--next.navbar-form.last > .btn-link + a,
+.c-sequence__navigation--next.navbar-form.il-viewcontrol-mode > .btn-link + a,
+.il-viewcontrol-sortation .c-sequence__navigation--next.navbar-form.dropdown > .btn-default.btn + a,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .c-sequence__navigation--next.navbar-form.l-bar__element > .btn-default.btn + a,
+.c-sequence__navigation--next.navbar-form > .btn-default + a,
+.c-sequence__navigation--next.navbar-form > a + a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button] + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-sortation > .btn-link + .btn-default, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.il-viewcontrol-sortation > input[type=button] + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-section > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.il-viewcontrol-section > input[type=button] + .btn-default,
 .il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button] + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.c-input-tree_select.btn-group > input[type=button] + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.c-input-tree_select.btn-group > input[type=button] + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.c-input-tree_select.btn-group > input[type=button] + .btn-default,
-.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .last.c-input-tree_select.btn-group > input[type=button] + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.c-input-tree_select.btn-group > input[type=button] + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.btn-group > .btn-link + .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.c-input-tree_select.btn-group > input[type=button] + .btn-default.btn,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.il-viewcontrol-pagination__sectioncontrol > input[type=button] + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.il-viewcontrol-pagination__num-of-items > input[type=button] + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.il-viewcontrol-pagination > input[type=button] + .btn-default,
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.last > input[type=button] + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-mode > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.il-viewcontrol-mode > input[type=button] + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .btn-group.l-bar__element > .btn-link + .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select.l-bar__element > input[type=button] + .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back > .btn-link + .btn-default, .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back.c-input-tree_select > input[type=button] + .btn-default, .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back.navbar-form > .btn-link + a, .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back.navbar-form.c-input-tree_select > input[type=button] + a,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next.c-input-tree_select > input[type=button] + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next.navbar-form > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next.navbar-form.c-input-tree_select > input[type=button] + a,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-ctrl,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.dropdown > .btn-default + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.dropdown > .btn-default + .btn-default.btn,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a + .btn-ctrl,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.navbar-form.dropdown > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.navbar-form.dropdown > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.navbar-form.dropdown > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.navbar-form.dropdown > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.navbar-form.dropdown > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-sortation > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-section > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .dropdown.l-bar__element > .btn-default + .btn-default.btn,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-ctrl,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-sortation > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-section > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__sectioncontrol > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__num-of-items > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination > a + .btn-link,
 .il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.navbar-form.dropdown > a + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.navbar-form.dropdown > a + .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-ctrl + .btn-link, .ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.btn-group > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.btn-group > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.btn-group > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.btn-group > .btn-default + .btn-link,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.btn-group > .btn-default.btn + .btn-link, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > .btn-ctrl + input[type=button], .ilTableNav > table > tbody > tr > td > .c-input-tree_select.il-viewcontrol-sortation.btn-group > .btn-default + input[type=button],
-.ilTableNav > table > tbody > tr > td > .c-input-tree_select.il-viewcontrol-section.btn-group > .btn-default + input[type=button],
-.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > .btn-default + input[type=button],
-.ilTableNav > table > tbody > tr > td > .c-input-tree_select.il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default + input[type=button],
-.ilTableNav > table > tbody > tr > td > .c-input-tree_select.il-viewcontrol-pagination__num-of-items.btn-group > .btn-default + input[type=button],
-.ilTableNav > table > tbody > tr > td > .c-input-tree_select.il-viewcontrol-pagination.btn-group > .btn-default + input[type=button],
-.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .c-input-tree_select.last.btn-group > .btn-default + input[type=button],
-.ilTableNav > table > tbody > tr > td > .c-input-tree_select.il-viewcontrol-mode.btn-group > .btn-default + input[type=button],
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .c-input-tree_select.l-bar__element.btn-group > .btn-default.btn + input[type=button], .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button] + .btn-link, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > .btn-link + input[type=button], .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button] + input[type=button],
-.ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group.dropdown > .btn-default + input[type=button],
-.ilTableNav > table > tbody > tr > td > .btn-group.navbar-form.dropdown > a + .btn-link,
-.ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group.navbar-form.dropdown > a + input[type=button],
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-mode > a + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.l-bar__element > a + .btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-ctrl + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-sortation > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-section > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-mode > .btn-default + .btn-link,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .btn-group.l-bar__element > .btn-default.btn + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > .btn-ctrl + input[type=button], .ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-sortation.c-input-tree_select > .btn-default + input[type=button],
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-section.c-input-tree_select > .btn-default + input[type=button],
+.il-viewcontrol-section .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > .btn-default + input[type=button],
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__sectioncontrol.c-input-tree_select > .btn-default + input[type=button],
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination__num-of-items.c-input-tree_select > .btn-default + input[type=button],
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-pagination.c-input-tree_select > .btn-default + input[type=button],
+.il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .btn-group.last.c-input-tree_select > .btn-default + input[type=button],
+.ilTableNav > table > tbody > tr > td > .btn-group.il-viewcontrol-mode.c-input-tree_select > .btn-default + input[type=button],
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .btn-group.l-bar__element.c-input-tree_select > .btn-default.btn + input[type=button], .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back > .btn-default + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back.c-input-tree_select > .btn-default + input[type=button], .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back.navbar-form > a + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back.navbar-form.c-input-tree_select > a + input[type=button],
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next.c-input-tree_select > .btn-default + input[type=button],
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next.navbar-form > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next.navbar-form.c-input-tree_select > a + input[type=button], .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button] + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > .btn-link + input[type=button], .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button] + input[type=button],
+.ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.btn-group.c-input-tree_select > .btn-default + input[type=button],
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group.c-input-tree_select > a + input[type=button],
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-ctrl + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.dropdown > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.dropdown > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.dropdown > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.dropdown > .btn-link + .btn-default,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.dropdown > .btn-default.btn + .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-link + .btn-default,
-.ilTableNav > table > tbody > tr > td > .c-input-tree_select.dropdown.btn-group > input[type=button] + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-sortation > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-section > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-pagination > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .dropdown.il-viewcontrol-mode > .btn-link + .btn-default,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .dropdown.l-bar__element > .btn-default.btn + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.dropdown.c-input-tree_select > input[type=button] + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > .btn-ctrl + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-sortation.navbar-form.dropdown > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-section.navbar-form.dropdown > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__sectioncontrol.navbar-form.dropdown > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination__num-of-items.navbar-form.dropdown > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-pagination.navbar-form.dropdown > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-ctrl + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-sortation > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-section > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__sectioncontrol > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination__num-of-items > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-pagination > .btn-link + a,
 .il-viewcontrol-pagination .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .il-viewcontrol-mode.navbar-form.dropdown > .btn-link + a,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .l-bar__element.navbar-form.dropdown > .btn-default.btn + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown.btn-group > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .c-input-tree_select.navbar-form.dropdown.btn-group > input[type=button] + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > .btn-default + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a + a {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.il-viewcontrol-mode > .btn-link + a,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.l-bar__element > .btn-default.btn + a,
+.ilTableNav > table > tbody > tr > td > .btn-group.dropdown.navbar-form > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .btn-group.dropdown.navbar-form.c-input-tree_select > input[type=button] + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-default + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + a {
   margin-left: 3px;
 }
 .btn-ctrl:focus-visible, .il-viewcontrol-sortation > .btn-default:focus-visible, .il-viewcontrol-sortation > .btn-link:focus-visible,
@@ -3116,9 +3196,11 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-mode > .btn-default:focus-visible,
 .il-viewcontrol-mode > .btn-link:focus-visible,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn:focus-visible,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:focus-visible, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus-visible, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button]:focus-visible,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:focus-visible, .c-sequence__navigation--back > .btn-default:focus-visible, .c-sequence__navigation--back.navbar-form > a:focus-visible,
+.c-sequence__navigation--next > .btn-default:focus-visible,
+.c-sequence__navigation--next.navbar-form > a:focus-visible, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus-visible, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button]:focus-visible,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:focus-visible,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:focus-visible {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
 }
@@ -3140,9 +3222,11 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-mode > .btn-default:hover,
 .il-viewcontrol-mode > .btn-link:hover,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn:hover,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:hover, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:hover, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button]:hover,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:hover, .c-sequence__navigation--back > .btn-default:hover, .c-sequence__navigation--back.navbar-form > a:hover,
+.c-sequence__navigation--next > .btn-default:hover,
+.c-sequence__navigation--next.navbar-form > a:hover, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:hover, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button]:hover,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:hover,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:hover {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:hover {
   text-decoration: none;
   background-color: white;
   color: #4c6586;
@@ -3168,9 +3252,11 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-mode > .btn-default:active,
 .il-viewcontrol-mode > .btn-link:active,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn:active,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:active, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:active, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button]:active,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:active, .c-sequence__navigation--back > .btn-default:active, .c-sequence__navigation--back.navbar-form > a:active,
+.c-sequence__navigation--next > .btn-default:active,
+.c-sequence__navigation--next.navbar-form > a:active, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:active, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button]:active,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:active,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:active {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:active {
   transform: none;
   background-color: white;
   color: #4c6586;
@@ -3196,9 +3282,11 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-mode > .btn-default:focus,
 .il-viewcontrol-mode > .btn-link:focus,
 .il-viewcontrol-sortation .dropdown > .btn-default.btn:focus,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:focus, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button]:focus,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn:focus, .c-sequence__navigation--back > .btn-default:focus, .c-sequence__navigation--back.navbar-form > a:focus,
+.c-sequence__navigation--next > .btn-default:focus,
+.c-sequence__navigation--next.navbar-form > a:focus, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button]:focus,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:focus,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:focus {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus {
   color: #4c6586;
   text-decoration: none;
 }
@@ -3220,9 +3308,11 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-mode > [disabled].btn-default,
 .il-viewcontrol-mode > [disabled].btn-link,
 .il-viewcontrol-sortation .dropdown > [disabled].btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > [disabled].btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > [disabled].btn-link, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[disabled][type=button],
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > [disabled].btn-default.btn, .c-sequence__navigation--back > [disabled].btn-default, .c-sequence__navigation--back.navbar-form > a[disabled],
+.c-sequence__navigation--next > [disabled].btn-default,
+.c-sequence__navigation--next.navbar-form > a[disabled], .ilTableNav > table > tbody > tr > td > .btn-group > [disabled].btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[disabled][type=button],
 .ilTableNav > table > tbody > tr > td > .dropdown > [disabled].btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a[disabled],
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a[disabled],
 .btn-ctrl fieldset[disabled],
 .il-viewcontrol-sortation > .btn-default fieldset[disabled],
 .il-viewcontrol-sortation > .btn-link fieldset[disabled],
@@ -3244,10 +3334,14 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-mode > .btn-link fieldset[disabled],
 .il-viewcontrol-sortation .dropdown > .btn-default.btn fieldset[disabled],
 .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn fieldset[disabled],
+.c-sequence__navigation--back > .btn-default fieldset[disabled],
+.c-sequence__navigation--back.navbar-form > a fieldset[disabled],
+.c-sequence__navigation--next > .btn-default fieldset[disabled],
+.c-sequence__navigation--next.navbar-form > a fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link fieldset[disabled],
-.ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button] fieldset[disabled],
+.ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button] fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default fieldset[disabled],
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a fieldset[disabled] {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a fieldset[disabled] {
   background-color: #b0b0b0;
   border-width: 1px;
   border-style: solid;
@@ -3274,13 +3368,15 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-mode > .engaged.btn-default,
 .il-viewcontrol-mode > .engaged.btn-link,
 .il-viewcontrol-sortation .dropdown > .engaged.btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .engaged.btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input.engaged[type=button],
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .engaged.btn-default.btn, .c-sequence__navigation--back > .engaged.btn-default, .c-sequence__navigation--back.navbar-form > a.engaged,
+.c-sequence__navigation--next > .engaged.btn-default,
+.c-sequence__navigation--next.navbar-form > a.engaged, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input.engaged[type=button],
 .ilTableNav > table > tbody > tr > td > .dropdown > .engaged.btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a.engaged {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a.engaged {
   background-color: white;
   border-width: 3px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #000;
 }
 .btn-ctrl.engaged, .il-viewcontrol-sortation > .engaged.btn-default, .il-viewcontrol-sortation > .engaged.btn-link,
@@ -3301,9 +3397,11 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .il-viewcontrol-mode > .engaged.btn-default,
 .il-viewcontrol-mode > .engaged.btn-link,
 .il-viewcontrol-sortation .dropdown > .engaged.btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .engaged.btn-default.btn, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input.engaged[type=button],
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .engaged.btn-default.btn, .c-sequence__navigation--back > .engaged.btn-default, .c-sequence__navigation--back.navbar-form > a.engaged,
+.c-sequence__navigation--next > .engaged.btn-default,
+.c-sequence__navigation--next.navbar-form > a.engaged, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input.engaged[type=button],
 .ilTableNav > table > tbody > tr > td > .dropdown > .engaged.btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a.engaged, .open .btn-ctrl, .open .il-viewcontrol-sortation > .btn-default, .open .il-viewcontrol-sortation > .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a.engaged, .open .btn-ctrl, .open .il-viewcontrol-sortation > .btn-default, .open .il-viewcontrol-sortation > .btn-link,
 .open .il-viewcontrol-section > .btn-default,
 .open .il-viewcontrol-section > .btn-link,
 .open .il-viewcontrol-section .btn-group > .btn-default,
@@ -3329,9 +3427,11 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .open .il-viewcontrol-sortation .dropdown > .btn-default.btn,
 .il-viewcontrol-sortation .open .dropdown > .btn-default.btn,
 .open .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .open .l-bar__element > .btn-default.btn, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .open .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button],
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .open .l-bar__element > .btn-default.btn, .open .c-sequence__navigation--back > .btn-default, .open .c-sequence__navigation--back.navbar-form > a,
+.open .c-sequence__navigation--next > .btn-default,
+.open .c-sequence__navigation--next.navbar-form > a, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .open .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button],
 .open .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.open .ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.open .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   border: 1px solid #4c6586;
   background-color: white;
 }
@@ -3361,15 +3461,17 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .open .il-viewcontrol-sortation .dropdown > .btn-default.btn,
 .il-viewcontrol-sortation .open .dropdown > .btn-default.btn,
 .open .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .open .l-bar__element > .btn-default.btn, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .open .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button],
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .open .l-bar__element > .btn-default.btn, .open .c-sequence__navigation--back > .btn-default, .open .c-sequence__navigation--back.navbar-form > a,
+.open .c-sequence__navigation--next > .btn-default,
+.open .c-sequence__navigation--next.navbar-form > a, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .open .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button],
 .open .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.open .ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.open .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   box-shadow: none;
 }
 
-.ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .ilTableNav > table > tbody > tr > td > .c-input-tree_select.btn-group > input[type=button],
+.ilTableNav > table > tbody > tr > td > .btn-group > .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-input-tree_select > input[type=button],
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   margin-left: 3px;
 }
 
@@ -3391,7 +3493,7 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
   border-color: transparent;
 }
 .btn-link:hover, .c-input-tree_select > input[type=button]:hover {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   text-decoration: underline;
   background-color: transparent;
 }
@@ -3406,7 +3508,7 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 }
 .btn-link.engaged, .c-input-tree_select > input.engaged[type=button] {
   color: #161616;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .btn-bulky, .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
@@ -3426,11 +3528,11 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 .btn-bulky:hover, .c-drilldown .c-drilldown__menulevel--trigger:hover, .il-link.link-bulky:hover,
 .il-drilldown .menulevel:hover {
   text-decoration: none;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #161616;
   border-width: 1px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .btn-bulky:active, .c-drilldown .c-drilldown__menulevel--trigger:active, .il-link.link-bulky:active,
 .il-drilldown .menulevel:active {
@@ -3460,7 +3562,7 @@ input.btn, .c-input-tree_select > input[type=button], .c-drilldown input.c-drill
 }
 .btn-bulky.engaged, .c-drilldown .engaged.c-drilldown__menulevel--trigger, .engaged.il-link.link-bulky,
 .il-drilldown .engaged.menulevel {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-width: 1px;
   border-style: solid;
   border-color: #f0f0f0;
@@ -3586,44 +3688,44 @@ button .minimize, button .close, button .c-input-tree_select .c-input-tree_selec
 }
 .btn-tag.btn-tag-relevance-verylow {
   color: #161616;
-  background-color: #b0b0b0;
-  border-color: #b0b0b0;
+  background-color: rgb(175.5, 175.5, 175.5);
+  border-color: rgb(175.5, 175.5, 175.5);
 }
 .btn-tag.btn-tag-relevance-low {
   color: #161616;
-  background-color: #a5b8ba;
-  border-color: #a5b8ba;
+  background-color: rgb(164.7, 184.0846153846, 186.3);
+  border-color: rgb(164.7, 184.0846153846, 186.3);
 }
 .btn-tag.btn-tag-relevance-middle {
   color: #161616;
-  background-color: #95c5ca;
-  border-color: #95c5ca;
+  background-color: rgb(148.8, 196.7230769231, 202.2);
+  border-color: rgb(148.8, 196.7230769231, 202.2);
 }
 .btn-tag.btn-tag-relevance-high {
   color: #161616;
-  background-color: #85d1da;
-  border-color: #85d1da;
+  background-color: rgb(132.9, 209.3615384615, 218.1);
+  border-color: rgb(132.9, 209.3615384615, 218.1);
 }
 .btn-tag.btn-tag-relevance-veryhigh {
   color: #161616;
   background-color: #75deea;
-  border-color: #85d1da;
+  border-color: rgb(132.9, 209.3615384615, 218.1);
 }
 .btn-tag:hover {
   text-decoration: none;
-  background-color: #3a4c65;
+  background-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3a4c65;
+  border-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .btn-tag:active {
   transform: none;
-  background-color: #273445;
+  background-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #273445;
+  border-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
 }
 .btn-tag:focus {
   color: white;
@@ -3783,7 +3885,7 @@ button .minimize, button .close, button .c-input-tree_select .c-input-tree_selec
 }
 .il-card .caption dl dt {
   font-weight: 400;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   padding-top: 6px;
 }
 .il-card .il-card-repository-head {
@@ -4148,7 +4250,7 @@ hr.il-divider-with-label {
 }
 
 .ui-dropzone.highlight-current {
-  border: 1px dashed #5c5c5c;
+  border: 1px dashed rgb(91.5, 91.5, 91.5);
   background-color: #FFF9BC;
 }
 
@@ -4278,7 +4380,7 @@ hr.il-divider-with-label {
 }
 .il-item .il-item-property-name {
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   overflow: hidden;
 }
 .il-item .il-item-property-name:not(:empty):after {
@@ -4434,30 +4536,30 @@ hr.il-divider-with-label {
   }
 }
 .c-launcher .btn-bulky {
-  background-color: #557b2e;
+  background-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   border-radius: 10px;
   min-width: 50%;
   width: max-content;
 }
 .c-launcher .btn-bulky:hover {
   text-decoration: none;
-  background-color: #3b5620;
+  background-color: rgb(59, 85.8181818182, 32.1818181818);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3b5620;
+  border-color: rgb(59, 85.8181818182, 32.1818181818);
 }
 .c-launcher .btn-bulky:active {
   transform: none;
-  background-color: #223112;
+  background-color: rgb(33.5, 48.7272727273, 18.2727272727);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #223112;
+  border-color: rgb(33.5, 48.7272727273, 18.2727272727);
 }
 .c-launcher .btn-bulky:focus {
   color: white;
@@ -4477,7 +4579,7 @@ hr.il-divider-with-label {
   background-color: white;
   border-width: 3px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: #000;
 }
 .c-launcher .btn-bulky[disabled] {
@@ -5091,15 +5193,15 @@ a[aria-disabled].il-link.link-bulky:hover {
 }
 .il-workflow-container .not-available.in-progress .text span,
 .il-workflow-container .no-longer-available.in-progress .text span {
-  color: #5c5c5c;
+  color: rgb(91.9, 91.9, 91.9);
 }
 .il-workflow-container .not-available.not-started::before,
 .il-workflow-container .no-longer-available.not-started::before {
-  color: #5c5c5c;
+  color: rgb(91.9, 91.9, 91.9);
 }
 .il-workflow-container .not-available .text,
 .il-workflow-container .no-longer-available .text {
-  color: #5c5c5c;
+  color: rgb(91.9, 91.9, 91.9);
 }
 .il-workflow-container .no-longer-available:before {
   content: "\e023";
@@ -5346,6 +5448,7 @@ a[aria-disabled].il-link.link-bulky:hover {
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
@@ -5490,6 +5593,7 @@ a[aria-disabled].il-link.link-bulky:hover {
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
@@ -5778,7 +5882,7 @@ a[aria-disabled].il-link.link-bulky:hover {
   filter: brightness(0) invert(1);
 }
 .il-mainbar-tools-button .btn-bulky.engaged {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #2c2c2c;
 }
 .il-mainbar-tools-button .btn-bulky.engaged .icon {
@@ -5829,7 +5933,7 @@ a[aria-disabled].il-link.link-bulky:hover {
 }
 
 .il-mainbar-tools-entries-bg {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   display: flex;
   height: 80px;
   width: 100%;
@@ -5870,6 +5974,7 @@ a[aria-disabled].il-link.link-bulky:hover {
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
@@ -6057,7 +6162,7 @@ a {
 }
 
 a:hover, a:focus {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   text-decoration: underline;
 }
 
@@ -6185,15 +6290,15 @@ strong, b {
 code {
   font-family: Pragmata, Menlo, "DejaVu LGC Sans Mono", "DejaVu Sans Mono", Consolas, "Everson Mono", "Lucida Console", "Andale Mono", "Nimbus Mono L", "Liberation Mono", FreeMono, "Osaka Monospaced", Courier, "New Courier", monospace;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 ::selection {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 ::-moz-selection {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 @media print {
@@ -6211,7 +6316,7 @@ code {
   color: #4c6586;
 }
 .c-maincontrols__footer a:hover, .c-maincontrols__footer a:focus, .c-maincontrols__footer .btn-link:hover, .c-maincontrols__footer .btn-link:focus {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .c-maincontrols__footer .btn-link {
   min-height: 0;
@@ -6408,15 +6513,15 @@ code {
   -webkit-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
   -moz-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
   box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-top: #dddddd none;
   border-bottom: #dddddd none;
   border-left: #dddddd none;
   border-right: #dddddd none;
-  color: contrast(greyscale(#e2e8ef), #3a4c65, white, 43%);
+  color: contrast(greyscale(rgb(226.2857142857, 231.6428571429, 238.7142857143)), rgb(57.5428571429, 76.4714285714, 101.4571428571), white, 43%);
 }
 .il-system-info.il-system-info-neutral a.glyph {
-  color: contrast(greyscale(#e2e8ef), #3a4c65, white, 43%);
+  color: contrast(greyscale(rgb(226.2857142857, 231.6428571429, 238.7142857143)), rgb(57.5428571429, 76.4714285714, 101.4571428571), white, 43%);
 }
 .il-system-info.il-system-info-important {
   -webkit-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
@@ -6591,20 +6696,20 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 
 .btn-default:hover, .navbar-form > a:hover {
   text-decoration: none;
-  background-color: #3a4c65;
+  background-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3a4c65;
+  border-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 
 .btn-default:active, .navbar-form > a:active {
   transform: none;
-  background-color: #273445;
+  background-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #273445;
+  border-color: rgb(39.0857142857, 51.9428571429, 68.9142857143);
 }
 
 .btn-default:focus, .navbar-form > a:focus {
@@ -6638,30 +6743,30 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   font-size: 0.75rem;
   padding: 3px 6px;
   gap: 6px;
-  background-color: #557b2e;
+  background-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   border-radius: 0px;
 }
 
 .btn-primary:hover {
   text-decoration: none;
-  background-color: #3b5620;
+  background-color: rgb(59, 85.8181818182, 32.1818181818);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #3b5620;
+  border-color: rgb(59, 85.8181818182, 32.1818181818);
 }
 
 .btn-primary:active {
   transform: none;
-  background-color: #223112;
+  background-color: rgb(33.5, 48.7272727273, 18.2727272727);
   color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #223112;
+  border-color: rgb(33.5, 48.7272727273, 18.2727272727);
 }
 
 .btn-primary:focus {
@@ -6684,13 +6789,15 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   background-color: white;
   border-width: 1px;
   border-style: solid;
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
   color: #161616;
 }
 
-.btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
+.btn-ctrl, .c-sequence__navigation--back > .btn-default, .c-sequence__navigation--back.navbar-form > a,
+.c-sequence__navigation--next > .btn-default,
+.c-sequence__navigation--next.navbar-form > a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   display: inline-flex;
   vertical-align: middle;
   align-items: center;
@@ -6709,40 +6816,56 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   font-size: 0.75rem;
   padding: 3px 6px;
   gap: 6px;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #4c6586;
   border-width: 1px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-radius: 10px;
 }
 
-.btn-ctrl + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-ctrl,
+.btn-ctrl + .btn-ctrl, .c-sequence__navigation--back > .btn-default + .btn-ctrl, .c-sequence__navigation--back.navbar-form > a + .btn-ctrl,
+.c-sequence__navigation--next > .btn-default + .btn-ctrl,
+.c-sequence__navigation--next.navbar-form > a + .btn-ctrl, .c-sequence__navigation--back > .btn-ctrl + .btn-default, .c-sequence__navigation--back > .btn-default + .btn-default, .c-sequence__navigation--back.navbar-form > a + .btn-default, .c-sequence__navigation--back.navbar-form > .btn-ctrl + a, .c-sequence__navigation--back.navbar-form > .btn-default + a, .c-sequence__navigation--back.navbar-form > a + a,
+.c-sequence__navigation--next > .btn-ctrl + .btn-default,
+.c-sequence__navigation--next > .btn-default + .btn-default,
+.c-sequence__navigation--next.navbar-form > a + .btn-default,
+.c-sequence__navigation--next.navbar-form > .btn-ctrl + a,
+.c-sequence__navigation--next.navbar-form > .btn-default + a,
+.c-sequence__navigation--next.navbar-form > a + a, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back > .btn-link + .btn-default, .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back.navbar-form > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next.navbar-form > .btn-link + a,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-ctrl,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-ctrl + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link,
-.ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-default + .btn-link,
-.ilTableNav > table > tbody > tr > td > .btn-group.navbar-form.dropdown > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-ctrl, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-ctrl + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back > .btn-default + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--back.navbar-form > a + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .btn-group.c-sequence__navigation--next.navbar-form > a + .btn-link, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-default + .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form.btn-group > a + .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-ctrl + .btn-default,
-.ilTableNav > table > tbody > tr > td > .dropdown.btn-group > .btn-link + .btn-default,
+.ilTableNav > table > tbody > tr > td > .btn-group.dropdown > .btn-link + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default + .btn-default,
 .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > .btn-ctrl + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown.btn-group > .btn-link + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > .btn-default + a,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a + a {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-ctrl + a,
+.ilTableNav > table > tbody > tr > td > .btn-group.dropdown.navbar-form > .btn-link + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > .btn-default + a,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a + a {
   margin-left: 3px;
 }
 
-.btn-ctrl:focus-visible, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus-visible,
+.btn-ctrl:focus-visible, .c-sequence__navigation--back > .btn-default:focus-visible, .c-sequence__navigation--back.navbar-form > a:focus-visible,
+.c-sequence__navigation--next > .btn-default:focus-visible,
+.c-sequence__navigation--next.navbar-form > a:focus-visible, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus-visible,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:focus-visible,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:focus-visible {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
 }
 
-.btn-ctrl:hover, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:hover,
+.btn-ctrl:hover, .c-sequence__navigation--back > .btn-default:hover, .c-sequence__navigation--back.navbar-form > a:hover,
+.c-sequence__navigation--next > .btn-default:hover,
+.c-sequence__navigation--next.navbar-form > a:hover, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:hover,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:hover,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:hover {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:hover {
   text-decoration: none;
   background-color: white;
   color: #4c6586;
@@ -6751,9 +6874,11 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   border-color: #4c6586;
 }
 
-.btn-ctrl:active, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:active,
+.btn-ctrl:active, .c-sequence__navigation--back > .btn-default:active, .c-sequence__navigation--back.navbar-form > a:active,
+.c-sequence__navigation--next > .btn-default:active,
+.c-sequence__navigation--next.navbar-form > a:active, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:active,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:active,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:active {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:active {
   transform: none;
   background-color: white;
   color: #4c6586;
@@ -6762,20 +6887,28 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   border-color: white;
 }
 
-.btn-ctrl:focus, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus,
+.btn-ctrl:focus, .c-sequence__navigation--back > .btn-default:focus, .c-sequence__navigation--back.navbar-form > a:focus,
+.c-sequence__navigation--next > .btn-default:focus,
+.c-sequence__navigation--next.navbar-form > a:focus, .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link:focus,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default:focus,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a:focus {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a:focus {
   color: #4c6586;
   text-decoration: none;
 }
 
-.btn-ctrl[disabled], .ilTableNav > table > tbody > tr > td > .btn-group > [disabled].btn-link,
+.btn-ctrl[disabled], .c-sequence__navigation--back > [disabled].btn-default, .c-sequence__navigation--back.navbar-form > a[disabled],
+.c-sequence__navigation--next > [disabled].btn-default,
+.c-sequence__navigation--next.navbar-form > a[disabled], .ilTableNav > table > tbody > tr > td > .btn-group > [disabled].btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > [disabled].btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a[disabled],
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a[disabled],
 .btn-ctrl fieldset[disabled],
+.c-sequence__navigation--back > .btn-default fieldset[disabled],
+.c-sequence__navigation--back.navbar-form > a fieldset[disabled],
+.c-sequence__navigation--next > .btn-default fieldset[disabled],
+.c-sequence__navigation--next.navbar-form > a fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default fieldset[disabled],
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a fieldset[disabled] {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a fieldset[disabled] {
   background-color: #b0b0b0;
   border-width: 1px;
   border-style: solid;
@@ -6785,34 +6918,42 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   transform: none;
 }
 
-.btn-ctrl.engaged, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link,
+.btn-ctrl.engaged, .c-sequence__navigation--back > .engaged.btn-default, .c-sequence__navigation--back.navbar-form > a.engaged,
+.c-sequence__navigation--next > .engaged.btn-default,
+.c-sequence__navigation--next.navbar-form > a.engaged, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .engaged.btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a.engaged {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a.engaged {
   background-color: white;
   border-width: 3px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #000;
 }
 
-.btn-ctrl.engaged, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link,
+.btn-ctrl.engaged, .c-sequence__navigation--back > .engaged.btn-default, .c-sequence__navigation--back.navbar-form > a.engaged,
+.c-sequence__navigation--next > .engaged.btn-default,
+.c-sequence__navigation--next.navbar-form > a.engaged, .ilTableNav > table > tbody > tr > td > .btn-group > .engaged.btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .engaged.btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a.engaged, .open .btn-ctrl, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a.engaged, .open .btn-ctrl, .open .c-sequence__navigation--back > .btn-default, .open .c-sequence__navigation--back.navbar-form > a,
+.open .c-sequence__navigation--next > .btn-default,
+.open .c-sequence__navigation--next.navbar-form > a, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .open .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.open .ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.open .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   border: 1px solid #4c6586;
   background-color: white;
 }
 
-.open .btn-ctrl, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
+.open .btn-ctrl, .open .c-sequence__navigation--back > .btn-default, .open .c-sequence__navigation--back.navbar-form > a,
+.open .c-sequence__navigation--next > .btn-default,
+.open .c-sequence__navigation--next.navbar-form > a, .open .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .open .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.open .ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.open .ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   box-shadow: none;
 }
 
 .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link,
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default,
-.ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a {
+.ilTableNav > table > tbody > tr > td > .dropdown.navbar-form > a {
   margin-left: 3px;
 }
 
@@ -6837,7 +6978,7 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 }
 
 .btn-link:hover {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   text-decoration: underline;
   background-color: transparent;
 }
@@ -6855,7 +6996,7 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 
 .btn-link.engaged {
   color: #161616;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .btn-bulky, .c-drilldown .c-drilldown__menulevel--trigger, .il-link.link-bulky,
@@ -6876,11 +7017,11 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 .btn-bulky:hover, .c-drilldown .c-drilldown__menulevel--trigger:hover, .il-link.link-bulky:hover,
 .il-drilldown .menulevel:hover {
   text-decoration: none;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #161616;
   border-width: 1px;
   border-style: solid;
-  border-color: #e2e8ef;
+  border-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .btn-bulky:active, .c-drilldown .c-drilldown__menulevel--trigger:active, .il-link.link-bulky:active,
@@ -6914,7 +7055,7 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 
 .btn-bulky.engaged, .c-drilldown .engaged.c-drilldown__menulevel--trigger, .engaged.il-link.link-bulky,
 .il-drilldown .engaged.menulevel {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-width: 1px;
   border-style: solid;
   border-color: #f0f0f0;
@@ -7127,7 +7268,7 @@ button .minimize, button .close {
   display: flex;
 }
 .c-drilldown.c-drilldown--filtered .c-drilldown__menu .c-drilldown__menulevel--trigger {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .c-drilldown.c-drilldown--filtered .c-drilldown__menu .c-drilldown__menulevel--trigger > .glyphicon-triangle-right {
   display: none;
@@ -7158,7 +7299,7 @@ button .minimize, button .close {
     overflow: visible;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > .c-drilldown__menulevel--trigger {
-    background-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul {
     overflow: auto;
@@ -7167,23 +7308,23 @@ button .minimize, button .close {
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .btn-bulky,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .link-bulky {
     display: flex;
-    background-color: #e2e8ef;
+    background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
     position: relative;
     z-index: 40;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .c-drilldown__menulevel--trigger:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .btn-bulky:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .link-bulky:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > .c-drilldown__menulevel--trigger {
     background-color: transparent;
     border-color: transparent;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > .c-drilldown__menulevel--trigger:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > ul > li > .c-drilldown__menulevel--trigger,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > ul > li > .btn-bulky,
@@ -7215,19 +7356,19 @@ button .minimize, button .close {
     width: 50%;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent > .c-drilldown__menuitem--engaged > .c-drilldown__menulevel--trigger {
-    background: #a1b3ca;
+    background: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged {
     overflow: auto;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged ~ .c-drilldown__menulevel--trigger {
-    background: #e2e8ef;
+    background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .c-drilldown__branch,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .btn-bulky,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .c-drilldown__menulevel--trigger,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .link-bulky {
-    background-color: #e2e8ef;
+    background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
     position: relative;
     z-index: 40;
   }
@@ -7235,8 +7376,8 @@ button .minimize, button .close {
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .btn-bulky:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .c-drilldown__menulevel--trigger:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .link-bulky:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
 }
 .c-drilldown hr {
@@ -7251,8 +7392,8 @@ button .minimize, button .close {
 .c-drilldown .btn-bulky:hover,
 .c-drilldown .link-bulky:hover,
 .c-drilldown .c-drilldown__menulevel--trigger:hover {
-  background-color: #a1b3ca;
-  border-color: #a1b3ca;
+  background-color: rgb(161.2, 178.7, 201.8);
+  border-color: rgb(161.2, 178.7, 201.8);
   color: inherit;
 }
 .c-drilldown .c-drilldown__menu--no-items,
@@ -7540,7 +7681,7 @@ button .minimize, button .close {
 }
 
 .il-filter.disabled .il-filter-inputs-active span {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .input-group-addon {
@@ -7687,7 +7828,7 @@ button .minimize, button .close {
   margin-top: -3px;
   margin-bottom: 0px;
   font-size: 160%;
-  color: #e2e8ef;
+  color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .il-input-rating .il-input-rating__none {
   float: left;
@@ -7698,14 +7839,14 @@ button .minimize, button .close {
   opacity: 100;
 }
 .il-input-rating .il-input-rating-scaleoption:checked ~ .il-input-rating-star {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .il-input-rating .il-input-rating-scaleoption:checked + label + span {
   display: block;
 }
 .il-input-rating .il-input-rating-star:hover,
 .il-input-rating .il-input-rating-star:hover ~ .il-input-rating-star {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 .il-input-rating .il-input-rating:not(:hover) .il-input-rating-scaleoption:checked + label + span {
   display: block;
@@ -7722,7 +7863,7 @@ button .minimize, button .close {
 .il-input-rating .il-input-rating__average {
   height: 1px;
   width: 100%;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .il-input-rating .il-input-rating__average_value {
   height: 1px;
@@ -7975,7 +8116,7 @@ button .minimize, button .close {
   display: flex;
 }
 .c-drilldown.c-drilldown--filtered .c-drilldown__menu .c-drilldown__menulevel--trigger {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .c-drilldown.c-drilldown--filtered .c-drilldown__menu .c-drilldown__menulevel--trigger > .glyphicon-triangle-right {
   display: none;
@@ -8006,7 +8147,7 @@ button .minimize, button .close {
     overflow: visible;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > .c-drilldown__menulevel--trigger {
-    background-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul {
     overflow: auto;
@@ -8015,23 +8156,23 @@ button .minimize, button .close {
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .btn-bulky,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .link-bulky {
     display: flex;
-    background-color: #e2e8ef;
+    background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
     position: relative;
     z-index: 40;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .c-drilldown__menulevel--trigger:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .btn-bulky:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .link-bulky:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > .c-drilldown__menulevel--trigger {
     background-color: transparent;
     border-color: transparent;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > .c-drilldown__menulevel--trigger:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > ul > li > .c-drilldown__menulevel--trigger,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > ul > li > .btn-bulky,
@@ -8063,19 +8204,19 @@ button .minimize, button .close {
     width: 50%;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent > .c-drilldown__menuitem--engaged > .c-drilldown__menulevel--trigger {
-    background: #a1b3ca;
+    background: rgb(161.2, 178.7, 201.8);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged {
     overflow: auto;
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged ~ .c-drilldown__menulevel--trigger {
-    background: #e2e8ef;
+    background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   }
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .c-drilldown__branch,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .btn-bulky,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .c-drilldown__menulevel--trigger,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .link-bulky {
-    background-color: #e2e8ef;
+    background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
     position: relative;
     z-index: 40;
   }
@@ -8083,8 +8224,8 @@ button .minimize, button .close {
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .btn-bulky:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .c-drilldown__menulevel--trigger:hover,
   .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent .c-drilldown__menulevel--engaged > li > .link-bulky:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
 }
 .c-drilldown hr {
@@ -8099,8 +8240,8 @@ button .minimize, button .close {
 .c-drilldown .btn-bulky:hover,
 .c-drilldown .link-bulky:hover,
 .c-drilldown .c-drilldown__menulevel--trigger:hover {
-  background-color: #a1b3ca;
-  border-color: #a1b3ca;
+  background-color: rgb(161.2, 178.7, 201.8);
+  border-color: rgb(161.2, 178.7, 201.8);
   color: inherit;
 }
 .c-drilldown .c-drilldown__menu--no-items,
@@ -8142,7 +8283,7 @@ button .minimize, button .close {
   cursor: default;
 }
 .c-input-tree_select .c-drilldown .c-input-node__name:hover {
-  border-color: #a1b3ca;
+  border-color: rgb(161.2, 178.7, 201.8);
 }
 .c-input-tree_select .c-drilldown .c-input-node__name, .c-input-tree_select .c-drilldown__menulevel--trigger {
   width: calc(100% - 50.4px);
@@ -8172,11 +8313,11 @@ button .minimize, button .close {
 }
 .c-input-tree_select .c-drilldown .c-input-node__select:hover {
   text-decoration: none;
-  background-color: #a1b3ca;
+  background-color: rgb(161.2, 178.7, 201.8);
   color: #161616;
   border-width: 1px;
   border-style: solid;
-  border-color: #a1b3ca;
+  border-color: rgb(161.2, 178.7, 201.8);
 }
 .c-input-tree_select .c-drilldown .c-input-node__select:active {
   background-color: rgba(0, 0, 0, 0);
@@ -8216,43 +8357,43 @@ button .minimize, button .close {
 }
 @container drilldown (min-width: 658px) {
   .c-input-tree_select .c-drilldown .c-drilldown__menulevel--engagedparent > .c-drilldown__menuitem--engaged > .c-input-node__select {
-    background: #a1b3ca;
+    background: rgb(161.2, 178.7, 201.8);
   }
   .c-input-tree_select .c-drilldown .c-drilldown__menulevel--engagedparent > li > .link-bulky.c-input-node__name {
     width: calc(50% - 50.4px);
   }
   .c-input-tree_select .c-drilldown .c-drilldown__menulevel--engaged ~ .c-input-node__select {
-    background: #a1b3ca;
+    background: rgb(161.2, 178.7, 201.8);
   }
   .c-input-tree_select .c-drilldown .c-drilldown__menulevel--engaged > li > .c-input-node__select {
-    background-color: #e2e8ef;
+    background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
     position: relative;
     z-index: 40;
   }
   .c-input-tree_select .c-drilldown .c-drilldown__menulevel--engaged > li > .c-input-node__select:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
   .c-input-tree_select .c-drilldown.c-drilldown__menulevel--engaged > .c-drilldown__branch > .c-input-node__select {
-    background-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
   }
   .c-input-tree_select .c-drilldown.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .c-input-node__select {
     display: flex;
-    background-color: #e2e8ef;
+    background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
     position: relative;
     z-index: 40;
   }
   .c-input-tree_select .c-drilldown.c-drilldown__menulevel--engaged > .c-drilldown__branch > ul > li > .c-input-node__select:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
   .c-input-tree_select .c-drilldown.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > .c-input-node__select {
     background-color: transparent;
     border-color: transparent;
   }
   .c-input-tree_select .c-drilldown.c-drilldown__menulevel--engaged > .c-drilldown__branch ~ .c-drilldown__branch > .c-input-node__select:hover {
-    background-color: #a1b3ca;
-    border-color: #a1b3ca;
+    background-color: rgb(161.2, 178.7, 201.8);
+    border-color: rgb(161.2, 178.7, 201.8);
   }
   .c-input-tree_select .c-drilldown:not(.c-drilldown--filtered) .c-drilldown__menulevel--engagedparent > li > .c-input-node__select {
     display: inline-block;
@@ -8324,8 +8465,8 @@ button .minimize, button .close {
   background-color: #f9f9f9;
 }
 .c-input:not([data-il-ui-component=section-field-input]):has(:focus-visible) {
-  box-shadow: 0px 0px 0px 9px #e2e8ef;
-  background-color: #e2e8ef;
+  box-shadow: 0px 0px 0px 9px rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .c-form .c-form__error-msg {
@@ -8333,8 +8474,8 @@ button .minimize, button .close {
   margin-bottom: 0;
 }
 .c-form .c-input[data-il-ui-component] input:invalid {
-  background-color: #ffd7d7;
-  border: 1px solid #ffd7d7;
+  background-color: rgb(255, 214.54, 214.54);
+  border: 1px solid rgb(255, 214.54, 214.54);
 }
 .c-form .c-input__help-byline {
   margin-top: 3px;
@@ -8348,7 +8489,7 @@ button .minimize, button .close {
   margin-top: 0;
 }
 .c-form .c-input[data-il-ui-component]:not([data-il-ui-component=section-field-input]):has(> .c-input__error-msg) {
-  border-inline-start: 6px solid #ffd7d7;
+  border-inline-start: 6px solid rgb(255, 214.54, 214.54);
   padding-left: 9px;
 }
 .c-form [data-il-ui-component=textarea-field-input] .c-input__field textarea,
@@ -8382,7 +8523,7 @@ div.alert ul {
   background-color: #f9f9f9;
   padding: 6px 26px;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .c-modal,
@@ -8673,8 +8814,81 @@ div.alert ul {
   overflow: hidden;
   text-overflow: ellipsis;
   font-style: italic;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   padding-left: 6px;
+}
+
+.c-sequence {
+  position: relative;
+  border: 1px solid #dddddd;
+  border-radius: 10px;
+  background-color: white;
+  padding: 0 15px;
+}
+.c-sequence__header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 15px;
+  padding-top: 9px;
+  background-color: white;
+  box-shadow: 0 6px 3px -3px rgba(0, 0, 0, 0.15);
+  z-index: 2;
+}
+.c-sequence__header .c-sequence__navigation {
+  display: grid;
+  grid-template-columns: max-content max-content max-content;
+  grid-template-areas: "back viewctrl next";
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  width: max-content;
+}
+.c-sequence__header .c-sequence__navigation--back {
+  grid-area: back;
+}
+.c-sequence__header .c-sequence__navigation--viewcontrols {
+  grid-area: viewctrl;
+}
+.c-sequence__header .c-sequence__navigation--viewcontrols .l-bar__space-keeper {
+  justify-content: center;
+}
+.c-sequence__header .c-sequence__navigation--next {
+  grid-area: next;
+}
+@media screen and (max-width: 768px) {
+  .c-sequence__header .c-sequence__navigation {
+    width: 100%;
+  }
+}
+.c-sequence__header__segment {
+  display: grid;
+  width: 100%;
+  padding: 12px 15px;
+  grid-template-areas: "title actions";
+  grid-template-columns: 1fr max-content;
+}
+.c-sequence__header__segment__title {
+  grid-area: title;
+}
+.c-sequence__header__segment__actions {
+  grid-area: actions;
+}
+.c-sequence__segment__contents {
+  margin: 0 15px;
+}
+@media screen and (max-width: 768px) {
+  .c-sequence__global-actions {
+    width: 100%;
+  }
+}
+
+.il-layout-page-content:has(> .breadcrumbs) .c-sequence__header {
+  top: 33px;
 }
 
 .panel {
@@ -9018,7 +9232,7 @@ div.alert ul {
   font-weight: bold;
   line-height: 18px;
   background-color: #fff;
-  border-bottom: 1px solid #f2f2f2;
+  border-bottom: 1px solid rgb(242.25, 242.25, 242.25);
   border-radius: 5px 5px 0 0;
 }
 
@@ -9034,7 +9248,7 @@ div.alert ul {
 }
 .webui-popover-inverse .webui-popover-title {
   background: #333;
-  border-bottom: 1px solid #3b3b3b;
+  border-bottom: 1px solid rgb(58.65, 58.65, 58.65);
   color: #eee;
 }
 
@@ -10402,7 +10616,7 @@ div.alert ul {
   color: #4c6586;
 }
 .glyph.highlighted {
-  color: #913f00;
+  color: rgb(144.8, 63.2, 0);
 }
 .glyph.highlighted:hover {
   color: #B54F00;
@@ -10412,7 +10626,7 @@ div.alert ul {
   pointer-events: none;
 }
 .glyph:hover, .glyph:focus {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
   text-decoration: none;
 }
 .glyph:focus-visible {
@@ -10700,132 +10914,132 @@ div.alert ul {
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-1 {
   background-color: #0e6252;
-  border-color: #55e7cb;
+  border-color: rgb(85.25, 230.75, 203.0357142857);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-2 {
   background-color: #107360;
-  border-color: #65ead0;
+  border-color: rgb(101.3740458015, 233.6259541985, 208.2442748092);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-3 {
   background-color: #896F06;
-  border-color: #f8db63;
+  border-color: rgb(248.1608391608, 218.5244755245, 98.8391608392);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-4 {
   background-color: #A06608;
-  border-color: #f8c97c;
+  border-color: rgb(248.4285714286, 200.7857142857, 123.5714285714);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-5 {
   background-color: #176437;
-  border-color: #6add9a;
+  border-color: rgb(106.2195121951, 220.7804878049, 153.8292682927);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-6 {
   background-color: #196f3d;
-  border-color: #74e0a1;
+  border-color: rgb(116.25, 223.75, 161.25);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-7 {
   background-color: #B25E15;
-  border-color: #f4c79f;
+  border-color: rgb(243.7085427136, 198.5427135678, 159.2914572864);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-8 {
   background-color: #a04000;
-  border-color: #ffa76d;
+  border-color: rgb(255, 167.4, 109);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-9 {
   background-color: #1d6fa5;
-  border-color: #a0cfee;
+  border-color: rgb(159.7422680412, 207.0824742268, 238.2577319588);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-10 {
   background-color: #1b557a;
-  border-color: #7ebce3;
+  border-color: rgb(126.4496644295, 187.5637583893, 226.5503355705);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-11 {
   background-color: #bf2718;
-  border-color: #f5b5ae;
+  border-color: rgb(244.8418604651, 180.5069767442, 174.1581395349);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-12 {
   background-color: #81261d;
-  border-color: #e48f86;
+  border-color: rgb(227.835443038, 142.5949367089, 134.164556962);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-13 {
   background-color: #713b87;
-  border-color: #d0b1dd;
+  border-color: rgb(208.2371134021, 177.0618556701, 220.9381443299);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-14 {
   background-color: #522764;
-  border-color: #bb87d0;
+  border-color: rgb(186.5179856115, 134.8561151079, 208.1438848921);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-15 {
   background-color: #6A747C;
-  border-color: #d6d9dc;
+  border-color: rgb(214.0260869565, 217.3304347826, 219.9739130435);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-16 {
   background-color: #34495e;
-  border-color: #98afc6;
+  border-color: rgb(151.9863013699, 175, 198.0136986301);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-17 {
   background-color: #2c3e50;
-  border-color: #8aa4be;
+  border-color: rgb(137.5806451613, 164, 190.4193548387);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-18 {
   background-color: #566566;
-  border-color: #bfc8c9;
+  border-color: rgb(190.9787234043, 200.3936170213, 201.0212765957);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-19 {
   background-color: #90175a;
-  border-color: #ec87bf;
+  border-color: rgb(235.8562874251, 135.1437125749, 190.9101796407);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-20 {
   background-color: #9e2b6e;
-  border-color: #e9accf;
+  border-color: rgb(232.5373134328, 172.4626865672, 207.4626865672);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-21 {
   background-color: #d22f10;
-  border-color: #f9c0b5;
+  border-color: rgb(249.3362831858, 191.6371681416, 180.6637168142);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-22 {
   background-color: #666d4e;
-  border-color: #c9cdba;
+  border-color: rgb(200.9090909091, 205.3636363636, 185.6363636364);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-23 {
   background-color: #715a32;
-  border-color: #d3bf9c;
+  border-color: rgb(211.1349693252, 190.9570552147, 155.8650306748);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-24 {
   background-color: #83693a;
-  border-color: #dbcbae;
+  border-color: rgb(219.0952380952, 203, 173.9047619048);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-25 {
   background-color: #963a30;
-  border-color: #e5b3ad;
+  border-color: rgb(228.8181818182, 178.6363636364, 173.1818181818);
   color: white;
 }
 .il-avatar.il-avatar-letter.il-avatar-letter-color-26 {
   background-color: #DE2F1B;
-  border-color: #f9d1cc;
+  border-color: rgb(248.8192771084, 208.7590361446, 204.1807228916);
   color: white;
 }
 
@@ -10939,7 +11153,7 @@ div.alert ul {
   border-color: #dddddd;
 }
 .il-table-presentation-row .il-table-presentation-row-expanded .il-table-presentation-details .il-table-presentation-fields .il-item-property-name {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .c-table-data .viewcontrols,
@@ -11125,7 +11339,7 @@ td.c-table-data__cell--highlighted {
 
 @media screen and (min-width: 769px) {
   .c-table-data__row:hover td.c-table-data__cell--highlighted {
-    background-color: #dedede;
+    background-color: rgb(222.15, 222.15, 222.15);
   }
 }
 
@@ -11291,14 +11505,14 @@ td.c-table-data__cell--highlighted {
   text-overflow: ellipsis;
   font-style: italic;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 .c-tree li.c-tree__node .c-tree__node__line > .c-tree__node__byline {
   padding-left: 4px;
   width: 100%;
 }
 .c-tree li.c-tree__node.highlighted > .c-tree__node__line {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .c-tree li.c-tree__node.expandable > .c-tree__node__line:before {
   color: #737373;
@@ -11332,276 +11546,276 @@ td.c-table-data__cell--highlighted {
   width: fit-content;
   min-height: 2.2rem;
   min-width: 2.2rem;
-  border: 1px solid #e2e8ef;
+  border: 1px solid rgb(226.2857142857, 231.6428571429, 238.7142857143);
   padding: 3px;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   border-radius: 10px;
 }
 
 .il-viewcontrol-sortation > .btn-default, .il-viewcontrol-sortation > .btn-link, .il-viewcontrol-sortation > .btn-ctrl, .il-viewcontrol-sortation > .btn-default.btn,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default.btn,
 .il-viewcontrol-section > .btn-default,
 .il-viewcontrol-section > .btn-link,
 .il-viewcontrol-section > .btn-ctrl,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-default.btn,
 .il-viewcontrol-section .btn-group > .btn-default,
 .il-viewcontrol-section .btn-group > .btn-link,
 .il-viewcontrol-section .btn-group > .btn-ctrl,
-.il-viewcontrol-section .il-viewcontrol-sortation .dropdown.btn-group > .btn-default.btn,
-.il-viewcontrol-sortation .il-viewcontrol-section .dropdown.btn-group > .btn-default.btn,
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default.btn,
+.il-viewcontrol-section .il-viewcontrol-sortation .btn-group.dropdown > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-section .btn-group.dropdown > .btn-default.btn,
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default.btn,
 .il-viewcontrol-pagination__sectioncontrol > .btn-default,
 .il-viewcontrol-pagination__sectioncontrol > .btn-link,
 .il-viewcontrol-pagination__sectioncontrol > .btn-ctrl,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default.btn,
 .il-viewcontrol-pagination__num-of-items > .btn-default,
 .il-viewcontrol-pagination__num-of-items > .btn-link,
 .il-viewcontrol-pagination__num-of-items > .btn-ctrl,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default.btn,
 .il-viewcontrol-pagination > .btn-default,
 .il-viewcontrol-pagination > .btn-link,
 .il-viewcontrol-pagination > .btn-ctrl,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-default.btn,
+.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-default.btn,
 .il-viewcontrol-pagination .dropdown > .btn-default,
 .il-viewcontrol-pagination .dropdown > .btn-link,
 .il-viewcontrol-pagination .dropdown > .btn-ctrl,
 .il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown > .btn-default.btn,
 .il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown > .btn-default.btn,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-default.btn,
 .il-viewcontrol-pagination .last > .btn-default,
 .il-viewcontrol-pagination .last > .btn-link,
 .il-viewcontrol-pagination .last > .btn-ctrl,
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-default.btn,
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-default.btn,
 .il-viewcontrol-mode > .btn-default,
 .il-viewcontrol-mode > .btn-link,
 .il-viewcontrol-mode > .btn-ctrl,
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-default.btn,
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-default.btn {
+.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-default.btn,
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-default.btn {
   min-height: 1.7rem;
   min-width: 1.7rem;
   border-radius: 10px;
 }
 .il-viewcontrol-sortation > .btn-ctrl:has(> .glyph.disabled), .il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled), .il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled), .il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-sortation.il-viewcontrol-section > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-section > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-section > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-sortation.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-sortation.l-bar__element > .btn-default.btn:has(> .glyph.disabled), .il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled), .il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-sortation .dropdown.btn-group > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .il-viewcontrol-section .dropdown.btn-group > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.btn-group > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .l-bar__element.btn-group > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .il-viewcontrol-sortation.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__sectioncontrol > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination__num-of-items > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-pagination > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-pagination > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.dropdown > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.dropdown > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .il-viewcontrol-sortation.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown.last > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown.last > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.last > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .l-bar__element.last > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .il-viewcontrol-sortation.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .dropdown.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-default:has(> .glyph.disabled),
-.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-link:has(> .glyph.disabled),
-.il-viewcontrol-mode > .btn-ctrl:has(> .glyph.disabled),
-.il-viewcontrol-sortation.il-viewcontrol-mode > .btn-default.btn:has(> .glyph.disabled),
-.il-viewcontrol-sortation .dropdown.il-viewcontrol-mode > .btn-default.btn:has(> .glyph.disabled),
-.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .l-bar__element.il-viewcontrol-mode > .btn-default.btn:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-sortation.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-section.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-section.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-sortation .btn-group.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-section .btn-group.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .btn-group.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-section .btn-group.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .btn-group.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .btn-group.last > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .btn-group.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-section .btn-group.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__sectioncontrol.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__sectioncontrol.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__sectioncontrol.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination__sectioncontrol.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination__num-of-items.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination__num-of-items.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination__num-of-items.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination__num-of-items.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination__num-of-items.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-pagination.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-pagination.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-sortation .dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-pagination .dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .dropdown.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .dropdown.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .dropdown.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .dropdown.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination .dropdown.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .dropdown.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-sortation .last.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-pagination .last.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .last.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-pagination .last.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-section .last.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-pagination .last.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-pagination .last.il-viewcontrol-mode > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-mode > .btn-ctrl:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-sortation .il-viewcontrol-mode.dropdown > .btn-default.btn:has(> .glyph.disabled),
+.il-table-presentation-viewcontrols .l-bar__space-keeper .l-bar__group .il-viewcontrol-mode.l-bar__element > .btn-default.btn:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-sortation > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-section > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-section > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-section .il-viewcontrol-mode.btn-group > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination__sectioncontrol > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination__num-of-items > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-mode.il-viewcontrol-pagination > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-mode.dropdown > .btn-link:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-default:has(> .glyph.disabled),
+.il-viewcontrol-pagination .il-viewcontrol-mode.last > .btn-link:has(> .glyph.disabled),
 .il-viewcontrol-mode > .btn-default:has(> .glyph.disabled),
 .il-viewcontrol-mode > .btn-link:has(> .glyph.disabled) {
   border: none;
   cursor: default;
   pointer-events: none;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .il-viewcontrol-sortation > .btn-default.btn,
@@ -11717,11 +11931,11 @@ div#agreement {
 
 .alert-success {
   color: #161616;
-  background-color: #ebf4e1;
-  border-color: #ebf4e1;
+  background-color: rgb(234.7, 243.9272727273, 225.4727272727);
+  border-color: rgb(234.7, 243.9272727273, 225.4727272727);
 }
 .alert-success hr {
-  border-top-color: #deedcf;
+  border-top-color: rgb(221.95, 236.9727272727, 206.9272727273);
 }
 .alert-success .alert-link {
   color: black;
@@ -11729,11 +11943,11 @@ div#agreement {
 
 .alert-info {
   color: #161616;
-  background-color: #deecf4;
-  border-color: #deecf4;
+  background-color: rgb(221.841875, 236.45, 243.638125);
+  border-color: rgb(221.841875, 236.45, 243.638125);
 }
 .alert-info hr {
-  border-top-color: #cbe2ed;
+  border-top-color: rgb(202.8496875, 225.825, 237.1303125);
 }
 .alert-info .alert-link {
   color: black;
@@ -11741,11 +11955,11 @@ div#agreement {
 
 .alert-warning {
   color: #161616;
-  background-color: #ffe5d1;
-  border-color: #ffe5d1;
+  background-color: rgb(255, 229.0435359116, 208.94);
+  border-color: rgb(255, 229.0435359116, 208.94);
 }
 .alert-warning hr {
-  border-top-color: #ffd7b7;
+  border-top-color: rgb(255, 214.6733701657, 183.44);
 }
 .alert-warning .alert-link {
   color: black;
@@ -11753,11 +11967,11 @@ div#agreement {
 
 .alert-danger {
   color: #161616;
-  background-color: #ffd7d7;
-  border-color: #ffd7d7;
+  background-color: rgb(255, 214.54, 214.54);
+  border-color: rgb(255, 214.54, 214.54);
 }
 .alert-danger hr {
-  border-top-color: #ffbdbd;
+  border-top-color: rgb(255, 189.04, 189.04);
 }
 .alert-danger .alert-link {
   color: black;
@@ -12503,7 +12717,7 @@ tbody.collapse.in {
   padding-left: 8px;
 }
 
-.btn-group > .btn-lg + .dropdown-toggle, .btn-group-lg.btn-group > .btn + .dropdown-toggle {
+.btn-group > .btn-lg + .dropdown-toggle, .btn-group.btn-group-lg > .btn + .dropdown-toggle {
   padding-right: 12px;
   padding-left: 12px;
 }
@@ -12794,7 +13008,7 @@ tbody.collapse.in {
   margin: 0;
   width: 12px;
   height: 12px;
-  background-color: #3a4c65;
+  background-color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 
 .carousel-caption {
@@ -12993,6 +13207,7 @@ tbody.collapse.in {
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
@@ -13037,7 +13252,7 @@ div.ilBlogListItemTitle h3 {
 
 div.ilBlogListItemSubTitle {
   margin-top: 5px;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-size: 0.75rem;
   text-align: right;
 }
@@ -13070,7 +13285,7 @@ td.ilBlogSideBlockContent {
 
 td.ilBlogSideBlockCommand {
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   border-bottom: 1px solid #dddddd;
   padding: 1px 3px;
   background-color: #f9f9f9;
@@ -13389,7 +13604,7 @@ td.chatroom {
   border-radius: 50%;
 }
 .ilChatroomUser .media-body h4, .ilChatroomUser .media-body p {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-size: 0.75rem;
   padding: 5px 3px 0 3px;
   line-height: 1em;
@@ -13397,7 +13612,7 @@ td.chatroom {
 }
 .ilChatroomUser .media-body h4 {
   padding-top: 0;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -13424,7 +13639,7 @@ td.chatroom {
   margin-left: 100px;
 }
 .ilChatroomUser .media:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .ilChatroomUser .dropdown-menu > li > button.btn {
   padding-left: 10px;
@@ -13871,7 +14086,7 @@ div.ilForumQuoteHead {
 }
 
 div.ilFrmPostHeader span.small {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .ilFrmPostContentContainer {
@@ -14359,7 +14574,7 @@ div#right_bottom_area iframe {
 .ilPollDescription {
   margin: 5px;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .ilPollQuestion {
@@ -14375,7 +14590,7 @@ div#right_bottom_area iframe {
   width: 97%;
   margin: 1.5%;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 img.ilPollQuestionImage {
@@ -14606,15 +14821,15 @@ div.il-survey-question {
 }
 
 div.ilSurveyPageEditDropArea {
-  border-color: #88be51;
-  color: #88be51;
-  background-color: #aed389;
+  border-color: rgb(135.5, 189.8181818182, 81.1818181818);
+  color: rgb(135.5, 189.8181818182, 81.1818181818);
+  background-color: rgb(173.75, 210.6818181818, 136.8181818182);
 }
 
 div.ilSurveyPageEditDropAreaSelected {
-  border-color: #88be51;
-  color: #88be51;
-  background-color: #94c564;
+  border-color: rgb(135.5, 189.8181818182, 81.1818181818);
+  color: rgb(135.5, 189.8181818182, 81.1818181818);
+  background-color: rgb(148.25, 196.7727272727, 99.7272727273);
 }
 
 div.ilSurveyPageEditAreaDragging {
@@ -15217,7 +15432,7 @@ div.ilc_Page.readonly textarea[disabled] {
   border: 1px solid #dddddd;
 }
 .c-test__dropzone.c-test__dropzone--hover {
-  background: #e2e8ef;
+  background: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 .c-test__dropzone.c-test__dropzone--active {
   display: block;
@@ -15240,7 +15455,7 @@ div.ilc_Page.readonly textarea[disabled] {
 
 .c-test__term {
   border: 1px solid #dddddd;
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   margin: 5px 10px 5px 0;
   padding: 3px;
   cursor: move;
@@ -15272,7 +15487,7 @@ div.ilc_Page.readonly textarea[disabled] {
   cursor: default;
 }
 .c-test__longmenu__selectionlist li:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 #tst_output {
@@ -15483,7 +15698,7 @@ li.ilWikiBlockItem {
   border: 0;
 }
 .il_VAccordionHead:hover, .il_HAccordionHead:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .il_VAccordionHead {
@@ -15506,7 +15721,7 @@ li.ilWikiBlockItem {
 
 .il_HAccordionHeadActive, .il_VAccordionHeadActive {
   background-image: url("../images/nav/tree_exp.svg");
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 .ilAccHideContent {
@@ -15555,7 +15770,7 @@ div.ilc_va_icont_VAccordICont {
   display: table;
 }
 #awareness-content .media:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 #awareness-content .glyphicon {
   font-size: inherit;
@@ -15619,7 +15834,7 @@ div.ilc_va_icont_VAccordICont {
 }
 
 #awareness-content .media-body h4, #awareness-content .media-body p {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-size: 0.75rem;
   padding: 5px 3px 0 3px;
   line-height: 1em;
@@ -15718,8 +15933,8 @@ div.ilc_va_icont_VAccordICont {
 }
 
 #awareness-content .ilHighlighted {
-  background-color: #e2e8ef;
-  color: #6f6f6f;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 .ilAwrnBadgeHidden {
@@ -15848,13 +16063,13 @@ h3.ilBlockHeader {
 /* possibly deprecated */
 .il_BlockInfo {
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 /* new class */
 div.ilBlockInfo {
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   padding: 1px 3px;
   background-color: #f9f9f9;
   text-align: right;
@@ -15870,7 +16085,7 @@ div.ilBlockContent {
 }
 
 div.ilBlockPropertyCaption {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 /* Services/Bookmarks */
@@ -16423,7 +16638,7 @@ div.ilListItemSection {
 }
 
 div.ilContainerListItemOuterHighlight {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   zoom: 1;
 }
 
@@ -16675,8 +16890,8 @@ button.copg-add.dropdown-toggle.btn:hover .il-copg-add-text,
 }
 
 button.copg-add.dropdown-toggle.btn:hover {
-  background-color: #e2e8ef;
-  color: #6f6f6f;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 [data-copg-ed-type=add-area] ul.dropdown-menu {
@@ -16684,14 +16899,14 @@ button.copg-add.dropdown-toggle.btn:hover {
 }
 
 button.copg-add:hover {
-  color: #88be51;
-  background-color: #f3f8ed;
+  color: rgb(135.5, 189.8181818182, 81.1818181818);
+  background-color: rgb(242.6, 248.2363636364, 236.9636363636);
 }
 
 div.il_droparea {
   padding: 1px 5px;
   border: 1px dashed #dddddd;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   text-align: center;
   font-size: 0.75rem;
   background-color: #fffed1;
@@ -16700,14 +16915,14 @@ div.il_droparea {
 }
 
 div.il_droparea:hover, div.ilCOPGDropActice, .il_droparea_valid_target {
-  border-color: #88be51;
-  color: #88be51;
-  background-color: #f3f8ed;
+  border-color: rgb(135.5, 189.8181818182, 81.1818181818);
+  color: rgb(135.5, 189.8181818182, 81.1818181818);
+  background-color: rgb(242.6, 248.2363636364, 236.9636363636);
 }
 
 div.ilCOPGNoPageContent {
   padding: 20px 5px;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 div.il_editarea_nojs {
@@ -16777,7 +16992,7 @@ div.il_editarea_disabled, div.copg-disabled-page {
 div.il_editarea_selected, div.copg-current-edit, #tinytarget_ifr {
   border-style: solid;
   border-width: 2px;
-  border-color: #bbda9b;
+  border-color: rgb(186.5, 217.6363636364, 155.3636363636);
 }
 
 div.il_editarea_selected:hover {
@@ -16860,7 +17075,7 @@ div.ilTinyMenuSection, .il-copg-button-group {
 div.ilTinyMenuSection p, .il-copg-button-group p {
   margin-bottom: 5px;
   padding: 2px 5px;
-  background-color: #efefef;
+  background-color: rgb(238.8, 238.8, 238.8);
 }
 
 div.ilTinyMenuSection button.btn {
@@ -16903,7 +17118,7 @@ div.il-copg-button-group-wide {
   margin: 0;
 }
 #iltinymenu .bd div .small {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-style: italic;
 }
 #iltinymenu .btn-default .mce-ico {
@@ -16980,7 +17195,7 @@ a.ilc_page_toc_PageTOCLink {
 }
 
 a.ilc_page_toc_PageTOCLink:hover {
-  color: #3a4c65;
+  color: rgb(57.5428571429, 76.4714285714, 101.4571428571);
 }
 
 a.ilc_page_toc_PageTOCLink:visited {
@@ -17088,11 +17303,11 @@ div.ilEditNew {
 }
 
 span.ilDiffDel {
-  background-color: #ff9c4f;
+  background-color: rgb(255, 155.817679558, 79);
 }
 
 span.ilDiffIns {
-  background-color: #bbda9b;
+  background-color: rgb(186.5, 217.6363636364, 155.3636363636);
 }
 
 a.nostyle:link, a.nostyle:visited {
@@ -17158,7 +17373,7 @@ a.nostyle:hover {
   text-align: center;
   display: table-cell;
   vertical-align: middle;
-  background-color: #3b5620;
+  background-color: rgb(59, 85.8181818182, 32.1818181818);
   color: white;
 }
 
@@ -17169,7 +17384,7 @@ a.nostyle:hover {
 }
 
 .ilCOPgEditStyleSelectionItem:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 ul#ilAdvSelListTable_style_selection {
@@ -17394,7 +17609,7 @@ p#copg-auto-save {
 .copg-new-content-placeholder,
 .copg-content-placeholder-lso-curriculum {
   text-align: center;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   padding: 20px;
 }
 .copg-new-content-placeholder .icon,
@@ -17535,14 +17750,14 @@ select[size] {
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
 }
 .form-control::-moz-placeholder {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   opacity: 1;
 }
 .form-control:-ms-input-placeholder {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 .form-control::-webkit-input-placeholder {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 .form-control[required]::-moz-placeholder {
   color: #161616;
@@ -18009,7 +18224,7 @@ div[id$=color-picker-menu] {
   cursor: default;
 }
 .c-form__autocomplete li:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 /* Services/Help */
@@ -18659,7 +18874,7 @@ span.ilNewsRssIcon {
 }
 span.ilNewsRssIcon:hover {
   text-decoration: none;
-  background-color: #823900;
+  background-color: rgb(130, 56.7403314917, 0);
 }
 
 /* timeline, see http://codepen.io/jasondavis/pen/fDGdK */
@@ -19066,10 +19281,10 @@ div.ilCreationFormSection .form-horizontal {
   background-color: white;
 }
 .table-striped > tbody > tr.ilObjListRow:hover > td {
-  background-color: #f3f5f8;
+  background-color: rgb(242.5571428571, 244.8785714286, 247.9428571429);
 }
 .table-striped > tbody > tr.ilObjListRow:hover:nth-child(2n+1) > td {
-  background-color: #f3f5f8;
+  background-color: rgb(242.5571428571, 244.8785714286, 247.9428571429);
 }
 
 [data-onscreenchat-inact-userid] {
@@ -19244,7 +19459,7 @@ div.ilCreationFormSection .form-horizontal {
 }
 #onscreenchat-container .chat-window-wrapper .chat li .chat-body p {
   margin: 0;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-size: 0.75rem;
 }
 #onscreenchat-container .chat-window-wrapper .panel {
@@ -19460,7 +19675,7 @@ div.ilSkill > h4 {
   margin: 10px 0;
   padding: 0;
   font-size: 0.875rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   float: left;
   clear: left;
 }
@@ -19560,7 +19775,7 @@ th.ilSkillEntryHead {
 }
 
 .ilSkillEvalItem.ilSkillEvalType3 {
-  border-color: #557b2e;
+  border-color: rgb(84.5, 122.9090909091, 46.0909090909);
 }
 
 .ilSkillEvalItem > .row > .ilSkillEvalType1 {
@@ -19572,7 +19787,7 @@ th.ilSkillEntryHead {
 }
 
 .ilSkillEvalItem > .row > .ilSkillEvalType3 {
-  color: #557b2e;
+  color: rgb(84.5, 122.9090909091, 46.0909090909);
 }
 
 .ilSkillFilter .ilToolbar select.form-control {
@@ -19951,7 +20166,7 @@ tr.tblheader {
 }
 
 .tblrowmarked {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #161616;
   padding: 3px;
 }
@@ -19971,7 +20186,7 @@ tr.tblheader {
 }
 
 .tblrowmarkedtop {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   color: #161616;
   padding: 3px;
   vertical-align: top;
@@ -20029,19 +20244,19 @@ td > img[src$="icon_custom.svg"] {
   border-radius: 3px;
 }
 .ilTag .ilTagRelHigh {
-  background-color: #85d1da;
+  background-color: rgb(132.9, 209.3615384615, 218.1);
   color: #161616;
 }
 .ilTag .ilTagRelMiddle {
-  background-color: #95c5ca;
+  background-color: rgb(148.8, 196.7230769231, 202.2);
   color: #161616;
 }
 .ilTag .ilTagRelLow {
-  background-color: #a5b8ba;
+  background-color: rgb(164.7, 184.0846153846, 186.3);
   color: #161616;
 }
 .ilTag .ilTagRelVeryLow {
-  background-color: #b0b0b0;
+  background-color: rgb(175.5, 175.5, 175.5);
   color: #161616;
 }
 .ilTag.ilHighlighted, .ilTag.ilHighlighted:hover {
@@ -20049,7 +20264,7 @@ td > img[src$="icon_custom.svg"] {
   color: white;
 }
 .ilTag.ilHighlighted:hover, .ilTag.ilHighlighted:hover:hover {
-  background-color: #9c4400;
+  background-color: rgb(155.5, 67.8701657459, 0);
 }
 
 a.ilTag:hover, a.ilTag:active {
@@ -20226,11 +20441,11 @@ div.ilChecklist ul a:hover {
 }
 
 div.ilChecklist ul li a:hover {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
 }
 
 div.ilChecklist ul li p, div.ilChecklist ul li p:hover {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
   font-size: 0.625rem;
   text-decoration: none;
   padding: 0;
@@ -20306,14 +20521,14 @@ li.il_Explorer {
 }
 
 a.il_HighlightedNode, .ilHighlighted {
-  background-color: #e2e8ef;
+  background-color: rgb(226.2857142857, 231.6428571429, 238.7142857143);
   padding: 0 5px;
 }
 
 li.ilExplSecHighlight {
   background-color: #f9f9f9 !important;
-  border-top: solid 2px #557196;
-  border-bottom: solid 2px #557196;
+  border-top: solid 2px rgb(85.2285714286, 113.2642857143, 150.2714285714);
+  border-bottom: solid 2px rgb(85.2285714286, 113.2642857143, 150.2714285714);
 }
 
 div.il_ExplorerItemDescription {
@@ -20513,7 +20728,7 @@ a.ilMediaLightboxClose:hover {
 .progress {
   height: 15px;
   min-width: 100px;
-  background-color: #b8b8b8;
+  background-color: rgb(184.25, 184.25, 184.25);
 }
 
 .progress-bar {
@@ -20775,7 +20990,7 @@ h3.ilProfileName {
 div.ilProfileSection {
   margin-top: 15px;
   font-size: 0.75rem;
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 h3.ilProfileSectionHead {
@@ -21347,7 +21562,7 @@ div.Access {
 }
 
 .light {
-  color: #6f6f6f;
+  color: rgb(111.25, 111.25, 111.25);
 }
 
 /*# sourceMappingURL=delos.css.map */


### PR DESCRIPTION
![Screenshot from 2024-11-11 13-58-35](https://github.com/user-attachments/assets/a00166c2-f86f-4055-a50a-edb34850d332)

This adds to the UI:
- a "Navigation" section
- a sequence player

The Sequence Navigation uses the same builder-pattern known from ui-tables: consumers will have to provide a binding
defining possible positions of the sequence (that has to be done at one point, anyways) and build a view/page/... = Segment with allowed contents.

Operating the sequnce will then display the segments one by one, also allowing for view controls as well as global and segment-specific actions.


This PR includes https://github.com/ILIAS-eLearning/ILIAS/pull/8436