### PR TITLE
T&A 43151: Fixes not being able to choose no answer in multiple choice question check

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -793,6 +793,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
             return 0.0;
         }
 
+        $found_values ??= [];
         $points = 0.0;
         foreach ($this->answers as $key => $answer) {
             if (in_array($key, $found_values)) {


### PR DESCRIPTION
An exception was being thrown when trying to check an multiple choice question where no answer was selected. This would put null into a variable that later in code must be an array.

A possible fix is to check if the variable is null and if so set it to an empty array.

[Mantis: 43151](https://mantis.ilias.de/view.php?id=43151)