### PR TITLE
T&A/10 40791: Replaces superglobal usages in TestQuestionPool component with RequestDataCollector

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php
@@ -1050,7 +1050,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
                 continue;
             }
 
-            if ($gap->getType() === assClozeGap::TYPE_SELECT && $value === -1) {
+            if ($gap->getType() === assClozeGap::TYPE_SELECT && $value == -1) {
                 continue;
             }
 
@@ -1071,26 +1071,20 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     {
         $solution_submit = [];
 
-        foreach ($this->test_request->getPostKeys() as $key) {
-            if (preg_match("/^gap_(\d+)/", $key, $matches)) {
-                $value = $this->test_request->retrieveArrayOfStringWithFilter($key, static function ($key) {
-                    return preg_match("/^gap_(\d+)/", $key);
-                });
-
-                if ($value === null || $value === ''
-                    || !preg_match('/^gap_(\d+)/', $key, $matches)) {
-                    continue;
-                }
-                $gap = $this->getGap((int) $matches[1]);
-                if ($gap === null
-                    || $gap->getType() === assClozeGap::TYPE_SELECT && $value === -1) {
-                    continue;
-                }
-                if ($gap->getType() === assClozeGap::TYPE_NUMERIC) {
-                    $value = str_replace(',', '.', $value);
-                }
-                $solution_submit[trim($matches[1])] = $value;
+        foreach ($this->questionpool_request->getPostKeys() as $post_key) {
+            $value = $this->questionpool_request->string($post_key);
+            if ($value === '' || !preg_match('/^gap_(\d+)/', $post_key, $matches)) {
+                continue;
             }
+            $gap = $this->getGap((int) $matches[1]);
+            if ($gap === null
+                || $gap->getType() === assClozeGap::TYPE_SELECT && $value === '-1') {
+                continue;
+            }
+            if ($gap->getType() === assClozeGap::TYPE_NUMERIC) {
+                $value = $this->questionpool_request->float($post_key);
+            }
+            $solution_submit[trim($matches[1])] = $value;
         }
 
         return $solution_submit;

--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php
@@ -23,7 +23,6 @@ use ILIAS\TestQuestionPool\Questions\QuestionAutosaveable;
 use ILIAS\TestQuestionPool\Questions\QuestionPartiallySaveable;
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
 use ILIAS\Refinery\Random\Group as RandomGroup;
-use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
  * Class for cloze tests
@@ -79,7 +78,6 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
     public ilAssQuestionFeedback $feedbackOBJ;
     protected $feedbackMode = ilAssClozeTestFeedback::FB_MODE_GAP_QUESTION;
     private RandomGroup $randomGroup;
-    private readonly RequestDataCollector $request_data_collector;
 
     public function __construct(
         string $title = "",
@@ -89,11 +87,9 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         string $question = ""
     ) {
         global $DIC;
-
         parent::__construct($title, $comment, $author, $owner, $question);
         $this->setQuestion($question); // @TODO: Should this be $question?? See setter for why this is not trivial.
         $this->randomGroup = $DIC->refinery()->random();
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     /**
@@ -1073,11 +1069,11 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
 
     public function getSolutionSubmitValidation(): array
     {
-        $solutionSubmit = [];
+        $solution_submit = [];
 
-        foreach ($this->request_data_collector->getPostKeys() as $key) {
+        foreach ($this->test_request->getPostKeys() as $key) {
             if (preg_match("/^gap_(\d+)/", $key, $matches)) {
-                $value = $this->request_data_collector->retrieveArrayOfStringWithFilter($key, static function ($key) {
+                $value = $this->test_request->retrieveArrayOfStringWithFilter($key, static function ($key) {
                     return preg_match("/^gap_(\d+)/", $key);
                 });
 
@@ -1093,11 +1089,11 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
                 if ($gap->getType() === assClozeGap::TYPE_NUMERIC) {
                     $value = str_replace(',', '.', $value);
                 }
-                $solutionSubmit[trim($matches[1])] = $value;
+                $solution_submit[trim($matches[1])] = $value;
             }
         }
 
-        return $solutionSubmit;
+        return $solution_submit;
     }
 
     protected function getSolutionSubmit(): array

--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php
@@ -1050,7 +1050,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
                 continue;
             }
 
-            if ($gap->getType() === assClozeGap::TYPE_SELECT && $value == -1) {
+            if ($gap->getType() === assClozeGap::TYPE_SELECT && $value === '-1') {
                 continue;
             }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -294,8 +294,8 @@ JS;
                     }
                     break;
             }
-            $assClozeGapCombinationObject = new assClozeGapCombination();
-            $assClozeGapCombinationObject::clearGapCombinationsFromDb($this->object->getId());
+            $ass_cloze_gab_combination = new assClozeGapCombination();
+            $ass_cloze_gab_combination::clearGapCombinationsFromDb($this->object->getId());
 
             $gap_combination = $this->request_data_collector->retrieveNestedArraysOfFloats('gap_combination', 4);
 
@@ -303,7 +303,7 @@ JS;
             if (is_array($gap_combination)) {
                 $gap_combination_values = $this->request_data_collector->retrieveNestedArraysOfFloats('gap_combination', 4);
 
-                $assClozeGapCombinationObject->saveGapCombinationToDb(
+                $ass_cloze_gab_combination->saveGapCombinationToDb(
                     $this->object->getId(),
                     $gap_combination,
                     $gap_combination_values

--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -175,9 +175,17 @@ JS;
 
                     $this->object->setGapShuffle($idx, 0);
 
-                    if ($this->ctrl->getCmd() != 'createGaps') {
-                        if (is_array($_POST['gap_' . $idx]['answer'])) {
-                            foreach ($_POST['gap_' . $idx]['answer'] as $order => $value) {
+                    $gap_idx = $this->post->retrieve(
+                        'gap_' . $idx,
+                        $this->refinery->byTrying([
+                            $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
+                            $this->refinery->always(['answer' => null, 'points' => null])
+                        ])
+                    );
+
+                    if ($this->ctrl->getCmd() !== 'createGaps') {
+                        if (is_array($gap_idx['answer'])) {
+                            foreach ($gap_idx as $order => $value) {
                                 $this->object->addGapAnswer($idx, $order, $value);
                             }
                         } else {
@@ -185,25 +193,48 @@ JS;
                         }
                     }
 
-                    if (is_array($_POST['gap_' . $idx]['points'])) {
-                        foreach ($_POST['gap_' . $idx]['points'] as $order => $value) {
+                    if (is_array($gap_idx['points'])) {
+                        foreach ($gap_idx['points'] as $order => $value) {
                             $this->object->setGapAnswerPoints($idx, $order, $value);
                         }
                     }
 
                     $k_gapsize = 'gap_' . $idx . '_gapsize';
-                    if ($this->request->isset($k_gapsize)) {
-                        $this->object->setGapSize($idx, $_POST[$k_gapsize]);
+                    if ($this->post->has($k_gapsize)) {
+                        $gap_size = $this->post->retrieve(
+                            $k_gapsize,
+                            $this->refinery->byTrying([
+                                $this->refinery->kindlyTo()->int(),
+                                $this->refinery->always(0)
+                            ])
+                        );
+
+                        $this->object->setGapSize($idx, $gap_size);
                     }
                     break;
 
                 case assClozeGap::TYPE_SELECT:
+                    $shuffle_idx = $this->post->retrieve(
+                        'shuffle_' . $idx,
+                        $this->refinery->byTrying([
+                            $this->refinery->kindlyTo()->int(),
+                            $this->refinery->always(0)
+                        ])
+                    );
 
-                    $this->object->setGapShuffle($idx, (int) (isset($_POST["shuffle_$idx"]) && $_POST["shuffle_$idx"]));
+                    $this->object->setGapShuffle($idx, $shuffle_idx);
 
-                    if ($this->ctrl->getCmd() != 'createGaps') {
-                        if (is_array($_POST['gap_' . $idx]['answer'])) {
-                            foreach ($_POST['gap_' . $idx]['answer'] as $order => $value) {
+                    $gap_idx = $this->post->retrieve(
+                        'gap_' . $idx,
+                        $this->refinery->byTrying([
+                            $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
+                            $this->refinery->always(['answer' => null, 'points' => null])
+                        ])
+                    );
+
+                    if ($this->ctrl->getCmd() !== 'createGaps') {
+                        if (is_array($gap_idx['answer'])) {
+                            foreach ($gap_idx['answer'] as $order => $value) {
                                 $this->object->addGapAnswer($idx, $order, $value);
                             }
                         } else {
@@ -211,8 +242,8 @@ JS;
                         }
                     }
 
-                    if (is_array($_POST['gap_' . $idx]['points'])) {
-                        foreach ($_POST['gap_' . $idx]['points'] as $order => $value) {
+                    if (is_array($gap_idx['points'])) {
+                        foreach ($gap_idx['points'] as $order => $value) {
                             $this->object->setGapAnswerPoints($idx, $order, $value);
                         }
                     }
@@ -227,70 +258,165 @@ JS;
                         break;
                     }
 
-                    $this->object->getGap($idx)->clearItems();
+                    $this->object->getGap($idx)?->clearItems();
 
-                    if ($this->post->has('gap_' . $idx . '_numeric')) {
+                    $gap_idx_numeric = $this->post->retrieve(
+                        'gap_' . $idx . '_numeric',
+                        $this->refinery->byTrying([
+                            $this->refinery->kindlyTo()->string(),
+                            $this->refinery->always(null)
+                        ])
+                    );
+
+                    if (is_string($gap_idx_numeric)) {
                         if ($this->ctrl->getCmd() !== 'createGaps') {
                             $this->object->addGapAnswer(
                                 $idx,
                                 0,
-                                str_replace(",", ".", $_POST['gap_' . $idx . '_numeric'])
+                                str_replace(',', '.', $gap_idx_numeric)
                             );
                         }
+
+                        $gap_idx_numeric_lower = $this->post->retrieve(
+                            'gap_' . $idx . '_numeric_lower',
+                            $this->refinery->byTrying([
+                                $this->refinery->kindlyTo()->string(),
+                                $this->refinery->always('')
+                            ])
+                        );
 
                         $this->object->setGapAnswerLowerBound(
                             $idx,
                             0,
-                            str_replace(",", ".", $_POST['gap_' . $idx . '_numeric_lower'])
+                            str_replace(',', '.', $gap_idx_numeric_lower)
+                        );
+
+                        $gap_idx_numeric_upper = $this->post->retrieve(
+                            'gap_' . $idx . '_numeric_upper',
+                            $this->refinery->byTrying([
+                                $this->refinery->kindlyTo()->string(),
+                                $this->refinery->always('')
+                            ])
                         );
 
                         $this->object->setGapAnswerUpperBound(
                             $idx,
                             0,
-                            str_replace(",", ".", $_POST['gap_' . $idx . '_numeric_upper'])
+                            str_replace(',', '.', $gap_idx_numeric_upper)
                         );
 
-                        $this->object->setGapAnswerPoints($idx, 0, $_POST['gap_' . $idx . '_numeric_points']);
+                        $gap_idx_numeric_points = $this->post->retrieve(
+                            'gap_' . $idx . '_numeric_points',
+                            $this->refinery->byTrying([
+                                $this->refinery->kindlyTo()->float(),
+                                $this->refinery->always(0.0)
+                            ])
+                        );
+
+                        $this->object->setGapAnswerPoints($idx, 0, $gap_idx_numeric_points);
                     } else {
-                        if ($this->ctrl->getCmd() != 'createGaps') {
+                        if ($this->ctrl->getCmd() !== 'createGaps') {
                             $this->object->addGapAnswer($idx, 0, '');
                         }
 
                         $this->object->setGapAnswerLowerBound($idx, 0, '');
-
                         $this->object->setGapAnswerUpperBound($idx, 0, '');
                     }
 
-                    if ($this->post->has('gap_' . $idx . '_gapsize')) {
-                        $this->object->setGapSize($idx, $_POST['gap_' . $idx . '_gapsize']);
+                    $gap_idx_size = $this->post->retrieve(
+                        'gap_' . $idx . '_gapsize',
+                        $this->refinery->byTrying([
+                            $this->refinery->kindlyTo()->int(),
+                            $this->refinery->always(null)
+                        ])
+                    );
+
+                    if (is_int($gap_idx_size)) {
+                        $this->object->setGapSize($idx, $gap_idx_size);
                     }
                     break;
             }
             $assClozeGapCombinationObject = new assClozeGapCombination();
-            $assClozeGapCombinationObject->clearGapCombinationsFromDb($this->object->getId());
-            if (
-                isset($_POST['gap_combination']) &&
-                is_array($_POST['gap_combination']) &&
-                count($_POST['gap_combination']) > 0
-            ) {
+            $assClozeGapCombinationObject::clearGapCombinationsFromDb($this->object->getId());
+
+            $gap_combination = $this->post->retrieve(
+                'gap_combination',
+                $this->refinery->byTrying([
+                    $this->refinery->kindlyTo()->listOf(
+                        $this->refinery->kindlyTo()->listOf(
+                            $this->refinery->kindlyTo()->listOf(
+                                $this->refinery->kindlyTo()->listOf(
+                                    $this->refinery->kindlyTo()->float()
+                                )
+                            )
+                        )
+                    ),
+                    $this->refinery->always(null)
+                ])
+            );
+
+            if (is_array($gap_combination)) {
+                $gap_combination_values = $this->post->retrieve(
+                    'gap_combination',
+                    $this->refinery->byTrying([
+                        $this->refinery->kindlyTo()->listOf(
+                            $this->refinery->kindlyTo()->listOf(
+                                $this->refinery->kindlyTo()->listOf(
+                                    $this->refinery->kindlyTo()->listOf(
+                                        $this->refinery->kindlyTo()->float()
+                                    )
+                                )
+                            )
+                        ),
+                        $this->refinery->always([])
+                    ])
+                );
+
                 $assClozeGapCombinationObject->saveGapCombinationToDb(
                     $this->object->getId(),
-                    $_POST['gap_combination'],
-                    $_POST['gap_combination_values']
+                    $gap_combination,
+                    $gap_combination_values
                 );
             }
         }
-        if ($this->ctrl->getCmd() != 'createGaps') {
+        if ($this->ctrl->getCmd() !== 'createGaps') {
             $this->object->updateClozeTextFromGaps();
         }
     }
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $this->object->setClozeText($_POST['cloze_text']);
-        $this->object->setTextgapRating($_POST["textgap_rating"]);
-        $this->object->setIdenticalScoring($_POST["identical_scoring"]);
-        $this->object->setFixedTextLength($_POST["fixedTextLength"]);
+        $this->object->setClozeText($this->post->retrieve(
+            'cloze_text',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always('')
+            ])
+        ));
+
+        $this->object->setTextgapRating($this->post->retrieve(
+            'textgap_rating',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always('')
+            ])
+        ));
+
+        $this->object->setIdenticalScoring($this->post->retrieve(
+            'identical_scoring',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->bool(),
+                $this->refinery->always(true)
+            ])
+        ));
+
+        $this->object->setFixedTextLength($this->post->retrieve(
+            'fixedTextLength',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->int(),
+                $this->refinery->always(null)
+            ])
+        ));
     }
 
     /**
@@ -745,7 +871,20 @@ JS;
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $this->object->deleteAnswerText($this->gapIndex, key($_POST['cmd']['removegap_' . $this->gapIndex]));
+
+        $cmd = $this->post->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf(
+                    $this->refinery->kindlyTo()->listOf(
+                        $this->refinery->kindlyTo()->int()
+                    )
+                ),
+                $this->refinery->always([])
+            ])
+        );
+
+        $this->object->deleteAnswerText($this->gapIndex, key($cmd['removegap_' . $this->gapIndex]));
         $this->editQuestion();
     }
 
@@ -753,7 +892,20 @@ JS;
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $this->object->addGapAnswer($this->gapIndex, key($_POST['cmd']['addgap_' . $this->gapIndex]) + 1, "");
+
+        $cmd = $this->post->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf(
+                    $this->refinery->kindlyTo()->listOf(
+                        $this->refinery->kindlyTo()->int()
+                    )
+                ),
+                $this->refinery->always([])
+            ])
+        );
+
+        $this->object->addGapAnswer($this->gapIndex, key($cmd['addgap_' . $this->gapIndex]) + 1, '');
         $this->editQuestion();
     }
 
@@ -1087,7 +1239,7 @@ JS;
         // get the solution of the user for the active pass or from the last pass if allowed
         $user_solution = [];
         if ($user_post_solutions !== false) {
-            $indexedSolution = $this->object->fetchSolutionSubmit($user_post_solutions);
+            $indexedSolution = $this->object->fetchSolutionSubmit();
             $user_solution = $this->object->fetchValuePairsFromIndexedValues($indexedSolution);
         } elseif ($active_id) {
             $user_solution = $this->object->getTestOutputSolutions($active_id, $pass);

--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -43,9 +43,9 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     jQuery.fn.extend({
         insertGapCodeAtCaret: function() {
             return this.each(function(i) {
-                var code_start = "[gap]"
-                var code_end = "[/gap]"
-                if (typeof tinyMCE != "undefined" && typeof tinyMCE.get('cloze_text') != "undefined") {
+                var code_start = '[gap]';
+                var code_end = '[/gap]';
+                if (typeof tinyMCE != 'undefined' && typeof tinyMCE.get('cloze_text') != 'undefined') {
                     var ed =  tinyMCE.get('cloze_text');
                     il.ClozeHelper.internetExplorerTinyMCECursorFix(ed);
                     ed.selection.setContent(code_start + ed.selection.getContent() + code_end);
@@ -130,18 +130,18 @@ JS;
         }
 
         $cloze_text = $this->removeIndizesFromGapText(
-            $this->request->raw('cloze_text')
+            $this->request_data_collector->raw('cloze_text')
         );
 
         $this->object->setQuestion(
-            $this->request->raw('question')
+            $this->request_data_collector->raw('question')
         );
 
         $this->writeQuestionGenericPostData();
         $this->object->setClozeText($cloze_text);
-        $this->object->setTextgapRating($this->request->raw('textgap_rating'));
-        $this->object->setIdenticalScoring((bool) ($this->request->raw('identical_scoring') ?? false));
-        $this->object->setFixedTextLength(($this->request->int('fixedTextLength') ?? 0));
+        $this->object->setTextgapRating($this->request_data_collector->raw('textgap_rating'));
+        $this->object->setIdenticalScoring((bool) ($this->request_data_collector->raw('identical_scoring') ?? false));
+        $this->object->setFixedTextLength(($this->request_data_collector->int('fixedTextLength') ?? 0));
         $this->writeAnswerSpecificPostData(new ilPropertyFormGUI());
         $this->saveTaxonomyAssignments();
         return 0;
@@ -175,12 +175,13 @@ JS;
 
                     $this->object->setGapShuffle($idx, 0);
 
-                    $gap_idx = $this->post->retrieve(
+                    $gap_idx = $this->request_data_collector->retrieveNestedArraysOfStrings(
                         'gap_' . $idx,
-                        $this->refinery->byTrying([
-                            $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
-                            $this->refinery->always(['answer' => null, 'points' => null])
-                        ])
+                        3,
+                        [
+                            'answer' => null,
+                            'points' => null
+                        ]
                     );
 
                     if ($this->ctrl->getCmd() !== 'createGaps') {
@@ -201,35 +202,22 @@ JS;
 
                     $k_gapsize = 'gap_' . $idx . '_gapsize';
                     if ($this->post->has($k_gapsize)) {
-                        $gap_size = $this->post->retrieve(
-                            $k_gapsize,
-                            $this->refinery->byTrying([
-                                $this->refinery->kindlyTo()->int(),
-                                $this->refinery->always(0)
-                            ])
-                        );
-
+                        $gap_size = $this->request_data_collector->retrieveIntValueFromPost($k_gapsize, 0);
                         $this->object->setGapSize($idx, $gap_size);
                     }
                     break;
 
                 case assClozeGap::TYPE_SELECT:
-                    $shuffle_idx = $this->post->retrieve(
-                        'shuffle_' . $idx,
-                        $this->refinery->byTrying([
-                            $this->refinery->kindlyTo()->int(),
-                            $this->refinery->always(0)
-                        ])
-                    );
-
+                    $shuffle_idx = $this->request_data_collector->retrieveIntValueFromPost('shuffle_' . $idx, 0);
                     $this->object->setGapShuffle($idx, $shuffle_idx);
 
-                    $gap_idx = $this->post->retrieve(
+                    $gap_idx = $this->request_data_collector->retrieveNestedArraysOfStrings(
                         'gap_' . $idx,
-                        $this->refinery->byTrying([
-                            $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
-                            $this->refinery->always(['answer' => null, 'points' => null])
-                        ])
+                        3,
+                        [
+                            'answer' => null,
+                            'points' => null
+                        ]
                     );
 
                     if ($this->ctrl->getCmd() !== 'createGaps') {
@@ -260,13 +248,7 @@ JS;
 
                     $this->object->getGap($idx)?->clearItems();
 
-                    $gap_idx_numeric = $this->post->retrieve(
-                        'gap_' . $idx . '_numeric',
-                        $this->refinery->byTrying([
-                            $this->refinery->kindlyTo()->string(),
-                            $this->refinery->always(null)
-                        ])
-                    );
+                    $gap_idx_numeric = $this->request_data_collector->retrieveStringFromPost('gap_' . $idx . '_numeric', null);
 
                     if (is_string($gap_idx_numeric)) {
                         if ($this->ctrl->getCmd() !== 'createGaps') {
@@ -277,13 +259,7 @@ JS;
                             );
                         }
 
-                        $gap_idx_numeric_lower = $this->post->retrieve(
-                            'gap_' . $idx . '_numeric_lower',
-                            $this->refinery->byTrying([
-                                $this->refinery->kindlyTo()->string(),
-                                $this->refinery->always('')
-                            ])
-                        );
+                        $gap_idx_numeric_lower = $this->request_data_collector->retrieveStringFromPost('gap_' . $idx . '_numeric_lower');
 
                         $this->object->setGapAnswerLowerBound(
                             $idx,
@@ -291,13 +267,7 @@ JS;
                             str_replace(',', '.', $gap_idx_numeric_lower)
                         );
 
-                        $gap_idx_numeric_upper = $this->post->retrieve(
-                            'gap_' . $idx . '_numeric_upper',
-                            $this->refinery->byTrying([
-                                $this->refinery->kindlyTo()->string(),
-                                $this->refinery->always('')
-                            ])
-                        );
+                        $gap_idx_numeric_upper = $this->request_data_collector->retrieveStringFromPost('gap_' . $idx . '_numeric_upper');
 
                         $this->object->setGapAnswerUpperBound(
                             $idx,
@@ -305,13 +275,7 @@ JS;
                             str_replace(',', '.', $gap_idx_numeric_upper)
                         );
 
-                        $gap_idx_numeric_points = $this->post->retrieve(
-                            'gap_' . $idx . '_numeric_points',
-                            $this->refinery->byTrying([
-                                $this->refinery->kindlyTo()->float(),
-                                $this->refinery->always(0.0)
-                            ])
-                        );
+                        $gap_idx_numeric_points = $this->request_data_collector->retrieveFloatValueFromPost('gap_' . $idx . '_numeric_points', 0.0);
 
                         $this->object->setGapAnswerPoints($idx, 0, $gap_idx_numeric_points);
                     } else {
@@ -323,13 +287,7 @@ JS;
                         $this->object->setGapAnswerUpperBound($idx, 0, '');
                     }
 
-                    $gap_idx_size = $this->post->retrieve(
-                        'gap_' . $idx . '_gapsize',
-                        $this->refinery->byTrying([
-                            $this->refinery->kindlyTo()->int(),
-                            $this->refinery->always(null)
-                        ])
-                    );
+                    $gap_idx_size = $this->request_data_collector->retrieveIntValueFromPost('gap_' . $idx . '_gapsize');
 
                     if (is_int($gap_idx_size)) {
                         $this->object->setGapSize($idx, $gap_idx_size);
@@ -339,38 +297,11 @@ JS;
             $assClozeGapCombinationObject = new assClozeGapCombination();
             $assClozeGapCombinationObject::clearGapCombinationsFromDb($this->object->getId());
 
-            $gap_combination = $this->post->retrieve(
-                'gap_combination',
-                $this->refinery->byTrying([
-                    $this->refinery->kindlyTo()->listOf(
-                        $this->refinery->kindlyTo()->listOf(
-                            $this->refinery->kindlyTo()->listOf(
-                                $this->refinery->kindlyTo()->listOf(
-                                    $this->refinery->kindlyTo()->float()
-                                )
-                            )
-                        )
-                    ),
-                    $this->refinery->always(null)
-                ])
-            );
+            $gap_combination = $this->request_data_collector->retrieveNestedArraysOfFloats('gap_combination', 4);
+
 
             if (is_array($gap_combination)) {
-                $gap_combination_values = $this->post->retrieve(
-                    'gap_combination',
-                    $this->refinery->byTrying([
-                        $this->refinery->kindlyTo()->listOf(
-                            $this->refinery->kindlyTo()->listOf(
-                                $this->refinery->kindlyTo()->listOf(
-                                    $this->refinery->kindlyTo()->listOf(
-                                        $this->refinery->kindlyTo()->float()
-                                    )
-                                )
-                            )
-                        ),
-                        $this->refinery->always([])
-                    ])
-                );
+                $gap_combination_values = $this->request_data_collector->retrieveNestedArraysOfFloats('gap_combination', 4);
 
                 $assClozeGapCombinationObject->saveGapCombinationToDb(
                     $this->object->getId(),
@@ -386,37 +317,10 @@ JS;
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $this->object->setClozeText($this->post->retrieve(
-            'cloze_text',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always('')
-            ])
-        ));
-
-        $this->object->setTextgapRating($this->post->retrieve(
-            'textgap_rating',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always('')
-            ])
-        ));
-
-        $this->object->setIdenticalScoring($this->post->retrieve(
-            'identical_scoring',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->bool(),
-                $this->refinery->always(true)
-            ])
-        ));
-
-        $this->object->setFixedTextLength($this->post->retrieve(
-            'fixedTextLength',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->int(),
-                $this->refinery->always(null)
-            ])
-        ));
+        $this->object->setClozeText($this->request_data_collector->retrieveStringFromPost('cloze_quest'));
+        $this->object->setTextgapRating($this->request_data_collector->retrieveStringFromPost('textgap_rating'));
+        $this->object->setIdenticalScoring($this->request_data_collector->retrieveBoolFromPost('textgap_rating', true));
+        $this->object->setFixedTextLength($this->request_data_collector->retrieveIntValueFromPost('fixedTextLength'));
     }
 
     /**
@@ -453,7 +357,7 @@ JS;
             $errors = !$form->checkInput();
             $form->setValuesByPost();
 
-            $gap_combinations = $this->request->raw('gap_combination');
+            $gap_combinations = $this->request_data_collector->raw('gap_combination');
             if (is_array($gap_combinations)
                 && $gap_combinations !== []
                 && $this->hasErrorInGapCombinationPoints($gap_combinations)) {
@@ -872,18 +776,7 @@ JS;
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
 
-        $cmd = $this->post->retrieve(
-            'cmd',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf(
-                    $this->refinery->kindlyTo()->listOf(
-                        $this->refinery->kindlyTo()->int()
-                    )
-                ),
-                $this->refinery->always([])
-            ])
-        );
-
+        $cmd = $this->request_data_collector->retrieveNestedArraysOfInts('cmd', 2, []);
         $this->object->deleteAnswerText($this->gapIndex, key($cmd['removegap_' . $this->gapIndex]));
         $this->editQuestion();
     }
@@ -893,18 +786,7 @@ JS;
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
 
-        $cmd = $this->post->retrieve(
-            'cmd',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf(
-                    $this->refinery->kindlyTo()->listOf(
-                        $this->refinery->kindlyTo()->int()
-                    )
-                ),
-                $this->refinery->always([])
-            ])
-        );
-
+        $cmd = $this->request_data_collector->retrieveNestedArraysOfInts('cmd', 2, []);
         $this->object->addGapAnswer($this->gapIndex, key($cmd['addgap_' . $this->gapIndex]) + 1, '');
         $this->editQuestion();
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -139,7 +139,7 @@ JS;
         $this->object->setClozeText($cloze_text);
         $this->object->setTextgapRating($this->request_data_collector->raw('textgap_rating'));
         $this->object->setIdenticalScoring($this->request_data_collector->bool('identical_scoring') ?? false);
-        $this->object->setFixedTextLength($this->request_data_collector->int('fixedTextLength'));
+        $this->object->setFixedTextLength($this->request_data_collector->int('fixedTextLength') ?? 0);
         $this->writeAnswerSpecificPostData(new ilPropertyFormGUI());
         $this->saveTaxonomyAssignments();
         return 0;

--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -45,7 +45,7 @@ class assClozeTestGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
             return this.each(function(i) {
                 var code_start = '[gap]';
                 var code_end = '[/gap]';
-                if (typeof tinyMCE != 'undefined' && typeof tinyMCE.get('cloze_text') != 'undefined') {
+                if (typeof tinyMCE !== 'undefined' && typeof tinyMCE.get('cloze_text') !== 'undefined') {
                     var ed =  tinyMCE.get('cloze_text');
                     il.ClozeHelper.internetExplorerTinyMCECursorFix(ed);
                     ed.selection.setContent(code_start + ed.selection.getContent() + code_end);

--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -1708,9 +1708,6 @@ JS;
             }
         }
 
-        $combinationPoints = $combinationPoints;
-        $combinationValues = $combinationValues;
-
         $assClozeGapCombinationObject = new assClozeGapCombination();
         $assClozeGapCombinationObject->clearGapCombinationsFromDb($this->object->getId());
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assErrorText.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assErrorText.php
@@ -303,7 +303,7 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     {
         return explode(
             ',',
-            $this->test_request->retrieveStringFromPost('qst_' . $this->getId())
+            $this->questionpool_request->string('qst_' . $this->getId())
         );
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assErrorText.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assErrorText.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\TestQuestionPool\Questions\QuestionLMExportable;
 use ILIAS\TestQuestionPool\Questions\QuestionAutosaveable;
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
+use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
  * Class for error text questions
@@ -56,6 +57,7 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     protected array $errordata = [];
     protected float $textsize;
     protected ?float $points_wrong = null;
+    private readonly RequestDataCollector $request_data_collector;
 
     public function __construct(
         string $title = '',
@@ -66,6 +68,8 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     ) {
         parent::__construct($title, $comment, $author, $owner, $question);
         $this->textsize = self::DEFAULT_TEXT_SIZE;
+        global $DIC;
+        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     public function isComplete(): bool
@@ -301,13 +305,10 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
 
     private function getAnswersFromRequest(): array
     {
-        return explode(',', $this->http->wrapper()->post()->retrieve(
-            'qst_' . $this->getId(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always('')
-            ])
-        ));
+        return explode(
+            ',',
+            $this->request_data_collector->retrieveStringFromPost('qst_' . $this->getId())
+        );
     }
 
     public function getQuestionType(): string

--- a/components/ILIAS/TestQuestionPool/classes/class.assErrorText.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assErrorText.php
@@ -301,11 +301,13 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
 
     private function getAnswersFromRequest(): array
     {
-        if (mb_strlen($_POST["qst_" . $this->getId()])) {
-            return explode(',', $_POST["qst_{$this->getId()}"]);
-        }
-
-        return [];
+        return explode(',', $this->http->wrapper()->post()->retrieve(
+            'qst_' . $this->getId(),
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always('')
+            ])
+        ));
     }
 
     public function getQuestionType(): string

--- a/components/ILIAS/TestQuestionPool/classes/class.assErrorText.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assErrorText.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 use ILIAS\TestQuestionPool\Questions\QuestionLMExportable;
 use ILIAS\TestQuestionPool\Questions\QuestionAutosaveable;
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
-use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
  * Class for error text questions
@@ -57,7 +56,6 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     protected array $errordata = [];
     protected float $textsize;
     protected ?float $points_wrong = null;
-    private readonly RequestDataCollector $request_data_collector;
 
     public function __construct(
         string $title = '',
@@ -68,8 +66,6 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     ) {
         parent::__construct($title, $comment, $author, $owner, $question);
         $this->textsize = self::DEFAULT_TEXT_SIZE;
-        global $DIC;
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     public function isComplete(): bool
@@ -307,7 +303,7 @@ class assErrorText extends assQuestion implements ilObjQuestionScoringAdjustable
     {
         return explode(
             ',',
-            $this->request_data_collector->retrieveStringFromPost('qst_' . $this->getId())
+            $this->test_request->retrieveStringFromPost('qst_' . $this->getId())
         );
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assErrorTextGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assErrorTextGUI.php
@@ -67,7 +67,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
 
     public function writeAnswerSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $errordata = $this->restructurePostDataForSaving($this->request->raw('errordata') ?? []);
+        $errordata = $this->restructurePostDataForSaving($this->request_data_collector->raw('errordata') ?? []);
         $this->object->setErrorData($errordata);
         $this->object->removeErrorDataWithoutPosition();
     }
@@ -89,22 +89,22 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
         $this->object->setQuestion(
-            $this->request->raw('question')
+            $this->request_data_collector->raw('question')
         );
 
         $this->object->setErrorText(
-            $this->request->raw('errortext')
+            $this->request_data_collector->raw('errortext')
         );
 
         $this->object->parseErrorText();
 
         $this->object->setPointsWrong(
-            $this->request->float('points_wrong') ?? self::DEFAULT_POINTS_WRONG
+            $this->request_data_collector->float('points_wrong') ?? self::DEFAULT_POINTS_WRONG
         );
 
         if (!$this->object->getSelfAssessmentEditingMode()) {
             $this->object->setTextSize(
-                $this->request->float('textsize')
+                $this->request_data_collector->float('textsize')
             );
         }
     }
@@ -514,7 +514,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     {
         $existing_errordata = $this->object->getErrorData();
         $this->object->flushErrorData();
-        $new_errordata = $this->request->raw('errordata');
+        $new_errordata = $this->request_data_collector->raw('errordata');
         $errordata = [];
         foreach ($new_errordata['points'] as $index => $points) {
             $errordata[$index] = $existing_errordata[$index]->withPoints(

--- a/components/ILIAS/TestQuestionPool/classes/class.assErrorTextGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assErrorTextGUI.php
@@ -67,8 +67,8 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
 
     public function writeAnswerSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $errordata = $this->restructurePostDataForSaving($this->request_data_collector->raw('errordata') ?? []);
-        $this->object->setErrorData($errordata);
+        $data = $this->restructurePostDataForSaving($this->request_data_collector->raw('errordata') ?? []);
+        $this->object->setErrorData($data);
         $this->object->removeErrorDataWithoutPosition();
     }
 
@@ -89,7 +89,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
         $this->object->setQuestion(
-            $this->request_data_collector->raw('question')
+            $this->request_data_collector->string('question')
         );
 
         $this->object->setErrorText(

--- a/components/ILIAS/TestQuestionPool/classes/class.assFileUpload.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFileUpload.php
@@ -941,7 +941,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
         );
     }
 
-    public function getCorrectSolutionForTextOutput(int $active_id, int $pass): array
+    public function getCorrectSolutionForTextOutput(int $active_id, int $pass): string
     {
         return '';
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assFileUpload.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFileUpload.php
@@ -20,9 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\Test\Participants\ParticipantRepository;
-
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
-
 use ILIAS\FileDelivery\Delivery\Disposition;
 use ILIAS\FileUpload\Exception\IllegalStateException;
 
@@ -370,7 +368,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
                 if ($data['value2'] === 'rid') {
                     $rid = $this->irss->manage()->find($data['value1']);
-                    if($rid === null) {
+                    if ($rid === null) {
                         continue;
                     }
                     $revision = $this->irss->manage()->getCurrentRevision($rid);
@@ -568,7 +566,15 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
                 if ($this->isFileDeletionAction()) {
                     if ($this->isFileDeletionSubmitAvailable()) {
-                        foreach ($_POST[self::DELETE_FILES_TBL_POSTVAR] as $solution_id) {
+                        $delete_files = $this->http->wrapper()->post()->retrieve(
+                            self::DELETE_FILES_TBL_POSTVAR,
+                            $this->refinery->byTrying([
+                                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                                $this->refinery->always([])
+                            ])
+                        );
+
+                        foreach ($delete_files as $solution_id) {
                             $this->removeSolutionRecordById($solution_id);
                         }
                     } else {
@@ -576,7 +582,15 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
                     }
                 } else {
                     if ($this->isFileReuseHandlingRequired()) {
-                        foreach ($_POST[self::REUSE_FILES_TBL_POSTVAR] as $solutionId) {
+                        $reuse_files = $this->http->wrapper()->post()->retrieve(
+                            self::REUSE_FILES_TBL_POSTVAR,
+                            $this->refinery->byTrying([
+                                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                                $this->refinery->always([])
+                            ])
+                        );
+
+                        foreach ($reuse_files as $solutionId) {
                             $solution = $this->getSolutionRecordById($solutionId);
 
                             $this->saveCurrentSolution(
@@ -629,10 +643,18 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     {
         $rids_to_delete = [];
         if ($this->isFileDeletionAction() && $this->isFileDeletionSubmitAvailable()) {
+            $delete_files = $this->http->wrapper()->post()->retrieve(
+                self::DELETE_FILES_TBL_POSTVAR,
+                $this->refinery->byTrying([
+                    $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                    $this->refinery->always([])
+                ])
+            );
+
             $res = $this->db->query(
                 "SELECT value1 FROM tst_solutions WHERE value2 = 'rid' AND " . $this->db->in(
                     'solution_id',
-                    $_POST[self::DELETE_FILES_TBL_POSTVAR],
+                    $delete_files,
                     false,
                     'integer'
                 )
@@ -696,7 +718,15 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
             // hey: prevPassSolutions - readability spree - get a chance to understand the code
             if ($this->isFileDeletionSubmitAvailable()) {
                 // hey.
-                $userSolution = $this->deletePreviewFileUploads($previewSession->getUserId(), $userSolution, $_POST['deletefiles']);
+                $delete_files = $this->http->wrapper()->post()->retrieve(
+                    self::DELETE_FILES_TBL_POSTVAR,
+                    $this->refinery->byTrying([
+                        $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                        $this->refinery->always([])
+                    ])
+                );
+
+                $userSolution = $this->deletePreviewFileUploads($previewSession->getUserId(), $userSolution, $delete_files);
             } else {
                 $this->tpl->setOnScreenMessage('info', $this->lng->txt('no_checkbox'), true);
             }

--- a/components/ILIAS/TestQuestionPool/classes/class.assFileUpload.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFileUpload.php
@@ -23,7 +23,6 @@ use ILIAS\Test\Participants\ParticipantRepository;
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
 use ILIAS\FileDelivery\Delivery\Disposition;
 use ILIAS\FileUpload\Exception\IllegalStateException;
-use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
  * Class for file upload questions
@@ -54,7 +53,6 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
     /** @var boolean Indicates whether completion by submission is enabled or not */
     protected $completion_by_submission = false;
-    private readonly RequestDataCollector $request_data_collector;
 
     /**
      * assFileUpload constructor
@@ -84,7 +82,6 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
         $local_dic = QuestionPoolDIC::dic();
         $this->participant_repository = $local_dic['participant_repository'];
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     /**
@@ -569,7 +566,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
                 if ($this->isFileDeletionAction()) {
                     if ($this->isFileDeletionSubmitAvailable()) {
-                        $delete_files = $this->request_data_collector->retrieveArraysOfInts(self::DELETE_FILES_TBL_POSTVAR);
+                        $delete_files = $this->test_request->retrieveArraysOfInts(self::DELETE_FILES_TBL_POSTVAR);
 
                         foreach ($delete_files as $solution_id) {
                             $this->removeSolutionRecordById($solution_id);
@@ -579,7 +576,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
                     }
                 } else {
                     if ($this->isFileReuseHandlingRequired()) {
-                        $reuse_files = $this->request_data_collector->retrieveArraysOfInts(self::REUSE_FILES_TBL_POSTVAR);
+                        $reuse_files = $this->test_request->retrieveArraysOfInts(self::REUSE_FILES_TBL_POSTVAR);
 
                         foreach ($reuse_files as $solutionId) {
                             $solution = $this->getSolutionRecordById($solutionId);
@@ -634,7 +631,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     {
         $rids_to_delete = [];
         if ($this->isFileDeletionAction() && $this->isFileDeletionSubmitAvailable()) {
-            $delete_files = $this->request_data_collector->retrieveArraysOfInts(self::DELETE_FILES_TBL_POSTVAR);
+            $delete_files = $this->test_request->retrieveArraysOfInts(self::DELETE_FILES_TBL_POSTVAR);
 
             $res = $this->db->query(
                 "SELECT value1 FROM tst_solutions WHERE value2 = 'rid' AND " . $this->db->in(
@@ -703,7 +700,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
             // hey: prevPassSolutions - readability spree - get a chance to understand the code
             if ($this->isFileDeletionSubmitAvailable()) {
                 // hey.
-                $delete_files = $this->request_data_collector->retrieveArraysOfInts(self::DELETE_FILES_TBL_POSTVAR);
+                $delete_files = $this->test_request->retrieveArraysOfInts(self::DELETE_FILES_TBL_POSTVAR);
 
                 $userSolution = $this->deletePreviewFileUploads($previewSession->getUserId(), $userSolution, $delete_files);
             } else {

--- a/components/ILIAS/TestQuestionPool/classes/class.assFileUpload.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFileUpload.php
@@ -566,7 +566,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
                 if ($this->isFileDeletionAction()) {
                     if ($this->isFileDeletionSubmitAvailable()) {
-                        $delete_files = $this->test_request->retrieveArraysOfInts(self::DELETE_FILES_TBL_POSTVAR);
+                        $delete_files = $this->questionpool_request->intArray(self::DELETE_FILES_TBL_POSTVAR);
 
                         foreach ($delete_files as $solution_id) {
                             $this->removeSolutionRecordById($solution_id);
@@ -576,7 +576,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
                     }
                 } else {
                     if ($this->isFileReuseHandlingRequired()) {
-                        $reuse_files = $this->test_request->retrieveArraysOfInts(self::REUSE_FILES_TBL_POSTVAR);
+                        $reuse_files = $this->questionpool_request->intArray(self::REUSE_FILES_TBL_POSTVAR);
 
                         foreach ($reuse_files as $solutionId) {
                             $solution = $this->getSolutionRecordById($solutionId);
@@ -631,7 +631,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     {
         $rids_to_delete = [];
         if ($this->isFileDeletionAction() && $this->isFileDeletionSubmitAvailable()) {
-            $delete_files = $this->test_request->retrieveArraysOfInts(self::DELETE_FILES_TBL_POSTVAR);
+            $delete_files = $this->questionpool_request->intArray(self::DELETE_FILES_TBL_POSTVAR);
 
             $res = $this->db->query(
                 "SELECT value1 FROM tst_solutions WHERE value2 = 'rid' AND " . $this->db->in(
@@ -700,7 +700,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
             // hey: prevPassSolutions - readability spree - get a chance to understand the code
             if ($this->isFileDeletionSubmitAvailable()) {
                 // hey.
-                $delete_files = $this->test_request->retrieveArraysOfInts(self::DELETE_FILES_TBL_POSTVAR);
+                $delete_files = $this->questionpool_request->intArray(self::DELETE_FILES_TBL_POSTVAR);
 
                 $userSolution = $this->deletePreviewFileUploads($previewSession->getUserId(), $userSolution, $delete_files);
             } else {

--- a/components/ILIAS/TestQuestionPool/classes/class.assFileUploadGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFileUploadGUI.php
@@ -74,33 +74,19 @@ class assFileUploadGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $points = $this->http->wrapper()->post()->retrieve(
-            'points',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always('0.0')
-            ])
-        );
+        $points = $this->request_data_collector->retrieveStringFromPost('points', '0.0');
 
         $this->object->setPoints((float) str_replace(',', '.', $points));
-        $this->object->setMaxSize($this->request->int('maxsize') !== 0 ? $this->request->int('maxsize') : null);
-
-        $allowed_extensions = $this->http->wrapper()->post()->retrieve(
-            'allowedextensions',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always('')
-            ])
+        $this->object->setMaxSize(
+            $this->request_data_collector->int('maxsize') !== 0
+                ? $this->request_data_collector->int('maxsize')
+                : null
         );
+
+        $allowed_extensions = $this->request_data_collector->retrieveStringFromPost('allowedextensions');
         $this->object->setAllowedExtensions($allowed_extensions);
 
-        $completion_by_submission = $this->http->wrapper()->post()->retrieve(
-            'completion_by_submission',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->int(),
-                $this->refinery->always(null)
-            ])
-        );
+        $completion_by_submission = $this->request_data_collector->retrieveIntValueFromPost('completion_by_submission');
         $this->object->setCompletionBySubmission($completion_by_submission === 1);
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assFileUploadGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFileUploadGUI.php
@@ -74,19 +74,11 @@ class assFileUploadGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $points = $this->request_data_collector->retrieveStringFromPost('points', '0.0');
+        $this->object->setPoints($this->request_data_collector->float('points'));
+        $this->object->setMaxSize($this->request_data_collector->int('maxsize') ?? null);
 
-        $this->object->setPoints((float) str_replace(',', '.', $points));
-        $this->object->setMaxSize(
-            $this->request_data_collector->int('maxsize') !== 0
-                ? $this->request_data_collector->int('maxsize')
-                : null
-        );
-
-        $allowed_extensions = $this->request_data_collector->retrieveStringFromPost('allowedextensions');
-        $this->object->setAllowedExtensions($allowed_extensions);
-
-        $completion_by_submission = $this->request_data_collector->retrieveIntValueFromPost('completion_by_submission');
+        $this->object->setAllowedExtensions($this->request_data_collector->string('allowedextensions'));
+        $completion_by_submission = $this->request_data_collector->int('completion_by_submission');
         $this->object->setCompletionBySubmission($completion_by_submission === 1);
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -98,15 +98,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
             }
 
             try {
-                $lifecycle = $this->http->wrapper()->post()->retrieve(
-                    'lifecycle',
-                    $this->refinery->byTrying([
-                        $this->refinery->kindlyTo()->string(),
-                        $this->refinery->always('')
-                    ])
-                );
-
-                $lifecycle = ilAssQuestionLifecycle::getInstance($lifecycle);
+                $lifecycle = ilAssQuestionLifecycle::getInstance($this->request_data_collector->string('lifecycle'));
                 $this->object->setLifecycle($lifecycle);
             } catch (ilTestQuestionPoolInvalidArgumentException $e) {
             }
@@ -782,29 +774,9 @@ class assFormulaQuestionGUI extends assQuestionGUI
      */
     public function checkInput(): bool
     {
-        $post = $this->http->wrapper()->post();
-
-        $title = $post->retrieve(
-            'title',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always(false)
-            ])
-        );
-        $author = $post->retrieve(
-            'author',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always(false)
-            ])
-        );
-        $question = $post->retrieve(
-            'question',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always(false)
-            ])
-        );
+        $title = $this->request_data_collector->retrieveStringFromPost('title');
+        $author = $this->request_data_collector->retrieveStringFromPost('author');
+        $question = $this->request_data_collector->retrieveStringFromPost('question');
 
         if (!$title || !$author || !$question) {
             $this->addErrorMessage($this->lng->txt('fill_out_all_required_fields'));

--- a/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -98,7 +98,15 @@ class assFormulaQuestionGUI extends assQuestionGUI
             }
 
             try {
-                $lifecycle = ilAssQuestionLifecycle::getInstance($_POST['lifecycle']);
+                $lifecycle = $this->http->wrapper()->post()->retrieve(
+                    'lifecycle',
+                    $this->refinery->byTrying([
+                        $this->refinery->kindlyTo()->string(),
+                        $this->refinery->always('')
+                    ])
+                );
+
+                $lifecycle = ilAssQuestionLifecycle::getInstance($lifecycle);
                 $this->object->setLifecycle($lifecycle);
             } catch (ilTestQuestionPoolInvalidArgumentException $e) {
             }
@@ -655,7 +663,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
                     $result_unit = $form->getItemByPostVar('unit_' . $result->getResult());
                     $rating_advanced = $form->getItemByPostVar('rating_advanced_' . $result->getResult());
                     if (((int) $result_unit->getValue() <= 0) && $rating_advanced->getChecked()) {
-                        unset($_POST['rating_advanced_' . $result->getResult()]);
+                        unset($_POST['rating_advanced_' . $result->getResult()]); // TODO
                         $rating_advanced->setDisabled(true);
                         $rating_advanced->setChecked(false);
                         $rating_advanced->setAlert($this->lng->txt('err_rating_advanced_not_allowed'));
@@ -774,11 +782,34 @@ class assFormulaQuestionGUI extends assQuestionGUI
      */
     public function checkInput(): bool
     {
-        if ((!$_POST["title"]) or (!$_POST["author"]) or (!$_POST["question"])) {
-            $this->addErrorMessage($this->lng->txt("fill_out_all_required_fields"));
+        $post = $this->http->wrapper()->post();
+
+        $title = $post->retrieve(
+            'title',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always(false)
+            ])
+        );
+        $author = $post->retrieve(
+            'author',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always(false)
+            ])
+        );
+        $question = $post->retrieve(
+            'question',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always(false)
+            ])
+        );
+
+        if (!$title || !$author || !$question) {
+            $this->addErrorMessage($this->lng->txt('fill_out_all_required_fields'));
             return false;
         }
-
 
         return true;
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -778,7 +778,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
         $author = $this->request_data_collector->string('author');
         $question = $this->request_data_collector->string('question');
 
-        if (!$title || !$author || !$question) {
+        if (empty($title) || empty($author) || empty($question)) {
             $this->addErrorMessage($this->lng->txt('fill_out_all_required_fields'));
             return false;
         }

--- a/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -179,8 +179,8 @@ class assFormulaQuestionGUI extends assQuestionGUI
                         $this->request_data_collector->int("result_type_{$result}")
                     );
                     $this->object->addResult($resObj);
-                    $available_units = $this->request_data_collector->retrieveArrayOfIntsFromPost("units_{$result}");
-                    if ($available_units !== null) {
+                    $available_units = $this->request_data_collector->intArray("units_{$result}");
+                    if (!empty($available_units)) {
                         $this->object->addResultUnits($resObj, $available_units);
                     }
                 }
@@ -774,9 +774,9 @@ class assFormulaQuestionGUI extends assQuestionGUI
      */
     public function checkInput(): bool
     {
-        $title = $this->request_data_collector->retrieveStringFromPost('title');
-        $author = $this->request_data_collector->retrieveStringFromPost('author');
-        $question = $this->request_data_collector->retrieveStringFromPost('question');
+        $title = $this->request_data_collector->string('title');
+        $author = $this->request_data_collector->string('author');
+        $question = $this->request_data_collector->string('question');
 
         if (!$title || !$author || !$question) {
             $this->addErrorMessage($this->lng->txt('fill_out_all_required_fields'));

--- a/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -63,7 +63,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
     public function suggestRange(): void
     {
         $this->setAdditionalContentEditingModeFromPost();
-        $suggest_range_for_result = $this->request->string('suggest_range_for');
+        $suggest_range_for_result = $this->request_data_collector->string('suggest_range_for');
         if ($this->writePostData()) {
             $this->tpl->setOnScreenMessage('info', $this->getErrorMessage());
         }
@@ -79,16 +79,16 @@ class assFormulaQuestionGUI extends assQuestionGUI
         $hasErrors = (!$always) ? $this->editQuestion(true) : false;
         $checked = true;
         if (!$hasErrors) {
-            $this->object->setTitle($this->request->string('title'));
-            $this->object->setAuthor($this->request->string('author'));
-            $this->object->setComment($this->request->string('comment'));
-            $this->object->setQuestion($this->request->string('question'));
+            $this->object->setTitle($this->request_data_collector->string('title'));
+            $this->object->setAuthor($this->request_data_collector->string('author'));
+            $this->object->setComment($this->request_data_collector->string('comment'));
+            $this->object->setQuestion($this->request_data_collector->string('question'));
 
             $this->object->parseQuestionText();
             $found_vars = [];
             $found_results = [];
 
-            foreach ($this->request->getParsedBody() as $key => $value) {
+            foreach ($this->request_data_collector->getParsedBody() as $key => $value) {
                 if (preg_match("/^unit_(\\\$v\d+)$/", $key, $matches)) {
                     array_push($found_vars, $matches[1]);
                 }
@@ -118,16 +118,16 @@ class assFormulaQuestionGUI extends assQuestionGUI
 
             foreach ($found_vars as $variable) {
                 if ($this->object->getVariable($variable) != null) {
-                    $unit = $this->request->int("unit_{$variable}");
+                    $unit = $this->request_data_collector->int("unit_{$variable}");
                     $varObj = new assFormulaQuestionVariable(
                         $variable,
-                        $this->request->float("range_min_{$variable}") ?? 0.0,
-                        $this->request->float("range_max_{$variable}") ?? 0.0,
+                        $this->request_data_collector->float("range_min_{$variable}") ?? 0.0,
+                        $this->request_data_collector->float("range_max_{$variable}") ?? 0.0,
                         $unit !== null ? $this->object->getUnitrepository()->getUnit(
                             $unit
                         ) : null,
-                        $this->request->float("precision_{$variable}"),
-                        $this->request->float("intprecision_{$variable}")
+                        $this->request_data_collector->float("precision_{$variable}"),
+                        $this->request_data_collector->float("intprecision_{$variable}")
                     );
                     $this->object->addVariable($varObj);
                 }
@@ -138,14 +138,14 @@ class assFormulaQuestionGUI extends assQuestionGUI
             foreach ($found_results as $result) {
                 $tmp_res_match = preg_match_all(
                     '/([$][v][0-9]*)/',
-                    $this->request->string("formula_{$result}"),
+                    $this->request_data_collector->string("formula_{$result}"),
                     $form_vars
                 );
                 $tmp_form_vars = array_merge($tmp_form_vars, $form_vars[0]);
 
                 $tmp_que_match = preg_match_all(
                     '/([$][v][0-9]*)/',
-                    $this->request->string('question'),
+                    $this->request_data_collector->string('question'),
                     $quest_vars
                 );
                 $tmp_quest_vars = array_merge($tmp_quest_vars, $quest_vars[0]);
@@ -168,26 +168,26 @@ class assFormulaQuestionGUI extends assQuestionGUI
             }
             foreach ($found_results as $result) {
                 if ($this->object->getResult($result) != null) {
-                    $unit = $this->request->int("unit_{$result}");
+                    $unit = $this->request_data_collector->int("unit_{$result}");
                     $resObj = new assFormulaQuestionResult(
                         $result,
-                        $this->request->float("range_min_{$result}") ?? 0.0,
-                        $this->request->float("range_max_{$result}") ?? 0.0,
-                        $this->request->float("tolerance_{$result}") ?? 0.0,
+                        $this->request_data_collector->float("range_min_{$result}") ?? 0.0,
+                        $this->request_data_collector->float("range_max_{$result}") ?? 0.0,
+                        $this->request_data_collector->float("tolerance_{$result}") ?? 0.0,
                         $unit !== null ? $this->object->getUnitrepository()->getUnit(
                             $unit
                         ) : null,
-                        $this->request->string("formula_{$result}"),
-                        $this->request->float("points_{$result}"),
-                        $this->request->float("precision_{$result}"),
-                        $this->request->int("rating_advanced_{$result}") !== 1,
-                        $this->request->int("rating_advanced_{$result}") === 1 ? $this->request->float("rating_sign_{$result}") : null,
-                        $this->request->int("rating_advanced_{$result}") === 1 ? $this->request->float("rating_value_{$result}") : null,
-                        $this->request->int("rating_advanced_{$result}") === 1 ? $this->request->float("rating_unit_{$result}") : null,
-                        $this->request->int("result_type_{$result}")
+                        $this->request_data_collector->string("formula_{$result}"),
+                        $this->request_data_collector->float("points_{$result}"),
+                        $this->request_data_collector->float("precision_{$result}"),
+                        $this->request_data_collector->int("rating_advanced_{$result}") !== 1,
+                        $this->request_data_collector->int("rating_advanced_{$result}") === 1 ? $this->request_data_collector->float("rating_sign_{$result}") : null,
+                        $this->request_data_collector->int("rating_advanced_{$result}") === 1 ? $this->request_data_collector->float("rating_value_{$result}") : null,
+                        $this->request_data_collector->int("rating_advanced_{$result}") === 1 ? $this->request_data_collector->float("rating_unit_{$result}") : null,
+                        $this->request_data_collector->int("result_type_{$result}")
                     );
                     $this->object->addResult($resObj);
-                    $available_units = $this->request->retrieveArrayOfIntsFromPost("units_{$result}");
+                    $available_units = $this->request_data_collector->retrieveArrayOfIntsFromPost("units_{$result}");
                     if ($available_units !== null) {
                         $this->object->addResultUnits($resObj, $available_units);
                     }
@@ -573,7 +573,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
         if ($save) {
             $found_vars = [];
             $found_results = [];
-            foreach ($this->request->getParsedBody() as $key => $value) {
+            foreach ($this->request_data_collector->getParsedBody() as $key => $value) {
                 if (preg_match("/^unit_(\\\$v\d+)$/", $key, $matches)) {
                     array_push($found_vars, $matches[1]);
                 }
@@ -583,7 +583,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
             }
 
 
-            foreach ($this->request->getParsedBody() as $key => $value) {
+            foreach ($this->request_data_collector->getParsedBody() as $key => $value) {
                 $item = $form->getItemByPostVar($key);
                 if ($item !== null) {
                     switch (get_class($item)) {
@@ -693,7 +693,7 @@ class assFormulaQuestionGUI extends assQuestionGUI
                 $errors = true;
                 $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_input_not_valid'));
             }
-            foreach ($this->request->getParsedBody() as $key => $value) {
+            foreach ($this->request_data_collector->getParsedBody() as $key => $value) {
                 $item = $form->getItemByPostVar($key);
                 if ($item !== null) {
                     switch (get_class($item)) {

--- a/components/ILIAS/TestQuestionPool/classes/class.assImagemapQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assImagemapQuestionGUI.php
@@ -227,10 +227,6 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->areaEditor('poly');
     }
 
-    /**
-     * Saves a shape of the area editor
-     * @throws ilCtrlException
-     */
     public function saveShape(): void
     {
         $coords = '';
@@ -262,9 +258,6 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->ctrl->redirect($this, 'editQuestion');
     }
 
-    /**
-     * @throws ilTemplateException|ilCtrlException
-     */
     public function areaEditor(string $shape = ''): void
     {
         if ($shape === '') {
@@ -273,7 +266,7 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
         $this->getQuestionTemplate();
 
-        $editorTpl = new ilTemplate('tpl.il_as_qpl_imagemap_question.html', true, true, 'components/ILIAS/TestQuestionPool');
+        $editor_tpl = new ilTemplate('tpl.il_as_qpl_imagemap_question.html', true, true, 'components/ILIAS/TestQuestionPool');
 
         $coords = [];
         $mapcoords = $this->request_data_collector->raw('image');
@@ -287,16 +280,16 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
             $coords[] = $cmd['areaEditor']['image'][0] . ',' . $cmd['areaEditor']['image'][1];
         }
         foreach ($coords as $value) {
-            $editorTpl->setCurrentBlock('hidden');
-            $editorTpl->setVariable('HIDDEN_NAME', 'image[mapcoords][]');
-            $editorTpl->setVariable('HIDDEN_VALUE', $value);
-            $editorTpl->parseCurrentBlock();
+            $editor_tpl->setCurrentBlock('hidden');
+            $editor_tpl->setVariable('HIDDEN_NAME', 'image[mapcoords][]');
+            $editor_tpl->setVariable('HIDDEN_VALUE', $value);
+            $editor_tpl->parseCurrentBlock();
         }
 
-        $editorTpl->setCurrentBlock('hidden');
-        $editorTpl->setVariable('HIDDEN_NAME', 'shape');
-        $editorTpl->setVariable('HIDDEN_VALUE', $shape);
-        $editorTpl->parseCurrentBlock();
+        $editor_tpl->setCurrentBlock('hidden');
+        $editor_tpl->setVariable('HIDDEN_NAME', 'shape');
+        $editor_tpl->setVariable('HIDDEN_VALUE', $shape);
+        $editor_tpl->parseCurrentBlock();
 
         $preview = new ilImagemapPreview($this->object->getImagePath() . $this->object->getImageFilename());
         foreach ($this->object->answers as $index => $answer) {
@@ -367,37 +360,34 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $preview->createPreview();
         $image_path = $this->object->getImagePathWeb() . $preview->getPreviewFilename($this->object->getImagePath(), $this->object->getImageFilename()) . '?img=' . time();
         if (!$hidearea) {
-            $editorTpl->setCurrentBlock('maparea');
-            $editorTpl->setVariable('IMAGEMAP_NAME', 'image');
+            $editor_tpl->setCurrentBlock('maparea');
+            $editor_tpl->setVariable('IMAGEMAP_NAME', 'image');
         } else {
-            $editorTpl->setCurrentBlock('imagearea');
-            $editorTpl->setVariable('ALT_IMAGE', $this->lng->txt('imagemap'));
+            $editor_tpl->setCurrentBlock('imagearea');
+            $editor_tpl->setVariable('ALT_IMAGE', $this->lng->txt('imagemap'));
         }
-        $editorTpl->setVariable('IMAGE_SOURCE', $image_path);
-        $editorTpl->parseCurrentBlock();
+        $editor_tpl->setVariable('IMAGE_SOURCE', $image_path);
+        $editor_tpl->parseCurrentBlock();
 
         if ($shape_title !== '') {
-            $editorTpl->setCurrentBlock('shapetitle');
-            $editorTpl->setVariable('VALUE_SHAPETITLE', $shape_title);
-            $editorTpl->parseCurrentBlock();
+            $editor_tpl->setCurrentBlock('shapetitle');
+            $editor_tpl->setVariable('VALUE_SHAPETITLE', $shape_title);
+            $editor_tpl->parseCurrentBlock();
         }
 
-        $editorTpl->setVariable('TEXT_IMAGEMAP', $this->lng->txt('imagemap'));
-        $editorTpl->setVariable('TEXT_SHAPETITLE', $this->lng->txt('ass_imap_hint'));
-        $editorTpl->setVariable('CANCEL', $this->lng->txt('cancel'));
-        $editorTpl->setVariable('SAVE', $this->lng->txt('save'));
-        $editorTpl->setVariable('DISABLED_SAVE', $disabled_save);
+        $editor_tpl->setVariable('TEXT_IMAGEMAP', $this->lng->txt('imagemap'));
+        $editor_tpl->setVariable('TEXT_SHAPETITLE', $this->lng->txt('ass_imap_hint'));
+        $editor_tpl->setVariable('CANCEL', $this->lng->txt('cancel'));
+        $editor_tpl->setVariable('SAVE', $this->lng->txt('save'));
+        $editor_tpl->setVariable('DISABLED_SAVE', $disabled_save);
 
         if (in_array($shape, assImagemapQuestion::AVAILABLE_SHAPES, true)) {
-            $editorTpl->setVariable('FORMACTION', $this->ctrl->getFormaction($this, 'add' . ucfirst($shape)));
+            $editor_tpl->setVariable('FORMACTION', $this->ctrl->getFormaction($this, 'add' . ucfirst($shape)));
         }
 
-        $this->tpl->setVariable('QUESTION_DATA', $editorTpl->get());
+        $this->tpl->setVariable('QUESTION_DATA', $editor_tpl->get());
     }
 
-    /**
-     * @throws ilCtrlException
-     */
     public function back(): void
     {
         $this->tpl->setOnScreenMessage('info', $this->lng->txt('msg_cancel'), true);

--- a/components/ILIAS/TestQuestionPool/classes/class.assKprimChoice.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assKprimChoice.php
@@ -601,7 +601,7 @@ class assKprimChoice extends assQuestion implements ilObjQuestionScoringAdjustab
         return 0;
     }
 
-    private function removeAnswerImage($position): void
+    public function removeAnswerImage($position): void
     {
         $answer = $this->getAnswer($position);
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assKprimChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assKprimChoiceGUI.php
@@ -80,19 +80,16 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
 
     public function removeImage(): void
     {
-        $cmd = $this->request_data_collector->retrieveNestedArraysOfStrings('cmd', 2, []);
-        $this->object->removeAnswerImage(key($cmd['removeImage'] ?? []));
-
+        $this->object->removeAnswerImage($this->request_data_collector->getCmdIndex('removeImage'));
         $this->object->saveToDb();
         $this->editQuestion();
     }
 
     public function downkprimanswers(): void
     {
-        $cmd = $this->request_data_collector->retrieveNestedArraysOfStrings('cmd', 2, []);
-
-        if (isset($cmd[__FUNCTION__]) && count($cmd[__FUNCTION__])) {
-            $this->object->moveAnswerDown(key($cmd[__FUNCTION__]));
+        $index = $this->request_data_collector->getCmdIndex(__FUNCTION__);
+        if (!empty($index)) {
+            $this->object->moveAnswerDown($index);
             $this->object->saveToDb();
         }
 
@@ -101,10 +98,9 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
 
     public function upkprimanswers(): void
     {
-        $cmd = $this->request_data_collector->retrieveNestedArraysOfStrings('cmd', 2, []);
-
-        if (isset($cmd[__FUNCTION__]) && count($cmd[__FUNCTION__])) {
-            $this->object->moveAnswerUp(key($cmd[__FUNCTION__]));
+        $index = $this->request_data_collector->getCmdIndex(__FUNCTION__);
+        if (!empty($index)) {
+            $this->object->moveAnswerUp($index);
             $this->object->saveToDb();
         }
 
@@ -122,8 +118,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
 
         if ($always && $answers_input instanceof ilFormPropertyGUI) {
             $answers_input->setIgnoreMissingUploadsEnabled(true);
-
-            $answer_input_postvar = $this->request_data_collector->retrieveNestedArraysOfStrings($answers_input->getPostVar(), 2, []);
+            $answer_input_postvar = $this->request_data_collector->strArray($answers_input->getPostVar(), 2);
 
             if (!$answers_input->checkUploads($answer_input_postvar)) {
                 $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_input_not_valid'));

--- a/components/ILIAS/TestQuestionPool/classes/class.assKprimChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assKprimChoiceGUI.php
@@ -72,7 +72,6 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
     protected function uploadImage(): void
     {
         $this->setAdditionalContentEditingModeFromPost();
-
         if ($this->writePostData(true) === 0) {
             $this->object->saveToDb();
             $this->editQuestion();
@@ -81,13 +80,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
 
     public function removeImage(): void
     {
-        $cmd = $this->http->wrapper()->post()->retrieve(
-            'cmd',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
-                $this->refinery->always([])
-            ])
-        );
+        $cmd = $this->request_data_collector->retrieveNestedArraysOfStrings('cmd', 2, []);
         $this->object->removeAnswerImage(key($cmd['removeImage'] ?? []));
 
         $this->object->saveToDb();
@@ -96,13 +89,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
 
     public function downkprimanswers(): void
     {
-        $cmd = $this->http->wrapper()->post()->retrieve(
-            'cmd',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
-                $this->refinery->always([])
-            ])
-        );
+        $cmd = $this->request_data_collector->retrieveNestedArraysOfStrings('cmd', 2, []);
 
         if (isset($cmd[__FUNCTION__]) && count($cmd[__FUNCTION__])) {
             $this->object->moveAnswerDown(key($cmd[__FUNCTION__]));
@@ -114,13 +101,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
 
     public function upkprimanswers(): void
     {
-        $cmd = $this->http->wrapper()->post()->retrieve(
-            'cmd',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
-                $this->refinery->always([])
-            ])
-        );
+        $cmd = $this->request_data_collector->retrieveNestedArraysOfStrings('cmd', 2, []);
 
         if (isset($cmd[__FUNCTION__]) && count($cmd[__FUNCTION__])) {
             $this->object->moveAnswerUp(key($cmd[__FUNCTION__]));
@@ -142,13 +123,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         if ($always && $answers_input instanceof ilFormPropertyGUI) {
             $answers_input->setIgnoreMissingUploadsEnabled(true);
 
-            $answer_input_postvar = $this->http->wrapper()->post()->retrieve(
-                $answers_input->getPostVar(),
-                $this->refinery->byTrying([
-                    $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
-                    $this->refinery->always([])
-                ])
-            );
+            $answer_input_postvar = $this->request_data_collector->retrieveNestedArraysOfStrings($answers_input->getPostVar(), 2, []);
 
             if (!$answers_input->checkUploads($answer_input_postvar)) {
                 $this->tpl->setOnScreenMessage('failure', $this->lng->txt('form_input_not_valid'));

--- a/components/ILIAS/TestQuestionPool/classes/class.assLongMenu.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assLongMenu.php
@@ -603,11 +603,12 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable,
             return [];
         }
 
+        $solution_submit = [];
         foreach ($answer as $key => $value) {
-            $solutionSubmit[$key] = $value;
+            $solution_submit[$key] = $value;
         }
 
-        return $solutionSubmit;
+        return $solution_submit;
     }
 
     protected function savePreviewData(ilAssQuestionPreviewSession $preview_session): void

--- a/components/ILIAS/TestQuestionPool/classes/class.assLongMenu.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assLongMenu.php
@@ -612,14 +612,7 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable,
 
     protected function savePreviewData(ilAssQuestionPreviewSession $preview_session): void
     {
-        $answer = $this->http->wrapper()->post()->retrieve(
-            'answer',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always([])
-            ])
-        );
-
+        $answer = $this->questionpool_request->retrieveArrayOfStringsFromPost('answer', []);
         $preview_session->setParticipantsSolution(array_map(static fn($value) => trim($value), $answer));
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assLongMenu.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assLongMenu.php
@@ -597,23 +597,16 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable,
 
     protected function getSolutionSubmit(): array
     {
-        $answer = $this->questionpool_request->retrieveArrayOfStringsFromPost('answer');
-
-        if ($answer === null) {
-            return [];
-        }
-
         $solution_submit = [];
-        foreach ($answer as $key => $value) {
+        foreach ($this->questionpool_request->strArray('answer') as $key => $value) {
             $solution_submit[$key] = $value;
         }
-
         return $solution_submit;
     }
 
     protected function savePreviewData(ilAssQuestionPreviewSession $preview_session): void
     {
-        $answer = $this->questionpool_request->retrieveArrayOfStringsFromPost('answer', []);
+        $answer = $this->questionpool_request->strArray('answer');
         $preview_session->setParticipantsSolution(array_map(static fn($value) => trim($value), $answer));
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assLongMenu.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assLongMenu.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 use ILIAS\TestQuestionPool\Questions\QuestionLMExportable;
 use ILIAS\TestQuestionPool\Questions\QuestionAutosaveable;
-
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
 
 class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable, QuestionLMExportable, QuestionAutosaveable
@@ -611,15 +610,17 @@ class assLongMenu extends assQuestion implements ilObjQuestionScoringAdjustable,
         return $solutionSubmit;
     }
 
-    protected function savePreviewData(ilAssQuestionPreviewSession $previewSession): void
+    protected function savePreviewData(ilAssQuestionPreviewSession $preview_session): void
     {
-        $answer = $_POST['answer'] ?? null;
-        if (is_array($answer)) {
-            $answer = array_map(function ($value) {
-                return trim($value);
-            }, $answer);
-        }
-        $previewSession->setParticipantsSolution($answer);
+        $answer = $this->http->wrapper()->post()->retrieve(
+            'answer',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([])
+            ])
+        );
+
+        $preview_session->setParticipantsSolution(array_map(static fn($value) => trim($value), $answer));
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.assLongMenuGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assLongMenuGUI.php
@@ -103,26 +103,26 @@ class assLongMenuGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjus
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
         $min_auto_complete = (int) $form->getInput('min_auto_complete');
-        $longmenu_text = $this->request->raw('longmenu_text') ?? '';
-        $hidden_text_files = $this->request->raw('hidden_text_files') ?? '';
-        $hidden_correct_answers = $this->request->raw('hidden_correct_answers') ?? [];
-        $long_menu_type = $this->request->raw('long_menu_type') ?? [];
+        $longmenu_text = $this->request_data_collector->raw('longmenu_text') ?? '';
+        $hidden_text_files = $this->request_data_collector->raw('hidden_text_files') ?? '';
+        $hidden_correct_answers = $this->request_data_collector->raw('hidden_correct_answers') ?? [];
+        $long_menu_type = $this->request_data_collector->raw('long_menu_type') ?? [];
         $this->object->setLongMenuTextValue(ilUtil::stripSlashes($longmenu_text));
         $this->object->setAnswers($this->trimArrayRecursive($this->stripSlashesRecursive(json_decode($hidden_text_files))));
         $this->object->setCorrectAnswers($this->trimArrayRecursive($this->stripSlashesRecursive(json_decode($hidden_correct_answers))));
         $this->object->setAnswerType(ilArrayUtil::stripSlashesRecursive($long_menu_type));
-        $this->object->setQuestion($this->request->raw('question'));
-        $this->object->setLongMenuTextValue($this->request->raw('longmenu_text'));
+        $this->object->setQuestion($this->request_data_collector->raw('question'));
+        $this->object->setLongMenuTextValue($this->request_data_collector->raw('longmenu_text'));
         $this->object->setMinAutoComplete($min_auto_complete);
-        $this->object->setIdenticalScoring($this->request->int('identical_scoring'));
+        $this->object->setIdenticalScoring($this->request_data_collector->int('identical_scoring'));
 
         $this->saveTaxonomyAssignments();
     }
 
     private function verifyAnswerOptions(): bool
     {
-        $longmenu_text = $this->request->raw('longmenu_text') ?? '';
-        $hidden_text_files = $this->request->raw('hidden_text_files') ?? '';
+        $longmenu_text = $this->request_data_collector->raw('longmenu_text') ?? '';
+        $hidden_text_files = $this->request_data_collector->raw('hidden_text_files') ?? '';
         $answer_options_from_text = preg_split(
             "/\\[" . assLongMenu::GAP_PLACEHOLDER . " (\\d+)\\]/",
             $longmenu_text
@@ -134,7 +134,7 @@ class assLongMenuGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjus
             return false;
         }
 
-        $correct_answers = $this->stripSlashesRecursive(json_decode($this->request->raw('hidden_correct_answers')));
+        $correct_answers = $this->stripSlashesRecursive(json_decode($this->request_data_collector->raw('hidden_correct_answers')));
         foreach ($correct_answers as $answer) {
             if (!is_numeric(str_replace(',', '.', $answer[1]))) {
                 $this->tpl->setOnScreenMessage('failure', $this->lng->txt('points_non_numeric_or_negative_msg'));
@@ -277,9 +277,9 @@ class assLongMenuGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjus
         ];
         $answers = $this->object->getAnswersObject();
 
-        if ($this->request->isset('hidden_text_files')) {
-            $question_parts['list'] = json_decode($this->request->raw('hidden_correct_answers')) ?? [];
-            $answers = $this->request->raw('hidden_text_files');
+        if ($this->request_data_collector->isset('hidden_text_files')) {
+            $question_parts['list'] = json_decode($this->request_data_collector->raw('hidden_correct_answers')) ?? [];
+            $answers = $this->request_data_collector->raw('hidden_text_files');
         }
 
         $this->tpl->addJavaScript('assets/js/longMenuQuestionGapBuilder.js');

--- a/components/ILIAS/TestQuestionPool/classes/class.assLongMenuGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assLongMenuGUI.php
@@ -103,16 +103,14 @@ class assLongMenuGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjus
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
         $min_auto_complete = (int) $form->getInput('min_auto_complete');
-        $longmenu_text = $this->request_data_collector->raw('longmenu_text') ?? '';
-        $hidden_text_files = $this->request_data_collector->raw('hidden_text_files') ?? '';
-        $hidden_correct_answers = $this->request_data_collector->raw('hidden_correct_answers') ?? [];
+        $hidden_text_files = $this->request_data_collector->string('hidden_text_files');
+        $hidden_correct_answers = $this->request_data_collector->string('hidden_correct_answers');
         $long_menu_type = $this->request_data_collector->raw('long_menu_type') ?? [];
-        $this->object->setLongMenuTextValue(ilUtil::stripSlashes($longmenu_text));
+        $this->object->setLongMenuTextValue($this->request_data_collector->string('longmenu_text'));
         $this->object->setAnswers($this->trimArrayRecursive($this->stripSlashesRecursive(json_decode($hidden_text_files))));
         $this->object->setCorrectAnswers($this->trimArrayRecursive($this->stripSlashesRecursive(json_decode($hidden_correct_answers))));
         $this->object->setAnswerType(ilArrayUtil::stripSlashesRecursive($long_menu_type));
-        $this->object->setQuestion($this->request_data_collector->raw('question'));
-        $this->object->setLongMenuTextValue($this->request_data_collector->raw('longmenu_text'));
+        $this->object->setQuestion($this->request_data_collector->string('question'));
         $this->object->setMinAutoComplete($min_auto_complete);
         $this->object->setIdenticalScoring($this->request_data_collector->int('identical_scoring'));
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
@@ -265,7 +265,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $cmd = $this->request->retrieveArrayOfIdentities('cmd');
+        $cmd = $this->testrequest->retrieveArrayOfIdentities('cmd');
         $this->object->deleteMatchingPair(key($cmd['removepairs'] ?? []));
         $this->editQuestion();
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
@@ -18,9 +18,6 @@
 
 declare(strict_types=1);
 
-use ILIAS\HTTP\Services as HTTPServices;
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * Matching question GUI representation
  *
@@ -37,22 +34,14 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
  */
 class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjustable, ilGuiAnswerScoringAdjustable
 {
-    protected HTTPServices $http;
-    protected RequestDataCollector $testrequest;
-
     public function __construct($id = -1)
     {
-        /** @var ILIAS\DI\Container $DIC */
-        global $DIC;
-        $this->http = $DIC['http'];
         parent::__construct();
         $this->object = new assMatchingQuestion();
         $this->setErrorMessage($this->lng->txt('msg_form_save_error'));
         if ($id >= 0) {
             $this->object->loadFromDb($id);
         }
-
-        $this->testrequest = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     /**
@@ -193,7 +182,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $cmd = $this->testrequest->retrieveArrayOfIdentities('cmd');
+        $cmd = $this->request_data_collector->retrieveArrayOfIdentities('cmd');
         $this->object->removeTermImage(key($cmd['removeimageterms'] ?? []));
         $this->editQuestion();
     }
@@ -209,7 +198,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $cmd = $this->testrequest->retrieveArrayOfIdentities('cmd');
+        $cmd = $this->request_data_collector->retrieveArrayOfIdentities('cmd');
         $this->object->removeDefinitionImage(key($cmd['removeimagedefinitions'] ?? []));
         $this->editQuestion();
     }
@@ -217,9 +206,8 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     public function addterms(): void
     {
         $this->setAdditionalContentEditingModeFromPost();
-        $this->writePostData(true); //FIXME
-        $cmd = $this->testrequest->retrieveArrayOfIdentities('cmd');
         $this->writePostData(true);
+        $cmd = $this->request_data_collector->retrieveArrayOfIdentities('cmd');
         $this->object->insertTerm(key($cmd['addterms'] ?? []) + 1);
         $this->editQuestion();
     }
@@ -227,9 +215,8 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     public function removeterms(): void
     {
         $this->setAdditionalContentEditingModeFromPost();
-        $this->writePostData(true); //FIXME
-        $cmd = $this->testrequest->retrieveArrayOfIdentities('cmd');
         $this->writePostData(true);
+        $cmd = $this->request_data_collector->retrieveArrayOfIdentities('cmd');
         $this->object->deleteTerm(key($cmd['removeterms'] ?? []));
         $this->editQuestion();
     }
@@ -238,7 +225,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $cmd = $this->testrequest->retrieveArrayOfIdentities('cmd');
+        $cmd = $this->request_data_collector->retrieveArrayOfIdentities('cmd');
         $this->object->insertDefinition(key($cmd['adddefinitions'] ?? []) + 1);
         $this->editQuestion();
     }
@@ -247,7 +234,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $cmd = $this->testrequest->retrieveArrayOfIdentities('cmd');
+        $cmd = $this->request_data_collector->retrieveArrayOfIdentities('cmd');
         $this->object->deleteDefinition(key($cmd['removedefinitions'] ?? []));
         $this->editQuestion();
     }
@@ -256,7 +243,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $cmd = $this->testrequest->retrieveArrayOfIdentities('cmd');
+        $cmd = $this->request_data_collector->retrieveArrayOfIdentities('cmd');
         $this->object->insertMatchingPair(key($cmd['addpairs'] ?? []) + 1);
         $this->editQuestion();
     }
@@ -265,7 +252,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $cmd = $this->testrequest->retrieveArrayOfIdentities('cmd');
+        $cmd = $this->request_data_collector->retrieveArrayOfIdentities('cmd');
         $this->object->deleteMatchingPair(key($cmd['removepairs'] ?? []));
         $this->editQuestion();
     }
@@ -921,9 +908,9 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
      */
     public function checkInput(): bool
     {
-        $title = $this->testrequest->retrieveStringFromPost('title');
-        $author = $this->testrequest->retrieveStringFromPost('author');
-        $question = $this->testrequest->retrieveStringFromPost('question');
+        $title = $this->request_data_collector->retrieveStringFromPost('title');
+        $author = $this->request_data_collector->retrieveStringFromPost('author');
+        $question = $this->request_data_collector->retrieveStringFromPost('question');
 
         return !(!$title || !$author || !$question);
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
@@ -906,7 +906,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $author = $this->request_data_collector->string('author');
         $question = $this->request_data_collector->string('question');
 
-        return !(!$title || !$author || !$question);
+        return !empty($title) && !empty($author) && !empty($question);
     }
 
     public function getSpecificFeedbackOutput(array $userSolution): string

--- a/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
@@ -69,16 +69,16 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->object->flushTerms();
         $this->object->flushDefinitions();
 
-        $r = $this->refinery->kindlyTo();
+        $kindlyTo = $this->refinery->kindlyTo();
 
         $uploads = $this->request_data_collector->getProcessedUploads();
         $allowed_mime_types = ['image/jpeg', 'image/png', 'image/gif'];
 
         if ($this->request_data_collector->isset('terms')) {
             $terms = $this->request_data_collector->raw('terms');
-            $answers = $this->request_helper->transformArray($terms, 'answer', $r->string());
-            $terms_image_names = $this->request_helper->transformArray($terms, 'imagename', $r->string());
-            $terms_identifiers = $this->request_helper->transformArray($terms, 'identifier', $r->int());
+            $answers = $this->request_helper->transformArray($terms, 'answer', $kindlyTo->string());
+            $terms_image_names = $this->request_helper->transformArray($terms, 'imagename', $kindlyTo->string());
+            $terms_identifiers = $this->request_helper->transformArray($terms, 'identifier', $kindlyTo->int());
 
             foreach ($answers as $index => $answer) {
                 $filename = $terms_image_names[$index] ?? '';
@@ -110,9 +110,9 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
         if ($this->request_data_collector->isset('definitions')) {
             $definitions = $this->request_data_collector->raw('definitions');
-            $answers = $this->request_helper->transformArray($definitions, 'answer', $r->string());
-            $definitions_image_names = $this->request_helper->transformArray($definitions, 'imagename', $r->string());
-            $definitions_identifiers = $this->request_helper->transformArray($definitions, 'identifier', $r->int());
+            $answers = $this->request_helper->transformArray($definitions, 'answer', $kindlyTo->string());
+            $definitions_image_names = $this->request_helper->transformArray($definitions, 'imagename', $kindlyTo->string());
+            $definitions_identifiers = $this->request_helper->transformArray($definitions, 'identifier', $kindlyTo->int());
 
             foreach ($answers as $index => $answer) {
                 $filename = $definitions_image_names[$index] ?? '';
@@ -143,9 +143,9 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
         if ($this->request_data_collector->isset('pairs')) {
             $pairs = $this->request_data_collector->raw('pairs');
-            $points_of_pairs = $this->request_helper->transformArray($pairs, 'points', $r->float());
-            $pair_terms = $this->request_helper->transformArray($pairs, 'term', $r->int());
-            $pair_definitions = $this->request_helper->transformArray($pairs, 'definition', $r->int());
+            $points_of_pairs = $this->request_helper->transformArray($pairs, 'points', $kindlyTo->float());
+            $pair_terms = $this->request_helper->transformArray($pairs, 'term', $kindlyTo->int());
+            $pair_definitions = $this->request_helper->transformArray($pairs, 'definition', $kindlyTo->int());
 
             foreach ($points_of_pairs as $index => $points) {
                 $term_id = $pair_terms[$index] ?? 0;

--- a/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
@@ -209,8 +209,15 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $position = key($_POST['cmd']['removeimageterms']);
-        $this->object->removeTermImage($position);
+        $cmd = $this->http->wrapper()->post()->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([])
+            ])
+        );
+        $this->object->removeTermImage(key($cmd['removeimageterms'] ?? []));
         $this->editQuestion();
     }
 
@@ -225,8 +232,15 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $position = key($_POST['cmd']['removeimagedefinitions']);
-        $this->object->removeDefinitionImage($position);
+        $cmd = $this->http->wrapper()->post()->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([])
+            ])
+        );
+        $this->object->removeDefinitionImage(key($cmd['removeimagedefinitions'] ?? []));
         $this->editQuestion();
     }
 
@@ -234,8 +248,16 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $position = key($_POST["cmd"]["addterms"]);
-        $this->object->insertTerm($position + 1);
+        $cmd = $this->http->wrapper()->post()->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([])
+            ])
+        );
+        $this->writePostData(true);
+        $this->object->insertTerm(key($cmd['addterms'] ?? []) + 1);
         $this->editQuestion();
     }
 
@@ -243,8 +265,16 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $position = key($_POST["cmd"]["removeterms"]);
-        $this->object->deleteTerm($position);
+        $cmd = $this->http->wrapper()->post()->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([]),
+            ])
+        );
+        $this->writePostData(true);
+        $this->object->deleteTerm(key($cmd['removeterms'] ?? []));
         $this->editQuestion();
     }
 
@@ -252,8 +282,15 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $position = key($_POST["cmd"]["adddefinitions"]);
-        $this->object->insertDefinition($position + 1);
+        $cmd = $this->http->wrapper()->post()->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([]),
+            ])
+        );
+        $this->object->insertDefinition(key($cmd['adddefinitions'] ?? []) + 1);
         $this->editQuestion();
     }
 
@@ -261,8 +298,15 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $position = key($_POST["cmd"]["removedefinitions"]);
-        $this->object->deleteDefinition($position);
+        $cmd = $this->http->wrapper()->post()->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([]),
+            ])
+        );
+        $this->object->deleteDefinition(key($cmd['removedefinitions'] ?? []));
         $this->editQuestion();
     }
 
@@ -270,8 +314,15 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $position = key($_POST["cmd"]["addpairs"]);
-        $this->object->insertMatchingPair($position + 1);
+        $cmd = $this->http->wrapper()->post()->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([]),
+            ])
+        );
+        $this->object->insertMatchingPair(key($cmd['addpairs'] ?? []) + 1);
         $this->editQuestion();
     }
 
@@ -279,8 +330,15 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     {
         $this->setAdditionalContentEditingModeFromPost();
         $this->writePostData(true);
-        $position = key($_POST["cmd"]["removepairs"]);
-        $this->object->deleteMatchingPair($position);
+        $cmd = $this->http->wrapper()->post()->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([]),
+            ])
+        );
+        $this->object->deleteMatchingPair(key($cmd['removepairs'] ?? []));
         $this->editQuestion();
     }
 
@@ -935,12 +993,30 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
     */
     public function checkInput(): bool
     {
-        if ($this->request->string('title') === ''
-            || $this->request->string('title') === ''
-            || $this->request->string('title') === 'question') {
-            return false;
-        }
-        return true;
+        $post = $this->http->wrapper()->post();
+        $title = $post->retrieve(
+            'title',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always('')
+            ])
+        );
+        $author = $post->retrieve(
+            'author',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always('')
+            ])
+        );
+        $question = $post->retrieve(
+            'question',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always('')
+            ])
+        );
+
+        return !(!$title || !$author || !$question);
     }
 
     public function getSpecificFeedbackOutput(array $userSolution): string

--- a/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
@@ -76,9 +76,9 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
         if ($this->request_data_collector->isset('terms')) {
             $terms = $this->request_data_collector->raw('terms');
-            $answers = $this->request_helper->transformArray($terms, 'answer', $kindlyTo->string());
-            $terms_image_names = $this->request_helper->transformArray($terms, 'imagename', $kindlyTo->string());
-            $terms_identifiers = $this->request_helper->transformArray($terms, 'identifier', $kindlyTo->int());
+            $answers = $this->forms_helper->transformArray($terms, 'answer', $kindlyTo->string());
+            $terms_image_names = $this->forms_helper->transformArray($terms, 'imagename', $kindlyTo->string());
+            $terms_identifiers = $this->forms_helper->transformArray($terms, 'identifier', $kindlyTo->int());
 
             foreach ($answers as $index => $answer) {
                 $filename = $terms_image_names[$index] ?? '';
@@ -110,9 +110,9 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
         if ($this->request_data_collector->isset('definitions')) {
             $definitions = $this->request_data_collector->raw('definitions');
-            $answers = $this->request_helper->transformArray($definitions, 'answer', $kindlyTo->string());
-            $definitions_image_names = $this->request_helper->transformArray($definitions, 'imagename', $kindlyTo->string());
-            $definitions_identifiers = $this->request_helper->transformArray($definitions, 'identifier', $kindlyTo->int());
+            $answers = $this->forms_helper->transformArray($definitions, 'answer', $kindlyTo->string());
+            $definitions_image_names = $this->forms_helper->transformArray($definitions, 'imagename', $kindlyTo->string());
+            $definitions_identifiers = $this->forms_helper->transformArray($definitions, 'identifier', $kindlyTo->int());
 
             foreach ($answers as $index => $answer) {
                 $filename = $definitions_image_names[$index] ?? '';
@@ -143,9 +143,9 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
         if ($this->request_data_collector->isset('pairs')) {
             $pairs = $this->request_data_collector->raw('pairs');
-            $points_of_pairs = $this->request_helper->transformArray($pairs, 'points', $kindlyTo->float());
-            $pair_terms = $this->request_helper->transformArray($pairs, 'term', $kindlyTo->int());
-            $pair_definitions = $this->request_helper->transformArray($pairs, 'definition', $kindlyTo->int());
+            $points_of_pairs = $this->forms_helper->transformArray($pairs, 'points', $kindlyTo->float());
+            $pair_terms = $this->forms_helper->transformArray($pairs, 'term', $kindlyTo->int());
+            $pair_definitions = $this->forms_helper->transformArray($pairs, 'definition', $kindlyTo->int());
 
             foreach ($points_of_pairs as $index => $points) {
                 $term_id = $pair_terms[$index] ?? 0;

--- a/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -50,7 +50,6 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
     public bool $is_singleline = true;
     public int $feedback_setting = 0;
     protected ?int $selection_limit = null;
-    protected RequestDataCollector $testrequest;
 
     public function setIsSingleline(bool $is_singleline): void
     {
@@ -83,7 +82,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         parent::__construct($title, $comment, $author, $owner, $question);
         $this->answers = [];
         $this->shuffle = true;
-        $this->testrequest = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
+        $this->test_request = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function getSelectionLimit(): ?int
@@ -391,7 +390,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
 
     protected function isForcedEmptySolution(array $solutionSubmit): bool
     {
-        $tst_force_form_diff_input = $this->testrequest->retrieveArrayOfStringsFromPost('tst_force_form_diff_input') ?? [];
+        $tst_force_form_diff_input = $this->test_request->retrieveArrayOfStringsFromPost('tst_force_form_diff_input') ?? [];
 
         return !count($solutionSubmit) && !empty($tst_force_form_diff_input);
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -385,13 +385,17 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         return true;
     }
 
-    protected function isForcedEmptySolution($solutionSubmit): bool
+    protected function isForcedEmptySolution(array $solutionSubmit): bool
     {
-        if (!count($solutionSubmit) && !empty($_POST['tst_force_form_diff_input'])) {
-            return true;
-        }
+        $tst_force_form_diff_input = $this->http->wrapper()->post()->retrieve(
+            'tst_force_form_diff_input',
+            $this->refinery->byTrying([
+              $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+              $this->refinery->always([])
+          ])
+        );
 
-        return false;
+        return !count($solutionSubmit) && !empty($tst_force_form_diff_input);
     }
 
     public function saveWorkingData(
@@ -399,9 +403,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         ?int $pass = null,
         bool $authorized = true
     ): bool {
-        if ($pass === null) {
-            $pass = ilObjTest::_getPass($active_id);
-        }
+        $pass = $pass ?? ilObjTest::_getPass($active_id);
 
         $answer = $this->getSolutionSubmit();
         $this->getProcessLocker()->executeUserSolutionUpdateLockOperation(

--- a/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -78,11 +78,9 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
         string $question = "",
         private int $output_type = self::OUTPUT_ORDER
     ) {
-        global $DIC;
         parent::__construct($title, $comment, $author, $owner, $question);
         $this->answers = [];
         $this->shuffle = true;
-        $this->test_request = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function getSelectionLimit(): ?int
@@ -390,8 +388,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
 
     protected function isForcedEmptySolution(array $solutionSubmit): bool
     {
-        $tst_force_form_diff_input = $this->test_request->retrieveArrayOfStringsFromPost('tst_force_form_diff_input') ?? [];
-
+        $tst_force_form_diff_input = $this->questionpool_request->strArray('tst_force_form_diff_input');
         return !count($solutionSubmit) && !empty($tst_force_form_diff_input);
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -629,9 +629,6 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         return ilLegacyFormElementsUtil::prepareTextareaOutput($output, true);
     }
 
-    /**
-     * @throws ilException
-     */
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
         $this->object->setShuffle($this->request_data_collector->bool('shuffle'));
@@ -667,8 +664,10 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         // Delete all existing answers and create new answers from the form data
         $this->object->flushAnswers();
 
-        $choice = $this->request_data_collector->rawArray('choice');
-        $choice = $this->cleanupAnswerText($choice, !$this->object->isSingleline());
+        $choice = $this->cleanupAnswerText(
+            $this->request_data_collector->rawArray('choice'),
+            !$this->object->isSingleline()
+        );
 
         if (!$this->object->isSingleline()) {
             foreach ($choice['answer'] as $index => $answer) {

--- a/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -168,7 +168,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
     public function addchoice(): void
     {
         $this->writePostData(true);
-        $position = key($this->request->raw('cmd')['addchoice']);
+        $position = key($this->testrequest->raw('cmd')['addchoice']);
         $this->object->addAnswer("", 0, $position + 1);
         $this->editQuestion();
     }
@@ -176,7 +176,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
     public function removechoice(): void
     {
         $this->writePostData(true);
-        $position = key($this->request->raw('cmd')['removechoice']);
+        $position = key($this->testrequest->raw('cmd')['removechoice']);
         $this->object->deleteAnswer($position);
         $this->editQuestion();
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assNumeric.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assNumeric.php
@@ -19,7 +19,6 @@
 declare(strict_types=1);
 
 use ILIAS\TestQuestionPool\Questions\QuestionAutosaveable;
-
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
 
 /**
@@ -212,7 +211,7 @@ class assNumeric extends assQuestion implements ilObjQuestionScoringAdjustable, 
 
     protected function getSolutionSubmit(): ?float
     {
-        return $this->questionpool_request->retrieveFloatValueFromPost('numeric_result');
+        return $this->questionpool_request->float('numeric_result') ?? null;
     }
 
     public function isValidSolutionSubmit($numeric_solution): bool

--- a/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
@@ -284,19 +284,14 @@ class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjust
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $this->object->setMaxChars($this->request_data_collector->retrieveIntValueFromPost('maxchars') ?? 6);
+        $this->object->setMaxChars($this->request_data_collector->int('maxchars') ?? 6);
     }
 
     public function writeAnswerSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $lowerlimit = $this->request_data_collector->retrieveFloatValueFromPost('lowerlimit') ?? 0.0;
-        $this->object->setLowerLimit($lowerlimit);
-
-        $upperlimit = $this->request_data_collector->retrieveFloatValueFromPost('upperlimit') ?? 0.0;
-        $this->object->setUpperLimit($upperlimit);
-
-        $points = $this->request_data_collector->retrieveStringValueFromPost('points') ?? '0.0';
-        $this->object->setPoints((float) str_replace(',', '.', $points));
+        $this->object->setLowerLimit($this->request_data_collector->float('lowerlimit'));
+        $this->object->setUpperLimit($this->request_data_collector->float('upperlimit'));
+        $this->object->setPoints($this->request_data_collector->float('points'));
     }
 
     public function populateQuestionSpecificFormPart(\ilPropertyFormGUI $form): ilPropertyFormGUI

--- a/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
@@ -15,6 +15,8 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
  * Numeric question GUI representation
  *
@@ -33,6 +35,8 @@
  */
 class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjustable, ilGuiAnswerScoringAdjustable
 {
+    protected RequestDataCollector $testrequest;
+
     /**
      * assNumericGUI constructor
      *
@@ -42,11 +46,13 @@ class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjust
      */
     public function __construct($id = -1)
     {
+        global $DIC;
         parent::__construct();
         $this->object = new assNumeric();
         if ($id >= 0) {
             $this->object->loadFromDb($id);
         }
+        $this->testrequest = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function getCommand($cmd)
@@ -284,44 +290,18 @@ class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjust
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $this->object->setMaxChars($this->http->wrapper()->post()->retrieve(
-            'maxchars',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->int(),
-                $this->refinery->always(6)
-            ])
-        ));
+        $this->object->setMaxChars($this->testrequest->retrieveIntValueFromPost('maxchars') ?? 6);
     }
 
     public function writeAnswerSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $post = $this->http->wrapper()->post();
-
-        $lowerlimit = $post->retrieve(
-            'lowerlimit',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->float(),
-                $this->refinery->always(0.0)
-            ])
-        );
+        $lowerlimit = $this->testrequest->retrieveFloatValueFromPost('lowerlimit') ?? 0.0;
         $this->object->setLowerLimit($lowerlimit);
 
-        $upperlimit = $post->retrieve(
-            'upperlimit',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->float(),
-                $this->refinery->always(0.0)
-            ])
-        );
+        $upperlimit = $this->testrequest->retrieveFloatValueFromPost('upperlimit') ?? 0.0;
         $this->object->setUpperLimit($upperlimit);
 
-        $points = $post->retrieve(
-            'points',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always('0.0')
-            ])
-        );
+        $points = $this->testrequest->retrieveStringValueFromPost('points') ?? '0.0';
         $this->object->setPoints((float) str_replace(',', '.', $points));
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
@@ -284,14 +284,45 @@ class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjust
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $this->object->setMaxChars($_POST["maxchars"]);
+        $this->object->setMaxChars($this->http->wrapper()->post()->retrieve(
+            'maxchars',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->int(),
+                $this->refinery->always(6)
+            ])
+        ));
     }
 
     public function writeAnswerSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $this->object->setLowerLimit($_POST['lowerlimit']);
-        $this->object->setUpperLimit($_POST['upperlimit']);
-        $this->object->setPoints((float) str_replace(',', '.', $_POST['points']));
+        $post = $this->http->wrapper()->post();
+
+        $lowerlimit = $post->retrieve(
+            'lowerlimit',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->float(),
+                $this->refinery->always(0.0)
+            ])
+        );
+        $this->object->setLowerLimit($lowerlimit);
+
+        $upperlimit = $post->retrieve(
+            'upperlimit',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->float(),
+                $this->refinery->always(0.0)
+            ])
+        );
+        $this->object->setUpperLimit($upperlimit);
+
+        $points = $post->retrieve(
+            'points',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always('0.0')
+            ])
+        );
+        $this->object->setPoints((float) str_replace(',', '.', $points));
     }
 
     public function populateQuestionSpecificFormPart(\ilPropertyFormGUI $form): ilPropertyFormGUI

--- a/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
@@ -15,8 +15,6 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * Numeric question GUI representation
  *
@@ -35,8 +33,6 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
  */
 class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjustable, ilGuiAnswerScoringAdjustable
 {
-    protected RequestDataCollector $testrequest;
-
     /**
      * assNumericGUI constructor
      *
@@ -46,13 +42,11 @@ class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjust
      */
     public function __construct($id = -1)
     {
-        global $DIC;
         parent::__construct();
         $this->object = new assNumeric();
         if ($id >= 0) {
             $this->object->loadFromDb($id);
         }
-        $this->testrequest = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function getCommand($cmd)
@@ -290,18 +284,18 @@ class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjust
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $this->object->setMaxChars($this->testrequest->retrieveIntValueFromPost('maxchars') ?? 6);
+        $this->object->setMaxChars($this->request_data_collector->retrieveIntValueFromPost('maxchars') ?? 6);
     }
 
     public function writeAnswerSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $lowerlimit = $this->testrequest->retrieveFloatValueFromPost('lowerlimit') ?? 0.0;
+        $lowerlimit = $this->request_data_collector->retrieveFloatValueFromPost('lowerlimit') ?? 0.0;
         $this->object->setLowerLimit($lowerlimit);
 
-        $upperlimit = $this->testrequest->retrieveFloatValueFromPost('upperlimit') ?? 0.0;
+        $upperlimit = $this->request_data_collector->retrieveFloatValueFromPost('upperlimit') ?? 0.0;
         $this->object->setUpperLimit($upperlimit);
 
-        $points = $this->testrequest->retrieveStringValueFromPost('points') ?? '0.0';
+        $points = $this->request_data_collector->retrieveStringValueFromPost('points') ?? '0.0';
         $this->object->setPoints((float) str_replace(',', '.', $points));
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontal.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontal.php
@@ -186,7 +186,7 @@ class assOrderingHorizontal extends assQuestion implements ilObjQuestionScoringA
 
     protected function getSolutionSubmit(): string
     {
-        return $this->questionpool_request->retrieveStringValueFromPost('orderresult');
+        return $this->questionpool_request->string('orderresult');
     }
 
     public function saveWorkingData(

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
@@ -294,9 +294,9 @@ class assOrderingHorizontalGUI extends assQuestionGUI implements ilGuiQuestionSc
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $this->object->setTextSize((float) str_replace(',', '.', $this->request_data_collector->raw('textsize') ?? '0.0'));
+        $this->object->setTextSize($this->request_data_collector->float('textsize'));
         $this->object->setOrderText($this->request_data_collector->raw('ordertext'));
-        $this->object->setPoints((float) str_replace(',', '.', $this->request_data_collector->raw('points')));
+        $this->object->setPoints($this->request_data_collector->float('points'));
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
@@ -294,9 +294,9 @@ class assOrderingHorizontalGUI extends assQuestionGUI implements ilGuiQuestionSc
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $this->object->setTextSize((float) str_replace(',', '.', $this->request->raw('textsize') ?? '0.0'));
-        $this->object->setOrderText($this->request->raw('ordertext'));
-        $this->object->setPoints((float) str_replace(',', '.', $this->request->raw('points')));
+        $this->object->setTextSize((float) str_replace(',', '.', $this->request_data_collector->raw('textsize') ?? '0.0'));
+        $this->object->setOrderText($this->request_data_collector->raw('ordertext'));
+        $this->object->setPoints((float) str_replace(',', '.', $this->request_data_collector->raw('points')));
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestion.php
@@ -1025,14 +1025,6 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
     }
 
     /**
-     * @return array
-     */
-    public function getSolutionPostSubmit(): array
-    {
-        return $this->fetchSolutionSubmit($_POST);
-    }
-
-    /**
      * @param $user_order
      * @param $nested_solution
      * @return int

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestion.php
@@ -1181,7 +1181,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
                     }
                 }
             }
-        } elseif ($this->getOrderingType() == OQ_NESTED_TERMS || $this->getOrderingType() == OQ_NESTED_PICTURES) {
+        } elseif ($this->getOrderingType() == self::OQ_NESTED_TERMS || $this->getOrderingType() == self::OQ_NESTED_PICTURES) {
             $index = 0;
             foreach ($form_submission_data_structure['content'] as $randomId => $content) {
                 $indentation = $form_submission_data_structure['indentation'];

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
@@ -73,7 +73,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->object->setContentType($this->object::OQ_CT_PICTURES);
         $this->object->saveToDb();
 
-        $values = $this->request->getParsedBody();
+        $values = $this->request_data_collector->getParsedBody();
         $values['thumb_geometry'] = $this->object->getThumbSize();
         $this->buildEditFormAfterTypeChange($values);
     }
@@ -88,7 +88,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $this->object->setContentType($this->object::OQ_CT_TERMS);
         $this->object->saveToDb();
 
-        $this->buildEditFormAfterTypeChange($this->request->getParsedBody());
+        $this->buildEditFormAfterTypeChange($this->request_data_collector->getParsedBody());
     }
 
     private function buildEditFormAfterTypeChange(array $values): void
@@ -110,7 +110,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $form = $this->buildNestingForm();
         $form->setValuesByPost();
         if ($form->checkInput()) {
-            $post = $this->request->raw(self::F_NESTED_ORDER);
+            $post = $this->request_data_collector->raw(self::F_NESTED_ORDER);
             $list = $this->object->getOrderingElementList();
 
             $ordered = [];
@@ -180,16 +180,16 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $thumb_size = $this->request->int('thumb_geometry');
+        $thumb_size = $this->request_data_collector->int('thumb_geometry');
         if ($thumb_size !== 0
             && $thumb_size !== $this->object->getThumbSize()) {
             $this->object->setThumbSize($thumb_size);
             $this->updateImageFiles();
         }
 
-        $this->object->setPoints($this->request->float('points'));
+        $this->object->setPoints($this->request_data_collector->float('points'));
 
-        $use_nested = $this->request->int(self::F_USE_NESTED) === 1;
+        $use_nested = $this->request_data_collector->int(self::F_USE_NESTED) === 1;
         $this->object->setNestingType($use_nested);
     }
 
@@ -199,7 +199,7 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $list = $form->getItemByPostVar(assOrderingQuestion::ORDERING_ELEMENT_FORM_FIELD_POSTVAR)
             ->getElementList($this->object->getId());
 
-        $use_nested = $this->request->int(self::F_USE_NESTED) === 1;
+        $use_nested = $this->request_data_collector->int(self::F_USE_NESTED) === 1;
 
         if ($use_nested) {
             $existing_list = $this->object->getOrderingElementList();

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
@@ -84,6 +84,7 @@ abstract class assQuestion implements Question
     protected \ilAssQuestionLifecycle $lifecycle;
     public \ilAssQuestionFeedback $feedbackOBJ;
     protected \ilAssQuestionPage $page;
+    protected RequestDataCollector $testrequest;
 
     protected int $id;
     protected string $title;
@@ -139,6 +140,7 @@ abstract class assQuestion implements Question
         $this->log = $ilLog;
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
+        $this->testrequest = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
 
         $this->thumb_size = self::DEFAULT_THUMB_SIZE;
 
@@ -221,13 +223,7 @@ abstract class assQuestion implements Question
 
     protected function getQuestionAction(): string
     {
-        $cmd = $this->http->wrapper()->post()->retrieve(
-            'cmd',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always(null)
-            ])
-        );
+        $cmd = $this->testrequest->retrieveArrayOfStringsFromPost('cmd');
 
         if (
             !isset($cmd[$this->questionActionCmd])
@@ -242,13 +238,7 @@ abstract class assQuestion implements Question
 
     protected function isNonEmptyItemListPostSubmission(string $post_submission_field_name): bool
     {
-        return !empty($this->http->wrapper()->post()->retrieve(
-            $post_submission_field_name,
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always([])
-            ])
-        ));
+        return !empty($this->testrequest->retrieveArrayOfStringsFromPost($post_submission_field_name) ?? []);
     }
 
     public function getCurrentUser(): ilObjUser

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
@@ -221,32 +221,34 @@ abstract class assQuestion implements Question
 
     protected function getQuestionAction(): string
     {
-        if (!isset($_POST['cmd']) || !isset($_POST['cmd'][$this->questionActionCmd])) {
+        $cmd = $this->http->wrapper()->post()->retrieve(
+            'cmd',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always(null)
+            ])
+        );
+
+        if (
+            !isset($cmd[$this->questionActionCmd])
+            || !is_array($cmd[$this->questionActionCmd])
+            || empty($cmd[$this->questionActionCmd])
+        ) {
             return '';
         }
 
-        if (!is_array($_POST['cmd'][$this->questionActionCmd]) || $_POST['cmd'][$this->questionActionCmd] === []) {
-            return '';
-        }
-
-        return key($_POST['cmd'][$this->questionActionCmd]);
+        return key($cmd[$this->questionActionCmd]);
     }
 
-    protected function isNonEmptyItemListPostSubmission(string $postSubmissionFieldname): bool
+    protected function isNonEmptyItemListPostSubmission(string $post_submission_field_name): bool
     {
-        if (!isset($_POST[$postSubmissionFieldname])) {
-            return false;
-        }
-
-        if (!is_array($_POST[$postSubmissionFieldname])) {
-            return false;
-        }
-
-        if (!count($_POST[$postSubmissionFieldname])) {
-            return false;
-        }
-
-        return true;
+        return !empty($this->http->wrapper()->post()->retrieve(
+            $post_submission_field_name,
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always([])
+            ])
+        ));
     }
 
     public function getCurrentUser(): ilObjUser

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
@@ -84,7 +84,6 @@ abstract class assQuestion implements Question
     protected \ilAssQuestionLifecycle $lifecycle;
     public \ilAssQuestionFeedback $feedbackOBJ;
     protected \ilAssQuestionPage $page;
-    protected RequestDataCollector $test_request;
 
     protected int $id;
     protected string $title;
@@ -140,7 +139,6 @@ abstract class assQuestion implements Question
         $this->log = $ilLog;
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
-        $this->test_request = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
 
         $this->thumb_size = self::DEFAULT_THUMB_SIZE;
 
@@ -223,22 +221,12 @@ abstract class assQuestion implements Question
 
     protected function getQuestionAction(): string
     {
-        $cmd = $this->test_request->retrieveArrayOfStringsFromPost('cmd');
-
-        if (
-            !isset($cmd[$this->questionActionCmd])
-            || !is_array($cmd[$this->questionActionCmd])
-            || empty($cmd[$this->questionActionCmd])
-        ) {
-            return '';
-        }
-
-        return key($cmd[$this->questionActionCmd]);
+        return $this->questionpool_request->getCmdIndex($this->questionActionCmd);
     }
 
     protected function isNonEmptyItemListPostSubmission(string $post_submission_field_name): bool
     {
-        return !empty($this->test_request->retrieveArrayOfStringsFromPost($post_submission_field_name) ?? []);
+        return !empty($this->questionpool_request->strArray($post_submission_field_name));
     }
 
     public function getCurrentUser(): ilObjUser
@@ -692,9 +680,9 @@ abstract class assQuestion implements Question
     }
 
     /**
-    * Returns the image path for web accessable images of a question.
-    * The image path is under the CLIENT_WEB_DIR in assessment/REFERENCE_ID_OF_QUESTION_POOL/ID_OF_QUESTION/images
-    */
+     * Returns the image path for web accessable images of a question.
+     * The image path is under the CLIENT_WEB_DIR in assessment/REFERENCE_ID_OF_QUESTION_POOL/ID_OF_QUESTION/images
+     */
     public function getImagePath($question_id = null, $object_id = null): string
     {
         if ($question_id === null) {
@@ -1152,11 +1140,11 @@ abstract class assQuestion implements Question
     }
 
     /**
-    * Creates a new question without an owner when a new question is created
-    * This assures that an ID is given to the question if a file upload or something else occurs
-    *
-    * @return integer ID of the new question
-    */
+     * Creates a new question without an owner when a new question is created
+     * This assures that an ID is given to the question if a file upload or something else occurs
+     *
+     * @return integer ID of the new question
+     */
     public function createNewQuestion(bool $a_create_page = true): int
     {
         $complete = '0';
@@ -1248,7 +1236,7 @@ abstract class assQuestion implements Question
             'complete' => ['integer', $this->isComplete()],
             "external_id" => ["text", $this->getExternalId()]
         ], [
-        "question_id" => ["integer", $this->getId()]
+            "question_id" => ["integer", $this->getId()]
         ]);
     }
 
@@ -1552,8 +1540,8 @@ abstract class assQuestion implements Question
     }
 
     /**
-    * Duplicates the files of a suggested solution if the question is duplicated
-    */
+     * Duplicates the files of a suggested solution if the question is duplicated
+     */
     protected function duplicateSuggestedSolutionFiles(int $parent_id, int $question_id): void
     {
         foreach ($this->suggested_solutions as $solution) {
@@ -1796,8 +1784,8 @@ abstract class assQuestion implements Question
     }
 
     /**
-    * Returns the maximum pass a users question solution
-    */
+     * Returns the maximum pass a users question solution
+     */
     public static function _getSolutionMaxPass(int $question_id, int $active_id): ?int
     {
         // the following code was the old solution which added the non answered
@@ -1896,15 +1884,15 @@ abstract class assQuestion implements Question
     }
 
     /**
-    * Sets the points, a learner has reached answering the question
-    * Additionally objective results are updated
-    *
-    * @param integer $user_id The database ID of the learner
-    * @param integer $test_id The database Id of the test containing the question
-    * @param integer $points The points the user has reached answering the question
-    * @return boolean true on success, otherwise false
-    * @access public
-    */
+     * Sets the points, a learner has reached answering the question
+     * Additionally objective results are updated
+     *
+     * @param integer $user_id The database ID of the learner
+     * @param integer $test_id The database Id of the test containing the question
+     * @param integer $points The points the user has reached answering the question
+     * @return boolean true on success, otherwise false
+     * @access public
+     */
     public static function _setReachedPoints(
         int $active_id,
         int $question_id,
@@ -2111,11 +2099,11 @@ abstract class assQuestion implements Question
     }
 
     /**
-    * Returns the user id and the test id for a given active id
-    *
-    * @param integer $active_id Active id for a test/user
-    * @return array Result array containing the user_id and test_id
-    */
+     * Returns the user id and the test id for a given active id
+     *
+     * @param integer $active_id Active id for a test/user
+     * @return array Result array containing the user_id and test_id
+     */
     public function getActiveUserData(int $active_id): array
     {
         $result = $this->db->queryF(

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestion.php
@@ -84,7 +84,7 @@ abstract class assQuestion implements Question
     protected \ilAssQuestionLifecycle $lifecycle;
     public \ilAssQuestionFeedback $feedbackOBJ;
     protected \ilAssQuestionPage $page;
-    protected RequestDataCollector $testrequest;
+    protected RequestDataCollector $test_request;
 
     protected int $id;
     protected string $title;
@@ -140,7 +140,7 @@ abstract class assQuestion implements Question
         $this->log = $ilLog;
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
-        $this->testrequest = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
+        $this->test_request = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
 
         $this->thumb_size = self::DEFAULT_THUMB_SIZE;
 
@@ -223,7 +223,7 @@ abstract class assQuestion implements Question
 
     protected function getQuestionAction(): string
     {
-        $cmd = $this->testrequest->retrieveArrayOfStringsFromPost('cmd');
+        $cmd = $this->test_request->retrieveArrayOfStringsFromPost('cmd');
 
         if (
             !isset($cmd[$this->questionActionCmd])
@@ -238,7 +238,7 @@ abstract class assQuestion implements Question
 
     protected function isNonEmptyItemListPostSubmission(string $post_submission_field_name): bool
     {
-        return !empty($this->testrequest->retrieveArrayOfStringsFromPost($post_submission_field_name) ?? []);
+        return !empty($this->test_request->retrieveArrayOfStringsFromPost($post_submission_field_name) ?? []);
     }
 
     public function getCurrentUser(): ilObjUser

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestDataCollector;
-use ILIAS\TestQuestionPool\RequestValidationHelper;
+use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 use ILIAS\TestQuestionPool\Questions\QuestionAutosaveable;
 use ILIAS\TestQuestionPool\Questions\SuggestedSolution\SuggestedSolution;
 use ILIAS\TestQuestionPool\Questions\SuggestedSolution\SuggestedSolutionsDatabaseRepository;
@@ -151,7 +151,7 @@ abstract class assQuestionGUI
     private bool $previousSolutionPrefilled = false;
 
     protected ilPropertyFormGUI $editForm;
-    protected readonly RequestValidationHelper $request_helper;
+    protected readonly ilTestLegacyFormsHelper $forms_helper;
     protected readonly RequestDataCollector $request_data_collector;
     protected bool $parent_type_is_lm = false;
 
@@ -182,7 +182,7 @@ abstract class assQuestionGUI
         $this->refinery = $DIC['refinery'];
 
         $local_dic = QuestionPoolDIC::dic();
-        $this->request_helper = $local_dic['request_validation_helper'];
+        $this->forms_helper = new ilTestLegacyFormsHelper();
         $this->request_data_collector = $local_dic['request_data_collector'];
         $this->questionrepository = $local_dic['question.general_properties.repository'];
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -24,7 +24,6 @@ use ILIAS\TestQuestionPool\Questions\QuestionAutosaveable;
 use ILIAS\TestQuestionPool\Questions\SuggestedSolution\SuggestedSolution;
 use ILIAS\TestQuestionPool\Questions\SuggestedSolution\SuggestedSolutionsDatabaseRepository;
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
-use ILIAS\HTTP\Services as Http;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Notes\GUIService;
 
@@ -121,7 +120,6 @@ abstract class assQuestionGUI
     protected ilGlobalPageTemplate $tpl;
     protected ilLanguage $lng;
     protected Refinery $refinery;
-    protected Http $http;
 
     protected $error;
     protected string $errormessage;
@@ -179,7 +177,6 @@ abstract class assQuestionGUI
         $this->logger = $DIC['ilLog'];
         $this->component_repository = $DIC['component.repository'];
         $this->refinery = $DIC['refinery'];
-        $this->http = $DIC->http();
 
         $local_dic = QuestionPoolDIC::dic();
         $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
@@ -1287,9 +1284,6 @@ abstract class assQuestionGUI
         $this->tpl->setVariable("ADM_CONTENT", $template->get());
     }
 
-    /**
-     * @throws ilCtrlException
-     */
     public function saveSuggestedSolutionType(): void
     {
         $solution_type = $this->request_data_collector->retrieveStringFromPost('solutiontype');

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -744,7 +744,7 @@ abstract class assQuestionGUI
 
     public function setAdditionalContentEditingModeFromPost(): void
     {
-        $additional_content_editing_mode = $this->request->retrieveStringValueFromPost('additional_content_editing_mode');
+        $additional_content_editing_mode = $this->request_data_collector->retrieveStringValueFromPost('additional_content_editing_mode');
         if ($additional_content_editing_mode !== null
             && in_array($additional_content_editing_mode, $this->object->getValidAdditionalContentEditingModes())) {
             $this->object->setAdditionalContentEditingMode($additional_content_editing_mode);

--- a/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -191,7 +191,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
     public function addchoice(): void
     {
         $this->writePostData(true);
-        $position = key($this->request->raw('cmd')['addchoice']);
+        $position = key($this->request_data_collector->raw('cmd')['addchoice']);
         $this->object->addAnswer("", 0, $position + 1);
         $this->editQuestion();
     }
@@ -199,7 +199,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
     public function removechoice(): void
     {
         $this->writePostData(true);
-        $position = key($this->request->raw('cmd')['removechoice']);
+        $position = key($this->request_data_collector->raw('cmd')['removechoice']);
         $this->object->deleteAnswer($position);
         $this->editQuestion();
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -525,9 +525,6 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         return ilLegacyFormElementsUtil::prepareTextareaOutput($output, true);
     }
 
-    /**
-     * @throws ilException
-     */
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
         $types = $this->request_data_collector->retrieveStringValueFromPost('types', '0');

--- a/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -527,14 +527,11 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $types = $this->request_data_collector->retrieveStringValueFromPost('types', '0');
+        $types = $this->request_data_collector->string('types') ?? '0';
         $this->object->setMultilineAnswerSetting($types);
+        $this->object->setShuffle($this->request_data_collector->bool('shuffle') ?? false);
 
-        $shuffle = $this->request_data_collector->retrieveBoolFromPost('shuffle', false);
-        $this->object->setShuffle($shuffle);
-
-        $choice = $this->request_data_collector->retrieveArrayOfArraysOfStringsFromPost('choice', null);
-
+        $choice = $this->request_data_collector->rawArray('choice');
         if (isset($choice['imagename']) && is_array($choice['imagename']) && $types === '1') {
             $this->object->setIsSingleline(true);
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('info_answer_type_change'), true);
@@ -543,8 +540,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         }
 
         $object_thumb_size = $this->object->getThumbSize();
-        $thumb_size = $this->request_data_collector->retrieveIntValueFromPost('thumb_size', $object_thumb_size);
-
+        $thumb_size = $this->request_data_collector->int('thumb_size') ?? $object_thumb_size;
         if ($thumb_size !== $object_thumb_size) {
             $this->object->setThumbSize($thumb_size);
             $this->rebuild_thumbnails = true;

--- a/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
@@ -408,7 +408,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
 
     protected function getSolutionSubmit(): string
     {
-        $text = $this->questionpool_request->retrieveStringValueFromPost('TEXT', '');
+        $text = $this->questionpool_request->string('TEXT', '');
 
         $text = ilObjAdvancedEditing::_getRichTextEditor() === 'tinymce'
             ? ilUtil::stripSlashes($text, false)

--- a/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 use ILIAS\TestQuestionPool\Questions\QuestionLMExportable;
 use ILIAS\TestQuestionPool\Questions\QuestionAutosaveable;
 use ILIAS\Test\Logging\AdditionalInformationGenerator;
-use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
  * Class for text questions
@@ -39,8 +38,6 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
 class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjustable, ilObjAnswerScoringAdjustable, QuestionLMExportable, QuestionAutosaveable
 {
     protected const HAS_SPECIFIC_FEEDBACK = false;
-
-    protected readonly RequestDataCollector $request_data_collector;
 
     public const SCORING_MODE_KEYWORD_RELATION_NONE = 'non';
     public const SCORING_MODE_KEYWORD_RELATION_ANY = 'any';
@@ -84,10 +81,8 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
         int $owner = -1,
         string $question = ""
     ) {
-        global $DIC;
         parent::__construct($title, $comment, $author, $owner, $question);
         $this->points = 1;
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function getMatchcondition(): int

--- a/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
@@ -845,7 +845,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
         return $solution_values[0]['value1'];
     }
 
-    public function getCorrectSolutionForTextOutput(int $active_id, int $pass): array
+    public function getCorrectSolutionForTextOutput(int $active_id, int $pass): array|string
     {
         switch ($this->getKeywordRelation()) {
             case self::SCORING_MODE_KEYWORD_RELATION_NONE:

--- a/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
@@ -408,7 +408,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
 
     protected function getSolutionSubmit(): string
     {
-        $text = $this->request_data_collector->retrieveStringValueFromPost('TEXT', '');
+        $text = $this->questionpool_request->retrieveStringValueFromPost('TEXT', '');
 
         $text = ilObjAdvancedEditing::_getRichTextEditor() === 'tinymce'
             ? ilUtil::stripSlashes($text, false)

--- a/components/ILIAS/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -521,9 +521,9 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
     {
         $this->setAdditionalContentEditingModeFromPost();
         ilSession::set('subquestion_index', 0);
-        $cmd = $this->request_data_collector->retrieveArrayOfBoolsFromPost('cmd');
+        $cmd = $this->request_data_collector->rawArray('cmd');
 
-        if (($cmd['addSuggestedSolution'] ?? false) && $this->writePostData()) {
+        if ($cmd['addSuggestedSolution'] && $this->writePostData()) {
             $this->tpl->setOnScreenMessage('info', $this->getErrorMessage());
             $this->editQuestion();
             return;
@@ -541,17 +541,10 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
 
     public function writeQuestionSpecificPostData(ilPropertyFormGUI $form): void
     {
-        $word_counter = $this->request_data_collector->retrieveBoolFromPost('wordcounter', false);
-        $this->object->setWordCounterEnabled($word_counter);
-
-        $max_chars = $this->request_data_collector->retrieveIntValueFromPost('maxchars', 0);
-        $this->object->setMaxNumOfChars($max_chars);
-
-        $text_rating = $this->request_data_collector->retrieveStringValueFromPost('text_rating', '');
-        $this->object->setTextRating($text_rating);
-
-        $scoring_mode = $this->request_data_collector->retrieveStringValueFromPost('scoring_mode');
-        $this->object->setKeywordRelation($scoring_mode);
+        $this->object->setWordCounterEnabled($this->request_data_collector->bool('wordcounter') ?? false);
+        $this->object->setMaxNumOfChars($this->request_data_collector->int('maxchars'));
+        $this->object->setTextRating($this->request_data_collector->string('text_rating'));
+        $this->object->setKeywordRelation($this->request_data_collector->string('scoring_mode'));
     }
 
     public function writeAnswerSpecificPostData(ilPropertyFormGUI $form): void
@@ -560,7 +553,7 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         switch ($this->object->getKeywordRelation()) {
             case assTextQuestion::SCORING_MODE_KEYWORD_RELATION_NONE:
                 $this->object->setAnswers([]);
-                $points = str_replace(',', '.', $this->request_data_collector->raw('non_keyword_points') ?? '');
+                $points = str_replace(',', '.', $this->request_data_collector->string('non_keyword_points'));
                 break;
             case assTextQuestion::SCORING_MODE_KEYWORD_RELATION_ANY:
                 $this->object->setAnswers($this->request_data_collector->raw('any_keyword'));
@@ -568,11 +561,11 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
                 break;
             case assTextQuestion::SCORING_MODE_KEYWORD_RELATION_ALL:
                 $this->object->setAnswers($this->request_data_collector->raw('all_keyword'));
-                $points = str_replace(',', '.', $this->request_data_collector->raw('all_keyword_points') ?? '');
+                $points = str_replace(',', '.', $this->request_data_collector->string('all_keyword_points'));
                 break;
             case assTextQuestion::SCORING_MODE_KEYWORD_RELATION_ONE:
                 $this->object->setAnswers($this->request_data_collector->raw('one_keyword'));
-                $points = (float) str_replace(',', '.', $this->request_data_collector->raw('one_keyword_points') ?? '');
+                $points = (float) str_replace(',', '.', $this->request_data_collector->string('one_keyword_points'));
                 break;
         }
         $this->object->setPoints((float) $points);

--- a/components/ILIAS/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * Text question GUI representation
  *
@@ -35,8 +33,6 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
 class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjustable, ilGuiAnswerScoringAdjustable
 {
     protected bool $tiny_mce_enabled;
-
-    protected readonly RequestDataCollector $request_data_collector;
     /**
      * assTextQuestionGUI constructor
      *
@@ -46,7 +42,6 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
      */
     public function __construct($id = -1)
     {
-        global $DIC;
         $this->tiny_mce_enabled = (new ilSetting('advanced_editing'))->get('advanced_editing_javascript_editor')
             === 'tinymce' ? true : false;
         parent::__construct();
@@ -54,7 +49,6 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         if ($id >= 0) {
             $this->object->loadFromDb($id);
         }
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.assTextSubsetGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextSubsetGUI.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * Multiple choice question GUI representation
  *
@@ -35,8 +33,6 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
  */
 class assTextSubsetGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjustable, ilGuiAnswerScoringAdjustable
 {
-    protected readonly RequestDataCollector $request_data_collector;
-
     private $answers_from_post;
 
     /**
@@ -48,13 +44,11 @@ class assTextSubsetGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
      */
     public function __construct($id = -1)
     {
-        global $DIC;
         parent::__construct();
         $this->object = new assTextSubset();
         if ($id >= 0) {
             $this->object->loadFromDb($id);
         }
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
@@ -17,7 +17,7 @@
  *********************************************************************/
 
 use ILIAS\TestQuestionPool\QuestionPoolDIC;
-use ILIAS\TestQuestionPool\RequestValidationHelper;
+use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
@@ -38,7 +38,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
     protected $minvalue = false;
     protected $minvalueShouldBeGreater = false;
 
-    protected RequestValidationHelper $request_helper;
+    protected ilTestLegacyFormsHelper $forms_helper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
 
@@ -53,9 +53,8 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         parent::__construct($a_title, $a_postvar);
 
         global $DIC;
-        $local_dic = QuestionPoolDIC::dic();
 
-        $this->request_helper = $local_dic['request_validation_helper'];
+        $this->forms_helper = new ilTestLegacyFormsHelper();
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
 
@@ -67,9 +66,9 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
     {
         $this->values = [];
 
-        $answers = $this->request_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
-        $images = $this->request_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->string());
-        $points = $this->request_helper->transformPoints($a_value);
+        $answers = $this->forms_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
+        $images = $this->forms_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->string());
+        $points = $this->forms_helper->transformPoints($a_value);
 
         foreach ($answers as $index => $value) {
             $answer = new ASS_AnswerBinaryStateImage(
@@ -80,7 +79,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
                 null,
                 -1
             );
-            if ($this->request_helper->inArray($images, $index)) {
+            if ($this->forms_helper->inArray($images, $index)) {
                 $answer->setImage($images[$index]);
             }
             $this->values[] = $answer;
@@ -235,7 +234,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         }
 
         // check points
-        $points = $this->request_helper->checkPointsInputEnoughPositive($data, true);
+        $points = $this->forms_helper->checkPointsInputEnoughPositive($data, true);
         if (!is_array($points)) {
             $this->setAlert($this->lng->txt($points));
             return false;
@@ -251,7 +250,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         }
 
         // check answers
-        $answers = $this->request_helper->transformArray($data, 'answer', $this->refinery->kindlyTo()->string());
+        $answers = $this->forms_helper->transformArray($data, 'answer', $this->refinery->kindlyTo()->string());
         foreach ($answers as $answer) {
             if ($answer === '') {
                 $this->setAlert($this->lng->txt('msg_input_is_required'));

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestValidationHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
@@ -52,7 +53,9 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         parent::__construct($a_title, $a_postvar);
 
         global $DIC;
-        $this->request_helper = new RequestValidationHelper($this->refinery);
+        $local_dic = QuestionPoolDIC::dic();
+
+        $this->request_helper = $local_dic['request_validation_helper'];
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
@@ -39,7 +39,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
 
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
-    protected readonly RequestDataCollector $requestDataCollector;
+    protected readonly RequestDataCollector $request_data_collector;
 
     /**
     * Constructor
@@ -54,11 +54,10 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         global $DIC;
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
+        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
 
         $this->setSize('25');
         $this->validationRegexp = "";
-
-        $this->requestDataCollector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function setValue($a_value): void
@@ -220,7 +219,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $found_values = $this->requestDataCollector->retrieveArrayOfStringsFromPost($this->getPostVar());
+        $found_values = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
 
         if (is_array($found_values)) {
             $found_values = ilArrayUtil::stripSlashesRecursive($found_values);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
@@ -38,6 +39,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
 
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
+    protected readonly RequestDataCollector $requestDataCollector;
 
     /**
     * Constructor
@@ -55,6 +57,8 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
 
         $this->setSize('25');
         $this->validationRegexp = "";
+
+        $this->requestDataCollector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function setValue($a_value): void
@@ -216,13 +220,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $found_values = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always(null)
-            ])
-        );
+        $found_values = $this->requestDataCollector->retrieveArrayOfStringsFromPost($this->getPostVar());
 
         if (is_array($found_values)) {
             $found_values = ilArrayUtil::stripSlashesRecursive($found_values);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
@@ -69,7 +69,14 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         $points = $this->request_helper->transformPoints($a_value);
 
         foreach ($answers as $index => $value) {
-            $answer = new ASS_AnswerBinaryStateImage($value, $points[$index], $index, true, null, -1);
+            $answer = new ASS_AnswerBinaryStateImage(
+                $value,
+                $points[$index] ?? 0.0,
+                $index,
+                true,
+                null,
+                -1
+            );
             if ($this->request_helper->inArray($images, $index)) {
                 $answer->setImage($images[$index]);
             }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionHintAbstractGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionHintAbstractGUI.php
@@ -32,7 +32,7 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
  */
 abstract class ilAssQuestionHintAbstractGUI
 {
-    protected RequestDataCollector $request;
+    protected RequestDataCollector $request_data_collector;
     protected ?assQuestionGUI $question_gui = null;
     protected ?assQuestion $question_obj = null;
     protected ilTabsGUI $tabs;
@@ -53,7 +53,7 @@ abstract class ilAssQuestionHintAbstractGUI
         $this->ctrl = $DIC['ilCtrl'];
 
         $local_dic = QuestionPoolDIC::dic();
-        $this->request = $local_dic['request_data_collector'];
+        $this->request_data_collector = $local_dic['request_data_collector'];
 
         $this->question_gui = $question_gui;
         $this->question_obj = $question_gui->getObject();

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionHintGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionHintGUI.php
@@ -78,13 +78,13 @@ class ilAssQuestionHintGUI extends ilAssQuestionHintAbstractGUI
     {
         if ($form instanceof ilPropertyFormGUI) {
             $form->setValuesByPost();
-        } elseif ($this->request->isset('hint_id') && (int) $this->request->raw('hint_id')) {
+        } elseif ($this->request_data_collector->isset('hint_id') && (int) $this->request_data_collector->raw('hint_id')) {
             $questionHint = new ilAssQuestionHint();
 
-            if (!$questionHint->load((int) $this->request->raw('hint_id'))) {
+            if (!$questionHint->load((int) $this->request_data_collector->raw('hint_id'))) {
                 $this->main_tpl->setOnScreenMessage(
                     'failure',
-                    'invalid hint id given: ' . $this->request->string('hint_id'),
+                    'invalid hint id given: ' . $this->request_data_collector->string('hint_id'),
                     true
                 );
                 $this->ctrl->redirectByClass(ilAssQuestionHintsGUI::class, ilAssQuestionHintsGUI::CMD_SHOW_LIST);
@@ -101,8 +101,8 @@ class ilAssQuestionHintGUI extends ilAssQuestionHintAbstractGUI
     private function saveFormCmd(): void
     {
         $questionHint = new ilAssQuestionHint();
-        if ($this->request->isset('hint_id')) {
-            $questionHint->load((int) $this->request->int('hint_id'));
+        if ($this->request_data_collector->isset('hint_id')) {
+            $questionHint->load((int) $this->request_data_collector->int('hint_id'));
 
             $hintJustCreated = false;
             $form = $this->buildForm($questionHint);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionHintRequestGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionHintRequestGUI.php
@@ -99,17 +99,17 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
 
     private function showHintCmd(): void
     {
-        if (!$this->request->isset('hintId') || $this->request->int('hintId') === 0) {
+        if (!$this->request_data_collector->isset('hintId') || $this->request_data_collector->int('hintId') === 0) {
             throw new ilTestException('no hint id given');
         }
 
-        $is_requested = $this->question_hint_tracking->isRequested($this->request->int('hintId'));
+        $is_requested = $this->question_hint_tracking->isRequested($this->request_data_collector->int('hintId'));
 
         if (!$is_requested) {
             throw new ilTestException('hint with given id is not yet requested for given testactive and testpass');
         }
 
-        $question_hint = ilAssQuestionHint::getInstanceById((int) $this->request->raw('hintId'));
+        $question_hint = ilAssQuestionHint::getInstanceById((int) $this->request_data_collector->raw('hintId'));
 
         if ($this->global_screen->tool()->context()->current()->getAdditionalData()
             ->exists(ilTestPlayerLayoutProvider::TEST_PLAYER_VIEW_TITLE)) {
@@ -118,7 +118,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
                 $this->parent_gui->getObject()->getTitle() . ' - ' . sprintf(
                     $this->lng->txt('tst_question_hints_form_header_edit'),
                     $question_hint->getIndex(),
-                    $this->request->int('sequence') ?? 0
+                    $this->request_data_collector->int('sequence') ?? 0
                 )
             );
         }
@@ -197,7 +197,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
 
     private function performRequestCmd(): void
     {
-        if (!$this->request->isset('hintId') || !(int) $this->request->raw('hintId')) {
+        if (!$this->request_data_collector->isset('hintId') || !(int) $this->request_data_collector->raw('hintId')) {
             throw new ilTestException('no hint id given');
         }
 
@@ -207,7 +207,7 @@ class ilAssQuestionHintRequestGUI extends ilAssQuestionHintAbstractGUI
             $this->ctrl->redirect($this, self::CMD_BACK_TO_QUESTION);
         }
 
-        if ($next_requestable_hint->getId() != (int) $this->request->raw('hintId')) {
+        if ($next_requestable_hint->getId() != (int) $this->request_data_collector->raw('hintId')) {
             throw new ilTestException('given hint id does not relate to the next requestable hint');
         }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionHintsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionHintsGUI.php
@@ -519,17 +519,17 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
 
     private function fetchHintIdsParameter(): array
     {
-        $hint_ids = [$this->request->int('hint_id')];
+        $hint_ids = [$this->request_data_collector->int('hint_id')];
         if ($hint_ids[0] !== 0) {
             return $hint_ids;
         }
 
-        return $this->request->retrieveArrayOfIntsFromPost('hint_ids') ?? [];
+        return $this->request_data_collector->intArray('hint_ids');
     }
 
     private function fetchHintIndexesParameter(): array
     {
-        $hint_indexes = $this->request->retrieveArrayOfIntsFromPost('hint_indexes') ?? [];
+        $hint_indexes = $this->request_data_collector->intArray('hint_indexes');
         asort($hint_indexes);
         return $hint_indexes;
     }
@@ -561,7 +561,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
 
     private function showHintCmd(): void
     {
-        if (!$this->request->isset('hintId') || !(int) $this->request->raw('hintId')) {
+        if (!$this->request_data_collector->isset('hintId') || !(int) $this->request_data_collector->raw('hintId')) {
             throw new ilTestException('no hint id given');
         }
 
@@ -573,7 +573,7 @@ class ilAssQuestionHintsGUI extends ilAssQuestionHintAbstractGUI
             $this->ctrl->getLinkTargetByClass(self::class, self::CMD_SHOW_LIST)
         );
 
-        $questionHint = ilAssQuestionHint::getInstanceById((int) $this->request->raw('hintId'));
+        $questionHint = ilAssQuestionHint::getInstanceById((int) $this->request_data_collector->raw('hintId'));
 
         // build form
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\HTTP\Services as HTTPServices;
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Refinery\Random\Group as RandomGroup;
@@ -90,11 +91,11 @@ class ilAssQuestionPreviewGUI
         private readonly Refinery $refinery,
         private readonly int $parent_obj_ref_id
     ) {
-        global $DIC;
         $this->tpl->addCss(ilObjStyleSheet::getContentStylePath(0));
         $this->tpl->addCss(ilObjStyleSheet::getSyntaxStylePath());
 
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
+        $local_dic = QuestionPoolDIC::dic();
+        $this->request_data_collector = $local_dic['request_data_collector'];
     }
 
     public function setInfoMessage(string $message): void
@@ -233,9 +234,8 @@ class ilAssQuestionPreviewGUI
 
     protected function isCommentingRequired(): bool
     {
-        $ref_id = $this->request_data_collector->retrieveIntValueFromPost('ref_id', 0);
-
-        return !$this->preview_settings->isTestRefId() && $this->rbac_system->checkAccess('read', (int) $ref_id);
+        return !$this->preview_settings->isTestRefId() &&
+            $this->rbac_system->checkAccess('read', $this->request_data_collector->getRefId());
     }
 
     public function showCmd(string $commands_panel_html = ''): void

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -26,6 +26,7 @@ use ILIAS\Refinery\Random\Seed\RandomSeed;
 use ILIAS\Refinery\Random\Seed\GivenSeed;
 use ILIAS\Refinery\Transformation;
 use ILIAS\GlobalScreen\Services as GlobalScreen;
+use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
  * @author		Björn Heyser <bheyser@databay.de>
@@ -53,6 +54,8 @@ class ilAssQuestionPreviewGUI
     public const TAB_ID_QUESTION = 'question';
 
     public const FEEDBACK_FOCUS_ANCHOR = 'focus';
+
+    protected readonly RequestDataCollector $request_data_collector;
 
     private ?assQuestionGUI $question_gui = null;
     private ?assQuestion $question_obj = null;
@@ -87,8 +90,11 @@ class ilAssQuestionPreviewGUI
         private readonly Refinery $refinery,
         private readonly int $parent_obj_ref_id
     ) {
+        global $DIC;
         $this->tpl->addCss(ilObjStyleSheet::getContentStylePath(0));
         $this->tpl->addCss(ilObjStyleSheet::getSyntaxStylePath());
+
+        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function setInfoMessage(string $message): void
@@ -227,13 +233,7 @@ class ilAssQuestionPreviewGUI
 
     protected function isCommentingRequired(): bool
     {
-        $ref_id = $this->http->wrapper()->query()->retrieve(
-            'ref_id',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->int(),
-                $this->refinery->always(0)
-            ])
-        );
+        $ref_id = $this->request_data_collector->retrieveIntValueFromPost('ref_id', 0);
 
         return !$this->preview_settings->isTestRefId() && $this->rbac_system->checkAccess('read', (int) $ref_id);
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -208,13 +208,7 @@ class ilAssQuestionSkillAssignmentsGUI
     private function saveSkillPointsCmd(): void
     {
         $success = true;
-        $skill_points = $this->http->wrapper()->post()->retrieve(
-            'skill_points',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->float()),
-                $this->refinery->always(null),
-            ])
-        );
+        $skill_points = $this->request->retrieveNestedArraysOfFloats('skill_points');
 
         if (is_array($skill_points)) {
             for ($i = 0; $i < 2; $i++) {
@@ -538,13 +532,7 @@ class ilAssQuestionSkillAssignmentsGUI
      */
     private function syncOriginalCmd(): void
     {
-        $questionId = $this->http->wrapper()->post()->retrieve(
-            'question_id',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->int(),
-                $this->refinery->always(0)
-            ])
-        );
+        $questionId = $this->request->retrieveIntValueFromPost('question_id', 0);
 
         if ($this->isTestQuestion($questionId) && $this->isSyncOriginalPossibleAndAllowed($questionId)) {
             $question = assQuestion::instantiateQuestion($questionId);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
@@ -17,7 +17,7 @@
  *********************************************************************/
 
 use ILIAS\TestQuestionPool\QuestionPoolDIC;
-use ILIAS\TestQuestionPool\RequestValidationHelper;
+use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 
 /**
 * This class represents a key value pair wizard property in a property form.
@@ -36,7 +36,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     protected $key_name = "";
     protected $value_name = "";
 
-    protected RequestValidationHelper $request_helper;
+    protected ilTestLegacyFormsHelper $forms_helper;
 
     /**
     * Constructor
@@ -47,14 +47,13 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     public function __construct($a_title = "", $a_postvar = "")
     {
         parent::__construct($a_title, $a_postvar);
-        $local_dic = QuestionPoolDIC::dic();
-        $this->request_helper = $local_dic['request_validation_helper'];
+        $this->forms_helper = new ilTestLegacyFormsHelper();
     }
 
     public function setValue($a_value): void
     {
-        $keys = $this->request_helper->transformArray($a_value, 'key', $this->refinery->kindlyTo()->string());
-        $points = $this->request_helper->transformPoints($a_value);
+        $keys = $this->forms_helper->transformArray($a_value, 'key', $this->refinery->kindlyTo()->string());
+        $points = $this->forms_helper->transformPoints($a_value);
 
         $this->values = [];
         foreach ($keys as $index => $key) {
@@ -221,7 +220,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
         }
 
         // check points
-        $points = $this->request_helper->checkPointsInput($data, $this->getRequired());
+        $points = $this->forms_helper->checkPointsInput($data, $this->getRequired());
         if (!is_array($points)) {
             $this->setAlert($this->lng->txt($points));
             return false;
@@ -234,8 +233,8 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
         }
 
         // check answers
-        $keys = $this->request_helper->transformArray($data, 'key', $kindlyTo->string());
-        $values = $this->request_helper->transformArray($data, 'value', $kindlyTo->string());
+        $keys = $this->forms_helper->transformArray($data, 'key', $kindlyTo->string());
+        $values = $this->forms_helper->transformArray($data, 'value', $kindlyTo->string());
         if (empty($keys) || empty($values)) {
             $this->setAlert($this->lng->txt('msg_input_is_required'));
             return false;

--- a/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestValidationHelper;
 
 /**
@@ -46,7 +47,8 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     public function __construct($a_title = "", $a_postvar = "")
     {
         parent::__construct($a_title, $a_postvar);
-        $this->request_helper = new RequestValidationHelper($this->refinery);
+        $local_dic = QuestionPoolDIC::dic();
+        $this->request_helper = $local_dic['request_validation_helper'];
     }
 
     public function setValue($a_value): void
@@ -210,7 +212,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     */
     public function checkInput(): bool
     {
-        $r = $this->refinery->kindlyTo();
+        $kindlyTo = $this->refinery->kindlyTo();
         $data = $this->raw($this->getPostVar());
 
         if (!is_array($data)) {
@@ -232,8 +234,8 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
         }
 
         // check answers
-        $keys = $this->request_helper->transformArray($data, 'key', $r->string());
-        $values = $this->request_helper->transformArray($data, 'value', $r->string());
+        $keys = $this->request_helper->transformArray($data, 'key', $kindlyTo->string());
+        $values = $this->request_helper->transformArray($data, 'value', $kindlyTo->string());
         if (empty($keys) || empty($values)) {
             $this->setAlert($this->lng->txt('msg_input_is_required'));
             return false;

--- a/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
 * This class represents a key value pair wizard property in a property form.
 *
@@ -32,6 +34,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     protected $value_maxlength = 150;
     protected $key_name = "";
     protected $value_name = "";
+    protected readonly RequestDataCollector $requestDataCollector;
 
     /**
     * Constructor
@@ -41,7 +44,10 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     */
     public function __construct($a_title = "", $a_postvar = "")
     {
+        global $DIC;
         parent::__construct($a_title, $a_postvar);
+
+        $this->requestDataCollector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function setValue($a_value): void
@@ -205,13 +211,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $post_var = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always(null)
-            ])
-        );
+        $post_var = $this->requestDataCollector->retrieveArrayOfStringsFromPost($this->getPostVar());
 
         $found_values = is_array($post_var) ? ilArrayUtil::stripSlashesRecursive($post_var) : null;
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
@@ -56,7 +56,11 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
 
         $this->values = [];
         foreach ($keys as $index => $key) {
-            $this->values[] = new assAnswerErrorText($key, $a_value['value'][$index], $points[$index]);
+            $this->values[] = new assAnswerErrorText(
+                $key,
+                $a_value['value'][$index] ?? '',
+                $points[$index] ?? 0.0
+            );
         }
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
@@ -34,7 +34,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
     protected $value_maxlength = 150;
     protected $key_name = "";
     protected $value_name = "";
-    protected readonly RequestDataCollector $requestDataCollector;
+    protected readonly RequestDataCollector $request_data_collector;
 
     /**
     * Constructor
@@ -47,7 +47,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
         global $DIC;
         parent::__construct($a_title, $a_postvar);
 
-        $this->requestDataCollector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
+        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function setValue($a_value): void
@@ -211,7 +211,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $post_var = $this->requestDataCollector->retrieveArrayOfStringsFromPost($this->getPostVar());
+        $post_var = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
 
         $found_values = is_array($post_var) ? ilArrayUtil::stripSlashesRecursive($post_var) : null;
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
@@ -26,7 +26,12 @@ class ilEssayKeywordWizardInputGUI extends ilSingleChoiceWizardInputGUI
 
         $this->values = [];
         foreach ($answers as $index => $value) {
-            $answer = new ASS_AnswerMultipleResponseImage($value, $points[$index], $index, $points_unchecked[$index]);
+            $answer = new ASS_AnswerMultipleResponseImage(
+                $value,
+                $points[$index] ?? 0.0,
+                $index,
+                $points_unchecked[$index] ?? 0.0
+            );
             $this->values[] = $answer;
         }
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
@@ -42,7 +42,6 @@ class ilEssayKeywordWizardInputGUI extends ilSingleChoiceWizardInputGUI
      */
     public function checkInput(): bool
     {
-        $r = $this->refinery->kindlyTo();
         $data = $this->raw($this->getPostVar());
 
         if (!is_array($data)) {

--- a/components/ILIAS/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -20,13 +18,9 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
 
 class ilEssayKeywordWizardInputGUI extends ilSingleChoiceWizardInputGUI
 {
-    protected readonly RequestDataCollector $request_data_collector;
     public function __construct($a_title = '', $a_postvar = '')
     {
-        global $DIC;
         parent::__construct($a_title, $a_postvar);
-
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function setValue($a_value): void

--- a/components/ILIAS/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
@@ -20,9 +20,9 @@ class ilEssayKeywordWizardInputGUI extends ilSingleChoiceWizardInputGUI
 {
     public function setValue($a_value): void
     {
-        $answers = $this->request_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
-        $points = $this->request_helper->transformPoints($a_value, 'points');
-        $points_unchecked = $this->request_helper->transformPoints($a_value, 'points_unchecked');
+        $answers = $this->forms_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
+        $points = $this->forms_helper->transformPoints($a_value, 'points');
+        $points_unchecked = $this->forms_helper->transformPoints($a_value, 'points_unchecked');
 
         $this->values = [];
         foreach ($answers as $index => $value) {
@@ -57,7 +57,7 @@ class ilEssayKeywordWizardInputGUI extends ilSingleChoiceWizardInputGUI
         }
 
         // check points
-        $result = $this->request_helper->checkPointsInputEnoughPositive($data, true);
+        $result = $this->forms_helper->checkPointsInputEnoughPositive($data, true);
         if (!is_array($result)) {
             $this->setAlert($this->lng->txt($result));
             return false;

--- a/components/ILIAS/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
@@ -1,4 +1,7 @@
 <?php
+
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +20,15 @@
 
 class ilEssayKeywordWizardInputGUI extends ilSingleChoiceWizardInputGUI
 {
+    protected readonly RequestDataCollector $request_data_collector;
+    public function __construct($a_title = '', $a_postvar = '')
+    {
+        global $DIC;
+        parent::__construct($a_title, $a_postvar);
+
+        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
+    }
+
     public function setValue($a_value): void
     {
         $this->values = [];
@@ -49,13 +61,7 @@ class ilEssayKeywordWizardInputGUI extends ilSingleChoiceWizardInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $post_var = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always(null)
-            ])
-        );
+        $post_var = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
 
         $found_values = is_array($post_var)
             ? ilArrayUtil::stripSlashesRecursive(

--- a/components/ILIAS/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * @author		Björn Heyser <bheyser@databay.de>
  * @version		$Id$
@@ -38,8 +36,6 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
      */
     protected $qstObject;
 
-    protected readonly RequestDataCollector $request_data_collector;
-
     private $files;
 
     private $ignoreMissingUploadsEnabled;
@@ -58,8 +54,6 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         $this->files = [];
 
         $this->ignoreMissingUploadsEnabled = false;
-
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function setFiles($files): void

--- a/components/ILIAS/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -82,9 +82,9 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
 
         $answer_type = $this->str('answer_type');
         $a_value = $this->cleanupAnswerText($a_value, $answer_type === 'multiLine');
-        $answers = $this->request_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
-        $imagename = $this->request_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->string());
-        $correctness = $this->request_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->bool());
+        $answers = $this->forms_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
+        $imagename = $this->forms_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->string());
+        $correctness = $this->forms_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->bool());
 
         foreach ($answers as $index => $value) {
             $answer = new ilAssKprimChoiceAnswer();
@@ -95,7 +95,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
             $answer->setImageFsDir($this->qstObject->getImagePath());
             $answer->setImageWebDir($this->qstObject->getImagePathWeb());
 
-            if ($this->request_helper->inArray($imagename, $index)) {
+            if ($this->forms_helper->inArray($imagename, $index)) {
                 $answer->setImageFile($imagename[$index]);
             }
 
@@ -126,7 +126,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         }
 
         // check correctness
-        $correctness = $this->request_helper->transformArray($data, 'correctness', $this->refinery->kindlyTo()->bool());
+        $correctness = $this->forms_helper->transformArray($data, 'correctness', $this->refinery->kindlyTo()->bool());
         if (count($answers) !== count($correctness)) {
             $this->setAlert($this->lng->txt('msg_input_is_required'));
             return false;

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestValidationHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
@@ -49,7 +50,9 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
         parent::__construct($a_title, $a_postvar);
 
         global $DIC;
-        $this->request_helper = new RequestValidationHelper($this->refinery);
+        $local_dic = QuestionPoolDIC::dic();
+
+        $this->request_helper = $local_dic['request_validation_helper'];
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
@@ -68,17 +68,17 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
         foreach ($terms as $index => $term) {
             $this->pairs[] = new assAnswerMatchingPair(
                 new assAnswerMatchingTerm('', '', $term),
-                new assAnswerMatchingDefinition('', '', $definitions[$index]),
+                new assAnswerMatchingDefinition('', '', $definitions[$index] ?? 0),
                 $points[$index]
             );
         }
 
-        $term_ids = explode(",", $a_value['term_id']);
+        $term_ids = explode(',', $a_value['term_id']);
         foreach ($term_ids as $id) {
             $this->terms[] = new assAnswerMatchingTerm('', '', (int) $id);
         }
 
-        $definition_ids = explode(",", $a_value['definition_id']);
+        $definition_ids = explode(',', $a_value['definition_id']);
         foreach ($definition_ids as $id) {
             $this->definitions[] = new assAnswerMatchingDefinition('', '', (int) $id);
         }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
@@ -36,6 +37,8 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
 
+    protected readonly RequestDataCollector $request_data_collector;
+
     /**
     * Constructor
     *
@@ -49,6 +52,8 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
         global $DIC;
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
+
+        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function setValue($a_value): void
@@ -136,13 +141,7 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $post_var = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always(null)
-            ])
-        );
+        $post_var = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
         $found_values = is_array($post_var) ? ilArrayUtil::stripSlashesRecursive($post_var) : $post_var;
 
         if (is_array($found_values)) {

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
@@ -16,17 +16,17 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
+use ILIAS\TestQuestionPool\RequestValidationHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
 /**
-* This class represents a key value pair wizard property in a property form.
-*
-* @author Helmut Schottmüller <ilias@aurealis.de>
-* @version $Id$
-* @ingroup	ServicesForm
-*/
+ * This class represents a key value pair wizard property in a property form.
+ *
+ * @author Helmut Schottmüller <ilias@aurealis.de>
+ * @version $Id$
+ * @ingroup    ServicesForm
+ */
 class ilMatchingPairWizardInputGUI extends ilTextInputGUI
 {
     protected $pairs = [];
@@ -34,26 +34,24 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
     protected $terms = [];
     protected $definitions = [];
 
+    protected RequestValidationHelper $request_helper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
 
-    protected readonly RequestDataCollector $request_data_collector;
-
     /**
-    * Constructor
-    *
-    * @param	string	$a_title	Title
-    * @param	string	$a_postvar	Post Variable
-    */
+     * Constructor
+     *
+     * @param string $a_title Title
+     * @param string $a_postvar Post Variable
+     */
     public function __construct($a_title = "", $a_postvar = "")
     {
         parent::__construct($a_title, $a_postvar);
 
         global $DIC;
+        $this->request_helper = new RequestValidationHelper($this->refinery);
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
-
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     public function setValue($a_value): void
@@ -61,141 +59,119 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
         $this->pairs = [];
         $this->terms = [];
         $this->definitions = [];
-        if (is_array($a_value)) {
-            if (isset($a_value['term']) && is_array($a_value['term'])) {
-                foreach ($a_value['term'] as $idx => $term) {
-                    $this->pairs[] = new assAnswerMatchingPair(
-                        new assAnswerMatchingTerm('', '', $term),
-                        new assAnswerMatchingDefinition('', '', $a_value['definition'][$idx]),
-                        (float) $a_value['points'][$idx]
-                    );
-                }
-            }
-            $term_ids = explode(",", $a_value['term_id']);
-            foreach ($term_ids as $id) {
-                $this->terms[] = new assAnswerMatchingTerm('', '', $id);
-            }
-            $definition_ids = explode(",", $a_value['definition_id']);
-            foreach ($definition_ids as $id) {
-                $this->definitions[] = new assAnswerMatchingDefinition('', '', $id);
-            }
+
+        $to_int = $this->refinery->kindlyTo()->int();
+        $points = $this->request_helper->transformPoints($a_value);
+        $terms = $this->request_helper->transformArray($a_value, 'term', $to_int);
+        $definitions = $this->request_helper->transformArray($a_value, 'definition', $to_int);
+
+        foreach ($terms as $index => $term) {
+            $this->pairs[] = new assAnswerMatchingPair(
+                new assAnswerMatchingTerm('', '', $term),
+                new assAnswerMatchingDefinition('', '', $definitions[$index]),
+                $points[$index]
+            );
+        }
+
+        $term_ids = explode(",", $a_value['term_id']);
+        foreach ($term_ids as $id) {
+            $this->terms[] = new assAnswerMatchingTerm('', '', (int) $id);
+        }
+
+        $definition_ids = explode(",", $a_value['definition_id']);
+        foreach ($definition_ids as $id) {
+            $this->definitions[] = new assAnswerMatchingDefinition('', '', (int) $id);
         }
     }
 
     /**
-    * Set terms.
-    *
-    * @param	array	$a_terms	Terms
-    */
+     * Set terms.
+     *
+     * @param array $a_terms Terms
+     */
     public function setTerms($a_terms): void
     {
         $this->terms = $a_terms;
     }
 
     /**
-    * Set definitions.
-    *
-    * @param	array	$a_definitions	Definitions
-    */
+     * Set definitions.
+     *
+     * @param array $a_definitions Definitions
+     */
     public function setDefinitions($a_definitions): void
     {
         $this->definitions = $a_definitions;
     }
 
     /**
-    * Set pairs.
-    *
-    * @param	array	$a_pairs	Pairs
-    */
+     * Set pairs.
+     *
+     * @param array $a_pairs Pairs
+     */
     public function setPairs($a_pairs): void
     {
         $this->pairs = $a_pairs;
     }
 
     /**
-    * Set allow move
-    *
-    * @param	boolean	$a_allow_move Allow move
-    */
+     * Set allow move
+     *
+     * @param boolean $a_allow_move Allow move
+     */
     public function setAllowMove($a_allow_move): void
     {
         $this->allowMove = $a_allow_move;
     }
 
     /**
-    * Get allow move
-    *
-    * @return	boolean	Allow move
-    */
+     * Get allow move
+     *
+     * @return    boolean    Allow move
+     */
     public function getAllowMove(): bool
     {
         return $this->allowMove;
     }
 
     /**
-    * Check input, strip slashes etc. set alert, if input is not ok.
-    * @return	boolean		Input ok, true/false
-    */
+     * Check input, strip slashes etc. set alert, if input is not ok.
+     * @return    boolean        Input ok, true/false
+     */
     public function checkInput(): bool
     {
-        global $DIC;
-        $lng = $DIC['lng'];
+        $to_int = $this->refinery->kindlyTo()->int();
+        $data = $this->raw($this->getPostVar());
 
-        $post_var = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
-        $found_values = is_array($post_var) ? ilArrayUtil::stripSlashesRecursive($post_var) : $post_var;
+        if (!is_array($data)) {
+            $this->setAlert($this->lng->txt('msg_input_is_required'));
+            return false;
+        }
 
-        if (is_array($found_values)) {
-            // check answers
-            if (isset($found_values['term']) && is_array($found_values['term'])) {
-                foreach ($found_values['term'] as $val) {
-                    if ($val < 1 && $this->getRequired()) {
-                        $this->setAlert($lng->txt('msg_input_is_required'));
-                        return false;
-                    }
-                }
-                foreach ($found_values['definition'] as $val) {
-                    if ($val < 1 && $this->getRequired()) {
-                        $this->setAlert($lng->txt('msg_input_is_required'));
-                        return false;
-                    }
-                }
-                $max = 0;
-                foreach ($found_values['points'] as $val) {
-                    if ($val === '' && $this->getRequired()) {
-                        $this->setAlert($lng->txt('msg_input_is_required'));
-                        return false;
-                    }
-                    $val = str_replace(',', '.', $val);
-                    if (!is_numeric($val)) {
-                        $this->setAlert($lng->txt('form_msg_numeric_value_required'));
-                        return false;
-                    }
+        // check points
+        $result_points = $this->request_helper->checkPointsInputEnoughPositive($data, true);
+        if (!is_array($result_points)) {
+            $this->setAlert($this->lng->txt($result_points));
+            return false;
+        }
 
-                    $val = (float) $val;
-                    if ($val > 0) {
-                        $max += $val;
-                    }
-                }
-                if ($max <= 0) {
-                    $this->setAlert($lng->txt('enter_enough_positive_points'));
-                    return false;
-                }
-            } elseif ($this->getRequired()) {
-                $this->setAlert($lng->txt('msg_input_is_required'));
+        // check answers
+        $terms = $this->request_helper->transformArray($data, 'term', $to_int);
+        $definitions = $this->request_helper->transformArray($data, 'definition', $to_int);
+        foreach ([$terms, $definitions] as $value) {
+            if ($value < 1 && $this->getRequired()) {
+                $this->setAlert($this->lng->txt('msg_input_is_required'));
                 return false;
             }
-        } elseif ($this->getRequired()) {
-            $this->setAlert($lng->txt('msg_input_is_required'));
-            return false;
         }
 
         return $this->checkSubItemsInput();
     }
 
     /**
-    * Insert property html
-    * @return	void	Size
-    */
+     * Insert property html
+     * @return    void    Size
+     */
     public function insert(ilTemplate $a_tpl): void
     {
         global $DIC;

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMatchingPairWizardInputGUI.php
@@ -17,7 +17,7 @@
  *********************************************************************/
 
 use ILIAS\TestQuestionPool\QuestionPoolDIC;
-use ILIAS\TestQuestionPool\RequestValidationHelper;
+use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
@@ -35,7 +35,7 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
     protected $terms = [];
     protected $definitions = [];
 
-    protected RequestValidationHelper $request_helper;
+    protected ilTestLegacyFormsHelper $forms_helper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
 
@@ -50,9 +50,8 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
         parent::__construct($a_title, $a_postvar);
 
         global $DIC;
-        $local_dic = QuestionPoolDIC::dic();
 
-        $this->request_helper = $local_dic['request_validation_helper'];
+        $this->forms_helper = new ilTestLegacyFormsHelper();
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
     }
@@ -64,9 +63,9 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
         $this->definitions = [];
 
         $to_int = $this->refinery->kindlyTo()->int();
-        $points = $this->request_helper->transformPoints($a_value);
-        $terms = $this->request_helper->transformArray($a_value, 'term', $to_int);
-        $definitions = $this->request_helper->transformArray($a_value, 'definition', $to_int);
+        $points = $this->forms_helper->transformPoints($a_value);
+        $terms = $this->forms_helper->transformArray($a_value, 'term', $to_int);
+        $definitions = $this->forms_helper->transformArray($a_value, 'definition', $to_int);
 
         foreach ($terms as $index => $term) {
             $this->pairs[] = new assAnswerMatchingPair(
@@ -152,15 +151,15 @@ class ilMatchingPairWizardInputGUI extends ilTextInputGUI
         }
 
         // check points
-        $result_points = $this->request_helper->checkPointsInputEnoughPositive($data, true);
+        $result_points = $this->forms_helper->checkPointsInputEnoughPositive($data, true);
         if (!is_array($result_points)) {
             $this->setAlert($this->lng->txt($result_points));
             return false;
         }
 
         // check answers
-        $terms = $this->request_helper->transformArray($data, 'term', $to_int);
-        $definitions = $this->request_helper->transformArray($data, 'definition', $to_int);
+        $terms = $this->forms_helper->transformArray($data, 'term', $to_int);
+        $definitions = $this->forms_helper->transformArray($data, 'definition', $to_int);
         foreach ([$terms, $definitions] as $value) {
             if ($value < 1 && $this->getRequired()) {
                 $this->setAlert($this->lng->txt('msg_input_is_required'));

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
@@ -42,6 +43,8 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
 
+    protected readonly RequestDataCollector $request_data_collector;
+
     public function __construct($a_title = "", $a_postvar = "")
     {
         parent::__construct($a_title, $a_postvar);
@@ -57,6 +60,8 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
         $lng = $DIC['lng'];
         $this->text_name = $lng->txt('answer_text');
         $this->image_name = $lng->txt('answer_image');
+
+        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     /**
@@ -165,13 +170,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $post_var = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always(null)
-            ])
-        );
+        $post_var = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
         $found_values = is_array($post_var)
             ? ilArrayUtil::stripSlashesRecursive(
                 $post_var,

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
@@ -17,7 +17,7 @@
  *********************************************************************/
 
 use ILIAS\TestQuestionPool\QuestionPoolDIC;
-use ILIAS\TestQuestionPool\RequestValidationHelper;
+use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
@@ -41,7 +41,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
     protected $suffixes = [];
     protected $hideImages = false;
 
-    protected RequestValidationHelper $request_helper;
+    protected ilTestLegacyFormsHelper $forms_helper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
 
@@ -52,7 +52,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
         global $DIC;
         $local_dic = QuestionPoolDIC::dic();
 
-        $this->request_helper = $local_dic['request_validation_helper'];
+        $this->forms_helper = new ilTestLegacyFormsHelper();
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
 
@@ -149,9 +149,9 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
     {
         $this->values = [];
 
-        $answers = $this->request_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
-        $imagename = $this->request_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->string());
-        $identifier = $this->request_helper->transformArray($a_value, 'identifier', $this->refinery->kindlyTo()->int());
+        $answers = $this->forms_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
+        $imagename = $this->forms_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->string());
+        $identifier = $this->forms_helper->transformArray($a_value, 'identifier', $this->refinery->kindlyTo()->int());
 
         foreach ($answers as $index => $value) {
             $this->values[] = new assAnswerMatchingTerm(
@@ -176,12 +176,12 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
         }
 
         // check answers
-        $answers = $this->request_helper->transformArray($data, 'answer', $this->refinery->kindlyTo()->string());
-        $images = $this->request_helper->transformArray($data, 'imagename', $this->refinery->kindlyTo()->string());
+        $answers = $this->forms_helper->transformArray($data, 'answer', $this->refinery->kindlyTo()->string());
+        $images = $this->forms_helper->transformArray($data, 'imagename', $this->refinery->kindlyTo()->string());
         foreach ($answers as $index => $value) {
             if (
                 $value === ''
-                && !$this->request_helper->inArray($images, $index)
+                && !$this->forms_helper->inArray($images, $index)
                 && !isset($_FILES[$this->getPostVar()]['tmp_name']['image'][$index])
             ) {
                 $this->setAlert($this->lng->txt('msg_input_is_required'));
@@ -208,8 +208,8 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
 
                             case UPLOAD_ERR_NO_FILE:
                                 if (
-                                    !$this->request_helper->inArray($images, $index)
-                                    && !$this->request_helper->inArray($answers, $index)
+                                    !$this->forms_helper->inArray($images, $index)
+                                    && !$this->forms_helper->inArray($answers, $index)
                                     && $this->getRequired()
                                 ) {
                                     $this->setAlert($this->lng->txt('form_msg_file_no_upload'));

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestValidationHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
@@ -49,7 +50,9 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
         parent::__construct($a_title, $a_postvar);
 
         global $DIC;
-        $this->request_helper = new RequestValidationHelper($this->refinery);
+        $local_dic = QuestionPoolDIC::dic();
+
+        $this->request_helper = $local_dic['request_validation_helper'];
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -17,12 +17,12 @@
  *********************************************************************/
 
 /**
-* This class represents a multiple choice wizard property in a property form.
-*
-* @author Helmut Schottmüller <ilias@aurealis.de>
-* @version $Id$
-* @ingroup	ServicesForm
-*/
+ * This class represents a multiple choice wizard property in a property form.
+ *
+ * @author Helmut Schottmüller <ilias@aurealis.de>
+ * @version $Id$
+ * @ingroup    ServicesForm
+ */
 class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
 {
     private string $pending;
@@ -30,178 +30,151 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
     public function setValue($a_value): void
     {
         $this->values = [];
-        if (is_array($a_value) && isset($a_value['answer']) && is_array($a_value['answer'])) {
-            foreach ($a_value['answer'] as $index => $value) {
-                $answer = new ASS_AnswerMultipleResponseImage($value, (float) ($a_value['points'][$index] ?? 0), $index);
-                $answer->setPointsChecked((float) ($a_value['points'][$index] ?? 0));
-                $answer->setPointsUnchecked((float) ($a_value['points_unchecked'][$index] ?? 0));
-                if (isset($a_value['imagename'][$index])) {
-                    $answer->setImage($a_value['imagename'][$index]);
-                }
-                $this->values[] = $answer;
+
+        $answers = $this->request_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
+        $points = $this->request_helper->transformPoints($a_value);
+        $points_unchecked = $this->request_helper->transformPoints($a_value, 'points_unchecked');
+        $images = $this->request_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->string());
+
+        foreach ($answers as $index => $value) {
+            $answer = new ASS_AnswerMultipleResponseImage($value, $points[$index], $index);
+            $answer->setPointsChecked($points[$index]);
+            $answer->setPointsUnchecked($points_unchecked[$index]);
+
+            if ($this->request_helper->inArray($images, $index)) {
+                $answer->setImage($images[$index]);
             }
+
+            $this->values[] = $answer;
         }
     }
 
     /**
-    * Check input, strip slashes etc. set alert, if input is not ok.
-    * @return	boolean		Input ok, true/false
-    */
+     * Check input, strip slashes etc. set alert, if input is not ok.
+     * @return    boolean        Input ok, true/false
+     */
     public function checkInput(): bool
     {
-        global $DIC;
-        $lng = $DIC['lng'];
+        $data = $this->raw($this->getPostVar());
 
-        $post_var = $this->getPostVar();
-        if (!$this->post_wrapper->has($post_var)) {
+        if (!is_array($data)) {
+            $this->setAlert($this->lng->txt('msg_input_is_required'));
             return false;
         }
 
-        $values = $this->post_wrapper->retrieve($post_var, $this->refinery->custom()->transformation(fn($v) => $v));
-
-        $values = ilArrayUtil::stripSlashesRecursive( //TODO: move into transform
-            $values,
-            false,
-            ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment")
-        );
-
-        $foundvalues = $values;
-
-        if (is_array($foundvalues)) {
-            // check answers
-            if (is_array($foundvalues['answer'])) {
-                foreach ($foundvalues['answer'] as $aidx => $answervalue) {
-                    if (((strlen($answervalue)) == 0) && (!isset($foundvalues['imagename']) || !isset($foundvalues['imagename'][$aidx]) || strlen($foundvalues['imagename'][$aidx]) == 0)) {
-                        $this->setAlert($lng->txt("msg_input_is_required"));
-                        return false;
-                    }
-
-                    if (mb_strlen($answervalue) > $this->getMaxLength()) {
-                        $this->setAlert($lng->txt("msg_input_char_limit_max"));
-                        return false;
-                    }
-                }
-            }
-            // check points
-            $max = 0;
-            if (is_array($foundvalues['points'])) {
-                foreach ($foundvalues['points'] as $points) {
-                    $points = str_replace(',', '.', $points);
-                    if ($points > $max) {
-                        $max = $points;
-                    }
-                    if (((strlen($points)) == 0) || (!is_numeric($points))) {
-                        $this->setAlert($lng->txt("form_msg_numeric_value_required"));
-                        return false;
-                    }
-                }
-                foreach ($foundvalues['points_unchecked'] as $points) {
-                    $points = str_replace(',', '.', $points);
-                    if (((strlen($points)) == 0) || (!is_numeric($points))) {
-                        $this->setAlert($lng->txt("form_msg_numeric_value_required"));
-                        return false;
-                    }
-                }
-            }
-            if ($max == 0) {
-                $this->setAlert($lng->txt("enter_enough_positive_points_checked"));
-                return false;
-            }
-
-            if (is_array($_FILES) && count($_FILES) && $this->getSingleline()) {
-                if (!$this->hideImages) {
-                    if (is_array($_FILES[$this->getPostVar()]['error']['image'])) {
-                        foreach ($_FILES[$this->getPostVar()]['error']['image'] as $index => $error) {
-                            // error handling
-                            if ($error > 0) {
-                                switch ($error) {
-                                    case UPLOAD_ERR_FORM_SIZE:
-                                    case UPLOAD_ERR_INI_SIZE:
-                                        $this->setAlert($lng->txt("form_msg_file_size_exceeds"));
-                                        return false;
-                                        break;
-
-                                    case UPLOAD_ERR_PARTIAL:
-                                        $this->setAlert($lng->txt("form_msg_file_partially_uploaded"));
-                                        return false;
-                                        break;
-
-                                    case UPLOAD_ERR_NO_FILE:
-                                        if ($this->getRequired()) {
-                                            if (isset($a_value['imagename']) && (!strlen($foundvalues['imagename'][$index])) && (!strlen($foundvalues['answer'][$index]))) {
-                                                $this->setAlert($lng->txt("form_msg_file_no_upload"));
-                                                return false;
-                                            }
-                                        }
-                                        break;
-
-                                    case UPLOAD_ERR_NO_TMP_DIR:
-                                        $this->setAlert($lng->txt("form_msg_file_missing_tmp_dir"));
-                                        return false;
-                                        break;
-
-                                    case UPLOAD_ERR_CANT_WRITE:
-                                        $this->setAlert($lng->txt("form_msg_file_cannot_write_to_disk"));
-                                        return false;
-                                        break;
-
-                                    case UPLOAD_ERR_EXTENSION:
-                                        $this->setAlert($lng->txt("form_msg_file_upload_stopped_ext"));
-                                        return false;
-                                        break;
-                                }
-                            }
-                        }
-                    } else {
-                        if ($this->getRequired()) {
-                            $this->setAlert($lng->txt("form_msg_file_no_upload"));
-                            return false;
-                        }
-                    }
-
-                    if (is_array($_FILES[$this->getPostVar()]['tmp_name']['image'])) {
-                        foreach ($_FILES[$this->getPostVar()]['tmp_name']['image'] as $index => $tmpname) {
-                            $filename = $_FILES[$this->getPostVar()]['name']['image'][$index];
-                            $filename_arr = pathinfo($filename);
-                            if (isset($filename_arr["extension"])) {
-                                $suffix = $filename_arr["extension"];
-                                $mimetype = $_FILES[$this->getPostVar()]['type']['image'][$index];
-                                $size_bytes = $_FILES[$this->getPostVar()]['size']['image'][$index];
-                                // check suffixes
-                                if (strlen($tmpname) && is_array($this->getSuffixes())) {
-                                    if (!in_array(strtolower($suffix), $this->getSuffixes())) {
-                                        $this->setAlert($lng->txt("form_msg_file_wrong_file_type"));
-                                        return false;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    if (is_array($_FILES[$this->getPostVar()]['tmp_name']['image'])) {
-                        foreach ($_FILES[$this->getPostVar()]['tmp_name']['image'] as $index => $tmpname) {
-                            $filename = $_FILES[$this->getPostVar()]['name']['image'][$index];
-                            $filename_arr = pathinfo($filename);
-                            if (isset($filename_arr["extension"])) {
-                                $suffix = $filename_arr["extension"];
-                                $mimetype = $_FILES[$this->getPostVar()]['type']['image'][$index];
-                                $size_bytes = $_FILES[$this->getPostVar()]['size']['image'][$index];
-                                // virus handling
-                                if (strlen($tmpname)) {
-                                    $vir = ilVirusScanner::virusHandling($tmpname, $filename);
-                                    if ($vir[0] == false) {
-                                        $this->setAlert($lng->txt("form_msg_file_virus_found") . "<br />" . $vir[1]);
-                                        return false;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        } else {
-            $this->setAlert($lng->txt("msg_input_is_required"));
+        // check points
+        $points = $this->request_helper->checkPointsInputEnoughPositive($data, true);
+        if (!is_array($points)) {
+            $this->setAlert($this->lng->txt($points));
             return false;
+        }
+        $points_unchecked = $this->request_helper->checkPointsInput($data, true, 'points_unchecked');
+        if (!is_array($points_unchecked)) {
+            $this->setAlert($this->lng->txt($points_unchecked));
+            return false;
+        }
+
+        // check answers
+        $answers = $this->checkAnswersInput($data);
+        if (!is_array($answers)) {
+            $this->setAlert($this->lng->txt($answers));
+            return false;
+        }
+        $images = $this->request_helper->transformArray($data, 'imagename', $this->refinery->kindlyTo()->string());
+
+        // check upload
+        if (is_array($_FILES) && count($_FILES) && $this->getSingleline()) {
+            if (!$this->hideImages) {
+                if (is_array($_FILES[$this->getPostVar()]['error']['image'])) {
+                    foreach ($_FILES[$this->getPostVar()]['error']['image'] as $index => $error) {
+                        // error handling
+                        if ($error > 0) {
+                            switch ($error) {
+                                case UPLOAD_ERR_FORM_SIZE:
+                                case UPLOAD_ERR_INI_SIZE:
+                                    $this->setAlert($this->lng->txt('form_msg_file_size_exceeds'));
+                                    return false;
+                                    break;
+
+                                case UPLOAD_ERR_PARTIAL:
+                                    $this->setAlert($this->lng->txt('form_msg_file_partially_uploaded'));
+                                    return false;
+                                    break;
+
+                                case UPLOAD_ERR_NO_FILE:
+                                    if (
+                                        !$this->request_helper->inArray($images, $index)
+                                        && !$this->request_helper->inArray($answers, $index)
+                                        && $this->getRequired()
+                                    ) {
+                                        $this->setAlert($this->lng->txt('form_msg_file_no_upload'));
+                                        return false;
+                                    }
+                                    break;
+
+                                case UPLOAD_ERR_NO_TMP_DIR:
+                                    $this->setAlert($this->lng->txt('form_msg_file_missing_tmp_dir'));
+                                    return false;
+                                    break;
+
+                                case UPLOAD_ERR_CANT_WRITE:
+                                    $this->setAlert($this->lng->txt('form_msg_file_cannot_write_to_disk'));
+                                    return false;
+                                    break;
+
+                                case UPLOAD_ERR_EXTENSION:
+                                    $this->setAlert($this->lng->txt('form_msg_file_upload_stopped_ext'));
+                                    return false;
+                                    break;
+                            }
+                        }
+                    }
+                } else {
+                    if ($this->getRequired()) {
+                        $this->setAlert($this->lng->txt('form_msg_file_no_upload'));
+                        return false;
+                    }
+                }
+
+                if (is_array($_FILES[$this->getPostVar()]['tmp_name']['image'])) {
+                    foreach ($_FILES[$this->getPostVar()]['tmp_name']['image'] as $index => $tmpname) {
+                        $filename = $_FILES[$this->getPostVar()]['name']['image'][$index];
+                        $filename_arr = pathinfo($filename);
+                        if (isset($filename_arr['extension'])) {
+                            $suffix = $filename_arr['extension'];
+                            $mimetype = $_FILES[$this->getPostVar()]['type']['image'][$index];
+                            $size_bytes = $_FILES[$this->getPostVar()]['size']['image'][$index];
+                            // check suffixes
+                            if (strlen($tmpname) && is_array($this->getSuffixes())) {
+                                if (!in_array(strtolower($suffix), $this->getSuffixes())) {
+                                    $this->setAlert($this->lng->txt('form_msg_file_wrong_file_type'));
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (is_array($_FILES[$this->getPostVar()]['tmp_name']['image'])) {
+                    foreach ($_FILES[$this->getPostVar()]['tmp_name']['image'] as $index => $tmpname) {
+                        $filename = $_FILES[$this->getPostVar()]['name']['image'][$index];
+                        $filename_arr = pathinfo($filename);
+                        if (isset($filename_arr['extension'])) {
+                            $suffix = $filename_arr['extension'];
+                            $mimetype = $_FILES[$this->getPostVar()]['type']['image'][$index];
+                            $size_bytes = $_FILES[$this->getPostVar()]['size']['image'][$index];
+                            // virus handling
+                            if (strlen($tmpname)) {
+                                $vir = ilVirusScanner::virusHandling($tmpname, $filename);
+                                if ($vir[0] == false) {
+                                    $this->setAlert($this->lng->txt('form_msg_file_virus_found') . '<br />' . $vir[1]);
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         return $this->checkSubItemsInput();

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -31,17 +31,17 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
     {
         $this->values = [];
 
-        $answers = $this->request_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
-        $points = $this->request_helper->transformPoints($a_value);
-        $points_unchecked = $this->request_helper->transformPoints($a_value, 'points_unchecked');
-        $images = $this->request_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->string());
+        $answers = $this->forms_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
+        $points = $this->forms_helper->transformPoints($a_value);
+        $points_unchecked = $this->forms_helper->transformPoints($a_value, 'points_unchecked');
+        $images = $this->forms_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->string());
 
         foreach ($answers as $index => $value) {
             $answer = new ASS_AnswerMultipleResponseImage($value, $points[$index] ?? 0.0, $index);
             $answer->setPointsChecked($points[$index] ?? 0.0);
             $answer->setPointsUnchecked($points_unchecked[$index] ?? 0.0);
 
-            if ($this->request_helper->inArray($images, $index)) {
+            if ($this->forms_helper->inArray($images, $index)) {
                 $answer->setImage($images[$index]);
             }
 
@@ -63,12 +63,12 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         }
 
         // check points
-        $points = $this->request_helper->checkPointsInputEnoughPositive($data, true);
+        $points = $this->forms_helper->checkPointsInputEnoughPositive($data, true);
         if (!is_array($points)) {
             $this->setAlert($this->lng->txt($points));
             return false;
         }
-        $points_unchecked = $this->request_helper->checkPointsInput($data, true, 'points_unchecked');
+        $points_unchecked = $this->forms_helper->checkPointsInput($data, true, 'points_unchecked');
         if (!is_array($points_unchecked)) {
             $this->setAlert($this->lng->txt($points_unchecked));
             return false;
@@ -80,7 +80,7 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
             $this->setAlert($this->lng->txt($answers));
             return false;
         }
-        $images = $this->request_helper->transformArray($data, 'imagename', $this->refinery->kindlyTo()->string());
+        $images = $this->forms_helper->transformArray($data, 'imagename', $this->refinery->kindlyTo()->string());
 
         // check upload
         if (is_array($_FILES) && count($_FILES) && $this->getSingleline()) {
@@ -103,8 +103,8 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
 
                                 case UPLOAD_ERR_NO_FILE:
                                     if (
-                                        !$this->request_helper->inArray($images, $index)
-                                        && !$this->request_helper->inArray($answers, $index)
+                                        !$this->forms_helper->inArray($images, $index)
+                                        && !$this->forms_helper->inArray($answers, $index)
                                         && $this->getRequired()
                                     ) {
                                         $this->setAlert($this->lng->txt('form_msg_file_no_upload'));

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -37,9 +37,9 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
         $images = $this->request_helper->transformArray($a_value, 'imagename', $this->refinery->kindlyTo()->string());
 
         foreach ($answers as $index => $value) {
-            $answer = new ASS_AnswerMultipleResponseImage($value, $points[$index], $index);
-            $answer->setPointsChecked($points[$index]);
-            $answer->setPointsUnchecked($points_unchecked[$index]);
+            $answer = new ASS_AnswerMultipleResponseImage($value, $points[$index] ?? 0.0, $index);
+            $answer->setPointsChecked($points[$index] ?? 0.0);
+            $answer->setPointsUnchecked($points_unchecked[$index] ?? 0.0);
 
             if ($this->request_helper->inArray($images, $index)) {
                 $answer->setImage($images[$index]);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -513,7 +513,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 break;
 
             case 'ilbulkeditquestionsgui':
-                if (!$ilAccess->checkAccess('read', '', $this->object->getRefId())) {
+                if (!$this->access->checkAccess('read', '', $this->object->getRefId())) {
                     $this->redirectAfterMissingWrite();
                 }
                 $this->tabs_gui->setBackTarget(

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -1566,7 +1566,16 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 }
             }
         }
-        if (isset($_POST['imagemap_x'])) {
+
+        $image_map_x = $this->http->wrapper()->post()->retrieve(
+            'imagemap_x',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always(null)
+            ])
+        );
+
+        if (isset($image_map_x)) {
             $force_active = true;
         }
         if (!$force_active) {

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -85,11 +85,9 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     protected URLBuilderToken $row_id_token;
     private Archives $archives;
 
-    protected RequestDataCollector $qplrequest;
+    protected RequestDataCollector $request_data_collector;
     protected GeneralQuestionPropertiesRepository $questionrepository;
     protected GlobalTestSettings $global_test_settings;
-
-    protected readonly RequestDataCollector $request_data_collector;
 
     public function __construct()
     {
@@ -112,11 +110,11 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->data_factory = new DataFactory();
 
         $local_dic = QuestionPoolDIC::dic();
-        $this->qplrequest = $local_dic['request_data_collector'];
+        $this->request_data_collector = $local_dic['request_data_collector'];
         $this->questionrepository = $local_dic['question.general_properties.repository'];
         $this->global_test_settings = $local_dic['global_test_settings'];
 
-        parent::__construct('', $this->qplrequest->getRefId(), true, false);
+        parent::__construct('', $this->request_data_collector->getRefId(), true, false);
 
         $this->ctrl->saveParameter($this, [
             'ref_id',
@@ -144,8 +142,6 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->row_id_token = $row_id_token;
 
         $this->notes_service->gui()->initJavascript();
-
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     protected function getQueryParamString(string $param): ?string
@@ -174,19 +170,19 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 
     public function executeCommand(): void
     {
-        $write_access = $this->access->checkAccess('write', '', $this->qplrequest->getRefId());
+        $write_access = $this->access->checkAccess('write', '', $this->request_data_collector->getRefId());
 
-        if ((!$this->access->checkAccess('read', '', $this->qplrequest->getRefId()))
-            && (!$this->access->checkAccess('visible', '', $this->qplrequest->getRefId()))) {
+        if ((!$this->access->checkAccess('read', '', $this->request_data_collector->getRefId()))
+            && (!$this->access->checkAccess('visible', '', $this->request_data_collector->getRefId()))) {
             $this->ilias->raiseError($this->lng->txt('permission_denied'), $this->ilias->error_obj->MESSAGE);
         }
 
         if (!$this->getCreationMode() &&
-            $this->access->checkAccess('read', '', $this->qplrequest->getRefId())) {
+            $this->access->checkAccess('read', '', $this->request_data_collector->getRefId())) {
             if ('qpl' === $this->object->getType()) {
                 $this->navigation_history->addItem(
-                    $this->qplrequest->getRefId(),
-                    ilLink::_getLink($this->qplrequest->getRefId(), "qpl"),
+                    $this->request_data_collector->getRefId(),
+                    ilLink::_getLink($this->request_data_collector->getRefId(), "qpl"),
                     'qpl',
                 );
             }
@@ -204,7 +200,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 
         $this->tpl->addCss(ilUtil::getStyleSheetLocation('output', 'test_print.css'), 'print');
 
-        $q_type = $this->qplrequest->string('question_type');
+        $q_type = $this->request_data_collector->string('question_type');
         switch ($next_class) {
             case 'ilcommonactiondispatchergui':
                 $gui = ilCommonActionDispatcherGUI::getInstanceFromAjaxCall();
@@ -241,7 +237,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                     $this->ref_id
                 );
 
-                $question_gui = assQuestion::instantiateQuestionGUI($this->qplrequest->int('q_id'));
+                $question_gui = assQuestion::instantiateQuestionGUI($this->request_data_collector->int('q_id'));
                 $gui->setPrimaryCmd(
                     $this->lng->txt('edit_question'),
                     $this->ctrl->getLinkTargetByClass(
@@ -314,7 +310,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 $this->lng->loadLanguageModule('content');
                 $this->ctrl->setReturnByClass('ilAssQuestionPageGUI', 'view');
                 $this->ctrl->setReturn($this, self::DEFAULT_CMD);
-                $page_gui = new ilAssQuestionPageGUI($this->qplrequest->getQuestionId());
+                $page_gui = new ilAssQuestionPageGUI($this->request_data_collector->getQuestionId());
                 $page_gui->obj->addUpdateListener(
                     $question,
                     'updateTimestamp'
@@ -406,7 +402,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 
                 $this->ctrl->setReturn($this, self::DEFAULT_CMD);
                 $gui = new ilLocalUnitConfigurationGUI(
-                    new ilUnitConfigurationRepository($this->qplrequest->getQuestionId())
+                    new ilUnitConfigurationRepository($this->request_data_collector->getQuestionId())
                 );
                 $this->ctrl->forwardCommand($gui);
                 break;
@@ -448,7 +444,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                     $this->tabs_gui,
                     $this->lng,
                     $this->help,
-                    $this->qplrequest,
+                    $this->request_data_collector,
                     true
                 );
                 $this->ctrl->forwardCommand($gui);
@@ -723,8 +719,8 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 break;
         }
 
-        if (!(strtolower($this->qplrequest->raw('baseClass')) == 'iladministrationgui'
-                || strtolower($this->qplrequest->raw('baseClass')) == 'ilrepositorygui')
+        if (!(strtolower($this->request_data_collector->raw('baseClass')) == 'iladministrationgui'
+                || strtolower($this->request_data_collector->raw('baseClass')) == 'ilrepositorygui')
             && $this->getCreationMode() != true) {
             $this->tpl->printToStdout();
         }
@@ -749,7 +745,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 
     public function downloadFileObject(): void
     {
-        $file = explode('_', $this->qplrequest->raw('file_id'));
+        $file = explode('_', $this->request_data_collector->raw('file_id'));
         $fileObj = new ilObjFile($file[count($file) - 1], false);
         $fileObj->sendFile();
         exit;
@@ -760,7 +756,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
      */
     public function fullscreenObject(): void
     {
-        $page_gui = new ilAssQuestionPageGUI($this->qplrequest->raw('pg_id'));
+        $page_gui = new ilAssQuestionPageGUI($this->request_data_collector->raw('pg_id'));
         $page_gui->showMediaFullscreen();
     }
 
@@ -769,8 +765,8 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
      */
     public function download_paragraphObject(): void
     {
-        $pg_obj = new ilAssQuestionPage($this->qplrequest->raw('pg_id'));
-        $pg_obj->sendParagraph($this->qplrequest->raw('par_id'), $this->qplrequest->raw('downloadtitle'));
+        $pg_obj = new ilAssQuestionPage($this->request_data_collector->raw('pg_id'));
+        $pg_obj->sendParagraph($this->request_data_collector->raw('par_id'), $this->request_data_collector->raw('downloadtitle'));
         exit;
     }
 
@@ -780,13 +776,13 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         list($subdir, $importdir, $xmlfile, $qtifile) = $this->buildImportDirectoriesFromImportFile($file_to_import);
 
         $new_obj = new ilObjQuestionPool(0, true);
-        $new_obj->setType($this->qplrequest->raw('new_type'));
+        $new_obj->setType($this->request_data_collector->raw('new_type'));
         $new_obj->setTitle('dummy');
         $new_obj->setDescription('questionpool import');
         $new_obj->create(true);
         $new_obj->createReference();
-        $new_obj->putInTree($this->qplrequest->getRefId());
-        $new_obj->setPermissions($this->qplrequest->getRefId());
+        $new_obj->putInTree($this->request_data_collector->getRefId());
+        $new_obj->setPermissions($this->request_data_collector->getRefId());
 
         $selected_questions = $this->retrieveSelectedQuestionsFromImportQuestionsSelectionForm(
             'importVerifiedFile',
@@ -919,7 +915,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     ): void {
 
         ilSession::set('qpl_import_selected_questions', $selected_questions);
-        $imp = new ilImport($this->qplrequest->getRefId());
+        $imp = new ilImport($this->request_data_collector->getRefId());
         $map = $imp->getMapping();
         $map->addMapping('components/ILIAS/TestQuestionPool', 'qpl', 'new_id', (string) $obj->getId());
         $imp->importObject($obj, $file_to_import, basename($file_to_import), 'qpl', 'components/ILIAS/TestQuestionPool', true);
@@ -1009,10 +1005,10 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 
         $this->tpl->setOnScreenMessage('question', $this->lng->txt('qpl_confirm_delete_questions'));
         $deleteable_questions = $this->object->getDeleteableQuestionDetails($questionIdsToDelete);
-        $table_gui = new ilQuestionBrowserTableGUI($this, self::DEFAULT_CMD, (($rbacsystem->checkAccess('write', $this->qplrequest->getRefId()) ? true : false)), true);
+        $table_gui = new ilQuestionBrowserTableGUI($this, self::DEFAULT_CMD, (($rbacsystem->checkAccess('write', $this->request_data_collector->getRefId()) ? true : false)), true);
         $table_gui->setShowRowsSelector(false);
         $table_gui->setLimit(PHP_INT_MAX);
-        $table_gui->setEditable($rbacsystem->checkAccess('write', $this->qplrequest->getRefId()));
+        $table_gui->setEditable($rbacsystem->checkAccess('write', $this->request_data_collector->getRefId()));
         $table_gui->setData($deleteable_questions);
         $this->tpl->setVariable('ADM_CONTENT', $table_gui->getHTML());
     }
@@ -1024,9 +1020,9 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     {
         $rbacsystem = $this->rbac_system;
 
-        $questionIdsToDelete = $this->qplrequest->isset('q_id') ? (array) $this->qplrequest->raw('q_id') : [];
-        if ($questionIdsToDelete === [] && $this->qplrequest->isset('q_id')) {
-            $questionIdsToDelete = [$this->qplrequest->getQuestionId()];
+        $questionIdsToDelete = $this->request_data_collector->isset('q_id') ? (array) $this->request_data_collector->raw('q_id') : [];
+        if ($questionIdsToDelete === [] && $this->request_data_collector->isset('q_id')) {
+            $questionIdsToDelete = [$this->request_data_collector->getQuestionId()];
         }
 
         $questionIdsToDelete = array_filter(array_map('intval', $questionIdsToDelete));
@@ -1040,12 +1036,12 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $table_gui = new ilQuestionBrowserTableGUI(
             $this,
             self::DEFAULT_CMD,
-            (($rbacsystem->checkAccess('write', $this->qplrequest->getRefId()) ? true : false)),
+            (($rbacsystem->checkAccess('write', $this->request_data_collector->getRefId()) ? true : false)),
             true
         );
         $table_gui->setShowRowsSelector(false);
         $table_gui->setLimit(PHP_INT_MAX);
-        $table_gui->setEditable($rbacsystem->checkAccess('write', $this->qplrequest->getRefId()));
+        $table_gui->setEditable($rbacsystem->checkAccess('write', $this->request_data_collector->getRefId()));
         $table_gui->setData($deleteable_questions);
         $this->tpl->setVariable('ADM_CONTENT', $table_gui->getHTML());
     }
@@ -1055,7 +1051,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
      */
     public function confirmDeleteQuestionsObject(): void
     {
-        $qst_ids = $this->qplrequest->retrieveArrayOfIntsFromPost('q_id') ?? [];
+        $qst_ids = $this->request_data_collector->retrieveArrayOfIntsFromPost('q_id') ?? [];
         foreach ($qst_ids as $value) {
             $this->object->deleteQuestion((int) $value);
             $this->object->cleanupClipboard((int) $value);
@@ -1111,7 +1107,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
      */
     public function questionsObject(RoundTripModal $import_questions_modal = null): void
     {
-        if (!$this->access->checkAccess("read", "", $this->qplrequest->getRefId())) {
+        if (!$this->access->checkAccess("read", "", $this->request_data_collector->getRefId())) {
             $this->infoScreenForward();
             return;
         }
@@ -1132,7 +1128,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         }
 
         $out = [];
-        if ($this->rbac_system->checkAccess('write', $this->qplrequest->getRefId())) {
+        if ($this->rbac_system->checkAccess('write', $this->request_data_collector->getRefId())) {
             $btn = $this->ui_factory->button()->primary(
                 $this->lng->txt('ass_create_question'),
                 $this->ctrl->getLinkTarget($this, 'createQuestionForm')
@@ -1166,7 +1162,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
 
     protected function fetchAuthoringQuestionIdParamater(): int
     {
-        $q_id = $this->qplrequest->getQuestionId();
+        $q_id = $this->request_data_collector->getQuestionId();
 
         if ($q_id === 0 || $this->object->checkQuestionParent($q_id)) {
             return $q_id;
@@ -1259,7 +1255,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             $this->ui_factory->button()->shy($this->lng->txt('detailed_output_printview'), $output_link_printview)
         ])->withLabel($this->lng->txt('output_mode'));
 
-        $output = $this->qplrequest->raw('output') ?? '';
+        $output = $this->request_data_collector->raw('output') ?? '';
 
         $table_gui = new ilQuestionPoolPrintViewTableGUI($this, 'print', $output);
         $data = $this->object->getPrintviewQuestions();
@@ -1320,7 +1316,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     public function createExportExcel(): void
     {
         $rbacsystem = $this->rbac_system;
-        if ($rbacsystem->checkAccess('write', $this->qplrequest->getRefId())) {
+        if ($rbacsystem->checkAccess('write', $this->request_data_collector->getRefId())) {
             $question_ids = &$this->object->getAllQuestionIds();
             $qpl_exp = new ilQuestionpoolExport($this->object, 'xlsx', $question_ids);
             $qpl_exp->buildExportFile();
@@ -1443,16 +1439,16 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                     $this->object->getTitle(),
                     $this->ctrl->getLinkTarget($this, ''),
                     '',
-                    $this->qplrequest->getRefId()
+                    $this->request_data_collector->getRefId()
                 );
-                $this->ctrl->setParameter($this, 'q_id', $this->qplrequest->getQuestionId());
+                $this->ctrl->setParameter($this, 'q_id', $this->request_data_collector->getQuestionId());
                 break;
         }
 
-        if (!is_array($this->qplrequest->raw('q_id')) && $this->qplrequest->raw('q_id') > 0 && $this->qplrequest->raw(
+        if (!is_array($this->request_data_collector->raw('q_id')) && $this->request_data_collector->raw('q_id') > 0 && $this->request_data_collector->raw(
             'cmd'
         ) !== self::DEFAULT_CMD) {
-            $question_gui = assQuestionGUI::_getQuestionGUI('', $this->qplrequest->getQuestionId());
+            $question_gui = assQuestionGUI::_getQuestionGUI('', $this->request_data_collector->getQuestionId());
             if ($question_gui !== null && $question_gui->getObject() instanceof assQuestion) {
                 $question = $question_gui->getObject();
                 $question->setObjId($this->object->getId());
@@ -1479,10 +1475,10 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     {
         parent::setTitleAndDescription();
 
-        if (!is_array($this->qplrequest->raw('q_id')) && $this->qplrequest->raw('q_id') > 0 && $this->qplrequest->raw(
+        if (!is_array($this->request_data_collector->raw('q_id')) && $this->request_data_collector->raw('q_id') > 0 && $this->request_data_collector->raw(
             'cmd'
         ) !== self::DEFAULT_CMD) {
-            $question_gui = assQuestionGUI::_getQuestionGUI('', $this->qplrequest->getQuestionId());
+            $question_gui = assQuestionGUI::_getQuestionGUI('', $this->request_data_collector->getQuestionId());
             if ($question_gui->getObject() instanceof assQuestion) {
                 $question = $question_gui->getObject();
                 $question->setObjId($this->object->getId());
@@ -1830,7 +1826,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             $this->object->getShowTaxonomies() ? $this->taxonomy->domain() : null,
             $this->notes_service,
             $this->object->getId(),
-            (int) $this->qplrequest->getRefId()
+            (int) $this->request_data_collector->getRefId()
         );
 
         /**

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -89,6 +89,8 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
     protected GeneralQuestionPropertiesRepository $questionrepository;
     protected GlobalTestSettings $global_test_settings;
 
+    protected readonly RequestDataCollector $request_data_collector;
+
     public function __construct()
     {
         /** @var ILIAS\DI\Container $DIC */
@@ -142,6 +144,8 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $this->row_id_token = $row_id_token;
 
         $this->notes_service->gui()->initJavascript();
+
+        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     protected function getQueryParamString(string $param): ?string
@@ -1567,13 +1571,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             }
         }
 
-        $image_map_x = $this->http->wrapper()->post()->retrieve(
-            'imagemap_x',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always(null)
-            ])
-        );
+        $image_map_x = $this->request_data_collector->retrieveStringValueFromPost('imagemap_x');
 
         if (isset($image_map_x)) {
             $force_active = true;

--- a/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -372,9 +372,6 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         return $this->checkSubItemsInput();
     }
 
-    /**
-     * @throws ilTemplateException
-     */
     public function insert(ilTemplate $a_tpl): void
     {
         $tpl = new ilTemplate('tpl.prop_singlechoicewizardinput.html', true, true, 'components/ILIAS/TestQuestionPool');

--- a/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -18,7 +18,7 @@
 
 use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestDataCollector;
-use ILIAS\TestQuestionPool\RequestValidationHelper;
+use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
@@ -39,7 +39,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     protected $showPoints = true;
     protected $hideImages = false;
 
-    protected RequestValidationHelper $request_helper;
+    protected ilTestLegacyFormsHelper $forms_helper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
 
@@ -62,15 +62,15 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
 
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
-        $this->request_helper = $local_dic['request_validation_helper'];
+        $this->forms_helper = new ilTestLegacyFormsHelper();
     }
 
     public function setValue($a_value): void
     {
         $this->values = [];
 
-        $answers = $this->request_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
-        $points = $this->request_helper->transformPoints($a_value);
+        $answers = $this->forms_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
+        $points = $this->forms_helper->transformPoints($a_value);
 
         foreach ($answers as $index => $value) {
             $answer = new ASS_AnswerBinaryStateImage(
@@ -234,10 +234,10 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     protected function checkAnswersInput(array $data): array|string
     {
         $to_string = $this->refinery->kindlyTo()->string();
-        $answers = $this->request_helper->transformArray($data, 'answer', $to_string);
-        $image_names = $this->request_helper->transformArray($data, 'imagename', $to_string);
+        $answers = $this->forms_helper->transformArray($data, 'answer', $to_string);
+        $image_names = $this->forms_helper->transformArray($data, 'imagename', $to_string);
         foreach ($answers as $index => $value) {
-            if ($value === '' && !$this->request_helper->inArray($image_names, $index)) {
+            if ($value === '' && !$this->forms_helper->inArray($image_names, $index)) {
                 return 'msg_input_is_required';
             }
 
@@ -259,7 +259,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         }
 
         // check points
-        $points = $this->request_helper->checkPointsInputEnoughPositive($data, true);
+        $points = $this->forms_helper->checkPointsInputEnoughPositive($data, true);
         if (!is_array($points)) {
             $this->setAlert($this->lng->txt($points));
             return false;
@@ -271,7 +271,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
             $this->setAlert($this->lng->txt($answers));
             return false;
         }
-        $image_names = $this->request_helper->transformArray($data, 'imagename', $this->refinery->kindlyTo()->string());
+        $image_names = $this->forms_helper->transformArray($data, 'imagename', $this->refinery->kindlyTo()->string());
 
 
         if (is_array($_FILES) && count($_FILES) && $this->getSingleline() && (!$this->hideImages)) {
@@ -293,7 +293,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
 
                             case UPLOAD_ERR_NO_FILE:
                                 if (
-                                    $this->getRequired() && !$this->request_helper->inArray($image_names, $index)
+                                    $this->getRequired() && !$this->forms_helper->inArray($image_names, $index)
                                 ) {
                                     $this->setAlert($this->lng->txt('form_msg_file_no_upload'));
                                     return false;

--- a/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -58,9 +58,11 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         $this->validationRegexp = '';
 
         global $DIC;
+        $local_dic = QuestionPoolDIC::dic();
+
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
-        $this->request_helper = new RequestValidationHelper($this->refinery);
+        $this->request_helper = $local_dic['request_validation_helper'];
     }
 
     public function setValue($a_value): void

--- a/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -73,11 +73,11 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         foreach ($answers as $index => $value) {
             $answer = new ASS_AnswerBinaryStateImage(
                 $value,
-                $points[$index],
+                $points[$index] ?? 0.0,
                 (int) $index,
                 true,
                 null,
-                (int) $a_value['answer_id'][$index]
+                (int) $a_value['answer_id'][$index] ?? 0
             );
             if (isset($a_value['imagename'][$index])) {
                 $answer->setImage($a_value['imagename'][$index]);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -16,8 +16,9 @@
  *
  *********************************************************************/
 
-use ILIAS\HTTP\Wrapper\ArrayBasedRequestWrapper as ArrayBasedRequestWrapper;
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestDataCollector;
+use ILIAS\TestQuestionPool\RequestValidationHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
@@ -38,11 +39,9 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     protected $showPoints = true;
     protected $hideImages = false;
 
-    protected ArrayBasedRequestWrapper $post_wrapper;
+    protected RequestValidationHelper $request_helper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
-
-    protected readonly RequestDataCollector $request_data_collector;
 
     /**
     * Constructor
@@ -59,36 +58,33 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         $this->validationRegexp = '';
 
         global $DIC;
-        $this->post_wrapper = $DIC->http()->wrapper()->post();
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
-
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
+        $this->request_helper = new RequestValidationHelper($this->refinery);
     }
 
     public function setValue($a_value): void
     {
         $this->values = [];
 
-        if (is_array($a_value)) {
-            foreach ($a_value['answer'] ?? [] as $index => $value) {
-                $points = (float) str_replace(',', '.', $a_value['points'][$index]);
-                $answer = new ASS_AnswerBinaryStateImage(
-                    (string) $value,
-                    $points,
-                    (int) $index,
-                    true,
-                    null,
-                    (int) $a_value['answer_id'][$index]
-                );
-                if (isset($a_value['imagename'][$index])) {
-                    $answer->setImage($a_value['imagename'][$index]);
-                }
-                $this->values[] = $answer;
+        $answers = $this->request_helper->transformArray($a_value, 'answer', $this->refinery->kindlyTo()->string());
+        $points = $this->request_helper->transformPoints($a_value);
+
+        foreach ($answers as $index => $value) {
+            $answer = new ASS_AnswerBinaryStateImage(
+                $value,
+                $points[$index],
+                (int) $index,
+                true,
+                null,
+                (int) $a_value['answer_id'][$index]
+            );
+            if (isset($a_value['imagename'][$index])) {
+                $answer->setImage($a_value['imagename'][$index]);
             }
+            $this->values[] = $answer;
         }
     }
-
 
     public function setValueByArray(array $a_values): void
     {
@@ -228,145 +224,142 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     }
 
     /**
-    * Check input, strip slashes etc. set alert, if input is not ok.
-    * @return	boolean		Input ok, true/false
-    */
+     * Checks the input of the answers and returns the answers as an array if the input is valid or a string with the
+     * error message if the input is invalid. The input is invalid if an answer is empty and no imagename was provided.
+     *
+     * @return string[]|string
+     */
+    protected function checkAnswersInput(array $data): array|string
+    {
+        $to_string = $this->refinery->kindlyTo()->string();
+        $answers = $this->request_helper->transformArray($data, 'answer', $to_string);
+        $image_names = $this->request_helper->transformArray($data, 'imagename', $to_string);
+        foreach ($answers as $index => $value) {
+            if ($value === '' && !$this->request_helper->inArray($image_names, $index)) {
+                return 'msg_input_is_required';
+            }
+
+            if (mb_strlen($value) > $this->getMaxLength()) {
+                return 'msg_input_char_limit_max';
+            }
+        }
+
+        return $answers;
+    }
+
     public function checkInput(): bool
     {
-        $post_var = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
+        $data = $this->raw($this->getPostVar());
 
-        $found_values = is_array($post_var) ? ilArrayUtil::stripSlashesRecursive(
-            $post_var,
-            true,
-            ilObjAdvancedEditing::_getUsedHTMLTagsAsString('assessment')
-        ) : null;
+        if (!is_array($data)) {
+            $this->setAlert($this->lng->txt('msg_input_is_required'));
+            return false;
+        }
 
-        if (is_array($found_values)) {
-            // check answers
-            if (is_array($found_values['answer'])) {
-                foreach ($found_values['answer'] as $aidx => $answervalue) {
-                    if ($answervalue === '' && (!isset($found_values['imagename'][$aidx]) || $found_values['imagename'][$aidx] === '')) {
-                        $this->setAlert($this->lng->txt('msg_input_is_required'));
-                        return false;
-                    }
+        // check points
+        $points = $this->request_helper->checkPointsInputEnoughPositive($data, true);
+        if (!is_array($points)) {
+            $this->setAlert($this->lng->txt($points));
+            return false;
+        }
 
-                    if (mb_strlen($answervalue) > $this->getMaxLength()) {
-                        $this->setAlert($this->lng->txt("msg_input_char_limit_max"));
-                        return false;
+        // check answers
+        $answers = $this->checkAnswersInput($data);
+        if (!is_array($answers)) {
+            $this->setAlert($this->lng->txt($answers));
+            return false;
+        }
+        $image_names = $this->request_helper->transformArray($data, 'imagename', $this->refinery->kindlyTo()->string());
+
+
+        if (is_array($_FILES) && count($_FILES) && $this->getSingleline() && (!$this->hideImages)) {
+            if (is_array($_FILES[$this->getPostVar()]['error']['image'])) {
+                foreach ($_FILES[$this->getPostVar()]['error']['image'] as $index => $error) {
+                    // error handling
+                    if ($error > 0) {
+                        switch ($error) {
+                            case UPLOAD_ERR_FORM_SIZE:
+                            case UPLOAD_ERR_INI_SIZE:
+                                $this->setAlert($this->lng->txt('form_msg_file_size_exceeds'));
+                                return false;
+                                break;
+
+                            case UPLOAD_ERR_PARTIAL:
+                                $this->setAlert($this->lng->txt('form_msg_file_partially_uploaded'));
+                                return false;
+                                break;
+
+                            case UPLOAD_ERR_NO_FILE:
+                                if (
+                                    $this->getRequired() && !$this->request_helper->inArray($image_names, $index)
+                                ) {
+                                    $this->setAlert($this->lng->txt('form_msg_file_no_upload'));
+                                    return false;
+                                }
+                                break;
+
+                            case UPLOAD_ERR_NO_TMP_DIR:
+                                $this->setAlert($this->lng->txt('form_msg_file_missing_tmp_dir'));
+                                return false;
+                                break;
+
+                            case UPLOAD_ERR_CANT_WRITE:
+                                $this->setAlert($this->lng->txt('form_msg_file_cannot_write_to_disk'));
+                                return false;
+                                break;
+
+                            case UPLOAD_ERR_EXTENSION:
+                                $this->setAlert($this->lng->txt('form_msg_file_upload_stopped_ext'));
+                                return false;
+                                break;
+                        }
                     }
                 }
-            }
-            // check points
-            $max = 0;
-            if (is_array($found_values['points'])) {
-                foreach ($found_values['points'] as $points) {
-                    $points = str_replace(',', '.', $points);
-                    $max = max($max, $points);
-                    if ($points === '' || !is_numeric($points)) {
-                        $this->setAlert($this->lng->txt('form_msg_numeric_value_required'));
-                        return false;
-                    }
-                }
-            }
-            if ($max === 0) {
-                $this->setAlert($this->lng->txt('enter_enough_positive_points'));
+            } elseif ($this->getRequired()) {
+                $this->setAlert($this->lng->txt('form_msg_file_no_upload'));
                 return false;
             }
 
-            if (is_array($_FILES) && count($_FILES) && $this->getSingleline() && (!$this->hideImages)) {
-                if (is_array($_FILES[$this->getPostVar()]['error']['image'])) {
-                    foreach ($_FILES[$this->getPostVar()]['error']['image'] as $index => $error) {
-                        // error handling
-                        if ($error > 0) {
-                            switch ($error) {
-                                case UPLOAD_ERR_FORM_SIZE:
-                                case UPLOAD_ERR_INI_SIZE:
-                                    $this->setAlert($this->lng->txt('form_msg_file_size_exceeds'));
-                                    return false;
-                                    break;
-
-                                case UPLOAD_ERR_PARTIAL:
-                                    $this->setAlert($this->lng->txt('form_msg_file_partially_uploaded'));
-                                    return false;
-                                    break;
-
-                                case UPLOAD_ERR_NO_FILE:
-                                    if (
-                                        $this->getRequired()
-                                        && !isset($found_values['imagename'][$index])
-                                        && $found_values['answer'][$index] === ''
-                                    ) {
-                                        $this->setAlert($this->lng->txt('form_msg_file_no_upload'));
-                                        return false;
-                                    }
-                                    break;
-
-                                case UPLOAD_ERR_NO_TMP_DIR:
-                                    $this->setAlert($this->lng->txt('form_msg_file_missing_tmp_dir'));
-                                    return false;
-                                    break;
-
-                                case UPLOAD_ERR_CANT_WRITE:
-                                    $this->setAlert($this->lng->txt('form_msg_file_cannot_write_to_disk'));
-                                    return false;
-                                    break;
-
-                                case UPLOAD_ERR_EXTENSION:
-                                    $this->setAlert($this->lng->txt('form_msg_file_upload_stopped_ext'));
-                                    return false;
-                                    break;
-                            }
+            if (is_array($_FILES[$this->getPostVar()]['tmp_name']['image'])) {
+                foreach ($_FILES[$this->getPostVar()]['tmp_name']['image'] as $index => $tmpname) {
+                    $filename = $_FILES[$this->getPostVar()]['name']['image'][$index];
+                    if ($filename !== '') {
+                        $filename_arr = pathinfo($filename);
+                        $suffix = $filename_arr['extension'];
+                        $mimetype = $_FILES[$this->getPostVar()]['type']['image'][$index];
+                        $size_bytes = $_FILES[$this->getPostVar()]['size']['image'][$index];
+                        // check suffixes
+                        if (
+                            $tmpname !== ''
+                            && is_array($this->getSuffixes())
+                            && !in_array(strtolower($suffix), $this->getSuffixes(), true)
+                        ) {
+                            $this->setAlert($this->lng->txt('form_msg_file_wrong_file_type'));
+                            return false;
                         }
                     }
-                } elseif ($this->getRequired()) {
-                    $this->setAlert($this->lng->txt('form_msg_file_no_upload'));
-                    return false;
                 }
+            }
 
-                if (is_array($_FILES[$this->getPostVar()]['tmp_name']['image'])) {
-                    foreach ($_FILES[$this->getPostVar()]['tmp_name']['image'] as $index => $tmpname) {
-                        $filename = $_FILES[$this->getPostVar()]['name']['image'][$index];
-                        if ($filename !== '') {
-                            $filename_arr = pathinfo($filename);
-                            $suffix = $filename_arr['extension'];
-                            $mimetype = $_FILES[$this->getPostVar()]['type']['image'][$index];
-                            $size_bytes = $_FILES[$this->getPostVar()]['size']['image'][$index];
-                            // check suffixes
-                            if (
-                                $tmpname !== ''
-                                && is_array($this->getSuffixes())
-                                && !in_array(strtolower($suffix), $this->getSuffixes(), true)
-                            ) {
-                                $this->setAlert($this->lng->txt('form_msg_file_wrong_file_type'));
+            if (is_array($_FILES[$this->getPostVar()]['tmp_name']['image'])) {
+                foreach ($_FILES[$this->getPostVar()]['tmp_name']['image'] as $index => $tmpname) {
+                    $filename = $_FILES[$this->getPostVar()]['name']['image'][$index];
+                    if ($filename !== '') {
+                        $filename_arr = pathinfo($filename);
+                        $suffix = $filename_arr['extension'];
+                        $mimetype = $_FILES[$this->getPostVar()]['type']['image'][$index];
+                        $size_bytes = $_FILES[$this->getPostVar()]['size']['image'][$index];
+                        // virus handling
+                        if ($tmpname !== '') {
+                            $vir = ilVirusScanner::virusHandling($tmpname, $filename);
+                            if ($vir[0] == false) {
+                                $this->setAlert($this->lng->txt('form_msg_file_virus_found') . '<br />' . $vir[1]);
                                 return false;
                             }
                         }
                     }
                 }
-
-                if (is_array($_FILES[$this->getPostVar()]['tmp_name']['image'])) {
-                    foreach ($_FILES[$this->getPostVar()]['tmp_name']['image'] as $index => $tmpname) {
-                        $filename = $_FILES[$this->getPostVar()]['name']['image'][$index];
-                        if ($filename !== '') {
-                            $filename_arr = pathinfo($filename);
-                            $suffix = $filename_arr['extension'];
-                            $mimetype = $_FILES[$this->getPostVar()]['type']['image'][$index];
-                            $size_bytes = $_FILES[$this->getPostVar()]['size']['image'][$index];
-                            // virus handling
-                            if ($tmpname !== '') {
-                                $vir = ilVirusScanner::virusHandling($tmpname, $filename);
-                                if ($vir[0] == false) {
-                                    $this->setAlert($this->lng->txt('form_msg_file_virus_found') . '<br />' . $vir[1]);
-                                    return false;
-                                }
-                            }
-                        }
-                    }
-                }
             }
-        } else {
-            $this->setAlert($this->lng->txt('msg_input_is_required'));
-            return false;
         }
 
         return $this->checkSubItemsInput();

--- a/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -64,23 +64,22 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     public function setValue($a_value): void
     {
         $this->values = [];
+
         if (is_array($a_value)) {
-            if (is_array($a_value['answer'])) {
-                foreach ($a_value['answer'] as $index => $value) {
-                    $points = (float) str_replace(",", ".", $a_value['points'][$index]);
-                    $answer = new ASS_AnswerBinaryStateImage(
-                        (string) $value,
-                        $points,
-                        (int) $index,
-                        true,
-                        null,
-                        (int) $a_value['answer_id'][$index]
-                    );
-                    if (isset($a_value['imagename'][$index])) {
-                        $answer->setImage($a_value['imagename'][$index]);
-                    }
-                    $this->values[] = $answer;
+            foreach ($a_value['answer'] ?? [] as $index => $value) {
+                $points = (float) str_replace(',', '.', $a_value['points'][$index]);
+                $answer = new ASS_AnswerBinaryStateImage(
+                    (string) $value,
+                    $points,
+                    (int) $index,
+                    true,
+                    null,
+                    (int) $a_value['answer_id'][$index]
+                );
+                if (isset($a_value['imagename'][$index])) {
+                    $answer->setImage($a_value['imagename'][$index]);
                 }
+                $this->values[] = $answer;
             }
         }
     }
@@ -229,19 +228,26 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     */
     public function checkInput(): bool
     {
-        if (is_array($_POST[$this->getPostVar()])) {
-            $foundvalues = ilArrayUtil::stripSlashesRecursive(
-                $_POST[$this->getPostVar()],
-                true,
-                ilObjAdvancedEditing::_getUsedHTMLTagsAsString("assessment")
-            );
-        }
-        if (is_array($foundvalues)) {
+        $post_var = $this->http->wrapper()->post()->retrieve(
+            $this->getPostVar(),
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always(null)
+            ])
+        );
+
+        $found_values = is_array($post_var) ? ilArrayUtil::stripSlashesRecursive(
+            $post_var,
+            true,
+            ilObjAdvancedEditing::_getUsedHTMLTagsAsString('assessment')
+        ) : null;
+
+        if (is_array($found_values)) {
             // check answers
-            if (is_array($foundvalues['answer'])) {
-                foreach ($foundvalues['answer'] as $aidx => $answervalue) {
-                    if (((strlen($answervalue)) == 0) && (!isset($foundvalues['imagename'][$aidx]) || strlen($foundvalues['imagename'][$aidx]) == 0)) {
-                        $this->setAlert($this->lng->txt("msg_input_is_required"));
+            if (is_array($found_values['answer'])) {
+                foreach ($found_values['answer'] as $aidx => $answervalue) {
+                    if ($answervalue === '' && (!isset($found_values['imagename'][$aidx]) || $found_values['imagename'][$aidx] === '')) {
+                        $this->setAlert($this->lng->txt('msg_input_is_required'));
                         return false;
                     }
 
@@ -253,20 +259,18 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
             }
             // check points
             $max = 0;
-            if (is_array($foundvalues['points'])) {
-                foreach ($foundvalues['points'] as $points) {
+            if (is_array($found_values['points'])) {
+                foreach ($found_values['points'] as $points) {
                     $points = str_replace(',', '.', $points);
-                    if ($points > $max) {
-                        $max = $points;
-                    }
-                    if (((strlen($points)) == 0) || (!is_numeric($points))) {
-                        $this->setAlert($this->lng->txt("form_msg_numeric_value_required"));
+                    $max = max($max, $points);
+                    if ($points === '' || !is_numeric($points)) {
+                        $this->setAlert($this->lng->txt('form_msg_numeric_value_required'));
                         return false;
                     }
                 }
             }
-            if ($max == 0) {
-                $this->setAlert($this->lng->txt("enter_enough_positive_points"));
+            if ($max === 0) {
+                $this->setAlert($this->lng->txt('enter_enough_positive_points'));
                 return false;
             }
 
@@ -278,62 +282,64 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                             switch ($error) {
                                 case UPLOAD_ERR_FORM_SIZE:
                                 case UPLOAD_ERR_INI_SIZE:
-                                    $this->setAlert($this->lng->txt("form_msg_file_size_exceeds"));
+                                    $this->setAlert($this->lng->txt('form_msg_file_size_exceeds'));
                                     return false;
                                     break;
 
                                 case UPLOAD_ERR_PARTIAL:
-                                    $this->setAlert($this->lng->txt("form_msg_file_partially_uploaded"));
+                                    $this->setAlert($this->lng->txt('form_msg_file_partially_uploaded'));
                                     return false;
                                     break;
 
                                 case UPLOAD_ERR_NO_FILE:
-                                    if ($this->getRequired()) {
-                                        if ((!isset($foundvalues['imagename'][$index])) && (!strlen($foundvalues['answer'][$index]))) {
-                                            $this->setAlert($this->lng->txt("form_msg_file_no_upload"));
-                                            return false;
-                                        }
+                                    if (
+                                        $this->getRequired()
+                                        && !isset($found_values['imagename'][$index])
+                                        && $found_values['answer'][$index] === ''
+                                    ) {
+                                        $this->setAlert($this->lng->txt('form_msg_file_no_upload'));
+                                        return false;
                                     }
                                     break;
 
                                 case UPLOAD_ERR_NO_TMP_DIR:
-                                    $this->setAlert($this->lng->txt("form_msg_file_missing_tmp_dir"));
+                                    $this->setAlert($this->lng->txt('form_msg_file_missing_tmp_dir'));
                                     return false;
                                     break;
 
                                 case UPLOAD_ERR_CANT_WRITE:
-                                    $this->setAlert($this->lng->txt("form_msg_file_cannot_write_to_disk"));
+                                    $this->setAlert($this->lng->txt('form_msg_file_cannot_write_to_disk'));
                                     return false;
                                     break;
 
                                 case UPLOAD_ERR_EXTENSION:
-                                    $this->setAlert($this->lng->txt("form_msg_file_upload_stopped_ext"));
+                                    $this->setAlert($this->lng->txt('form_msg_file_upload_stopped_ext'));
                                     return false;
                                     break;
                             }
                         }
                     }
-                } else {
-                    if ($this->getRequired()) {
-                        $this->setAlert($this->lng->txt("form_msg_file_no_upload"));
-                        return false;
-                    }
+                } elseif ($this->getRequired()) {
+                    $this->setAlert($this->lng->txt('form_msg_file_no_upload'));
+                    return false;
                 }
 
                 if (is_array($_FILES[$this->getPostVar()]['tmp_name']['image'])) {
                     foreach ($_FILES[$this->getPostVar()]['tmp_name']['image'] as $index => $tmpname) {
                         $filename = $_FILES[$this->getPostVar()]['name']['image'][$index];
-                        if ($filename != '') {
+                        if ($filename !== '') {
                             $filename_arr = pathinfo($filename);
-                            $suffix = $filename_arr["extension"];
+                            $suffix = $filename_arr['extension'];
                             $mimetype = $_FILES[$this->getPostVar()]['type']['image'][$index];
                             $size_bytes = $_FILES[$this->getPostVar()]['size']['image'][$index];
                             // check suffixes
-                            if (strlen($tmpname) && is_array($this->getSuffixes())) {
-                                if (!in_array(strtolower($suffix), $this->getSuffixes())) {
-                                    $this->setAlert($this->lng->txt("form_msg_file_wrong_file_type"));
-                                    return false;
-                                }
+                            if (
+                                $tmpname !== ''
+                                && is_array($this->getSuffixes())
+                                && !in_array(strtolower($suffix), $this->getSuffixes(), true)
+                            ) {
+                                $this->setAlert($this->lng->txt('form_msg_file_wrong_file_type'));
+                                return false;
                             }
                         }
                     }
@@ -342,16 +348,16 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                 if (is_array($_FILES[$this->getPostVar()]['tmp_name']['image'])) {
                     foreach ($_FILES[$this->getPostVar()]['tmp_name']['image'] as $index => $tmpname) {
                         $filename = $_FILES[$this->getPostVar()]['name']['image'][$index];
-                        if ($filename != '') {
+                        if ($filename !== '') {
                             $filename_arr = pathinfo($filename);
-                            $suffix = $filename_arr["extension"];
+                            $suffix = $filename_arr['extension'];
                             $mimetype = $_FILES[$this->getPostVar()]['type']['image'][$index];
                             $size_bytes = $_FILES[$this->getPostVar()]['size']['image'][$index];
                             // virus handling
-                            if (strlen($tmpname)) {
+                            if ($tmpname !== '') {
                                 $vir = ilVirusScanner::virusHandling($tmpname, $filename);
                                 if ($vir[0] == false) {
-                                    $this->setAlert($this->lng->txt("form_msg_file_virus_found") . "<br />" . $vir[1]);
+                                    $this->setAlert($this->lng->txt('form_msg_file_virus_found') . '<br />' . $vir[1]);
                                     return false;
                                 }
                             }
@@ -360,7 +366,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                 }
             }
         } else {
-            $this->setAlert($this->lng->txt("msg_input_is_required"));
+            $this->setAlert($this->lng->txt('msg_input_is_required'));
             return false;
         }
 
@@ -369,7 +375,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
 
     public function insert(ilTemplate $a_tpl): void
     {
-        $tpl = new ilTemplate("tpl.prop_singlechoicewizardinput.html", true, true, "components/ILIAS/TestQuestionPool");
+        $tpl = new ilTemplate('tpl.prop_singlechoicewizardinput.html', true, true, 'components/ILIAS/TestQuestionPool');
         $i = 0;
         foreach ($this->values as $value) {
             if ($this->getSingleline()) {
@@ -388,106 +394,106 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                             'ALT_IMAGE',
                             ilLegacyFormElementsUtil::prepareFormOutput($value->getAnswertext())
                         );
-                        $tpl->setVariable("TXT_DELETE_EXISTING", $this->lng->txt("delete_existing_file"));
-                        $tpl->setVariable("IMAGE_ROW_NUMBER", $i);
-                        $tpl->setVariable("IMAGE_POST_VAR", $this->getPostVar());
+                        $tpl->setVariable('TXT_DELETE_EXISTING', $this->lng->txt('delete_existing_file'));
+                        $tpl->setVariable('IMAGE_ROW_NUMBER', $i);
+                        $tpl->setVariable('IMAGE_POST_VAR', $this->getPostVar());
                         $tpl->parseCurrentBlock();
                     }
                     $tpl->setCurrentBlock('addimage');
-                    $tpl->setVariable("IMAGE_BROWSE", $this->lng->txt('select_file'));
-                    $tpl->setVariable("IMAGE_ID", $this->getPostVar() . "[image][$i]");
-                    $tpl->setVariable("IMAGE_SUBMIT", $this->lng->txt("upload"));
-                    $tpl->setVariable("IMAGE_ROW_NUMBER", $i);
-                    $tpl->setVariable("IMAGE_POST_VAR", $this->getPostVar());
+                    $tpl->setVariable('IMAGE_BROWSE', $this->lng->txt('select_file'));
+                    $tpl->setVariable('IMAGE_ID', $this->getPostVar() . "[image][$i]");
+                    $tpl->setVariable('IMAGE_SUBMIT', $this->lng->txt('upload'));
+                    $tpl->setVariable('IMAGE_ROW_NUMBER', $i);
+                    $tpl->setVariable('IMAGE_POST_VAR', $this->getPostVar());
                     $tpl->parseCurrentBlock();
                 }
 
                 if (is_object($value)) {
-                    $tpl->setCurrentBlock("prop_text_propval");
+                    $tpl->setCurrentBlock('prop_text_propval');
                     $tpl->setVariable(
-                        "PROPERTY_VALUE",
+                        'PROPERTY_VALUE',
                         ilLegacyFormElementsUtil::prepareFormOutput($value->getAnswertext())
                     );
                     $tpl->parseCurrentBlock();
                     if ($this->getShowPoints()) {
-                        $tpl->setCurrentBlock("prop_points_propval");
+                        $tpl->setCurrentBlock('prop_points_propval');
                         $tpl->setVariable(
-                            "PROPERTY_VALUE",
+                            'PROPERTY_VALUE',
                             ilLegacyFormElementsUtil::prepareFormOutput($value->getPoints())
                         );
                         $tpl->parseCurrentBlock();
                     }
-                    $tpl->setCurrentBlock("prop_answer_id_propval");
-                    $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput($value->getId()));
+                    $tpl->setCurrentBlock('prop_answer_id_propval');
+                    $tpl->setVariable('PROPERTY_VALUE', ilLegacyFormElementsUtil::prepareFormOutput($value->getId()));
                     $tpl->parseCurrentBlock();
                 }
                 $tpl->setCurrentBlock('singleline');
-                $tpl->setVariable("SIZE", $this->getSize());
-                $tpl->setVariable("SINGLELINE_ID", $this->getPostVar() . "[answer][$i]");
-                $tpl->setVariable("SINGLELINE_ROW_NUMBER", $i);
-                $tpl->setVariable("SINGLELINE_POST_VAR", $this->getPostVar());
-                $tpl->setVariable("MAXLENGTH", $this->getMaxLength());
+                $tpl->setVariable('SIZE', $this->getSize());
+                $tpl->setVariable('SINGLELINE_ID', $this->getPostVar() . "[answer][$i]");
+                $tpl->setVariable('SINGLELINE_ROW_NUMBER', $i);
+                $tpl->setVariable('SINGLELINE_POST_VAR', $this->getPostVar());
+                $tpl->setVariable('MAXLENGTH', $this->getMaxLength());
                 if ($this->getDisabled()) {
-                    $tpl->setVariable("DISABLED_SINGLELINE", " disabled=\"disabled\"");
+                    $tpl->setVariable('DISABLED_SINGLELINE', ' disabled="disabled"');
                 }
                 $tpl->parseCurrentBlock();
             } elseif (!$this->getSingleline()) {
                 if (is_object($value)) {
                     if ($this->getShowPoints()) {
-                        $tpl->setCurrentBlock("prop_points_propval");
+                        $tpl->setCurrentBlock('prop_points_propval');
                         $tpl->setVariable(
-                            "PROPERTY_VALUE",
+                            'PROPERTY_VALUE',
                             ilLegacyFormElementsUtil::prepareFormOutput($value->getPoints())
                         );
                         $tpl->parseCurrentBlock();
                     }
-                    $tpl->setCurrentBlock("prop_answer_id_propval");
-                    $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput($value->getId()));
+                    $tpl->setCurrentBlock('prop_answer_id_propval');
+                    $tpl->setVariable('PROPERTY_VALUE', ilLegacyFormElementsUtil::prepareFormOutput($value->getId()));
                     $tpl->parseCurrentBlock();
                 }
                 $tpl->setCurrentBlock('multiline');
                 $tpl->setVariable(
-                    "PROPERTY_VALUE",
+                    'PROPERTY_VALUE',
                     ilLegacyFormElementsUtil::prepareFormOutput($value->getAnswertext())
                 );
-                $tpl->setVariable("MULTILINE_ID", $this->getPostVar() . "[answer][$i]");
-                $tpl->setVariable("MULTILINE_ROW_NUMBER", $i);
-                $tpl->setVariable("MULTILINE_POST_VAR", $this->getPostVar());
+                $tpl->setVariable('MULTILINE_ID', $this->getPostVar() . "[answer][$i]");
+                $tpl->setVariable('MULTILINE_ROW_NUMBER', $i);
+                $tpl->setVariable('MULTILINE_POST_VAR', $this->getPostVar());
                 $tpl->setVariable("MAXLENGTH", $this->getMaxLength());
                 if ($this->getDisabled()) {
-                    $tpl->setVariable("DISABLED_MULTILINE", " disabled=\"disabled\"");
+                    $tpl->setVariable('DISABLED_MULTILINE', ' disabled="disabled"');
                 }
                 $tpl->parseCurrentBlock();
             }
             if ($this->getAllowMove()) {
-                $tpl->setCurrentBlock("move");
-                $tpl->setVariable("ID", $this->getPostVar() . "[$i]");
-                $tpl->setVariable("UP_BUTTON", $this->renderer->render(
+                $tpl->setCurrentBlock('move');
+                $tpl->setVariable('ID', $this->getPostVar() . "[$i]");
+                $tpl->setVariable('UP_BUTTON', $this->renderer->render(
                     $this->glyph_factory->up()->withAction('#')
                 ));
-                $tpl->setVariable("DOWN_BUTTON", $this->renderer->render(
+                $tpl->setVariable('DOWN_BUTTON', $this->renderer->render(
                     $this->glyph_factory->down()->withAction('#')
                 ));
                 $tpl->parseCurrentBlock();
             }
             if ($this->getShowPoints()) {
-                $tpl->setCurrentBlock("points");
-                $tpl->setVariable("POINTS_ID", $this->getPostVar() . "[points][$i]");
-                $tpl->setVariable("POINTS_POST_VAR", $this->getPostVar());
-                $tpl->setVariable("POINTS_ROW_NUMBER", $i);
+                $tpl->setCurrentBlock('points');
+                $tpl->setVariable('POINTS_ID', $this->getPostVar() . "[points][$i]");
+                $tpl->setVariable('POINTS_POST_VAR', $this->getPostVar());
+                $tpl->setVariable('POINTS_ROW_NUMBER', $i);
                 $tpl->parseCurrentBlock();
             }
-            $tpl->setCurrentBlock("row");
-            $tpl->setVariable("POST_VAR", $this->getPostVar());
-            $tpl->setVariable("ROW_NUMBER", $i);
-            $tpl->setVariable("ID", $this->getPostVar() . "[answer][$i]");
+            $tpl->setCurrentBlock('row');
+            $tpl->setVariable('POST_VAR', $this->getPostVar());
+            $tpl->setVariable('ROW_NUMBER', $i);
+            $tpl->setVariable('ID', $this->getPostVar() . "[answer][$i]");
             if ($this->getDisabled()) {
-                $tpl->setVariable("DISABLED_POINTS", " disabled=\"disabled\"");
+                $tpl->setVariable('DISABLED_POINTS', ' disabled="disabled"');
             }
-            $tpl->setVariable("ADD_BUTTON", $this->renderer->render(
+            $tpl->setVariable('ADD_BUTTON', $this->renderer->render(
                 $this->glyph_factory->add()->withAction('#')
             ));
-            $tpl->setVariable("REMOVE_BUTTON", $this->renderer->render(
+            $tpl->setVariable('REMOVE_BUTTON', $this->renderer->render(
                 $this->glyph_factory->remove()->withAction('#')
             ));
             $tpl->parseCurrentBlock();
@@ -497,43 +503,43 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         if ($this->getSingleline()) {
             if (!$this->hideImages) {
                 if (is_array($this->getSuffixes())) {
-                    $suff_str = $delim = "";
+                    $suff_str = $delim = '';
                     foreach ($this->getSuffixes() as $suffix) {
-                        $suff_str .= $delim . "." . $suffix;
-                        $delim = ", ";
+                        $suff_str .= $delim . '.' . $suffix;
+                        $delim = ', ';
                     }
                     $tpl->setCurrentBlock('allowed_image_suffixes');
-                    $tpl->setVariable("TXT_ALLOWED_SUFFIXES", $this->lng->txt("file_allowed_suffixes") . " " . $suff_str);
+                    $tpl->setVariable('TXT_ALLOWED_SUFFIXES', $this->lng->txt('file_allowed_suffixes') . ' ' . $suff_str);
                     $tpl->parseCurrentBlock();
                 }
-                $tpl->setCurrentBlock("image_heading");
-                $tpl->setVariable("ANSWER_IMAGE", $this->lng->txt('answer_image'));
-                $tpl->setVariable("TXT_MAX_SIZE", ilFileUtils::getFileSizeInfo());
+                $tpl->setCurrentBlock('image_heading');
+                $tpl->setVariable('ANSWER_IMAGE', $this->lng->txt('answer_image'));
+                $tpl->setVariable('TXT_MAX_SIZE', ilFileUtils::getFileSizeInfo());
                 $tpl->parseCurrentBlock();
             }
         }
 
         if ($this->getShowPoints()) {
-            $tpl->setCurrentBlock("points_heading");
-            $tpl->setVariable("POINTS_TEXT", $this->lng->txt('points'));
+            $tpl->setCurrentBlock('points_heading');
+            $tpl->setVariable('POINTS_TEXT', $this->lng->txt('points'));
             $tpl->parseCurrentBlock();
         }
 
-        $tpl->setVariable("ELEMENT_ID", $this->getPostVar());
-        $tpl->setVariable("TEXT_YES", $this->lng->txt('yes'));
-        $tpl->setVariable("TEXT_NO", $this->lng->txt('no'));
-        $tpl->setVariable("DELETE_IMAGE_HEADER", $this->lng->txt('delete_image_header'));
-        $tpl->setVariable("DELETE_IMAGE_QUESTION", $this->lng->txt('delete_image_question'));
-        $tpl->setVariable("ANSWER_TEXT", $this->lng->txt('answer_text'));
-        $tpl->setVariable("COMMANDS_TEXT", $this->lng->txt('actions'));
+        $tpl->setVariable('ELEMENT_ID', $this->getPostVar());
+        $tpl->setVariable('TEXT_YES', $this->lng->txt('yes'));
+        $tpl->setVariable('TEXT_NO', $this->lng->txt('no'));
+        $tpl->setVariable('DELETE_IMAGE_HEADER', $this->lng->txt('delete_image_header'));
+        $tpl->setVariable('DELETE_IMAGE_QUESTION', $this->lng->txt('delete_image_question'));
+        $tpl->setVariable('ANSWER_TEXT', $this->lng->txt('answer_text'));
+        $tpl->setVariable('COMMANDS_TEXT', $this->lng->txt('actions'));
 
-        $a_tpl->setCurrentBlock("prop_generic");
-        $a_tpl->setVariable("PROP_GENERIC", $tpl->get());
+        $a_tpl->setCurrentBlock('prop_generic');
+        $a_tpl->setVariable('PROP_GENERIC', $tpl->get());
         $a_tpl->parseCurrentBlock();
 
         global $DIC;
         $tpl = $DIC['tpl'];
-        $tpl->addJavascript("assets/js/answerwizardinput.js");
-        $tpl->addJavascript("assets/js/singlechoicewizard.js");
+        $tpl->addJavascript('assets/js/answerwizardinput.js');
+        $tpl->addJavascript('assets/js/singlechoicewizard.js');
     }
 }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilSuggestedSolutionSelectorGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilSuggestedSolutionSelectorGUI.php
@@ -162,13 +162,19 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $_POST[$this->getPostVar()] =
-            ilUtil::stripSlashes($_POST[$this->getPostVar()]);
-        if ($this->getRequired() && trim($_POST[$this->getPostVar()]) == "") {
-            $this->setAlert($lng->txt("msg_input_is_required"));
+        $post_var = $this->http->wrapper()->post()->retrieve(
+            $this->getPostVar(),
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always('')
+            ])
+        );
 
+        if ($this->getRequired() && trim(ilUtil::stripSlashes($post_var)) === '') {
+            $this->setAlert($lng->txt('msg_input_is_required'));
             return false;
         }
+
         return $this->checkSubItemsInput();
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilSuggestedSolutionSelectorGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilSuggestedSolutionSelectorGUI.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
 * This class represents a selection list property in a property form.
 *
@@ -33,8 +31,6 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     protected $intlink;
     protected $intlinktext;
 
-    protected readonly RequestDataCollector $request_data_collector;
-
     /**
     * Constructor
     *
@@ -45,9 +41,6 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     {
         parent::__construct($a_title, $a_postvar);
         $this->setType("select");
-
-        global $DIC;
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     /**
@@ -166,13 +159,8 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     */
     public function checkInput(): bool
     {
-        global $DIC;
-        $lng = $DIC['lng'];
-
-        $post_var = $this->request_data_collector->retrieveStringValueFromPost($this->getPostVar(), '');
-
-        if ($this->getRequired() && trim(ilUtil::stripSlashes($post_var)) === '') {
-            $this->setAlert($lng->txt('msg_input_is_required'));
+        if ($this->getRequired() && $this->str($this->getPostVar()) === '') {
+            $this->setAlert($this->lng->txt('msg_input_is_required'));
             return false;
         }
 
@@ -181,9 +169,6 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
 
     public function insert($a_tpl): void
     {
-        global $DIC;
-        $lng = $DIC['lng'];
-
         $template = new ilTemplate("tpl.prop_suggestedsolutionselector.html", true, true, "components/ILIAS/TestQuestionPool");
 
         foreach ($this->getOptions() as $option_value => $option_text) {
@@ -200,7 +185,7 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
         }
         if ($this->getInternalLink()) {
             $template->setCurrentBlock("delete_internallink");
-            $template->setVariable("TEXT_DELETE_INTERNALLINK", $lng->txt("remove_solution"));
+            $template->setVariable("TEXT_DELETE_INTERNALLINK", $this->lng->txt("remove_solution"));
             $template->setVariable("POST_VAR", $this->getPostVar());
             $template->parseCurrentBlock();
             $template->setCurrentBlock("internal_link");
@@ -216,7 +201,10 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
                 " disabled=\"disabled\""
             );
         }
-        $template->setVariable("TEXT_ADD_INTERNALLINK", ($this->getInternalLink()) ? $lng->txt("change") : $lng->txt("add"));
+        $template->setVariable(
+            "TEXT_ADD_INTERNALLINK",
+            ($this->getInternalLink()) ? $this->lng->txt("change") : $this->lng->txt("add")
+        );
         $template->setVariable("CMD_ADD_INTERNALLINK", $this->getAddCommand());
         $template->parseCurrentBlock();
         $a_tpl->setCurrentBlock("prop_generic");

--- a/components/ILIAS/TestQuestionPool/classes/class.ilSuggestedSolutionSelectorGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilSuggestedSolutionSelectorGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
 * This class represents a selection list property in a property form.
 *
@@ -31,6 +33,8 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     protected $intlink;
     protected $intlinktext;
 
+    protected readonly RequestDataCollector $request_data_collector;
+
     /**
     * Constructor
     *
@@ -41,6 +45,9 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
     {
         parent::__construct($a_title, $a_postvar);
         $this->setType("select");
+
+        global $DIC;
+        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     /**
@@ -162,13 +169,7 @@ class ilSuggestedSolutionSelectorGUI extends ilSubEnabledFormPropertyGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $post_var = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always('')
-            ])
-        );
+        $post_var = $this->request_data_collector->retrieveStringValueFromPost($this->getPostVar(), '');
 
         if ($this->getRequired() && trim(ilUtil::stripSlashes($post_var)) === '') {
             $this->setAlert($lng->txt('msg_input_is_required'));

--- a/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\HTTP\Services as Http;
+use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\TestQuestionPool\Import\TestQuestionsImportTrait;
 
 /**
@@ -37,38 +39,48 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
     private $pool_obj;
     private ilObjUser $user;
 
+    private Http $http;
+    private Refinery $refinery;
+
+    public function __construct()
+    {
+        global $DIC;
+        parent::__construct();
+
+        $this->http = $DIC->http();
+        $this->refinery = $DIC->refinery();
+    }
+
     /**
      * Import XML
-     * @param
-     * @return void
+     * @throws ilDatabaseException|ilObjectNotFoundException|ilSaxParserException
      */
     public function importXmlRepresentation(string $a_entity, string $a_id, string $a_xml, ilImportMapping $a_mapping): void
     {
+        global $DIC;
         // Container import => pool object already created
         if (($new_id = $a_mapping->getMapping('components/ILIAS/Container', 'objs', $a_id)) !== null) {
             $new_obj = ilObjectFactory::getInstanceByObjId((int) $new_id, false);
-            $new_obj->getObjectProperties()->storePropertyIsOnline($new_obj->getObjectProperties()->getPropertyIsOnline()->withOffline()); // sets Question pools to always online
+            $new_obj?->getObjectProperties()->storePropertyIsOnline($new_obj?->getObjectProperties()->getPropertyIsOnline()->withOffline()); // sets Question pools to always online
 
             $selected_questions = [];
-            list($importdir, $xmlfile, $qtifile) = $this->buildImportDirectoriesFromContainerImport(
+            [$importdir, $xmlfile, $qtifile] = $this->buildImportDirectoriesFromContainerImport(
                 $this->getImportDirectory()
             );
-        } elseif (($new_id = $a_mapping->getMapping('components/ILIAS/TestQuestionPool', 'qpl', "new_id")) !== null) {
+        } elseif (($new_id = $a_mapping->getMapping('components/ILIAS/TestQuestionPool', 'qpl', 'new_id')) !== null) {
             $new_obj = ilObjectFactory::getInstanceByObjId((int) $new_id, false);
 
             $selected_questions = ilSession::get('qpl_import_selected_questions');
-            list($subdir, $importdir, $xmlfile, $qtifile) = $this->buildImportDirectoriesFromImportFile(
+            [$subdir, $importdir, $xmlfile, $qtifile] = $this->buildImportDirectoriesFromImportFile(
                 ilSession::get('path_to_import_file')
             );
             ilSession::clear('qpl_import_selected_questions');
         } else {
             // Shouldn't happen
-            global $DIC; /* @var ILIAS\DI\Container $DIC */
             $DIC['ilLog']->write(__METHOD__ . ': non container and no tax mapping, perhaps old qpl export');
             return;
         }
 
-        global $DIC; /* @var ILIAS\DI\Container $DIC */
         if (!file_exists($xmlfile)) {
             $DIC['ilLog']->write(__METHOD__ . ': Cannot find xml definition: ' . $xmlfile);
             return;
@@ -80,28 +92,35 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
 
         $this->pool_obj = $new_obj;
 
-        $new_obj->fromXML($xmlfile);
+        $new_obj?->fromXML($xmlfile);
+
+        $qpl_new = $this->http->wrapper()->post()->retrieve(
+            'qpl_new',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->string(),
+                $this->refinery->always('')
+            ])
+        );
 
         // set another question pool name (if possible)
-        if (isset($_POST["qpl_new"]) && strlen($_POST["qpl_new"])) {
-            $new_obj->setTitle($_POST["qpl_new"]);
+        if ($qpl_new !== '') {
+            $new_obj?->setTitle($qpl_new);
         }
 
-        $new_obj->update();
-        $new_obj->saveToDb();
+        $new_obj?->update();
+        $new_obj?->saveToDb();
 
         // FIXME: Copied from ilObjQuestionPoolGUI::importVerifiedFileObject
         // TODO: move all logic to ilObjQuestionPoolGUI::importVerifiedFile and call
         // this method from ilObjQuestionPoolGUI and ilTestImporter
 
-        global $DIC; /* @var ILIAS\DI\Container $DIC */
-        $DIC['ilLog']->write(__METHOD__ . ': xml file: ' . $xmlfile . ", qti file:" . $qtifile);
+        $DIC['ilLog']->write(__METHOD__ . ': xml file: ' . $xmlfile . ', qti file:' . $qtifile);
 
         $qtiParser = new ilQTIParser(
             $importdir,
             $qtifile,
             ilQTIParser::IL_MO_PARSE_QTI,
-            $new_obj->getId(),
+            $new_obj?->getId(),
             $selected_questions
         );
         $qtiParser->startParsing();
@@ -119,39 +138,39 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
             $newQuestionId = (string) $v['pool']; // yes, this is the new question id ^^
 
             $a_mapping->addMapping(
-                "components/ILIAS/Taxonomy",
-                "tax_item",
-                "qpl:quest:$oldQuestionId",
+                'components/ILIAS/Taxonomy',
+                'tax_item',
+                'qpl:quest:$oldQuestionId',
                 $newQuestionId
             );
 
             $a_mapping->addMapping(
-                "components/ILIAS/Taxonomy",
-                "tax_item_obj_id",
-                "qpl:quest:$oldQuestionId",
-                (string) $new_obj->getId()
+                'components/ILIAS/Taxonomy',
+                'tax_item_obj_id',
+                'qpl:quest:$oldQuestionId',
+                (string) $new_obj?->getId()
             );
 
             $a_mapping->addMapping(
-                "components/ILIAS/TestQuestionPool",
-                "quest",
+                'components/ILIAS/TestQuestionPool',
+                'quest',
                 $oldQuestionId,
                 $newQuestionId
             );
         }
 
-        $this->importQuestionSkillAssignments($xmlfile, $a_mapping, $new_obj->getId());
+        $this->importQuestionSkillAssignments($xmlfile, $a_mapping, $new_obj?->getId());
 
-        $a_mapping->addMapping("components/ILIAS/TestQuestionPool", "qpl", $a_id, (string) $new_obj->getId());
+        $a_mapping->addMapping('components/ILIAS/TestQuestionPool', 'qpl', $a_id, (string) $new_obj->getId());
         $a_mapping->addMapping(
-            "components/ILIAS/MetaData",
-            "md",
-            $a_id . ":0:qpl",
-            $new_obj->getId() . ":0:qpl"
+            'components/ILIAS/MetaData',
+            'md',
+            $a_id . ':0:qpl',
+            $new_obj->getId() . ':0:qpl'
         );
 
 
-        $new_obj->saveToDb();
+        $new_obj?->saveToDb();
     }
 
     /**
@@ -161,13 +180,13 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
      */
     public function finalProcessing(ilImportMapping $a_mapping): void
     {
-        $maps = $a_mapping->getMappingsOfEntity("components/ILIAS/TestQuestionPool", "qpl");
+        $maps = $a_mapping->getMappingsOfEntity('components/ILIAS/TestQuestionPool', 'qpl');
         foreach ($maps as $old => $new) {
-            if ($old != "new_id" && (int) $old > 0) {
+            if ($old !== 'new_id' && (int) $old > 0) {
                 // get all new taxonomys of this object
-                $new_tax_ids = $a_mapping->getMapping("components/ILIAS/Taxonomy", "tax_usage_of_obj", (string) $old);
+                $new_tax_ids = $a_mapping->getMapping('components/ILIAS/Taxonomy', 'tax_usage_of_obj', (string) $old);
                 if ($new_tax_ids !== null) {
-                    $tax_ids = explode(":", $new_tax_ids);
+                    $tax_ids = explode(':', $new_tax_ids);
                     foreach ($tax_ids as $tid) {
                         ilObjTaxonomy::saveUsage((int) $tid, (int) $new);
                     }
@@ -176,6 +195,9 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
         }
     }
 
+    /**
+     * @throws ilSaxParserException
+     */
     protected function importQuestionSkillAssignments($xmlFile, ilImportMapping $mappingRegistry, $targetParentObjId): void
     {
         $parser = new ilAssQuestionSkillAssignmentXmlParser($xmlFile);

--- a/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -59,7 +59,7 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
         // Container import => pool object already created
         if (($new_id = $a_mapping->getMapping('components/ILIAS/Container', 'objs', $a_id)) !== null) {
             $new_obj = ilObjectFactory::getInstanceByObjId((int) $new_id, false);
-            $new_obj?->getObjectProperties()->storePropertyIsOnline($new_obj?->getObjectProperties()->getPropertyIsOnline()->withOffline()); // sets Question pools to always online
+            $new_obj->getObjectProperties()->storePropertyIsOnline($new_obj->getObjectProperties()->getPropertyIsOnline()->withOffline()); // sets Question pools to always online
 
             $selected_questions = [];
             [$importdir, $xmlfile, $qtifile] = $this->buildImportDirectoriesFromContainerImport(
@@ -90,17 +90,17 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
 
         $this->pool_obj = $new_obj;
 
-        $new_obj?->fromXML($xmlfile);
+        $new_obj->fromXML($xmlfile);
 
         $qpl_new = $this->request_data_collector->string('qpl_new');
 
         // set another question pool name (if possible)
         if ($qpl_new !== '') {
-            $new_obj?->setTitle($qpl_new);
+            $new_obj->setTitle($qpl_new);
         }
 
-        $new_obj?->update();
-        $new_obj?->saveToDb();
+        $new_obj->update();
+        $new_obj->saveToDb();
 
         // FIXME: Copied from ilObjQuestionPoolGUI::importVerifiedFileObject
         // TODO: move all logic to ilObjQuestionPoolGUI::importVerifiedFile and call
@@ -112,7 +112,7 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
             $importdir,
             $qtifile,
             ilQTIParser::IL_MO_PARSE_QTI,
-            $new_obj?->getId(),
+            $new_obj->getId(),
             $selected_questions
         );
         $qtiParser->startParsing();
@@ -140,7 +140,7 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
                 'components/ILIAS/Taxonomy',
                 'tax_item_obj_id',
                 'qpl:quest:$oldQuestionId',
-                (string) $new_obj?->getId()
+                (string) $new_obj->getId()
             );
 
             $a_mapping->addMapping(
@@ -151,7 +151,7 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
             );
         }
 
-        $this->importQuestionSkillAssignments($xmlfile, $a_mapping, $new_obj?->getId());
+        $this->importQuestionSkillAssignments($xmlfile, $a_mapping, $new_obj->getId());
 
         $a_mapping->addMapping('components/ILIAS/TestQuestionPool', 'qpl', $a_id, (string) $new_obj->getId());
         $a_mapping->addMapping(
@@ -162,7 +162,7 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
         );
 
 
-        $new_obj?->saveToDb();
+        $new_obj->saveToDb();
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\HTTP\Services as Http;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\TestQuestionPool\Import\TestQuestionsImportTrait;
+use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
  * Importer class for question pools
@@ -33,6 +34,9 @@ use ILIAS\TestQuestionPool\Import\TestQuestionsImportTrait;
 class ilTestQuestionPoolImporter extends ilXmlImporter
 {
     use TestQuestionsImportTrait;
+
+    protected readonly RequestDataCollector $request_data_collector;
+
     /**
      * @var ilObjQuestionPool
      */
@@ -49,6 +53,8 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
 
         $this->http = $DIC->http();
         $this->refinery = $DIC->refinery();
+
+        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
     }
 
     /**
@@ -94,13 +100,7 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
 
         $new_obj?->fromXML($xmlfile);
 
-        $qpl_new = $this->http->wrapper()->post()->retrieve(
-            'qpl_new',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->string(),
-                $this->refinery->always('')
-            ])
-        );
+        $qpl_new = $this->request_data_collector->retrieveStringValueFromPost('qpl_new', '');
 
         // set another question pool name (if possible)
         if ($qpl_new !== '') {

--- a/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -19,6 +19,7 @@
 declare(strict_types=1);
 
 use ILIAS\TestQuestionPool\Import\TestQuestionsImportTrait;
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
@@ -43,10 +44,10 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
 
     public function __construct()
     {
-        global $DIC;
         parent::__construct();
 
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
+        $local_dic = QuestionPoolDIC::dic();
+        $this->request_data_collector = $local_dic['request_data_collector'];
     }
 
     /**
@@ -91,7 +92,7 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
 
         $new_obj?->fromXML($xmlfile);
 
-        $qpl_new = $this->request_data_collector->retrieveStringValueFromPost('qpl_new', '');
+        $qpl_new = $this->request_data_collector->string('qpl_new');
 
         // set another question pool name (if possible)
         if ($qpl_new !== '') {

--- a/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -18,8 +18,6 @@
 
 declare(strict_types=1);
 
-use ILIAS\HTTP\Services as Http;
-use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\TestQuestionPool\Import\TestQuestionsImportTrait;
 use ILIAS\TestQuestionPool\RequestDataCollector;
 
@@ -35,31 +33,24 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
 {
     use TestQuestionsImportTrait;
 
-    protected readonly RequestDataCollector $request_data_collector;
-
     /**
      * @var ilObjQuestionPool
      */
     private $pool_obj;
     private ilObjUser $user;
 
-    private Http $http;
-    private Refinery $refinery;
+    protected readonly RequestDataCollector $request_data_collector;
 
     public function __construct()
     {
         global $DIC;
         parent::__construct();
 
-        $this->http = $DIC->http();
-        $this->refinery = $DIC->refinery();
-
-        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $DIC->upload());
+        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     /**
      * Import XML
-     * @throws ilDatabaseException|ilObjectNotFoundException|ilSaxParserException
      */
     public function importXmlRepresentation(string $a_entity, string $a_id, string $a_xml, ilImportMapping $a_mapping): void
     {
@@ -195,9 +186,6 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
         }
     }
 
-    /**
-     * @throws ilSaxParserException
-     */
     protected function importQuestionSkillAssignments($xmlFile, ilImportMapping $mappingRegistry, $targetParentObjId): void
     {
         $parser = new ilAssQuestionSkillAssignmentXmlParser($xmlFile);

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
@@ -40,7 +40,7 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
 
     public function setValue($a_value): void
     {
-        foreach ($this->request_helper->transformPoints($a_value) as $index => $value) {
+        foreach ($this->forms_helper->transformPoints($a_value) as $index => $value) {
             $this->values[$index]->setPoints($value);
         }
     }
@@ -48,7 +48,7 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
     public function checkInput(): bool
     {
         if (!$this->isHidePointsEnabled()) {
-            $points = $this->request_helper->checkPointsInputEnoughPositive($this->raw($this->getPostVar()), true);
+            $points = $this->forms_helper->checkPointsInputEnoughPositive($this->raw($this->getPostVar()), true);
             if (!is_array($points)) {
                 $this->setAlert($this->lng->txt($points));
                 return false;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * Class ilTextSubsetCorrectionsInputGUI
  *
@@ -33,14 +31,9 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
      */
     protected bool $hidePointsEnabled = false;
 
-    private RequestDataCollector $request_data_collector;
-
     public function __construct(string $a_title = '', string $a_postvar = '')
     {
         parent::__construct($a_title, $a_postvar);
-        global $DIC;
-
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     /**
@@ -121,9 +114,6 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
         return $this->checkSubItemsInput();
     }
 
-    /**
-     * @throws ilTemplateException
-     */
     public function insert(ilTemplate $a_tpl): void
     {
         global $DIC;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
@@ -29,7 +29,7 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
     /**
      * @var bool
      */
-    protected $hidePointsEnabled = false;
+    protected bool $hidePointsEnabled = false;
 
     /**
      * @return bool
@@ -49,11 +49,9 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
 
     public function setValue($a_value): void
     {
-        if (is_array($a_value)) {
-            if (is_array($a_value['points'])) {
-                foreach ($a_value['points'] as $index => $value) {
-                    $this->values[$index]->setPoints($a_value['points'][$index]);
-                }
+        if (is_array($a_value) && is_array($a_value['points'])) {
+            foreach ($a_value['points'] as $index => $value) {
+                $this->values[$index]->setPoints($a_value['points'][$index]);
             }
         }
     }
@@ -62,88 +60,96 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
     {
         global $DIC;
         $lng = $DIC['lng'];
-        $foundvalues = $_POST[$this->getPostVar()];
+
+        $found_values = $this->http->wrapper()->post()->retrieve(
+            $this->getPostVar(),
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
+                $this->refinery->always(null)
+            ])
+        );
 
         if ($this->isHidePointsEnabled()) {
             return true;
         }
 
-        if (is_array($foundvalues)) {
+        if (is_array($found_values)) {
             // check points
             $max = 0;
-            if (is_array($foundvalues['points'])) {
-                foreach ($foundvalues['points'] as $points) {
-                    $points = str_replace(',', '.', $points);
-                    if ($points > $max) {
-                        $max = $points;
-                    }
-                    if (((strlen($points)) == 0) || (!is_numeric($points))) {
-                        $this->setAlert($lng->txt("form_msg_numeric_value_required"));
+            foreach ($found_values['points'] ?? [] as $points) {
+                $points = str_replace(',', '.', $points);
+                $max = max($max, $points);
+                if ($points === '' || !is_numeric($points)) {
+                    $this->setAlert($lng->txt('form_msg_numeric_value_required'));
+                    return false;
+                }
+
+                if ($this->minvalueShouldBeGreater()) {
+                    if (
+                        trim($points) !== ''
+                        && $this->getMinValue() !== false
+                        && $points <= $this->getMinValue()
+                    ) {
+                        $this->setAlert($lng->txt('form_msg_value_too_low'));
                         return false;
                     }
-                    if ($this->minvalueShouldBeGreater()) {
-                        if (trim($points) != "" &&
-                            $this->getMinValue() !== false &&
-                            $points <= $this->getMinValue()) {
-                            $this->setAlert($lng->txt("form_msg_value_too_low"));
-
-                            return false;
-                        }
-                    } else {
-                        if (trim($points) != "" &&
-                            $this->getMinValue() !== false &&
-                            $points < $this->getMinValue()) {
-                            $this->setAlert($lng->txt("form_msg_value_too_low"));
-
-                            return false;
-                        }
-                    }
+                } elseif (
+                    trim($points) !== ''
+                    && $this->getMinValue() !== false
+                    && $points < $this->getMinValue()
+                ) {
+                    $this->setAlert($lng->txt('form_msg_value_too_low'));
+                    return false;
                 }
             }
-            if ($max == 0) {
-                $this->setAlert($lng->txt("enter_enough_positive_points"));
+
+            if ($max === 0) {
+                $this->setAlert($lng->txt('enter_enough_positive_points'));
                 return false;
             }
         } else {
-            $this->setAlert($lng->txt("msg_input_is_required"));
+            $this->setAlert($lng->txt('msg_input_is_required'));
             return false;
         }
 
         return $this->checkSubItemsInput();
     }
 
+    /**
+     * @throws ilTemplateException
+     */
     public function insert(ilTemplate $a_tpl): void
     {
         global $DIC;
         $lng = $DIC['lng'];
 
-        $tpl = new ilTemplate("tpl.prop_textsubsetcorrection_input.html", true, true, "components/ILIAS/TestQuestionPool");
+        $tpl = new ilTemplate('tpl.prop_textsubsetcorrection_input.html', true, true, 'components/ILIAS/TestQuestionPool');
         $i = 0;
         foreach ($this->values as $value) {
             if (!$this->isHidePointsEnabled()) {
-                $tpl->setCurrentBlock("points");
-                $tpl->setVariable("POST_VAR", $this->getPostVar());
-                $tpl->setVariable("ROW_NUMBER", $i);
-                $tpl->setVariable("POINTS_ID", $this->getPostVar() . "[points][$i]");
-                $tpl->setVariable("POINTS", ilLegacyFormElementsUtil::prepareFormOutput($value->getPoints()));
+                $tpl->setCurrentBlock('points');
+                $tpl->setVariable('POST_VAR', $this->getPostVar());
+                $tpl->setVariable('ROW_NUMBER', $i);
+                $tpl->setVariable('POINTS_ID', $this->getPostVar() . "[points][$i]");
+                $tpl->setVariable('POINTS', ilLegacyFormElementsUtil::prepareFormOutput($value->getPoints()));
                 $tpl->parseCurrentBlock();
             }
 
-            $tpl->setCurrentBlock("row");
-            $tpl->setVariable("ANSWER", ilLegacyFormElementsUtil::prepareFormOutput($value->getAnswertext()));
+            $tpl->setCurrentBlock('row');
+            $tpl->setVariable('ANSWER', ilLegacyFormElementsUtil::prepareFormOutput($value->getAnswertext()));
             $tpl->parseCurrentBlock();
             $i++;
         }
 
-        $tpl->setVariable("ELEMENT_ID", $this->getPostVar());
-        $tpl->setVariable("ANSWER_TEXT", $this->getTextInputLabel($lng));
+        $tpl->setVariable('ELEMENT_ID', $this->getPostVar());
+        $tpl->setVariable('ANSWER_TEXT', $this->getTextInputLabel($lng));
 
         if (!$this->isHidePointsEnabled()) {
-            $tpl->setVariable("POINTS_TEXT", $this->getPointsInputLabel($lng));
+            $tpl->setVariable('POINTS_TEXT', $this->getPointsInputLabel($lng));
         }
 
-        $a_tpl->setCurrentBlock("prop_generic");
-        $a_tpl->setVariable("PROP_GENERIC", $tpl->get());
+        $a_tpl->setCurrentBlock('prop_generic');
+        $a_tpl->setVariable('PROP_GENERIC', $tpl->get());
         $a_tpl->parseCurrentBlock();
     }
 }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
  * Class ilTextSubsetCorrectionsInputGUI
  *
@@ -30,6 +32,16 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
      * @var bool
      */
     protected bool $hidePointsEnabled = false;
+
+    private RequestDataCollector $request_data_collector;
+
+    public function __construct(string $a_title = '', string $a_postvar = '')
+    {
+        parent::__construct($a_title, $a_postvar);
+        global $DIC;
+
+        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
+    }
 
     /**
      * @return bool
@@ -61,13 +73,7 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $found_values = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always(null)
-            ])
-        );
+        $found_values = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
 
         if ($this->isHidePointsEnabled()) {
             return true;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
@@ -26,92 +26,36 @@
  */
 class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
 {
-    /**
-     * @var bool
-     */
-    protected bool $hidePointsEnabled = false;
+    protected bool $hide_points_enabled = false;
 
-    public function __construct(string $a_title = '', string $a_postvar = '')
-    {
-        parent::__construct($a_title, $a_postvar);
-    }
-
-    /**
-     * @return bool
-     */
     public function isHidePointsEnabled(): bool
     {
-        return $this->hidePointsEnabled;
+        return $this->hide_points_enabled;
     }
 
-    /**
-     * @param bool $hidePointsEnabled
-     */
-    public function setHidePointsEnabled(bool $hidePointsEnabled): void
+    public function setHidePointsEnabled(bool $hide_points_enabled): void
     {
-        $this->hidePointsEnabled = $hidePointsEnabled;
+        $this->hide_points_enabled = $hide_points_enabled;
     }
 
     public function setValue($a_value): void
     {
-        if (is_array($a_value) && is_array($a_value['points'])) {
-            foreach ($a_value['points'] as $index => $value) {
-                $this->values[$index]->setPoints($a_value['points'][$index]);
-            }
+        foreach ($this->request_helper->transformPoints($a_value) as $index => $value) {
+            $this->values[$index]->setPoints($value);
         }
     }
 
     public function checkInput(): bool
     {
-        global $DIC;
-        $lng = $DIC['lng'];
-
-        $found_values = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
-
-        if ($this->isHidePointsEnabled()) {
-            return true;
-        }
-
-        if (is_array($found_values)) {
-            // check points
-            $max = 0;
-            foreach ($found_values['points'] ?? [] as $points) {
-                $points = str_replace(',', '.', $points);
-                $max = max($max, $points);
-                if ($points === '' || !is_numeric($points)) {
-                    $this->setAlert($lng->txt('form_msg_numeric_value_required'));
-                    return false;
-                }
-
-                if ($this->minvalueShouldBeGreater()) {
-                    if (
-                        trim($points) !== ''
-                        && $this->getMinValue() !== false
-                        && $points <= $this->getMinValue()
-                    ) {
-                        $this->setAlert($lng->txt('form_msg_value_too_low'));
-                        return false;
-                    }
-                } elseif (
-                    trim($points) !== ''
-                    && $this->getMinValue() !== false
-                    && $points < $this->getMinValue()
-                ) {
-                    $this->setAlert($lng->txt('form_msg_value_too_low'));
-                    return false;
-                }
-            }
-
-            if ($max === 0) {
-                $this->setAlert($lng->txt('enter_enough_positive_points'));
+        if (!$this->isHidePointsEnabled()) {
+            $points = $this->request_helper->checkPointsInputEnoughPositive($this->raw($this->getPostVar()), true);
+            if (!is_array($points)) {
+                $this->setAlert($this->lng->txt($points));
                 return false;
             }
-        } else {
-            $this->setAlert($lng->txt('msg_input_is_required'));
-            return false;
         }
 
-        return $this->checkSubItemsInput();
+        return true;
     }
 
     public function insert(ilTemplate $a_tpl): void

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
@@ -47,12 +47,10 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
 
     public function checkInput(): bool
     {
-        if (!$this->isHidePointsEnabled()) {
-            $points = $this->forms_helper->checkPointsInputEnoughPositive($this->raw($this->getPostVar()), true);
-            if (!is_array($points)) {
-                $this->setAlert($this->lng->txt($points));
-                return false;
-            }
+        $points = $this->forms_helper->checkPointsInputEnoughPositive($this->raw($this->getPostVar()), true);
+        if (!$this->isHidePointsEnabled() && !is_array($points)) {
+            $this->setAlert($this->lng->txt($points));
+            return false;
         }
 
         return true;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssClozeTestCombinationVariantsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssClozeTestCombinationVariantsInputGUI.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * Class ilAssClozeTestCombinationVariantsInputGUI
  *
@@ -28,13 +26,9 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
  */
 class ilAssClozeTestCombinationVariantsInputGUI extends ilAnswerWizardInputGUI
 {
-    private RequestDataCollector $request_data_collector;
-
     public function __construct(string $a_title = '', string $a_postvar = '')
     {
         parent::__construct($a_title, $a_postvar);
-        global $DIC;
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     public function setValue($a_value): void
@@ -88,17 +82,14 @@ class ilAssClozeTestCombinationVariantsInputGUI extends ilAnswerWizardInputGUI
         return true;
     }
 
-    /**
-     * @throws ilTemplateException
-     */
     public function insert(ilTemplate $a_tpl): void
     {
         $tpl = new ilTemplate('tpl.prop_gap_combi_answers_input.html', true, true, 'components/ILIAS/TestQuestionPool');
         $gaps = [];
 
         foreach ($this->values as $variant) {
-            foreach ($variant['gaps'] as $gapIndex => $answer) {
-                $gaps[$gapIndex] = $gapIndex;
+            foreach ($variant['gaps'] as $gap_index => $answer) {
+                $gaps[$gap_index] = $gap_index;
 
                 $tpl->setCurrentBlock('gap_answer');
                 $tpl->setVariable('GAP_ANSWER', $answer);
@@ -111,9 +102,9 @@ class ilAssClozeTestCombinationVariantsInputGUI extends ilAnswerWizardInputGUI
             $tpl->parseCurrentBlock();
         }
 
-        foreach ($gaps as $gapIndex) {
+        foreach ($gaps as $gap_index) {
             $tpl->setCurrentBlock('gap_header');
-            $tpl->setVariable('GAP_HEADER', 'Gap ' . ($gapIndex + 1));
+            $tpl->setVariable('GAP_HEADER', 'Gap ' . ($gap_index + 1));
             $tpl->parseCurrentBlock();
         }
 

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssClozeTestCombinationVariantsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssClozeTestCombinationVariantsInputGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
  * Class ilAssClozeTestCombinationVariantsInputGUI
  *
@@ -26,6 +28,15 @@
  */
 class ilAssClozeTestCombinationVariantsInputGUI extends ilAnswerWizardInputGUI
 {
+    private RequestDataCollector $request_data_collector;
+
+    public function __construct(string $a_title = '', string $a_postvar = '')
+    {
+        parent::__construct($a_title, $a_postvar);
+        global $DIC;
+        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
+    }
+
     public function setValue($a_value): void
     {
         if (is_array($a_value) && is_array($a_value['points'])) {
@@ -40,14 +51,7 @@ class ilAssClozeTestCombinationVariantsInputGUI extends ilAnswerWizardInputGUI
         global $DIC;
         $lng = $DIC->language();
 
-        $values = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->float()),
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->int()),
-                $this->refinery->always(null)
-            ])
-        );
+        $values = $this->request_data_collector->retrieveFloatArrayOrIntArrayFromPost($this->getPostVar());
 
         $max = 0;
         foreach ($values['points'] ?? [] as $points) {

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssClozeTestCombinationVariantsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssClozeTestCombinationVariantsInputGUI.php
@@ -28,7 +28,7 @@ class ilAssClozeTestCombinationVariantsInputGUI extends ilAnswerWizardInputGUI
 {
     public function setValue($a_value): void
     {
-        foreach ($this->request_helper->transformPoints($a_value) as $index => $value) {
+        foreach ($this->forms_helper->transformPoints($a_value) as $index => $value) {
             $this->values[$index]['points'] = $value;
         }
     }
@@ -36,7 +36,7 @@ class ilAssClozeTestCombinationVariantsInputGUI extends ilAnswerWizardInputGUI
     public function checkInput(): bool
     {
         // check points
-        $points = $this->request_helper->checkPointsInputEnoughPositive($this->raw($this->getPostVar()), true);
+        $points = $this->forms_helper->checkPointsInputEnoughPositive($this->raw($this->getPostVar()), true);
         if (!is_array($points)) {
             $this->setAlert($this->lng->txt($points));
             return false;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssClozeTestCombinationVariantsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssClozeTestCombinationVariantsInputGUI.php
@@ -26,59 +26,21 @@
  */
 class ilAssClozeTestCombinationVariantsInputGUI extends ilAnswerWizardInputGUI
 {
-    public function __construct(string $a_title = '', string $a_postvar = '')
-    {
-        parent::__construct($a_title, $a_postvar);
-    }
-
     public function setValue($a_value): void
     {
-        if (is_array($a_value) && is_array($a_value['points'])) {
-            foreach ($a_value['points'] as $idx => $term) {
-                $this->values[$idx]['points'] = $a_value['points'][$idx];
-            }
+        foreach ($this->request_helper->transformPoints($a_value) as $index => $value) {
+            $this->values[$index]['points'] = $value;
         }
     }
 
     public function checkInput(): bool
     {
-        global $DIC;
-        $lng = $DIC->language();
-
-        $values = $this->request_data_collector->retrieveFloatArrayOrIntArrayFromPost($this->getPostVar());
-
-        $max = 0;
-        foreach ($values['points'] ?? [] as $points) {
-            $max = max($max, $points);
-            if ($points === '' || !is_numeric($points)) {
-                $this->setAlert($lng->txt('form_msg_numeric_value_required'));
-                return false;
-            }
-
-            if ($this->minvalueShouldBeGreater()) {
-                if (
-                    trim($points) !== ''
-                    && $this->getMinValue() !== false
-                    && $points <= $this->getMinValue()
-                ) {
-                    $this->setAlert($lng->txt('form_msg_value_too_low'));
-                    return false;
-                }
-            } elseif (
-                trim($points) !== ''
-                && $this->getMinValue() !== false
-                && $points < $this->getMinValue()
-            ) {
-                $this->setAlert($lng->txt('form_msg_value_too_low'));
-                return false;
-            }
-        }
-
-        if ($max === 0) {
-            $this->setAlert($lng->txt('enter_enough_positive_points'));
+        // check points
+        $points = $this->request_helper->checkPointsInputEnoughPositive($this->raw($this->getPostVar()), true);
+        if (!is_array($points)) {
+            $this->setAlert($this->lng->txt($points));
             return false;
         }
-
         return true;
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * Class ilAssErrorTextCorrections
  *
@@ -28,14 +26,11 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
  */
 class ilAssErrorTextCorrectionsInputGUI extends ilErrorTextWizardInputGUI
 {
-    private RequestDataCollector $request_data_collector;
-
     public function __construct(string $a_title = '', string $a_postvar = '')
     {
         parent::__construct($a_title, $a_postvar);
-        global $DIC;
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
+
     public function setValue($a_value): void
     {
         if (is_array($a_value) && is_array($a_value['points'])) {
@@ -74,9 +69,6 @@ class ilAssErrorTextCorrectionsInputGUI extends ilErrorTextWizardInputGUI
         return $this->checkSubItemsInput();
     }
 
-    /**
-     * @throws ilTemplateException
-     */
     public function insert(ilTemplate $a_tpl): void
     {
         global $DIC;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php
@@ -28,7 +28,7 @@ class ilAssErrorTextCorrectionsInputGUI extends ilErrorTextWizardInputGUI
 {
     public function setValue($a_value): void
     {
-        foreach ($this->request_helper->transformPoints($a_value) as $index => $points) {
+        foreach ($this->forms_helper->transformPoints($a_value) as $index => $points) {
             $this->values[$index] = $this->values[$index]->withPoints($points);
         }
     }
@@ -36,7 +36,7 @@ class ilAssErrorTextCorrectionsInputGUI extends ilErrorTextWizardInputGUI
     public function checkInput(): bool
     {
         $data = $this->raw($this->getPostVar());
-        $result = $this->request_helper->checkPointsInput($data, $this->getRequired());
+        $result = $this->forms_helper->checkPointsInput($data, $this->getRequired());
 
         if (!is_array($result)) {
             $this->setAlert($this->lng->txt($result));

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssErrorTextCorrectionsInputGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
  * Class ilAssErrorTextCorrections
  *
@@ -26,6 +28,14 @@
  */
 class ilAssErrorTextCorrectionsInputGUI extends ilErrorTextWizardInputGUI
 {
+    private RequestDataCollector $request_data_collector;
+
+    public function __construct(string $a_title = '', string $a_postvar = '')
+    {
+        parent::__construct($a_title, $a_postvar);
+        global $DIC;
+        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
+    }
     public function setValue($a_value): void
     {
         if (is_array($a_value) && is_array($a_value['points'])) {
@@ -39,13 +49,7 @@ class ilAssErrorTextCorrectionsInputGUI extends ilErrorTextWizardInputGUI
 
     public function checkInput(): bool
     {
-        $found_values = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always(null)
-            ])
-        );
+        $found_values = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
 
         if (!is_array($found_values['points'])) {
             $this->setAlert($this->lng->txt('msg_input_is_required'));

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
@@ -16,8 +16,6 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * Class class.ilAssMatchingPairCorrectionsInputGUI
  *
@@ -81,9 +79,6 @@ class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
         return $this->checkSubItemsInput();
     }
 
-    /**
-     * @throws ilTemplateException
-     */
     public function insert(ilTemplate $a_tpl): void
     {
         $tpl = new ilTemplate('tpl.prop_matchingpaircorrection_input.html', true, true, 'components/ILIAS/TestQuestionPool');

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
@@ -29,13 +29,10 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
 class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
 {
     private string $path_including_prefix;
-    private RequestDataCollector $request_data_collector;
 
     public function __construct(string $a_title = '', string $a_postvar = '')
     {
         parent::__construct($a_title, $a_postvar);
-        global $DIC;
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     public function getPairs(): array
@@ -59,7 +56,7 @@ class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
 
     public function checkInput(): bool
     {
-        $found_values = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
+        $found_values = $this->request_data_collector->retrieveNestedArraysOfStrings($this->getPostVar());
 
         if (is_array($found_values)) {
             $max = 0;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
@@ -39,7 +39,7 @@ class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
     }
     public function setValue($a_value): void
     {
-        foreach ($this->request_helper->transformPoints($a_value) as $index => $value) {
+        foreach ($this->forms_helper->transformPoints($a_value) as $index => $value) {
             $this->pairs[$index] = $this->pairs[$index]->withPoints($value);
         }
     }
@@ -47,7 +47,7 @@ class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
     public function checkInput(): bool
     {
         $data = $this->raw($this->getPostVar());
-        $result = $this->request_helper->checkPointsInput($data, $this->getRequired());
+        $result = $this->forms_helper->checkPointsInput($data, $this->getRequired());
 
         if (!is_array($result)) {
             $this->setAlert($this->lng->txt($result));

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
  * Class class.ilAssMatchingPairCorrectionsInputGUI
  *
@@ -27,6 +29,14 @@
 class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
 {
     private string $path_including_prefix;
+    private RequestDataCollector $request_data_collector;
+
+    public function __construct(string $a_title = '', string $a_postvar = '')
+    {
+        parent::__construct($a_title, $a_postvar);
+        global $DIC;
+        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
+    }
 
     public function getPairs(): array
     {
@@ -49,13 +59,7 @@ class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
 
     public function checkInput(): bool
     {
-        $found_values = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                $this->refinery->always(null)
-            ])
-        );
+        $found_values = $this->request_data_collector->retrieveArrayOfStringsFromPost($this->getPostVar());
 
         if (is_array($found_values)) {
             $max = 0;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
@@ -32,8 +32,8 @@ class ilAssMultipleChoiceCorrectionsInputGUI extends ilMultipleChoiceWizardInput
 
     public function setValue($a_value): void
     {
-        $points = $this->request_helper->transformPoints($a_value, 'points');
-        $points_unchecked = $this->request_helper->transformPoints($a_value, 'points_unchecked');
+        $points = $this->forms_helper->transformPoints($a_value, 'points');
+        $points_unchecked = $this->forms_helper->transformPoints($a_value, 'points_unchecked');
 
         foreach ($this->values as $index => $value) {
             $this->values[$index]->setPoints($points[$index] ?? 0.0);
@@ -45,13 +45,13 @@ class ilAssMultipleChoiceCorrectionsInputGUI extends ilMultipleChoiceWizardInput
     {
         $data = $this->raw($this->getPostVar());
 
-        $result = $this->request_helper->checkPointsInputEnoughPositive($data, $this->getRequired(), 'points');
+        $result = $this->forms_helper->checkPointsInputEnoughPositive($data, $this->getRequired(), 'points');
         if (!is_array($result)) {
             $this->setAlert($this->lng->txt($result));
             return false;
         }
 
-        $result = $this->request_helper->checkPointsInput($data, $this->getRequired(), 'points_unchecked');
+        $result = $this->forms_helper->checkPointsInput($data, $this->getRequired(), 'points_unchecked');
         if (!is_array($result)) {
             $this->setAlert($this->lng->txt($result));
             return false;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
@@ -36,8 +36,8 @@ class ilAssMultipleChoiceCorrectionsInputGUI extends ilMultipleChoiceWizardInput
         $points_unchecked = $this->request_helper->transformPoints($a_value, 'points_unchecked');
 
         foreach ($this->values as $index => $value) {
-            $this->values[$index]->setPoints($points[$index]);
-            $this->values[$index]->setPointsUnchecked($points_unchecked[$index]);
+            $this->values[$index]->setPoints($points[$index] ?? 0.0);
+            $this->values[$index]->setPointsUnchecked($points_unchecked[$index] ?? 0.0);
         }
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
@@ -15,8 +15,6 @@
  *
  *********************************************************************/
 
-use ILIAS\Refinery\ConstraintViolationException;
-
 /**
  * Class ilAssSingleChoiceCorrectionsInputGUI
  *
@@ -34,65 +32,28 @@ class ilAssMultipleChoiceCorrectionsInputGUI extends ilMultipleChoiceWizardInput
 
     public function setValue($a_value): void
     {
-        if (is_array($a_value)) {
-            if (is_array($a_value['points']) && is_array($a_value['points_unchecked'])) {
-                foreach ($this->values as $index => $value) {
-                    $this->values[$index]->setPoints($a_value['points'][$index]);
-                    $this->values[$index]->setPointsUnchecked($a_value['points_unchecked'][$index]);
-                }
-            }
+        $points = $this->request_helper->transformPoints($a_value, 'points');
+        $points_unchecked = $this->request_helper->transformPoints($a_value, 'points_unchecked');
+
+        foreach ($this->values as $index => $value) {
+            $this->values[$index]->setPoints($points[$index]);
+            $this->values[$index]->setPointsUnchecked($points_unchecked[$index]);
         }
     }
 
     public function checkInput(): bool
     {
-        $foundvalues = $this->post_wrapper->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying(
-                [
-                    $this->refinery->container()->mapValues(
-                        $this->refinery->identity()
-                    ),
-                    $this->refinery->always([])
-                ]
-            )
-        );
+        $data = $this->raw($this->getPostVar());
 
-        if ($foundvalues === []) {
-            $this->setAlert($this->lng->txt("msg_input_is_required"));
+        $result = $this->request_helper->checkPointsInputEnoughPositive($data, $this->getRequired(), 'points');
+        if (!is_array($result)) {
+            $this->setAlert($this->lng->txt($result));
             return false;
         }
 
-        if (!is_array($foundvalues['points'])) {
-            $this->setAlert($this->lng->txt("enter_enough_positive_points"));
-            return false;
-        }
-
-        $max = 0;
-        foreach ($foundvalues['points'] as $points) {
-            try {
-                $points = $this->refinery->kindlyTo()->float()->transform($points);
-            } catch (ConstraintViolationException $e) {
-                $this->setAlert($this->lng->txt("form_msg_numeric_value_required"));
-                return false;
-            }
-            if ($points > $max) {
-                $max = $points;
-            }
-        }
-        foreach ($foundvalues['points_unchecked'] as $points) {
-            try {
-                $points = $this->refinery->kindlyTo()->float()->transform($points);
-            } catch (ConstraintViolationException $e) {
-                $this->setAlert($this->lng->txt("form_msg_numeric_value_required"));
-                return false;
-            }
-            if ($points > $max) {
-                $max = $points;
-            }
-        }
-        if ($max == 0) {
-            $this->setAlert($this->lng->txt("enter_enough_positive_points"));
+        $result = $this->request_helper->checkPointsInput($data, $this->getRequired(), 'points_unchecked');
+        if (!is_array($result)) {
+            $this->setAlert($this->lng->txt($result));
             return false;
         }
 

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssOrderingFormValuesObjectsConverter.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssOrderingFormValuesObjectsConverter.php
@@ -16,8 +16,7 @@
  *
  *********************************************************************/
 
-use ILIAS\HTTP\Services as Http;
-use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -64,16 +63,12 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
      */
     protected $thumbnailPrefix;
 
-    private readonly Http $http;
-
-    private readonly Refinery $refinery;
+    private readonly RequestDataCollector $request_data_collector;
 
     public function __construct()
     {
         global $DIC;
-
-        $this->http = $DIC->http();
-        $this->refinery = $DIC->refinery();
+        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     /**
@@ -392,13 +387,7 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
             return false;
         }
 
-        $cmd = $this->http->wrapper()->post()->retrieve(
-            'cmd',
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()))),
-                $this->refinery->always(null)
-            ])
-        );
+        $cmd = $this->request_data_collector->retrieveNestedArraysOfStrings('cmd', 3);
 
         if (!isset($cmd[$this->getImageRemovalCommand()])) {
             return false;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssOrderingFormValuesObjectsConverter.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssOrderingFormValuesObjectsConverter.php
@@ -189,21 +189,21 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
     {
         $values = [];
 
-        foreach ($elements as $identifier => $orderingElement) {
+        foreach ($elements as $identifier => $ordering_element) {
             switch ($this->getContext()) {
                 case self::CONTEXT_MAINTAIN_ELEMENT_TEXT:
 
-                    $values[$identifier] = $this->getTextContentValueFromObject($orderingElement);
+                    $values[$identifier] = $this->getTextContentValueFromObject($ordering_element);
                     break;
 
                 case self::CONTEXT_MAINTAIN_ELEMENT_IMAGE:
 
-                    $values[$identifier] = $this->getImageContentValueFromObject($orderingElement);
+                    $values[$identifier] = $this->getImageContentValueFromObject($ordering_element);
                     break;
 
                 case self::CONTEXT_MAINTAIN_HIERARCHY:
 
-                    $values[$identifier] = $this->getStructValueFromObject($orderingElement);
+                    $values[$identifier] = $this->getStructValueFromObject($ordering_element);
                     break;
 
                 default:
@@ -242,22 +242,22 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
         ];
     }
 
-    protected function needsConvertToElements($valuesOrElements): bool
+    protected function needsConvertToElements($values_or_elements): bool
     {
-        if (!count($valuesOrElements)) {
+        if (!count($values_or_elements)) {
             return false;
         }
 
-        return !(current($valuesOrElements) instanceof ilAssOrderingElement);
+        return !(current($values_or_elements) instanceof ilAssOrderingElement);
     }
 
-    public function manipulateFormSubmitValues(array $submitValues): array
+    public function manipulateFormSubmitValues(array $submit_values): array
     {
-        if ($this->needsConvertToElements($submitValues)) {
-            $submitValues = $this->constructElementsFromValues($submitValues);
+        if ($this->needsConvertToElements($submit_values)) {
+            $submit_values = $this->constructElementsFromValues($submit_values);
         }
 
-        return $submitValues;
+        return $submit_values;
     }
 
     public function constructElementsFromValues(array $values): array
@@ -313,9 +313,9 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
         return $this->fetchSubmittedFileUploadProperty($fileUpload, 'tmp_name');
     }
 
-    protected function fetchSubmittedFileUploadProperty(mixed $fileUpload, string $property)
+    protected function fetchSubmittedFileUploadProperty(mixed $file_upload, string $property)
     {
-        return $fileUpload[$property] ?? null;
+        return $file_upload[$property] ?? null;
     }
 
     protected function fetchElementFileUpload($identifier)
@@ -325,30 +325,30 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
 
     protected function fetchSubmittedUploadFiles(): array
     {
-        $submittedUploadFiles = $this->getFileSubmitDataRestructuredByIdentifiers();
+        $submitted_upload_files = $this->getFileSubmitDataRestructuredByIdentifiers();
         //$submittedUploadFiles = $this->getFileSubmitsHavingActualUpload($submittedUploadFiles);
-        return $submittedUploadFiles;
+        return $submitted_upload_files;
     }
 
-    protected function getFileSubmitsHavingActualUpload(array $submittedUploadFiles): array
+    protected function getFileSubmitsHavingActualUpload(array $submitted_upload_files): array
     {
-        foreach ($submittedUploadFiles as $identifier => $uploadProperties) {
-            if (!isset($uploadProperties['tmp_name'])) {
-                unset($submittedUploadFiles[$identifier]);
+        foreach ($submitted_upload_files as $identifier => $upload_properties) {
+            if (!isset($upload_properties['tmp_name'])) {
+                unset($submitted_upload_files[$identifier]);
                 continue;
             }
 
-            if ($uploadProperties['tmp_name'] === '') {
-                unset($submittedUploadFiles[$identifier]);
+            if ($upload_properties['tmp_name'] === '') {
+                unset($submitted_upload_files[$identifier]);
                 continue;
             }
 
-            if (!is_uploaded_file($uploadProperties['tmp_name'])) {
-                unset($submittedUploadFiles[$identifier]);
+            if (!is_uploaded_file($upload_properties['tmp_name'])) {
+                unset($submitted_upload_files[$identifier]);
             }
         }
 
-        return $submittedUploadFiles;
+        return $submitted_upload_files;
     }
 
     /**
@@ -356,19 +356,19 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
      */
     protected function getFileSubmitDataRestructuredByIdentifiers(): array
     {
-        $submittedUploadFiles = [];
+        $submitted_upload_files = [];
 
         foreach ($this->getFileSubmitData() as $uploadProperty => $valueElement) {
-            foreach ($valueElement as $elementIdentifier => $uploadValue) {
-                if (!isset($submittedUploadFiles[$elementIdentifier])) {
-                    $submittedUploadFiles[$elementIdentifier] = [];
+            foreach ($valueElement as $element_identifier => $uploadValue) {
+                if (!isset($submitted_upload_files[$element_identifier])) {
+                    $submitted_upload_files[$element_identifier] = [];
                 }
 
-                $submittedUploadFiles[$elementIdentifier][$uploadProperty] = $uploadValue;
+                $submitted_upload_files[$element_identifier][$uploadProperty] = $uploadValue;
             }
         }
 
-        return $submittedUploadFiles;
+        return $submitted_upload_files;
     }
 
     protected function getFileSubmitData(): array
@@ -393,16 +393,16 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
             return false;
         }
 
-        $fieldArr = $cmd[$this->getImageRemovalCommand()];
+        $field_arr = $cmd[$this->getImageRemovalCommand()];
 
-        if (!isset($fieldArr[$this->getPostVar()])) {
+        if (!isset($field_arr[$this->getPostVar()])) {
             return false;
         }
 
         return (string) str_replace(
             ilIdentifiedMultiValuesJsPositionIndexRemover::IDENTIFIER_INDICATOR_PREFIX,
             '',
-            (string) key($fieldArr[$this->getPostVar()])
+            (string) key($field_arr[$this->getPostVar()])
         ) === (string) $identifier;
     }
 }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssOrderingFormValuesObjectsConverter.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssOrderingFormValuesObjectsConverter.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
@@ -67,8 +68,8 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
 
     public function __construct()
     {
-        global $DIC;
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
+        $local_dic = QuestionPoolDIC::dic();
+        $this->request_data_collector = $local_dic['request_data_collector'];
     }
 
     /**
@@ -387,7 +388,7 @@ class ilAssOrderingFormValuesObjectsConverter implements ilFormValuesManipulator
             return false;
         }
 
-        $cmd = $this->request_data_collector->retrieveNestedArraysOfStrings('cmd', 3);
+        $cmd = $this->request_data_collector->strArray('cmd', 3);
 
         if (!isset($cmd[$this->getImageRemovalCommand()])) {
             return false;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
@@ -15,6 +15,8 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
  * Class ilAssSingleChoiceCorrectionsInputGUI
  *
@@ -30,6 +32,15 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
      */
     protected $qstObject;
 
+    private readonly RequestDataCollector $request_data_collector;
+
+    public function __construct(string $a_title = '', string $a_postvar = '')
+    {
+        parent::__construct($a_title, $a_postvar);
+        global $DIC;
+        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
+    }
+
     public function setValue($a_value): void
     {
         if (is_array($a_value) && is_array($a_value['points'])) {
@@ -44,13 +55,7 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $found_values = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
-                $this->refinery->always(null)
-            ])
-        );
+        $found_values = $this->request_data_collector->retrieveNestedArraysOfStrings($this->getPostVar(), 2);
 
         if (is_array($found_values)) {
             // check points

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
@@ -32,7 +32,7 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
 
     public function setValue($a_value): void
     {
-        foreach ($this->request_helper->transformPoints($a_value) as $index => $value) {
+        foreach ($this->forms_helper->transformPoints($a_value) as $index => $value) {
             $this->values[$index]->setPoints($value);
         }
     }
@@ -41,7 +41,7 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
     {
         $data = $this->raw($this->getPostVar());
 
-        $result = $this->request_helper->checkPointsInputEnoughPositive($data, $this->getRequired());
+        $result = $this->forms_helper->checkPointsInputEnoughPositive($data, $this->getRequired());
         if (!is_array($result)) {
             $this->setAlert($this->lng->txt($result));
             return false;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
@@ -32,11 +32,9 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
 
     public function setValue($a_value): void
     {
-        if (is_array($a_value)) {
-            if (is_array($a_value['points'])) {
-                foreach ($a_value['points'] as $index => $value) {
-                    $this->values[$index]->setPoints($value);
-                }
+        if (is_array($a_value) && is_array($a_value['points'])) {
+            foreach ($a_value['points'] as $index => $value) {
+                $this->values[$index]->setPoints($value);
             }
         }
     }
@@ -46,28 +44,35 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $foundvalues = $_POST[$this->getPostVar()];
-        if (is_array($foundvalues)) {
+        $found_values = $this->http->wrapper()->post()->retrieve(
+            $this->getPostVar(),
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
+                $this->refinery->always(null)
+            ])
+        );
+
+        if (is_array($found_values)) {
             // check points
             $max = 0;
-            if (is_array($foundvalues['points'])) {
-                foreach ($foundvalues['points'] as $points) {
+            if (is_array($found_values['points'])) {
+                foreach ($found_values['points'] as $points) {
                     $points = str_replace(',', '.', $points);
-                    if ($points > $max) {
-                        $max = $points;
-                    }
-                    if (((strlen($points)) == 0) || (!is_numeric($points))) {
-                        $this->setAlert($lng->txt("form_msg_numeric_value_required"));
+                    $max = max($max, $points);
+
+                    if ($points === '' || !is_numeric($points)) {
+                        $this->setAlert($lng->txt('form_msg_numeric_value_required'));
                         return false;
                     }
                 }
             }
-            if ($max == 0) {
-                $this->setAlert($lng->txt("enter_enough_positive_points"));
+
+            if ($max === 0) {
+                $this->setAlert($lng->txt('enter_enough_positive_points'));
                 return false;
             }
         } else {
-            $this->setAlert($lng->txt("msg_input_is_required"));
+            $this->setAlert($lng->txt('msg_input_is_required'));
             return false;
         }
 
@@ -79,9 +84,7 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
         global $DIC; /* @var ILIAS\DI\Container $DIC */
         $lng = $DIC->language();
 
-        $tpl = new ilTemplate("tpl.prop_singlechoicecorrection_input.html", true, true, "components/ILIAS/TestQuestionPool");
-
-        $i = 0;
+        $tpl = new ilTemplate('tpl.prop_singlechoicecorrection_input.html', true, true, 'components/ILIAS/TestQuestionPool');
 
         if ($this->values === null) {
             $this->values = $this->value;
@@ -109,35 +112,35 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
                 }
             }
 
-            $tpl->setCurrentBlock("answer");
-            $tpl->setVariable("ANSWER", $value->getAnswertext());
+            $tpl->setCurrentBlock('answer');
+            $tpl->setVariable('ANSWER', $value->getAnswertext());
             $tpl->parseCurrentBlock();
 
-            $tpl->setCurrentBlock("prop_points_propval");
-            $tpl->setVariable("POINTS_POST_VAR", $this->getPostVar());
-            $tpl->setVariable("PROPERTY_VALUE", ilLegacyFormElementsUtil::prepareFormOutput($value->getPoints()));
+            $tpl->setCurrentBlock('prop_points_propval');
+            $tpl->setVariable('POINTS_POST_VAR', $this->getPostVar());
+            $tpl->setVariable('PROPERTY_VALUE', ilLegacyFormElementsUtil::prepareFormOutput($value->getPoints()));
             $tpl->parseCurrentBlock();
 
-            $tpl->setCurrentBlock("row");
+            $tpl->setCurrentBlock('row');
             $tpl->parseCurrentBlock();
         }
 
         if ($this->qstObject->isSingleline()) {
-            $tpl->setCurrentBlock("image_heading");
-            $tpl->setVariable("ANSWER_IMAGE", $lng->txt('answer_image'));
-            $tpl->setVariable("TXT_MAX_SIZE", ilFileUtils::getFileSizeInfo());
+            $tpl->setCurrentBlock('image_heading');
+            $tpl->setVariable('ANSWER_IMAGE', $lng->txt('answer_image'));
+            $tpl->setVariable('TXT_MAX_SIZE', ilFileUtils::getFileSizeInfo());
             $tpl->parseCurrentBlock();
         }
 
-        $tpl->setCurrentBlock("points_heading");
-        $tpl->setVariable("POINTS_TEXT", $lng->txt('points'));
+        $tpl->setCurrentBlock('points_heading');
+        $tpl->setVariable('POINTS_TEXT', $lng->txt('points'));
         $tpl->parseCurrentBlock();
 
-        $tpl->setVariable("ELEMENT_ID", $this->getPostVar());
-        $tpl->setVariable("ANSWER_TEXT", $lng->txt('answer_text'));
+        $tpl->setVariable('ELEMENT_ID', $this->getPostVar());
+        $tpl->setVariable('ANSWER_TEXT', $lng->txt('answer_text'));
 
-        $a_tpl->setCurrentBlock("prop_generic");
-        $a_tpl->setVariable("PROP_GENERIC", $tpl->get());
+        $a_tpl->setCurrentBlock('prop_generic');
+        $a_tpl->setVariable('PROP_GENERIC', $tpl->get());
         $a_tpl->parseCurrentBlock();
     }
 }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
@@ -15,8 +15,6 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\RequestDataCollector;
-
 /**
  * Class ilAssSingleChoiceCorrectionsInputGUI
  *

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
@@ -30,48 +30,20 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
      */
     protected $qstObject;
 
-    public function __construct(string $a_title = '', string $a_postvar = '')
-    {
-        parent::__construct($a_title, $a_postvar);
-    }
-
     public function setValue($a_value): void
     {
-        if (is_array($a_value) && is_array($a_value['points'])) {
-            foreach ($a_value['points'] as $index => $value) {
-                $this->values[$index]->setPoints($value);
-            }
+        foreach ($this->request_helper->transformPoints($a_value) as $index => $value) {
+            $this->values[$index]->setPoints($value);
         }
     }
 
     public function checkInput(): bool
     {
-        global $DIC;
-        $lng = $DIC['lng'];
+        $data = $this->raw($this->getPostVar());
 
-        $found_values = $this->request_data_collector->retrieveNestedArraysOfStrings($this->getPostVar(), 2);
-
-        if (is_array($found_values)) {
-            // check points
-            $max = 0;
-            if (is_array($found_values['points'])) {
-                foreach ($found_values['points'] as $points) {
-                    $points = str_replace(',', '.', $points);
-                    $max = max($max, $points);
-
-                    if ($points === '' || !is_numeric($points)) {
-                        $this->setAlert($lng->txt('form_msg_numeric_value_required'));
-                        return false;
-                    }
-                }
-            }
-
-            if ($max === 0) {
-                $this->setAlert($lng->txt('enter_enough_positive_points'));
-                return false;
-            }
-        } else {
-            $this->setAlert($lng->txt('msg_input_is_required'));
+        $result = $this->request_helper->checkPointsInputEnoughPositive($data, $this->getRequired());
+        if (!is_array($result)) {
+            $this->setAlert($this->lng->txt($result));
             return false;
         }
 

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
@@ -32,13 +32,9 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
      */
     protected $qstObject;
 
-    private readonly RequestDataCollector $request_data_collector;
-
     public function __construct(string $a_title = '', string $a_postvar = '')
     {
         parent::__construct($a_title, $a_postvar);
-        global $DIC;
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     public function setValue($a_value): void

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestDataCollector;
+
 /**
  * Class ilImagemapCorrectionsInputGUI
  *
@@ -26,6 +28,15 @@
  */
 class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
 {
+    private readonly RequestDataCollector $request_data_collector;
+
+    public function __construct(string $a_title = '', string $a_postvar = '')
+    {
+        parent::__construct($a_title, $a_postvar);
+        global $DIC;
+        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
+    }
+
     public function setValueByArray(array $a_values): void
     {
         $this->setAreasByArray($a_values[$this->getPostVar()]['coords']);
@@ -51,13 +62,7 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        $post_var = $this->http->wrapper()->post()->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
-                $this->refinery->always(null)
-            ])
-        );
+        $post_var = $this->request_data_collector->retrieveNestedArraysOfStrings($this->getPostVar(), 2);
         $post_var = is_array($post_var) ? ilArrayUtil::stripSlashesRecursive($post_var) : $post_var;
 
         $max = 0;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
@@ -33,8 +33,7 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
     public function __construct(string $a_title = '', string $a_postvar = '')
     {
         parent::__construct($a_title, $a_postvar);
-        global $DIC;
-        $this->request_data_collector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
+        $this->request_data_collector = new RequestDataCollector($this->http, $this->refinery, $this->upload_service);
     }
 
     public function setValueByArray(array $a_values): void
@@ -92,9 +91,6 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
         return true;
     }
 
-    /**
-     * @throws ilTemplateException
-     */
     public function insert(ilTemplate $a_tpl): void
     {
         global $DIC;

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
@@ -33,8 +33,8 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
 
     public function setAreasByArray($a_areas): void
     {
-        $points = $this->request_helper->transformPoints($a_areas, 'points');
-        $points_unchecked = $this->request_helper->transformPoints($a_areas, 'points_unchecked');
+        $points = $this->forms_helper->transformPoints($a_areas, 'points');
+        $points_unchecked = $this->forms_helper->transformPoints($a_areas, 'points_unchecked');
 
         foreach ($this->areas as $index => $name) {
             $points_unchecked[$index] = $points_unchecked[$index] && $this->getPointsUncheckedFieldEnabled()
@@ -53,7 +53,7 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
             return false;
         }
 
-        $result = $this->request_helper->checkPointsInputEnoughPositive($data['coords'], $this->getRequired());
+        $result = $this->forms_helper->checkPointsInputEnoughPositive($data['coords'], $this->getRequired());
         if (!is_array($result)) {
             if ($result === 'msg_input_is_required') {
                 $this->setAlert($this->lng->txt('form_msg_area_missing_points'));

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
@@ -149,10 +149,5 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
         $a_tpl->setCurrentBlock('prop_generic');
         $a_tpl->setVariable('PROP_GENERIC', $template->get());
         $a_tpl->parseCurrentBlock();
-
-        #global $DIC;
-        #$tpl = $DIC['tpl'];
-        #$tpl->addJavascript('assets/js/ServiceFormWizardInput.js');
-        #$tpl->addJavascript(assets/js/imagemap.js');
     }
 }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapCorrectionsInputGUI.php
@@ -35,7 +35,7 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
     {
         if (is_array($a_areas['points'])) {
             foreach ($this->areas as $idx => $name) {
-                if ($this->getPointsUncheckedFieldEnabled() && isset($a_areas['points_unchecked'])) {
+                if (isset($a_areas['points_unchecked']) && $this->getPointsUncheckedFieldEnabled()) {
                     $this->areas[$idx]->setPointsUnchecked($a_areas['points_unchecked'][$idx]);
                 } else {
                     $this->areas[$idx]->setPointsUnchecked(0);
@@ -51,69 +51,80 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
         global $DIC;
         $lng = $DIC['lng'];
 
-        if (is_array($_POST[$this->getPostVar()])) {
-            $_POST[$this->getPostVar()] = ilArrayUtil::stripSlashesRecursive($_POST[$this->getPostVar()]);
-        }
+        $post_var = $this->http->wrapper()->post()->retrieve(
+            $this->getPostVar(),
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string())),
+                $this->refinery->always(null)
+            ])
+        );
+        $post_var = is_array($post_var) ? ilArrayUtil::stripSlashesRecursive($post_var) : $post_var;
 
         $max = 0;
-        if (is_array($_POST[$this->getPostVar()]['coords']['points'])) {
-            foreach ($_POST[$this->getPostVar()]['coords']['points'] as $idx => $name) {
-                if ((!strlen($_POST[$this->getPostVar()]['coords']['points'][$idx])) && ($this->getRequired())) {
+        if (is_array($post_var['coords']['points'])) {
+            foreach ($post_var['coords']['points'] as $idx => $name) {
+                if ($post_var['coords']['points'][$idx] === '' && $this->getRequired()) {
                     $this->setAlert($lng->txt('form_msg_area_missing_points'));
                     return false;
                 }
-                if ((!is_numeric($_POST[$this->getPostVar()]['coords']['points'][$idx]))) {
+
+                if (!is_numeric($post_var['coords']['points'][$idx])) {
                     $this->setAlert($lng->txt('form_msg_numeric_value_required'));
                     return false;
                 }
-                if ($_POST[$this->getPostVar()]['coords']['points'][$idx] > 0) {
-                    $max = $_POST[$this->getPostVar()]['coords']['points'][$idx];
+
+                if ($post_var['coords']['points'][$idx] > 0) {
+                    $max = (int) $post_var['coords']['points'][$idx];
                 }
             }
         }
 
-        if ($max == 0) {
-            $this->setAlert($lng->txt("enter_enough_positive_points"));
+        if ($max === 0) {
+            $this->setAlert($lng->txt('enter_enough_positive_points'));
             return false;
         }
+
         return true;
     }
 
+    /**
+     * @throws ilTemplateException
+     */
     public function insert(ilTemplate $a_tpl): void
     {
         global $DIC;
         $lng = $DIC['lng'];
 
-        $template = new ilTemplate("tpl.prop_imagemapquestioncorrection_input.html", true, true, "components/ILIAS/TestQuestionPool");
+        $template = new ilTemplate('tpl.prop_imagemapquestioncorrection_input.html', true, true, 'components/ILIAS/TestQuestionPool');
 
-        if ($this->getImage() != "") {
-            $template->setCurrentBlock("image");
+        if ($this->getImage() !== '') {
+            $template->setCurrentBlock('image');
             if (count($this->getAreas())) {
                 $preview = new ilImagemapPreview($this->getImagePath() . $this->getValue());
                 foreach ($this->getAreas() as $index => $area) {
-                    $preview->addArea($index, $area->getArea(), $area->getCoords(), $area->getAnswertext(), "", "", true, $this->getLineColor());
+                    $preview->addArea($index, $area->getArea(), $area->getCoords(), $area->getAnswertext(), '', '', true, $this->getLineColor());
                 }
                 $preview->createPreview();
-                $imagepath = $this->getImagePathWeb() . $preview->getPreviewFilename($this->getImagePath(), $this->getValue()) . "?img=" . time();
-                $template->setVariable("SRC_IMAGE", $imagepath);
+                $imagepath = $this->getImagePathWeb() . $preview->getPreviewFilename($this->getImagePath(), $this->getValue()) . '?img=' . time();
+                $template->setVariable('SRC_IMAGE', $imagepath);
             } else {
-                $template->setVariable("SRC_IMAGE", $this->getImage());
+                $template->setVariable('SRC_IMAGE', $this->getImage());
             }
-            $template->setVariable("ALT_IMAGE", $this->getAlt());
-            $template->setVariable("POST_VAR_D", $this->getPostVar());
+            $template->setVariable('ALT_IMAGE', $this->getAlt());
+            $template->setVariable('POST_VAR_D', $this->getPostVar());
             $template->parseCurrentBlock();
         }
 
         if (is_array($this->getAreas()) && $this->getAreas()) {
             $counter = 0;
             foreach ($this->getAreas() as $area) {
-                if (strlen($area->getPoints())) {
+                if ($area->getPoints() !== '') {
                     $template->setCurrentBlock('area_points_value');
                     $template->setVariable('VALUE_POINTS', $area->getPoints());
                     $template->parseCurrentBlock();
                 }
                 if ($this->getPointsUncheckedFieldEnabled()) {
-                    if (strlen($area->getPointsUnchecked())) {
+                    if ($area->getPointsUnchecked() !== '') {
                         $template->setCurrentBlock('area_points_unchecked_value');
                         $template->setVariable('VALUE_POINTS_UNCHECKED', $area->getPointsUnchecked());
                         $template->parseCurrentBlock();
@@ -123,7 +134,7 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
                     $template->parseCurrentBlock();
                 }
                 $template->setCurrentBlock('row');
-                if (strlen($area->getAnswertext())) {
+                if ($area->getAnswertext() !== '') {
                     $template->setVariable('ANSWER_AREA', $area->getAnswertext());
                 }
                 $template->setVariable('POST_VAR_R', $this->getPostVar());
@@ -136,36 +147,36 @@ class ilImagemapCorrectionsInputGUI extends ilImagemapFileInputGUI
                 $template->parseCurrentBlock();
                 $counter++;
             }
-            $template->setCurrentBlock("areas");
-            $template->setVariable("TEXT_NAME", $lng->txt("ass_imap_hint"));
+            $template->setCurrentBlock('areas');
+            $template->setVariable('TEXT_NAME', $lng->txt('ass_imap_hint'));
             if ($this->getPointsUncheckedFieldEnabled()) {
-                $template->setVariable("TEXT_POINTS", $lng->txt("points_checked"));
+                $template->setVariable('TEXT_POINTS', $lng->txt('points_checked'));
 
                 $template->setCurrentBlock('area_points_unchecked_head');
-                $template->setVariable("TEXT_POINTS_UNCHECKED", $lng->txt("points_unchecked"));
+                $template->setVariable('TEXT_POINTS_UNCHECKED', $lng->txt('points_unchecked'));
                 $template->parseCurrentBlock();
             } else {
-                $template->setVariable("TEXT_POINTS", $lng->txt("points"));
+                $template->setVariable('TEXT_POINTS', $lng->txt('points'));
             }
-            $template->setVariable("TEXT_SHAPE", $lng->txt("shape"));
-            $template->setVariable("TEXT_COORDINATES", $lng->txt("coordinates"));
-            $template->setVariable("TEXT_COMMANDS", $lng->txt("actions"));
+            $template->setVariable('TEXT_SHAPE', $lng->txt('shape'));
+            $template->setVariable('TEXT_COORDINATES', $lng->txt('coordinates'));
+            $template->setVariable('TEXT_COMMANDS', $lng->txt('actions'));
             $template->parseCurrentBlock();
         }
 
-        $template->setVariable("POST_VAR", $this->getPostVar());
-        $template->setVariable("ID", $this->getFieldId());
-        $template->setVariable("TXT_BROWSE", $lng->txt("select_file"));
-        $template->setVariable("TXT_MAX_SIZE", $lng->txt("file_notice") . " " .
+        $template->setVariable('POST_VAR', $this->getPostVar());
+        $template->setVariable('ID', $this->getFieldId());
+        $template->setVariable('TXT_BROWSE', $lng->txt('select_file'));
+        $template->setVariable('TXT_MAX_SIZE', $lng->txt('file_notice') . ' ' .
             $this->getMaxFileSizeString());
 
-        $a_tpl->setCurrentBlock("prop_generic");
-        $a_tpl->setVariable("PROP_GENERIC", $template->get());
+        $a_tpl->setCurrentBlock('prop_generic');
+        $a_tpl->setVariable('PROP_GENERIC', $template->get());
         $a_tpl->parseCurrentBlock();
 
-        global $DIC;
-        $tpl = $DIC['tpl'];
-        #$tpl->addJavascript("assets/js/ServiceFormWizardInput.js");
-        #$tpl->addJavascript(assets/js/imagemap.js");
+        #global $DIC;
+        #$tpl = $DIC['tpl'];
+        #$tpl->addJavascript('assets/js/ServiceFormWizardInput.js');
+        #$tpl->addJavascript(assets/js/imagemap.js');
     }
 }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\RequestValidationHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
@@ -35,6 +36,7 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
 
     protected $pointsUncheckedFieldEnabled = false;
 
+    protected RequestValidationHelper $request_helper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
 
@@ -49,6 +51,7 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
         parent::__construct($a_title, $a_postvar);
 
         global $DIC;
+        $this->request_helper = new RequestValidationHelper($this->refinery);
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
     }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
@@ -17,7 +17,7 @@
  *********************************************************************/
 
 use ILIAS\TestQuestionPool\QuestionPoolDIC;
-use ILIAS\TestQuestionPool\RequestValidationHelper;
+use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
 
@@ -37,7 +37,7 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
 
     protected $pointsUncheckedFieldEnabled = false;
 
-    protected RequestValidationHelper $request_helper;
+    protected ilTestLegacyFormsHelper $forms_helper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
 
@@ -52,9 +52,8 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
         parent::__construct($a_title, $a_postvar);
 
         global $DIC;
-        $local_dic = QuestionPoolDIC::dic();
 
-        $this->request_helper = $local_dic['request_validation_helper'];
+        $this->forms_helper = new ilTestLegacyFormsHelper();
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
     }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestValidationHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
@@ -51,7 +52,9 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
         parent::__construct($a_title, $a_postvar);
 
         global $DIC;
-        $this->request_helper = new RequestValidationHelper($this->refinery);
+        $local_dic = QuestionPoolDIC::dic();
+
+        $this->request_helper = $local_dic['request_validation_helper'];
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
     }

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilKprimChoiceCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilKprimChoiceCorrectionsInputGUI.php
@@ -41,19 +41,9 @@ class ilKprimChoiceCorrectionsInputGUI extends ilKprimChoiceWizardInputGUI
 
     public function checkInput(): bool
     {
-        $foundvalues = $this->post_wrapper->retrieve(
-            $this->getPostVar(),
-            $this->refinery->byTrying(
-                [
-                    $this->refinery->container()->mapValues(
-                        $this->refinery->identity()
-                    ),
-                    $this->refinery->always([])
-                ]
-            )
-        );
+        $data = $this->raw($this->getPostVar());
 
-        if (!isset($foundvalues['correctness']) || count($foundvalues['correctness']) < count($this->values)) {
+        if (!is_array($data['correctness']) || count($data['correctness']) < count($this->values)) {
             $this->setAlert($this->lng->txt("msg_input_is_required"));
             return false;
         }

--- a/components/ILIAS/TestQuestionPool/classes/ilTestLegacyFormsHelper.php
+++ b/components/ILIAS/TestQuestionPool/classes/ilTestLegacyFormsHelper.php
@@ -22,11 +22,18 @@ use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Refinery\Transformation;
 
-class RequestValidationHelper
+/**
+ * @deprecated This class is no longer needed when using the ks input components.
+ */
+class ilTestLegacyFormsHelper
 {
+    protected Refinery $refinery;
+
     public function __construct(
-        protected Refinery $refinery
+
     ) {
+        global $DIC;
+        $this->refinery = $DIC['refinery'];
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
@@ -47,22 +47,22 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         $this->manipulationsEnabled = $manipulationsEnabled;
     }
 
-    /**
-     * @throws ilException
-     */
     public function __construct(
-        $parentOBJ,
-        $parentCmd,
+        $parent_obj,
+        $parent_cmd,
         ilCtrl $ctrl,
         ilLanguage $lng
     ) {
+        global $DIC;
+
         $this->lng = $lng;
         $this->ctrl = $ctrl;
+        $this->requestDataCollector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
 
         $this->setId('assQstSkl');
         $this->setPrefix('assQstSkl');
 
-        parent::__construct($parentOBJ, $parentCmd);
+        parent::__construct($parent_obj, $parent_cmd);
 
         $this->setStyle('table', 'fullwidth');
 
@@ -71,13 +71,8 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         $this->enable('header');
         $this->disable('sort');
         $this->disable('select_all');
-        global $DIC;
-        $this->requestDataCollector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
-    /**
-     * @throws ilCtrlException
-     */
     public function init(): void
     {
         $this->initColumns();
@@ -106,9 +101,6 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         $this->addColumn($this->lng->txt('actions'), 'actions', '20%');
     }
 
-    /**
-     * @throws ilTemplateException|ilCtrlException
-     */
     public function fillRow(array $a_set): void
     {
         $assignments = $this->skillQuestionAssignmentList->getAssignmentsByQuestionId($a_set['question_id']);
@@ -179,9 +171,6 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         return $this->areManipulationsEnabled() ? $cnt + 1 : $cnt;
     }
 
-    /**
-     * @throws ilCtrlException
-     */
     private function getManageCompetenceAssignsActionLink(): string
     {
         $href = $this->ctrl->getLinkTarget(
@@ -192,9 +181,6 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         return $this->buildActionLink($href, $this->lng->txt('tst_manage_competence_assigns'));
     }
 
-    /**
-     * @throws ilCtrlException
-     */
     private function getCompetenceAssignPropertiesFormLink(ilAssQuestionSkillAssignment $assignment): string
     {
         $this->ctrl->setParameter($this->parent_obj, 'skill_base_id', $assignment->getSkillBaseId());
@@ -220,9 +206,6 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         return "<a href=\"{$href}\" title=\"{$label}\">{$label}</a>";
     }
 
-    /**
-     * @throws ilCtrlException
-     */
     private function buildActionColumnHTML($assignments): string
     {
         $actions = [];

--- a/components/ILIAS/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
@@ -268,6 +268,14 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
 
     private function isSkillPointInputRequired(ilAssQuestionSkillAssignment $assignment): bool
     {
-        return !(!$this->areManipulationsEnabled() || $assignment->hasEvalModeBySolution());
+        if (!$this->areManipulationsEnabled()) {
+            return false;
+        }
+
+        if ($assignment->hasEvalModeBySolution()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/components/ILIAS/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
@@ -16,8 +16,7 @@
  *
  *********************************************************************/
 
-use ILIAS\HTTP\Services as Http;
-use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
  * @author		Björn Heyser <bheyser@databay.de>
@@ -27,13 +26,10 @@ use ILIAS\Refinery\Factory as Refinery;
  */
 class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
 {
-    private readonly Http $http;
-    private readonly Refinery $refinery;
-
     private ilAssQuestionSkillAssignmentList $skillQuestionAssignmentList;
+    private RequestDataCollector $requestDataCollector;
 
     private bool $loadSkillPointsFromRequest = false;
-
     private bool $manipulationsEnabled;
 
     public function setSkillQuestionAssignmentList(ilAssQuestionSkillAssignmentList $assignmentList): void
@@ -58,14 +54,10 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         $parentOBJ,
         $parentCmd,
         ilCtrl $ctrl,
-        ilLanguage $lng,
-        $http,
-        $refinery
+        ilLanguage $lng
     ) {
         $this->lng = $lng;
         $this->ctrl = $ctrl;
-        $this->http = $http;
-        $this->refinery = $refinery;
 
         $this->setId('assQstSkl');
         $this->setPrefix('assQstSkl');
@@ -79,6 +71,8 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         $this->enable('header');
         $this->disable('sort');
         $this->disable('select_all');
+        global $DIC;
+        $this->requestDataCollector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
     }
 
     /**
@@ -279,13 +273,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         ]);
 
         if ($this->loadSkillPointsFromRequest) {
-            $skill_points = $this->http->wrapper()->post()->retrieve(
-                'skill_points',
-                $this->refinery->byTrying([
-                    $this->refinery->kindlyTo()->listOf($this->refinery->kindlyTo()->string()),
-                    $this->refinery->always([])
-                ])
-            );
+            $skill_points = $this->requestDataCollector->retrieveNestedArraysOfStrings('skill_points', 2) ?? [];
 
             $points = ilUtil::stripSlashes($skill_points[$assignmentKey] ?? '');
         } else {

--- a/components/ILIAS/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\RequestDataCollector;
 
 /**
@@ -27,7 +28,7 @@ use ILIAS\TestQuestionPool\RequestDataCollector;
 class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
 {
     private ilAssQuestionSkillAssignmentList $skillQuestionAssignmentList;
-    private RequestDataCollector $requestDataCollector;
+    private RequestDataCollector $request_data_collector;
 
     private bool $loadSkillPointsFromRequest = false;
     private bool $manipulationsEnabled;
@@ -53,11 +54,11 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         ilCtrl $ctrl,
         ilLanguage $lng
     ) {
-        global $DIC;
-
         $this->lng = $lng;
         $this->ctrl = $ctrl;
-        $this->requestDataCollector = new RequestDataCollector($DIC->http(), $DIC->refinery(), $DIC->upload());
+
+        $local_dic = QuestionPoolDIC::dic();
+        $this->request_data_collector = $local_dic['request_data_collector'];
 
         $this->setId('assQstSkl');
         $this->setPrefix('assQstSkl');
@@ -256,8 +257,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
         ]);
 
         if ($this->loadSkillPointsFromRequest) {
-            $skill_points = $this->requestDataCollector->retrieveNestedArraysOfStrings('skill_points', 2) ?? [];
-
+            $skill_points = $this->request_data_collector->strArray('skill_points', 2);
             $points = ilUtil::stripSlashes($skill_points[$assignmentKey] ?? '');
         } else {
             $points = $assignment->getSkillPoints();

--- a/components/ILIAS/TestQuestionPool/src/QuestionPoolDIC.php
+++ b/components/ILIAS/TestQuestionPool/src/QuestionPoolDIC.php
@@ -51,8 +51,6 @@ class QuestionPoolDIC extends PimpleContainer
                 $DIC['refinery'],
                 $DIC['upload']
             );
-        $dic['request_validation_helper'] = static fn($c): RequestValidationHelper =>
-            new RequestValidationHelper($DIC['refinery']);
         $dic['question.repo.suggestedsolutions'] = static fn($c): SuggestedSolutionsDatabaseRepository =>
             new SuggestedSolutionsDatabaseRepository($DIC['ilDB']);
         $dic['question.general_properties.repository'] = static fn($c): GeneralQuestionPropertiesRepository =>

--- a/components/ILIAS/TestQuestionPool/src/QuestionPoolDIC.php
+++ b/components/ILIAS/TestQuestionPool/src/QuestionPoolDIC.php
@@ -51,6 +51,8 @@ class QuestionPoolDIC extends PimpleContainer
                 $DIC['refinery'],
                 $DIC['upload']
             );
+        $dic['request_validation_helper'] = static fn($c): RequestValidationHelper =>
+            new RequestValidationHelper($DIC['refinery']);
         $dic['question.repo.suggestedsolutions'] = static fn($c): SuggestedSolutionsDatabaseRepository =>
             new SuggestedSolutionsDatabaseRepository($DIC['ilDB']);
         $dic['question.general_properties.repository'] = static fn($c): GeneralQuestionPropertiesRepository =>

--- a/components/ILIAS/TestQuestionPool/src/RequestDataCollector.php
+++ b/components/ILIAS/TestQuestionPool/src/RequestDataCollector.php
@@ -43,7 +43,6 @@ class RequestDataCollector
 
     /**
      * @return UploadResult[]
-     * @throws IllegalStateException
      */
     public function getProcessedUploads(): array
     {

--- a/components/ILIAS/TestQuestionPool/src/RequestDataCollector.php
+++ b/components/ILIAS/TestQuestionPool/src/RequestDataCollector.php
@@ -41,7 +41,7 @@ class RequestDataCollector
     }
 
     /**
-     * @return UploadResult[]
+     * @return array<UploadResult>
      */
     public function getProcessedUploads(): array
     {
@@ -58,7 +58,7 @@ class RequestDataCollector
     }
 
     /**
-     * @param string[] $http_names An array of keys used as structure for the HTTP name (e.g. ['terms', 'image'] for $_FILES['terms']['image'])
+     * @param array<string> $http_names An array of keys used as structure for the HTTP name (e.g. ['terms', 'image'] for $_FILES['terms']['image'])
      * @param int $index
      * @return string|null
      */
@@ -118,7 +118,7 @@ class RequestDataCollector
     }
 
     /**
-     * @return string[]
+     * @return array<string>
      */
     public function getIds(): array
     {
@@ -158,7 +158,7 @@ class RequestDataCollector
     }
 
     /**
-     * @return int[]
+     * @return array<int>
      */
     public function getUnitIds(): array
     {
@@ -166,7 +166,7 @@ class RequestDataCollector
     }
 
     /**
-     * @return int[]
+     * @return array<int>
      */
     public function getUnitCategoryIds(): array
     {

--- a/components/ILIAS/TestQuestionPool/src/RequestDataCollector.php
+++ b/components/ILIAS/TestQuestionPool/src/RequestDataCollector.php
@@ -192,10 +192,6 @@ class RequestDataCollector
                 $this->refinery->always([])
             ])
         );
-        return array_map(
-            fn(string $v): array => json_decode($v),
-            $this->questionpool_request->retrieveArrayOfStringsFromPost('matching')
-        );
     }
 
     public function getPostKeys(): array

--- a/components/ILIAS/TestQuestionPool/src/RequestValidationHelper.php
+++ b/components/ILIAS/TestQuestionPool/src/RequestValidationHelper.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+namespace ILIAS\TestQuestionPool;
+
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Refinery\Transformation;
+
+class RequestValidationHelper
+{
+    public function __construct(
+        protected Refinery $refinery
+    ) {
+    }
+
+    /**
+     * Checks if the provides points of an input are valid. The function returns the language key of the error message
+     * if either the input is not an array or one of the points are not numeric. If the input is valid, the function
+     * returns the points as an array of floats.
+     *
+     * @return string|float[]
+     */
+    public function checkPointsInput($data, bool $required, string $key = 'points'): string|array
+    {
+        if (!is_array($data) || !is_array($data[$key])) {
+            return $required ? 'msg_input_is_required' : [];
+        }
+
+        try {
+            $points = $this->refinery->to()->listOf($this->refinery->kindlyTo()->float())->transform($data[$key]);
+        } catch (ConstraintViolationException $e) {
+            return 'form_msg_numeric_value_required';
+        }
+
+        if (count($points) === 0) {
+            return $required ? 'msg_input_is_required' : [];
+        }
+
+        return $points;
+    }
+
+    /**
+     * Extends the checkPointsInput function by checking if at least one point is greater than 0.0. If not, the function
+     * returns the language key of the error message.
+     *
+     * @return string|float[]
+     */
+    public function checkPointsInputEnoughPositive($data, bool $required, string $key = 'points'): string|array
+    {
+        $points = $this->checkPointsInput($data, $required, $key);
+        if (!is_array($points)) {
+            return $points;
+        }
+
+        if (max($points) === 0.0) {
+            return 'enter_enough_positive_points';
+        }
+
+        return $points;
+    }
+
+    public function transformArray($data, string $key, Transformation $transformation): array
+    {
+        if (!is_array($data) || !isset($data[$key]) || !is_array($data[$key])) {
+            return [];
+        }
+
+        return $this->refinery->byTrying([
+            $this->refinery->kindlyTo()->listOf($transformation),
+            $this->refinery->always([])
+        ])->transform($data[$key]);
+    }
+
+    /**
+     * @return array<float>
+     */
+    public function transformPoints($data, string $key = 'points'): array
+    {
+        return $this->transformArray($data, $key, $this->refinery->kindlyTo()->float());
+    }
+
+    /**
+     * Returns true if the given key is set in the array and the value is not empty.
+     */
+    public function inArray($array, $key): bool
+    {
+        return is_array($array) && array_key_exists($key, $array) && !empty($array[$key]);
+    }
+}

--- a/components/ILIAS/TestQuestionPool/src/RequestValidationHelper.php
+++ b/components/ILIAS/TestQuestionPool/src/RequestValidationHelper.php
@@ -38,7 +38,7 @@ class RequestValidationHelper
      */
     public function checkPointsInput($data, bool $required, string $key = 'points'): string|array
     {
-        if (!is_array($data) || !is_array($data[$key])) {
+        if (!is_array($data) || !$this->inArray($data, $key)) {
             return $required ? 'msg_input_is_required' : [];
         }
 

--- a/components/ILIAS/TestQuestionPool/src/RequestValidationHelper.php
+++ b/components/ILIAS/TestQuestionPool/src/RequestValidationHelper.php
@@ -77,7 +77,7 @@ class RequestValidationHelper
 
     public function transformArray($data, string $key, Transformation $transformation): array
     {
-        if (!is_array($data) || !isset($data[$key]) || !is_array($data[$key])) {
+        if (!$this->inArray($data, $key)) {
             return [];
         }
 

--- a/components/ILIAS/TestQuestionPool/templates/default/tpl.il_as_cloze_gap_builder.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tpl.il_as_cloze_gap_builder.html
@@ -18,7 +18,7 @@
     .disabled
     {
         width:16px;
-        height:16px:
+        height:16px;
         background-color:blue;
     }
     .gap_combination_spacer_applied

--- a/components/ILIAS/TestQuestionPool/tests/RequestValidationHelperTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/RequestValidationHelperTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\TestQuestionPool\RequestValidationHelper;
+
+class RequestValidationHelperTest extends assBaseTestCase
+{
+    private RequestValidationHelper $object;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $lng_mock = $this->getMockBuilder(ILIAS\Language\Language::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $refinery = new Refinery(new DataFactory(), $lng_mock);
+        $this->object = new RequestValidationHelper($refinery);
+    }
+
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(RequestValidationHelper::class, $this->object);
+    }
+
+    public function test_checkPointsFromRequest_shouldAbort_whenEmptyData(): void
+    {
+        $data = [];
+        $expected = 'msg_input_is_required';
+        $actual = $this->object->checkPointsInput($data, true);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_checkPointsFromRequest_shouldAbort_whenEmptyPoints(): void
+    {
+        $data = ['points' => []];
+        $expected = 'msg_input_is_required';
+        $actual = $this->object->checkPointsInput($data, true);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_checkPointsFromRequest_shouldReturn_whenEmptyPoints(): void
+    {
+        $data = ['points' => []];
+        $expected = [];
+        $actual = $this->object->checkPointsInput($data, false);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_checkPointsFromRequest_shouldAbort_whenNonNumericPoints(): void
+    {
+        $data = ['points' => [1, 5.2, 'not a number']];
+        $expected = 'form_msg_numeric_value_required';
+        $actual = $this->object->checkPointsInput($data, false);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_checkPointsFromRequest_shouldReturn_whenPointsAsString(): void
+    {
+        $data = ['points' => [1, 5.2, '7.8', '9,1']];
+        $expected = [1.0, 5.2, 7.8, 9.1];
+        $actual = $this->object->checkPointsInput($data, false);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_checkPointsFromRequest_shouldAbort_whenZeroPoints(): void
+    {
+        $data = ['points' => [0, -6]];
+        $expected = 'enter_enough_positive_points';
+        $actual = $this->object->checkPointsInputEnoughPositive($data, true);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_checkPointsFromRequest_shouldReturn_whenNonZeroPoints(): void
+    {
+        $data = ['points' => [1, 5.2, 7.8, 9.1]];
+        $expected = [1.0, 5.2, 7.8, 9.1];
+        $actual = $this->object->checkPointsInputEnoughPositive($data, true);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_inArray_shouldReturnFalse_whenEmptyArray(): void
+    {
+        $array = [];
+        $key = 'test';
+        $this->assertFalse($this->object->inArray($array, $key));
+    }
+
+    public function test_inArray_shouldReturnFalse_whenKeyNotFound(): void
+    {
+        $array = ['not_test' => 'value'];
+        $key = 'test';
+        $this->assertFalse($this->object->inArray($array, $key));
+    }
+
+    public function test_inArray_shouldReturnTrue_whenKeyFound(): void
+    {
+        $array = ['test' => 'value'];
+        $key = 'test';
+        $this->assertTrue($this->object->inArray($array, $key));
+    }
+    public function test_inArray_shouldReturnFalse_whenEmptyStringValue(): void
+    {
+        $array = ['test' => ''];
+        $key = 'test';
+        $this->assertFalse($this->object->inArray($array, $key));
+    }
+
+    public function test_inArray_shouldReturnFalse_whenEmptyArrayValue(): void
+    {
+        $array = ['test' => []];
+        $key = 'test';
+        $this->assertFalse($this->object->inArray($array, $key));
+    }
+}

--- a/components/ILIAS/TestQuestionPool/tests/RequestValidationHelperTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/RequestValidationHelperTest.php
@@ -20,11 +20,11 @@ declare(strict_types=1);
 
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Factory as Refinery;
-use ILIAS\TestQuestionPool\RequestValidationHelper;
+use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 
 class RequestValidationHelperTest extends assBaseTestCase
 {
-    private RequestValidationHelper $object;
+    private ilTestLegacyFormsHelper $object;
 
     protected function setUp(): void
     {
@@ -33,13 +33,13 @@ class RequestValidationHelperTest extends assBaseTestCase
         $lng_mock = $this->getMockBuilder(ILIAS\Language\Language::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $refinery = new Refinery(new DataFactory(), $lng_mock);
-        $this->object = new RequestValidationHelper($refinery);
+        $this->setGlobalVariable('refinery', new Refinery(new DataFactory(), $lng_mock));
+        $this->object = new ilTestLegacyFormsHelper();
     }
 
     public function testConstruct(): void
     {
-        $this->assertInstanceOf(RequestValidationHelper::class, $this->object);
+        $this->assertInstanceOf(ilTestLegacyFormsHelper::class, $this->object);
     }
 
     public function test_checkPointsFromRequest_shouldAbort_whenEmptyData(): void


### PR DESCRIPTION
Hi everyone, 

this PR introduces a major refactoring in which @matheuszych , @bidzanaaron, @FBartz28 and I replaced all direct `$_POST` and `$_GET` accesses in TQPL by using `RequestDataCollector`. Sorry that the PR is that large, we have summarized the changes here.


### Coding Style Refactoring

At all places we came across we:

- Converted CamelCase notation of class properties to snake_case
- Added data types to method signatures
- Removed unnecessary `@return` and `@param` annotations from PHP-Docs when types are recognizable in the method signature
- Removed empty constructors that only call the parent constructor
- Removed local `$lng` variables loaded from the DIC, as they are provided as a property by the parent class in all cases

### Replacement of Superglobals

- All accesses to the $_POST array were replaced with accesses to the wrapper through `RequestDataCollector`
- For safer access to arrays, we adjusted the methods in the `RequestDataCollector` so that nested arrays can be accessed as well
- Renamed property with the name `$request` to clarify that it's not the request itself but the wrapper
- At places where it was recognizable to us through method signatures or doc comments, we directly converted the data into the expected data type. At all other places, they are processed without transformation
- At places where the type cannot be determined with certainty, we implemented the check for whether the value is set using the `empty()` function instead of a null check

### Refactoring of the `setValue` Functions

The problem here was that in these two functions, the data from the requests are processed directly. The entire logic for validation is implemented simultaneously in many places. This is a problem because not all checks were always implemented here. Examples:

- In some of these functions, it was checked whether the keys are contained in the request array, in others it was simply assumed
- In some functions, it was ensured that the points are correctly converted to `floats` (via the `str_replace` function), in other places this was missing
- In some functions, the answers were converted by type casts, in others by the Refinery, and in others not at all

Therefore, we have outsourced these conversion functions, which work similarly for most question types and GUI classes, into a separate helper class. Here, for example, the `transformPoints` method ensures that points are always converted to `float` - regardless of whether they were transmitted as a string or numeric value.

### Refactoring of the `checkInput` Functions

The same applies here as for the `setValue` function. Additionally, missing type conversions pose a big problem when strict type checks with `===` are performed, but it wasn't ensured beforehand that the data is also in the expected format. That's why we have also outsourced the validation functions.

The validation functions handle type conversion and checking simultaneously. They work in such a way that upon successful conversion without errors, they return the array with the converted values. If an error occurs, a string is returned containing the language identifier for the error message.

### Minor Bugfixes / Code Smells

- **[class.assClozeTest.php:1053](https://github.com/ILIAS-eLearning/ILIAS/blob/ca090615444fb6b71c2e5da6b71f4c4970eb36b1/components/ILIAS/TestQuestionPool/classes/class.assClozeTest.php#L1054C13-L1054C81):** Type checking doesn't make sense here as the input can be present as both a string and a number
- **[class.assClozeTestGUI.php:1677](https://github.com/ILIAS-eLearning/ILIAS/blob/ca090615444fb6b71c2e5da6b71f4c4970eb36b1/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php#L1677C8-L1677C49)**: Removed self-assignment of local variables
- **[class.assKprimChoice.php `removeAnswerImage`](https://github.com/ILIAS-eLearning/ILIAS/blob/ca090615444fb6b71c2e5da6b71f4c4970eb36b1/components/ILIAS/TestQuestionPool/classes/class.assKprimChoice.php#L604)**: Method must be public
- **[class.assOrderingQuestion.php:1192](https://github.com/ILIAS-eLearning/ILIAS/blob/ca090615444fb6b71c2e5da6b71f4c4970eb36b1/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestion.php#L1192)**: Fixed undefined constants
- **[class.ilObjQuestionPoolGUI.php:512](https://github.com/ILIAS-eLearning/ILIAS/blob/ca090615444fb6b71c2e5da6b71f4c4970eb36b1/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php#L512)**: Replaced undefined variable `$ilAccess` with `$this->access`
- **[tpl.il_as_cloze_gap_builder.html](https://github.com/ILIAS-eLearning/ILIAS/blob/ca090615444fb6b71c2e5da6b71f4c4970eb36b1/components/ILIAS/TestQuestionPool/templates/default/tpl.il_as_cloze_gap_builder.html#L21)**: Replaced incorrect CSS rule separator