### PR TITLE
T&A/10 40791: Replaces superglobal usages in Test component with RequestDataCollector

### DIFF
--- a/components/ILIAS/Test/classes/Confirmations/class.ilTestSettingsChangeConfirmationGUI.php
+++ b/components/ILIAS/Test/classes/Confirmations/class.ilTestSettingsChangeConfirmationGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
+
 /**
  * @author		Björn Heyser <bheyser@databay.de>
  * @version		$Id$
@@ -26,15 +28,14 @@ declare(strict_types=1);
  */
 class ilTestSettingsChangeConfirmationGUI extends ilConfirmationGUI
 {
-    protected ilObjTest $testOBJ;
     private ?string $oldQuestionSetType;
     private ?string $newQuestionSetType;
     private ?bool $questionLossInfoEnabled;
 
-    public function __construct(ilObjTest $testOBJ)
-    {
-        $this->testOBJ = $testOBJ;
-
+    public function __construct(
+        private readonly RequestDataCollector $request_data_collector,
+        protected readonly ilObjTest $testOBJ
+    ) {
         parent::__construct();
     }
 
@@ -93,13 +94,15 @@ class ilTestSettingsChangeConfirmationGUI extends ilConfirmationGUI
 
     public function populateParametersFromPost(): void
     {
-        foreach ($_POST as $key => $value) {
-            if (strcmp($key, "cmd") != 0) {
+        foreach ($this->request_data_collector->getPostKeys() as $key) {
+            if ($key !== 'cmd') {
+                $value = $this->request_data_collector->raw($key);
+
                 if (is_array($value)) {
                     foreach ($value as $k => $v) {
                         $this->addHiddenItem("{$key}[{$k}]", $v);
                     }
-                } else {
+                } elseif (is_string($value)) {
                     $this->addHiddenItem($key, $value);
                 }
             }

--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -1964,7 +1964,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
      */
     public function deleteDefaultsObject()
     {
-        $defaults_ids = $this->testrequest->retrieveArrayOfInts('chb_defaults');
+        $defaults_ids = $this->testrequest->retrieveArrayOfIntsFromPost('chb_defaults');
         if ($defaults_ids !== null && $defaults_ids !== []) {
             foreach ($defaults_ids as $test_default_id) {
                 $this->getTestObject()->deleteDefaults($test_default_id);
@@ -1989,7 +1989,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
      */
     public function applyDefaultsObject($confirmed = false): void
     {
-        $defaults = $this->testrequest->retrieveArrayOfInts('chb_defaults');
+        $defaults = $this->testrequest->retrieveArrayOfIntsFromPost('chb_defaults');
         if ($defaults !== []) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('tst_defaults_apply_select_one'));
 

--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -719,6 +719,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                     $this->component_repository,
                     $this->getTestObject(),
                     $this->questionrepository,
+                    $this->testrequest,
                     $this->ref_id
                 );
                 $this->ctrl->forwardCommand($gui);
@@ -1963,7 +1964,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
      */
     public function deleteDefaultsObject()
     {
-        $defaults_ids = $this->testrequest->getArrayOfIntsFromPost('chb_defaults');
+        $defaults_ids = $this->testrequest->retrieveArrayOfInts('chb_defaults');
         if ($defaults_ids !== null && $defaults_ids !== []) {
             foreach ($defaults_ids as $test_default_id) {
                 $this->getTestObject()->deleteDefaults($test_default_id);
@@ -1986,10 +1987,10 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
     /**
      * Applies the selected test defaults
      */
-    public function applyDefaultsObject($confirmed = false)
+    public function applyDefaultsObject($confirmed = false): void
     {
-        $defaults = $this->testrequest->getArrayOfStringsFromPost('chb_defaults');
-        if ($defaults !== null && $defaults !== []) {
+        $defaults = $this->testrequest->retrieveArrayOfInts('chb_defaults');
+        if ($defaults !== []) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('tst_defaults_apply_select_one'));
 
             $this->defaultsObject();
@@ -2030,7 +2031,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
 
             default:
 
-                $confirmation = new ilTestSettingsChangeConfirmationGUI($this->getTestObject());
+                $confirmation = new ilTestSettingsChangeConfirmationGUI($this->testrequest, $this->getTestObject());
 
                 $confirmation->setFormAction($this->ctrl->getFormAction($this));
                 $confirmation->setCancel($this->lng->txt('cancel'), 'defaults');

--- a/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
@@ -593,12 +593,12 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         $this->tpl->setContent($this->ctrl->getHTML($confirm));
     }
 
-    public function cancelDeletePass()
+    public function cancelDeletePass(): void
     {
-        $this->redirectToPassDeletionContext($_POST['context']);
+        $this->redirectToPassDeletionContext($this->testrequest->strVal('context'));
     }
 
-    private function redirectToPassDeletionContext($context)
+    private function redirectToPassDeletionContext(string $context): void
     {
         switch ($context) {
             case ilTestPassDeletionConfirmationGUI::CONTEXT_PASS_OVERVIEW:
@@ -611,13 +611,11 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
         }
     }
 
-    public function performDeletePass()
+    public function performDeletePass(): void
     {
-        if (isset($_POST['context']) && strlen($_POST['context'])) {
-            $context = $_POST['context'];
-        } else {
-            $context = ilTestPassDeletionConfirmationGUI::CONTEXT_PASS_OVERVIEW;
-        }
+        $context = $this->testrequest->strVal('context') ?? ilTestPassDeletionConfirmationGUI::CONTEXT_PASS_OVERVIEW;
+        $active_fi = $this->testrequest->int('active_id');
+        $pass = $this->testrequest->int('pass');
 
         if (!$this->object->isPassDeletionAllowed()) {
             $this->redirectToPassDeletionContext($context);
@@ -625,22 +623,11 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
 
         $ilDB = $this->db;
 
-        $active_fi = null;
-        $pass = null;
-
-        if (isset($_POST['active_id']) && (int) $_POST['active_id']) {
-            $active_fi = $_POST['active_id'];
-        }
-
-        if (isset($_POST['pass']) && is_numeric($_POST['pass'])) {
-            $pass = $_POST['pass'];
-        }
-
-        if (is_null($active_fi) || is_null($pass)) {
+        if ($active_fi === 0 || $pass === 0) {
             $this->ctrl->redirect($this, 'outUserResultsOverview');
         }
 
-        if ($pass == $this->object->_getResultPass($active_fi)) {
+        if ($pass === $this->object::_getResultPass($active_fi)) {
             $this->ctrl->redirect($this, 'outUserResultsOverview');
         }
 

--- a/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestEvaluationGUI.php
@@ -627,7 +627,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
             $this->ctrl->redirect($this, 'outUserResultsOverview');
         }
 
-        if ($pass === $this->object::_getResultPass($active_fi)) {
+        if ($pass === ilObjTest::_getResultPass($active_fi)) {
             $this->ctrl->redirect($this, 'outUserResultsOverview');
         }
 

--- a/components/ILIAS/Test/classes/class.ilTestParticipantsGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestParticipantsGUI.php
@@ -121,15 +121,15 @@ class ilTestParticipantsGUI
         $filter_closure = $this->participant_access_filter->getManageParticipantsUserFilter($this->test_obj->getRefId());
         $filtered_user_ids = $filter_closure($user_ids);
 
-        $countusers = 0;
+        $users_count = 0;
+        $client_ips = $this->testrequest->retrieveArrayOfStrings('client_ip');
         foreach ($filtered_user_ids as $user_id) {
-            $client_ip = $this->testrequest->raw('client_ip')[$countusers] ?? '';
-            $this->test_obj->inviteUser($user_id, $client_ip);
-            $countusers++;
+            $this->test_obj->inviteUser($user_id, $client_ips[$users_count] ?? '');
+            $users_count++;
         }
 
         $message = '';
-        if ($countusers) {
+        if ($users_count) {
             $message = $this->lng->txt('tst_invited_selected_users');
         }
         if (strlen($message)) {

--- a/components/ILIAS/Test/classes/class.ilTestParticipantsGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestParticipantsGUI.php
@@ -132,7 +132,7 @@ class ilTestParticipantsGUI
         if ($users_count > 0) {
             $message = $this->lng->txt('tst_invited_selected_users');
         }
-        if (strlen($message) !== 0) {
+        if ($message !== '') {
             $this->main_tpl->setOnScreenMessage('info', $message, true);
         } else {
             $this->main_tpl->setOnScreenMessage('info', $this->lng->txt('tst_invited_nobody'), true);

--- a/components/ILIAS/Test/classes/class.ilTestParticipantsGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestParticipantsGUI.php
@@ -132,7 +132,7 @@ class ilTestParticipantsGUI
         if ($users_count > 0) {
             $message = $this->lng->txt('tst_invited_selected_users');
         }
-        if (strlen($message) > 0) {
+        if (strlen($message) !== 0) {
             $this->main_tpl->setOnScreenMessage('info', $message, true);
         } else {
             $this->main_tpl->setOnScreenMessage('info', $this->lng->txt('tst_invited_nobody'), true);

--- a/components/ILIAS/Test/classes/class.ilTestParticipantsGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestParticipantsGUI.php
@@ -122,17 +122,17 @@ class ilTestParticipantsGUI
         $filtered_user_ids = $filter_closure($user_ids);
 
         $users_count = 0;
-        $client_ips = $this->testrequest->retrieveArrayOfStrings('client_ip');
+        $client_ips = $this->testrequest->retrieveArrayOfStringsFromPost('client_ip');
         foreach ($filtered_user_ids as $user_id) {
             $this->test_obj->inviteUser($user_id, $client_ips[$users_count] ?? '');
             $users_count++;
         }
 
         $message = '';
-        if ($users_count) {
+        if ($users_count > 0) {
             $message = $this->lng->txt('tst_invited_selected_users');
         }
-        if (strlen($message)) {
+        if (strlen($message) > 0) {
             $this->main_tpl->setOnScreenMessage('info', $message, true);
         } else {
             $this->main_tpl->setOnScreenMessage('info', $this->lng->txt('tst_invited_nobody'), true);

--- a/components/ILIAS/Test/classes/class.ilTestPasswordProtectionGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPasswordProtectionGUI.php
@@ -110,7 +110,7 @@ class ilTestPasswordProtectionGUI
 
     private function saveEnteredPasswordCmd(): void
     {
-        $this->password_checker->setUserEnteredPassword($_POST["password"]);
+        $this->password_checker->setUserEnteredPassword($this->testrequest->strVal('password'));
 
         if (!$this->password_checker->isUserEnteredPasswordCorrect()) {
             $this->password_checker->logWrongEnteredPassword();

--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2762,7 +2762,7 @@ JS;
     protected function getNavigationUrlParameter(): string
     {
         $navigation_url = $this->testrequest->strVal('test_player_navigation_url');
-        if (strlen($navigation_url) > 0) {
+        if (strlen($navigation_url) !== 0) {
             $navigation_url_parts = parse_url($navigation_url);
             $ilias_url_parts = parse_url(ilUtil::_getHttpPath());
 

--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -358,8 +358,9 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         if (!$saved
             || ($question_obj instanceof QuestionPartiallySaveable
                 && !$question_obj->validateSolutionSubmit())) {
+
             $this->ctrl->setParameter($this, 'save_error', '1');
-            ilSession::set('previouspost', $_POST);
+            ilSession::set('previouspost', $this->testrequest->getParsedBody());
         }
 
         return $saved;
@@ -665,10 +666,10 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
      *
      * Sets a session variable with the test access code for an anonymous test user
      */
-    public function setAnonymousIdCmd()
+    public function setAnonymousIdCmd(): void
     {
         if ($this->test_session->isAnonymousUser()) {
-            $this->test_session->setAccessCodeToSession($_POST['anonymous_id']);
+            $this->test_session->setAccessCodeToSession($this->testrequest->strVal('anonymous_id'));
         }
 
         $this->ctrl->redirectByClass([ilRepositoryGUI::class, ilObjTestGUI::class, ilInfoScreenGUI::class]);
@@ -851,7 +852,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
      */
     public function autosaveCmd(): void
     {
-        if (!is_countable($_POST) || count($_POST) === 0) {
+        if (count($this->testrequest->getPostKeys()) > 0) {
             echo '';
             exit;
         }
@@ -861,15 +862,12 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
             exit;
         }
 
-        $authorize = !$this->getAnswerChangedParameter();
-        $res = $this->saveQuestionSolution($authorize, true);
-
-        if ($res) {
-            echo $this->lng->txt("autosave_success");
+        if ($this->saveQuestionSolution(!$this->getAnswerChangedParameter(), true)) {
+            echo $this->lng->txt('autosave_success');
             exit;
         }
 
-        echo $this->lng->txt("autosave_failed");
+        echo $this->lng->txt('autosave_failed');
         exit;
     }
 
@@ -2756,20 +2754,15 @@ JS;
         return $nextcmd !== '' ? $nextcmd : null;
     }
 
-    protected function getNextSequenceParameter(): ?int
+    protected function getNextSequenceParameter(): int
     {
-        if (isset($_POST['nextseq']) && is_numeric($_POST['nextseq'])) {
-            return (int) $_POST['nextseq'];
-        }
-
-        return null;
+        return $this->testrequest->int('nextseq');
     }
 
-    protected function getNavigationUrlParameter(): ?string
+    protected function getNavigationUrlParameter(): string
     {
-        if (isset($_POST['test_player_navigation_url'])) {
-            $navigation_url = $_POST['test_player_navigation_url'];
-
+        $navigation_url = $this->testrequest->strVal('test_player_navigation_url');
+        if ($navigation_url) {
             $navigation_url_parts = parse_url($navigation_url);
             $ilias_url_parts = parse_url(ilUtil::_getHttpPath());
 
@@ -2777,8 +2770,7 @@ JS;
                 return $navigation_url;
             }
         }
-
-        return null;
+        return '';
     }
 
     protected function getAnswerChangedParameter(): bool
@@ -2801,13 +2793,13 @@ JS;
         $this->setAnswerChangedParameter($this->getAnswerChangedParameter());
     }
 
-    protected function saveNavigationPreventConfirmation()
+    protected function saveNavigationPreventConfirmation(): void
     {
-        if (!empty($_POST['save_on_navigation_prevent_confirmation'])) {
+        if ($this->testrequest->bool('save_on_navigation_prevent_confirmation')) {
             ilSession::set('save_on_navigation_prevent_confirmation', true);
         }
 
-        if (!empty($_POST[self::FOLLOWUP_QST_LOCKS_PREVENT_CONFIRMATION_PARAM])) {
+        if ($this->testrequest->bool(self::FOLLOWUP_QST_LOCKS_PREVENT_CONFIRMATION_PARAM)) {
             ilSession::set(self::FOLLOWUP_QST_LOCKS_PREVENT_CONFIRMATION_PARAM, true);
         }
     }

--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2762,7 +2762,7 @@ JS;
     protected function getNavigationUrlParameter(): string
     {
         $navigation_url = $this->testrequest->strVal('test_player_navigation_url');
-        if ($navigation_url) {
+        if (strlen($navigation_url) > 0) {
             $navigation_url_parts = parse_url($navigation_url);
             $ilias_url_parts = parse_url(ilUtil::_getHttpPath());
 

--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2762,7 +2762,7 @@ JS;
     protected function getNavigationUrlParameter(): string
     {
         $navigation_url = $this->testrequest->strVal('test_player_navigation_url');
-        if (strlen($navigation_url) !== 0) {
+        if ($navigation_url !== '') {
             $navigation_url_parts = parse_url($navigation_url);
             $ilias_url_parts = parse_url(ilUtil::_getHttpPath());
 

--- a/components/ILIAS/Test/classes/class.ilTestSkillAdministrationGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestSkillAdministrationGUI.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
 use ILIAS\Test\Logging\TestLogger;
 use ILIAS\Test\Presentation\TabsManager;
@@ -47,6 +48,7 @@ class ilTestSkillAdministrationGUI
         private ilComponentRepository $component_repository,
         private ilObjTest $test_obj,
         private GeneralQuestionPropertiesRepository $questionrepository,
+        private RequestDataCollector $request_data_collector,
         private int $ref_id
     ) {
     }
@@ -94,7 +96,14 @@ class ilTestSkillAdministrationGUI
                 $this->tabs_manager->activateTab(TabsManager::TAB_ID_SETTINGS);
                 $this->tabs_manager->activateSubTab(TabsManager::SETTINGS_SUBTAB_ID_ASSIGN_SKILL_TRESHOLDS);
 
-                $gui = new ilTestSkillLevelThresholdsGUI($this->ctrl, $this->tpl, $this->lng, $this->db, $this->test_obj->getTestId());
+                $gui = new ilTestSkillLevelThresholdsGUI(
+                    $this->ctrl,
+                    $this->tpl,
+                    $this->lng,
+                    $this->db,
+                    $this->request_data_collector,
+                    $this->test_obj->getTestId()
+                );
                 $gui->setQuestionAssignmentColumnsEnabled(!$this->test_obj->isRandomTest());
                 $gui->setQuestionContainerId($this->test_obj->getId());
                 $this->ctrl->forwardCommand($gui);

--- a/components/ILIAS/Test/classes/class.ilTestSkillLevelThresholdsGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestSkillLevelThresholdsGUI.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
+
 /**
  * @author		Björn Heyser <bheyser@databay.de>
  * @version		$Id$
@@ -39,6 +41,7 @@ class ilTestSkillLevelThresholdsGUI
         private readonly ilGlobalTemplateInterface $tpl,
         private readonly ilLanguage $lng,
         private readonly ilDBInterface $db,
+        private readonly RequestDataCollector $request_data_collector,
         private readonly int $test_id
     ) {
     }
@@ -86,20 +89,20 @@ class ilTestSkillLevelThresholdsGUI
 
     private function saveSkillThresholdsCmd(): void
     {
-        if (strtolower($_SERVER['REQUEST_METHOD']) == 'post') {
+        if (strtolower($_SERVER['REQUEST_METHOD']) === 'post') {
             $assignment_list = $this->buildSkillQuestionAssignmentList();
             $assignment_list->loadFromDb();
 
             $valid = true;
 
             $table = $this->getPopulatedTable();
-            $elements = $table->getInputElements((array) ($_POST['rendered'] ?? []));
+            $elements = $table->getInputElements($this->request_data_collector->retrieveArrayOfStrings('rendered'));
             foreach ($elements as $elm) {
                 if (!$elm->checkInput()) {
                     $valid = false;
                 }
 
-                $elm->setValue($_POST[$elm->getPostVar()]);
+                $elm->setValue($this->request_data_collector->strVal($elm->getPostVar()));
             }
 
             if (!$valid) {
@@ -111,9 +114,9 @@ class ilTestSkillLevelThresholdsGUI
             $threshold = [];
             foreach ($elements as $elm) {
                 $key = $elm->getPostVar();
-                $value = $_POST[$key];
                 $matches = null;
                 if (preg_match('/^threshold_(\d+?):(\d+?)_(\d+?)$/', $key, $matches) && is_array($matches)) {
+                    $value = $this->request_data_collector->int($key);
                     $threshold[$matches[1] . ':' . $matches[2]][$matches[3]] = $value;
                 }
             }
@@ -129,7 +132,7 @@ class ilTestSkillLevelThresholdsGUI
                 $thresholds_by_level = [];
 
                 foreach ($levels as $level) {
-                    if (isset($threshold[$skillKey]) && isset($threshold[$skillKey][$level['id']])) {
+                    if (isset($threshold[$skillKey][$level['id']])) {
                         $skill_level_threshold = new ilTestSkillLevelThreshold($this->db);
 
                         $skill_level_threshold->setTestId($this->getTestId());

--- a/components/ILIAS/Test/classes/class.ilTestSkillLevelThresholdsGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestSkillLevelThresholdsGUI.php
@@ -96,7 +96,7 @@ class ilTestSkillLevelThresholdsGUI
             $valid = true;
 
             $table = $this->getPopulatedTable();
-            $elements = $table->getInputElements($this->request_data_collector->retrieveArrayOfStrings('rendered'));
+            $elements = $table->getInputElements($this->request_data_collector->retrieveArrayOfStringsFromPost('rendered'));
             foreach ($elements as $elm) {
                 if (!$elm->checkInput()) {
                     $valid = false;

--- a/components/ILIAS/Test/classes/class.ilTestSkillLevelThresholdsGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestSkillLevelThresholdsGUI.php
@@ -89,7 +89,7 @@ class ilTestSkillLevelThresholdsGUI
 
     private function saveSkillThresholdsCmd(): void
     {
-        if ($this->request_data_collector->isMethod('post')) {
+        if ($this->request_data_collector->isMethod('POST')) {
             $assignment_list = $this->buildSkillQuestionAssignmentList();
             $assignment_list->loadFromDb();
 

--- a/components/ILIAS/Test/classes/class.ilTestSkillLevelThresholdsGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestSkillLevelThresholdsGUI.php
@@ -89,7 +89,7 @@ class ilTestSkillLevelThresholdsGUI
 
     private function saveSkillThresholdsCmd(): void
     {
-        if (strtolower($_SERVER['REQUEST_METHOD']) === 'post') {
+        if ($this->request_data_collector->isMethod('post')) {
             $assignment_list = $this->buildSkillQuestionAssignmentList();
             $assignment_list->loadFromDb();
 

--- a/components/ILIAS/Test/src/RequestDataCollector.php
+++ b/components/ILIAS/Test/src/RequestDataCollector.php
@@ -140,7 +140,7 @@ class RequestDataCollector
 
     public function isMethod(string $method): bool
     {
-        return strtolower($this->http->request()->getMethod()) === strtolower($method);
+        return $this->http->request()->getMethod() === $method;
     }
 
     /**

--- a/components/ILIAS/Test/src/RequestDataCollector.php
+++ b/components/ILIAS/Test/src/RequestDataCollector.php
@@ -22,8 +22,8 @@ namespace ILIAS\Test;
 
 use ILIAS\HTTP\Services as HTTPServices;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
 use ILIAS\Repository\BaseGUIRequest;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 use function array_map;
@@ -38,10 +38,7 @@ class RequestDataCollector
         HTTPServices $http,
         Refinery $refinery
     ) {
-        $this->initRequest(
-            $http,
-            $refinery
-        );
+        $this->initRequest($http, $refinery);
     }
 
     public function getRequest(): ServerRequestInterface
@@ -118,10 +115,9 @@ class RequestDataCollector
     /**
      * @return mixed|null
      */
-    public function raw(string $key)
+    public function raw(string $key): mixed
     {
-        $no_transform = $this->refinery->identity();
-        return $this->get($key, $no_transform);
+        return $this->get($key, $this->refinery->identity());
     }
 
     public function strVal(string $key): string
@@ -134,35 +130,40 @@ class RequestDataCollector
         return $this->http->request()->getParsedBody();
     }
 
-    public function getArrayOfIntsFromPost(string $key): ?array
+    public function getQueryKeys(): array
     {
-        $p = $this->http->wrapper()->post();
-        $r = $this->refinery;
-        if (!$p->has($key)) {
-            return null;
-        }
-
-        return $p->retrieve(
-            $key,
-            $r->container()->mapValues(
-                $r->kindlyTo()->int()
-            )
-        );
+        return $this->http->wrapper()->query()->keys();
     }
 
-    public function getArrayOfStringsFromPost(string $key): ?array
+    public function getPostKeys(): array
     {
-        $p = $this->http->wrapper()->post();
-        $r = $this->refinery;
-        if (!$p->has($key)) {
-            return null;
-        }
+        return $this->http->wrapper()->post()->keys();
+    }
 
-        return $p->retrieve(
+    /**
+     * @return array<string>
+     */
+    public function retrieveArrayOfStrings(string $key): array
+    {
+        return $this->retrieveArray($key, $this->refinery->kindlyTo()->string());
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function retrieveArrayOfInts(string $key): array
+    {
+        return $this->retrieveArray($key, $this->refinery->kindlyTo()->int());
+    }
+
+    private function retrieveArray(string $key, Transformation $transformation): array
+    {
+        return $this->http->wrapper()->post()->retrieve(
             $key,
-            $r->container()->mapValues(
-                $r->kindlyTo()->string()
-            )
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($transformation),
+                $this->refinery->always([])
+            ])
         );
     }
 

--- a/components/ILIAS/Test/src/RequestDataCollector.php
+++ b/components/ILIAS/Test/src/RequestDataCollector.php
@@ -140,6 +140,11 @@ class RequestDataCollector
         return $this->http->wrapper()->post()->keys();
     }
 
+    public function isMethod(string $method): bool
+    {
+        return strtolower($this->http->request()->getMethod()) === strtolower($method);
+    }
+
     /**
      * @return array<string>
      */

--- a/components/ILIAS/Test/src/RequestDataCollector.php
+++ b/components/ILIAS/Test/src/RequestDataCollector.php
@@ -130,11 +130,9 @@ class RequestDataCollector
         return $this->http->request()->getParsedBody();
     }
 
-    public function getQueryKeys(): array
-    {
-        return $this->http->wrapper()->query()->keys();
-    }
-
+    /**
+     * @deprecated
+     */
     public function getPostKeys(): array
     {
         return $this->http->wrapper()->post()->keys();
@@ -148,20 +146,20 @@ class RequestDataCollector
     /**
      * @return array<string>
      */
-    public function retrieveArrayOfStrings(string $key): array
+    public function retrieveArrayOfStringsFromPost(string $key): array
     {
-        return $this->retrieveArray($key, $this->refinery->kindlyTo()->string());
+        return $this->retrieveArrayFromPost($key, $this->refinery->kindlyTo()->string());
     }
 
     /**
      * @return array<int>
      */
-    public function retrieveArrayOfInts(string $key): array
+    public function retrieveArrayOfIntsFromPost(string $key): array
     {
-        return $this->retrieveArray($key, $this->refinery->kindlyTo()->int());
+        return $this->retrieveArrayFromPost($key, $this->refinery->kindlyTo()->int());
     }
 
-    private function retrieveArray(string $key, Transformation $transformation): array
+    private function retrieveArrayFromPost(string $key, Transformation $transformation): array
     {
         return $this->http->wrapper()->post()->retrieve(
             $key,

--- a/components/ILIAS/Test/tests/confirmations/ilTestSettingsChangeConfirmationGUITest.php
+++ b/components/ILIAS/Test/tests/confirmations/ilTestSettingsChangeConfirmationGUITest.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-use ILIAS\DI\Container;
+use ILIAS\Test\RequestDataCollector;
 
 /**
  * Class ilTestSettingsChangeConfirmationGUITest
@@ -33,7 +33,8 @@ class ilTestSettingsChangeConfirmationGUITest extends ilTestBaseTestCase
         parent::setUp();
 
         $this->testSettingsChangeConfirmationGUI = new ilTestSettingsChangeConfirmationGUI(
-            $this->getMockBuilder(ilObjTest::class)->disableOriginalConstructor()->getMock()
+            $this->createMock(RequestDataCollector::class),
+            $this->createMock(ilObjTest::class)
         );
     }
 

--- a/components/ILIAS/Test/tests/ilTestSkillAdministrationGUITest.php
+++ b/components/ILIAS/Test/tests/ilTestSkillAdministrationGUITest.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\Test\RequestDataCollector;
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
 
 /**
@@ -43,6 +44,7 @@ class ilTestSkillAdministrationGUITest extends ilTestBaseTestCase
             $this->createMock(ilComponentRepository::class),
             $this->getTestObjMock(),
             $this->createMock(GeneralQuestionPropertiesRepository::class),
+            $this->createMock(RequestDataCollector::class),
             201
         );
     }

--- a/components/ILIAS/Test/tests/ilTestSkillLevelThresholdsGUITest.php
+++ b/components/ILIAS/Test/tests/ilTestSkillLevelThresholdsGUITest.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\RequestDataCollector;
+
 /**
  * Class ilTestSkillLevelThresholdsGUITest
  * @author Marvin Beym <mbeym@databay.de>
@@ -37,6 +39,7 @@ class ilTestSkillLevelThresholdsGUITest extends ilTestBaseTestCase
             $this->createMock(ilGlobalPageTemplate::class),
             $this->createMock(ilLanguage::class),
             $this->createMock(ilDBInterface::class),
+            $this->createMock(RequestDataCollector::class),
             $this->testId
         );
     }


### PR DESCRIPTION
Hi everyone, 

this is the revised and rebased version of #7803 by @matheuszych:

> Superglobal variables such as $_GET or $_POST should not be accessed directly. Instead, use the request and refinery mechanisms. Currently, there are four instances where this change is not feasible due to limitations in the request and refinery systems, but these will be addressed in the future.

[Mantis: 40791](https://mantis.ilias.de/view.php?id=40791)

We are looking forward to feedback!
Best,
@lukas-heinrich 