### PR TITLE
NPM: Add `linkifyjs` and `linkify-element`

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -8,6 +8,8 @@
     "test": "tests"
   },
   "dependencies": {
+    "linkify-element": "^4.1.3",
+    "linkifyjs": "^4.1.3"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
This PR adds `linkifyjs` and `linkify-element` as NPM dependency.

General Information:
- [X] these dependencies were already used in ILIAS.
- [X] License: MIT

Usage:

- CoPage: Used in paragraphs
- LearningModule: Used for the export
- OnScreenChat: components/ILIAS/OnScreenChat/js/onscreenchat.js
- Chatroom: components/ILIAS/Chatroom/resources/js/src/ChatMessageArea.js

Wrapped By:

- components/ILIAS/Link/resources/js/ilExtLink.js

Reasoning:

`linkifyjs` is used by the OnScreenChat and Chatroom to transform URL-like strings into clickable HTML link elements. Without this library all kind of URL-like strings (see: https://linkify.js.org/) are not transformed anymore and our users will have to copy the strings manually into the browser address input. I doubt we can support this feature with a few regular expressions maintained by the ILIAS community.

`linkify-element` is maintained in the same repo.

Maintenance:
- `linkifyjs` is actively maintained, although it is feature-complete. In the last months a few bug fixes and improvements have been committed.

Links:

- NPM: https://www.npmjs.com/package/linkifyjs / https://www.npmjs.com/package/linkify-element
- GitHub: https://github.com/Hypercontext/linkifyjs
- Documentation: https://linkify.js.org/docs/

