### PR TITLE
OrgU: #42977, move calls from global to object-specific settings

### DIFF
--- a/components/ILIAS/AccessControl/classes/class.ilPermissionGUI.php
+++ b/components/ILIAS/AccessControl/classes/class.ilPermissionGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/AccessControl/classes/class.ilPermissionGUI.php
+++ b/components/ILIAS/AccessControl/classes/class.ilPermissionGUI.php
@@ -973,7 +973,7 @@ class ilPermissionGUI
             $perm
         );
 
-        if (ilOrgUnitGlobalSettings::getInstance()->isPositionAccessActiveForObject($this->gui_obj->getObject()->getId())) {
+        if (ilOrgUnitObjectPositionSetting::getFor($this->gui_obj->getObject()->getId())->isActive()) {
             $this->tabs->addSubTabTarget(
                 self::TAB_POSITION_PERMISSION_SETTINGS,
                 $this->ctrl->getLinkTarget($this, ilPermissionGUI::CMD_PERM_POSITIONS),

--- a/components/ILIAS/Exercise/classes/class.ilObjExercise.php
+++ b/components/ILIAS/Exercise/classes/class.ilObjExercise.php
@@ -303,7 +303,7 @@ class ilObjExercise extends ilObject
         // org unit setting
         $orgu_object_settings = new ilOrgUnitObjectPositionSetting($new_obj->getId());
         $orgu_object_settings->setActive(
-            (int) ilOrgUnitGlobalSettings::getInstance()->isPositionAccessActiveForObject($this->getId())
+            (int) ilOrgUnitObjectPositionSetting::getFor($this->getId())->isActive()
         );
         $orgu_object_settings->update();
 

--- a/components/ILIAS/Exercise/classes/class.ilObjExerciseGUI.php
+++ b/components/ILIAS/Exercise/classes/class.ilObjExerciseGUI.php
@@ -507,10 +507,9 @@ class ilObjExerciseGUI extends ilObjectGUI
         $a_values['tfeedback'] = $tfeedback;
 
         // orgunit position setting enabled
-        $a_values['obj_orgunit_positions'] = ilOrgUnitGlobalSettings::getInstance()
-                                                                    ->isPositionAccessActiveForObject(
-                                                                        $this->object->getId()
-                                                                    );
+        $a_values['obj_orgunit_positions'] =
+            ilOrgUnitObjectPositionSetting::getFor($this->object->getId())
+            ->isActive();
 
         $a_values['cont_custom_md'] = ilContainer::_lookupContainerSetting(
             $this->object->getId(),

--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -581,10 +581,6 @@ class ilObject
             $this->getObjectProperties()->storePropertyIsOnline($property_is_online);
         }
 
-        if ($this->obj_definition->isOrgUnitPermissionType($this->type)) {
-            ilOrgUnitObjectPositionSetting::getFor($this->id)->initFromGlobalSettings();
-        }
-
         // the line ($this->read();) messes up meta data handling: meta data,
         // that is not saved at this time, gets lost, so we query for the dates alone
         $sql =

--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -582,7 +582,7 @@ class ilObject
         }
 
         if ($this->obj_definition->isOrgUnitPermissionType($this->type)) {
-            ilOrgUnitGlobalSettings::getInstance()->saveDefaultPositionActivationStatus($this->id);
+            ilOrgUnitObjectPositionSetting::getFor($this->id)->initFromGlobalSettings();
         }
 
         // the line ($this->read();) messes up meta data handling: meta data,

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectServiceSettingsGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectServiceSettingsGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * GUI class for service settings (calendar, notes, comments)

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectServiceSettingsGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectServiceSettingsGUI.php
@@ -251,7 +251,7 @@ class ilObjectServiceSettingsGUI
         if (in_array(self::ORGU_POSITION_ACCESS, $services)) {
             $position_settings = ilOrgUnitObjectPositionSetting::getFor($obj_id);
             if (
-                $position_settings->isGloballyEnabled()
+                $position_settings->isActiveForOwnType()
             ) {
                 $lia = new ilCheckboxInputGUI(
                     $GLOBALS['DIC']->language()->txt('obj_orgunit_positions'),

--- a/components/ILIAS/ILIASObject/classes/class.ilObjectServiceSettingsGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectServiceSettingsGUI.php
@@ -249,11 +249,9 @@ class ilObjectServiceSettingsGUI
             }
         }
         if (in_array(self::ORGU_POSITION_ACCESS, $services)) {
-            $position_settings = ilOrgUnitGlobalSettings::getInstance()->getObjectPositionSettingsByType(
-                ilObject::_lookupType($obj_id)
-            );
+            $position_settings = ilOrgUnitObjectPositionSetting::getFor($obj_id);
             if (
-                $position_settings->isActive()
+                $position_settings->isGloballyEnabled()
             ) {
                 $lia = new ilCheckboxInputGUI(
                     $GLOBALS['DIC']->language()->txt('obj_orgunit_positions'),
@@ -262,11 +260,9 @@ class ilObjectServiceSettingsGUI
                 $lia->setInfo($GLOBALS['DIC']->language()->txt('obj_orgunit_positions_info'));
                 $lia->setValue("1");
                 $lia->setChecked(
-                    ilOrgUnitGlobalSettings::getInstance()->isPositionAccessActiveForObject($obj_id)
+                    $position_settings->isActive()
                 );
-                if (!$position_settings->isChangeableForObject()) {
-                    $lia->setDisabled(true);
-                }
+                $lia->setDisabled(!$position_settings->isChangeable());
                 $form->addItem($lia);
             }
         }

--- a/components/ILIAS/OrgUnit/classes/Positions/Permissions/class.ilOrgUnitPermissionTableGUI.php
+++ b/components/ILIAS/OrgUnit/classes/Positions/Permissions/class.ilOrgUnitPermissionTableGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.

--- a/components/ILIAS/OrgUnit/classes/Positions/Permissions/class.ilOrgUnitPermissionTableGUI.php
+++ b/components/ILIAS/OrgUnit/classes/Positions/Permissions/class.ilOrgUnitPermissionTableGUI.php
@@ -168,9 +168,7 @@ class ilOrgUnitPermissionTableGUI extends ilTable2GUI
             "ops" => $ops_ids,
             "template" => $from_templates,
         ];
-        if (ilOrgUnitGlobalSettings::getInstance()
-                                   ->isPositionAccessActiveForObject($this->getObjId())
-        ) {
+        if (ilOrgUnitObjectPositionSetting::getFor($this->getObjId())->isActive()) {
             $perms[] = [
                 "header_command" => true,
                 "positions" => $positions,

--- a/components/ILIAS/OrgUnit/classes/Settings/class.ilOrgUnitGlobalSettings.php
+++ b/components/ILIAS/OrgUnit/classes/Settings/class.ilOrgUnitGlobalSettings.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +17,6 @@
  ********************************************************************
  */
 
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
-
 /**
  * Global settings for org units
  * @author Stefan Meyer <smeyer.ilias@gmx.de>
@@ -28,11 +27,6 @@ class ilOrgUnitGlobalSettings
     protected ?ilObjectDefinition $object_definition = null;
     /** @var ilOrgUnitObjectTypePositionSetting[] */
     private array $position_settings = [];
-    /**
-     * Array with key obj_id => active status
-     * @param bool[]
-     */
-    private array $object_position_cache = [];
 
     private function __construct()
     {
@@ -57,63 +51,6 @@ class ilOrgUnitGlobalSettings
         }
 
         return $this->position_settings[$a_obj_type];
-    }
-
-    /**
-     * Check of position access is activate for object
-     */
-    public function isPositionAccessActiveForObject(int $a_obj_id): bool
-    {
-        if (isset($this->object_position_cache[$a_obj_id])) {
-            return $this->object_position_cache[$a_obj_id];
-        }
-        $type = ilObject::_lookupType($a_obj_id);
-        try {
-            $type_settings = $this->getObjectPositionSettingsByType($type);
-        } catch (\InvalidArgumentException $invalid_type_exception) {
-            $this->object_position_cache[$a_obj_id] = false;
-
-            return false;
-        }
-
-        if (!$type_settings->isActive()) {
-            $this->object_position_cache[$a_obj_id] = false;
-
-            return false;
-        }
-        if (!$type_settings->isChangeableForObject()) {
-            $this->object_position_cache[$a_obj_id] = true;
-
-            return true;
-        }
-        $object_position = new ilOrgUnitObjectPositionSetting($a_obj_id);
-
-        if ($object_position->hasObjectSpecificActivation()) {
-            $this->object_position_cache[$a_obj_id] = $object_position->isActive();
-        } else {
-            $this->object_position_cache[$a_obj_id] = (bool) $type_settings->getActivationDefault();
-        }
-
-        return $this->object_position_cache[$a_obj_id];
-    }
-
-    /**
-     * Set and save the default activation status according to settings.
-     * @param int $a_obj_id
-     */
-    public function saveDefaultPositionActivationStatus(int $a_obj_id): void
-    {
-        $type = ilObject::_lookupType($a_obj_id);
-        try {
-            $type_settings = $this->getObjectPositionSettingsByType($type);
-        } catch (\InvalidArgumentException $ex) {
-            return;
-        }
-        if ($type_settings->isActive()) {
-            $object_setting = new ilOrgUnitObjectTypePositionSetting($a_obj_id);
-            $object_setting->setActive($type_settings->getActivationDefault());
-            $object_setting->update();
-        }
     }
 
     private function readSettings(): void

--- a/components/ILIAS/OrgUnit/classes/class.ilOrgUnitPositionAccess.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilOrgUnitPositionAccess.php
@@ -34,7 +34,6 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     public function __construct(ilAccess $access)
     {
         global $DIC;
-        $this->set = ilOrgUnitGlobalSettings::getInstance();
         $this->access = $access;
         $this->user = $DIC->user();
 
@@ -292,7 +291,6 @@ class ilOrgUnitPositionAccess implements ilOrgUnitPositionAccessHandler, ilOrgUn
     private function isPositionActiveForRefId(int $ref_id): bool
     {
         $obj_id = $this->getObjIdForRefId($ref_id); // TODO this will change to ref_id!!
-
-        return $this->set->isPositionAccessActiveForObject($obj_id);
+        return ilOrgUnitObjectPositionSetting::getFor($obj_id)->isActive();
     }
 }


### PR DESCRIPTION
Settings for single repository objecs used to be in ilOrgUnitGlobalSettings; they rather belong to ilOrgUnitObjectPositionSetting.

Then, initialization of the settings is not necessary, they work in a tristate allowing to fall back on global defaults if no explicit value was set.

Please see https://mantis.ilias.de/view.php?id=42977#c110034