### PR TITLE
CSS: Fix Hidden Border on Drilldown Left

### DIFF
--- a/templates/default/070-components/UI-framework/Menu/_ui-component_drilldown.scss
+++ b/templates/default/070-components/UI-framework/Menu/_ui-component_drilldown.scss
@@ -98,6 +98,9 @@ $c-drilldown-selected-bg: $il-main-dark-bg;
     .c-drilldown__menulevel--trigger {
         @extend .btn;
         @extend .btn-bulky;
+        &:focus-visible {
+            z-index: 100;
+        }
     }
 
     // visibility of menu items

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7649,6 +7649,9 @@ button .minimize, button .close {
 .c-drilldown header.c-drilldown__header--showbacknav .c-drilldown__filter {
   display: none;
 }
+.c-drilldown .c-drilldown__menulevel--trigger:focus-visible {
+  z-index: 100;
+}
 .c-drilldown .c-drilldown__menu .c-drilldown__menulevel--trigger,
 .c-drilldown .c-drilldown__menu .btn-bulky,
 .c-drilldown .c-drilldown__menu .link-bulky,


### PR DESCRIPTION
Hi @Amstutz 

This fixes a problem in the object selection drilldown where a bit of the `focus-visible`-border might be hidden by the elements in the second column (if shown in a two column layout). I fixed this in the drilldown only, as adding this to the mixin, in my mind, could possibly have side-effects.

See: https://mantis.ilias.de/view.php?id=42419#c110656

Thanks and best,
@kergomard 