### PR TITLE
Chatroom: Add `mysql2`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,8 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+    "mysql2": "^3.11.5"
+  }
+}


### PR DESCRIPTION
This PR adds `mysql2` as NPM dependency for the chatroom.

General Information:
- [ ] this dependency was already used in ILIAS.
- [X] License: MIT

Usages:

- components/ILIAS/Chatroom/chat/Persistence/Database.js

Wrapped By:

- Database (see: components/ILIAS/Chatroom/chat/Persistence/Database.js)

Reasoning:

This dependency is a replacement for the `mysql` dependency, which was not updated since 2022, as noted in the dependency PR for ILIAS 10: #6773.

`mysql2` is a mysql driver for Node.js. It is used to communicate with a mysql (or mariadb) server.

Maintenance:

`mysql2` is actively maintained and regularly updated (The latest release is from 28.11.2024).

Links:

- NPM: https://www.npmjs.com/package/mysql2
- GitHub: https://github.com/sidorares/node-mysql2
- Documentation: https://sidorares.github.io/node-mysql2/docs/documentation