### PR TITLE
42733: Restore CAS auth functionality

### DIFF
--- a/Services/CAS/classes/class.ilAuthProviderCAS.php
+++ b/Services/CAS/classes/class.ilAuthProviderCAS.php
@@ -45,20 +45,6 @@ class ilAuthProviderCAS extends ilAuthProvider
         $this->settings = ilCASSettings::getInstance();
     }
 
-    private function getIliasBaseUrl(): string
-    {
-        // Get the scheme (http or https)
-        $scheme = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http";
-
-        // Get the host name and port if available
-        $host = $_SERVER['HTTP_HOST'];
-
-        // Construct the base URL
-        $baseUrl = $scheme . "://" . $host;
-
-        return $baseUrl;
-    }
-
     protected function getSettings(): ilCASSettings
     {
         return $this->settings;
@@ -67,7 +53,6 @@ class ilAuthProviderCAS extends ilAuthProvider
     public function doAuthentication(ilAuthStatus $status): bool
     {
         $this->getLogger()->debug('Starting cas authentication attempt... ');
-        $baseUrl = $this->getIliasBaseUrl();
 
         try {
             // If you need a logger, uncomment this, the use statements
@@ -96,7 +81,7 @@ class ilAuthProviderCAS extends ilAuthProvider
                 $this->getSettings()->getServer(),
                 $this->getSettings()->getPort(),
                 $this->getSettings()->getUri(),
-                $baseUrl
+                ilUtil::_getHttpPath()
             );
 
             phpCAS::setNoCasServerValidation();

--- a/Services/CAS/classes/class.ilAuthProviderCAS.php
+++ b/Services/CAS/classes/class.ilAuthProviderCAS.php
@@ -18,26 +18,13 @@
 
 declare(strict_types=1);
 
-// use Monolog\Formatter\LineFormatter;
-// use Monolog\Handler\StreamHandler;
-// use Monolog\Logger;
-
 /**
  * CAS authentication provider
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
  */
 class ilAuthProviderCAS extends ilAuthProvider
 {
-    // private ilCASSettings $settings;
-    // /**
-    //  * @var string
-    //  */
-    // private $logPath;
-    //
-    // /**
-    //  * @var Logger
-    //  */
-    // private $logger;
+    private ilCASSettings $settings;
 
     public function __construct(ilAuthCredentials $credentials)
     {
@@ -55,22 +42,7 @@ class ilAuthProviderCAS extends ilAuthProvider
         $this->getLogger()->debug('Starting cas authentication attempt... ');
 
         try {
-            // If you need a logger, uncomment this, the use statements
-            // and variables above and remove   phpCAS::setLogger(null);
-            // from below.
-            // The logger essentially gives you a trace through the
-            // entire CAS-call-stack.
-            //
-            // $this->logPath = tempnam(sys_get_temp_dir(), 'phpCAS');
-            // $this->logger = new Logger('name');
-            // $handler = new StreamHandler($this->logPath);
-            // $format = "%message%\n";
-            // $formatter = new LineFormatter($format);
-            // $handler->setFormatter($formatter);
-            // $this->logger->pushHandler($handler);
-            // phpCAS::setLogger($this->logger);
-
-            phpCAS::setLogger(null);
+            phpCAS::setLogger($this->getLogger());
             // Caution: If you set this to "true", there might be output
             // and the redirect won't work and you get an ILIAS Whoopsy
             // Though, you may need to for debugging other issues.

--- a/Services/CAS/classes/class.ilAuthProviderCAS.php
+++ b/Services/CAS/classes/class.ilAuthProviderCAS.php
@@ -42,7 +42,8 @@ class ilAuthProviderCAS extends ilAuthProvider
         $this->getLogger()->debug('Starting cas authentication attempt... ');
 
         try {
-            phpCAS::setLogger($this->getLogger());
+            // Uncomment the following line to get trace-level loggin by CAS
+            //phpCAS::setLogger($this->getLogger());
             // Caution: If you set this to "true", there might be output
             // and the redirect won't work and you get an ILIAS Whoopsy
             // Though, you may need to for debugging other issues.

--- a/Services/CAS/classes/class.ilAuthProviderCAS.php
+++ b/Services/CAS/classes/class.ilAuthProviderCAS.php
@@ -6,19 +6,21 @@ declare(strict_types=1);
 // use Monolog\Handler\StreamHandler;
 // use Monolog\Logger;
 
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ */
 
 /**
  * CAS authentication provider

--- a/Services/CAS/classes/class.ilAuthProviderCAS.php
+++ b/Services/CAS/classes/class.ilAuthProviderCAS.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- */
+ *********************************************************************/
 
 /**
  * CAS authentication provider

--- a/Services/CAS/classes/class.ilAuthProviderCAS.php
+++ b/Services/CAS/classes/class.ilAuthProviderCAS.php
@@ -1,11 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
-// use Monolog\Formatter\LineFormatter;
-// use Monolog\Handler\StreamHandler;
-// use Monolog\Logger;
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -21,6 +15,12 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
+
+// use Monolog\Formatter\LineFormatter;
+// use Monolog\Handler\StreamHandler;
+// use Monolog\Logger;
 
 /**
  * CAS authentication provider

--- a/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
+++ b/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
@@ -54,6 +54,13 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
      */
     public function offsetUnset($offset): void
     {
-        throw new LogicException("Modifying global Request-Array such as \$_GET is not allowed!");
+        if ($offset === 'ticket') {
+            // Allow phpCAS to unset the 'ticket'
+            // they do this in CAS/Client.php#L1070
+            // unset($_GET['ticket']);
+            parent::offsetUnset($offset);
+        } else {
+            throw new LogicException("Modifying global Request-Array such as \$_GET is not allowed!");
+        }
     }
 }

--- a/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
+++ b/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
@@ -9,22 +9,19 @@ use ILIAS\Refinery\KeyValueAccess;
 use LogicException;
 use OutOfBoundsException;
 
-/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
+/******************************************************************************
  *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
+ * This file is part of ILIAS, a powerful learning management system.
+ *
+ * ILIAS is licensed with the GPL-3.0, you should have received a copy
+ * of said license along with the source code.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
+ *      https://www.ilias.de
+ *      https://github.com/ILIAS-eLearning
  *
- */
-
+ *****************************************************************************/
 /**
  * Class SuperGlobalDropInReplacement
  * This Class wraps SuperGlobals such as $_GET and $_POST to prevent modifying them in a future version.
@@ -57,13 +54,6 @@ class SuperGlobalDropInReplacement extends KeyValueAccess
      */
     public function offsetUnset($offset): void
     {
-        if ($offset === 'ticket') {
-            // Allow phpCAS to unset the 'ticket'
-            // they do this in CAS/Client.php#L1070
-            // unset($_GET['ticket']);
-            parent::offsetUnset($offset);
-        } else {
-            throw new LogicException("Modifying global Request-Array such as \$_GET is not allowed!");
-        }
+        throw new LogicException("Modifying global Request-Array such as \$_GET is not allowed!");
     }
 }

--- a/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
+++ b/src/HTTP/Wrapper/SuperGlobalDropInReplacement.php
@@ -9,19 +9,22 @@ use ILIAS\Refinery\KeyValueAccess;
 use LogicException;
 use OutOfBoundsException;
 
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ */
+
 /**
  * Class SuperGlobalDropInReplacement
  * This Class wraps SuperGlobals such as $_GET and $_POST to prevent modifying them in a future version.


### PR DESCRIPTION
- ~Allow `phpCAS` to `unset` variables~
- do not use deprecated `phpCAS::setDebug()`
- fix call to `phpCAS::client()` by providing ILIAS base URL
- Add more debug logging

https://mantis.ilias.de/view.php?id=42733