### PR TITLE
Style/TestCases: update path to KS Docu and drop references-tag

### DIFF
--- a/components/ILIAS/Style/classes/Setup/TestRailXMLWriter.php
+++ b/components/ILIAS/Style/classes/Setup/TestRailXMLWriter.php
@@ -112,7 +112,6 @@ class TestRailXMLWriter
         $xml_case->addChild('template', 'Test Case');
         $xml_case->addChild('type', 'Other');
         $xml_case->addChild('priority', '4 - Must Test');
-        $xml_case->addChild('references', 'Other');
         $xml_cust = $xml_case->addChild('custom');
         $xml_cust->addChild('preconds', "\n" . trim($preconditions) . "\n");
         $xml_cust->addChild('steps', "\n" . trim($steps) . "\n");

--- a/components/ILIAS/Style/classes/Setup/templates/testrail.case.xml
+++ b/components/ILIAS/Style/classes/Setup/templates/testrail.case.xml
@@ -1,5 +1,5 @@
 <!-- BEGIN preconditions -->
-You are in the test installation in the section **Administration → Layout and Navigation → Layout → Delos → Documentation**.
+You are in the test installation in the section **Administration → Layout and Navigation → Layout → System Styles → Documentation**.
 <!-- END preconditions -->
 
 <!-- BEGIN steps_show -->


### PR DESCRIPTION
Fabian asked me to amend the path to the UI docu in the testrail-cases and leave out the references-tag (both relevant not for this season, but the next round in 11).
