### PR TITLE
Fix redirect issue when accessing tests from favorites

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTestAccess.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestAccess.php
@@ -364,7 +364,7 @@ class ilObjTestAccess extends ilObjectAccess implements ilConditionHandling
         $commands = [
             ["permission" => "write", "cmd" => "questionsTabGateway", "lang_var" => "tst_edit_questions"],
             ["permission" => "write", "cmd" => "ILIAS\Test\Settings\MainSettings\SettingsMainGUI::showForm", "lang_var" => "settings"],
-            ["permission" => "read", "cmd" => "testScreen", "lang_var" => "tst_run", "default" => true]
+            ["permission" => "read", "cmd" => "ILIAS\Test\Presentation\TestScreenGUI::testScreen", "lang_var" => "tst_run", "default" => true]
         ];
 
         return $commands;

--- a/components/ILIAS/Test/classes/class.ilObjTestListGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestListGUI.php
@@ -141,7 +141,7 @@ class ilObjTestListGUI extends ilObjectListGUI
         }
         $commands = parent::getCommands();
         if ($this->access->checkAccess('read', '', $this->ref_id)) {
-            $this->insertCommand($this->getCommandLink('testScreen'), $this->lng->txt('tst_start_test'));
+            $this->insertCommand($this->getCommandLink('ILIAS\Test\Presentation\TestScreenGUI::testScreen'), $this->lng->txt('tst_start_test'));
         }
         return $commands;
     }


### PR DESCRIPTION
This PR is related to Mantis Ticket https://mantis.ilias.de/view.php?id=42858.
This change addresses the issue for ILIAS 10 and later versions.

Best,
@thojou 