### PR TITLE
ContentStyle: Fix missing `max` key in schema version for exports

### DIFF
--- a/components/ILIAS/Style/classes/class.ilStyleExporter.php
+++ b/components/ILIAS/Style/classes/class.ilStyleExporter.php
@@ -46,7 +46,8 @@ class ilStyleExporter extends ilXmlExporter
                 "namespace" => "http://www.ilias.de/Services/Style/10_0",
                 "xsd_file" => "ilias_style_10.xsd",
                 "uses_dataset" => true,
-                "min" => "10.0"),
+                "min" => "10.0",
+                "max" => ""),
             "8.0" => array(
                 "namespace" => "http://www.ilias.de/Services/Style/8",
                 "xsd_file" => "ilias_style_8.xsd",


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=43090

If approved, this must be be picked to `trunk` as well (and maybe to 9.x, but I did not check this).