### PR TITLE
User: Fix self registration crashes if text fields are not required

### DIFF
--- a/Services/User/classes/Profile/class.ilUserProfile.php
+++ b/Services/User/classes/Profile/class.ilUserProfile.php
@@ -363,6 +363,7 @@ class ilUserProfile
         ?ilObjUser $user
     ): ilFormPropertyGUI {
         $text_input = new ilTextInputGUI($this->lng->txt($lang_var), 'usr_' . $field_id);
+        $text_input->setValue('');
         if ($user !== null) {
             $text_input->setValue($user->$method() ?? '');
         }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42869

If approved, please check whether this must be picked to other maintained branches.