### PR TITLE
Chatroom: Add `node-schedule`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,8 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+    "node-schedule": "^2.1.0"
+  }
+}


### PR DESCRIPTION
This PR adds `node-schedule` as NPM dependency for the chatroom.

General Information:
- [X] this dependency was already used in ILIAS.
- [X] License: MIT


Usages:
- components/ILIAS/Chatroom/chat/Bootstrap/SetupClearMessagesProcess.js
- components/ILIAS/Chatroom/chat/Bootstrap/UserSettingsProcess.js

Wrapped By:

- Not applicable

Reasoning:

`node-schedule` is a flexible cron-like (and not-cron-like) job scheduler for Node.js. It allows us to schedule jobs (arbitrary functions) for execution at specific dates/times, with optional recurrence rules. It only uses a single timer at any given time (rather than reevaluating upcoming jobs every second/minute). It is used to cleanup messages (and correspoding/related data) according to the configured ILIAS deletion policy. Furthermore it is used to pull user preferences from the ILIAS backend.

Maintenance:

`node-schedule` has a lot of contributions, however the last commit and release is from January 2023. This could be a potential risk for new releases of Node.js in the future or potential security issues. If we could not rely on this library anymore, we will have to check if there are good alternatives.

Links:

- NPM: https://www.npmjs.com/package/node-schedule
- GitHub: https://github.com/node-schedule/node-schedule
- Documentation: https://github.com/node-schedule/node-schedule#readme

