### PR TITLE
Docs/Authorities: Add `tjoussen` to authorities for "Login, Auth & Registration"

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -989,8 +989,10 @@ of ILIAS. The file contains the following fields:
 * **Login, Auth & Registration**
     * Authority to Sign off on Conceptual Changes: [PerPascalSeeland](https://docu.ilias.de/go/usr/31492)
         , [mjansen](https://docu.ilias.de/go/usr/8784)
+        , [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Authority to Sign off on Code Changes: [PerPascalSeeland](https://docu.ilias.de/go/usr/31492)
         , [mjansen](https://docu.ilias.de/go/usr/8784)
+        , [tjoussen](https://docu.ilias.de/go/usr/103745)
     * Authority to Curate Test Cases: [PerPascalSeeland](https://docu.ilias.de/go/usr/31492)
         , [mjansen](https://docu.ilias.de/go/usr/8784)
     * Authority to (De-)Assign Authorities: [PerPascalSeeland](https://docu.ilias.de/go/usr/31492)


### PR DESCRIPTION
Hey,

With this PR, I would kindly ask to be added to the Authorities for "Login, Auth & Registration". Specifically, I am requesting the following assignments:

* Authority to Sign off on Conceptual Changes
* Authority to Sign off on Code Changes

**Coordination with Current Authority Holder**
As per the guidelines, I have contacted @mjansenDatabay, who holds the Authority to (De-)Assign Authorities, to discuss this proposal. Additionally, we have made efforts to reach out to other current authorities for this component but have not received a response as of the time of this submission.

Thank you for considering this request. I am happy to provide any further clarification or discuss this proposal in more detail.

Best,
@thojou 