### PR TITLE
NPM: Add chart.js as dependency

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -8,6 +8,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "chart.js": "^4.4.7",
   },
   "devDependencies": {
   },


### PR DESCRIPTION
This PR suggests adding `chart.js` (v. 4.4.7) as npm package.

General Information:
* [X] this dependency was already used in ILIAS.
* [X] MIT license

Usage:
* `components/ILIAS/Poll`
* `components/ILIAS/Skill`

Wrapped By:
* `ILIAS\UI\Implementation\Component\Chart\Bar`

Reasoning:
* `chart.js` provides a set of frequently used chart types (like bar charts, line charts, pie charts,...). The charts are responsive, animated, interactive and HTML5-based.
* Among [many charting libraries ](https://awesome.cube.dev/?tools=charts&ref=eco-chartjs) for JavaScript application developers, Chart.js is currently the most popular one according to [GitHub stars ](https://github.com/chartjs/Chart.js)(~65,000) and [npm downloads ](https://www.npmjs.com/package/chart.js)(~3,800,000 weekly).

Maintenance:
* `chart.js` is actively maintained by multiple contributors. New releases are published every few weeks/months.

Links:
* Packagist: https://www.npmjs.com/package/chart.js
* GitHub: https://github.com/chartjs/Chart.js
* Documentation: https://www.chartjs.org/docs/latest/