### PR TITLE
10/UI/view controls/42965

### DIFF
--- a/components/ILIAS/Contact/resources/buddy_system.js
+++ b/components/ILIAS/Contact/resources/buddy_system.js
@@ -250,7 +250,7 @@
         })
         .on('click', trigger_selector, onWidgetClick);
 
-      document.addEventListener('click', clearAllDropDowns, true);
+      document.addEventListener('click', clearAllDropDowns);
     },
   };
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
@@ -101,14 +101,17 @@ class Renderer extends AbstractComponentRenderer
                     });"
             );
         }
+        $component = $component->withAdditionalOnLoadCode(
+            fn($id) => "
+                document.querySelector('#$id ul.dropdown-menu').addEventListener(
+                    'click',
+                    (event) => event.stopPropagation()
+                )"
+        );
 
         $component = $component->withAdditionalOnLoadCode(
-            fn($id) => "$('#{$id} > .dropdown-menu')
-                .on('click', (event) =>  event.stopPropagation());"
-        );
-        $component = $component->withAdditionalOnLoadCode(
             fn($id) =>
-            "il.UI.dropdown.init(document.getElementById(\"$id\"));"
+            "il.UI.dropdown.init(document.getElementById('$id'));"
         );
 
         $id = $this->bindJavaScript($component);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42965

buddy_system.js clears dropdowns; if the document-event is registered with "useCapture", VCs cannot stop propagation.
