### PR TITLE
Init/LoginPage: Don't show login item in "MetaBar" on "index" action

### DIFF
--- a/Services/Init/classes/Provider/StartUpMetaBarProvider.php
+++ b/Services/Init/classes/Provider/StartUpMetaBarProvider.php
@@ -128,7 +128,7 @@ class StartUpMetaBarProvider extends AbstractStaticMetaBarProvider
 
     private function isUserOnLoginPage(UriInterface $uri): bool
     {
-        return preg_match('%^.*/login.php$%', $uri->getPath()) === 1;
+        return preg_match('%^.*(?:/login\.php|/)$%', $uri->getPath()) === 1;
     }
 
     private function appendUrlParameterString(string $existing_url, string $addition): string


### PR DESCRIPTION
This PR suggest to hide the "Login" item in the "MetaBar" in case the "Index" action ("/") is requested.

If approved, this PR must be picked to all maintained branches.