### PR TITLE
CI: ignore deleted files in pipeline checks

### DIFF
--- a/scripts/Import/Functions.sh
+++ b/scripts/Import/Functions.sh
@@ -11,7 +11,7 @@ function get_changed_files() {
     CHANGED_FILES=$(git diff-tree --name-only --diff-filter=ACMRT --no-commit-id -r ${GH_SHA} | grep -e '.php$' -e '.js$')
   else
     URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files"
-    CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | grep -e '\.php$' -e '\.js$')
+    CHANGED_FILES=$(curl -s -X GET -G $URL | jq -r '.[] | select(.status != "removed") | .filename' | grep -e '\.php$' -e '\.js$')
   fi
   printf "${CHANGED_FILES[*]}"
 }


### PR DESCRIPTION
Hi everyone, 

in some PR-Checks, I noticed that the pipeline fails because the cs-fixer and copyright check tries to read files that have been deleted. Locally I could not reproduce this, because a git command is used to get the changed files locally, but in the pipeline an API call is made. The local command gets the mask `--diff-filter=ACMRT` to exclude deleted files. I have adapted the function so that the [API call](https://docs.github.com/de/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files) gets a filter to exclude deleted files too.

I look forward to feedback,
@lukas-heinrich 