### PR TITLE
Add `PHPOffice/PhpSpreadsheet` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"phpoffice/phpspreadsheet": "^3.5",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Assessment:
The situation is not ideal, as we seem to be relying mostly on one maintainer about who we know very little. PHPOffice as a project has more contributors and it can be assumed that they perform some oversight, but the development is ongoing and issue fixes are current.

General Information:
- Name of the dependency: `PHPOffice/PhpSpreadsheet`
- Version: `3.5`
- [x] this dependency was already used in ILIAS.
- [x] the dependency's license is compatible with ILIAS' license: MIT License

Type of dependency:
- [x] composer
- [ ] npm

Usage:
- Bookingpool
- Datacollection
- Exercise
- MyStaff
- OrgUnits
- Polls
- Category
- SCORM
- StudyProgramme
- Survey
- Test
- LearningProgress
- Tracking
- Wiki
- and possibly more

Wrapped By:
- Excel Service

Reasoning:
* Is the de facto standard for dealing with spreadsheets in PHP.
* Is actively developed even if by only one person.
* In wide use in the code base.
* Specially `xlsx` is a very  complex standard which we should definitely NOT try to implement ourselves.

Maintenance:
- Mostly one maintainer [oleibmann](https://github.com/oleibman). Not much information about him available. Occasional contributions by others. Part of `PHPOffice` with more contributors.
- Fixes for CVEs have been forthcoming (no information on delay between notification and fix).
- Regular updates (~1 commit per day).

Links:
- Packagist: https://packagist.org/packages/phpoffice/phpspreadsheet
- GitHub: https://github.com/PHPOffice/PhpSpreadsheet
- Documentation: https://phpspreadsheet.readthedocs.io/en/latest/

Alternatives:
* [PHP_XLSXWriter](https://github.com/mk-j/PHP_XLSXWriter), no commits in 2024
* [PhpXlsxGenerator](https://github.com/codexworld/PhpXlsxGenerator), no commits in 2024, only writing
* [simplexlsx](https://github.com/shuchkin/simplexlsx) and [simplexlsxgen](https://github.com/shuchkin/simplexlsxgen), very few commits in 2024, single maintainer