### PR TITLE
Init webui-popover.min.js

### DIFF
--- a/components/ILIAS/UI/UI.php
+++ b/components/ILIAS/UI/UI.php
@@ -79,6 +79,8 @@ class UI implements Component\Component
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "js/Page/stdpage.js");
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
+            new Component\Resource\NodeModule("webui-popover/dist/jquery.webui-popover.min.js");
+        $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "js/Popover/popover.js");
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "js/Table/dist/table.min.js");
@@ -113,10 +115,7 @@ class UI implements Component\Component
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\NodeModule("mediaelement/build/renderers/vimeo.min.js");
         */
-        /* This library was missing after discussing dependencies for ILIAS 10
-        $contribute[Component\Resource\PublicAsset::class] = fn() =>
-            new Component\Resource\NodeModule("webui-popover/dist/jquery.webui-popover.min.js");
-        */
+
 
 
         // This is included via anonymous classes as a testament to the fact, that


### PR DESCRIPTION
After https://github.com/ILIAS-eLearning/ILIAS/pull/8377 has been merged, the node module must be initialized, so the Popovers can work properly.