### PR TITLE
LegalDocuments: Use updated footer api to provide links & modals

### DIFF
--- a/components/ILIAS/LegalDocuments/classes/Conductor.php
+++ b/components/ILIAS/LegalDocuments/classes/Conductor.php
@@ -27,7 +27,6 @@ use Closure;
 use ILIAS\Data\Result;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Data\Result\Error;
-use ILIAS\UI\Component\MainControls\Footer;
 use ILIAS\Refinery\Transformation;
 use ilStartUpGUI;
 use ilObjUser;
@@ -97,9 +96,9 @@ class Conductor
         );
     }
 
-    public function modifyFooter(Footer $footer): Footer
+    public function modifyFooter(Closure $footer): Closure
     {
-        return array_reduce($this->internal->all('footer'), fn($footer, Closure $proc) => $proc($footer), $footer);
+        return array_reduce($this->internal->all('footer'), fn(Closure $footer, Closure $proc) => $proc($footer), $footer);
     }
 
     public function agree(string $gui, string $cmd): void

--- a/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/ModifyFooter.php
+++ b/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/ConsumerSlots/ModifyFooter.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\LegalDocuments\ConsumerToolbox\ConsumerSlots;
 
+use ilLink;
 use ILIAS\LegalDocuments\Value\DocumentContent;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\MainControls\Footer;
@@ -29,6 +30,7 @@ use ILIAS\Data\Result\Ok;
 use ILIAS\LegalDocuments\Provide;
 use ilTemplate;
 use Closure;
+use ILIAS\UI\Component\Modal\Modal;
 
 final class ModifyFooter
 {
@@ -41,28 +43,33 @@ final class ModifyFooter
         private readonly User $user,
         private readonly Provide $legal_documents,
         private readonly Closure $render,
-        private readonly Closure $create_template
+        private readonly Closure $create_template,
+        private readonly ?Closure $goto_link,
     ) {
     }
 
-    public function __invoke(Footer $footer): Footer
+    public function __invoke(Closure $footer): Closure
     {
         return $this->user->acceptedVersion()->map(
-            $this->renderModal($footer)
+            fn($document) => $this->footer($footer, $this->renderModal($document))
         )->except(
-            fn() => new Ok($footer)
+            fn() => new Ok(
+                !$this->goto_link || $this->user->isLoggedIn() ?
+                    $footer :
+                    $this->footer($footer, ($this->goto_link)())
+            )
         )->value();
     }
 
-    public function renderModal(Footer $footer): Closure
+    public function renderModal(DocumentContent $content): Modal
     {
-        return fn(DocumentContent $content): Footer => $footer->withAdditionalModalAndTrigger($this->ui->create()->modal()->roundtrip($content->title(), [
+        return $this->ui->create()->modal()->roundtrip($content->title(), [
             $this->ui->create()->legacy($this->ui->txt('usr_agreement_footer_intro')),
             $this->ui->create()->divider()->horizontal(),
             $this->legal_documents->document()->contentAsComponent($content),
             $this->ui->create()->divider()->horizontal(),
             $this->withdrawalButton(),
-        ]), $this->ui->create()->button()->shy($this->ui->txt('usr_agreement'), ''));
+        ]);
     }
 
     public function withdrawalButton(): Component
@@ -78,5 +85,13 @@ final class ModifyFooter
         );
 
         return $this->ui->create()->legacy($template->get());
+    }
+
+    /**
+     * @param URI|Modal $value
+     */
+    private function footer(Closure $footer, object $value): Closure
+    {
+        return $footer($this->legal_documents->id(), $this->ui->txt('usr_agreement'), $value);
     }
 }

--- a/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/Slot.php
+++ b/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/Slot.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\LegalDocuments\ConsumerToolbox;
 
+use ILIAS\Data\URI;
+use ilLink;
 use ILIAS\Refinery\Constraint;
 use ILIAS\LegalDocuments\ConsumerToolbox\ConsumerSlots\OnlineStatusFilter;
 use ILIAS\LegalDocuments\ConsumerToolbox\ConsumerSlots\SelfRegistration;
@@ -69,9 +71,10 @@ class Slot
         return new Agreement($user, $this->blocks->ui(), $this->blocks->routing(), $this->blocks->withRequest(...));
     }
 
-    public function modifyFooter(User $user): ModifyFooter
+    public function modifyFooter(User $user, ?string $goto_target = null): ModifyFooter
     {
-        return new ModifyFooter($this->blocks->ui(), $user, $this->provide, fn($arg) => $this->container->ui()->renderer()->render($arg), $this->template(...));
+        $link = $goto_target ? static fn() => new URI(ilLink::_getLink(null, 'usr', [], $goto_target)) : null;
+        return new ModifyFooter($this->blocks->ui(), $user, $this->provide, fn($arg) => $this->container->ui()->renderer()->render($arg), $this->template(...), $link);
     }
 
     /**

--- a/components/ILIAS/LegalDocuments/classes/GlobalScreen/FooterProvider.php
+++ b/components/ILIAS/LegalDocuments/classes/GlobalScreen/FooterProvider.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\LegalDocuments\GlobalScreen;
+
+use ILIAS\LegalDocuments\Conductor;
+use ILIAS\DI\Container;
+use ILIAS\GlobalScreen\Scope\MetaBar\Provider\AbstractStaticFooterProvider;
+use ILIAS\UI\Factory as UIFactory;
+use ILIAS\GlobalScreen\Identification\IdentificationInterface as Id;
+use ilFooterStandardGroupsProvider;
+use ilFooterStandardGroups;
+use Closure;
+use ILIAS\UI\Component\Modal\Modal;
+use ILIAS\GlobalScreen\Scope\Footer\Factory\isItem;
+
+class FooterProvider extends AbstractStaticFooterProvider
+{
+    private readonly Id $parent_id;
+    private readonly Conductor $ldoc;
+
+    public function __construct(Container $dic)
+    {
+        parent::__construct($dic);
+        $this->parent_id = (new ilFooterStandardGroupsProvider($dic))->getIdentificationFor(ilFooterStandardGroups::LEGAL_INFORMATION);
+        $this->ldoc = $dic['legalDocuments'];
+    }
+
+    public function getGroups(): array
+    {
+        return [];
+    }
+
+    public function getEntries(): array
+    {
+        return array_map(
+            fn(array $args) => $this->item(...$args),
+            $this->ldoc->modifyFooter($this->collect([]))()
+        );
+    }
+
+    private function collect(array $items): Closure
+    {
+        return function (...$args) use ($items) {
+            if ($args === []) {
+                return $items;
+            }
+            return $this->collect(array_merge($items, [$args]));
+        };
+    }
+
+    private function item(string $id, string $title, object $obj): isItem
+    {
+        return $obj instanceof Modal ?
+            $this->item_factory->modal($this->id_factory->identifier($id), $title, $obj)->withParent($this->parent_id) :
+            $this->item_factory->link($this->id_factory->identifier($id), $title)->withAction($obj);
+    }
+}

--- a/components/ILIAS/LegalDocuments/tests/ConductorTest.php
+++ b/components/ILIAS/LegalDocuments/tests/ConductorTest.php
@@ -48,6 +48,7 @@ use ilObjUser;
 use ILIAS\LegalDocuments\ConsumerToolbox\Routing;
 use ILIAS\Data\Result\Error;
 use ilStartUpGUI;
+use Closure;
 
 require_once __DIR__ . '/ContainerMock.php';
 
@@ -122,9 +123,9 @@ class ConductorTest extends TestCase
 
     public function testModifyFooter(): void
     {
-        $footer = $this->mock(Footer::class);
+        $footer = fn() => null;
 
-        $modify_footer = function (Footer $f) use ($footer) {
+        $modify_footer = function (Closure $f) use ($footer) {
             $this->assertSame($footer, $f);
             return $f;
         };

--- a/components/ILIAS/TermsOfService/classes/Consumer.php
+++ b/components/ILIAS/TermsOfService/classes/Consumer.php
@@ -71,7 +71,7 @@ class Consumer implements ConsumerInterface
 
         return $slot->canWithdraw($blocks->slot()->withdrawProcess($user, $global_settings, $this->userHasWithdrawn(...)))
                     ->hasAgreement($blocks->slot()->agreement($user), self::GOTO_NAME)
-                    ->showInFooter($blocks->slot()->modifyFooter($user))
+                    ->showInFooter($blocks->slot()->modifyFooter($user, self::GOTO_NAME))
                     ->showOnLoginPage($blocks->slot()->showOnLoginPage())
                     ->onSelfRegistration($blocks->slot()->selfRegistration($user, $build_user))
                     ->hasOnlineStatusFilter($blocks->slot()->onlineStatusFilter($this->usersWhoDidntAgree($this->container->database())))

--- a/components/ILIAS/UICore/classes/Screen/PageContentProvider.php
+++ b/components/ILIAS/UICore/classes/Screen/PageContentProvider.php
@@ -171,11 +171,6 @@ class PageContentProvider extends AbstractModificationProvider
         return $subtab_title . $tab_title;
     }
 
-    public function getFooterModification(CalledContexts $screen_context_stack): ?FooterModification
-    {
-        return $this->globalScreen()->layout()->factory()->footer()->withModification(fn(?Footer $footer): ?Footer => $this->dic['legalDocuments']->modifyFooter($footer));
-    }
-
     /**
      * @deprecated this is needed as long as the PageContentProvider is the only place which stores the permalink
      */


### PR DESCRIPTION
This PR changes the `LegalDocuments` to use the new footer API based on this PR: https://github.com/ILIAS-eLearning/ILIAS/pull/8359.

This PR fixes Mantis Bug: https://mantis.ilias.de/view.php?id=42339 (Show goto links in the footer for anonymous user)