### PR TITLE
ORGU / MD: 42725, delete OrgUnit type assignments if ...

### DIFF
--- a/components/ILIAS/AdvancedMetaData/classes/Record/class.ilAdvancedMDRecord.php
+++ b/components/ILIAS/AdvancedMetaData/classes/Record/class.ilAdvancedMDRecord.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
+declare(strict_types=1);
 
 /**
  * @defgroup ServicesAdvancedMetaData Services/AdvancedMetaData
@@ -34,6 +48,7 @@ class ilAdvancedMDRecord
     protected array $scopes = [];
 
     protected ilDBInterface $db;
+    protected ilAppEventHandler $il_app_event_handler;
 
     /**
      * Singleton constructor
@@ -52,6 +67,8 @@ class ilAdvancedMDRecord
         if ($this->getRecordId()) {
             $this->read();
         }
+
+        $this->il_app_event_handler = $DIC->event();
     }
 
     public static function _getInstanceByRecordId(int $a_record_id): ilAdvancedMDRecord
@@ -416,8 +433,16 @@ class ilAdvancedMDRecord
 
     public function delete(): void
     {
-        ilAdvancedMDRecord::_delete($this->getRecordId());
-        ilAdvancedMDRecordScope::deleteByRecordId($this->getRecordId());
+        $record_id = $this->getRecordId();
+        $this->il_app_event_handler->raise(
+            'components/ILIAS/AdvancedMetaData',
+            'recordDeleted',
+            [
+                'record_id' => $record_id
+            ]
+        );
+        ilAdvancedMDRecord::_delete($record_id);
+        ilAdvancedMDRecordScope::deleteByRecordId($record_id);
     }
 
     public function enabledScope(): bool
@@ -891,5 +916,18 @@ class ilAdvancedMDRecord
         }
 
         return $res;
+    }
+
+    public static function _lookupTypeById(int $id): ?string
+    {
+        global $DIC;
+        $ilDB = $DIC['ilDB'];
+        $query = "SELECT obj_type FROM adv_md_record_objs " . PHP_EOL
+            . "WHERE record_id = " . $ilDB->quote($id, 'integer');
+        $res = $ilDB->query($query);
+        if ($row = $ilDB->fetchAssoc($res)) {
+            return $row["obj_type"];
+        }
+        return null;
     }
 }

--- a/components/ILIAS/AdvancedMetaData/classes/Record/class.ilAdvancedMDRecord.php
+++ b/components/ILIAS/AdvancedMetaData/classes/Record/class.ilAdvancedMDRecord.php
@@ -434,11 +434,17 @@ class ilAdvancedMDRecord
     public function delete(): void
     {
         $record_id = $this->getRecordId();
+        $record_types = [];
+        foreach ($this->getAssignedObjectTypes() as $obj_type) {
+            $record_types[] = $obj_type['obj_type'];
+
+        }
         $this->il_app_event_handler->raise(
             'components/ILIAS/AdvancedMetaData',
             'recordDeleted',
             [
-                'record_id' => $record_id
+                'record_id' => $record_id,
+                'record_types' => $record_types
             ]
         );
         ilAdvancedMDRecord::_delete($record_id);
@@ -916,18 +922,5 @@ class ilAdvancedMDRecord
         }
 
         return $res;
-    }
-
-    public static function _lookupTypeById(int $id): ?string
-    {
-        global $DIC;
-        $ilDB = $DIC['ilDB'];
-        $query = "SELECT obj_type FROM adv_md_record_objs " . PHP_EOL
-            . "WHERE record_id = " . $ilDB->quote($id, 'integer');
-        $res = $ilDB->query($query);
-        if ($row = $ilDB->fetchAssoc($res)) {
-            return $row["obj_type"];
-        }
-        return null;
     }
 }

--- a/components/ILIAS/AdvancedMetaData/service.xml
+++ b/components/ILIAS/AdvancedMetaData/service.xml
@@ -9,4 +9,7 @@
 		<pluginslot id="amdc" name="AdvancedMDClaiming" />
 	</pluginslots>
 	<logging/>
+    <events>
+        <event type="listen" id="components/ILIAS/AdvancedMetaData" />
+    </events>
 </service>

--- a/components/ILIAS/AdvancedMetaData/service.xml
+++ b/components/ILIAS/AdvancedMetaData/service.xml
@@ -10,6 +10,6 @@
 	</pluginslots>
 	<logging/>
     <events>
-        <event type="listen" id="components/ILIAS/AdvancedMetaData" />
+        <event type="raise" id="recordDeleted" />
     </events>
 </service>

--- a/components/ILIAS/AdvancedMetaData/tests/record/ilAdvancedMDRecordObjectOrderingsTest.php
+++ b/components/ILIAS/AdvancedMetaData/tests/record/ilAdvancedMDRecordObjectOrderingsTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use ILIAS\DI\Container;
 
@@ -64,5 +82,6 @@ class ilAdvancedMDRecordObjectOrderingsTest extends TestCase
         $this->dic = new Container();
         $GLOBALS['DIC'] = $this->dic;
         $this->setGlobalVariable('ilDB', $this->createMock(ilDBInterface::class));
+        $this->setGlobalVariable('ilAppEventHandler', $this->createMock(ilAppEventHandler::class));
     }
 }

--- a/components/ILIAS/OrgUnit/classes/Setup/class.ilOrgUnitRemoveDeletedMDSetsMigration.php
+++ b/components/ILIAS/OrgUnit/classes/Setup/class.ilOrgUnitRemoveDeletedMDSetsMigration.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\ResourceStorage\Collection\ResourceCollection;
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Migration;
+
+class ilOrgUnitRemoveDeletedMDSetsMigration implements Migration
+{
+    protected ilResourceStorageMigrationHelper $helper;
+
+    public function getLabel(): string
+    {
+        return 'Deleted meta data set assignments are removed for OrgUnit types';
+    }
+
+    public function getDefaultAmountOfStepsPerRun(): int
+    {
+        return 1000;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return ilResourceStorageMigrationHelper::getPreconditions();
+    }
+
+    public function prepare(Environment $environment): void
+    {
+        $this->helper = new ilResourceStorageMigrationHelper(
+            new ilOrgUnitTypeStakeholder(),
+            $environment
+        );
+    }
+
+    public function step(Environment $environment): void
+    {
+        $this->helper->getDatabase()->setLimit(1);
+        $res = $this->helper->getDatabase()->query(
+            'SELECT rec_id FROM orgu_types_adv_md_rec' . PHP_EOL
+            . 'WHERE rec_id NOT IN (' . PHP_EOL
+            . 'SELECT record_id FROM adv_md_record' . PHP_EOL
+            . ')'
+        );
+        $row = $this->helper->getDatabase()->fetchAssoc($res);
+        $rec_id = (int) $row['rec_id'];
+
+        $query = 'DELETE FROM orgu_types_adv_md_rec' . PHP_EOL
+            . 'WHERE rec_id = ' . $this->helper->getDatabase()->quote($rec_id, 'integer');
+        $this->helper->getDatabase()->manipulate($query);
+
+    }
+
+    public function getRemainingAmountOfSteps(): int
+    {
+        $res = $this->helper->getDatabase()->query(
+            'SELECT COUNT(rec_id) as amount FROM orgu_types_adv_md_rec' . PHP_EOL
+            . 'WHERE rec_id NOT IN (' . PHP_EOL
+            . 'SELECT record_id FROM adv_md_record' . PHP_EOL
+            . ')'
+        );
+        $row = $this->helper->getDatabase()->fetchObject($res);
+        return (int) ($row->amount ?? 0);
+    }
+}

--- a/components/ILIAS/OrgUnit/classes/Setup/class.ilOrgUnitSetupAgent.php
+++ b/components/ILIAS/OrgUnit/classes/Setup/class.ilOrgUnitSetupAgent.php
@@ -63,7 +63,9 @@ class ilOrgUnitSetupAgent implements Setup\Agent
 
     public function getMigrations(): array
     {
-        return [];
+        return [
+            new ilOrgUnitRemoveDeletedMDSetsMigration()
+        ];
     }
 
     public function getNamedObjectives(?Setup\Config $config = null): array

--- a/components/ILIAS/OrgUnit/classes/Types/class.ilOrgUnitType.php
+++ b/components/ILIAS/OrgUnit/classes/Types/class.ilOrgUnitType.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\ResourceStorage\Services as IRSS;
 
 /**
@@ -787,5 +789,13 @@ class ilOrgUnitType
             return '';
         }
         return $this->irss->consume()->src($rid)->getSrc();
+    }
+
+    public static function deleteOrgUnitTypeAssignmentByRecId(int $rec_id): void
+    {
+        global $DIC;
+        $ilDB = $DIC['ilDB'];
+        $sql = 'DELETE FROM orgu_types_adv_md_rec WHERE rec_id = ' . $ilDB->quote($rec_id, 'integer');
+        $res = $ilDB->manipulate($sql);
     }
 }

--- a/components/ILIAS/OrgUnit/classes/class.ilOrgUnitAppEventListener.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilOrgUnitAppEventListener.php
@@ -49,7 +49,8 @@ class ilOrgUnitAppEventListener
                 switch ($a_event) {
                     case 'recordDeleted':
                         $delete_record_id = $a_parameter['record_id'];
-                        if (ilAdvancedMDRecord::_lookupTypeById($delete_record_id) == 'orgu') {
+                        $record_types = $a_parameter['record_types'];
+                        if (in_array('orgu', $record_types)) {
                             ilOrgUnitType::deleteOrgUnitTypeAssignmentByRecId($delete_record_id);
                         }
                         break;

--- a/components/ILIAS/OrgUnit/classes/class.ilOrgUnitAppEventListener.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilOrgUnitAppEventListener.php
@@ -45,6 +45,15 @@ class ilOrgUnitAppEventListener
                         break;
                 }
                 break;
+            case 'components/ILIAS/AdvancedMetaData':
+                switch ($a_event) {
+                    case 'recordDeleted':
+                        $delete_record_id = $a_parameter['record_id'];
+                        if (ilAdvancedMDRecord::_lookupTypeById($delete_record_id) == 'orgu') {
+                            ilOrgUnitType::deleteOrgUnitTypeAssignmentByRecId($delete_record_id);
+                        }
+                        break;
+                }
         }
     }
 

--- a/components/ILIAS/OrgUnit/module.xml
+++ b/components/ILIAS/OrgUnit/module.xml
@@ -16,6 +16,7 @@
     <events>
         <event type="raise" id="delete"/>
         <event type="listen" id="components/ILIAS/Tree"/>
+        <event type="listen" id="components/ILIAS/AdvancedMetaData" />
     </events>
     <pluginslots>
         <pluginslot id="orgutypehk" name="OrgUnitTypeHook"/>

--- a/components/ILIAS/OrgUnit/tests/ilModulesOrgUnitTest.php
+++ b/components/ILIAS/OrgUnit/tests/ilModulesOrgUnitTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use ILIAS\DI\Container;
@@ -84,8 +84,8 @@ class ilModulesOrgUnitTest extends TestCase
         $rec = new stdClass();
         $rec->icon = '';
         $rec->owner = 13;
-        $rec->last_update = 0;
-        $rec->create_date = 0;
+        $rec->last_update = "0";
+        $rec->create_date = "0";
         $rec->default_lang = 'en';
 
         $this->db_mock->method('numRows')->willReturn(1);


### PR DESCRIPTION
... any advanced meta data set is assigned and deleted without de-assigning the set beforehand. 

Remove assigned meta data sets (by OrgUnit > Types) which were deleted but not de-assigned via a setup objective achieve process.

https://mantis.ilias.de/view.php?id=42725

Please note that you have to run 'php cli/setup.php achieve orgunit.removeDeletedMDSetsFromOrgUnitTypes'.