### PR TITLE
Auth/LoginForm: Show concrete messages for username/password fields

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -496,14 +496,34 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             $fields[self::PROP_AUTH_MODE] = $auth_mode;
         }
 
-        $fields = $fields + [
+        $fields += [
             self::PROP_USERNAME => $field_factory
                 ->text($this->lng->txt('username'))
-                ->withRequired(true),
+                ->withRequired(
+                    true,
+                    $this->refinery->custom()->constraint(
+                        static function (string $value): bool {
+                            return $value !== '';
+                        },
+                        static function (Closure $lng, string $value): string {
+                            return $lng('auth_required_username');
+                        }
+                    )
+                ),
             self::PROP_PASSWORD => $field_factory
                 ->password($this->lng->txt('password'))
                 ->withRevelation(true)
-                ->withRequired(true)
+                ->withRequired(
+                    true,
+                    $this->refinery->custom()->constraint(
+                        static function (string $value): bool {
+                            return $value !== '';
+                        },
+                        static function (Closure $lng, string $value): string {
+                            return $lng('auth_required_password');
+                        }
+                    )
+                )
                 ->withAdditionalTransformation(
                     $this->refinery->custom()->transformation(
                         static function (ILIAS\Data\Password $value): string {

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2075,6 +2075,8 @@ auth#:#auth_oidc_update_field_info#:#Automatisch aktualisieren
 auth#:#auth_oidc_update_role_info#:#Nur bei Erstanmeldung (automatische Synchronisierung) anwenden
 auth#:#auth_oidconnect#:#OpenID Connect
 auth#:#auth_page_type_auth#:#Login-Seite
+auth#:#auth_required_password#:#Bitte geben Sie ein Passwort ein.
+auth#:#auth_required_username#:#Bitte geben Sie einen Anmeldenamen ein.
 auth#:#auth_saml#:#SAML
 auth#:#auth_saml_add_idp_btn#:#Identity - hinzufügen
 auth#:#auth_saml_add_idp_md_error#:#Der eingegeben Wert entsprach leider nicht einem wohlgeformten XML-Dokument. Bitte stellen Sie sicher, dass das XML einen gültigen Identity-Provider enthält.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2075,6 +2075,8 @@ auth#:#auth_oidc_update_field_info#:#Update Automatically
 auth#:#auth_oidc_update_role_info#:#Only Synchronise Automatically the First Time a User Logs In.
 auth#:#auth_oidconnect#:#OpenID Connect
 auth#:#auth_page_type_auth#:#Login Page
+auth#:#auth_required_password#:#Please enter a password.
+auth#:#auth_required_username#:#Please enter a username.
 auth#:#auth_saml#:#SAML
 auth#:#auth_saml_add_idp_btn#:#Add new Identity Provider
 auth#:#auth_saml_add_idp_md_error#:#The given value was not a valid XML document. Ensure the XML contains a valid Identity Provider.


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42298

If approved, this must be picked to `release_10` and `trunk` as well.