### PR TITLE
T&A 43220: fix Excel Export by adding file extension

### DIFF
--- a/components/ILIAS/Test/src/ExportImport/ResultsExportExcel.php
+++ b/components/ILIAS/Test/src/ExportImport/ResultsExportExcel.php
@@ -44,12 +44,16 @@ class ResultsExportExcel implements Exporter
         private readonly \ilLanguage $lng,
         private readonly \ilObjUser $current_user,
         private readonly \ilObjTest $test_obj,
-        private readonly string $filename = '',
+        private string $filename = '',
         private readonly bool $scoredonly = true,
     ) {
         $this->user_date_format = $this->current_user->getDateTimeFormat();
         $this->aggregated_data = $test_obj->getAggregatedResultsData();
         $this->worksheet = new \ilExcel();
+
+        if (!str_contains($this->filename, '.xlsx')) {
+            $this->filename .= '.xlsx';
+        }
     }
 
     public function withFilterByActiveId(int $active_id): self

--- a/components/ILIAS/Test/src/ExportImport/ResultsExportExcel.php
+++ b/components/ILIAS/Test/src/ExportImport/ResultsExportExcel.php
@@ -44,16 +44,12 @@ class ResultsExportExcel implements Exporter
         private readonly \ilLanguage $lng,
         private readonly \ilObjUser $current_user,
         private readonly \ilObjTest $test_obj,
-        private string $filename = '',
+        private readonly string $filename = '',
         private readonly bool $scoredonly = true,
     ) {
         $this->user_date_format = $this->current_user->getDateTimeFormat();
         $this->aggregated_data = $test_obj->getAggregatedResultsData();
         $this->worksheet = new \ilExcel();
-
-        if (!str_contains($this->filename, '.xlsx')) {
-            $this->filename .= '.xlsx';
-        }
     }
 
     public function withFilterByActiveId(int $active_id): self
@@ -124,6 +120,13 @@ class ResultsExportExcel implements Exporter
     public function write(): ?string
     {
         $path = \ilFileUtils::ilTempnam() . $this->filename;
+
+        $this->worksheet->setFormat(\ilExcel::FORMAT_XML);
+        $extension = '.' . strtolower(\ilExcel::FORMAT_XML);
+        if (!str_ends_with($path, $extension)) {
+            $path .= $extension;
+        }
+
         $this->worksheet->writeToFile($path);
         return $path;
     }


### PR DESCRIPTION
Hi everyone,

This PR is related to https://mantis.ilias.de/view.php?id=43220 and addresses an issue when exporting as Excel file without specifying a file extension.

The issue is caused by the fact that the ilExcel class revises the file name without returning the new path before writing to an output. When exporting a file without an extension, it will be appended automatically. Therefore, the path in the export classes is no longer correct and operations like copying the file will fail.

Best,
@lukas-heinrich 