### PR TITLE
[FEATURE] UI: align `Table\Factory` parameter order

### DIFF
--- a/components/ILIAS/AccessControl/src/Log/Table.php
+++ b/components/ILIAS/AccessControl/src/Log/Table.php
@@ -93,6 +93,7 @@ class Table implements DataRetrieval
         $cf = $this->ui_factory->table()->column();
 
         return $this->ui_factory->table()->data(
+            $this,
             $this->lng->txt('rbac_log'),
             [
                 self::COLUMN_DATE => $cf->date(
@@ -105,7 +106,6 @@ class Table implements DataRetrieval
                 self::COLUMN_CHANGES => $cf->text($this->lng->txt('rbac_changes'))
                     ->withIsSortable(false)
             ],
-            $this
         )->withRequest($this->request);
     }
 

--- a/components/ILIAS/AdministrativeNotification/classes/Table.php
+++ b/components/ILIAS/AdministrativeNotification/classes/Table.php
@@ -54,9 +54,9 @@ class Table
         $data_retrieval = new DataRetrieval();
 
         $this->components[] = $this->ui_factory->table()->data(
+            $data_retrieval,
             $this->lng->txt('notifications'),
             $columns,
-            $data_retrieval
         )->withActions($actions)->withRequest(
             $DIC->http()->request()
         );

--- a/components/ILIAS/Authentication/classes/Pages/AuthPageLanguagesOverviewTable.php
+++ b/components/ILIAS/Authentication/classes/Pages/AuthPageLanguagesOverviewTable.php
@@ -60,7 +60,7 @@ class AuthPageLanguagesOverviewTable implements UI\Component\Table\DataRetrieval
 
         return $this->ui_factory
             ->table()
-            ->data($this->lng->txt($this->context->pageLanguageIdentifier(true)), $columns, $this)
+            ->data($this, $this->lng->txt($this->context->pageLanguageIdentifier(true)), $columns)
             ->withId(self::class . '_' . $this->context->value)
             ->withOrder(new \ILIAS\Data\Order('language', \ILIAS\Data\Order::ASC))
             ->withActions($actions)

--- a/components/ILIAS/Badge/classes/class.ilBadgeImageTemplateTableGUI.php
+++ b/components/ILIAS/Badge/classes/class.ilBadgeImageTemplateTableGUI.php
@@ -214,7 +214,7 @@ class ilBadgeImageTemplateTableGUI implements DataRetrieval
 
         $table = $this->factory
             ->table()
-            ->data($this->lng->txt('badge_image_templates'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('badge_image_templates'), $this->getColumns())
             ->withId(self::class)
             ->withOrder(new Order('title', Order::ASC))
             ->withActions($this->getActions($url_builder, $action_parameter_token, $row_id_token))

--- a/components/ILIAS/Badge/classes/class.ilBadgePersonalTableGUI.php
+++ b/components/ILIAS/Badge/classes/class.ilBadgePersonalTableGUI.php
@@ -287,9 +287,9 @@ class ilBadgePersonalTableGUI implements DataRetrieval
         $table = $this->factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('badge_personal_badges'),
                 $this->getColumns($date_format),
-                $this
             )
             ->withId(self::class)
             ->withOrder(new Order('title', Order::ASC))

--- a/components/ILIAS/Badge/classes/class.ilBadgeTableGUI.php
+++ b/components/ILIAS/Badge/classes/class.ilBadgeTableGUI.php
@@ -305,7 +305,7 @@ class ilBadgeTableGUI implements DataRetrieval
 
         $table = $this->factory
             ->table()
-            ->data($this->lng->txt('obj_bdga'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('obj_bdga'), $this->getColumns())
             ->withId(self::class . '_' . $this->parent_id)
             ->withOrder(new Order('title', Order::ASC))
             ->withActions($this->getActions($url_builder, $action_parameter_token, $row_id_token))

--- a/components/ILIAS/Badge/classes/class.ilBadgeTypesTableGUI.php
+++ b/components/ILIAS/Badge/classes/class.ilBadgeTypesTableGUI.php
@@ -228,7 +228,7 @@ class ilBadgeTypesTableGUI implements DataRetrieval
 
         $table = $this->factory
             ->table()
-            ->data($this->lng->txt('badge_types'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('badge_types'), $this->getColumns())
             ->withId(self::class)
             ->withOrder(new Order('name', Order::ASC))
             ->withActions($this->getActions($url_builder, $action_parameter_token, $row_id_token))

--- a/components/ILIAS/Badge/classes/class.ilBadgeUserTableGUI.php
+++ b/components/ILIAS/Badge/classes/class.ilBadgeUserTableGUI.php
@@ -384,7 +384,7 @@ class ilBadgeUserTableGUI implements DataRetrieval
 
         $table = $this->factory
             ->table()
-            ->data($title, $this->getColumns(), $this)
+            ->data($this, $title, $this->getColumns())
             ->withId(self::class . '_' . $this->parent_ref_id)
             ->withOrder(new Order('name', Order::ASC))
             ->withActions($this->getActions($url_builder, $action_parameter_token, $row_id_token))

--- a/components/ILIAS/Badge/classes/class.ilObjectBadgeTableGUI.php
+++ b/components/ILIAS/Badge/classes/class.ilObjectBadgeTableGUI.php
@@ -350,7 +350,7 @@ class ilObjectBadgeTableGUI implements DataRetrieval
 
         $table = $this->factory
             ->table()
-            ->data($this->lng->txt('badge_object_badges'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('badge_object_badges'), $this->getColumns())
             ->withId(self::class)
             ->withOrder(new Order('title', Order::ASC))
             ->withActions($this->getActions($url_builder, $action_parameter_token, $row_id_token))

--- a/components/ILIAS/Bibliographic/classes/Admin/Library/class.ilBiblLibraryTableGUI.php
+++ b/components/ILIAS/Bibliographic/classes/Admin/Library/class.ilBiblLibraryTableGUI.php
@@ -65,9 +65,9 @@ class ilBiblLibraryTableGUI implements DataRetrieval
     private function buildTable(): DataTable
     {
         return $this->ui_factory->table()->data(
+            $this,
             $this->lng->txt('bibl_settings_libraries'),
             $this->getColumns(),
-            $this
         )->withActions(
             $this->getActions()
         )->withRange(

--- a/components/ILIAS/Bibliographic/classes/Field/DataRetrieval.php
+++ b/components/ILIAS/Bibliographic/classes/Field/DataRetrieval.php
@@ -27,7 +27,7 @@ use ILIAS\UI\Component\Table\OrderingRowBuilder;
  * Class DataRetrieval
  *
  */
-class DataRetrieval implements I\OrderingBinding
+class DataRetrieval implements I\OrderingRetrieval
 {
     private \ilLanguage $lng;
 

--- a/components/ILIAS/Bibliographic/classes/Field/Table.php
+++ b/components/ILIAS/Bibliographic/classes/Field/Table.php
@@ -65,9 +65,9 @@ class Table
         );
 
         $this->components[] = $this->table = $this->ui_factory->table()->ordering(
+            $data_retrieval,
             $this->lng->txt('filter'),
             $columns,
-            $data_retrieval,
             new URI(
                 ILIAS_HTTP_PATH . "/" . $this->ctrl->getLinkTarget($this->calling_gui, \ilBiblAdminFieldGUI::CMD_SAVE_ORDERING)
             )

--- a/components/ILIAS/Bibliographic/classes/FieldFilter/Table.php
+++ b/components/ILIAS/Bibliographic/classes/FieldFilter/Table.php
@@ -56,9 +56,9 @@ class Table
         );
 
         $this->components[] = $this->ui_factory->table()->data(
+            $data_retrieval,
             $this->lng->txt('filter'),
             $columns,
-            $data_retrieval
         )->withActions($actions)->withRequest(
             $DIC->http()->request()
         );

--- a/components/ILIAS/Blog/Settings/class.BlockSettingsGUI.php
+++ b/components/ILIAS/Blog/Settings/class.BlockSettingsGUI.php
@@ -25,7 +25,7 @@ use ILIAS\Blog\InternalGUIService;
 use ILIAS\Repository\Form\FormAdapterGUI;
 use ILIAS\Blog\InternalDataService;
 use ILIAS\UI\URLBuilder;
-use ILIAS\UI\Component\Table\OrderingBinding;
+use ILIAS\UI\Component\Table\OrderingRetrieval;
 use ILIAS\UI\Component\Table\OrderingRowBuilder;
 use ILIAS\Data\URI;
 use ILIAS\UI\Component\Table\Ordering;
@@ -85,7 +85,7 @@ class BlockSettingsGUI
             $settings,
             $this->obj_id,
             $this->in_repository
-        ) implements OrderingBinding {
+        ) implements OrderingRetrieval {
             protected array $records;
 
             public function __construct(
@@ -115,7 +115,7 @@ class BlockSettingsGUI
 
         $target = $ctrl->getLinkTargetByClass([self::class], "saveOrder");
         $target = (new URI(ILIAS_HTTP_PATH . "/" . $target));
-        $table = $f->table()->ordering($lng->txt("blog_nav_sortorder"), $columns, $data_retrieval, $target)
+        $table = $f->table()->ordering($data_retrieval, $target, $lng->txt("blog_nav_sortorder"), $columns)
                    ->withActions($actions)
                    ->withRequest($request);
 

--- a/components/ILIAS/Calendar/classes/ConsultationHours/BookingTableGUI.php
+++ b/components/ILIAS/Calendar/classes/ConsultationHours/BookingTableGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -105,9 +106,9 @@ class BookingTableGUI implements DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('cal_ch_ch'),
                 $this->getColumns(),
-                $this
             )
             ->withId(self::class)
             ->withActions($this->getActions())

--- a/components/ILIAS/Certificate/classes/Overview/CertificateOverviewTable.php
+++ b/components/ILIAS/Certificate/classes/Overview/CertificateOverviewTable.php
@@ -208,6 +208,7 @@ class CertificateOverviewTable implements DataRetrieval
             $date_format = $this->data_factory->dateFormat()->withTime24($this->user->getDateFormat());
         }
         return $ui_table->data(
+            $this,
             $this->lng->txt('certificates'),
             [
                 'certificate_id' => $ui_table->column()->text($this->lng->txt('certificate_id')),
@@ -216,7 +217,6 @@ class CertificateOverviewTable implements DataRetrieval
                 'obj_id' => $ui_table->column()->text($this->lng->txt('object_id')),
                 'owner' => $ui_table->column()->text($this->lng->txt('owner'))
             ],
-            $this
         )
             ->withOrder(new Order('issue_date', Order::DESC))
             ->withId('certificateOverviewTable')

--- a/components/ILIAS/Chatroom/classes/Bans/BannedUsersTable.php
+++ b/components/ILIAS/Chatroom/classes/Bans/BannedUsersTable.php
@@ -61,7 +61,7 @@ class BannedUsersTable implements UI\Component\Table\DataRetrieval
 
         return $this->ui_factory
             ->table()
-            ->data($this->lng->txt('ban_table_title'), $columns, $this)
+            ->data($this, $this->lng->txt('ban_table_title'), $columns)
             ->withId(self::class . '_' . $this->room_id)
             ->withOrder(new \ILIAS\Data\Order('datetime', \ILIAS\Data\Order::DESC))
             ->withActions($actions)

--- a/components/ILIAS/Conditions/classes/Configuration/ConditionTriggerTableGUI.php
+++ b/components/ILIAS/Conditions/classes/Configuration/ConditionTriggerTableGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -161,9 +162,9 @@ class ConditionTriggerTableGUI implements DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('active_preconditions'),
                 $this->getColumns(),
-                $this
             )
             ->withId(self::class)
             ->withActions($this->getActions())

--- a/components/ILIAS/Contact/classes/MailingLists/MailingListsMembersTable.php
+++ b/components/ILIAS/Contact/classes/MailingLists/MailingListsMembersTable.php
@@ -55,12 +55,12 @@ class MailingListsMembersTable implements UI\Component\Table\DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 \sprintf(
                     $this->lng->txt('mail_members_of_mailing_list'),
                     $this->mailing_list->getTitle()
                 ),
                 $columns,
-                $this
             )
             ->withId(self::class . '_' . $this->mailing_list->getId())
             ->withOrder(new \ILIAS\Data\Order('login', \ILIAS\Data\Order::ASC))

--- a/components/ILIAS/Contact/classes/MailingLists/MailingListsTable.php
+++ b/components/ILIAS/Contact/classes/MailingLists/MailingListsTable.php
@@ -66,9 +66,9 @@ class MailingListsTable implements UI\Component\Table\DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('mail_mailing_lists'),
                 $columns,
-                $this
             )
             ->withOrder(new \ILIAS\Data\Order('title', \ILIAS\Data\Order::ASC))
             ->withId(self::class)

--- a/components/ILIAS/Contact/classes/MemberSearch/MailMemberSearchTable.php
+++ b/components/ILIAS/Contact/classes/MemberSearch/MailMemberSearchTable.php
@@ -56,9 +56,9 @@ class MailMemberSearchTable implements UI\Component\Table\DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('members'),
                 $columns,
-                $this
             )
             ->withId(self::class . '_' . $this->ref_id)
             ->withOrder(new \ILIAS\Data\Order('login', \ILIAS\Data\Order::ASC))

--- a/components/ILIAS/Cron/src/Job/Manager/UI/JobTable.php
+++ b/components/ILIAS/Cron/src/Job/Manager/UI/JobTable.php
@@ -448,7 +448,7 @@ class JobTable implements \ILIAS\UI\Component\Table\DataRetrieval
     {
         return $this->ui_factory
             ->table()
-            ->data($this->lng->txt('cron_jobs'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('cron_jobs'), $this->getColumns())
             ->withActions($this->getActions())
             ->withId(self::class)
             ->withRequest($this->request)

--- a/components/ILIAS/Dashboard/classes/class.ilDashboardPageLanguageSelectGUI.php
+++ b/components/ILIAS/Dashboard/classes/class.ilDashboardPageLanguageSelectGUI.php
@@ -68,12 +68,12 @@ class ilDashboardPageLanguageSelectGUI
         );
 
         $table = $this->dic->ui()->factory()->table()->data(
+            new Language(),
             $this->dic->language()->txt('dash_co_lang'),
             [
                 'name' => $this->dic->ui()->factory()->table()->column()->text($this->dic->language()->txt('language'))->withIsSortable(false),
                 'user_count' => $this->dic->ui()->factory()->table()->column()->text($this->dic->language()->txt('users'))->withIsSortable(false)
             ],
-            new Language()
         )->withActions($actions);
 
         $this->dic->ui()->mainTemplate()->setContent(

--- a/components/ILIAS/DidacticTemplate/classes/Setting/class.ilDidacticTemplateSettingsTableGUI.php
+++ b/components/ILIAS/DidacticTemplate/classes/Setting/class.ilDidacticTemplateSettingsTableGUI.php
@@ -137,9 +137,9 @@ class ilDidacticTemplateSettingsTableGUI
         }
 
         return $this->ui_factory->table()->data(
+            $data_retrieval,
             $this->lng->txt('didactic_available_templates'),
             $columns,
-            $data_retrieval
         )
             ->withActions($actions)
             ->withRequest($this->http->request());

--- a/components/ILIAS/Export/classes/ExportHandler/Table/Handler.php
+++ b/components/ILIAS/Export/classes/ExportHandler/Table/Handler.php
@@ -268,12 +268,12 @@ class Handler implements ilExportHandlerTableInterface
             return;
         }
         $this->table = $this->ui_services->factory()->table()->data(
-            $this->lng->txt("exp_export_files"),
-            $this->getColumns(),
             $this->export_handler->table()->dataRetrieval()
                 ->withExportOptions($this->export_options)
                 ->withExportObject($this->context->exportObject())
-                ->withExportGUI($this->context->exportGUIObject())
+                ->withExportGUI($this->context->exportGUIObject()),
+            $this->lng->txt("exp_export_files"),
+            $this->getColumns(),
         )
             ->withId(self::TABLE_ID)
             ->withActions($this->getActions())

--- a/components/ILIAS/Forum/classes/Drafts/ForumDraftsTable.php
+++ b/components/ILIAS/Forum/classes/Drafts/ForumDraftsTable.php
@@ -121,9 +121,9 @@ class ForumDraftsTable implements DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('drafts'),
                 $this->getColumns(),
-                $this
             )
             ->withId(
                 'frm_drafts_' . substr(

--- a/components/ILIAS/Forum/classes/Moderation/ForumModeratorsTable.php
+++ b/components/ILIAS/Forum/classes/Moderation/ForumModeratorsTable.php
@@ -58,7 +58,7 @@ class ForumModeratorsTable implements UI\Component\Table\DataRetrieval
 
         return $this->ui_factory
             ->table()
-            ->data($this->lng->txt('frm_moderators'), $columns, $this)
+            ->data($this, $this->lng->txt('frm_moderators'), $columns)
             ->withId(self::class . '_' . $this->forum_moderators->getRefId())
             ->withOrder(new \ILIAS\Data\Order('login', \ILIAS\Data\Order::ASC))
             ->withActions($actions)

--- a/components/ILIAS/Forum/classes/Statistics/ForumStatisticsTable.php
+++ b/components/ILIAS/Forum/classes/Statistics/ForumStatisticsTable.php
@@ -81,9 +81,9 @@ class ForumStatisticsTable implements DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('frm_moderators'),
                 $this->getColumns(),
-                $this
             )
             ->withId(self::class . '_' . $this->forum->getId())
             ->withRequest($this->request);

--- a/components/ILIAS/GlobalScreen_/classes/UI/Footer/Entries/EntriesTable.php
+++ b/components/ILIAS/GlobalScreen_/classes/UI/Footer/Entries/EntriesTable.php
@@ -26,13 +26,13 @@ use ILIAS\UI\Component\Table\Ordering;
 use ILIAS\UI\URLBuilder;
 use ILIAS\UI\URLBuilderToken;
 use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Renderer\Hasher;
-use ILIAS\UI\Component\Table\OrderingBinding;
+use ILIAS\UI\Component\Table\OrderingRetrieval;
 use ILIAS\UI\Component\Table\OrderingRowBuilder;
 use ILIAS\GlobalScreen\UI\Footer\Groups\Group;
 use ILIAS\GlobalScreen_\UI\UIHelper;
 use ILIAS\GlobalScreen\UI\Footer\Translation\TranslationsRepository;
 
-class EntriesTable implements OrderingBinding
+class EntriesTable implements OrderingRetrieval
 {
     use Hasher;
     use UIHelper   ;
@@ -90,6 +90,8 @@ class EntriesTable implements OrderingBinding
         return $this->ui_factory
             ->table()
             ->ordering(
+                $this,
+                $here_uri,
                 $this->group->getTitle(),
                 [
                     self::COLUMN_TITLE => $this->ui_factory->table()->column()->text(
@@ -99,8 +101,6 @@ class EntriesTable implements OrderingBinding
                         $this->translator->translate('active', 'entry')
                     )
                 ],
-                $this,
-                $here_uri
             )
             ->withRequest($this->request)
             ->withActions(

--- a/components/ILIAS/GlobalScreen_/classes/UI/Footer/Groups/GroupsTable.php
+++ b/components/ILIAS/GlobalScreen_/classes/UI/Footer/Groups/GroupsTable.php
@@ -26,12 +26,12 @@ use ILIAS\UI\Component\Table\Ordering;
 use ILIAS\UI\URLBuilder;
 use ILIAS\UI\URLBuilderToken;
 use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Renderer\Hasher;
-use ILIAS\UI\Component\Table\OrderingBinding;
+use ILIAS\UI\Component\Table\OrderingRetrieval;
 use ILIAS\UI\Component\Table\OrderingRowBuilder;
 use ILIAS\GlobalScreen_\UI\UIHelper;
 use ILIAS\GlobalScreen\UI\Footer\Translation\TranslationsRepository;
 
-class GroupsTable implements OrderingBinding
+class GroupsTable implements OrderingRetrieval
 {
     use Hasher;
     use UIHelper;
@@ -97,6 +97,8 @@ class GroupsTable implements OrderingBinding
         return $this->ui_factory
             ->table()
             ->ordering(
+                $this,
+                $here_uri,
                 $this->translator->translate('groups'),
                 [
                     self::COLUMN_TITLE => $this->ui_factory->table()->column()->link(
@@ -109,8 +111,6 @@ class GroupsTable implements OrderingBinding
                         $this->translator->translate('items', 'group')
                     ),
                 ],
-                $this,
-                $here_uri
             )
             ->withRequest($this->request)
             ->withActions(

--- a/components/ILIAS/Glossary/Table/DownloadListTable.php
+++ b/components/ILIAS/Glossary/Table/DownloadListTable.php
@@ -58,7 +58,7 @@ class DownloadListTable
         $data_retrieval = $this->getDataRetrieval();
 
         $table = $this->ui_fac->table()
-                              ->data($this->lng->txt("download"), $columns, $data_retrieval)
+                              ->data($data_retrieval, $this->lng->txt("download"), $columns)
                               ->withId(
                                   self::class . "_" .
                                   $this->glossary->getRefId()

--- a/components/ILIAS/Glossary/Table/class.GlossaryAutoLinkTable.php
+++ b/components/ILIAS/Glossary/Table/class.GlossaryAutoLinkTable.php
@@ -88,7 +88,7 @@ class GlossaryAutoLinkTable
         }
 
         $table = $this->ui_fac->table()
-                              ->data($this->lng->txt("cont_auto_glossaries"), $columns, $data_retrieval)
+                              ->data($data_retrieval, $this->lng->txt("cont_auto_glossaries"), $columns)
                               ->withId(
                                   self::class . "_" .
                                   $this->glossary->getRefId()

--- a/components/ILIAS/Glossary/Table/class.GlossaryForeignTermTable.php
+++ b/components/ILIAS/Glossary/Table/class.GlossaryForeignTermTable.php
@@ -58,9 +58,9 @@ class GlossaryForeignTermTable
 
         $table = $this->ui_fac->table()
                               ->data(
+                                  $data_retrieval,
                                   $this->foreign_glossary->getTitle() . ": " .$this->lng->txt("glo_select_terms"),
                                   $columns,
-                                  $data_retrieval
                               )
                               ->withId(
                                   self::class . "_" .

--- a/components/ILIAS/Glossary/Table/class.TermDefinitionBulkCreationTable.php
+++ b/components/ILIAS/Glossary/Table/class.TermDefinitionBulkCreationTable.php
@@ -53,7 +53,7 @@ class TermDefinitionBulkCreationTable
         $data_retrieval = $this->getDataRetrieval();
 
         $table = $this->ui_fac->table()
-                              ->data($this->lng->txt("glo_term_definition_pairs"), $columns, $data_retrieval)
+                              ->data($data_retrieval, $this->lng->txt("glo_term_definition_pairs"), $columns)
                               ->withId(
                                   self::class . "_" .
                                   $this->glossary->getRefId()

--- a/components/ILIAS/Glossary/Table/class.TermListTable.php
+++ b/components/ILIAS/Glossary/Table/class.TermListTable.php
@@ -134,7 +134,7 @@ class TermListTable
         }
 
         $table = $this->ui_fac->table()
-                              ->data($this->lng->txt("cont_terms"), $columns, $data_retrieval)
+                              ->data($data_retrieval, $this->lng->txt("cont_terms"), $columns)
                               ->withId(
                                   self::class . "_" .
                                   $this->glossary->getRefId()

--- a/components/ILIAS/Glossary/Table/class.TermUsagesTable.php
+++ b/components/ILIAS/Glossary/Table/class.TermUsagesTable.php
@@ -55,7 +55,7 @@ class TermUsagesTable
 
         $glo_id = \ilGlossaryTerm::_lookGlossaryID($this->term_id);
         $table = $this->ui_fac->table()
-                              ->data($this->lng->txt("cont_usage"), $columns, $data_retrieval)
+                              ->data($data_retrieval, $this->lng->txt("cont_usage"), $columns)
                               ->withId(
                                   self::class . "_" .
                                   $glo_id . "_" .

--- a/components/ILIAS/LDAP/src/Server/UI/ServerTable.php
+++ b/components/ILIAS/LDAP/src/Server/UI/ServerTable.php
@@ -214,9 +214,9 @@ readonly class ServerTable implements \ILIAS\UI\Component\Table\DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('ldap_servers'),
                 $this->getColumnDefinition(),
-                $this
             )
             ->withId(self::class)
             ->withOrder(new \ILIAS\Data\Order('title', \ILIAS\Data\Order::ASC))

--- a/components/ILIAS/Language/classes/class.ilLanguageFolderTable.php
+++ b/components/ILIAS/Language/classes/class.ilLanguageFolderTable.php
@@ -67,9 +67,9 @@ class ilLanguageFolderTable implements DataTableInterface\DataRetrieval
     public function getTable(): DataTable\Data
     {
         $table = $this->ui_factory->table()->data(
+            $this,
             '',
             $this->getColums(),
-            $this
         );
         if ($this->access->checkAccess('write', '', $this->folder->getId())) {
             $table = $table->withActions($this->getActions());

--- a/components/ILIAS/Language/classes/class.ilLanguageStatisticsTable.php
+++ b/components/ILIAS/Language/classes/class.ilLanguageStatisticsTable.php
@@ -42,9 +42,9 @@ class ilLanguageStatisticsTable implements DataTableInterface\DataRetrieval
     public function getTable(): DataTable\Data
     {
         return $this->ui_factory->table()->data(
+            $this,
             '',
             $this->getColums(),
-            $this
         );
     }
 

--- a/components/ILIAS/LearningModule/Editing/OrderingRetrieval.php
+++ b/components/ILIAS/LearningModule/Editing/OrderingRetrieval.php
@@ -25,7 +25,7 @@ use ILIAS\Data\Range;
 use ILIAS\Data\Order;
 use ILIAS\UI\Component\Table\OrderingRowBuilder;
 
-class OrderingBinding implements Table\OrderingBinding
+class OrderingRetrieval implements Table\OrderingRetrieval
 {
     public function __construct(
         protected RetrievalInterface $retrieval

--- a/components/ILIAS/LearningModule/Editing/class.TableAdapterGUI.php
+++ b/components/ILIAS/LearningModule/Editing/class.TableAdapterGUI.php
@@ -273,12 +273,12 @@ class TableAdapterGUI
                     ILIAS_HTTP_PATH . '/' .
                     $this->ctrl->getLinkTarget($this->parent_gui, $this->order_cmd)
                 );
-                $table_retrieval = new OrderingBinding($this->retrieval);
+                $table_retrieval = new OrderingRetrieval($this->retrieval);
                 $this->table = $this
                     ->ui
                     ->factory()
                     ->table()
-                    ->ordering($this->title, $columns, $table_retrieval, $uri)
+                    ->ordering($table_retrieval, $uri, $this->title, $columns)
                     ->withId($this->id)
                     ->withActions($actions)
                     ->withRequest($this->http->request());
@@ -288,7 +288,7 @@ class TableAdapterGUI
                     ->ui
                     ->factory()
                     ->table()
-                    ->data($this->title, $columns, $table_retrieval)
+                    ->data($table_retrieval, $this->title, $columns)
                     ->withId($this->id)
                     ->withActions($actions)
                     ->withRequest($this->http->request());

--- a/components/ILIAS/LegalDocuments/classes/Table/DocumentTable.php
+++ b/components/ILIAS/LegalDocuments/classes/Table/DocumentTable.php
@@ -33,7 +33,7 @@ use ILIAS\LegalDocuments\Value\Criterion;
 use ILIAS\LegalDocuments\Value\Document;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Table\Action\Single;
-use ILIAS\UI\Component\Table\OrderingBinding;
+use ILIAS\UI\Component\Table\OrderingRetrieval;
 use ILIAS\UI\Component\Table\OrderingRow;
 use ILIAS\UI\Component\Table\OrderingRowBuilder;
 use ILIAS\UI\Component\Table\Action\Multi;
@@ -45,7 +45,7 @@ use ilObjUser;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-class DocumentTable implements OrderingBinding
+class DocumentTable implements OrderingRetrieval
 {
     public const CMD_EDIT_DOCUMENT = 'editDocument';
     public const CMD_DELETE_DOCUMENT = 'deleteDocument';
@@ -95,6 +95,8 @@ class DocumentTable implements OrderingBinding
         }
 
         $table = $uiTable->ordering(
+            $this,
+            (new URI((string) $this->request->getUri()))->withParameter('cmd', 'saveOrder'),
             $this->ui->txt('tbl_docs_title'),
             [
                 'title' => $uiTable->column()->text($this->ui->txt('tbl_docs_head_title')),
@@ -102,8 +104,6 @@ class DocumentTable implements OrderingBinding
                 'change' => $uiTable->column()->date($this->ui->txt('tbl_docs_head_last_change'), $date_format),
                 'criteria' => $uiTable->column()->text($this->ui->txt('tbl_docs_head_criteria')),
             ],
-            $this,
-            (new URI((string) $this->request->getUri()))->withParameter('cmd', 'saveOrder')
         )
             ->withId('legalDocsTable')
             ->withRequest($this->request);

--- a/components/ILIAS/Mail/classes/Attachments/MailAttachmentTableGUI.php
+++ b/components/ILIAS/Mail/classes/Attachments/MailAttachmentTableGUI.php
@@ -71,9 +71,9 @@ class MailAttachmentTableGUI implements \ILIAS\UI\Component\Table\DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('attachment'),
                 $this->getColumnDefinition(),
-                $this
             )
             ->withId(self::class . '_' . $this->mode->name)
             ->withOrder(new \ILIAS\Data\Order('filename', \ILIAS\Data\Order::ASC))

--- a/components/ILIAS/Mail/classes/Folder/MailFolderTableUI.php
+++ b/components/ILIAS/Mail/classes/Folder/MailFolderTableUI.php
@@ -91,9 +91,9 @@ class MailFolderTableUI implements \ILIAS\UI\Component\Table\DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->getTableTitle(),
                 $this->getColumnDefinition(),
-                $this
             )
             ->withId(self::class)
             ->withOrder(new Order('date', Order::DESC))

--- a/components/ILIAS/MediaCast/classes/class.ilMediaCastManageTableGUI.php
+++ b/components/ILIAS/MediaCast/classes/class.ilMediaCastManageTableGUI.php
@@ -239,7 +239,7 @@ class ilMediaCastManageTableGUI implements Table\DataRetrieval
         )->withAsync();
 
         $table = $f->table()
-                   ->data($this->lng->txt("mcst_items"), $this->getColumns(), $this)
+                   ->data($this, $this->lng->txt("mcst_items"), $this->getColumns())
                    ->withActions($actions)
                    ->withRequest($this->http->request());
         return $table;

--- a/components/ILIAS/MetaData/classes/Settings/Vocabularies/class.ilMDVocabulariesGUI.php
+++ b/components/ILIAS/MetaData/classes/Settings/Vocabularies/class.ilMDVocabulariesGUI.php
@@ -404,13 +404,13 @@ class ilMDVocabulariesGUI
         )->withAsync(true);
 
         return $this->ui_factory->table()->data(
-            $this->lng->txt('md_vocab_table_title'),
-            $columns,
             new DataRetrieval(
                 $this->vocab_manager,
                 $this->presentation,
                 $this->ui_factory
-            )
+            ),
+            $this->lng->txt('md_vocab_table_title'),
+            $columns,
         )->withActions($actions)->withRequest($this->http->request());
     }
 

--- a/components/ILIAS/OrgUnit/classes/Positions/UserAssignment/class.ilOrgUnitUserAssignmentGUI.php
+++ b/components/ILIAS/OrgUnit/classes/Positions/UserAssignment/class.ilOrgUnitUserAssignmentGUI.php
@@ -272,7 +272,7 @@ class ilOrgUnitUserAssignmentGUI extends BaseCommands
         );
 
         return $this->ui_factory->table()
-            ->data($position->getTitle(), $columns, $this->assignmentRepo)
+            ->data($this->assignmentRepo, $position->getTitle(), $columns)
             ->withId(implode('.', ['orgustaff',$this->getParentRefId(),$position->getId()]))
             ->withActions($actions)
             ->withAdditionalParameters([

--- a/components/ILIAS/OrgUnit/classes/Positions/class.ilOrgUnitPositionGUI.php
+++ b/components/ILIAS/OrgUnit/classes/Positions/class.ilOrgUnitPositionGUI.php
@@ -377,7 +377,7 @@ class ilOrgUnitPositionGUI extends BaseCommands
         ];
 
         return $this->ui_factory->table()
-            ->data('', $columns, $this->positionRepo)
+            ->data($this->positionRepo, '', $columns)
             ->withId('orgu_positions')
             ->withActions($actions);
     }

--- a/components/ILIAS/OrgUnit/classes/Types/class.ilOrgUnitTypeGUI.php
+++ b/components/ILIAS/OrgUnit/classes/Types/class.ilOrgUnitTypeGUI.php
@@ -425,7 +425,7 @@ class ilOrgUnitTypeGUI
         ];
 
         return $this->ui_factory->table()
-            ->data('', $columns, $this->getTableDataRetrieval())
+            ->data($this->getTableDataRetrieval(), '', $columns)
             ->withId('orgu_types')
             ->withActions($actions);
     }

--- a/components/ILIAS/ResourceStorage/classes/Collections/View/RequestToDataTable.php
+++ b/components/ILIAS/ResourceStorage/classes/Collections/View/RequestToDataTable.php
@@ -79,6 +79,7 @@ class RequestToDataTable implements RequestToComponents, DataRetrieval
     protected function buildTable(): Data
     {
         return $this->ui_factory->table()->data(
+            $this,
             '', // $this->request->getTitle() we already have the title in the panel
             [
                 self::F_TITLE => $this->ui_factory->table()->column()->text(
@@ -95,7 +96,6 @@ class RequestToDataTable implements RequestToComponents, DataRetrieval
                     $this->language->txt(self::F_TYPE)
                 )->withIsSortable(false),
             ],
-            $this
         )->withRequest(
             $this->http->request()
         )->withActions(

--- a/components/ILIAS/ResourceStorage/classes/Container/View/RequestToDataTable.php
+++ b/components/ILIAS/ResourceStorage/classes/Container/View/RequestToDataTable.php
@@ -165,6 +165,7 @@ class RequestToDataTable implements RequestToComponents, DataRetrieval
     protected function buildTable(): Data
     {
         return $this->ui_factory->table()->data(
+            $this,
             $this->request->getTitle(), // we already have the title in the panel
             [
                 self::F_TITLE => $this->ui_factory->table()->column()->text(
@@ -181,7 +182,6 @@ class RequestToDataTable implements RequestToComponents, DataRetrieval
                     $this->language->txt(self::F_TYPE)
                 )->withIsSortable(true),
             ],
-            $this
         )->withRequest(
             $this->http->request()
         )->withActions(

--- a/components/ILIAS/Saml/classes/class.ilSamlIdpTableGUI.php
+++ b/components/ILIAS/Saml/classes/class.ilSamlIdpTableGUI.php
@@ -60,9 +60,9 @@ final class ilSamlIdpTableGUI implements \ILIAS\UI\Component\Table\DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('auth_saml_idps'),
                 $this->getColumnDefinition(),
-                $this
             )
             ->withId(self::class)
             ->withOrder(new \ILIAS\Data\Order('title', \ILIAS\Data\Order::ASC))

--- a/components/ILIAS/Skill/Table/classes/class.AssignMaterialsTable.php
+++ b/components/ILIAS/Skill/Table/classes/class.AssignMaterialsTable.php
@@ -80,7 +80,7 @@ class AssignMaterialsTable
 
         $title = $this->node_manager->getWrittenPath($this->basic_skill_id);
         $table = $this->ui_fac->table()
-                              ->data($title, $columns, $data_retrieval)
+                              ->data($data_retrieval, $title, $columns)
                               ->withId(
                                   self::class . "_" .
                                   $this->top_skill_id . "_" .

--- a/components/ILIAS/Skill/Table/classes/class.AssignedObjectsTable.php
+++ b/components/ILIAS/Skill/Table/classes/class.AssignedObjectsTable.php
@@ -68,7 +68,7 @@ class AssignedObjectsTable
         $data_retrieval = $this->getDataRetrieval();
 
         $table = $this->ui_fac->table()
-                              ->data($this->lng->txt("skmg_assigned_objects"), $columns, $data_retrieval)
+                              ->data($data_retrieval, $this->lng->txt("skmg_assigned_objects"), $columns)
                               ->withId(
                                   self::class . "_" .
                                   $this->parent_obj::class . "_" .

--- a/components/ILIAS/Skill/Table/classes/class.LevelResourcesTable.php
+++ b/components/ILIAS/Skill/Table/classes/class.LevelResourcesTable.php
@@ -128,7 +128,7 @@ class LevelResourcesTable
         }
 
         $table = $this->ui_fac->table()
-                              ->data($this->lng->txt("skmg_suggested_resources"), $columns, $data_retrieval)
+                              ->data($data_retrieval, $this->lng->txt("skmg_suggested_resources"), $columns)
                               ->withId(
                                   self::class . "_" .
                                   $this->base_skill_id . "_" .

--- a/components/ILIAS/Skill/Table/classes/class.ProfileTable.php
+++ b/components/ILIAS/Skill/Table/classes/class.ProfileTable.php
@@ -109,7 +109,7 @@ class ProfileTable
         }
 
         $table = $this->ui_fac->table()
-                              ->data($this->lng->txt("skmg_skill_profiles"), $columns, $data_retrieval)
+                              ->data($data_retrieval, $this->lng->txt("skmg_skill_profiles"), $columns)
                               ->withId(
                                   self::class . "_" .
                                   $this->skill_tree_id

--- a/components/ILIAS/Skill/Table/classes/class.ProfileUserAssignmentTable.php
+++ b/components/ILIAS/Skill/Table/classes/class.ProfileUserAssignmentTable.php
@@ -107,7 +107,7 @@ class ProfileUserAssignmentTable
         }
 
         $table = $this->ui_fac->table()
-                              ->data($this->lng->txt("skmg_assigned_users"), $columns, $data_retrieval)
+                              ->data($data_retrieval, $this->lng->txt("skmg_assigned_users"), $columns)
                               ->withId(
                                   self::class . "_" .
                                   $this->profile->getId()

--- a/components/ILIAS/Skill/Table/classes/class.TreeTable.php
+++ b/components/ILIAS/Skill/Table/classes/class.TreeTable.php
@@ -64,7 +64,7 @@ class TreeTable
         $data_retrieval = $this->getDataRetrieval();
 
         $table = $this->ui_fac->table()
-                              ->data($this->lng->txt("skmg_skill_trees"), $columns, $data_retrieval)
+                              ->data($data_retrieval, $this->lng->txt("skmg_skill_trees"), $columns)
                               ->withId(self::class)
                               ->withActions($actions)
                               ->withRequest($this->request);

--- a/components/ILIAS/StudyProgramme/classes/model/Types/class.ilStudyProgrammeTypeDBRepository.php
+++ b/components/ILIAS/StudyProgramme/classes/model/Types/class.ilStudyProgrammeTypeDBRepository.php
@@ -709,9 +709,9 @@ class ilStudyProgrammeTypeDBRepository implements ilStudyProgrammeTypeRepository
     public function getTable(): DataTable\Data
     {
         return $this->ui_factory->table()->data(
+            $this,
             $this->lng->txt('prg_subtypes'),
             $this->getColums(),
-            $this
         );
     }
 

--- a/components/ILIAS/Test/classes/class.ilTestArchiver.php
+++ b/components/ILIAS/Test/classes/class.ilTestArchiver.php
@@ -598,9 +598,9 @@ class ilTestArchiver
         );
 
         $table = $this->ui_factory->table()->data(
+            $this->getDataRetrievalForAttemptOverviewTable($result_array),
             $test_result_title_builder->getPassDetailsHeaderLabel($attempt + 1),
             $this->getColumnsForAttemptOverviewTable($test_obj->isOfferingQuestionHintsEnabled()),
-            $this->getDataRetrievalForAttemptOverviewTable($result_array)
         )->withRequest($this->request);
         $template->setVariable(
             'PASS_DETAILS',

--- a/components/ILIAS/Test/classes/class.ilTestToplistGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestToplistGUI.php
@@ -136,7 +136,7 @@ class ilTestToplistGUI
             $order_by
         );
         return $this->ui_factory->table()
-            ->data($title, $table->getColumns(), $table)
+            ->data($table, $title, $table->getColumns())
             ->withRequest($this->http_state->request());
     }
 

--- a/components/ILIAS/Test/src/Logging/LogTable.php
+++ b/components/ILIAS/Test/src/Logging/LogTable.php
@@ -100,9 +100,9 @@ class LogTable implements Table\DataRetrieval
     public function getTable(): Table\Data
     {
         return $this->ui_factory->table()->data(
+            $this,
             $this->lng->txt('history'),
             $this->getColums(),
-            $this
         )->withActions($this->getActions());
     }
 

--- a/components/ILIAS/Test/src/Participants/ParticipantTable.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTable.php
@@ -319,9 +319,9 @@ class ParticipantTable implements DataRetrieval
         return $this->ui_factory
             ->table()
             ->data(
+                $this,
                 $this->lng->txt('list_of_participants'),
                 $this->getColumns(),
-                $this
             )
             ->withId(self::ID)
             ->withRequest($request)

--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsBrowserTable.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsBrowserTable.php
@@ -57,9 +57,9 @@ class QuestionsBrowserTable implements DataRetrieval
     public function getComponent(ServerRequestInterface $request, ?array $filter): Data
     {
         return $this->ui_factory->table()->data(
+            $this,
             $this->lng->txt('list_of_questions'),
             $this->getColumns(),
-            $this
         )->withId($this->table_id)
         ->withActions($this->getActions())
         ->withRequest($request)

--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsOfAttemptTable.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsOfAttemptTable.php
@@ -102,9 +102,9 @@ class QuestionsOfAttemptTable implements DataRetrieval
         }
 
         $components[] = $this->ui_factory->table()->data(
+            $this,
             $this->lng->txt('question_summary'),
             $this->getColumns(),
-            $this
         )
             ->withRequest($this->http->request())
             ->withId('listofquestions');

--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsTable.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsTable.php
@@ -25,12 +25,12 @@ use ILIAS\Test\Questions\Properties\Repository as TestQuestionsRepository;
 use ILIAS\Test\Questions\Properties\Properties as TestQuestionProperties;
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Component\Table\Ordering;
-use ILIAS\UI\Component\Table\OrderingBinding;
+use ILIAS\UI\Component\Table\OrderingRetrieval;
 use ILIAS\UI\Component\Table\OrderingRowBuilder;
 use ILIAS\Language\Language;
 use Psr\Http\Message\ServerRequestInterface;
 
-class QuestionsTable implements OrderingBinding
+class QuestionsTable implements OrderingRetrieval
 {
     /**
      * @param array $data <string, mixed>
@@ -49,10 +49,10 @@ class QuestionsTable implements OrderingBinding
     public function getTableComponent(): Ordering
     {
         $table = $this->ui_factory->table()->ordering(
+            $this,
+            $this->table_actions->getOrderActionUrl(),
             $this->lng->txt('list_of_questions'),
             $this->getColumns(),
-            $this,
-            $this->table_actions->getOrderActionUrl()
         )
         ->withId((string) $this->test_obj->getId())
         ->withActions($this->table_actions->getActions())

--- a/components/ILIAS/Test/src/Questions/RandomQuestionSetNonAvailablePoolsTable.php
+++ b/components/ILIAS/Test/src/Questions/RandomQuestionSetNonAvailablePoolsTable.php
@@ -84,7 +84,7 @@ class RandomQuestionSetNonAvailablePoolsTable implements DataRetrieval
     public function getComponent(): DataTable
     {
         return $this->ui_factory->table()
-            ->data($this->lng->txt('tst_non_avail_pools_table'), $this->getColumns(), $this)
+            ->data($this, $this->lng->txt('tst_non_avail_pools_table'), $this->getColumns())
             ->withRequest($this->request)
             ->withActions($this->getActions())
             ->withId('tst_non_avail_pools_table');

--- a/components/ILIAS/Test/src/Questions/RandomQuestionSetSourcePoolDefinitionListTable.php
+++ b/components/ILIAS/Test/src/Questions/RandomQuestionSetSourcePoolDefinitionListTable.php
@@ -24,7 +24,7 @@ use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\URI;
 use ILIAS\Test\Utilities\TitleColumnsBuilder;
 use ILIAS\Test\RequestDataCollector;
-use ILIAS\UI\Component\Table\OrderingBinding;
+use ILIAS\UI\Component\Table\OrderingRetrieval;
 use ILIAS\UI\Component\Table\OrderingRowBuilder;
 use ILIAS\UI\Component\Table\Ordering as OrderingTable;
 use ILIAS\UI\Factory as UIFactory;
@@ -34,7 +34,7 @@ use ilTestRandomQuestionSetSourcePoolDefinitionList as PoolDefinitionList;
 use ilTestRandomQuestionSetConfigGUI as ConfigGUI;
 use Psr\Http\Message\ServerRequestInterface;
 
-class RandomQuestionSetSourcePoolDefinitionListTable implements OrderingBinding
+class RandomQuestionSetSourcePoolDefinitionListTable implements OrderingRetrieval
 {
     private URI $target;
     private URLBuilder $url_builder;
@@ -111,10 +111,10 @@ class RandomQuestionSetSourcePoolDefinitionListTable implements OrderingBinding
     {
         return $this->ui_factory->table()
             ->ordering(
+                $this,
+                $this->getTarget(ConfigGUI::CMD_SAVE_SRC_POOL_DEF_LIST),
                 $this->lng->txt('tst_src_quest_pool_def_list_table'),
                 $this->getColumns(),
-                $this,
-                $this->getTarget(ConfigGUI::CMD_SAVE_SRC_POOL_DEF_LIST)
             )
             ->withActions($this->getActions())
             ->withRequest($this->request)

--- a/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTable.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTable.php
@@ -64,6 +64,7 @@ class ScoringByQuestionTable
 
         $f = $this->ui_factory->table();
         $table = $f->data(
+            $data_retrieval->withFilterData($ui_service->filter()->getData($filter) ?? []),
             $title,
             [
                 self::COLUMN_NAME => $f->column()->text($this->lng->txt('name'))->withIsSortable(true),
@@ -87,7 +88,6 @@ class ScoringByQuestionTable
                 self::COLUMN_FINALIZED_BY => $f->column()->text($this->lng->txt('finalized_by'))->withIsSortable(true),
                 self::COLUMN_FINALIZED_ON => $f->column()->date($this->lng->txt('finalized_on'), $date_format)->withIsSortable(true)
             ],
-            $data_retrieval->withFilterData($ui_service->filter()->getData($filter) ?? [])
         )->withActions(
             [
                 self::ACTION_SCORING => $f->action()->single(

--- a/components/ILIAS/Test/src/Scoring/Marks/MarkSchemaTable.php
+++ b/components/ILIAS/Test/src/Scoring/Marks/MarkSchemaTable.php
@@ -50,6 +50,7 @@ class MarkSchemaTable implements DataRetrieval
         $f = $this->ui_factory->table();
 
         $table = $f->data(
+            $this,
             $this->lng->txt('mark_schema'),
             [
                 'name' => $f->column()->text($this->lng->txt('tst_mark_short_form')),
@@ -69,7 +70,6 @@ class MarkSchemaTable implements DataRetrieval
                     )
                 )
             ],
-            $this
         );
 
         if (!$this->marks_editable) {

--- a/components/ILIAS/TestQuestionPool/src/Questions/Presentation/QuestionTable.php
+++ b/components/ILIAS/TestQuestionPool/src/Questions/Presentation/QuestionTable.php
@@ -61,9 +61,9 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
     public function getTable(): Table\Data
     {
         return $this->ui_factory->table()->data(
+            $this,
             $this->lng->txt('questions'),
             $this->getColums(),
-            $this
         )
         ->withActions($this->getActions())
         ->withId('qpt' . $this->parent_obj_id . '_' . $this->request_ref_id);

--- a/components/ILIAS/UI/src/Component/Table/Factory.php
+++ b/components/ILIAS/UI/src/Component/Table/Factory.php
@@ -183,14 +183,15 @@ interface Factory
      *         initially set to "-1". When focused, this changes to "0".
      *
      * ---
-     * @param string     $title
-     * @param array<string, Column\Column>     $columns
      * @return \ILIAS\UI\Component\Table\Data
+     * @param DataRetrieval                $data_retrieval
+     * @param string                       $title
+     * @param array<string, Column\Column> $columns
      */
     public function data(
+        DataRetrieval $data_retrieval,
         string $title,
         array $columns,
-        DataRetrieval $data_retrieval
     ): Data;
 
 
@@ -294,14 +295,16 @@ interface Factory
      *         identify and distinguish records.
      *
      * ---
-     * @param string     $title
-     * @param array<string, Column\Column>     $columns
+     * @param OrderingRetrieval            $ordering_retrieval
+     * @param URI                          $target_url
+     * @param string                       $title
+     * @param array<string, Column\Column> $columns
      * @return \ILIAS\UI\Component\Table\Ordering
      */
     public function ordering(
+        OrderingRetrieval $ordering_retrieval,
+        URI $target_url,
         string $title,
         array $columns,
-        OrderingBinding $retrieval,
-        URI $target_url
     ): Ordering;
 }

--- a/components/ILIAS/UI/src/Component/Table/OrderingRetrieval.php
+++ b/components/ILIAS/UI/src/Component/Table/OrderingRetrieval.php
@@ -22,7 +22,7 @@ namespace ILIAS\UI\Component\Table;
 
 use Generator;
 
-interface OrderingBinding
+interface OrderingRetrieval
 {
     /**
      * This is called by the (ordering-)table to retrieve rows;

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Factory.php
@@ -49,9 +49,9 @@ class Factory implements T\Factory
     }
 
     public function data(
+        T\DataRetrieval $data_retrieval,
         string $title,
         array $columns,
-        T\DataRetrieval $data_retrieval
     ): Data {
         return new Data(
             $this->signal_generator,
@@ -77,10 +77,10 @@ class Factory implements T\Factory
     }
 
     public function ordering(
+        T\OrderingRetrieval $ordering_retrieval,
+        URI $target_url,
         string $title,
         array $columns,
-        T\OrderingBinding $binding,
-        URI $target_url
     ): Ordering {
         return new Ordering(
             $this->signal_generator,
@@ -89,7 +89,7 @@ class Factory implements T\Factory
             $this->ordering_row_builder,
             $title,
             $columns,
-            $binding,
+            $ordering_retrieval,
             $target_url,
             $this->storage
         );

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Ordering.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Ordering.php
@@ -42,7 +42,7 @@ class Ordering extends AbstractTable implements T\Ordering
         protected OrderingRowBuilder $row_builder,
         string $title,
         array $columns,
-        protected T\OrderingBinding $binding,
+        protected T\OrderingRetrieval $binding,
         protected URI $target_url,
         \ArrayAccess $storage
     ) {
@@ -65,7 +65,7 @@ class Ordering extends AbstractTable implements T\Ordering
             ->withVisibleColumns($this->getVisibleColumns());
     }
 
-    public function getDataBinding(): T\OrderingBinding
+    public function getDataBinding(): T\OrderingRetrieval
     {
         return $this->binding;
     }

--- a/components/ILIAS/UI/src/examples/Table/Action/Multi/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Action/Multi/base.php
@@ -129,5 +129,5 @@ function getExampleTable($f)
             return 6;
         }
     };
-    return $f->table()->data('a data table with actions', $columns, $data_retrieval);
+    return $f->table()->data($data_retrieval, 'a data table with actions', $columns);
 }

--- a/components/ILIAS/UI/src/examples/Table/Action/Single/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Action/Single/base.php
@@ -127,5 +127,5 @@ function getExampleTable($f)
             return 6;
         }
     };
-    return $f->table()->data('a data table with actions', $columns, $data_retrieval);
+    return $f->table()->data($data_retrieval, 'a data table with actions', $columns);
 }

--- a/components/ILIAS/UI/src/examples/Table/Action/Standard/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Action/Standard/base.php
@@ -133,5 +133,5 @@ function getExampleTable($f)
             return 6;
         }
     };
-    return $f->table()->data('a data table with actions', $columns, $data_retrieval);
+    return $f->table()->data($data_retrieval, 'a data table with actions', $columns);
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/Boolean/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/Boolean/base.php
@@ -90,7 +90,7 @@ function base()
         }
     };
 
-    $table = $f->table()->data('Boolean Columns', $columns, $data_retrieval)
+    $table = $f->table()->data($data_retrieval, 'Boolean Columns', $columns)
         ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/Date/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/Date/base.php
@@ -69,7 +69,7 @@ function base()
         }
     };
 
-    $table = $f->table()->data('Date Columns', $columns, $data_retrieval)
+    $table = $f->table()->data($data_retrieval, 'Date Columns', $columns)
         ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/EMail/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/EMail/base.php
@@ -69,7 +69,7 @@ function base()
         }
     };
 
-    $table = $f->table()->data('eMail Columns', $columns, $data_retrieval)
+    $table = $f->table()->data($data_retrieval, 'eMail Columns', $columns)
         ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/Link/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/Link/base.php
@@ -77,7 +77,7 @@ function base(): string
         }
     };
 
-    $table = $f->table()->data('Link Columns', $columns, $data_retrieval)
+    $table = $f->table()->data($data_retrieval, 'Link Columns', $columns)
         ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/LinkListing/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/LinkListing/base.php
@@ -78,7 +78,7 @@ function base(): string
         }
     };
 
-    $table = $f->table()->data('Link List Columns', $columns, $data_retrieval)
+    $table = $f->table()->data($data_retrieval, 'Link List Columns', $columns)
                ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/Number/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/Number/base.php
@@ -83,7 +83,7 @@ function base()
         }
     };
 
-    $table = $f->table()->data('Number Columns', $columns, $data_retrieval)
+    $table = $f->table()->data($data_retrieval, 'Number Columns', $columns)
         ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/Status/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/Status/base.php
@@ -72,7 +72,7 @@ function base()
         }
     };
 
-    $table = $f->table()->data('Status Columns', $columns, $data_retrieval)
+    $table = $f->table()->data($data_retrieval, 'Status Columns', $columns)
         ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/StatusIcon/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/StatusIcon/base.php
@@ -80,7 +80,7 @@ function base()
         }
     };
 
-    $table = $f->table()->data('StatusIcons Columns', $columns, $data_retrieval)
+    $table = $f->table()->data($data_retrieval, 'StatusIcons Columns', $columns)
         ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/Text/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/Text/base.php
@@ -76,7 +76,7 @@ function base()
         }
     };
 
-    $table = $f->table()->data('Text Columns', $columns, $data_retrieval)
+    $table = $f->table()->data($data_retrieval, 'Text Columns', $columns)
         ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/TimeSpan/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/TimeSpan/base.php
@@ -70,7 +70,7 @@ function base()
         }
     };
 
-    $table = $f->table()->data('TimeSpan Columns', $columns, $data_retrieval)
+    $table = $f->table()->data($data_retrieval, 'TimeSpan Columns', $columns)
         ->withRequest($DIC->http()->request());
     return $r->render($table);
 }

--- a/components/ILIAS/UI/src/examples/Table/Data/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Data/base.php
@@ -246,7 +246,7 @@ function base()
      * with an ID for the table, parameters will be stored throughout url changes
      */
     $table = $f->table()
-            ->data('a data table', $columns, $data_retrieval)
+            ->data($data_retrieval, 'a data table', $columns)
             ->withId('example_base')
             ->withActions($actions)
 

--- a/components/ILIAS/UI/src/examples/Table/Data/repo_implementation.php
+++ b/components/ILIAS/UI/src/examples/Table/Data/repo_implementation.php
@@ -72,9 +72,9 @@ class DataTableDemoRepo implements I\DataRetrieval
     public function getTableForRepresentation(): \ILIAS\UI\Implementation\Component\Table\Data
     {
         return $this->ui_factory->table()->data(
+            $this,
             'a data table from a repository',
             $this->getColumsForRepresentation(),
-            $this
         );
     }
 

--- a/components/ILIAS/UI/src/examples/Table/Data/without_data.php
+++ b/components/ILIAS/UI/src/examples/Table/Data/without_data.php
@@ -63,6 +63,7 @@ function without_data(): string
     };
 
     $table = $factory->table()->data(
+        $empty_retrieval,
         'Empty Data Table',
         [
             'col1' => $factory->table()->column()->text('Column 1')
@@ -70,7 +71,6 @@ function without_data(): string
             'col2' => $factory->table()->column()->number('Column 2')
                 ->withIsSortable(false),
         ],
-        $empty_retrieval
     );
 
     return $renderer->render($table->withRequest($request));

--- a/components/ILIAS/UI/src/examples/Table/Ordering/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Ordering/base.php
@@ -94,7 +94,7 @@ function base()
     /**
      * This is the data binding: retrieve rows and write back the order of records.
      */
-    $data_retrieval = new class ($f, $r) implements I\OrderingBinding {
+    $data_retrieval = new class ($f, $r) implements I\OrderingRetrieval {
         protected array $records;
 
         public function __construct(
@@ -158,7 +158,7 @@ function base()
     };
 
     $target = (new URI((string) $request->getUri()))->withParameter('ordering_example', 1);
-    $table = $f->table()->ordering('ordering table', $columns, $data_retrieval, $target)
+    $table = $f->table()->ordering($data_retrieval, $target, 'ordering table', $columns)
         ->withActions($actions)
         ->withRequest($request);
 

--- a/components/ILIAS/UI/src/examples/Table/Ordering/disabled.php
+++ b/components/ILIAS/UI/src/examples/Table/Ordering/disabled.php
@@ -56,7 +56,7 @@ function disabled()
             ->withHighlight(true)
     ];
 
-    $data_retrieval = new class ($f, $r) implements I\OrderingBinding {
+    $data_retrieval = new class ($f, $r) implements I\OrderingRetrieval {
         protected array $records;
 
         public function __construct(
@@ -87,7 +87,7 @@ function disabled()
      * Disable the ordering (e.g. due to missing permissions)
      */
     $target = (new URI((string) $request->getUri()));
-    $table = $f->table()->ordering('ordering table with disabled ordering', $columns, $data_retrieval, $target)
+    $table = $f->table()->ordering($data_retrieval, $target, 'ordering table with disabled ordering', $columns)
         ->withOrderingDisabled(true)
         ->withRequest($request);
 

--- a/components/ILIAS/UI/src/examples/Table/Ordering/external.php
+++ b/components/ILIAS/UI/src/examples/Table/Ordering/external.php
@@ -64,7 +64,7 @@ function external()
             ->withHighlight(true)
     ];
 
-    $data_retrieval = new class ($f, $r) implements I\OrderingBinding {
+    $data_retrieval = new class ($f, $r) implements I\OrderingRetrieval {
         protected array $records;
 
         public function __construct(
@@ -114,7 +114,7 @@ function external()
      * Alter the URL the tables posts its positions to (here: just add a parameter).
      */
     $target = (new URI((string) $request->getUri()))->withParameter('ordering_example', 3);
-    $table = $f->table()->ordering('sort the letters', $columns, $data_retrieval, $target)
+    $table = $f->table()->ordering($data_retrieval, $target, 'sort the letters', $columns)
         ->withRequest($request);
 
     /**

--- a/components/ILIAS/UI/tests/Component/Table/DataRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/DataRendererTest.php
@@ -261,7 +261,7 @@ class DataRendererTest extends TableTestBase
         ];
         $sortation_signal = new I\Signal('sort_header_signal_id');
         $sortation_signal->addOption('value', 'f1:ASC');
-        $table = $this->getUIFactory()->table()->data('', $columns, $data)
+        $table = $this->getUIFactory()->table()->data($data, '', $columns)
             ->withRequest($this->getDummyRequest());
         $renderer->p_renderTableHeader($this->getDefaultRenderer(), $table, $tpl, $sortation_signal);
 
@@ -343,7 +343,7 @@ EOT;
 
         $sortation_signal = null;
 
-        $table = $this->getUIFactory()->table()->data('', $columns, $data)
+        $table = $this->getUIFactory()->table()->data($data, '', $columns)
             ->withRequest($this->getDummyRequest());
         $renderer->p_renderTableHeader($this->getDefaultRenderer(), $table, $tpl, $sortation_signal);
         $actual = $this->brutallyTrimHTML($tpl->get());
@@ -423,7 +423,7 @@ EOT;
 
         $sortation_signal = null;
 
-        $table = $this->getUIFactory()->table()->data('', $columns, $data)
+        $table = $this->getUIFactory()->table()->data($data, '', $columns)
             ->withActions($actions)
             ->withRequest($this->getDummyRequest());
         $renderer->p_renderActionsHeader($this->getDefaultRenderer(), $table, $tpl);
@@ -551,7 +551,7 @@ EOT;
             'f5' => $this->getUIFactory()->table()->column()->text('f5'),
         ];
 
-        $table = $this->getTableFactory()->data('', $columns, $data)
+        $table = $this->getTableFactory()->data($data, '', $columns)
             ->withRequest($this->getDummyRequest());
 
         $html = $this->getDefaultRenderer()->render($table);

--- a/components/ILIAS/UI/tests/Component/Table/DataTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/DataTest.php
@@ -72,7 +72,7 @@ class DataTest extends TableTestBase
     {
         $data = $this->getDataRetrieval();
         $cols = ['f0' => $this->getTableFactory()->column()->text("col1")];
-        $table = $this->getTableFactory()->data('title', $cols, $data);
+        $table = $this->getTableFactory()->data($data, 'title', $cols);
         $this->assertInstanceOf(Order::class, $table->getOrder());
         $this->assertInstanceOf(Range::class, $table->getRange());
         $this->assertInstanceOf(I\Signal::class, $table->getAsyncActionSignal());
@@ -88,7 +88,7 @@ class DataTest extends TableTestBase
         $this->expectException(\InvalidArgumentException::class);
         $data = $this->getDataRetrieval();
         $cols = ['f0' => "col1"];
-        $table = $this->getTableFactory()->data('title', $cols, $data);
+        $table = $this->getTableFactory()->data($data, 'title', $cols);
     }
 
     public function testDataTableConstructionWithoutColumns(): void
@@ -96,7 +96,7 @@ class DataTest extends TableTestBase
         $this->expectException(\InvalidArgumentException::class);
         $data = $this->getDataRetrieval();
         $cols = [];
-        $table = $this->getTableFactory()->data('title', $cols, $data);
+        $table = $this->getTableFactory()->data($data, 'title', $cols);
     }
 
     public function testDataTableColumns(): void
@@ -106,7 +106,7 @@ class DataTest extends TableTestBase
             'f0' => $f->text("col1"),
             'f1' => $f->text("col2")
         ];
-        $table = $this->getTableFactory()->data('title', $cols, $this->getDataRetrieval());
+        $table = $this->getTableFactory()->data($this->getDataRetrieval(), 'title', $cols);
 
         $this->assertEquals(2, $table->getColumnCount());
         $check = [
@@ -130,7 +130,7 @@ class DataTest extends TableTestBase
             $f->standard('act0', $builder, $token)
         ];
         $cols = ['f0' => $this->getTableFactory()->column()->text("col1")];
-        $table = $this->getTableFactory()->data('title', $cols, $this->getDataRetrieval())
+        $table = $this->getTableFactory()->data($this->getDataRetrieval(), 'title', $cols)
             ->withActions($actions);
 
         $this->assertEquals($actions, $table->getAllActions());
@@ -142,7 +142,7 @@ class DataTest extends TableTestBase
     {
         $data = $this->getDataRetrieval();
         $cols = ['f0' => $this->getTableFactory()->column()->text("col1")];
-        $table = $this->getTableFactory()->data('title', $cols, $data);
+        $table = $this->getTableFactory()->data($data, 'title', $cols);
         return $table;
     }
 
@@ -194,7 +194,7 @@ class DataTest extends TableTestBase
                 ->withIsOptional(true, false),
             'f2' => $this->getTableFactory()->column()->text('')
         ];
-        $table = $this->getTableFactory()->data('title', $cols, $data);
+        $table = $this->getTableFactory()->data($data, 'title', $cols);
         $this->assertEquals(3, $table->getColumnCount());
         $this->assertEquals(['f0', 'f2'], array_keys($table->getVisibleColumns()));
         $this->assertEquals(0, $table->getVisibleColumns()['f0']->getIndex());

--- a/components/ILIAS/UI/tests/Component/Table/DataViewControlsTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/DataViewControlsTest.php
@@ -63,7 +63,7 @@ class DataViewControlsTest extends TableTestBase
     protected function getTable(int $total_count, array $columns): array
     {
         $factory = $this->getTableFactory();
-        $table = $factory->data('Table', $columns, $this->getDataRetrieval($total_count));
+        $table = $factory->data($this->getDataRetrieval($total_count), 'Table', $columns);
         return $table->applyViewControls([], []);
     }
 


### PR DESCRIPTION
Hi all,

We have noticed in #7143 that the order of factory parameters for `Table\Factory::data()` and `Table\Factory::ordering()` are not aligned with the order of input fields, such as for the new (proposed) `Field\TreeMultiSelect` and `Field\TreeSelect` inputs.

This PR therefore proposes to change the order of parameters, so the `Table\*Retrieval` instance comes as first argument, not the last. This also amends all usages inside ILIAS.

Kind regards,
@thibsy 