### PR TITLE
Composer: Add seld/jsonlint as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"seld/jsonlint": "^1.11",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `seld/jsonlint` as composer dependency.

Usage:
* This allows the setup to give more informative error messages regarding the json that is used for config.

Wrapped By:
* Not applicable, functionality is only used internally in the setup and not provided to other ILIAS components.

Reasoning:
* The PHP json parser does not give information where a given json is faulty. This degrades user experience since we can only say "your json is wrong" but not where the actual error is located.

Maintenance:
* The library received its last update in July '24. It seems to be feature complete, though.
* The maintainer Jordi Boggiano works on packagist and composer and is a well known person in the PHP community.
* The functionality provided by this library is not super important but more for quality of life. We could easily decide to ditch the library if any problems arise.

Links:
* Packagist: https://packagist.org/packages/seld/jsonlint
* GitHub: https://github.com/Seldaek/jsonlint