### PR TITLE
Tracking/Forum: use KS form in lp settings

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectLP.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectLP.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,11 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\UI\Component\Input\Field\Group;
+use ILIAS\UI\Component\Input\Input;
 
 /**
  * Base class for object lp connectors
@@ -695,8 +698,13 @@ class ilObjectLP
         return false;
     }
 
-    public function initInvidualModeOptions(ilRadioGroupInputGUI $modeRadio): void
+    /**
+     * Post vars for input groups is taken from array keys.
+     * @return Group[]
+     */
+    public function initInvidualModeOptions(): array
     {
+        return [];
     }
 
     public function shouldFetchIndividualModeFromFormSubmission(): bool
@@ -704,16 +712,33 @@ class ilObjectLP
         return false;
     }
 
-    public function fetchIndividualModeFromFormSubmission(ilPropertyFormGUI $form): int
-    {
+    /**
+     * @param string $selected_group post var of the selected group
+     * @param array  $group_data data of the that group as array, as processed by the KS
+     */
+    public function fetchIndividualModeFromFormSubmission(
+        string $selected_group,
+        array $group_data
+    ): int {
         return 0;
     }
 
-    public function appendModeConfiguration(int $mode, ilRadioOption $modeElement): void
+    /**
+     * @return Input[]
+     */
+    public function appendModeConfiguration(int $mode): array
     {
+        return [];
     }
 
-    public function saveModeConfiguration(ilPropertyFormGUI $form, bool &$modeChanged): void
-    {
+    /**
+     * @param string $selected_group post var of the selected group
+     * @param array  $group_data data of the that group as array, as processed by the KS
+     */
+    public function saveModeConfiguration(
+        string $selected_group,
+        array $group_data,
+        bool &$modeChanged
+    ): void {
     }
 }


### PR DESCRIPTION
This PR moves the Learning Progress settings form in objects to KS, as part of [this feature](https://docu.ilias.de/go/wiki/wpage_7382_1357).

Tracking offers an interface that allows other components to add to the form. That interface also had to be changed accordingly, along with its usage in consumers. Currently, the only such consumer is the Forum.

Cheers, @schmitz-ilias 