### PR TITLE
Export: Don't expect `max` key, export provides might not have define…

### DIFF
--- a/components/ILIAS/Export/classes/class.ilXmlExporter.php
+++ b/components/ILIAS/Export/classes/class.ilXmlExporter.php
@@ -129,7 +129,7 @@ abstract class ilXmlExporter
         foreach ($svs as $k => $sv) {
             if (!$found) {
                 if (version_compare($sv["min"], ILIAS_VERSION_NUMERIC, "<=")
-                    && ($sv["max"] == "" || version_compare($sv["max"], ILIAS_VERSION_NUMERIC, ">="))) {
+                    && (!isset($sv["max"]) || $sv["max"] == "" || version_compare($sv["max"], ILIAS_VERSION_NUMERIC, ">="))) {
                     $rsv = $sv;
                     $rsv["schema_version"] = $k;
                     $found = true;


### PR DESCRIPTION
…d it

See: https://mantis.ilias.de/view.php?id=43090

If approved, this must be be picked to `trunk` as well (and maybe to 9.x, but I did not check this).