### PR TITLE
Auth/LoginForm: Don't show `err_wrong_login` if form is invalid

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -709,7 +709,6 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         }
 
         if (!$form_valid) {
-            $this->mainTemplate->setOnScreenMessage('failure', $this->lng->txt('err_wrong_login'));
             $this->showLoginPage($form);
             return;
         }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42298

If approved, this must be picked to `release_10` and `trunk` as well.