### PR TITLE
Repository: re-add paramter for loc redirect (42783)

### DIFF
--- a/components/ILIAS/Repository/classes/class.ilRepositoryGUI.php
+++ b/components/ILIAS/Repository/classes/class.ilRepositoryGUI.php
@@ -184,6 +184,11 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
                 $this->ctrl->redirectByClass($next_class, "");
             }
 
+            if ($this->ctrl->getCmd() === 'redirectLocToTest') {
+                $this->ctrl->saveParameterByClass($next_class, 'tid');
+                $this->ctrl->redirectByClass($next_class, $this->ctrl->getCmd());
+            }
+
             if ($this->ctrl->getCmd() !== "showRepTree") {
                 $this->ctrl->redirectByClass($next_class, $this->ctrl->getCmd());
             }


### PR DESCRIPTION
This PR fixes [42783](https://mantis.ilias.de/view.php?id=42783) by re-adding a parameter on redirect that got lost because of ilCtrl refactorings. Course and Test use Repository as a go-between, so the issue has to be fixed there. An alternative would be to set the relevant links differently in `ilObjTestListGUI::modifyTitleLink`.

EDIT: This should also fix [43045](https://mantis.ilias.de/view.php?id=43045).