### PR TITLE
T&A 42760 Fix has answered questions for scored attempt 

### DIFF
--- a/components/ILIAS/Test/src/Participants/Participant.php
+++ b/components/ILIAS/Test/src/Participants/Participant.php
@@ -183,11 +183,7 @@ class Participant
 
     public function hasAnsweredQuestionsForScoredAttempt(): bool
     {
-        if (!$this->hasAttemptOverviewInformation()) {
-            return false;
-        }
-
-        return $this->attempt_overview->hasAnsweredQuestions();
+        return $this->attempt_overview?->hasAnsweredQuestions() ?? false;
     }
 
     public function getRemainingDuration(


### PR DESCRIPTION
This PR addresses https://mantis.ilias.de/view.php?id=42760.

During a recent refactoring, a new method was introduced to check for scored attempts. However, it appears that a typo occurred in the implementation. Specifically, instead of calling `getAttemptOverviewInformation` to verify if the reference exists,
 the code mistakenly used `hasAttemptOverviewInformation`.

To resolve this, I refactored the code to use the null-coalescing operator, ensuring the proper method is utilized and the reference is correctly checked.

Best,
@thojou 