### PR TITLE
Composer: Add `captainhook/captainhook` and `captainhook/plugin-compo…

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -51,6 +51,8 @@
 		"ext-imagick": "*",
 	},
 	"require-dev": {
+		"captainhook/captainhook": "^5.24",
+		"captainhook/plugin-composer": "^5.3"
 	},
 	"autoload": {
 		"psr-4" : {


### PR DESCRIPTION
…ser` as dev dependency

This PR suggests adding `captainhook/captainhook` (v. `5.24`) and `captainhook/plugin-composer` (v. `5.3`) as composer dependencies.

General Information:
* [X] this dependency was already used in ILIAS.
* [X] License: MIT
 
Usage:
* Executed during multiple `Composer` and `Git` actions (depending on our shared and possible individual configuration files)

Wrapped By:
* Not applicable

Reasoning:
* `CaptainHook` is an easy to use and very flexible `Git hook` library for PHP developers. It enables us to configure our `Git hook` actions in a simple (and shared) JSON file.
* `CaptainHook` helps us to enforce PHP code style and language file structure policies. Generally speaking it allows the execution of any script for arbitrary actions, so developers can easily extend the shared configuration by e.g. executing unit tests before a `git push`, or checking commit messages against a configured ruleset.

Maintenance:
* `CaptainHook` is well maintained (see: https://github.com/captainhookphp/captainhook/commits/main) and widely used in the PHP community.
* The risk of relying on this library is small. It is a development dependency all mandatory code policies are enforced again by our GitHub CI pipeline on the Git remote server.

Links:
* Packagist: https://packagist.org/packages/captainhook/captainhook / https://packagist.org/packages/captainhook/plugin-composer
* GitHub: https://github.com/captainhookphp/captainhook / https://github.com/captainhookphp/plugin-composer
* Documentation: https://captainhookphp.github.io/captainhook/