### PR TITLE
Composer: Add celtic/lti as dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"celtic/lti": "^5.0.0",
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR adds `celtic/lti` as composer dependency.

Usage:
* Used in `LTIConsumer` & `LTIProvider` components.

Wrapped By:
* components/ILIAS/LTIConsumer
* components/ILIAS/LTIProvider

Reasoning:
* The `celtic/lti` library provides a robust and feature-rich implementation of the LTI (Learning Tools Interoperability) protocol. It supports LTI versions 1.1, 1.2, and 1.3, along with various extensions, services, and updated security models.
* It simplifies the implementation of LTI in tool providers by abstracting communication, transforming data into useful objects, and enabling features like consumer key management, collaboration setups, and advanced outcomes service handling.

Maintenance:
* Actively maintained with **49 releases** and a recent update (v5.1.4) released **2 weeks ago**.
* The library is developed by a dedicated team of contributors and has consistent updates to align with evolving LTI standards.

Links:
* **GitHub Repository:** [https://github.com/celtic-project/LTI-PHP](https://github.com/celtic-project/LTI-PHP)
* **Documentation:** [https://github.com/celtic-project/LTI-PHP/wiki](https://github.com/celtic-project/LTI-PHP/wiki)
* **Official Website:** [http://celtic-project.org/](http://celtic-project.org/)