### PR TITLE
Mail: Hide BCC in internal messages (ILIAS >= 9)

### DIFF
--- a/Services/Mail/classes/class.ilMail.php
+++ b/Services/Mail/classes/class.ilMail.php
@@ -739,7 +739,7 @@ class ilMail
                 $this->user_id,
                 $mail_data->getAttachments(),
                 $mail_data->getTo(),
-                $mail_data->getCc(),
+                '',
                 '',
                 'unread',
                 $mail_data->getSubject(),


### PR DESCRIPTION
This PR suggests to ignore the BCC recipients when storing the database records (for "Internal Mails") for all (TO/CC/BCC) recipients.
The sender will (of course) still see the BCC recipients in the user interface.

See: https://mantis.ilias.de/view.php?id=43029#c110260

If approved, this must be picked to all mtainined branches.