### PR TITLE
T&A Fix redirect issue when accessing tests from favorites.

### DIFF
--- a/Modules/Test/classes/class.ilObjTestAccess.php
+++ b/Modules/Test/classes/class.ilObjTestAccess.php
@@ -365,7 +365,7 @@ class ilObjTestAccess extends ilObjectAccess implements ilConditionHandling
         $commands = [
             ["permission" => "write", "cmd" => "questionsTabGateway", "lang_var" => "tst_edit_questions"],
             ["permission" => "write", "cmd" => "ilObjTestSettingsMainGUI::showForm", "lang_var" => "settings"],
-            ["permission" => "read", "cmd" => "testScreen", "lang_var" => "tst_run", "default" => true],
+            ["permission" => "read", "cmd" => "ilTestScreenGUI::testScreen", "lang_var" => "tst_run", "default" => true],
             ["permission" => "tst_statistics", "cmd" => "outEvaluation", "lang_var" => "tst_statistical_evaluation"],
             ["permission" => "read", "cmd" => "userResultsGateway", "lang_var" => "tst_user_results"],
             ["permission" => "write", "cmd" => "testResultsGateway", "lang_var" => "results"],

--- a/Modules/Test/classes/class.ilObjTestListGUI.php
+++ b/Modules/Test/classes/class.ilObjTestListGUI.php
@@ -142,7 +142,7 @@ class ilObjTestListGUI extends ilObjectListGUI
     {
         $commands = parent::getCommands();
         if ($this->access->checkAccess('read', '', $this->ref_id)) {
-            $this->insertCommand($this->getCommandLink('testScreen'), $this->lng->txt('tst_start_test'));
+            $this->insertCommand($this->getCommandLink('ilTestScreenGUI::testScreen'), $this->lng->txt('tst_start_test'));
         }
         return $this->handleUserResultsCommand($commands);
     }


### PR DESCRIPTION
This PR is related to https://mantis.ilias.de/view.php?id=42858.

Contrary to the issue description, the bug is already present in ILIAS 9.
A separate PR will address the issue for ILIAS 10 and Trunk.

Best regards,
@thojou