### PR TITLE
Mail: Hide BCC in internal messages (ILIAS 8)

### DIFF
--- a/Services/Mail/classes/class.ilMail.php
+++ b/Services/Mail/classes/class.ilMail.php
@@ -610,7 +610,7 @@ class ilMail
             $this->sendChanneledMails(
                 $to,
                 $cc,
-                $bcc,
+                '',
                 $toUsrIds,
                 $subject,
                 $message,
@@ -628,7 +628,7 @@ class ilMail
             $this->sendChanneledMails(
                 $to,
                 $cc,
-                $bcc,
+                '',
                 $otherUsrIds,
                 $subject,
                 $this->replacePlaceholders($message, 0, false),
@@ -645,7 +645,7 @@ class ilMail
             $this->sendChanneledMails(
                 $to,
                 $cc,
-                $bcc,
+                '',
                 $usrIds,
                 $subject,
                 $message,


### PR DESCRIPTION
This PR suggests to ignore the BCC recipients when storing the database records (for "Internal Mails") for all (TO/CC/BCC) recipients.
The sender will (of course) still see the BCC recipients in the user interface.

See: https://mantis.ilias.de/view.php?id=43029#c110260