### PR TITLE
NPM: Add MathJax (Updated PR #8262)

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -8,6 +8,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "mathjax": "^3.2.2"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
This PR adds `mathjax` as NPM dependency.

Usage:

- Page editor: text content
- Forum: thread, post, reply
- Survey: introductory message, final statement
- Test Questions: question text, feedback, hints
- Cloze Question: cloze text
- Kprim Question: answers
- Matching Question: terms, definitions
- SC Question: answers
- MC Question: answers
- Ordering Question: answers

Wrapped By:
- components/ILIAS/UI/resources/js/MathJax/mathjax.js 
if PR [Stramline LatexUsage](https://github.com/ILIAS-eLearning/ILIAS/pull/8256) is merged.

Reasoning:

See Feature Request [Streamline Latex Usage](https://docu.ilias.de/go/wiki/wpage_5614_1357)

MathJax is currently added as third-party software.  It is configured with a URL in the ILIAS administration. That allows ILIAS administrators to adapt their MathJax support, but they need the MathJax CDN or must maintain a local copy themselves. This makes it difficult to compare installations and reproduce errors in the ILIAS test installation. Updates in the case of security problems are the responsibility of local administrators. With MathJax as an npm dependency, this gets much more predictable.

Furthermore, ILIAS components that export HTML content can include MathJax in their exported archives instead of linking it from a CDN.

Maintenance:

MathJax is the de-facto standard for rendering LaTeX on web pages. It is supported by strong partners (IEEE, Elsevier). It is actively developed. In the last month, 24 pull requests have been merged to the source repository.

Links:

NPM: https://www.npmjs.com/package/mathjax
GitHub: https://github.com/mathjax
Documentation: https://www.mathjax.org