### PR TITLE
[FIX] UI: Align `Container\Form` renderers

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Form.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Form.php
@@ -61,20 +61,4 @@ abstract class Form extends Container implements C\Input\Container\Form\Form
     {
         return new PostDataFromServerRequest($request);
     }
-
-    /**
-     * @inheritdoc
-     */
-    public function getPromptButtons(): array
-    {
-        return [];
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getPromptTitle(): string
-    {
-        return '';
-    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/FormRendererFactory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/FormRendererFactory.php
@@ -25,17 +25,17 @@ use ILIAS\UI\Component;
 
 class FormRendererFactory extends Render\DefaultRendererFactory
 {
-    public const NO_BUTTONS_FORM = [
+    public const FORM_CONTEXTS_WITHOUT_BUTTONS = [
         'StateStatePrompt',
         'RoundTripModal',
     ];
 
     public function getRendererInContext(Component\Component $component, array $contexts): Render\AbstractComponentRenderer
     {
-        $has_context_without_buttons = array_intersect(self::NO_BUTTONS_FORM, $contexts);
+        $has_context_without_buttons = array_intersect(self::FORM_CONTEXTS_WITHOUT_BUTTONS, $contexts);
 
         if (! empty($has_context_without_buttons)) {
-            return new NoButtonsContextRenderer(
+            return new FormWithoutSubmitButtonsContextRenderer(
                 $this->ui_factory,
                 $this->tpl_factory,
                 $this->lng,

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/FormWithoutSubmitButtonsContextRenderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/FormWithoutSubmitButtonsContextRenderer.php
@@ -27,25 +27,27 @@ use ILIAS\UI\Renderer as RendererInterface;
 use ILIAS\UI\Component;
 use LogicException;
 
-class NoButtonsContextRenderer extends AbstractComponentRenderer
+class FormWithoutSubmitButtonsContextRenderer extends Renderer
 {
     /**
      * @inheritdoc
      */
     public function render(Component\Component $component, RendererInterface $default_renderer): string
     {
-        if (!$component instanceof Form\Form) {
-            $this->cannotHandleComponent($component);
+        if ($component instanceof Form\Standard) {
+            return $this->renderFormWithoutSubmitButtons($component, $default_renderer);
         }
-        return $this->renderNoSubmit($component, $default_renderer);
+
+        $this->cannotHandleComponent($component);
     }
 
-    protected function renderNoSubmit(
-        Form\Form $component,
+    protected function renderFormWithoutSubmitButtons(
+        Form\Standard $component,
         RendererInterface $default_renderer
     ): string {
-        $tpl = $this->getTemplate("tpl.no_submit.html", true, true);
+        $tpl = $this->getTemplate("tpl.without_submit_buttons.html", true, true);
 
+        $this->maybeAddDedicatedName($component, $tpl);
         $this->maybeAddRequired($component, $tpl);
         $this->addPostURL($component, $tpl);
         $this->maybeAddError($component, $tpl);
@@ -74,42 +76,5 @@ class NoButtonsContextRenderer extends AbstractComponentRenderer
         $tpl->setVariable("ID", $id);
 
         return $tpl->get();
-    }
-
-    protected function addPostURL(Component\Input\Container\Form\FormWithPostURL $component, Template $tpl): void
-    {
-        if ('' !== ($url = $component->getPostURL())) {
-            $tpl->setCurrentBlock("action");
-            $tpl->setVariable("URL", $url);
-            $tpl->parseCurrentBlock();
-        }
-    }
-
-    protected function maybeAddError(Form\Form $component, Template $tpl): void
-    {
-        if (null !== ($error = $component->getError())) {
-            $tpl->setCurrentBlock("error");
-            $tpl->setVariable("ERROR", $error);
-            $tpl->parseCurrentBlock();
-        }
-    }
-
-    protected function maybeAddRequired(Form\Form $component, Template $tpl): void
-    {
-        if ($component->hasRequiredInputs()) {
-            $tpl->setVariable("TXT_REQUIRED_TOP", $this->txt("required_field"));
-            $tpl->setVariable("TXT_REQUIRED", $this->txt("required_field"));
-        }
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getComponentInterfaceName(): array
-    {
-        return [
-            Component\Input\Container\Form\Standard::class,
-            FormWithoutSubmitButton::class,
-        ];
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Renderer.php
@@ -38,20 +38,14 @@ class Renderer extends AbstractComponentRenderer
             return $this->renderStandard($component, $default_renderer);
         }
 
-        if ($component instanceof Form\FormWithoutSubmitButton) {
-            return $this->renderNoSubmit($component, $default_renderer);
-        }
-
         $this->cannotHandleComponent($component);
     }
 
     protected function renderStandard(Form\Standard $component, RendererInterface $default_renderer): string
     {
         $tpl = $this->getTemplate("tpl.standard.html", true, true);
-        if ($component->getDedicatedName() !== null) {
-            $tpl->setVariable("NAME", 'name="' . $component->getDedicatedName() . '"');
-        }
 
+        $this->maybeAddDedicatedName($component, $tpl);
         $this->maybeAddRequired($component, $tpl);
         $this->addPostURL($component, $tpl);
         $this->maybeAddError($component, $tpl);
@@ -68,39 +62,11 @@ class Renderer extends AbstractComponentRenderer
         return $tpl->get();
     }
 
-    protected function renderNoSubmit(Form\FormWithoutSubmitButton $component, RendererInterface $default_renderer): string
+    protected function maybeAddDedicatedName(Form\Form $component, Template $tpl): void
     {
-        $tpl = $this->getTemplate("tpl.no_submit.html", true, true);
-
-        $this->maybeAddRequired($component, $tpl);
-        $this->addPostURL($component, $tpl);
-        $this->maybeAddError($component, $tpl);
-
-        $tpl->setVariable("INPUTS", $default_renderer->render($component->getInputGroup()));
-
-        /** @var $component Form\FormWithoutSubmitButton */
-        $enriched_component = $component->withAdditionalOnLoadCode(
-            static function (string $id) use ($component): string {
-                return "
-                    // @TODO: we need to refactor the signal-management to prevent using jQuery here.
-                    $(document).on('{$component->getSubmitSignal()}', function () {
-                        let form = document.getElementById('$id');
-                        if (!form instanceof HTMLFormElement) {
-                            throw new Error(`Element '$id' is not an instance of HTMLFormElement.`);
-                        }
-                        
-                        // @TODO: we should use the triggering button as an emitter here. When doing
-                        // so, please also change file.js processFormSubmissionHook().
-                        form.requestSubmit();
-                    });
-                ";
-            }
-        );
-
-        $id = $this->bindJavaScript($enriched_component) ?? $this->createId();
-        $tpl->setVariable("ID", $id);
-
-        return $tpl->get();
+        if ($component->getDedicatedName() !== null) {
+            $tpl->setVariable("NAME", 'name="' . $component->getDedicatedName() . '"');
+        }
     }
 
     protected function addPostURL(Component\Input\Container\Form\FormWithPostURL $component, Template $tpl): void

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Standard.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Standard.php
@@ -25,6 +25,7 @@ use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Implementation\Component\Input;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
 use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
+use ILIAS\UI\Implementation\Component\Prompt\IsPromptContentInternal;
 use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable as JavaScriptBindableTrait;
 use ILIAS\UI\Component\JavaScriptBindable;
@@ -32,7 +33,7 @@ use ILIAS\UI\Component\JavaScriptBindable;
 /**
  * This implements a standard form.
  */
-class Standard extends Form implements C\Input\Container\Form\Standard, JavaScriptBindable
+class Standard extends Form implements C\Input\Container\Form\Standard, IsPromptContentInternal, JavaScriptBindable
 {
     use HasPostURL;
     use JavaScriptBindableTrait;
@@ -55,10 +56,10 @@ class Standard extends Form implements C\Input\Container\Form\Standard, JavaScri
     /**
      * @inheritDoc
      */
-    public function withSubmitLabel(string $caption): C\Input\Container\Form\Standard
+    public function withSubmitLabel(string $label): C\Input\Container\Form\Standard
     {
         $clone = clone $this;
-        $clone->submit_caption = $caption;
+        $clone->submit_caption = $label;
         return $clone;
     }
 
@@ -68,6 +69,16 @@ class Standard extends Form implements C\Input\Container\Form\Standard, JavaScri
     public function getSubmitLabel(): ?string
     {
         return $this->submit_caption;
+    }
+
+    public function getPromptButtons(): array
+    {
+        return [];
+    }
+
+    public function getPromptTitle(): string
+    {
+        return '';
     }
 
     public function getSubmitSignal(): Signal

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.without_submit_buttons.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.without_submit_buttons.html
@@ -1,8 +1,6 @@
 <form id="{ID}" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data"<!-- BEGIN reference_error --> describedby="{ERROR_ID}"<!-- END reference_error --> {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post">
 	<!-- BEGIN error -->
-	<div id="{ERROR_ID}" class="c-form__error-msg alert alert-danger">
-		{ERROR}
-	</div>
+	<div class="c-form__error-msg alert alert-danger" id="{ERROR_ID}"><span class="sr-only">{ERROR_LABEL}: </span>{ERROR}</div>
 	<!-- END error -->
 
 	{INPUTS}

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/FormWithoutSubmitButtonsTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/FormWithoutSubmitButtonsTest.php
@@ -56,7 +56,7 @@ class InputNameSource implements NameSource
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
  */
-class NoSubmitFormTest extends \ILIAS_UI_TestBase
+class FormWithoutSubmitButtonsTest extends \ILIAS_UI_TestBase
 {
     protected SignalGenerator $signal_generator;
     protected NameSource $namesource;
@@ -144,7 +144,8 @@ class NoSubmitFormTest extends \ILIAS_UI_TestBase
     public function testRenderWithError(): void
     {
         $post_url = 'http://ilias.localhost/some_url?param1=foo&param2=bar';
-        $error_lang_var = 'ui_error_in_group';
+        $error_lang_var = 'ui_error';
+        $error_lang_var_in_group = 'ui_error_in_group';
 
         $dummy_input = $this->buildInputFactory()->text('test_label')->withAdditionalTransformation(
             $this->refinery->custom()->constraint(
@@ -171,11 +172,12 @@ class NoSubmitFormTest extends \ILIAS_UI_TestBase
         $form = $form->withRequest($request);
         $data = $form->getData();
 
-        $expected_html =
-            "<form id=\"id_1\" role=\"form\" class=\"c-form c-form--horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\">" .
-            "<div id=\"\" class=\"c-form__error-msg alert alert-danger\">$error_lang_var</div>" .
-            $dummy_input->getCanonicalName() .
-            "</form>";
+        $expected_html = <<<EOT
+<form id="id_2" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" describedby="id_1" action="$post_url" method="post">
+    <div class="c-form__error-msg alert alert-danger" id="id_1"><span class="sr-only">$error_lang_var:</span>$error_lang_var_in_group
+    </div>{$dummy_input->getCanonicalName()}
+</form>
+EOT;
 
         $context = $this->createMock(\ILIAS\UI\Component\Modal\RoundTrip::class);
         $context->method('getCanonicalName')->willReturn('RoundTripModal');


### PR DESCRIPTION
Hi folks,

I noticed there are some remnants of the `Form\FormWithoutSubmitButtons` component, which has been replaced by a context renderer in #7045. This PR removes the duplicate logic and streamlines both forms, so they use (almost) the same HTML structure and functionalities. While at it, I also noticed that the `Prompt\IsPromptContentInternal` implementation was missing and the method declarations were (imo) on the wrong level.

Kind regards,
@thibsy 