### PR TITLE
Composer: Add `ezyang/htmlpurifier` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"ezyang/htmlpurifier": "^4.18"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR suggests adding `ezyang/htmlpurifier` (v. `4.18`) as composer dependency.

General Information:
* [X] this dependency was already used in ILIAS.
* [X] License: LGPL-2.1

Usage:
* `components/ILIAS/Html`

Wrapped By:
* `\ilHtmlPurifierAbstractLibWrapper` (implements `\ilHtmlPurifierInterface`)

Reasoning:
* `HTMLPurifier` is a standards-compliant HTML filter library written in PHP. It will not only remove all malicious code (better known as XSS) with a thoroughly audited, secure yet permissive whitelist, it will also make sure your documents are standards compliant, something only achievable with a comprehensive knowledge of W3C's specifications.
* We should not try to/do not want to reinvent the wheel in ILIAS and rely on this security library when filtering HTML code.

Maintenance:
* `HTMLPurifier` is actively maintained by multiple contributors. There is recent activity (even last week, see: https://github.com/ezyang/htmlpurifier/commits/master).
* Security issues are always fixed in a timely manner followed by new releases. Similar to ILIAS the project provides a mailing list for security advisories: http://htmlpurifier.org/contact .

Alternatives:
* https://github.com/symfony/html-sanitizer

Links:
* Packagist: https://packagist.org/packages/ezyang/htmlpurifier
* GitHub: https://github.com/ezyang/htmlpurifier
* Documentation: http://htmlpurifier.org/docs