### PR TITLE
Form/Calendar: move datetime and duration inputs to native html (42458)

### DIFF
--- a/components/ILIAS/Form/classes/class.ilBirthdayInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilBirthdayInputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * This class represents a text property in a property form.

--- a/components/ILIAS/Form/classes/class.ilBirthdayInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilBirthdayInputGUI.php
@@ -29,15 +29,4 @@ class ilBirthdayInputGUI extends ilDateTimeInputGUI
     {
         return date("Y") - 100;
     }
-
-    protected function parseDatePickerConfig(): array
-    {
-        $config = parent::parseDatePickerConfig();
-
-        $config["viewMode"] = "years";
-        $config["calendarWeeks"] = false;
-        $config["showTodayButton"] = false;
-
-        return $config;
-    }
 }

--- a/components/ILIAS/Form/classes/class.ilDateDurationInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilDateDurationInputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * input GUI for a time span (start and end date)

--- a/components/ILIAS/Form/classes/class.ilDateDurationInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilDateDurationInputGUI.php
@@ -136,11 +136,6 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
         return $this->showtime;
     }
 
-    public function getShowSeconds(): bool
-    {
-        return false;
-    }
-
     public function setStartYear(int $a_year): void
     {
         $this->startyear = $a_year;
@@ -234,14 +229,10 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
                 $this->setStart($parsed);
                 $valid_start = true;
             }
-        } else {
-            if (!$this->getRequired() && !trim($end)) {
-                $valid_start = true;
-            } else {
-                if ($this->openIntervalsAllowed() && !strlen(trim($start))) {
-                    $valid_start = true;
-                }
-            }
+        } elseif (!$this->getRequired() && !trim($end)) {
+            $valid_start = true;
+        } elseif ($this->openIntervalsAllowed() && !strlen(trim($start))) {
+            $valid_start = true;
         }
 
         $valid_end = false;
@@ -251,14 +242,10 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
                 $this->setEnd($parsed);
                 $valid_end = true;
             }
-        } else {
-            if (!$this->getRequired() && !trim($start)) {
-                $valid_end = true;
-            } else {
-                if ($this->openIntervalsAllowed() && !strlen(trim($end))) {
-                    $valid_end = true;
-                }
-            }
+        } elseif (!$this->getRequired() && !trim($start)) {
+            $valid_end = true;
+        } elseif ($this->openIntervalsAllowed() && !strlen(trim($end))) {
+            $valid_end = true;
         }
 
         if ($this->getStartYear()) {
@@ -307,14 +294,12 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
             if (!$this->getEnd()) {
                 $ret["end"] = null;
             }
-        } else {
-            if (
-                !$this->getStart() ||
-                !$this->getEnd()
-            ) {
-                $ret["start"] = null;
-                $ret["end"] = null;
-            }
+        } elseif (
+            !$this->getStart() ||
+            !$this->getEnd()
+        ) {
+            $ret["start"] = null;
+            $ret["end"] = null;
         }
         $ret["fullday"] = (bool) ($ret["tgl"] ?? false);
         return $ret;
@@ -322,22 +307,16 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
 
     protected function getDatePickerTimeFormat(): int
     {
-        return (int) $this->getShowTime() + (int) $this->getShowSeconds();
+        return (int) $this->getShowTime();
     }
 
-    /**
-     * parse properties to datepicker config
-     */
-    protected function parseDatePickerConfig(): array
+    protected function getDatetimeFormatForInput(): string
     {
-        $config = null;
-        if ($this->getMinuteStepSize()) {
-            $config['stepping'] = $this->getMinuteStepSize();
+        $format = 'Y-m-d';
+        if ($this->getShowTime()) {
+            $format .= '\TH:i';
         }
-        if ($this->getStartYear()) {
-            $config['minDate'] = $this->getStartYear() . '-01-01';
-        }
-        return $config;
+        return $format;
     }
 
     public function render(): string
@@ -351,7 +330,7 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
         if ($this->enabledToggleFullTime()) {
             $this->setShowTime(true);
 
-            $toggle_id = md5($this->getPostVar() . '_fulltime'); // :TODO: unique?
+            $toggle_id = 't' . md5($this->getPostVar() . '_fulltime'); // :TODO: unique?
 
             $tpl->setCurrentBlock('toggle_fullday');
             $tpl->setVariable('DATE_TOGGLE_ID', $this->getPostVar() . '[tgl]');
@@ -365,25 +344,30 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
         // config picker
         if (!$this->getDisabled()) {
             // :TODO: unique?
-            $picker_start_id = md5($this->getPostVar() . '_start');
-            $picker_end_id = md5($this->getPostVar() . '_end');
+            $picker_start_id = 'p' . md5($this->getPostVar() . '_start');
+            $picker_end_id = 'p' . md5($this->getPostVar() . '_end');
 
             $tpl->setVariable('DATEPICKER_START_ID', $picker_start_id);
             $tpl->setVariable('DATEPICKER_END_ID', $picker_end_id);
 
-            ilCalendarUtil::addDateTimePicker(
-                $picker_start_id,
-                $this->getDatePickerTimeFormat(),
-                $this->parseDatePickerConfig(),
-                $picker_end_id,
-                $this->parseDatePickerConfig(),
-                $toggle_id,
-                "subform_" . $this->getPostVar()
+            $this->global_tpl->addOnLoadCode(
+                'il.Form.initDateDurationPicker("' .
+                $picker_start_id . '","' .
+                $picker_end_id . '","' .
+                $toggle_id .
+                '");'
             );
         } else {
             $tpl->setVariable('DATEPICKER_START_DISABLED', 'disabled="disabled" ');
             $tpl->setVariable('DATEPICKER_END_DISABLED', 'disabled="disabled" ');
         }
+
+        $type = 'date';
+        if ($this->getShowTime()) {
+            $type = 'datetime-local';
+        }
+        $tpl->setVariable('DATEPICKER_START_TYPE', $type);
+        $tpl->setVariable('DATEPICKER_END_TYPE', $type);
 
         $start_txt = $this->getStartText();
         if ($start_txt === null) {
@@ -409,25 +393,32 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
         $tpl->setVariable('DATE_START_ID', $this->getPostVar() . '[start]');
         $tpl->setVariable('DATE_END_ID', $this->getPostVar() . '[end]');
 
-        // placeholder
-        // :TODO: i18n?
-        $pl_format = ilCalendarUtil::getUserDateFormat($this->getDatePickerTimeFormat());
-        $tpl->setVariable('START_PLACEHOLDER', $pl_format);
-        $tpl->setVariable('END_PLACEHOLDER', $pl_format);
+        /*
+         * For date input, step is in days, for datetime-local
+         * it is in seconds.
+         */
+        $step_size = $this->getMinuteStepSize() * 60;
+        if (!$this->getShowTime()) {
+            $step_size = 1;
+        }
+        $tpl->setVariable('DATEPICKER_START_STEP', $step_size);
+        $tpl->setVariable('DATEPICKER_END_STEP', $step_size);
 
-        // accessibility description
-        $tpl->setVariable(
-            'DESCRIPTION',
-            ilLegacyFormElementsUtil::prepareFormOutput($lng->txt("form_date_aria_desc") . " " . $pl_format)
-        );
-
+        if ($this->getStartYear()) {
+            $min = DateTimeImmutable::createFromFormat(
+                'Y',
+                (string) $this->getStartYear()
+            )->format($this->getDatetimeFormatForInput());
+            $tpl->setVariable('DATEPICKER_START_MIN', $min);
+            $tpl->setVariable('DATEPICKER_END_MIN', $min);
+        }
 
         // values
 
+        $out_format = $this->getDatetimeFormatForInput();
         $date_value = htmlspecialchars($this->invalid_input_start);
         if (!$date_value &&
             $this->getStart()) {
-            $out_format = ilCalendarUtil::getUserDateFormat($this->getDatePickerTimeFormat(), true);
             $date_value = $this->getStart()->get(IL_CAL_FKT_DATE, $out_format, $ilUser->getTimeZone());
         }
         $tpl->setVariable('DATEPICKER_START_VALUE', $date_value);
@@ -435,7 +426,6 @@ class ilDateDurationInputGUI extends ilSubEnabledFormPropertyGUI implements ilTa
         $date_value = htmlspecialchars($this->invalid_input_end);
         if (!$date_value &&
             $this->getEnd()) {
-            $out_format = ilCalendarUtil::getUserDateFormat($this->getDatePickerTimeFormat(), true);
             $date_value = $this->getEnd()->get(IL_CAL_FKT_DATE, $out_format, $ilUser->getTimeZone());
         }
         $tpl->setVariable('DATEPICKER_END_VALUE', $date_value);

--- a/components/ILIAS/Form/classes/class.ilDateTimeInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilDateTimeInputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * This class represents a date/time property in a property form.

--- a/components/ILIAS/Form/classes/class.ilDateTimeInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilDateTimeInputGUI.php
@@ -29,7 +29,6 @@ class ilDateTimeInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableF
     protected ?ilDateTime $date = null;
     protected string $time = "00:00:00";
     protected bool $showtime = false;
-    protected bool $showseconds = false;
     protected int $minute_step_size = 5;
     protected ?int $startyear = null;
     protected string $invalid_input = '';
@@ -102,16 +101,6 @@ class ilDateTimeInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableF
         return $this->minute_step_size;
     }
 
-    public function setShowSeconds(bool $a_showseconds): void
-    {
-        $this->showseconds = $a_showseconds;
-    }
-
-    public function getShowSeconds(): bool
-    {
-        return $this->showseconds;
-    }
-
     public function setValueByArray(array $a_values): void
     {
         $incoming = $a_values[$this->getPostVar()] ?? "";
@@ -124,7 +113,7 @@ class ilDateTimeInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableF
 
     protected function getDatePickerTimeFormat(): int
     {
-        return (int) $this->getShowTime() + (int) $this->getShowSeconds();
+        return (int) $this->getShowTime();
     }
 
     public function hasInvalidInput(): bool
@@ -180,36 +169,26 @@ class ilDateTimeInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableF
     public function getInput(): ?string
     {
         if ($this->valid && $this->getDate() !== null) {
-            // getInput() should return a generic format
-            $post_format = $this->getShowTime()
-                ? IL_CAL_DATETIME
-                : IL_CAL_DATE;
-            return $this->getDate()->get($post_format);
+            return $this->getDate()->get(
+                IL_CAL_FKT_DATE,
+                $this->getDatetimeFormatForInput()
+            );
         }
         return null;
     }
 
     public function setSideBySide(bool $a_val): void
     {
-        $this->side_by_side = $a_val;
+        // not relevant for native html date(time) pickers
     }
 
-    public function getSideBySide(): bool
+    protected function getDatetimeFormatForInput(): string
     {
-        return $this->side_by_side;
-    }
-
-    protected function parseDatePickerConfig(): array
-    {
-        $config = null;
-        if ($this->getMinuteStepSize()) {
-            $config['stepping'] = $this->getMinuteStepSize();
+        $format = 'Y-m-d';
+        if ($this->getShowTime()) {
+            $format .= '\TH:i';
         }
-        if ($this->getStartYear()) {
-            $config['minDate'] = $this->getStartYear() . '-01-01';
-        }
-        $config['sideBySide'] = $this->getSideBySide();
-        return $config;
+        return $format;
     }
 
     public function render(): string
@@ -221,38 +200,43 @@ class ilDateTimeInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableF
 
         // config picker
         if (!$this->getDisabled()) {
-            $picker_id = md5($this->getPostVar()); // :TODO: unique?
+            $picker_id = 'p' . md5($this->getPostVar()); // :TODO: unique?
             $tpl->setVariable('DATEPICKER_ID', $picker_id);
-
-            ilCalendarUtil::addDateTimePicker(
-                $picker_id,
-                $this->getDatePickerTimeFormat(),
-                $this->parseDatePickerConfig(),
-                null,
-                null,
-                null,
-                "subform_" . $this->getPostVar()
-            );
         } else {
             $tpl->setVariable('DATEPICKER_DISABLED', 'disabled="disabled" ');
         }
 
-        // :TODO: i18n?
-        $pl_format = ilCalendarUtil::getUserDateFormat($this->getDatePickerTimeFormat());
-        $tpl->setVariable('PLACEHOLDER', $pl_format);
-
-        // accessibility description
-        $tpl->setVariable(
-            'DESCRIPTION',
-            ilLegacyFormElementsUtil::prepareFormOutput($lng->txt("form_date_aria_desc") . " " . $pl_format)
-        );
+        $type = 'date';
+        if ($this->getShowTime()) {
+            $type = 'datetime-local';
+        }
+        $tpl->setVariable('DATEPICKER_TYPE', $type);
 
         // current value
+        $out_format = $this->getDatetimeFormatForInput();
         $date_value = htmlspecialchars($this->invalid_input);
         if (!$date_value &&
             $this->getDate()) {
-            $out_format = ilCalendarUtil::getUserDateFormat($this->getDatePickerTimeFormat(), true);
             $date_value = $this->getDate()->get(IL_CAL_FKT_DATE, $out_format, $ilUser->getTimeZone());
+        }
+        $tpl->setVariable('DATEPICKER_START_VALUE', $date_value);
+
+        /*
+         * For date input, step is in days, for datetime-local
+         * it is in seconds.
+         */
+        $step_size = $this->getMinuteStepSize() * 60;
+        if (!$this->getShowTime()) {
+            $step_size = 1;
+        }
+        $tpl->setVariable('DATEPICKER_STEP', $step_size);
+
+        if ($this->getStartYear()) {
+            $min = DateTimeImmutable::createFromFormat(
+                'Y',
+                (string) $this->getStartYear()
+            )->format($this->getDatetimeFormatForInput());
+            $tpl->setVariable('DATEPICKER_MIN', $min);
         }
 
         $tpl->setVariable('DATEPICKER_VALUE', $date_value);
@@ -267,21 +251,8 @@ class ilDateTimeInputGUI extends ilSubEnabledFormPropertyGUI implements ilTableF
 
     public function getOnloadCode(): array
     {
-        $code = [];
-        if (!$this->getDisabled()) {
-            $picker_id = md5($this->getPostVar());
-
-            $code = ilCalendarUtil::getCodeForPicker(
-                $picker_id,
-                $this->getDatePickerTimeFormat(),
-                $this->parseDatePickerConfig(),
-                null,
-                null,
-                null,
-                "subform_" . $this->getPostVar()
-            );
-        }
-        return $code;
+        // no js necessary anymore
+        return [];
     }
 
     public function insert(ilTemplate $a_tpl): void

--- a/components/ILIAS/Form/templates/default/tpl.prop_datetime.html
+++ b/components/ILIAS/Form/templates/default/tpl.prop_datetime.html
@@ -1,11 +1,7 @@
 <div class="ilFormInnerCol">
 <div class="form-group form-inline">
 	<div class="input-group date" id="{DATEPICKER_ID}">
-		<input aria-describedby="date_desc_{DATE_ID}" type="text" class="form-control" placeholder="{PLACEHOLDER}" value="{DATEPICKER_VALUE}" id="{DATE_ID}" name="{DATE_ID}" {DATEPICKER_DISABLED} {REQUIRED} />
-		<p class="sr-only" id="date_desc_{DATE_ID}">{DESCRIPTION}</p>
-		<span class="input-group-addon">
-			<span class="glyphicon glyphicon-calendar"></span>
-		</span>
+		<input aria-describedby="date_desc_{DATE_ID}" type="{DATEPICKER_TYPE}" class="form-control" value="{DATEPICKER_VALUE}" step="{DATEPICKER_STEP}" min="{DATEPICKER_MIN}" id="{DATE_ID}" name="{DATE_ID}" {DATEPICKER_DISABLED} {REQUIRED} />
 	</div>
 </div>
 </div>

--- a/components/ILIAS/Form/templates/default/tpl.prop_datetime_duration.html
+++ b/components/ILIAS/Form/templates/default/tpl.prop_datetime_duration.html
@@ -1,8 +1,8 @@
 <div class="row">
 	<!-- BEGIN toggle_fullday -->
 	<div class="ilFormInnerCol">
-		<div class="form-group form-inline">		
-			<div class="input-group">		
+		<div class="form-group form-inline">
+			<div class="input-group">
 				<input type="checkbox" name="{DATE_TOGGLE_ID}" id="{FULLDAY_TOGGLE_ID}" value="1"{FULLDAY_TOGGLE_CHECKED} {FULLDAY_TOGGLE_DISABLED} />
 			</div>
 			<label class=control-label" for="{FULLDAY_TOGGLE_ID}">{TXT_TOGGLE_FULLDAY}</label>
@@ -14,11 +14,7 @@
 			<!-- BEGIN start_label_bl -->
 			<!-- END start_label_bl -->
 			<div class="input-group date<!-- BEGIN start_width_bl --> noop<!-- END start_width_bl -->" id="{DATEPICKER_START_ID}">
-				<input aria-label="{START_ARIA_LABEL}" aria-describedby="start_date_desc_{DATE_START_ID}" type="text" class="form-control" placeholder="{START_PLACEHOLDER}" value="{DATEPICKER_START_VALUE}" id="{DATE_START_ID}" name="{DATE_START_ID}"{DATEPICKER_START_DISABLED} {START_REQUIRED}/>
-				<p class="sr-only" id="start_date_desc_{DATE_START_ID}">{DESCRIPTION}</p>
-				<span class="input-group-addon">
-					<span class="glyphicon glyphicon-calendar"></span>
-				</span>
+				<input aria-label="{START_ARIA_LABEL}" type="{DATEPICKER_START_TYPE}" class="form-control" value="{DATEPICKER_START_VALUE}" step="{DATEPICKER_START_STEP}" min="{DATEPICKER_START_MIN}" id="{DATE_START_ID}" name="{DATE_START_ID}"{DATEPICKER_START_DISABLED} {START_REQUIRED}/>
 			</div>
 			<br /><label class="control-label">{START_LABEL}</label>
 		</div>
@@ -28,11 +24,7 @@
 			<!-- BEGIN end_label_bl -->
 			<!-- END end_label_bl -->
 			<div class="input-group date<!-- BEGIN end_width_bl --> noop<!-- END end_width_bl -->" id="{DATEPICKER_END_ID}">
-				<input aria-label="{END_ARIA_LABEL}" aria-describedby="end_date_desc_{DATE_END_ID}" type="text" class="form-control" placeholder="{END_PLACEHOLDER}" value="{DATEPICKER_END_VALUE}" name="{DATE_END_ID}"{DATEPICKER_END_DISABLED} {END_REQUIRED} />
-				<p class="sr-only" id="end_date_desc_{DATE_END_ID}">{DESCRIPTION}</p>
-				<span class="input-group-addon">
-					<span class="glyphicon glyphicon-calendar"></span>
-				</span>
+				<input aria-label="{END_ARIA_LABEL}" type="{DATEPICKER_END_TYPE}" class="form-control" value="{DATEPICKER_END_VALUE}" step="{DATEPICKER_END_STEP}" min="{DATEPICKER_END_MIN}" name="{DATE_END_ID}"{DATEPICKER_END_DISABLED} {END_REQUIRED} />
 			</div>
 					<br /><label class="control-label">{END_LABEL}</label>
 		</div>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -9898,7 +9898,6 @@ fold#:#fold_settings#:#Ordnereigenschaften
 form#:#email_not_match#:#Ihre Eingaben für die E-Mail-Adresse stimmen nicht überein! Bitte geben Sie die E-Mail-Adresse erneut ein.
 form#:#form_alphabet_all#:#Alle
 form#:#form_chars_remaining#:#Verbleibende Zeichen:
-form#:#form_date_aria_desc#:#Es ist folgendes Eingabeformat gefordert:
 form#:#form_date_duration_end#:#Ende
 form#:#form_date_duration_start#:#Start
 form#:#form_days#:#Tage

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -9899,7 +9899,6 @@ fold#:#fold_settings#:#Folder Settings
 form#:#email_not_match#:#Your entries for the e-mail address don't match! Please re-enter your e-mail address.
 form#:#form_alphabet_all#:#All
 form#:#form_chars_remaining#:#Characters remaining:
-form#:#form_date_aria_desc#:#The following input format is required:
 form#:#form_date_duration_end#:#End
 form#:#form_date_duration_start#:#Start
 form#:#form_days#:#Days


### PR DESCRIPTION
This PR fixes [42458](https://mantis.ilias.de/view.php?id=42458) by using native html `datetime-local`/`date` inputs in `ilDateTimeInputGUI` and `ilDateDurationInputGUI`. This removes the dependency on bootstrap for the datetime picker, and allows us to get rid of a bunch of js and surrounding php code. Some js is still needed to restore previous functionality of duration inputs (setting minimum for the end date dynamically to the value of the start date, shifting the end when changing the start to keep the difference, full day toggle), this PR rebuilds that part of it for the new input types.

Note that some configurations of the inputs then don't apply anymore: since this relies on the browser-specific implementations for the picker, custom configs like for `ilBirthdayInputGUI` are not possible. I also removed the unused option to show seconds in `ilDateTimeInputGUI` (supporting this would technically be possible, but is a bit fiddly).

Lastly, step size for minutes is still configurable, but behaves quite a lot differently than in the bootstrap implementation. The new behavior should be discussed, but I don't think it's worth delaying this fix as a whole because of this. I will open a separate Mantis ticket (**Edit:** [42740](https://mantis.ilias.de/view.php?id=42740)) explaining this issue further.

Cheers, @schmitz-ilias 