### PR TITLE
Composer: Add ifsnop/mysqldump-php as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"ifsnop/mysqldump-php": "2.11",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `ifsnop/mysqldump-php` as composer dependency.

Usage:
* Provides engine to dump database in standard sql for an export.

Wrapped By:
* Not applicable, functionality is only used internally in database service and not provided to other ILIAS components.

Reasoning:
* One could use standard mysqldump-tool via `exec` instead, but this would introduce an exec call that would be marked during white box sec-analysis.
* The library offers facilities for filtering data, which could become an extra benefit sometime, e.g. for creating distributable dumps.

Maintenance:
* The last release of the library was in March '23. There are 45 contributors although most contributions are from two people. There is no obvious backing from some company or organisation. The code is based on some script that is a lot older.
* This library doesn't seem to be the most reliable on, but since we could easily fall back to standard mysql dumper, the risk seems tolerable.

Links:
* Packagist: https://packagist.org/packages/ifsnop/mysqldump-php
* GitHub: https://github.com/ifsnop/mysqldump-php