### PR TITLE
jQueryUI/Maphilight: Remove files and usages from codebase

### DIFF
--- a/components/ILIAS/Accordion/classes/class.ilAccordionGUI.php
+++ b/components/ILIAS/Accordion/classes/class.ilAccordionGUI.php
@@ -230,8 +230,6 @@ class ilAccordionGUI
 
         ilYuiUtil::initConnection($tpl);
 
-        iljQueryUtil::initjQueryUI($tpl);
-
         foreach (self::getLocalJavascriptFiles() as $f) {
             $tpl->addJavaScript($f, true, 3);
         }

--- a/components/ILIAS/COPage/PC/MediaObject/class.ilPCMediaObject.php
+++ b/components/ILIAS/COPage/PC/MediaObject/class.ilPCMediaObject.php
@@ -493,9 +493,7 @@ class ilPCMediaObject extends ilPageContent
     public function getJavascriptFiles(
         string $a_mode
     ): array {
-        //$js_files = ilPlayerUtil::getJsFilePaths();
-        $js_files[] = iljQueryUtil::getLocalMaphilightPath();
-        return $js_files;
+        return [];
     }
 
     public function getCssFiles(

--- a/components/ILIAS/COPage/Resources/ResourcesCollector.php
+++ b/components/ILIAS/COPage/Resources/ResourcesCollector.php
@@ -65,7 +65,6 @@ class ResourcesCollector
         // (for all other modes they are included automatically)
         if ($this->output_mode == \ilPageObjectGUI::OFFLINE) {
             $this->js_files[] = \iljQueryUtil::getLocaljQueryPath();
-            $this->js_files[] = \iljQueryUtil::getLocaljQueryUIPath();
             $this->js_files[] = 'assets/js/Basic.js';
             $this->js_files[] = 'assets/js/mathjax_config.js';
             $this->js_files[] = 'node_modules/mathjax/es5/tex-chtml-full.js';

--- a/components/ILIAS/DataCollection/classes/class.ilDataCollectionGlobalTemplate.php
+++ b/components/ILIAS/DataCollection/classes/class.ilDataCollectionGlobalTemplate.php
@@ -473,7 +473,6 @@ class ilDataCollectionGlobalTemplate implements ilGlobalTemplateInterface
 
         // always load jQuery
         iljQueryUtil::initjQuery();
-        iljQueryUtil::initjQueryUI();
 
         $this->addBlockFile("CONTENT", "content", "tpl.adm_content.html");
         $this->addBlockFile("STATUSLINE", "statusline", "tpl.statusline.html");

--- a/components/ILIAS/Help/classes/class.ilHelpGUI.php
+++ b/components/ILIAS/Help/classes/class.ilHelpGUI.php
@@ -326,7 +326,6 @@ class ilHelpGUI implements ilCtrlBaseClassInterface
 
         $a_tpl->addJavaScript("assets/js/ilHelp.js");
         $a_tpl->addJavaScript("assets/js/accordion.js");
-        iljQueryUtil::initMaphilight();
         $a_tpl->addJavaScript("components/ILIAS/COPage/js/ilCOPagePres.js");
 
         $this->setCtrlPar();

--- a/components/ILIAS/MediaObjects/MediaObject/class.ilObjMediaObjectGUI.php
+++ b/components/ILIAS/MediaObjects/MediaObject/class.ilObjMediaObjectGUI.php
@@ -1577,7 +1577,6 @@ class ilObjMediaObjectGUI extends ilObjectGUI
         }
 
         iljQueryUtil::initjQuery($a_tpl);
-        $a_tpl->addJavaScript(iljQueryUtil::getLocalMaphilightPath());
         $a_tpl->addJavaScript("components/ILIAS/COPage/js/ilCOPagePres.js");
 
         //ilPlayerUtil::initMediaElementJs($a_tpl);

--- a/components/ILIAS/OnScreenChat/classes/class.ilOnScreenChatGUI.php
+++ b/components/ILIAS/OnScreenChat/classes/class.ilOnScreenChatGUI.php
@@ -306,7 +306,6 @@ class ilOnScreenChatGUI implements ilCtrlBaseClassInterface
             ], $page);
 
             iljQueryUtil::initjQuery($page);
-            iljQueryUtil::initjQueryUI($page);
             ilLinkifyUtil::initLinkify($page);
 
             $page->addJavaScript('assets/js/modal.min.js');

--- a/components/ILIAS/RTE/classes/class.ilRTEGlobalTemplate.php
+++ b/components/ILIAS/RTE/classes/class.ilRTEGlobalTemplate.php
@@ -189,7 +189,6 @@ class ilRTEGlobalTemplate implements ilGlobalTemplateInterface
         }
 
         iljQueryUtil::initjQuery();
-        iljQueryUtil::initjQueryUI();
 
         $this->addBlockFile('CONTENT', 'content', 'tpl.adm_content.html');
         $this->addBlockFile('STATUSLINE', 'statusline', 'tpl.statusline.html');

--- a/components/ILIAS/Search/classes/class.ilMainMenuSearchGUI.php
+++ b/components/ILIAS/Search/classes/class.ilMainMenuSearchGUI.php
@@ -75,7 +75,6 @@ class ilMainMenuSearchGUI
     public function getHTML(): string
     {
         iljQueryUtil::initjQuery();
-        iljQueryUtil::initjQueryUI();
 
         $this->tpl = new ilTemplate('tpl.main_menu_search.html', true, true, 'components/ILIAS/Search');
         if ($this->user->getId() != ANONYMOUS_USER_ID) {

--- a/components/ILIAS/StudyProgramme/classes/class.ilStudyProgrammeExpandableProgressListGUI.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilStudyProgrammeExpandableProgressListGUI.php
@@ -267,7 +267,6 @@ class ilStudyProgrammeExpandableProgressListGUI extends ilStudyProgrammeProgress
             return false;
         }
 
-        iljQueryUtil::initjQueryUI();
         $this->tpl->addJavaScript("assets/js/accordion.js", true, 3);
         $this->js_added = true;
     }

--- a/components/ILIAS/UICore/classes/class.ilGlobalPageTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilGlobalPageTemplate.php
@@ -98,7 +98,6 @@ class ilGlobalPageTemplate implements ilGlobalTemplateInterface
     protected function prepareBasicJS(): void
     {
         iljQueryUtil::initjQuery($this);
-        iljQueryUtil::initjQueryUI($this);
         $this->gs->layout()->meta()->addJs("assets/js/Basic.js", true, 1);
         ilBuddySystemGUI::initializeFrontend($this);
         ilOnScreenChatGUI::initializeFrontend($this);

--- a/components/ILIAS/UICore/classes/class.ilGlobalTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilGlobalTemplate.php
@@ -523,7 +523,6 @@ class ilGlobalTemplate implements ilGlobalTemplateInterface
 
         // always load jQuery
         iljQueryUtil::initjQuery();
-        iljQueryUtil::initjQueryUI();
 
         $this->addBlockFile("CONTENT", "content", "tpl.adm_content.html");
         $this->addBlockFile("STATUSLINE", "statusline", "tpl.statusline.html");

--- a/components/ILIAS/jQuery/classes/class.iljQueryUtil.php
+++ b/components/ILIAS/jQuery/classes/class.iljQueryUtil.php
@@ -44,26 +44,7 @@ class iljQueryUtil
         }
 
         $a_tpl->addJavaScript(self::getLocaljQueryPath(), true, 0);
-        $a_tpl->addJavaScript('assets/js/jquery-migrate.min.js', true, 0);
     }
-
-
-    /**
-     * inits and adds the jQuery-UI JS-File to the global template
-     * (see included_components.txt for included components)
-     */
-    public static function initjQueryUI(?ilGlobalTemplateInterface $a_tpl = null): void
-    {
-        global $DIC;
-
-        if ($a_tpl === null) {
-            $a_tpl = $DIC["tpl"];
-        }
-
-        // Important: jQueryUI has to be included before(!) the bootstrap JS file
-        $a_tpl->addJavaScript(self::getLocaljQueryUIPath(), true, 0);
-    }
-
 
     /**
      * @return string local path of jQuery file
@@ -71,39 +52,5 @@ class iljQueryUtil
     public static function getLocaljQueryPath(): string
     {
         return "assets/js/jquery" . self::$min . ".js";
-    }
-
-
-    /**
-     * @return string local path of jQuery UI file
-     */
-    public static function getLocaljQueryUIPath(): string
-    {
-        return "./assets/js/jquery-ui" . self::$min . ".js";
-    }
-
-    //
-    // Maphilight plugin
-    //
-
-    /**
-     * Inits and add maphilight to the general template
-     */
-    public static function initMaphilight(): void
-    {
-        global $DIC;
-
-        $tpl = $DIC["tpl"];
-
-        $tpl->addJavaScript(self::getLocalMaphilightPath(), true, 1);
-    }
-
-
-    /**
-     * Get local path of maphilight file
-     */
-    public static function getLocalMaphilightPath(): string
-    {
-        return "./assets/js/jquery.maphilight.min.js";
     }
 }

--- a/components/ILIAS/jQuery/tests/PathTest.php
+++ b/components/ILIAS/jQuery/tests/PathTest.php
@@ -38,13 +38,5 @@ class PathTest extends TestCase
             "",
             iljQueryUtil::getLocaljQueryPath()
         );
-        $this->assertNotEquals(
-            "",
-            iljQueryUtil::getLocaljQueryUIPath()
-        );
-        $this->assertNotEquals(
-            "",
-            iljQueryUtil::getLocalMaphilightPath()
-        );
     }
 }


### PR DESCRIPTION
This PR removes the usages and global page inclusion of `jQueryUI` and `Maphighlight` from our code base.

Both libraries are not included in our NPM dependencies, which results in 404 errors (unnecessary HTTP requests).

![Bildschirmfoto vom 2024-12-04 15-37-38](https://github.com/user-attachments/assets/ad4c3680-6355-46f4-b00e-ec51dccdd153)
![Bildschirmfoto vom 2024-12-04 15-37-24](https://github.com/user-attachments/assets/f4af7240-7905-45d1-94ff-1c1466c34472)


If approved, this MUST be picked to `release_10` as well.

Fixes:
- https://mantis.ilias.de/view.php?id=44785
- https://mantis.ilias.de/view.php?id=44784