### PR TITLE
TinyMCE: Remove abandoned plugin leftovers

### DIFF
--- a/components/ILIAS/RTE/classes/class.ilRTE.php
+++ b/components/ILIAS/RTE/classes/class.ilRTE.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 use ILIAS\HTTP\Agent\AgentDetermination;
 
 /**
@@ -28,8 +28,6 @@ use ILIAS\HTTP\Agent\AgentDetermination;
  */
 class ilRTE
 {
-    public const ILIAS_IMG_MANAGER_PLUGIN = 'ilias_image_manager_plugin';
-
     protected ilGlobalTemplateInterface $tpl;
     protected ilCtrlInterface $ctrl;
     protected ilObjUser $user;

--- a/components/ILIAS/RTE/classes/class.ilTinyMCE.php
+++ b/components/ILIAS/RTE/classes/class.ilTinyMCE.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Tiny MCE editor class
@@ -383,8 +383,6 @@ class ilTinyMCE extends ilRTE
             if (in_array('img', $a_html_tags)) {
                 //array_push($theme_advanced_buttons, 'advimage');
                 $theme_advanced_buttons[] = 'image';
-                $theme_advanced_buttons[] = 'ibrowser';
-                $theme_advanced_buttons[] = 'ilimgupload';
             }
             if (in_array('a', $a_html_tags)) {
                 $theme_advanced_buttons[] = 'link';
@@ -497,8 +495,6 @@ class ilTinyMCE extends ilRTE
         if (in_array('img', $a_html_tags)) {
             //array_push($theme_advanced_buttons, 'advimage');
             $theme_advanced_buttons[] = 'image';
-            $theme_advanced_buttons[] = 'ibrowser';
-            $theme_advanced_buttons[] = 'ilimgupload';
         }
         if (in_array('a', $a_html_tags)) {
             $theme_advanced_buttons[] = 'link';


### PR DESCRIPTION
This PR removes leftovers of already abandoned/remove ILIAS plugin for the "TinyMCE" editor.

Currently the still existing button definitions for `ibrowser` and `ilimgupload` result in unnecessary (and failing) HTTP requests.

If approved, this must be picked to `trunk`.