### PR TITLE
[FEATURE] UI: rename `Field\ColorPicker` to `Field\ColorSelect`.

### DIFF
--- a/components/ILIAS/Test/src/Settings/GlobalSettings/GlobalTestSettings.php
+++ b/components/ILIAS/Test/src/Settings/GlobalSettings/GlobalTestSettings.php
@@ -244,7 +244,7 @@ class GlobalTestSettings
                     $lng->txt('ass_process_lock')
                 )->withByline($lng->txt('ass_process_lock_desc'))
                 ->withValue($this->process_lock_mode === ProcessLockModes::ASS_PROC_LOCK_MODE_NONE ? null : [$this->process_lock_mode->value]),
-                'image_map_line_color' => $ff->colorPicker($lng->txt('imap_line_color'))
+                'image_map_line_color' => $ff->colorSelect($lng->txt('imap_line_color'))
                     ->withValue('#' . $this->image_map_line_color),
                 'user_identifier' => $ff->select(
                     $lng->txt('user_criteria'),

--- a/components/ILIAS/UI/src/Component/Input/Field/ColorSelect.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/ColorSelect.php
@@ -25,6 +25,6 @@ use ILIAS\UI\Component\Input\Container\Form\FormInput;
 /**
  * @author Patrick Bechtold <patrick.bechtold@kroepelin-projekte.de>
  */
-interface ColorPicker extends FormInput
+interface ColorSelect extends FormInput
 {
 }

--- a/components/ILIAS/UI/src/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Factory.php
@@ -711,9 +711,9 @@ interface Factory
      * ---
      * @param string      $label
      * @param string|null $byline
-     * @return \ILIAS\UI\Component\Input\Field\ColorPicker
+     * @return \ILIAS\UI\Component\Input\Field\ColorSelect
      */
-    public function colorPicker(string $label, ?string $byline = null): ColorPicker;
+    public function colorSelect(string $label, ?string $byline = null): ColorSelect;
 
     /**
      * ---

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/ColorSelect.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/ColorSelect.php
@@ -29,7 +29,7 @@ use Closure;
 /**
  * @author Patrick Bechtold <patrick.bechtold@kroepelin-projekte.de>
  */
-class ColorPicker extends FormInput implements C\Input\Field\ColorPicker
+class ColorSelect extends FormInput implements C\Input\Field\ColorSelect
 {
     /**
      * Input constructor.

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
@@ -158,9 +158,9 @@ class Factory implements I\Factory
         return new Hidden($this->data_factory, $this->refinery);
     }
 
-    public function colorpicker(string $label, ?string $byline = null): ColorPicker
+    public function colorSelect(string $label, ?string $byline = null): ColorSelect
     {
-        return new ColorPicker($this->data_factory, $this->refinery, $label, $byline);
+        return new ColorSelect($this->data_factory, $this->refinery, $label, $byline);
     }
 
     public function markdown(I\MarkdownRenderer $md_renderer, string $label, ?string $byline = null): Markdown

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -146,8 +146,8 @@ class Renderer extends AbstractComponentRenderer
             case ($component instanceof F\Hidden):
                 return $this->renderHiddenField($component);
 
-            case ($component instanceof F\ColorPicker):
-                return $this->renderColorPickerField($component, $default_renderer);
+            case ($component instanceof F\ColorSelect):
+                return $this->renderColorSelectField($component, $default_renderer);
 
             case ($component instanceof F\Rating):
                 return $this->renderRatingField($component, $default_renderer);
@@ -980,9 +980,9 @@ class Renderer extends AbstractComponentRenderer
         return $mime_type_string;
     }
 
-    protected function renderColorPickerField(F\ColorPicker $component, RendererInterface $default_renderer): string
+    protected function renderColorSelectField(F\ColorSelect $component, RendererInterface $default_renderer): string
     {
-        $tpl = $this->getTemplate("tpl.colorpicker.html", true, true);
+        $tpl = $this->getTemplate("tpl.color_select.html", true, true);
         $this->applyName($component, $tpl);
         $tpl->setVariable('VALUE', $component->getValue());
 

--- a/components/ILIAS/UI/src/examples/Input/Field/ColorSelect/base.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/ColorSelect/base.php
@@ -1,29 +1,13 @@
 <?php
 
-/**
- * This file is part of ILIAS, a powerful learning management system
- * published by ILIAS open source e-Learning e.V.
- *
- * ILIAS is licensed with the GPL-3.0,
- * see https://www.gnu.org/licenses/gpl-3.0.en.html
- * You should have received a copy of said license along with the
- * source code, too.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- * https://www.ilias.de
- * https://github.com/ILIAS-eLearning
- *
- *********************************************************************/
-
 declare(strict_types=1);
 
-namespace ILIAS\UI\examples\Input\Field\ColorPicker;
+namespace ILIAS\UI\examples\Input\Field\ColorSelect;
 
 /**
  * ---
  * description: >
- *   Base example showing how to plug a colorpicker into a form
+ *   Base example showing how to plug a Colour Select Field into a form.
  *
  * expected output: >
  *   ILIAS shows the rendered Component.
@@ -38,7 +22,7 @@ function base()
     $request = $DIC->http()->request();
 
     //Step 1: Define the input field
-    $color_input = $ui->input()->field()->colorpicker("Color", "click to select a color");
+    $color_input = $ui->input()->field()->colorSelect("Color", "click to select a color");
 
     //Step 2: Define the form and attach the field.
     $form = $ui->input()->container()->form()->standard('#', ['color' => $color_input]);

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.color_select.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.color_select.html
@@ -1,0 +1,1 @@
+<input id="{ID}" type="color"<!-- BEGIN name --> name="{NAME}"<!-- END name --> value="{VALUE}" class="c-field-color-select"/>

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.colorpicker.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.colorpicker.html
@@ -1,1 +1,0 @@
-<input id="{ID}" type="color"<!-- BEGIN name --> name="{NAME}"<!-- END name --> value="{VALUE}" class="c-field-color-picker"/>

--- a/components/ILIAS/UI/tests/Component/Input/Field/ColorSelectTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/ColorSelectTest.php
@@ -29,7 +29,7 @@ use ILIAS\Data;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 
-class ColorPickerInputTest extends ILIAS_UI_TestBase
+class ColorSelectTest extends ILIAS_UI_TestBase
 {
     use CommonFieldRendering;
 
@@ -43,9 +43,9 @@ class ColorPickerInputTest extends ILIAS_UI_TestBase
     public function testImplementsFactoryInterface(): void
     {
         $f = $this->getFieldFactory();
-        $cp = $f->colorpicker("label", "byline");
+        $cp = $f->colorSelect("label", "byline");
         $this->assertInstanceOf(\ILIAS\UI\Component\Input\Container\Form\FormInput::class, $cp);
-        $this->assertInstanceOf(Field\ColorPicker::class, $cp);
+        $this->assertInstanceOf(Field\ColorSelect::class, $cp);
     }
 
     public function testRender(): void
@@ -53,12 +53,12 @@ class ColorPickerInputTest extends ILIAS_UI_TestBase
         $f = $this->getFieldFactory();
         $label = "label";
         $byline = "byline";
-        $cp = $f->colorpicker($label, $byline)->withNameFrom($this->name_source);
+        $cp = $f->colorSelect($label, $byline)->withNameFrom($this->name_source);
 
         $expected = $this->getFormWrappedHtml(
-            'color-picker-field-input',
+            'color-select-field-input',
             $label,
-            '<input id="id_1" type="color" name="name_0" value="" class="c-field-color-picker"/>',
+            '<input id="id_1" type="color" name="name_0" value="" class="c-field-color-select"/>',
             $byline,
             'id_1'
         );
@@ -69,13 +69,13 @@ class ColorPickerInputTest extends ILIAS_UI_TestBase
     {
         $f = $this->getFieldFactory();
         $label = "label";
-        $colorpicker = $f->colorpicker($label, null)->withNameFrom($this->name_source);
+        $color_select = $f->colorSelect($label, null)->withNameFrom($this->name_source);
 
-        $this->testWithError($colorpicker);
-        $this->testWithNoByline($colorpicker);
-        $this->testWithRequired($colorpicker);
-        $this->testWithDisabled($colorpicker);
-        $this->testWithAdditionalOnloadCodeRendersId($colorpicker);
+        $this->testWithError($color_select);
+        $this->testWithNoByline($color_select);
+        $this->testWithRequired($color_select);
+        $this->testWithDisabled($color_select);
+        $this->testWithAdditionalOnloadCodeRendersId($color_select);
     }
 
     public function testRenderValue(): void
@@ -84,14 +84,14 @@ class ColorPickerInputTest extends ILIAS_UI_TestBase
         $label = "label";
         $byline = "byline";
         $value = "value_0";
-        $cp = $f->colorpicker($label, $byline)
+        $cp = $f->colorSelect($label, $byline)
                 ->withValue($value)
                 ->withNameFrom($this->name_source);
 
         $expected = $this->getFormWrappedHtml(
-            'color-picker-field-input',
+            'color-select-field-input',
             $label,
-            '<input id="id_1" type="color" name="name_0" value="value_0" class="c-field-color-picker"/>',
+            '<input id="id_1" type="color" name="name_0" value="value_0" class="c-field-color-select"/>',
             $byline,
             'id_1'
         );
@@ -104,7 +104,7 @@ class ColorPickerInputTest extends ILIAS_UI_TestBase
         $label = "label";
         $byline = "byline";
         $name = "name_0";
-        $cp = $f->colorpicker($label, $byline)
+        $cp = $f->colorSelect($label, $byline)
                 ->withNameFrom($this->name_source)
                 ->withRequired(true);
 
@@ -124,8 +124,8 @@ class ColorPickerInputTest extends ILIAS_UI_TestBase
     public function testNullValue(): void
     {
         $f = $this->getFieldFactory();
-        $colorpicker = $f->colorpicker("label", "byline");
+        $color_select = $f->colorSelect("label", "byline");
         $this->expectException(\InvalidArgumentException::class);
-        $colorpicker->withValue(null);
+        $color_select->withValue(null);
     }
 }


### PR DESCRIPTION
Hi all,

We have noticed in #7143 that the `Field\ColorPicker` should actually be called `Field\ColorSelect` instead. This PR therefore aligns the input with the new (proposed) `Field\TreeSelect` and `Field\TreeMultiSelect`, and the existing `Field\Select` and `Field\MultiSelect` inputs. I hope to have catched all occurrences.

Please note that I deliberately used the US spelling instead of the UK one (`color` instead of `colour`), because we would need to mix up two formats at one point, since e.g. the HTML input type is spelled in US.

Kind regards,
@thibsy 