### PR TITLE
Add `dflydev/fig-cookies` as composer Dependency for ILIAS 11

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"dflydev/fig-cookies": "v3.1.0"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Assessment:
dflydev/fig-cookies is a lightweight PHP library that simplifies cookie handling by providing a PSR-7-compliant interface for working with cookies in HTTP requests and responses.

General Information:
- Name of the dependency: `dflydev/fig-cookies`
- Version: `v3.1.0`
- [X] this dependency was already used in ILIAS.
- [X] the dependency's license is compatible with ILIAS' license: MIT

Type of dependency:
- [X] composer
- [ ] npm

Usage:
* `\ILIAS\HTTP\Services`

Reasoning:
The library ensures that cookie management in ILIAS remains consistent and standardized across the project, offering easy integration with other PSR-7-compliant libraries, and providing a clean API for setting, getting, and deleting cookies.

Maintenance:
Last update of the Library: 2023-07-18, PHP Version: ^7.2 || ^8.0

Links:
* Packagist: https://packagist.org/packages/dflydev/fig-cookies
* GitHub: https://github.com/dflydev/dflydev-fig-cookies.git
* Documentation: 

Alternatives:
Alternatives like native PHP functions (setcookie, $_COOKIE) are simpler but lack the structured and modern approach of dflydev/fig-cookies, while libraries like symfony/http-foundation are more comprehensive but may be overkill for basic cookie management, making dflydev/fig-cookies a more efficient and lightweight choice for ILIAS.
