### PR TITLE
User/SelfRegistration: Fix wrong PHP type when rendering role selection

### DIFF
--- a/components/ILIAS/User/classes/Profile/class.ilUserProfile.php
+++ b/components/ILIAS/User/classes/Profile/class.ilUserProfile.php
@@ -562,7 +562,7 @@ class ilUserProfile
             if (count($options) === 1) {
                 $roles_input = new ilHiddenInputGUI('usr_' . $field_id);
                 $keys = array_keys($options);
-                $roles_input->setValue(array_shift($keys));
+                $roles_input->setValue((string) array_shift($keys));
                 return $roles_input;
             }
 


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42712

If approved, this must be picked to `trunk` as well.