### PR TITLE
Added PHP-JWT and LTI-PHP dependencies to composer_new.json

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,8 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"firebase/php-jwt": "*",
+		"celtic/lti": "^5.0.0",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
We have added these two dependencies for inclusion in future versions of ILIAS as they are necessary for the proper functioning of the LTI component