### PR TITLE
T&A fix 42872: CharSelectorConfig::setDefinition TypeError

### DIFF
--- a/Modules/Test/classes/class.ilObjTestSettingsGeneralGUI.php
+++ b/Modules/Test/classes/class.ilObjTestSettingsGeneralGUI.php
@@ -1266,8 +1266,8 @@ class ilObjTestSettingsGeneralGUI extends ilTestSettingsGUI
         if ($this->isCharSelectorPropertyRequired()) {
             require_once 'Services/UIComponent/CharSelector/classes/class.ilCharSelectorGUI.php';
             $char_selector = new ilCharSelectorGUI(ilCharSelectorConfig::CONTEXT_TEST);
-            $char_selector->getConfig()->setAvailability($this->testOBJ->getCharSelectorAvailability());
-            $char_selector->getConfig()->setDefinition($this->testOBJ->getCharSelectorDefinition());
+            $char_selector->getConfig()->setAvailability((int) $this->testOBJ->getCharSelectorAvailability());
+            $char_selector->getConfig()->setDefinition((string) $this->testOBJ->getCharSelectorDefinition());
             $char_selector->addFormProperties($form);
             $char_selector->setFormValues($form);
         }

--- a/Services/UIComponent/CharSelector/classes/class.ilCharSelectorGUI.php
+++ b/Services/UIComponent/CharSelector/classes/class.ilCharSelectorGUI.php
@@ -194,9 +194,9 @@ class ilCharSelectorGUI implements ilCtrlBaseClassInterface
      */
     public function getFormValues(ilPropertyFormGUI $a_form): void
     {
-        $this->config->setAvailability($a_form->getInput('char_selector_availability'));
-        $this->config->setAddedBlocks($a_form->getInput('char_selector_blocks'));
-        $this->config->setCustomItems($a_form->getInput('char_selector_custom_items'));
+        $this->config->setAvailability((int) $a_form->getInput('char_selector_availability'));
+        $this->config->setAddedBlocks((array) $a_form->getInput('char_selector_blocks'));
+        $this->config->setCustomItems((string) $a_form->getInput('char_selector_custom_items'));
     }
 
     /**


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=42872

No merge to release_9 required since CharSelector is removed there.