### PR TITLE
Dashboard: remove option to manage recommended content

### DIFF
--- a/Services/Repository/RecommendedContent/classes/class.ilDashboardRecommendedContentGUI.php
+++ b/Services/Repository/RecommendedContent/classes/class.ilDashboardRecommendedContentGUI.php
@@ -126,7 +126,7 @@ class ilDashboardRecommendedContentGUI extends ilDashboardBlockGUI
 
     public function removeMultipleEnabled(): bool
     {
-        return true;
+        return false;
     }
 
     public function getRemoveMultipleActionText(): string


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43103

This seems to be a conceptional flaw of the dashboard refactoring.

Recommended content is not individually managed but by role.
Therefore, there is no way for a user to change that content.

@fhelfer FYI