### PR TITLE
[FIX] #42452 UI: select `File\Dropzone` file input correctly.

### DIFF
--- a/components/ILIAS/UI/resources/js/Dropzone/File/dropzone.js
+++ b/components/ILIAS/UI/resources/js/Dropzone/File/dropzone.js
@@ -1,4 +1,19 @@
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ * *******************************************************************
+ *
  * this script is responsible for the dropzone highlighting and
  * file processing.
  *
@@ -58,7 +73,7 @@ il.UI = il.UI || {};
 
             let dropzone = $(`#${dropzone_id}`);
             dropzones[dropzone_id] = {
-                file_input_id: dropzone.find(SELECTOR.file_input).attr('id'),
+                file_input_id: dropzone.find(SELECTOR.file_input).closest('.c-input').attr('id'),
             };
 
             initDropzoneEventListeners(dropzone);


### PR DESCRIPTION
Hi folks,

This fixes an issue where the `File\Dropzone` does not delegate files properly to the actual `Field\File` input, by amending the DOM-search to the new inputs HTML structure.

See https://mantis.ilias.de/view.php?id=42452

Kind regards,
@thibsy 