### PR TITLE
Chatroom: Add `uuid`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,8 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+    "uuid": "^11.0.3"
+  }
+}


### PR DESCRIPTION
This PR adds `uuid` as NPM dependency for the chatroom.

General Information:
- [ ] this dependency was already used in ILIAS.
- [X] License: MIT

Usages:

- components/ILIAS/Chatroom/chat/Persistence/Conversation.js
- components/ILIAS/Chatroom/chat/Persistence/ConversationAddUser.js
- components/ILIAS/Chatroom/chat/Persistence/ConversationMessage.js

Wrapped By:

- Not applicable

Reasoning:

`uuid` will be used to retrieve UUID values for the Node.js based ILIAS chat server, similar to the ramsey/uuid library we use in PHP for the ILIAS backend. It will replace the `uui` library (which is still used for that chat server).

Maintenance:

`uuid` is a well maintained package with a lot of contributions. It is an active project, the latest release is from 04.11.2024.

Please note that in ILIAS 10 the (deprecated) package `node-uuid` was used, which is now changed to the correct `uuid` package.

Links:

- NPM: https://www.npmjs.com/package/uuid
- GitHub: https://github.com/uuidjs/uuid
- Documentation: https://github.com/uuidjs/uuid?tab=readme-ov-file#api-summary