### PR TITLE
Composer: Add mustache/mustache as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"mustache/mustache": "^2.14",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `mustache/mustache` as composer dependency.

Usage:
* Provides templating mechanism for mails, to replace the naive search and replace we have used until now.

Wrapped By:
* Not applicable, functionality is only used internally in database service and not provided to other ILIAS components.

Reasoning:
* Mustache is in a good place between expressiveness and ease of use. User testing has shown that typical administrative users can indeed understand mustache easy enough to leverage its power to create mail templates.
* Mustache is a well standardized templating language that has implementations in many languages. The specs have been stable for a long time.

Maintenance:
* The library is widely used by many PHP projects. It has 41 contributors, but the most contributions have been made by one person. There is no visible backing from any organisation. There haven't been any releases for over a year.
* The library doesn't seem to be in a super good place risk wise, but the missing releases could also be just a sign for a stable library for a stable spec. Since Mustache is a standard and widely use spec we can expect other PHP implementations even if this concrete implementation might become unmaintained someday. So the risk seems tolerable.

Links:
* Packagist: https://packagist.org/packages/mustache/mustache
* GitHub: https://github.com/bobthecow/mustache.php
* Documentation: https://mustache.github.io/