### PR TITLE
Init/Auth: Init global user for "blocked authentication" state (fix f…

### DIFF
--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -1440,7 +1440,7 @@ class ilInitialisation
         }
 
         if (
-            !$DIC['ilAuthSession']->isAuthenticated() or
+            !$DIC['ilAuthSession']->isAuthenticated() ||
             $DIC['ilAuthSession']->isExpired()
         ) {
             if ($GLOBALS['DIC']['ilAuthSession']->isExpired()) {
@@ -1451,6 +1451,7 @@ class ilInitialisation
             $current_script = substr(strrchr($_SERVER["PHP_SELF"], "/"), 1);
             if (self::blockedAuthentication($current_script)) {
                 ilLoggerFactory::getLogger('init')->debug('Authentication is started in current script.');
+                self::initUserAccount();
                 // nothing todo: authentication is done in current script
                 return;
             }


### PR DESCRIPTION
…or `$DIC->user()->getId() === 0)`

See:
- https://mantis.ilias.de/view.php?id=42681
- https://mantis.ilias.de/view.php?id=41601

This is the sister PR of #7991 .

If merged, this must be picked to `release_10` as well.