### PR TITLE
Certificate Bugfix #0042876: Fix Saving Certificate with <br> is no valid XHTML

### DIFF
--- a/components/ILIAS/Certificate/classes/File/Template/XLS/class.ilXlsFoParser.php
+++ b/components/ILIAS/Certificate/classes/File/Template/XLS/class.ilXlsFoParser.php
@@ -72,6 +72,7 @@ class ilXlsFoParser
         $content = preg_replace("/<p>(\\s)*?<\\/p>/", "<p></p>", $content);
         $content = str_replace("<p></p>", "<p class=\"emptyrow\"></p>", $content);
         $content = str_replace("&nbsp;", "&#160;", $content);
+        $content = str_replace('<br>', '<br/>', $content);
         $content = preg_replace("//", "", $content);
 
         $this->xmlChecker->parse($content);

--- a/components/ILIAS/Certificate/classes/Form/class.ilFormFieldParser.php
+++ b/components/ILIAS/Certificate/classes/Form/class.ilFormFieldParser.php
@@ -105,9 +105,6 @@ class ilFormFieldParser
         // dirty hack: the php xslt processing seems not to recognize the following
         // replacements, so we do it in the code as well
         $content = str_replace(["&#xA0;", "&#160;"], "<br />", $content);
-        $content = preg_replace('~\x{00a0}~siu', '', $content);
-        $content = str_replace('<p></p>', '<br/>', $content);
-
 
         return [
             'pageformat' => $pagesize,

--- a/components/ILIAS/Certificate/classes/Form/class.ilFormFieldParser.php
+++ b/components/ILIAS/Certificate/classes/Form/class.ilFormFieldParser.php
@@ -91,7 +91,7 @@ class ilFormFieldParser
             }
         }
 
-        $xsl = file_get_contents(__DIR__ . '/../../xml/xhtml2fo.xsl');
+        $xsl = file_get_contents(__DIR__ . '/../../xml/fo2xhtml.xsl');
         if ($content !== '' && (is_string($xsl) && $xsl !== '')) {
             $args = [
                 '/_xml' => $content,
@@ -105,6 +105,9 @@ class ilFormFieldParser
         // dirty hack: the php xslt processing seems not to recognize the following
         // replacements, so we do it in the code as well
         $content = str_replace(["&#xA0;", "&#160;"], "<br />", $content);
+        $content = preg_replace('~\x{00a0}~siu', '', $content);
+        $content = str_replace('<p></p>', '<br/>', $content);
+
 
         return [
             'pageformat' => $pagesize,


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42876

This Fixes the error message for <br> Tags being invalid XHTML
And also the removal of empty lines as well as the <p> tags adding unpleasing empty lines