### PR TITLE
Composer: Add firebase/php-jwt as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"firebase/php-jwt": "*",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `firebase/php-jwt` as composer dependency.

Usage:
* Used in `LTIConsumer` & `LTIProvider` components.

Wrapped By:
* components/ILIAS/LTIConsumer
* components/ILIAS/LTIProvider

Reasoning:
* The php-jwt dependency is used in LTIProvider and LTIConsumer to handle JWT (JSON Web Tokens) for secure communication and authentication between platforms, ensuring token creation, validation, and decoding in compliance with LTI standards.

Maintenance:
* The php-jwt dependency, maintained by Google's Firebase team, provides robust support for JWT handling with regular updates, ensuring reliability and alignment with current security standards.

Links:
* https://github.com/firebase/php-jwt