### PR TITLE
Use linkify-element in ilExtLink

### DIFF
--- a/components/ILIAS/Chatroom/classes/gui/class.ilChatroomHistoryGUI.php
+++ b/components/ILIAS/Chatroom/classes/gui/class.ilChatroomHistoryGUI.php
@@ -213,7 +213,8 @@ class ilChatroomHistoryGUI extends ilChatroomGUIHandler
         $roomTpl->setVariable('PERIOD_FORM', $durationForm->getHTML());
 
         if ($room && $messages !== []) {
-            $this->mainTpl->addJavaScript('assets/js/socket.io.js');
+            ilLinkifyUtil::initLinkify($this->mainTpl);
+            $this->mainTpl->addJavaScript('assets/js/socket.io.min.js');
             $this->mainTpl->addJavaScript('assets/js/Chatroom.min.js');
             $roomTpl->setVariable('CHAT', (new ilChatroomViewGUI($this->gui))->readOnlyChatWindow($room, array_column($messages, 'message'))->get());
         } else {

--- a/components/ILIAS/Chatroom/classes/gui/class.ilChatroomViewGUI.php
+++ b/components/ILIAS/Chatroom/classes/gui/class.ilChatroomViewGUI.php
@@ -83,6 +83,7 @@ class ilChatroomViewGUI extends ilChatroomGUIHandler
      */
     private function setupTemplate(): void
     {
+        ilLinkifyUtil::initLinkify($this->mainTpl);
         $this->mainTpl->addJavaScript('assets/js/socket.io.min.js');
         $this->mainTpl->addJavaScript('assets/js/Chatroom.min.js');
         $this->mainTpl->addJavaScript('assets/js/AdvancedSelectionList.js');

--- a/components/ILIAS/Link/Link.php
+++ b/components/ILIAS/Link/Link.php
@@ -41,9 +41,7 @@ class Link implements Component\Component
             new Component\Resource\ComponentJS($this, "ilExtLink.js");
         $contribute[Component\Resource\PublicAsset::class] = static fn() =>
             new Component\Resource\NodeModule("linkifyjs/dist/linkify.min.js");
-        /* This library was missing after discussing dependencies for ILIAS 10
         $contribute[Component\Resource\PublicAsset::class] = static fn() =>
-            new Component\Resource\NodeModule("linkifyjs/dist/linkify-jquery.min.js");
-        */
+            new Component\Resource\NodeModule("linkify-element/dist/linkify-element.min.js");
     }
 }

--- a/components/ILIAS/Link/classes/class.ilLinkifyUtil.php
+++ b/components/ILIAS/Link/classes/class.ilLinkifyUtil.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Linkify utility class
@@ -50,7 +50,7 @@ class ilLinkifyUtil
     {
         return [
             "assets/js/linkify.min.js",
-            "assets/js/linkify-jquery.min.js",
+            "assets/js/linkify-element.min.js",
             "assets/js/ilExtLink.js"
         ];
     }

--- a/components/ILIAS/Link/resources/ilExtLink.js
+++ b/components/ILIAS/Link/resources/ilExtLink.js
@@ -1,3 +1,19 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 if (typeof il == "undefined") {
 	il = {};
 }
@@ -8,11 +24,14 @@ il.ExtLink = {
 	 * Linkify wrapper
 	 */
 	autolink: function (selector, link_class) {
-		$(selector).linkify({
+		const options = {
 			validate: {
 				url: (val) => /^https?:\/\//.test(val), // only allow URLs that begin with a protocol
 				email: false // don't linkify emails
 			}
+		};
+		$(selector).each(function () {
+			linkifyElement(this, options);
 		});
 		if (typeof link_class !== "undefined") {
 			$(selector).find('a.linkified').addClass(link_class);

--- a/components/ILIAS/OnScreenChat/classes/class.ilOnScreenChatGUI.php
+++ b/components/ILIAS/OnScreenChat/classes/class.ilOnScreenChatGUI.php
@@ -312,12 +312,12 @@ class ilOnScreenChatGUI implements ilCtrlBaseClassInterface
             $page->addJavaScript('assets/js/modal.js');
             $page->addJavaScript('assets/js/socket.io.min.js');
             $page->addJavaScript('assets/js/Chatroom.min.js');
-            $page->addJavascript('assets/js/moment-with-locales.min.js');
-            $page->addJavascript('assets/js/browser_notifications.js');
-            $page->addJavascript('assets/js/onscreenchat-notifications.js');
-            $page->addJavascript('assets/js/moment.js');
-            $page->addJavascript('assets/js/chat.js');
-            $page->addJavascript('assets/js/onscreenchat.js');
+            $page->addJavaScript('assets/js/moment-with-locales.min.js');
+            $page->addJavaScript('assets/js/browser_notifications.js');
+            $page->addJavaScript('assets/js/onscreenchat-notifications.js');
+            $page->addJavaScript('assets/js/moment.js');
+            $page->addJavaScript('assets/js/chat.js');
+            $page->addJavaScript('assets/js/onscreenchat.js');
             $page->addOnLoadCode("il.Chat.setConfig(" . json_encode($chatConfig, JSON_THROW_ON_ERROR) . ");");
             $page->addOnLoadCode("il.OnScreenChat.setConfig(" . json_encode($guiConfig, JSON_THROW_ON_ERROR) . ");");
             $page->addOnLoadCode("il.OnScreenChat.init();");


### PR DESCRIPTION
This PR implements the change from the dependency `linkify-jquery` to `linkify-element` in ilExtLink.js, which was added in the PR #8169.