### PR TITLE
Add `@rollup/plugin-commonjs` as npm Dependency for ILIAS 11

### DIFF
--- a/package_new.json
+++ b/package_new.json
@@ -10,6 +10,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^28.0.1",
   },
   "scripts": {
     "test": "mocha --recursive"


### PR DESCRIPTION
Assessment:
<!-- Given all facts and considerations, describe why this is a dependency 
that should be included into ILIAS. -->
This package converts CommonJS, or JavaScript code prior to ES6, into ES6 compatible code at runtime.

General Information:
- Name of the dependency: `@rollup/plugin-commonjs`
- Version: `28.0.1`
- [ ] this dependency was already used in ILIAS.
- [x] the dependency's license is compatible with ILIAS' license. (MIT)

Type of dependency:
- [ ] composer
- [x] npm

Usage:
<!-- Describe how the dependency is used in ILIAS by listing FQDN of 
components or even classes.-->
* `components/ILIAS/UI/resources/js/Input/Field/file.js` (to be refactored)

Reasoning:
<!-- Explain why this dependency is needed and why it is the best choice. -->
* Rollup.js, the module bundler we are using, demands that the code which should be bundled is compatible with ES6. However, since we are using third party libraries in our code, it sometimes happens that a library does not provide a ES6 compatible format. This is when we need to transform the code before we can bundle it. This plugin is usually only used together with the @rollup/plugin-node-resolve package.

Maintenance:
<!-- Describe the maintenance status of the dependency. Facts like the 
amount of maintainers, activity in the repository and other information 
could be relevant. We'd like to avoid 'dead' dependecies. -->
* The package is part of Rollup.js' [plugin repository](https://github.com/rollup/plugins), which is actively maintained and receives yearly major releases and ~monthly to ~weekly minor/patch updates.

Links:
- Packagist/NPM: https://www.npmjs.com/package/@rollup/plugin-commonjs
- GitHub: https://github.com/rollup/plugins/tree/master/packages/commonjs/#readme
- Documentation: https://rollupjs.org/introduction/#importing-commonjs

Alternatives:
<!-- List alternatives to the dependency if possible and explain why they were 
not chosen. -->
There are no alternatives. This package is specific to our JavaScript module bundler.

