### PR TITLE
Composer: Add `ramsey/uuid` as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"ramsey/uuid": "^4.7"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR suggests adding `ramsey/uuid` (v. `4.7`) as composer dependency.

General Information:
* [X] this dependency was already used in ILIAS.
* [X] License: MIT

Usage:
* `component/ILIAS/Certificate`
* `component/ILIAS/CoPage`
* `component/ILIAS/ResourceStorage`

Wrapped By:
* `\ILIAS\Data\UUID\RamseyUuidWrapper`

Reasoning:
* `ramsey/uuid` With 513,691,061 usages and 12,470 stars on packagist, "ramsey" is the most widely used library for creating UUIDs and is the basis for many other implementations.

Maintenance:
* `ramsey/uuid` is actively maintained by multiple contributors. There is recent activity in past weeks: https://github.com/ramsey/uuid/commits/4.x.

Links:
* Packagist: https://packagist.org/packages/ramsey/uuid
* GitHub: https://github.com/ramsey/uuid
* Documentation: https://uuid.ramsey.dev/en/stable/