### PR TITLE
Maps: 42771, remove OpenStreetMaps Label and Link from within the map itself. …

### DIFF
--- a/components/ILIAS/Maps/resources/ServiceOpenLayers.js
+++ b/components/ILIAS/Maps/resources/ServiceOpenLayers.js
@@ -1,4 +1,19 @@
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+/**
  * @module ol/events/Event
  */
 /**
@@ -21124,16 +21139,7 @@ var __extends$Y = (undefined && undefined.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-/**
- * The attribution containing a link to the OpenStreetMap Copyright and License
- * page.
- * @const
- * @type {string}
- * @api
- */
-var ATTRIBUTION = '&#169; ' +
-    '<a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> ' +
-    'contributors.';
+
 /**
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
@@ -21174,9 +21180,6 @@ var OSM = /** @class */ (function (_super) {
         var attributions;
         if (options.attributions !== undefined) {
             attributions = options.attributions;
-        }
-        else {
-            attributions = [ATTRIBUTION];
         }
         var crossOrigin = options.crossOrigin !== undefined ? options.crossOrigin : 'anonymous';
         var url = options.url !== undefined


### PR DESCRIPTION
…It should only be visible below the map. 

https://mantis.ilias.de/view.php?id=42771