### PR TITLE
LegalDocuments: Fix modal displayed in ilObjUserGUI

### DIFF
--- a/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/Blocks.php
+++ b/components/ILIAS/LegalDocuments/classes/ConsumerToolbox/Blocks.php
@@ -151,7 +151,7 @@ class Blocks
             $this->container->language()->loadLanguageModule('ldoc');
             $user = $build_user($user);
 
-            $value = $user->acceptedVersion()->map(function (DocumentContent $content) use ($lang_key, $user): ilNonEditableValueGUI {
+            $value = $user->acceptedVersion()->map(function (DocumentContent $content) use ($lang_key, $user): array {
                 $input = new ilNonEditableValueGUI($this->ui()->txt($lang_key), $lang_key);
                 $input->setValue($this->formatDate($user->agreeDate()->value()));
                 $modal = $this->ui()->create()->modal()->lightbox([
@@ -160,10 +160,10 @@ class Blocks
 
                 $titleLink = $this->ui()->create()->button()->shy($content->title(), '#')->withOnClick($modal->getShowSignal());
                 $sub = new ilNonEditableValueGUI($this->ui()->txt('agreement_document'), '', true);
-                $sub->setValue($this->container->ui()->renderer()->render([$titleLink, $modal]));
+                $sub->setValue($this->container->ui()->renderer()->render($titleLink));
                 $input->addSubItem($sub);
 
-                return $input;
+                return [$input, $modal];
             })->except(fn() => new Ok($this->ui()->txt('never')))->value();
 
             return [$lang_key => $value];

--- a/components/ILIAS/User/classes/class.ilObjUserGUI.php
+++ b/components/ILIAS/User/classes/class.ilObjUserGUI.php
@@ -360,7 +360,7 @@ class ilObjUserGUI extends ilObjectGUI
 
         $this->initCreate();
         $this->initForm('create');
-        $this->tpl->setContent($this->form_gui->getHTML());
+        $this->renderForm();
     }
 
     /**
@@ -384,7 +384,7 @@ class ilObjUserGUI extends ilObjectGUI
 
         if (!$this->form_gui->checkInput()) {
             $this->form_gui->setValuesByPost();
-            $this->tpl->setContent($this->form_gui->getHTML());
+            $this->renderForm();
             return;
         }
 
@@ -522,7 +522,7 @@ class ilObjUserGUI extends ilObjectGUI
         // get form
         $this->initForm('edit');
         $this->getValues();
-        $this->tpl->setContent($this->form_gui->getHTML());
+        $this->renderForm();
     }
 
     protected function loadValuesFromForm(string $a_mode = 'create'): ilObjUser
@@ -718,7 +718,7 @@ class ilObjUserGUI extends ilObjectGUI
             } catch (ilUserException $e) {
                 $this->tpl->setOnScreenMessage('failure', $e->getMessage());
                 $this->form_gui->setValuesByPost();
-                $this->tpl->setContent($this->form_gui->getHTML());
+                $this->renderForm();
                 return;
             }
 
@@ -1974,5 +1974,10 @@ class ilObjUserGUI extends ilObjectGUI
             && !$this->rbac_system->checkAccess('cat_administrate_users', $this->object->getTimeLimitOwner())) {
             $this->ilias->raiseError($this->lng->txt('msg_no_perm_modify_user'), $this->ilias->error_obj->MESSAGE);
         }
+    }
+
+    private function renderForm(): void
+    {
+        $this->tpl->setContent($this->legal_documents->userManagementModals() . $this->form_gui->getHTML());
     }
 }


### PR DESCRIPTION
This PR fixes https://mantis.ilias.de/view.php?id=42746

The issue is that the KS Modal uses a form for the Modal close button which results in a form within a form which is invalid HTML (The Modal is rendered inside a `ilNonEditableValueGUI`).
This means that the Modal must be rendered outside of the form. Sadly I don't see another solution than the proposed one (which is to call into `LegalDocuments` whenever the form is rendered) but I'm open to other solutions.