### PR TITLE
Certificate: skip empty ul elements when translating to fo (43008)

### DIFF
--- a/Services/Certificate/xml/xhtml2fo.xsl
+++ b/Services/Certificate/xml/xhtml2fo.xsl
@@ -507,7 +507,7 @@
 		<xsl:attribute name="space-after">1em</xsl:attribute>
 	</xsl:attribute-set>
 
-	<xsl:template match="ul">
+	<xsl:template match="ul[*]">
 		<fo:list-block xsl:use-attribute-sets="ul" xmlns:fo="http://www.w3.org/1999/XSL/Format">
 			<xsl:apply-templates select="node()"/>
 		</fo:list-block>
@@ -746,7 +746,7 @@
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>
-	
+
 	<xsl:template name="getColor">
 		<xsl:param name="s"/>
 		<xsl:value-of select="$s" />


### PR DESCRIPTION
This PR is a possible fix for [43008](https://mantis.ilias.de/view.php?id=43008). It makes it so that empty `ul`-elements in the certificate text are ignored when saving the certificate configuration. This of course does not affect already generated certificates in `il_cert_user_cert`, those stay broken.

Please triple check this change, I'm very close to completely clueless about the whole xhtml to fo mechanism. 