### PR TITLE
Fix: 0042595

### DIFF
--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderReleasedObjectsTableGUI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderReleasedObjectsTableGUI.php
@@ -56,6 +56,10 @@ class ilLTIProviderReleasedObjectsTableGUI extends ilObjectTableGUI
      */
     public function fillRow(array $a_set): void
     {
+        if (!isset($a_set['type'])) {
+            $a_set['type'] = '';
+        }
+
         parent::fillRow($a_set);
 
         $this->tpl->setVariable('CONSUMER_TITLE', $a_set['consumer']);


### PR DESCRIPTION
Prevent the object type from arriving as null in the object table in "Object Releases".