### PR TITLE
LTI: Authentication check for registering new LTI providers and HTML escaping

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderList.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderList.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilLTIConsumeProviderList
@@ -390,8 +390,8 @@ class ilLTIConsumeProviderList implements Iterator
             $tblRow = array();
 
             $tblRow['id'] = $provider->getId();
-            $tblRow['title'] = $provider->getTitle();
-            $tblRow['description'] = $provider->getDescription();
+            $tblRow['title'] = htmlspecialchars($provider->getTitle());
+            $tblRow['description'] = htmlspecialchars($provider->getDescription());
             $tblRow['category'] = $provider->getCategory();
             $tblRow['keywords'] = $this->getKeywordsFormatted($provider->getKeywordsArray());
             $tblRow['outcome'] = $provider->getHasOutcome();

--- a/components/ILIAS/LTIConsumer/ltiregstart.php
+++ b/components/ILIAS/LTIConsumer/ltiregstart.php
@@ -24,11 +24,8 @@ chdir("../../../");
 ilInitialisation::initILIAS();
 global $DIC;
 
-if (strtoupper($DIC->http()->request()->getMethod()) !== "GET") {
-    $DIC->http()->saveResponse(
-        $DIC->http()->response()
-            ->withStatus(400)
-    );
+if (!$DIC->user()->getId() || $DIC->user()->getId() === ANONYMOUS_USER_ID) {
+    ilObjLTIConsumer::sendResponseError(401, "unauthorized");
 }
 
 $params = $DIC->http()->wrapper()->query();


### PR DESCRIPTION
The LTIConsumer creation entry point has been modified to add a user check and an unused get method check has been removed.

Added htmlspecialchars to ilObjLTIConsumerProviderList::getTableDataUsedBy in the title and description of the table providers.

Moved strict_types to avoid error in copyright check.