### PR TITLE
CSV: Explicitly pass `escape` argument (PHP 8.4)

### DIFF
--- a/components/ILIAS/AuthApache/classes/class.ilAuthProviderApache.php
+++ b/components/ILIAS/AuthApache/classes/class.ilAuthProviderApache.php
@@ -65,7 +65,7 @@ final class ilAuthProviderApache extends ilAuthProvider implements ilAuthProvide
 
         $validIndicatorValues = array_filter(array_map(
             'trim',
-            str_getcsv($this->settings->get('apache_auth_indicator_value', ''))
+            str_getcsv($this->settings->get('apache_auth_indicator_value', ''), ',', '"', '\\')
         ));
         //TODO PHP8-REVIEW: $DIC->http()->request()->getServerParams()['apache_auth_indicator_name']
         if (

--- a/components/ILIAS/CSV/classes/class.ilCSVReader.php
+++ b/components/ILIAS/CSV/classes/class.ilCSVReader.php
@@ -26,13 +26,14 @@ class ilCSVReader
     private array $data = [];
     private string $separator = ';';
     private string $delimiter = '""';
+    private string $escape = '\\';
     private int $length = 1024;
 
     private function parse(): void
     {
         $row = 0;
 
-        while (($line = fgetcsv($this->file_resource, $this->length, $this->separator)) !== false) {
+        while (($line = fgetcsv($this->file_resource, $this->length, $this->separator, $this->escape)) !== false) {
             $line_count = count($line);
             for ($col = 0; $col < $line_count; $col++) {
                 $this->data[$row][$col] = $this->unquote($line[$col]);

--- a/components/ILIAS/Scorm2004/classes/class.ilObjSCORM2004LearningModule.php
+++ b/components/ILIAS/Scorm2004/classes/class.ilObjSCORM2004LearningModule.php
@@ -487,8 +487,8 @@ class ilObjSCORM2004LearningModule extends ilObjSCORMLearningModule
         $obj_id = $this->getID();
         $users = array();
         $usersToDelete = array();
-        $fields = fgetcsv($fhandle, 4096, ';');
-        while (($csv_rows = fgetcsv($fhandle, 4096, ";")) !== false) {
+        $fields = fgetcsv($fhandle, 4096, ';', '"', '\\');
+        while (($csv_rows = fgetcsv($fhandle, 4096, ";", '"', '\\')) !== false) {
             $user_id = 0;
             $data = array_combine($fields, $csv_rows);
             //no check the format - sufficient to import users

--- a/components/ILIAS/ScormAicc/classes/class.ilObjSCORMLearningModule.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilObjSCORMLearningModule.php
@@ -565,7 +565,7 @@ class ilObjSCORMLearningModule extends ilObjSAHSLearningModule
         $fhandle = fopen($a_file, "r");
 
         //the top line is the field names
-        $fields = fgetcsv($fhandle, 2 ** 16, ';');
+        $fields = fgetcsv($fhandle, 2 ** 16, ';', '"', '\\');
         //lets check the import method
         fclose($fhandle);
 
@@ -599,10 +599,10 @@ class ilObjSCORMLearningModule extends ilObjSAHSLearningModule
         $fhandle = fopen($a_file, "r");
 
         $obj_id = $this->getID();
-        $fields = fgetcsv($fhandle, 2 ** 16, ';');
+        $fields = fgetcsv($fhandle, 2 ** 16, ';', '"', '\\');
         $users = array();
         $usersToDelete = array();
-        while (($csv_rows = fgetcsv($fhandle, 2 ** 16, ";")) !== false) {
+        while (($csv_rows = fgetcsv($fhandle, 2 ** 16, ";", '"', '\\')) !== false) {
             $user_id = 0;
             $data = array_combine($fields, $csv_rows);
             //no check the format - sufficient to import users
@@ -804,13 +804,13 @@ class ilObjSCORMLearningModule extends ilObjSAHSLearningModule
 
         $fhandle = fopen($a_file, "r");
 
-        $fields = fgetcsv($fhandle, 2 ** 16, ';');
+        $fields = fgetcsv($fhandle, 2 ** 16, ';', '"', '\\');
         $users = array();
         $a_last_access = array();
         $a_time = array();
         $a_package_attempts = array();
         $a_module_version = array();
-        while (($csv_rows = fgetcsv($fhandle, 2 ** 16, ";")) !== false) {
+        while (($csv_rows = fgetcsv($fhandle, 2 ** 16, ";", '"', '\\')) !== false) {
             $data = array_combine($fields, $csv_rows);
             if ($data['Userid']) {
                 $user_id = $this->parseUserId($data['Userid']);


### PR DESCRIPTION
See: https://www.php.net/manual/en/migration84.deprecated.php

Using the default value for the escape parameter for the SplFileObject::setCsvControl(), SplFileObject::fputcsv(), and SplFileObject::fgetcsv() is now deprecated. It must be passed explicitly either positionally or via named arguments. This does not apply to SplFileObject::fputcsv() and SplFileObject::fgetcsv() if SplFileObject::setCsvControl() was used to set a new default value.