### PR TITLE
T&A: Fix Info-Page Form Tags

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -2701,7 +2701,6 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface
             $this->trackTestObjectReadEvent();
         }
         $info = new ilInfoScreenGUI($this);
-        $info->setOpenFormTag(false);
 
         if ($this->isCommandClassAnyInfoScreenChild()) {
             return $this->ctrl->forwardCommand($info);


### PR DESCRIPTION
This PR is related to Mantis Ticket: https://mantis.ilias.de/view.php?id=40636.
Since the info page automatically wraps content in a form by default, and the test info page always requires a form, the `setOpenFormTag(false)` call has been removed.

This change can also be cherry-picked into later versions if needed.

Best regards,
@thojou