### PR TITLE
T&A 41608 Fix invalid array key access for string value in test default settings

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -2492,9 +2492,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
         }
 
         if (!$confirmed) {
-            $defaults = $this->object->getTestDefaults($_POST["chb_defaults"][0]);
+            $defaults = $this->object->getTestDefaults((int) $_POST["chb_defaults"][0]);
         } else {
-            $defaults = $this->object->getTestDefaults($_POST["confirmed_defaults_id"][0]);
+            $defaults = $this->object->getTestDefaults((int) $_POST["confirmed_defaults_id"]);
         }
 
         $defaultSettings = unserialize($defaults["defaults"]);


### PR DESCRIPTION
This PR aims to address the problem reported in Mantis issue https://mantis.ilias.de/view.php?id=41608.

If a default setting for “random questions” is applied to a test with fixed questions (and at least one question present), an error occurs due to a missing or invalid key.

The issue arises in the `applyDefaultsObject` function when loading default settings with a confirmation dialog. Specifically, the code attempts to access `$_POST["confirmed_defaults_id"][0]`. However, the value of `$_POST["confirmed_defaults_id"]` is a **string**, not an array. As a result, the code incorrectly processes only the first character of the string.

This becomes problematic when default setting IDs exceed a single digit. For instance, IDs starting from 10 are misinterpreted as **1** (for 10, 11, 12, etc.), while IDs starting from 20 are interpreted as **2**.

To resolve this, I removed the numeric key access and cast the value to an integer.

Kind regards,  
@bidzanaaron 