### PR TITLE
10/UI/Input load section styling correctly 42739

### DIFF
--- a/templates/default/070-components/UI-framework/Input/_ui-component_input.scss
+++ b/templates/default/070-components/UI-framework/Input/_ui-component_input.scss
@@ -35,6 +35,7 @@
 @use "_ui-component_file.scss";
 @use "_ui-component_markdown.scss";
 @use "_ui-component_rating.scss";
+@use "ui-component_section";
 @use "_ui-component_numeric.scss";
 @use "_ui-component_optionalgroups.scss";
 
@@ -42,7 +43,7 @@
 /// general form container styling
 .c-form {
   margin-bottom: l.$il-margin-xxlarge-vertical;
-  
+
   .c-form__header,
   .c-form__footer {
     display: grid;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -4528,6 +4528,30 @@ hr.il-divider-with-label {
   width: 55%;
 }
 
+.c-form .c-input[data-il-ui-component=section-field-input].c-input {
+  margin-bottom: 30px;
+  display: flex;
+  flex-direction: column;
+}
+.c-form .c-input[data-il-ui-component=section-field-input].c-input > label {
+  order: 1;
+  width: 100%;
+  margin-bottom: 9px;
+  font-size: 1.5rem;
+}
+.c-form .c-input[data-il-ui-component=section-field-input].c-input > .c-input__help-byline {
+  width: 100%;
+  order: 2;
+}
+.c-form .c-input[data-il-ui-component=section-field-input].c-input > .c-input__error-msg {
+  order: 3;
+}
+.c-form .c-input[data-il-ui-component=section-field-input].c-input > .c-input__field {
+  margin-top: 12px;
+  width: 100%;
+  order: 4;
+}
+
 .c-input-numeric {
   min-width: 60px;
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42739

# Issue

Sections titles are positioned in column to the left of their content.

![image](https://github.com/user-attachments/assets/603959f9-58db-47db-9fc8-857ca4444dcc)

# Change

The section scss file was never imported (maybe as a result of an incomplete merge at some point). With "ui-component_section" loaded by _ui-component_input, the section title is shown on top of the section and not beside it.

![image](https://github.com/user-attachments/assets/2c488589-dac1-40a8-bb06-bebdab222faf)