### PR TITLE
Fix style_id type

### DIFF
--- a/Services/COPage/PC/Section/class.ilPCSectionGUI.php
+++ b/Services/COPage/PC/Section/class.ilPCSectionGUI.php
@@ -138,7 +138,7 @@ class ilPCSectionGUI extends ilPageContentGUI
             "AdvancedKnowledge" => $lng->txt("cont_AdvancedKnowledge"));
     }
 
-    public static function _getCharacteristics(string $a_style_id): array
+    public static function _getCharacteristics(int $a_style_id): array
     {
         global $DIC;
 


### PR DESCRIPTION
Just a type fix, style id is used as `int` in all other classes and services