### PR TITLE
Add `rollup` as npm Dependency for ILIAS 11

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -10,6 +10,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "rollup": "^4.28.1",
   },
   "scripts": {
     "test": "mocha --recursive"


### PR DESCRIPTION
Assessment:
<!-- Given all facts and considerations, describe why this is a dependency 
that should be included into ILIAS. -->
Rollup is a JavaScript module bundler, which is used to compile small pieces of code into one big file that should be used or delivered to the client.

General Information:
- Name of the dependency: `rollup`
- Version: `4.28.1`
- [x] this dependency was already used in ILIAS.
- [x] the dependency's license is compatible with ILIAS' license. (MIT)

Type of dependency:
- [ ] composer
- [x] npm

Usage:
<!-- Describe how the dependency is used in ILIAS by listing FQDN of 
components or even classes.-->
* `components/ILIAS/UI/resources/js/*` (many usages)

Reasoning:
<!-- Explain why this dependency is needed and why it is the best choice. -->
* We need a module bundler to create bundled JavaScript assets which are shipped to the client.
* Rollup has a plugin eco-system, which provides some plugins we need to properly create our bundles.

Maintenance:
<!-- Describe the maintenance status of the dependency. Facts like the 
amount of maintainers, activity in the repository and other information 
could be relevant. We'd like to avoid 'dead' dependecies. -->
* The package is actively maintained.
* The package has an active commit history.
* The package is used by 15Mil.

Links:
* Packagist/NPM: https://www.npmjs.com/package/rollup
* GitHub: https://github.com/rollup/rollup
* Documentation: https://rollupjs.org/

Alternatives:
<!-- List alternatives to the dependency if possible and explain why they were 
not chosen. -->
There are several alternatives. However, for the time being, it would be too much of an effort to exchange the module bundler since we maintain many small bundles instead of one big one, so many config files would need to be rewritten. Besides, the differences between module bundlers are very small.
* `webpack`
* `parcel`
* `vite`

