### PR TITLE
[Bugfix 42401]Lang Vars for Test-specific Placeholder Texts were bogus

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2787,11 +2787,11 @@ certificate#:#certificate_text_info#:#Bitte geben Sie hier den Text des Zertifik
 certificate#:#certificate_unit_description#:#Geben Sie Maße immer in der Form WERT[cm|mm|in|pt|pc|px|em] an, d.h. 10mm oder 3in
 certificate#:#certificate_usage#:#Bitte beachten Sie, dass die Verwendung und Erstellung von Zertifikaten nur möglich ist, wenn Sie den Java-Server von ILIAS verwenden. Der Java-Server wird in der Hauptseite der Administration in der Kategorie Web-Services konfiguriert und ist unter anderem für die Generierung von PDF-Dateien erforderlich.
 certificate#:#certificate_var_max_points#:#46
-certificate#:#certificate_var_result_mark_long#:#Gut
-certificate#:#certificate_var_result_mark_short#:#2
-certificate#:#certificate_var_result_passed#:#bestanden
-certificate#:#certificate_var_result_percent#:#83%
-certificate#:#certificate_var_result_points#:#38
+certificate#:#certificate_var_result_mark_long#:#Die offizielle Bezeichnung der erreichten Note wird angezeigt.
+certificate#:#certificate_var_result_mark_short#:#Die Kurzbereichnung der erreichten Note wird angezeigt. 
+certificate#:#certificate_var_result_passed#:#Angabe, ob der Test bestanden wurde oder nicht.
+certificate#:#certificate_var_result_percent#:#Angabe, wie viel Prozent im Test erreicht wurden.
+certificate#:#certificate_var_result_points#:#Angabe, wie viele Punkte im Test erreicht wurden.
 certificate#:#certificate_var_user_birthday#:#08.05.1977
 certificate#:#certificate_var_user_city#:#Köln
 certificate#:#certificate_var_user_country#:#Deutschland

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2786,12 +2786,12 @@ certificate#:#certificate_text#:#Text des Zertifikats
 certificate#:#certificate_text_info#:#Bitte geben Sie hier den Text des Zertifikats ein. Falls der WYSIWYG-Edtior in der ILIAS-Administration deaktiviert wurde, können Sie hier dennoch gültiges XHTML zur Formatierung nutzen.<br><br>
 certificate#:#certificate_unit_description#:#Geben Sie Maße immer in der Form WERT[cm|mm|in|pt|pc|px|em] an, d.h. 10mm oder 3in
 certificate#:#certificate_usage#:#Bitte beachten Sie, dass die Verwendung und Erstellung von Zertifikaten nur möglich ist, wenn Sie den Java-Server von ILIAS verwenden. Der Java-Server wird in der Hauptseite der Administration in der Kategorie Web-Services konfiguriert und ist unter anderem für die Generierung von PDF-Dateien erforderlich.
-certificate#:#certificate_var_max_points#:#46
-certificate#:#certificate_var_result_mark_long#:#Die offizielle Bezeichnung der erreichten Note wird angezeigt.
-certificate#:#certificate_var_result_mark_short#:#Die Kurzbereichnung der erreichten Note wird angezeigt. 
-certificate#:#certificate_var_result_passed#:#Angabe, ob der Test bestanden wurde oder nicht.
-certificate#:#certificate_var_result_percent#:#Angabe, wie viel Prozent im Test erreicht wurden.
-certificate#:#certificate_var_result_points#:#Angabe, wie viele Punkte im Test erreicht wurden.
+certificate#:#certificate_var_max_points#:#Maximale Punktzahl im verwendeten Test
+certificate#:#certificate_var_result_mark_long#:#Erreichte Note in der Form 'Offizielle Bezeichnung'
+certificate#:#certificate_var_result_mark_short#:#Erreichte Note in der Form 'Kurzbezeichnung'
+certificate#:#certificate_var_result_passed#:#Angabe, ob der Test bestanden wurde oder nicht
+certificate#:#certificate_var_result_percent#:#Anzahl der erreichten Prozent im Test
+certificate#:#certificate_var_result_points#:#Anzahl der erreichten Punkte im Test
 certificate#:#certificate_var_user_birthday#:#08.05.1977
 certificate#:#certificate_var_user_city#:#Köln
 certificate#:#certificate_var_user_country#:#Deutschland

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2790,7 +2790,7 @@ certificate#:#certificate_var_max_points#:#Maximale Punktzahl im verwendeten Tes
 certificate#:#certificate_var_result_mark_long#:#Erreichte Note in der Form 'Offizielle Bezeichnung'
 certificate#:#certificate_var_result_mark_short#:#Erreichte Note in der Form 'Kurzbezeichnung'
 certificate#:#certificate_var_result_passed#:#Angabe, ob der Test bestanden wurde oder nicht
-certificate#:#certificate_var_result_percent#:#Anzahl der erreichten Prozent im Test
+certificate#:#certificate_var_result_percent#:#Anzahl der erreichten Prozente im Test
 certificate#:#certificate_var_result_points#:#Anzahl der erreichten Punkte im Test
 certificate#:#certificate_var_user_birthday#:#08.05.1977
 certificate#:#certificate_var_user_city#:#Köln

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2786,12 +2786,12 @@ certificate#:#certificate_text#:#Certificate Text
 certificate#:#certificate_text_info#:#Please enter the certificate text. If the WYSIWYG editor is disabled in the ILIAS administration, you can still use valid XHTML to format the text.<br><br>
 certificate#:#certificate_unit_description#:#Enter units of measure as VALUE[cm|mm|in|pt|pc|px|em], e.g. 10mm or 3in
 certificate#:#certificate_usage#:#Please note that the usage of certificates is only available if the ILIAS Java-Server is running. The configuration for Java-Server is available in Administration » General Settings » Server, sub-tab Java-Server.
-certificate#:#certificate_var_max_points#:#46
-certificate#:#certificate_var_result_mark_long#:#Good
-certificate#:#certificate_var_result_mark_short#:#B
-certificate#:#certificate_var_result_passed#:#passed
-certificate#:#certificate_var_result_percent#:#83%
-certificate#:#certificate_var_result_points#:#38
+certificate#:#certificate_var_max_points#:#Maximum number of points in the test used
+certificate#:#certificate_var_result_mark_long#:#Achieved mark presented in 'official form'
+certificate#:#certificate_var_result_mark_short#:#Achieved mark presented in 'short form'
+certificate#:#certificate_var_result_passed#:#Information on whether the test was passed or not
+certificate#:#certificate_var_result_percent#:#Percentage achieved in the test
+certificate#:#certificate_var_result_points#:#Number of points achieved in the test
 certificate#:#certificate_var_user_birthday#:#1977-05-08
 certificate#:#certificate_var_user_city#:#Anytown, NY
 certificate#:#certificate_var_user_country#:#USA


### PR DESCRIPTION
I corrected them for ILIAS 9. This is needed for ILIAS 9, 10, Trunk. :)

Mantis Issue: https://mantis.ilias.de/view.php?id=42401