### PR TITLE
Add `ifsnop/mysqldump-php` as composer Dependency for ILIAS 11

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"ifsnop/mysqldump-php": "v2.10"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Assessment:
ifsnop/mysqldump-php is a PHP library that facilitates the creation of MySQL database backups by generating SQL dump files, providing a simple and reliable solution for database exportation.

General Information:
- Name of the dependency: `ifsnop/mysqldump-php`
- Version: `v2.10`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: {{LICENSE}}

Type of dependency:
- [X] composer
- [ ] npm

Usage:
* `\MysqlDumper`

Reasoning:
The library offers an easy-to-use interface for generating MySQL dumps directly from PHP, supporting features like compression and excluding specific tables, making it an efficient tool for ILIAS projects requiring automated database backups.

Maintenance:
Last update of the Library: 2023-02-09, PHP Version: >=5.3.0

Links:
* Packagist: https://packagist.org/packages/ifsnop/mysqldump-php
* GitHub: https://github.com/ifsnop/mysqldump-php.git
* Documentation: https://github.com/ifsnop/mysqldump-php

Alternatives:
Alternatives like db-dumper are more complex and offer additional features that may not be necessary for ILIAS, while mysqldump command-line tool requires additional configuration and is less integrated into the PHP codebase. ifsnop/mysqldump-php strikes a good balance of simplicity, functionality, and ease of integration with ILIAS.
