### PR TITLE
Add `ramsey/uuid` as composer Dependency for ILIAS 11

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"ramsey/uuid": "4.7.6"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Assessment:
ramsey/uuid is a reliable and widely used PHP library for generating Universally Unique Identifiers (UUIDs), supporting all major UUID versions and ensuring compatibility with industry standards.

General Information:
- Name of the dependency: `ramsey/uuid`
- Version: `4.7.6`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [X] composer
- [ ] npm

Usage:
* `\ILIAS\Data\UUID\Uuid`

Reasoning:
The library provides a robust and efficient solution for generating UUIDs, with a clean API, solid documentation, and performance optimization, making it ideal for use in ILIAS projects where unique identifiers are crucial.

Maintenance:
Last update of the Library: 2024-04-27, PHP Version: ^8.0

Links:
* Packagist: https://packagist.org/packages/ramsey/uuid
* GitHub: https://github.com/ramsey/uuid.git
* Documentation: 

Alternatives:
Alternatives like symfony/uid offer similar functionality but are tightly coupled to the Symfony ecosystem, whereas ramsey/uuid is more framework-agnostic and widely adopted, making it a better fit for ILIAS, which aims for flexibility and broad compatibility.
