### PR TITLE
42176: Shuffling Answer options does not work in Matching Questions in ILIAS Learning Modules

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
@@ -285,20 +285,20 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
 
         if ($result->numRows() == 1) {
             $data = $ilDB->fetchAssoc($result);
-            $this->setId((int)$question_id);
-            $this->setObjId((int)$data["obj_fi"]);
+            $this->setId((int) $question_id);
+            $this->setObjId((int) $data["obj_fi"]);
             $this->setTitle((string) $data["title"]);
             $this->setComment((string) $data["description"]);
-            $this->setOriginalId((int)$data["original_id"]);
-            $this->setNrOfTries((int)$data['nr_of_tries']);
+            $this->setOriginalId((int) $data["original_id"]);
+            $this->setNrOfTries((int) $data['nr_of_tries']);
             $this->setAuthor($data["author"]);
-            $this->setPoints((float)$data["points"]);
-            $this->setOwner((int)$data["owner"]);
+            $this->setPoints((float) $data["points"]);
+            $this->setOwner((int) $data["owner"]);
             include_once("./Services/RTE/classes/class.ilRTE.php");
             $this->setQuestion(ilRTE::_replaceMediaObjectImageSrc((string) $data["question_text"], 1));
-            $this->setThumbGeometry((int)$data["thumb_geometry"]);
+            $this->setThumbGeometry((int) $data["thumb_geometry"]);
             $this->setShuffle($data["shuffle"] != '0');
-            $this->setShuffleMode((int)$data['shuffle']);
+            $this->setShuffleMode((int) $data['shuffle']);
             $this->setMatchingMode($data['matching_mode'] === null ? self::MATCHING_MODE_1_ON_1 : $data['matching_mode']);
 
             try {
@@ -322,7 +322,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         $this->terms = [];
         if ($result->numRows() > 0) {
             while ($data = $ilDB->fetchAssoc($result)) {
-                $term = $this->createMatchingTerm($data['term'] ?? '', $data['picture'] ?? '', (int)$data['ident']);
+                $term = $this->createMatchingTerm($data['term'] ?? '', $data['picture'] ?? '', (int) $data['ident']);
                 $this->terms[] = $term;
                 $termids[$data['term_id']] = $term;
             }
@@ -338,7 +338,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         $this->definitions = array();
         if ($result->numRows() > 0) {
             while ($data = $ilDB->fetchAssoc($result)) {
-                $definition = $this->createMatchingDefinition($data['definition'] ?? '', $data['picture'] ?? '', (int)$data['ident']);
+                $definition = $this->createMatchingDefinition($data['definition'] ?? '', $data['picture'] ?? '', (int) $data['ident']);
                 array_push($this->definitions, $definition);
                 $definitionids[$data['def_id']] = $definition;
             }
@@ -355,12 +355,12 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
                 $pair = $this->createMatchingPair(
                     $termids[$data['term_fi']],
                     $definitionids[$data['definition_fi']],
-                    (float)$data['points']
+                    (float) $data['points']
                 );
                 array_push($this->matchingpairs, $pair);
             }
         }
-        parent::loadFromDb((int)$question_id);
+        parent::loadFromDb((int) $question_id);
     }
 
 
@@ -885,7 +885,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         if (is_null($pass)) {
             $pass = $this->getSolutionMaxPass($active_id);
         }
-        $result = $this->getCurrentSolutionResultSet($active_id, (int)$pass, $authorizedSolution);
+        $result = $this->getCurrentSolutionResultSet($active_id, (int) $pass, $authorizedSolution);
         while ($data = $ilDB->fetchAssoc($result)) {
             if (strcmp($data["value1"], "") != 0) {
                 if (!isset($found_values[$data['value2']])) {
@@ -1058,7 +1058,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
             } else {
                 // create thumbnail file
                 $thumbpath = $imagepath . $this->getThumbPrefix() . $savename;
-                ilShellUtil::convertImage($imagepath . $savename, $thumbpath, "JPEG", (string)$this->getThumbGeometry());
+                ilShellUtil::convertImage($imagepath . $savename, $thumbpath, "JPEG", (string) $this->getThumbGeometry());
             }
             if ($result && (strcmp($image_filename, $previous_filename) != 0) && (strlen($previous_filename))) {
                 $this->deleteImagefile($previous_filename);
@@ -1386,6 +1386,9 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
             ];
         }
         $result['terms'] = $terms;
+
+        // #42176 init shuffler with a new seed, otherwise definitions will be shuffled like the terms
+        $this->setShuffler($this->randomGroup->shuffleArray(new RandomSeed()));
 
         $definitions = [];
         foreach ($this->getShuffler()->transform($this->getDefinitions()) as $def) {

--- a/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
@@ -1387,7 +1387,6 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         }
         $result['terms'] = $terms;
 
-        // #42176 init shuffler with a new seed, otherwise definitions will be shuffled like the terms
         $this->setShuffler($this->randomGroup->shuffleArray(new RandomSeed()));
 
         $definitions = [];


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42176

The relevant change is at the bottom in the function toJSON. The shuffler has to be initialized again for the definitions. Otherwise they would be shuffled in the same way as the terms before.  I guess this could be a general problem of the shuffle transformation.
