### PR TITLE
Add `league/commonmark` as composer Dependency for ILIAS 11

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"league/commonmark": "2.5.3"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Assessment:
league/commonmark is a robust and extensible PHP library for parsing and rendering Markdown, offering compliance with the CommonMark specification and providing advanced features like extensions and customizations.

General Information:
- Name of the dependency: `league/commonmark`
- Version: `2.5.3`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: BSD 3

Type of dependency:
- [X] composer
- [ ] npm

Usage:
* `\ILIAS\UI\Implementation\Component\Input\Field\Markdown`

Reasoning:
The library simplifies Markdown processing with a modern, object-oriented design, making it easy to integrate and extend for specific project needs while ensuring high performance and standards compliance.

Maintenance:
Last update of the Library: 2024-08-16, PHP Version: ^7.4 || ^8.0

Links:
* Packagist: https://packagist.org/packages/league/commonmark
* GitHub: https://github.com/thephpleague/commonmark.git
* Documentation: https://commonmark.thephpleague.com

Alternatives:
Alternatives like parsedown are simpler but lack extensibility and have a history of security concerns, while lower-level implementations require more development effort to match the flexibility and compliance offered by league/commonmark.
