### PR TITLE
UI / Legacy: 42497, adjust carousel controls for lightboxes depending…

### DIFF
--- a/templates/default/070-components/UI-framework/Modal/_ui-component_modal.scss
+++ b/templates/default/070-components/UI-framework/Modal/_ui-component_modal.scss
@@ -91,8 +91,15 @@ $il-modal-dark-carousel-color: $il-main-bg !default;
 			.modal-header {
 				border-bottom-color: $il-modal-light-color;
 			}
+			.modal-title {
+				padding: 0px;
+			}
+			.carousel-inner {
+				padding: 0px;
+			}
 			.carousel-control {
 				color: $il-modal-dark-carousel-color;
+				width: 15%;
 			}
 		}
 		.close {
@@ -158,6 +165,7 @@ $il-modal-dark-carousel-color: $il-main-bg !default;
 	font-size: $il-font-size-large;
 	margin: 0;
 	line-height: $modal-title-line-height;
+	padding: 0px 39px;
   }
   
   // Modal body

--- a/templates/default/070-components/legacy/_component_carousel.scss
+++ b/templates/default/070-components/legacy/_component_carousel.scss
@@ -8,14 +8,16 @@
 $carousel-text-shadow:                        0 1px 2px rgba(0,0,0,.6) !default;
 
 $carousel-control-color:                      $il-link-color !default;
-$carousel-control-width:                      15% !default;
 $carousel-control-opacity:                    .5 !default;
 $carousel-control-font-size:                  20px !default;
+$carousel-control-width:                      $carousel-control-font-size !default;
 
 $carousel-indicator-active-bg:                $il-link-hover-color !default;
 $carousel-indicator-border-color:             $il-link-color !default;
 
 $carousel-caption-color:                      $il-link-color !default;
+
+$carousel-inner-padding:                      0px 24px !default;
 
 // section based on bootstrap 3 - see /templates/default/Guidelines_SCSS-Coding.md
 
@@ -29,6 +31,7 @@ $carousel-caption-color:                      $il-link-color !default;
     overflow: hidden;
     width: 100%;
     min-height: 400px;
+    padding: $carousel-inner-padding;
 
     .item:not(.text-only) .item-content {
         display: flex;
@@ -73,6 +76,9 @@ $carousel-caption-color:                      $il-link-color !default;
         &.active {
           @include translate3d(0, 0, 0);
           left: 0;
+           &.text-only {
+             padding: 0 15px;
+           }
         }
       }
     }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6650,8 +6650,15 @@ div.alert ul > li:before {
 .modal.il-modal-lightbox-dark .modal-content .modal-header {
   border-bottom-color: white;
 }
+.modal.il-modal-lightbox-dark .modal-content .modal-title {
+  padding: 0px;
+}
+.modal.il-modal-lightbox-dark .modal-content .carousel-inner {
+  padding: 0px;
+}
 .modal.il-modal-lightbox-dark .modal-content .carousel-control {
   color: white;
+  width: 15%;
 }
 .modal.il-modal-lightbox-dark .close {
   color: white;
@@ -6716,6 +6723,7 @@ div.alert ul > li:before {
   font-size: 1rem;
   margin: 0;
   line-height: 1.428571429;
+  padding: 0px 39px;
 }
 
 .modal-body {
@@ -10326,6 +10334,7 @@ tbody.collapse.in {
   overflow: hidden;
   width: 100%;
   min-height: 400px;
+  padding: 0px 24px;
 }
 .carousel-inner .item:not(.text-only) .item-content {
   display: flex;
@@ -10378,6 +10387,9 @@ tbody.collapse.in {
     transform: translate3d(0, 0, 0);
     left: 0;
   }
+  .carousel-inner > .item.next.left.text-only, .carousel-inner > .item.prev.right.text-only, .carousel-inner > .item.active.text-only {
+    padding: 0 15px;
+  }
 }
 .carousel-inner > .active,
 .carousel-inner > .next,
@@ -10415,7 +10427,7 @@ tbody.collapse.in {
   top: 0;
   left: 0;
   bottom: 0;
-  width: 15%;
+  width: 20px;
   filter: alpha(opacity=50);
   opacity: 0.5;
   font-size: 20px;


### PR DESCRIPTION
… on the lightbox modal type.

https://mantis.ilias.de/view.php?id=42497

After discussing different solutions with @catenglaender  I created this PR as a draft. Please review and discuss if we should implement this solution. 

Currently the modal's title got a new padding to align with the modals content and the carousel controls are pushed to the sides to avoid overlapping with the modal content.
![Image 1](https://github.com/user-attachments/assets/8b6d4dd3-c5d8-4e0c-915b-efa3bbc1e469)

Without the new padding the modal's title and content won't align.
![Image 2](https://github.com/user-attachments/assets/06e00d02-8d63-4f76-8bca-cfbe105df70e)

The carousel controls won't change for Lightbox Modal Image Pages.
![Image 3](https://github.com/user-attachments/assets/9f180415-dffe-4dea-9daf-55685cfe830c)

If you're fine with this solution let me know if we want to add the new modal title padding too.

The background color will stay light for all lightbox modals except for those with at least one image. This was approved [in this PR](https://github.com/ILIAS-eLearning/ILIAS/pull/5661) and [in this Feature Wiki Entry](https://docu.ilias.de/ilias.php?baseClass=ilwikihandlergui&cmdNode=16i:rp&cmdClass=ilobjwikigui&cmd=viewPage&ref_id=1357&wpg_id=7725).