### PR TITLE
Footer: Copy permalink to clipboard (ILIAS 10)

### DIFF
--- a/components/ILIAS/UI/UI.php
+++ b/components/ILIAS/UI/UI.php
@@ -104,6 +104,8 @@ class UI implements Component\Component
             new Component\Resource\NodeModule("chart.js/dist/chart.umd.js");
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "js/Progress/dist/progress.min.js");
+        $contribute[Component\Resource\PublicAsset::class] = fn() =>
+            new Component\Resource\ComponentJS($this, "js/MainControls/dist/footer.min.js");
         /*
         those are contributed by MediaObjects
         $contribute[Component\Resource\PublicAsset::class] = fn() =>

--- a/components/ILIAS/UI/resources/js/MainControls/dist/footer.min.js
+++ b/components/ILIAS/UI/resources/js/MainControls/dist/footer.min.js
@@ -1,0 +1,15 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+!function(e){"use strict";var t=Object.freeze({__proto__:null,copyText:e=>{if(window.navigator.clipboard)return window.navigator.clipboard.writeText(e);const t=document.createElement("span"),o=document.createRange(),n=window.getSelection();t.textContent=e,document.body.appendChild(t),o.selectNodeContents(t),n.addRange(o);const r=document.execCommand("copy");return n.removeAllRanges(),t.remove(),r?Promise.resolve():Promise.reject(new Error("Unable to copy text."))},showTooltip:(e,t)=>{const o=(Array.from(document.getElementsByTagName("main")).find((e=>!e.hidden))||document.body).getBoundingClientRect();e.parentNode.classList.add("c-tooltip--visible");const n=e.getBoundingClientRect();o.left>n.left?e.style.transform="translateX(calc("+(o.left-n.left)+"px - 50%))":o.right<n.right&&(e.style.transform="translateX(calc("+(o.right-n.right)+"px - 50%))"),setTimeout((()=>{e.parentNode.classList.remove("c-tooltip--visible")}),t)}});e.Footer={permalink:t}}(il);

--- a/components/ILIAS/UI/resources/js/MainControls/rollup.config.js
+++ b/components/ILIAS/UI/resources/js/MainControls/rollup.config.js
@@ -48,4 +48,23 @@ export default [
     external: ['il', 'jquery'],
   },
 
+  {
+    input: './src/footer.js',
+    output: {
+      file: './dist/footer.min.js',
+      format: 'iife',
+      banner: copyright,
+      plugins: [
+        terser({
+          format: {
+            comments: preserveCopyright,
+          },
+        }),
+      ],
+      globals: {
+        il: 'il',
+      },
+    },
+    external: ['il'],
+  },
 ];

--- a/components/ILIAS/UI/resources/js/MainControls/src/footer.js
+++ b/components/ILIAS/UI/resources/js/MainControls/src/footer.js
@@ -1,0 +1,19 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+import il from 'il';
+import * as permalink from './footer/permalink';
+
+il.Footer = { permalink };

--- a/components/ILIAS/UI/resources/js/MainControls/src/footer/permalink.js
+++ b/components/ILIAS/UI/resources/js/MainControls/src/footer/permalink.js
@@ -1,0 +1,55 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+/**
+ * @param {string} text
+ * @returns {Promise}
+ */
+export const copyText = text => {
+  if (window.navigator.clipboard) {
+    return window.navigator.clipboard.writeText(text);
+  }
+
+  const node = document.createElement('span');
+  const range = document.createRange();
+  const selection = window.getSelection();
+
+  node.textContent = text;
+  document.body.appendChild(node);
+  range.selectNodeContents(node);
+  selection.addRange(range);
+
+  const success = document.execCommand('copy');
+  selection.removeAllRanges();
+  node.remove();
+
+  return success ? Promise.resolve() : Promise.reject(new Error('Unable to copy text.'));
+};
+
+export const showTooltip = (node, delay) => {
+  const main = (Array.from(document.getElementsByTagName('main')).find(n => !n.hidden) || document.body).getBoundingClientRect();
+  node.parentNode.classList.add('c-tooltip--visible');
+  const r = node.getBoundingClientRect();
+
+  if (main.left > r.left) {
+    node.style.transform = 'translateX(calc(' + (main.left - r.left) + 'px - 50%))';
+  } else if (main.right < r.right) {
+    node.style.transform = 'translateX(calc(' + (main.right - r.right) + 'px - 50%))';
+  }
+
+  setTimeout(() => {
+    node.parentNode.classList.remove('c-tooltip--visible');
+  }, delay);
+};

--- a/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MainControls/Renderer.php
@@ -430,15 +430,10 @@ class Renderer extends AbstractComponentRenderer
         // maybe render section 1 (permanent link):
         $permanent_url = $component->getPermanentURL();
         if (null !== $permanent_url) {
-            $this->parseAdditionalFooterSectionItems(
-                $template,
-                $default_renderer,
-                'permanent-link',
-                $this->txt('footer_permanent_link'),
-                [
-                    [$this->getUIFactory()->link()->standard($this->txt('perma_link'), (string) $permanent_url), null],
-                ],
-            );
+            $template->setCurrentBlock('with_additional_item');
+            $template->setVariable('ITEM_CONTENT', $this->permanentLink((string) $permanent_url, $default_renderer));
+            $template->parseCurrentBlock();
+            $this->parseFooterSection($template, 'permanent-link', $this->txt('footer_permanent_link'));
         }
 
         // maybe render section 2 (link groups):
@@ -589,5 +584,30 @@ class Renderer extends AbstractComponentRenderer
         $registry->register('assets/js/maincontrols.min.js');
         $registry->register('assets/js/GS.js');
         $registry->register('assets/js/system_info.js');
+        $registry->register('assets/js/footer.min.js');
+    }
+
+    private function permanentLink(string $permanent_url, RendererInterface $renderer): string
+    {
+        $template = $this->getTemplate("tpl.permanent-link.html", true, true);
+
+        $code = function (string $id) use ($permanent_url): string {
+            $id = $this->jsonEncode($id);
+            $perm_url = $this->jsonEncode((string) $permanent_url);
+
+            return "document.getElementById($id).addEventListener('click', e => il.Footer.permalink.copyText($perm_url)
+                        .then(() => il.Footer.permalink.showTooltip(e.target.nextElementSibling, 5000)));";
+        };
+        $button = $this->getUIFactory()->button()->shy($this->txt('copy_perma_link'), '')->withAdditionalOnLoadCode($code);
+
+        $template->setVariable('PERMANENT', $renderer->render($button));
+        $template->setVariable('PERMANENT_TOOLTIP', $this->txt('perma_link_copied'));
+
+        return $template->get();
+    }
+
+    private function jsonEncode($value): string
+    {
+        return json_encode($value, JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_THROW_ON_ERROR);
     }
 }

--- a/components/ILIAS/UI/src/templates/default/MainControls/tpl.permanent-link.html
+++ b/components/ILIAS/UI/src/templates/default/MainControls/tpl.permanent-link.html
@@ -1,0 +1,6 @@
+<div class="c-tooltip__container c-tooltip--top" aria-live="polite">
+    {PERMANENT}
+    <div class="c-tooltip c-tooltip--hidden" role="tooltip">
+        {PERMANENT_TOOLTIP}
+    </div>
+</div>

--- a/components/ILIAS/UI/tests/Client/MainControls/permalink.test.js
+++ b/components/ILIAS/UI/tests/Client/MainControls/permalink.test.js
@@ -1,0 +1,160 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import { copyText, showTooltip } from '../../../../src/UI/templates/js/MainControls/src/footer/permalink';
+
+const expectOneCall = () => {
+  const expected = [];
+  const called = [];
+
+  return {
+    callOnce: (proc = () => {}) => {
+      const f = (...args) => {
+        if (called.includes(f)) {
+          throw new Error('Called more than once.');
+        }
+        called.push(f);
+        return proc(...args);
+      };
+      expected.push(f);
+
+      return f;
+    },
+    finish: () => expected.forEach(proc => {
+      if (!called.includes(proc)) {
+        throw new Error('Never called.');
+      }
+    }),
+  };
+};
+
+describe('Test permalink copy to clipboard', () => {
+  const saved = {};
+  beforeEach(() => {
+    saved.window = globalThis.window;
+    saved.document = globalThis.document;
+  });
+  afterEach(() => {
+    globalThis.window = saved.window;
+    globalThis.document = saved.document;
+  });
+
+  it('Clipboard API', () => {
+    let written = null;
+    const response = {};
+    const writeText = s => {
+      written = s;
+      return response;
+    };
+    globalThis.window = { navigator: { clipboard: { writeText } } };
+    expect(copyText('foo')).to.be.equal(response);
+    expect(written).to.be.equal('foo');
+  });
+
+  it('Legacy Clipboard API', () => {
+    const {callOnce, finish} = expectOneCall();
+    const node = { remove: callOnce() };
+    const range = {
+      selectNodeContents: callOnce(n => expect(n).to.be.equal(node))
+    };
+    const selection = {
+      addRange: callOnce(x => expect(x).to.be.equal(range)),
+      removeAllRanges: callOnce(),
+    };
+
+    globalThis.window = {
+      navigator: {},
+      getSelection: callOnce(() => selection),
+    };
+
+    globalThis.document = {
+      createRange: callOnce(() => range),
+
+      createElement: callOnce(text => {
+        expect(text).to.be.equal('span');
+        return node;
+      }),
+
+      execCommand: callOnce(s => {
+        expect(s).to.be.equal('copy');
+        return true;
+      }),
+
+      body: {
+        appendChild: callOnce(n => {
+          expect(n).to.be.equal(node);
+          expect(n.textContent).to.be.equal('foo');
+        }),
+      },
+    };
+
+    return copyText('foo').then(finish);
+  });
+});
+
+describe('Test permanentlink show tooltip', () => {
+  const saved = {};
+  beforeEach(() => {
+    saved.setTimeout = globalThis.setTimeout;
+    saved.document = globalThis.document;
+  });
+  afterEach(() => {
+    globalThis.setTimeout = saved.setTimeout;
+    globalThis.document = saved.document;
+  });
+
+  const testTooltip = (mainRect, nodeRect, expectTransform = null) => () => {
+    const {callOnce, finish} = expectOneCall();
+    let callTimeout = null;
+    globalThis.document = {
+      getElementsByTagName: callOnce(tag => {
+        expect(tag).to.be.equal('main');
+        return [
+          {getBoundingClientRect: callOnce(() => mainRect)}
+        ];
+      }),
+    };
+
+    globalThis.setTimeout = callOnce((proc, delay) => {
+      callTimeout = proc;
+      expect(delay).to.be.equal(4321);
+    });
+
+    const isTooltipClass = name => expect(name).to.be.equal('c-tooltip--visible');
+    const node = {
+      parentNode: {
+        classList: {
+          add: callOnce(isTooltipClass),
+          remove: callOnce(isTooltipClass),
+        },
+      },
+      getBoundingClientRect: callOnce(() => nodeRect),
+      style: {transform: null},
+    };
+    showTooltip(node, 4321);
+
+    expect(callTimeout).not.to.be.equal(null);
+    expect(node.style.transform).to.be.equal(expectTransform);
+
+    callTimeout();
+    finish();
+  };
+
+  it('Show tooltip', testTooltip({left: 0, right: 10}, {left: 1, right: 9}));
+  it('Show tooltip left aligned', testTooltip({left: 5, right: 10}, {left: 3, right: 9}, 'translateX(calc(2px - 50%))'));
+  it('Show tooltip right aligned', testTooltip({left: 0, right: 7}, {left: 1, right: 9}, 'translateX(calc(-2px - 50%))'));
+});

--- a/components/ILIAS/UI/tests/Component/MainControls/FooterTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/FooterTest.php
@@ -99,15 +99,23 @@ class FooterTest extends ILIAS_UI_TestBase
         $footer = $this->getUIFactory()->mainControls()->footer();
         $footer = $footer->withPermanentURL($this->uri_mock);
 
-        $this->link_factory->expects($this->once())->method('standard')->with('perma_link', $this->uri_mock);
+        $this->button_factory->expects($this->once())->method('shy')->with('copy_perma_link', '');
+        $this->shy_mock->expects($this->once())->method('withAdditionalOnLoadCode')->willReturnSelf();
 
-        $renderer = $this->getDefaultRenderer(null, [$this->link_mock]);
+        $renderer = $this->getDefaultRenderer(null, [$this->shy_mock]);
         $actual_html = $renderer->render($footer);
 
         $expected_html = <<<EOT
 <footer class="c-maincontrols c-maincontrols__footer">
     <section class="c-maincontrols__footer-grid" data-section="permanent-link" aria-label="footer_permanent_link" tabindex="0">
-        <div class="c-maincontrols__footer-grid__item text-left">$this->link_html</div>
+        <div class="c-maincontrols__footer-grid__item text-left">
+            <div class="c-tooltip__container c-tooltip--top" aria-live="polite">
+                $this->shy_html
+                <div class="c-tooltip c-tooltip--hidden" role="tooltip">
+                    perma_link_copied
+                </div>
+            </div>
+        </div>
     </section>
 </footer>
 EOT;

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -3817,6 +3817,7 @@ common#:#copy_all#:#Alle kopieren
 common#:#copy_n_of_suffix#:#- Kopie (%1$s)
 common#:#copy_of#:#Kopie von
 common#:#copy_of_suffix#:#- Kopie
+common#:#copy_perma_link#:#Link in Zwischenablage kopieren
 common#:#copy_selected_items#:#Kopieren
 common#:#count#:#Anzahl
 common#:#counter_novelty#:#Neuigkeiten
@@ -5293,6 +5294,7 @@ common#:#pd_items_news#:#Einschließlich Neuigkeiten der ausgewählten Objekte
 common#:#pdf_export#:#PDF-Export
 common#:#perm_settings#:#Rechte
 common#:#perma_link#:#Link zu dieser Seite
+common#:#perma_link_copied#:#Link zu dieser Seite wurde in die Zwischenablage kopiert.
 common#:#permission#:#Recht
 common#:#permission_denied#:#Kein Zugriffsrecht
 common#:#permission_settings#:#Rechteeinstellungen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -3818,6 +3818,7 @@ common#:#copy_all#:#Copy all
 common#:#copy_n_of_suffix#:#- Copy (%1$s)
 common#:#copy_of#:#Copy of
 common#:#copy_of_suffix#:#- Copy
+common#:#copy_perma_link#:#Copy link to clipboard
 common#:#copy_selected_items#:#Copy
 common#:#count#:#Count
 common#:#counter_novelty#:#News
@@ -5294,6 +5295,7 @@ common#:#pd_items_news#:#Include News of Personal Items
 common#:#pdf_export#:#PDF Export
 common#:#perm_settings#:#Permissions
 common#:#perma_link#:#Permanent Link
+common#:#perma_link_copied#:#Link to this page has been copied to the clipboard.
 common#:#permission#:#Permission
 common#:#permission_denied#:#Permission Denied
 common#:#permission_settings#:#Object Permission Settings


### PR DESCRIPTION
Sister PR to: #7498

As the Footer has been reworked from 10 upwards, the permanemt link does not have a specific template block for itself anymore.

So this PR adds a new template file: `components/ILIAS/UI/src/templates/default/MainControls/tpl.permanent-link.html` for the copy permanent link HTML part.

Alternatively I could add a new permanent link specific block in the existent template `components/ILIAS/UI/src/templates/default/MainControls/tpl.footer.html` if that would be preferred. I'm also open to other solutions.