### PR TITLE
[BUGFIX 42668] Undefined Array Access when saving the ilObjLanguageExtGUI (Overwrite Language Variables GUI) with lanugage variables that contian a dot

### DIFF
--- a/Services/Language/classes/class.ilObjLanguageExtGUI.php
+++ b/Services/Language/classes/class.ilObjLanguageExtGUI.php
@@ -413,6 +413,7 @@ class ilObjLanguageExtGUI extends ilObjectGUI
         $remarks_array = array();
         $post = (array) ($this->http->request()->getParsedBody() ?? []);
         foreach ($post as $key => $value) {
+            $orginal_key = $key;
             // mantis #25237
             // @see https://php.net/manual/en/language.variables.external.php
             $key = str_replace(["_POSTDOT_", "_POSTSPACE_"], [".", " "], $key);
@@ -429,7 +430,7 @@ class ilObjLanguageExtGUI extends ilObjectGUI
                 $save_array[$key] = $value;
 
                 // the comment has the key of the language with the suffix
-                $remarks_array[$key] = $post[$key . $this->lng->separator . "comment"];
+                $remarks_array[$key] = $post[$orginal_key . $this->lng->separator . "comment"];
             }
         }
 
@@ -754,7 +755,7 @@ class ilObjLanguageExtGUI extends ilObjectGUI
 
         $this->ctrl->redirect($this, "maintain");
     }
-    
+
     /**
      * View the language settings
      */
@@ -763,7 +764,7 @@ class ilObjLanguageExtGUI extends ilObjectGUI
         $form = $this->initNewSettingsForm();
         $this->tpl->setContent($form->getHTML());
     }
-    
+
     /**
     * Set the language settings
     */
@@ -785,26 +786,26 @@ class ilObjLanguageExtGUI extends ilObjectGUI
 
         $this->tpl->setContent($form->getHTML());
     }
-    
+
     protected function initNewSettingsForm(): ilPropertyFormGUI
     {
         global $DIC;
         $ilSetting = $DIC->settings();
         $translate_key = "lang_translate_" . $this->object->key;
         $translate = (bool) $ilSetting->get($translate_key, '0');
-        
+
         require_once("./Services/Form/classes/class.ilPropertyFormGUI.php");
         $form = new ilPropertyFormGUI();
         $form->setFormAction($this->ctrl->getFormAction($this));
         $form->setTitle($this->lng->txt("language_settings"));
         $form->setPreventDoubleSubmission(false);
         $form->addCommandButton('saveSettings', $this->lng->txt("language_change_settings"));
-    
+
         $ci = new ilCheckboxInputGUI($this->lng->txt("language_translation_enabled"), "translation");
         $ci->setChecked($translate);
         $ci->setInfo($this->lng->txt("language_note_translation"));
         $form->addItem($ci);
-        
+
         return $form;
     }
 


### PR DESCRIPTION
Hello,

there is an error/warning/bug that is triggered when a language variable key contains a dot:

/Services/Language/classes/class.ilObjLanguageExtGUI.php in ilObjLanguageExtGUI::saveObject at line 434
e.g.
Warning: Undefined array key "ui_uihk_plugin#:#ui_uihk_plugin_object_type.2#:#comment"

This means that the remark for such variables is always null/not defined or resulting in a error.

This is because the original key contains a _POSTDOT_ that is replaced but used on the post array again.


Mantis https://mantis.ilias.de/view.php?id=42668