### PR TITLE
T&A 43168/43170: fix: 'Argument 2 ($points) must be of type float, string given'

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
@@ -649,7 +649,8 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
 
         for ($i = 0; $i < $count; $i++) {
             if ($withPoints) {
-                $this->addAnswer($answers['answer'][$i], $answers['points'][$i]);
+                $points = $this->refinery->kindlyTo()->float()->transform($answers['points'][$i]);
+                $this->addAnswer($answers['answer'][$i], $points);
             } else {
                 $this->addAnswer($answers[$i], 0);
             }

--- a/components/ILIAS/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -553,7 +553,7 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         switch ($this->object->getKeywordRelation()) {
             case assTextQuestion::SCORING_MODE_KEYWORD_RELATION_NONE:
                 $this->object->setAnswers([]);
-                $points = str_replace(',', '.', $this->request_data_collector->string('non_keyword_points'));
+                $points = $this->request_data_collector->float('non_keyword_points');
                 break;
             case assTextQuestion::SCORING_MODE_KEYWORD_RELATION_ANY:
                 $this->object->setAnswers($this->request_data_collector->raw('any_keyword'));
@@ -561,11 +561,11 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
                 break;
             case assTextQuestion::SCORING_MODE_KEYWORD_RELATION_ALL:
                 $this->object->setAnswers($this->request_data_collector->raw('all_keyword'));
-                $points = str_replace(',', '.', $this->request_data_collector->string('all_keyword_points'));
+                $points = $this->request_data_collector->float('all_keyword_points');
                 break;
             case assTextQuestion::SCORING_MODE_KEYWORD_RELATION_ONE:
                 $this->object->setAnswers($this->request_data_collector->raw('one_keyword'));
-                $points = (float) str_replace(',', '.', $this->request_data_collector->string('one_keyword_points'));
+                $points = $this->request_data_collector->float('one_keyword_points');
                 break;
         }
         $this->object->setPoints((float) $points);


### PR DESCRIPTION
Hi everyone,

this PR is related to [43168](https://mantis.ilias.de/view.php?id=43168) and [43170](https://mantis.ilias.de/view.php?id=43170), which are both caused by a missing type cast. 

I use the Refinery at this point, because the conversion from separator `',' => '.'` also has to happen at this point, and I think using the Refinery is a better approach than using a `str_replace`. 

I look forward to Feedback.
Best,
@lukas-heinrich 