### PR TITLE
10/UI/MainControls/ModeInfo example push footer down

### DIFF
--- a/components/ILIAS/UI/src/examples/MainControls/ModeInfo/modeinfo.php
+++ b/components/ILIAS/UI/src/examples/MainControls/ModeInfo/modeinfo.php
@@ -60,10 +60,14 @@ function renderModeInfoFullscreenMode(\ILIAS\DI\Container $dic)
     );
 
     $page = $f->layout()->page()->standard(
-        [$f->panel()->standard(
-            'Mode Info Example',
-            $panel_content
-        )],
+        [
+            $f->legacy("<div id='mainspacekeeper'><div style='padding: 15px;'>"),
+            $f->panel()->standard(
+                'Mode Info Example',
+                $panel_content
+            ),
+            $f->legacy("</div></div>")
+        ],
         $f->mainControls()->metaBar()->withAdditionalEntry(
             'help',
             $f->button()->bulky($f->symbol()->glyph()->help(), 'Help', '#')


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42418

# Issue

On the Kitchen Sink example page for the Mode Info, the footer isn't pushed down to the bottom of the page.

![image](https://github.com/user-attachments/assets/39ea531d-fc5a-4a22-8ba1-7d55834b22cb)

# Change

Example now adds mainspacekeeper div as a legacy component to simulate a page structure like it is generally found in ILIAS.

![image](https://github.com/user-attachments/assets/4f4bf7b4-1365-4a0f-8498-f3feb37889c0)

# Outlook

Once we have actual content layout components they will most likely manage the spacing and size of the content container. Hey, in ILIAS 11 maybe? :D