### PR TITLE
Exercise: fix setting of property lp_user_id (42651)

### DIFF
--- a/components/ILIAS/Exercise/classes/class.ilObjExerciseGUI.php
+++ b/components/ILIAS/Exercise/classes/class.ilObjExerciseGUI.php
@@ -93,8 +93,9 @@ class ilObjExerciseGUI extends ilObjectGUI
             throw new ilExerciseException("Assignment ID does not match Exercise.");
         }
 
-        $this->lp_user_id = ($this->exercise_request->getUserId() > 0)
-            ?: $this->user->getId();
+        $this->lp_user_id = ($this->exercise_request->getUserId() > 0) ?
+            $this->exercise_request->getUserId() :
+            $this->user->getId();
         $this->requested_sort_order = $this->exercise_request->getSortOrder();
         $this->requested_sort_by = $this->exercise_request->getSortBy();
         $this->requested_offset = $this->exercise_request->getOffset();


### PR DESCRIPTION
This PR fixes [42651](https://mantis.ilias.de/view.php?id=42651), by setting a property in `ilObjExerciseGUI` properly. There have been no changes in those lines of code since ILIAS 8, not sure why it's triggered an error now and not before.