### PR TITLE
LegacyForm: Fix Error on Big File

### DIFF
--- a/components/ILIAS/Form/classes/class.ilFileInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilFileInputGUI.php
@@ -338,6 +338,8 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
             );
         }
 
+        $f_tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
+        $f_tpl->setVariable('MAX_SIZE', $this->getMaxFileSizeInt());
         $f_tpl->setVariable("POST_VAR", $this->getPostVar());
         $f_tpl->setVariable("ID", $this->getFieldId());
         $f_tpl->setVariable("SIZE", $this->getSize());
@@ -383,6 +385,12 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
 
     protected function getMaxFileSizeString(): string
     {
+        //format for display in mega-bytes
+        return sprintf("%.1f MB", $this->getMaxFileSizeInt() / 1024 / 1024);
+    }
+
+    protected function getMaxFileSizeInt(): int
+    {
         // get the value for the maximal uploadable filesize from the php.ini (if available)
         $umf = ini_get("upload_max_filesize");
         // get the value for the maximal post data from the php.ini (if available)
@@ -407,9 +415,6 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
         if (!$max_filesize) {
             $max_filesize = max($umf, $pms);
         }
-
-        //format for display in mega-bytes
-        $max_filesize = sprintf("%.1f MB", $max_filesize / 1024 / 1024);
 
         return $max_filesize;
     }

--- a/components/ILIAS/Form/classes/class.ilImageFileInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilImageFileInputGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,9 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+
+declare(strict_types=1);
 
 /**
  * This class represents an image file property in a property form.

--- a/components/ILIAS/Form/classes/class.ilImageFileInputGUI.php
+++ b/components/ILIAS/Form/classes/class.ilImageFileInputGUI.php
@@ -162,6 +162,8 @@ class ilImageFileInputGUI extends ilFileInputGUI
             $i_tpl->parseCurrentBlock();
         }
 
+        $i_tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
+        $i_tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
         $i_tpl->setVariable("POST_VAR", $this->getPostVar());
         $i_tpl->setVariable("ID", $this->getFieldId());
 

--- a/components/ILIAS/Form/resources/Form.js
+++ b/components/ILIAS/Form/resources/Form.js
@@ -51,8 +51,24 @@ il.Form = {
     // trigger event on fileselect
     $(document).on('change', `${selectorPrefix}.btn-file :file`, function () {
       const input = $(this);
+      const dt = new DataTransfer();
+      let label = '';
+
+      input.parents('.input-group').next().addClass('help-block').removeClass('ui-input-file-input-error-msg');
+      input.get(0).files.forEach(
+        (item) => {
+          if (item.size <= input.attr('data-maxsize')) {
+            dt.items.add(item);
+          } else {
+            label = input.attr('data-maxsize-warning');
+            input.parents('.input-group').next().removeClass('help-block').addClass('ui-input-file-input-error-msg');
+          }
+        }
+      );
+      input.get(0).files = dt.files;
+
       const numFiles = input.get(0).files ? input.get(0).files.length : 1;
-      const label = input.val().replace(/\\/g, '/').replace(/.*\//, '');
+      label += input.val().replace(/\\/g, '/').replace(/.*\//, '');
       input.trigger('fileselect', [numFiles, label]);
     });
 

--- a/components/ILIAS/Form/resources/Form.js
+++ b/components/ILIAS/Form/resources/Form.js
@@ -49,7 +49,7 @@ il.Form = {
     // see http://www.abeautifulsite.net/whipping-file-inputs-into-shape-with-bootstrap-3/
 
     // trigger event on fileselect
-    $(document).on('change', `${selectorPrefix}.btn-file :file`, function () {
+    $(document).on('change', `${selectorPrefix}.btn-file :file`, function (e) {
       const input = $(this);
       const dt = new DataTransfer();
       let label = '';
@@ -62,6 +62,7 @@ il.Form = {
           } else {
             label = input.attr('data-maxsize-warning');
             input.parents('.input-group').next().removeClass('help-block').addClass('ui-input-file-input-error-msg');
+            e.stopImmediatePropagation();
           }
         }
       );

--- a/components/ILIAS/Form/templates/default/tpl.prop_file.html
+++ b/components/ILIAS/Form/templates/default/tpl.prop_file.html
@@ -3,17 +3,17 @@
 		<div class="help-block">{TXT_FILENAME_HINT}</div>
 <!--  END filename -->
 		<!-- BEGIN prop_file_propval --><div style="margin-bottom:3px; margin-left:3px;"><span class="subtitle">{FILE_VAL}</span></div><!-- END prop_file_propval -->
-		
+
 		<div class="input-group">
 			<span class="input-group-btn">
 				<span class="btn btn-default btn-file">
-					{TXT_BROWSE}<input type="file" id="{ID}" name="{POST_VAR}"{DISABLED}/>
+					{TXT_BROWSE}<input type="file" id="{ID}" name="{POST_VAR}" data-maxsize="{MAX_SIZE}" data-maxsize-warning="{MAX_SIZE_WARNING}"{DISABLED}/>
 				</span>
 			</span>
 			<input tabindex="-1" type="text" class="form-control" readonly="readonly"{DISABLED}>
 		</div>
-				
-		<!--<input type="file" id="{ID}" name="{POST_VAR}" size="{SIZE}"{DISABLED} />-->
+
+		<!--<input type="file" id="{ID}" name="{POST_VAR}" size="{SIZE}" data-maxsize="{MAX_SIZE}" data-maxsize-warning="{MAX_SIZE_WARNING}"{DISABLED} />-->
 		<!-- BEGIN max_size -->
 		<div class="help-block">{TXT_MAX_SIZE}</div>
 		<!-- END max_size -->

--- a/components/ILIAS/Form/templates/default/tpl.prop_image_file.html
+++ b/components/ILIAS/Form/templates/default/tpl.prop_image_file.html
@@ -1,7 +1,7 @@
 <div class="input-group">
 	<span class="input-group-btn">
 		<span class="btn btn-default btn-file">
-			{TXT_BROWSE}<input type="file" id="{ID}" name="{POST_VAR}"{DISABLED}/>
+			{TXT_BROWSE}<input type="file" id="{ID}" name="{POST_VAR}" data-maxsize="{MAX_SIZE}" data-maxsize-warning="{MAX_SIZE_WARNING}"{DISABLED}/>
 		</span>
 	</span>
 	<input tabindex="-1" type="text" class="form-control" readonly="readonly"{DISABLED}>

--- a/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
+++ b/components/ILIAS/Test/tests/ilTestBaseTestCaseTrait.php
@@ -327,6 +327,11 @@ trait ilTestBaseTestCaseTrait
         );
     }
 
+    protected function addGlobal_uiUploadLimitResolver(): void
+    {
+        $this->setGlobalVariable('ui.upload_limit_resolver', $this->createMock(\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class));
+    }
+
     protected function getFileDelivery(): \ILIAS\FileDelivery\Services
     {
         $data_signer = new ILIAS\FileDelivery\Token\DataSigner(

--- a/components/ILIAS/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -174,6 +174,8 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                     $tpl->setCurrentBlock('addimage');
                     $tpl->setVariable("IMAGE_BROWSE", $this->lng->txt('select_file'));
                     $tpl->setVariable("IMAGE_ID", $this->getPostVar() . "[image][{$value->getPosition()}]");
+                    $tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
+                    $tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
                     $tpl->setVariable("IMAGE_SUBMIT", $this->lng->txt("upload"));
                     $tpl->setVariable("IMAGE_ROW_NUMBER", $value->getPosition());
                     $tpl->setVariable("IMAGE_POST_VAR", $this->getPostVar());

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
@@ -16,10 +16,10 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\QuestionPoolDIC;
 use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
  * This class represents a single choice wizard property in a property form.
@@ -44,17 +44,18 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
     protected ilTestLegacyFormsHelper $forms_helper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
+    protected UploadLimitResolver $upload_limit;
 
     public function __construct($a_title = "", $a_postvar = "")
     {
         parent::__construct($a_title, $a_postvar);
 
         global $DIC;
-        $local_dic = QuestionPoolDIC::dic();
 
         $this->forms_helper = new ilTestLegacyFormsHelper();
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
+        $this->upload_limit = $DIC['ui.upload_limit_resolver'];
 
         $this->setSuffixes(["jpg", "jpeg", "png", "gif"]);
         $this->setSize('40');
@@ -300,6 +301,8 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
                 $tpl->setCurrentBlock('addimage');
                 $tpl->setVariable("IMAGE_BROWSE", $lng->txt('select_file'));
                 $tpl->setVariable("IMAGE_ID", $this->getPostVar() . "[image][$i]");
+                $tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
+                $tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
                 $tpl->setVariable("IMAGE_SUBMIT", $lng->txt("upload"));
                 $tpl->setVariable("IMAGE_ROW_NUMBER", $i);
                 $tpl->setVariable("IMAGE_POST_VAR", $this->getPostVar());

--- a/components/ILIAS/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -216,6 +216,8 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                     $tpl->setCurrentBlock('addimage');
                     $tpl->setVariable("IMAGE_BROWSE", $lng->txt('select_file'));
                     $tpl->setVariable("IMAGE_ID", $this->getPostVar() . "[image][$i]");
+                    $tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
+                    $tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
                     $tpl->setVariable("IMAGE_SUBMIT", $lng->txt("upload"));
                     $tpl->setVariable("IMAGE_ROW_NUMBER", $i);
                     $tpl->setVariable("IMAGE_POST_VAR", $this->getPostVar());

--- a/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -16,11 +16,10 @@
  *
  *********************************************************************/
 
-use ILIAS\TestQuestionPool\QuestionPoolDIC;
-use ILIAS\TestQuestionPool\RequestDataCollector;
 use ILIAS\TestQuestionPool\ilTestLegacyFormsHelper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
 * This class represents a single choice wizard property in a property form.
@@ -42,6 +41,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     protected ilTestLegacyFormsHelper $forms_helper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
+    protected UploadLimitResolver $upload_limit;
 
     /**
     * Constructor
@@ -58,10 +58,9 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         $this->validationRegexp = '';
 
         global $DIC;
-        $local_dic = QuestionPoolDIC::dic();
-
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
+        $this->upload_limit = $DIC['ui.upload_limit_resolver'];
         $this->forms_helper = new ilTestLegacyFormsHelper();
     }
 
@@ -397,6 +396,8 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                     $tpl->setCurrentBlock('addimage');
                     $tpl->setVariable('IMAGE_BROWSE', $this->lng->txt('select_file'));
                     $tpl->setVariable('IMAGE_ID', $this->getPostVar() . "[image][$i]");
+                    $tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
+                    $tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
                     $tpl->setVariable('IMAGE_SUBMIT', $this->lng->txt('upload'));
                     $tpl->setVariable('IMAGE_ROW_NUMBER', $i);
                     $tpl->setVariable('IMAGE_POST_VAR', $this->getPostVar());

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
@@ -376,6 +376,8 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
         $template->setVariable("POST_VAR", $this->getPostVar());
         $template->setVariable("ID", $this->getFieldId());
         $template->setVariable("TXT_BROWSE", $lng->txt("select_file"));
+        $template->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
+        $template->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
         $template->setVariable("TXT_MAX_SIZE", $lng->txt("file_notice") . " " .
         $this->getMaxFileSizeString());
 

--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilMultipleImagesInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilMultipleImagesInputGUI.php
@@ -18,6 +18,7 @@
 
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -57,6 +58,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
     protected ilGlobalTemplateInterface $tpl;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
+    protected UploadLimitResolver $upload_limit;
 
     /**
      * Constructor
@@ -73,6 +75,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
         $this->tpl = $DIC->ui()->mainTemplate();
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
+        $this->upload_limit = $DIC['ui.upload_limit_resolver'];
 
         $this->setSuffixes(["jpg", "jpeg", "png", "gif"]);
         $this->setSize(25);
@@ -327,6 +330,8 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
 
             $tpl->setVariable('IMAGE_BROWSE', $lng->txt('select_file'));
             $tpl->setVariable('IMAGE_ID', $this->getMultiValuePosIndexedSubFieldId($identifier, self::IMAGE_UPLOAD_SUBFIELD_NAME, $i));
+            $tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
+            $tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
             $tpl->setVariable('TXT_IMAGE_SUBMIT', $lng->txt('upload'));
             $tpl->setVariable('IMAGE_CMD_UPLOAD', $this->buildMultiValueSubmitVar($identifier, $i, $this->getImageUploadCommand()));
             $tpl->setVariable('UPLOAD_IMAGE_POST_VAR', $this->getMultiValuePostVarSubFieldPosIndexed($identifier, self::IMAGE_UPLOAD_SUBFIELD_NAME, $i));

--- a/components/ILIAS/TestQuestionPool/templates/default/tpl.il_as_qpl_longmenu_question_gap.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tpl.il_as_qpl_longmenu_question_gap.html
@@ -54,7 +54,7 @@
 		<div class="input-group">
 			<span class="input-group-btn">
 				<span class="btn btn-default btn-file">
-					{TXT_BROWSE}<input class="upload" type="file" name="file" size="30" />
+					{TXT_BROWSE}<input class="upload" type="file" name="file" size="30" data-maxsize="{MAX_SIZE}" data-maxsize-warning="{MAX_SIZE_WARNING}" />
 				</span>
 			</span>
 			<input type="text" class="form-control" readonly="readonly">

--- a/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_imagemap_file.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_imagemap_file.html
@@ -1,7 +1,7 @@
 <div class="input-group">
 	<span class="input-group-btn">
 		<span class="btn btn-default btn-file">
-			{TXT_BROWSE}<input type="file" id="{ID}" name="{POST_VAR}" size="30" />
+			{TXT_BROWSE}<input type="file" id="{ID}" name="{POST_VAR}" size="30" data-maxsize="{MAX_SIZE}" data-maxsize-warning="{MAX_SIZE_WARNING}"/>
 		</span>
 	</span>
 	<input type="text" class="form-control" readonly="readonly">

--- a/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_kprimchoicewizardinput.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_kprimchoicewizardinput.html
@@ -23,7 +23,7 @@
 								<div class="input-group">
 									<span class="input-group-btn">
 										<span class="btn btn-default btn-file">
-											{IMAGE_BROWSE} <input class="upload" type="file" id="{IMAGE_ID}" name="{IMAGE_POST_VAR}[image][{IMAGE_ROW_NUMBER}]" size="20" />
+											{IMAGE_BROWSE} <input class="upload" type="file" id="{IMAGE_ID}" name="{IMAGE_POST_VAR}[image][{IMAGE_ROW_NUMBER}]" size="20" data-maxsize="{MAX_SIZE}" data-maxsize-warning="{MAX_SIZE_WARNING}" />
 										</span>
 									</span>
 									<input type="text" class="form-control" readonly="readonly">

--- a/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_matchingwizardinput.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_matchingwizardinput.html
@@ -27,7 +27,7 @@
 							<div class="input-group">
 								<span class="input-group-btn">
 									<span class="btn btn-default btn-file">
-										{IMAGE_BROWSE} <input type="file" id="{IMAGE_ID}" name="{IMAGE_POST_VAR}[image][{IMAGE_ROW_NUMBER}]" size="20"/>
+										{IMAGE_BROWSE} <input type="file" id="{IMAGE_ID}" name="{IMAGE_POST_VAR}[image][{IMAGE_ROW_NUMBER}]" size="20" data-maxsize="{MAX_SIZE}" data-maxsize-warning="{MAX_SIZE_WARNING}"/>
 									</span>
 								</span>
 								<input type="text" class="form-control" readonly="readonly">

--- a/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_multi_image_inp.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_multi_image_inp.html
@@ -12,7 +12,7 @@
                             <div class="input-group">
                                 <span class="input-group-btn">
                                     <span class="btn btn-default btn-file">
-                                        {IMAGE_BROWSE} <input class="upload" type="file" id="{IMAGE_ID}" name="{UPLOAD_IMAGE_POST_VAR}" size="20" />
+                                        {IMAGE_BROWSE} <input class="upload" type="file" id="{IMAGE_ID}" name="{UPLOAD_IMAGE_POST_VAR}" size="20" data-maxsize="{MAX_SIZE}" data-maxsize-warning="{MAX_SIZE_WARNING}" />
                                     </span>
                                 </span>
                                 <input tabindex="-1" type="text" class="form-control" readonly="readonly">

--- a/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_multiplechoicewizardinput.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_multiplechoicewizardinput.html
@@ -38,7 +38,7 @@
 							<div class="input-group">
 								<span class="input-group-btn">
 									<span class="btn btn-default btn-file">
-										{IMAGE_BROWSE} <input class="upload" type="file" id="{IMAGE_ID}" name="{IMAGE_POST_VAR}[image][{IMAGE_ROW_NUMBER}]" size="20" />
+										{IMAGE_BROWSE} <input class="upload" type="file" id="{IMAGE_ID}" name="{IMAGE_POST_VAR}[image][{IMAGE_ROW_NUMBER}]" size="20" data-maxsize="{MAX_SIZE}" data-maxsize-warning="{MAX_SIZE_WARNING}" />
 									</span>
 								</span>
 								<input type="text" class="form-control" readonly="readonly">

--- a/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_singlechoicewizardinput.html
+++ b/components/ILIAS/TestQuestionPool/templates/default/tpl.prop_singlechoicewizardinput.html
@@ -33,7 +33,7 @@
 							<div class="input-group">
 								<span class="input-group-btn">
 									<span class="btn btn-default btn-file">
-										{IMAGE_BROWSE} <input class="upload" type="file" id="{IMAGE_ID}" name="{IMAGE_POST_VAR}[image][{IMAGE_ROW_NUMBER}]" size="20" />
+										{IMAGE_BROWSE} <input class="upload" type="file" id="{IMAGE_ID}" name="{IMAGE_POST_VAR}[image][{IMAGE_ROW_NUMBER}]" size="20" data-maxsize="{MAX_SIZE}" data-maxsize-warning="{MAX_SIZE_WARNING}" />
 									</span>
 								</span>
 								<input type="text" class="form-control" readonly="readonly">

--- a/components/ILIAS/TestQuestionPool/tests/ilAssMultipleChoiceCorrectionsInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssMultipleChoiceCorrectionsInputGUITest.php
@@ -37,6 +37,7 @@ class ilAssMultipleChoiceCorrectionsInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilAssMultipleChoiceCorrectionsInputGUI();
     }

--- a/components/ILIAS/TestQuestionPool/tests/ilAssOrderingImagesInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssOrderingImagesInputGUITest.php
@@ -37,6 +37,7 @@ class ilAssOrderingImagesInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilAssOrderingImagesInputGUI($this->createMock(ilAssOrderingFormValuesObjectsConverter::class), '');
     }

--- a/components/ILIAS/TestQuestionPool/tests/ilAssSingleChoiceCorrectionsInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssSingleChoiceCorrectionsInputGUITest.php
@@ -37,6 +37,7 @@ class ilAssSingleChoiceCorrectionsInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilAssSingleChoiceCorrectionsInputGUI();
     }

--- a/components/ILIAS/TestQuestionPool/tests/ilEssayKeywordWizardInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilEssayKeywordWizardInputGUITest.php
@@ -37,6 +37,7 @@ class ilEssayKeywordWizardInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilEssayKeywordWizardInputGUI();
     }

--- a/components/ILIAS/TestQuestionPool/tests/ilHtmlImageMapFileInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilHtmlImageMapFileInputGUITest.php
@@ -35,6 +35,8 @@ class ilHtmlImageMapFileInputGUITest extends assBaseTestCase
     {
         parent::setUp();
 
+        $this->addGlobal_uiUploadLimitResolver();
+
         $this->object = new ilHtmlImageMapFileInputGUI();
     }
 

--- a/components/ILIAS/TestQuestionPool/tests/ilImagemapCorrectionsInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilImagemapCorrectionsInputGUITest.php
@@ -37,6 +37,7 @@ class ilImagemapCorrectionsInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilImagemapCorrectionsInputGUI();
     }

--- a/components/ILIAS/TestQuestionPool/tests/ilImagemapFileInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilImagemapFileInputGUITest.php
@@ -37,6 +37,7 @@ class ilImagemapFileInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilImagemapFileInputGUI();
     }

--- a/components/ILIAS/TestQuestionPool/tests/ilKprimChoiceCorrectionsInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilKprimChoiceCorrectionsInputGUITest.php
@@ -37,6 +37,7 @@ class ilKprimChoiceCorrectionsInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilKprimChoiceCorrectionsInputGUI();
     }

--- a/components/ILIAS/TestQuestionPool/tests/ilKprimChoiceWizardInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilKprimChoiceWizardInputGUITest.php
@@ -37,6 +37,7 @@ class ilKprimChoiceWizardInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilKprimChoiceWizardInputGUI();
     }

--- a/components/ILIAS/TestQuestionPool/tests/ilMatchingWizardInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilMatchingWizardInputGUITest.php
@@ -37,6 +37,7 @@ class ilMatchingWizardInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilMatchingWizardInputGUI();
     }

--- a/components/ILIAS/TestQuestionPool/tests/ilMultipleChoiceWizardInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilMultipleChoiceWizardInputGUITest.php
@@ -37,6 +37,7 @@ class ilMultipleChoiceWizardInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilMultipleChoiceWizardInputGUI();
     }

--- a/components/ILIAS/TestQuestionPool/tests/ilMultipleImagesInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilMultipleImagesInputGUITest.php
@@ -37,6 +37,7 @@ class ilMultipleImagesInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new class () extends ilMultipleImagesInputGUI {
             protected function isValidFilenameInput($filenameInput): bool

--- a/components/ILIAS/TestQuestionPool/tests/ilSingleChoiceWizardInputGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilSingleChoiceWizardInputGUITest.php
@@ -37,6 +37,7 @@ class ilSingleChoiceWizardInputGUITest extends assBaseTestCase
 
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_uiUploadLimitResolver();
 
         $this->object = new ilSingleChoiceWizardInputGUI();
     }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=42862

There is a problem in all ILIAS-Versions using the file-upload in Legacy-Forms: If a file is uploaded that is bigger than the `post_max_size` in php, the `$_POST` array is going to be empty. As the command is in the array, the system has no clue where to go and where you land simply depends on the default command and on a big of luck for it not to go completely sideways.

This fix is hacky at best, but it avoids the biggest issue as it moves the check for the filesize to the moment of uploading the file (as it is in the new forms). There surely are far better solutions, but as this is in an unmaintained component, this is the best I can propose with my limited time.

This should be ported to all accepted versions, if accepted.

Best,
@kergomard 