### PR TITLE
Chatroom: Add `socket.io` and `socket.io-client`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,9 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+    "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1"
+  }
+}


### PR DESCRIPTION
This PR adds `socket.io` and `socket.io-client` as NPM dependency for the chatroom.

General Information:
- [X] this dependency was already used in ILIAS.
- [X] License: MIT

Usages:

- components/ILIAS/Chatroom
- components/ILIAS/OnScreenChat

Wrapped By:

- il.Chat (see: components/ILIAS/OnScreenChat/js/chat.js)
- ServerConnector see:
  - components/ILIAS/Chatroom/resources/js/src/ServerConnector.js
  - components/ILIAS/Chatroom/resources/js/src/run.js

Reasoning:

`socket.io` is a library that enables low-latency, bidirectional and event-based communication between a client and a server. It is used in the Node.js based ILIAS chat server, which relies on the provided WebSocket low-level transport mechanisms. Socket.IO offers HTTP long-polling as a fallback option, which is useful in environments that don't support WebSockets.

Maintenance:

`socket.io` is a well maintained package with major releases every few years and recent activities.

Links:

- NPM: https://www.npmjs.com/package/socket.io / https://www.npmjs.com/package/socket.io-client
- GitHub: https://github.com/socketio/socket.io (they are maintained in the same repo)
- Documentation: https://socket.io/docs/

