### PR TITLE
User Bugfix #0042870: UserAutocomplete Limit is being ignored

### DIFF
--- a/Services/User/classes/class.ilUserAutoComplete.php
+++ b/Services/User/classes/class.ilUserAutoComplete.php
@@ -243,6 +243,7 @@ class ilUserAutoComplete
             }
             $recs[$rec['usr_id']] = $rec;
             $usrIds[] = $rec['usr_id'];
+            $cnt++;
         }
         $callable_name = null;
         if (is_callable($this->user_filter, true, $callable_name)) {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42870

`ilUserAutoComplete::$limit` is being ignored since `$cnt` isn't incremented in `getList()`
Also present in newer releases

Best, @fhelfer 