### PR TITLE
TA: 39183, insert marker for error-text positions w/o correct text

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assErrorText.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorText.php
@@ -667,17 +667,17 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
         array $correctness_icons
     ): string {
         $text = $this->getTextForPosition($position, $paragraph, $show_correct_solution);
-        if ($text === '') {
-            return '';
-        }
         $class = $this->getClassForPosition($position, $show_correct_solution, $selections);
+
+        if ($text === '') {
+            $text = ' [ ]';
+        }
         $img = $this->getCorrectnessIconForPosition(
             $position,
             $graphical_output,
             $selections,
             $correctness_icons
         );
-
         return ' ' . $this->getErrorTokenHtml($text, $class, $use_link_tags) . $img;
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=39183
![Screenshot from 2024-11-13 14-45-05](https://github.com/user-attachments/assets/c677905b-be0c-41cd-840e-4f4c279a7579)
