### PR TITLE
Composer: Add geshi lib

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"geshi/geshi": "^1.0.9.1"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
Usage:

Syntax highlighter for common programming/script languages.

Wrapped By:

components/ILIAS/COPage (internally)

Reasoning:

Main use is in the code element of the page editor. This helps greatly to read code snippets when teaching programming. Afaik it is also being used in the KS documentation.

Maintenance:

Almost 20 years on gitub, little maintenance in the last years, has around 50 contributors, there is a reported PHP 8.1 issue that we did not experience so far. If there will be no maintenance, we might use a fork, create a fork, get into contact with one of the contributors, switch to an alternative like https://github.com/scrivo/highlight.php or abandon the feature.

Links:

Packagist: https://packagist.org/packages/geshi/geshi
GitHub: https://github.com/GeSHi/geshi-1.0

License: Packagist page says GPL-2.0+, Github page says GPL-2.0
