### PR TITLE
[FIX] UI: properly count inputs of `Field\HasDynamicInputs` templates.

### DIFF
--- a/components/ILIAS/UI/resources/js/Input/Field/dynamic_inputs_renderer.js
+++ b/components/ILIAS/UI/resources/js/Input/Field/dynamic_inputs_renderer.js
@@ -1,4 +1,19 @@
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ * *******************************************************************
+ *
  * this script is responsible for clientside rendering of Inputs
  * ILIAS\UI\Component\Input\Field\DynamicInputsAware.
  *
@@ -82,13 +97,9 @@ il.UI.Input = il.UI.Input || {};
      * @param {int} sub_input_count
      */
     let addInputTemplateIds = function (template_html, sub_input_count) {
-      if (1 >= sub_input_count) {
-        return replaceAll(template_html, INPUT_ID_PLACEHOLDER, generateId());
-      }
-
       // Ids must not be all the same, therefore we need to generate
       // one for each sub-input contained in the template.
-      for (let i = 0; i < sub_input_count; i++) {
+      for (let i = 0; i <= sub_input_count; i++) {
         template_html = replaceAll(
           template_html,
           `${INPUT_ID_PLACEHOLDER}_${i}`,

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -960,7 +960,7 @@ class Renderer extends AbstractComponentRenderer
         string $template_html
     ): FI\HasDynamicInputs {
         $dynamic_inputs_template_html = $this->replaceTemplateIds($template_html);
-        $dynamic_input_count = count($input->getDynamicInputs());
+        $dynamic_input_count = $this->countInputsWithoutGroupsRecursively($input->getTemplateForDynamicInputs());
 
         // note that $dynamic_inputs_template_html is in tilted single quotes (`),
         // because otherwise the html syntax might collide with normal ones.
@@ -978,6 +978,23 @@ class Renderer extends AbstractComponentRenderer
                 });
             ";
         });
+    }
+
+    /**
+     * Counts all inputs and nested inputs of groups, without counting groups themselves.
+     */
+    protected function countInputsWithoutGroupsRecursively(FormInput|Input $input): int
+    {
+        if (!($input instanceof Component\Input\Group)) {
+            return 1;
+        }
+
+        $count = 0;
+        foreach ($input->getInputs() as $sub_input) {
+            $count += $this->countInputsWithoutGroupsRecursively($sub_input);
+        }
+
+        return $count;
     }
 
     protected function replaceTemplateIds(string $template_html): string


### PR DESCRIPTION
Hi folks,

I noticed we are using the wrong method to count the amount of rendered input fields for implementors of `Field\HasDynamicInputs`.

This implicitly caused the `Field\File` input to stop uploading after one file, even though multiple files are added (see https://mantis.ilias.de/view.php?id=42451).

This affects all maintained versions and should be picked for ILIAS 8, 9 and trunk as well. If approved, I can pick this myself, since there might be changes required for ILIAS 8 and 9.

Kind regards,
@thibsy 