### PR TITLE
Contact: Close dropdown on other dropdown click

### DIFF
--- a/components/ILIAS/Contact/resources/buddy_system.js
+++ b/components/ILIAS/Contact/resources/buddy_system.js
@@ -250,7 +250,7 @@
         })
         .on('click', trigger_selector, onWidgetClick);
 
-      $(document).on('click', clearAllDropDowns);
+      document.addEventListener('click', clearAllDropDowns, true);
     },
   };
 


### PR DESCRIPTION
This PR closes the dropdowns in the Contact BuddySystem when clicking on another UI Dropdown.