### PR TITLE
Change URL of Test-System

### DIFF
--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -106,7 +106,7 @@ is set to `COMPACT`.
 <a name="reference-system"></a>
 ## Reference System
 
-The ILIAS Testserver (https://test7.ilias.de) is currently configured as follows:
+The ILIAS Testserver (https://test9.ilias.de) is currently configured as follows:
 
 | Package        | Version          |
 |----------------|------------------|


### PR DESCRIPTION
Hi @acgruber, 

at today's meeting, we discussed the 'quality' of the information in the install.md about the recommended software versions at the ILIAS Süd Meeting. I commented, that one should look at the information in the Reference System section. Therefore, I changed the typo in the test system URL to test9.ilias.de. Many institutions at today's meeting said, that they update in the next weeks and months to ILIAS 9. Maybe a check or a revision of the install.md for ILIAS 9 would be useful for these admins. I surely would help, if I could, but I am only a user, not a system admin.

As this is only a typo fix, I directly merge.