### PR TITLE
Mantis 42807: Fix error if user has no initial test but final results

### DIFF
--- a/Services/Container/Content/ObjectiveView/class.ObjectiveRenderer.php
+++ b/Services/Container/Content/ObjectiveView/class.ObjectiveRenderer.php
@@ -926,8 +926,8 @@ class ObjectiveRenderer
         $initial_lim = null;
         if ($this->loc_settings->worksWithInitialTest()) {
             if (array_key_exists('initial', $a_lo_result)) {
-                $initial_res = (int) $a_lo_result['initial']['result_perc'];
-                $initial_lim = (int) $a_lo_result['initial']['limit_perc'];
+                $initial_res = (int) ($a_lo_result['initial']['result_perc'] ?? 0);
+                $initial_lim = (int) ($a_lo_result['initial']['limit_perc'] ?? 100);
             }
             if (
                 ($a_lo_result['type'] ?? \ilLOUserResults::TYPE_UNDEFINED) == \ilLOUserResults::TYPE_INITIAL &&


### PR DESCRIPTION
Possible fix for mantis 42807

I used the same syntax as used in ILIAS 8 class.ilContainerObjectiveGUI.php, but I changed the replacement value for limit to 100 (%). In the (not to be expected) case the limit is not set, this uses the maximum amount (100%) as replacement, so that an objective is not accidentally fulfilled.

the same should apply to ILIAS 10 and trunk, but the files are moved (due to the component revision) in 10 and slightly changed in trunk.