### PR TITLE
UI: 43155, fix tooltip issue for toggle buttons.

### DIFF
--- a/components/ILIAS/UI/resources/js/Core/dist/core.js
+++ b/components/ILIAS/UI/resources/js/Core/dist/core.js
@@ -70,7 +70,7 @@
      ********************************************************************
      */
 
-     /**
+    /**
      * This represents one tooltip on the page.
      */
     class Tooltip {
@@ -110,7 +110,7 @@
       #main = null;
 
       constructor(element) {
-        this.#container = element.parentElement;
+        this.#container = element.closest('.c-tooltip__container');
         this.#element = element;
         this.#document = element.ownerDocument;
         this.#window = this.#document.defaultView || this.#document.parentWindow;

--- a/components/ILIAS/UI/resources/js/Core/src/core.Tooltip.js
+++ b/components/ILIAS/UI/resources/js/Core/src/core.Tooltip.js
@@ -15,7 +15,7 @@
  ********************************************************************
  */
 
- /**
+/**
  * This represents one tooltip on the page.
  */
 class Tooltip {
@@ -55,7 +55,7 @@ class Tooltip {
   #main = null;
 
   constructor(element) {
-    this.#container = element.parentElement;
+    this.#container = element.closest('.c-tooltip__container');
     this.#element = element;
     this.#document = element.ownerDocument;
     this.#window = this.#document.defaultView || this.#document.parentWindow;

--- a/components/ILIAS/UI/tests/Client/Tooltip.test.js
+++ b/components/ILIAS/UI/tests/Client/Tooltip.test.js
@@ -14,7 +14,7 @@
  */
 
 import { describe, it } from 'node:test';
-import { strict } from 'node:assert/strict'
+import { strict } from 'node:assert/strict';
 import Tooltip from '../../resources/js/Core/src/core.Tooltip.js';
 
 describe('tooltip class exists', () => {
@@ -57,7 +57,9 @@ describe('tooltip initializes', () => {
       return `attribute-${which}`;
     },
     ownerDocument: document,
-    parentElement: container,
+    closest() {
+      return container;
+    },
   };
 
   var tooltip = {
@@ -126,7 +128,9 @@ describe('tooltip show works', () => {
       return `attribute-${which}`;
     },
     ownerDocument: document,
-    parentElement: container,
+    closest() {
+      return container;
+    },
   };
 
   var tooltip = {
@@ -146,8 +150,8 @@ describe('tooltip show works', () => {
 
     object.showTooltip();
 
-    strict.deepEqual(addEventListenerDocument[0],{ e: 'keydown', h: object.onKeyDown });
-    strict.deepEqual(addEventListenerDocument[1],{ e: 'pointerdown', h: object.onPointerDown });
+    strict.deepEqual(addEventListenerDocument[0], { e: 'keydown', h: object.onKeyDown });
+    strict.deepEqual(addEventListenerDocument[1], { e: 'pointerdown', h: object.onPointerDown });
   });
 
   it('adds visibility classes from tooltip', () => {
@@ -199,7 +203,9 @@ describe('tooltip hide works', () => {
       return `attribute-${which}`;
     },
     ownerDocument: document,
-    parentElement: container,
+    closest() {
+      return container;
+    },
   };
 
   var tooltip = {
@@ -217,8 +223,8 @@ describe('tooltip hide works', () => {
 
     object.hideTooltip();
 
-    strict.deepEqual(removeEventListener[0],{ e: 'keydown', h: object.onKeyDown });
-    strict.deepEqual(removeEventListener[1],{ e: 'pointerdown', h: object.onPointerDown });
+    strict.deepEqual(removeEventListener[0], { e: 'keydown', h: object.onKeyDown });
+    strict.deepEqual(removeEventListener[1], { e: 'pointerdown', h: object.onPointerDown });
   });
 
   it('removes visibility classes from tooltip', () => {
@@ -264,7 +270,7 @@ describe('tooltip hide works', () => {
 
     object.onKeyDown({ key: 'Strg' });
 
-    strict.equal(hideTooltipCalled, false)
+    strict.equal(hideTooltipCalled, false);
     object.hideTooltip = keep;
   });
 
@@ -299,7 +305,7 @@ describe('tooltip hide works', () => {
 
     object.onPointerDown({ target: object.tooltip, preventDefault });
 
-    strict.equal(hideTooltipCalled, false)
+    strict.equal(hideTooltipCalled, false);
     strict.equal(preventDefaultCalled, true);
     object.hideTooltip = keep;
   });
@@ -363,7 +369,9 @@ describe('tooltip is on top if there is not enough space below', () => {
       return `attribute-${which}`;
     },
     ownerDocument: document,
-    parentElement: container,
+    closest() {
+      return container;
+    },
   };
 
   let clientRect = null;
@@ -456,7 +464,9 @@ describe('tooltip moves to left or right if there is not enough space', () => {
       return `attribute-${which}`;
     },
     ownerDocument: document,
-    parentElement: container,
+    closest() {
+      return container;
+    },
   };
 
   let clientRect = null;
@@ -538,7 +548,9 @@ describe('get display rect', () => {
       return `attribute-${which}`;
     },
     ownerDocument: document,
-    parentElement: container,
+    closest() {
+      return container;
+    },
   };
 
   const clientRect = null;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43155

**NOTE:** 
The extra <div> container around label and button is corrupting the handling of core.Tooltip.js.. 
The JS adds another class to the parent div of the element (here: button). Therefore the new class was added to <div class="il-toggle-item"> instead of <div class="c-tooltip__container">. See following:

```
Regular and working:
<div class="c-tooltip__container">
	<button>...</button>
	<div class="c-tooltip c-tooltip--hidden"></div>
</div>


(Old) case and not working:
<div class="c-tooltip__container">
	<div class="il-toggle-item">
		<label>...</label>
		<button>...</button>
	<div>
	<div class="c-tooltip c-tooltip--hidden"></div>
</div>```
 ```

**UPDATE:**
In [this comment](https://github.com/ILIAS-eLearning/ILIAS/pull/8708#issuecomment-2879515852) below I explained why the changes mentioned above were reverted.
 