### PR TITLE
UI: Set Autofocus on Filter in Drilldown

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Menu/tpl.drilldown.html
+++ b/components/ILIAS/UI/src/templates/default/Menu/tpl.drilldown.html
@@ -4,7 +4,7 @@
         <div></div>
         <div class="c-drilldown__filter">
             <label for='{ID_FILTER}' class="control-label">{LABEL}</label>
-            <input id='{ID_FILTER}' type="text" name='{NAME}' class="form-control" />
+            <input id='{ID_FILTER}' type="text" name='{NAME}' class="form-control" autofocus />
         </div>
         <div class="c-drilldown__backnav">
             {BACKNAV}

--- a/components/ILIAS/UI/tests/Client/Menu/Drilldown/drilldown.test.js
+++ b/components/ILIAS/UI/tests/Client/Menu/Drilldown/drilldown.test.js
@@ -20,7 +20,7 @@ const parsedHtml = `<section class="c-drilldown" id="id_2">
         <div></div>
         <div class="c-drilldown__filter">
             <label for="id_3" class="control-label">filter_nodes_in</label>
-            <input id="id_3" type="text" name="" class="form-control">
+            <input id="id_3" type="text" name="" class="form-control" autofocus >
         </div>
         <div class="c-drilldown__backnav">
             <button class="btn btn-bulky" id="id_1" aria-label="back">

--- a/components/ILIAS/UI/tests/Component/MainControls/Slate/DrilldownSlateTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/Slate/DrilldownSlateTest.php
@@ -100,7 +100,7 @@ class DrilldownSlateTest extends ILIAS_UI_TestBase
                             <div></div>
                             <div class="c-drilldown__filter">
                                 <label for=\'id_3\' class="control-label">filter_nodes_in</label>
-                                <input id=\'id_3\' type="text" name=\'\' class="form-control" />
+                                <input id=\'id_3\' type="text" name=\'\' class="form-control" autofocus />
                             </div>
                             <div class="c-drilldown__backnav">
                                 <button class="btn btn-bulky" id="id_1" aria-label="back">

--- a/components/ILIAS/UI/tests/Component/Menu/Drilldown/drilldown_test.html
+++ b/components/ILIAS/UI/tests/Component/Menu/Drilldown/drilldown_test.html
@@ -4,7 +4,7 @@
         <div></div>
         <div class="c-drilldown__filter">
             <label for='id_3' class="control-label">filter_nodes_in</label>
-            <input id='id_3' type="text" name='' class="form-control" />
+            <input id='id_3' type="text" name='' class="form-control" autofocus />
         </div>
         <div class="c-drilldown__backnav">
             <button class="btn btn-bulky" id="id_1" aria-label="back">


### PR DESCRIPTION
Hi all

This PR changes the behavior according to https://mantis.ilias.de/view.php?id=42093

There are drawbacks though:
- This will might lead mobile device to display the on-screen keyboard when the drilldown becomes visible.
- This will yank screenreaders to this position, when the drillown becomes visible, when it is inside a dialog-tag or when the input is visible from the start (ie: doesn't happen in mainbar, does happen in object-creation-modal).

Alternatively I could do this in the object-creation-modal through js, but I think it is a good idea to have a broader discussion before I do that.

Best,
@kergomard 

@yvseiler :  I added you as a reviewer as maybe you (or somebody else of the UI/UX/A11x-experts has a better grip on this and a more founded opinion. Thanks!