### PR TITLE
CSS: Small Addition to Avoid Dragging Subelements

### DIFF
--- a/templates/default/070-components/legacy/Modules/_component_test_legacy.scss
+++ b/templates/default/070-components/legacy/Modules/_component_test_legacy.scss
@@ -628,21 +628,25 @@ div.ilc_Page.readonly textarea[disabled]
     width: 100%;
 }
 
-.c-test__definition
-{
+.c-test__definition {
     border: $il-test-dropzone-border;
     background-color: $il-test-definition-bg-color;
     margin: 5px 10px 5px 0;
     padding: $il-test-matching-padding;
 }
 
-.c-test__term
-{
+.c-test__term {
     border: $il-test-dropzone-border;
     background-color: $il-test-term-bg-color;
     margin: 5px 10px 5px 0;
     padding: $il-test-matching-padding;
     cursor: move;
+}
+
+.c-test__term, .dd-item {
+    .ilc_qimg_QuestionImage {
+        pointer-events: none;
+    }
 }
 
 .draggableDisabled

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -14386,6 +14386,10 @@ div.ilc_Page.readonly textarea[disabled] {
   cursor: move;
 }
 
+.c-test__term .ilc_qimg_QuestionImage, .dd-item .ilc_qimg_QuestionImage {
+  pointer-events: none;
+}
+
 .draggableDisabled {
   background-color: #b0b0b0;
 }


### PR DESCRIPTION
Hi @Amstutz 

This is a very small improvement for draggable elements in the test and assessment. This way images in them do not get separated from their parent elements (that should be dragged).

I added two small line-brake-fixes. I thought the change was small enough, so that they wouldn't bother. I hope this is ok.

If accepted, I would kindly ask you to cherry-picked to trunk.

Thank you very much,
@kergomard