### PR TITLE
Composer: add phpunit/phpunit as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -51,6 +51,7 @@
 		"ext-imagick": "*",
 	},
 	"require-dev": {
+		"phpunit/phpunit": "^11.5",
 	},
 	"autoload": {
 		"psr-4" : {


### PR DESCRIPTION
This PR adds `phpunit/phpunit` as composer dependency.
**(11.5 is due December 06, 2024)**

Usage:
* We use it to run unit tests.

Wrapped By:
* Not applicable, provides the binary and classes for test management.

Reasoning:
* Its the standard PHP testing framework.

Maintenance:
* Won't go away any time soon.

Links:
* Documentation: https://phpunit.de