### PR TITLE
UI: add Input\Container::withInput for awesome flexibility

### DIFF
--- a/components/ILIAS/UI/src/Component/Input/Container/Container.php
+++ b/components/ILIAS/UI/src/Component/Input/Container/Container.php
@@ -24,6 +24,7 @@ use ILIAS\UI\Component\Component;
 use ILIAS\Refinery\Transformation;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\UI\Component\Input\Input;
+use ILIAS\UI\Component\Input\InputData;
 
 /**
  * This describes commonalities between all Containers for Inputs, such as Forms.
@@ -40,9 +41,21 @@ interface Container extends Component
     /**
      * Get a form like this where data from the request is attached.
      *
+     * This calls `withInputData` with a properly wrapped request.
+     *
      * @return static
      */
     public function withRequest(ServerRequestInterface $request): self;
+
+    /**
+     * Get a form like this where some input data is attached.
+     *
+     * This is a more powerful version of `withRequest` that allows to provide
+     * data from arbitrary to the form. This is one piece that turns the inputs
+     * from the UI framework into a truly generic input description that can be
+     * used in various contexts.
+     */
+    public function withInput(InputData $input_data): self;
 
     /**
      * Apply a transformation to the data of the form.

--- a/components/ILIAS/UI/src/Component/Input/InputData.php
+++ b/components/ILIAS/UI/src/Component/Input/InputData.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\UI\Implementation\Component\Input;
+namespace ILIAS\UI\Component\Input;
 
 use LogicException;
 

--- a/components/ILIAS/UI/src/Implementation/Component/Dropzone/File/File.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Dropzone/File/File.php
@@ -33,6 +33,7 @@ use ILIAS\Refinery\Transformation;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\UI\Component\ReplaceSignal;
 use ILIAS\UI\Component\Input\Container\Form\FormInput;
+use ILIAS\UI\Component\Input\InputData;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>
@@ -215,6 +216,13 @@ abstract class File implements FileDropzone
     {
         $clone = clone $this;
         $clone->modal = $clone->modal->withRequest($request);
+        return $clone;
+    }
+
+    public function withInput(InputData $input_data): self
+    {
+        $clone = clone $this;
+        $clone->modal = $clone->modal->withInput($request);
         return $clone;
     }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ArrayInputData.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ArrayInputData.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Input;
 
 use LogicException;
+use ILIAS\UI\Component\Input\InputData;
 
 /**
  * @author  Thibeau Fuhrer <thf@studer-raimann.ch>

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Container.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Container.php
@@ -23,7 +23,7 @@ namespace ILIAS\UI\Implementation\Component\Input\Container;
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component as CI;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Refinery\Transformation;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\Data\Result;
@@ -63,10 +63,15 @@ abstract class Container implements C\Input\Container\Container
      */
     public function withRequest(ServerRequestInterface $request): self
     {
-        $post_data = $this->extractRequestData($request);
+        return $this->withInput(
+            $this->extractRequestData($request)
+        );
+    }
 
+    public function withInput(InputData $input_data): self
+    {
         $clone = clone $this;
-        $clone->input_group = $this->getInputGroup()->withInput($post_data);
+        $clone->input_group = $this->getInputGroup()->withInput($input_data);
         $clone->result = $clone->input_group->getContent();
 
         if (!$clone->result->isok()) {

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Filter/Filter.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Filter/Filter.php
@@ -27,6 +27,7 @@ use ILIAS\UI\Implementation\Component\SignalGeneratorInterface;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\UI\Implementation\Component\Input\QueryParamsFromServerRequest;
+use ILIAS\UI\Component\Input\InputData;
 
 /**
  * This implements commonalities between all Filters.
@@ -243,7 +244,7 @@ abstract class Filter implements C\Input\Container\Filter\Filter, CI\Input\NameS
     /**
      * Extract post data from request.
      */
-    protected function extractParamData(ServerRequestInterface $request): CI\Input\InputData
+    protected function extractParamData(ServerRequestInterface $request): InputData
     {
         return new QueryParamsFromServerRequest($request);
     }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Form.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Form.php
@@ -22,7 +22,7 @@ namespace ILIAS\UI\Implementation\Component\Input\Container\Form;
 
 use ILIAS\UI\Implementation\Component\Input\Container\Container;
 use ILIAS\UI\Component as C;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\UI\Implementation\Component\Input\PostDataFromServerRequest;
 use ILIAS\UI\Implementation\Component\Input\NameSource;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/ViewControl/ViewControl.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/ViewControl/ViewControl.php
@@ -31,11 +31,10 @@ use ILIAS\UI\Implementation\Component\Input\Container\Container;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\Result;
 use ILIAS\Refinery\Transformation;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\Input\StackedInputData;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Component as C;
-
 use ILIAS\UI\Implementation\Component\Input\ViewControl\HasInputGroup;
 
 abstract class ViewControl extends Container implements I\ViewControl
@@ -109,7 +108,7 @@ abstract class ViewControl extends Container implements I\ViewControl
         C\Input\Group $component = null,
         array $input_values = []
     ): array {
-        if(is_null($component)) {
+        if (is_null($component)) {
             $component = $this->getInputGroup();
         }
         foreach ($component->getInputs() as $input) {
@@ -119,7 +118,7 @@ abstract class ViewControl extends Container implements I\ViewControl
             if ($input instanceof HasInputGroup) {
                 $input_values = $this->getComponentInternalValues($input->getInputGroup(), $input_values);
             }
-            if($name = $input->getName()) {
+            if ($name = $input->getName()) {
                 $input_values[$input->getName()] = $input->getValue();
             }
         }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/DynamicInputDataIterator.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/DynamicInputDataIterator.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,9 +16,12 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\UI\Implementation\Component\Input;
 
 use Iterator;
+use ILIAS\UI\Component\Input\InputData;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Checkbox.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Checkbox.php
@@ -23,7 +23,7 @@ namespace ILIAS\UI\Implementation\Component\Input\Field;
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Implementation\Component\Triggerer;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Refinery\Constraint;
 use Closure;
 use LogicException;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/FormInput.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/FormInput.php
@@ -27,7 +27,7 @@ use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Implementation\Component\Triggerer;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data\Result;
 use Generator;
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/HasDynamicInputsBase.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/HasDynamicInputsBase.php
@@ -23,7 +23,7 @@ namespace ILIAS\UI\Implementation\Component\Input\Field;
 use ILIAS\UI\Implementation\Component\Input\DynamicInputDataIterator;
 use ILIAS\UI\Implementation\Component\Input\DynamicInputsNameSource;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Component\Input\Container\Form\FormInput as FormInputInterface;
 use ILIAS\UI\Component\Input\Field\HasDynamicInputs;
 use ILIAS\Refinery\Factory as Refinery;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/OptionalGroup.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/OptionalGroup.php
@@ -22,7 +22,7 @@ namespace ILIAS\UI\Implementation\Component\Input\Field;
 use ILIAS\Refinery\Constraint;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Implementation\Component\Triggerer;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Component\Input\Field as I;
 use LogicException;
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Radio.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Radio.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
 use ILIAS\UI\Component as C;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Implementation\Component\Triggerer;
 use ILIAS\Refinery\Constraint;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/SwitchableGroup.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/SwitchableGroup.php
@@ -24,7 +24,7 @@ use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Constraint;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Implementation\Component\Triggerer;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Component\Input\Field as I;
 use ILIAS\Language\Language;
 use LogicException;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Tag.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Tag.php
@@ -24,7 +24,7 @@ use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\Result\Ok;
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Component\Signal;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use stdClass;
 use ILIAS\Refinery\Constraint;
 use InvalidArgumentException;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Group.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Group.php
@@ -26,6 +26,7 @@ use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\Result;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Language\Language;
+use ILIAS\UI\Component\Input\InputData;
 
 /**
  * @author Thibeau Fuhrer <thibeau@sr.solutions>

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Input.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Input.php
@@ -27,7 +27,7 @@ use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Refinery\Transformation;
 use ILIAS\UI\Component\Signal;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
 use ILIAS\UI\Implementation\Component\JavaScriptBindable;
 use ILIAS\UI\Implementation\Component\Triggerer;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/InputInternal.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/InputInternal.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input;
 
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Component\Input\Input;
 use ILIAS\Data\Result;
 use ILIAS\UI\Implementation\Component\Input\NameSource;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/PostDataFromServerRequest.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/PostDataFromServerRequest.php
@@ -22,6 +22,7 @@ namespace ILIAS\UI\Implementation\Component\Input;
 
 use Psr\Http\Message\ServerRequestInterface;
 use LogicException;
+use ILIAS\UI\Component\Input\InputData;
 
 /**
  * Implements interaction of input element with post data from

--- a/components/ILIAS/UI/src/Implementation/Component/Input/QueryParamsFromServerRequest.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/QueryParamsFromServerRequest.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input;
 
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use Psr\Http\Message\ServerRequestInterface;
 use LogicException;
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/StackedInputData.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/StackedInputData.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input;
 
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use Psr\Http\Message\ServerRequestInterface;
 use LogicException;
 
@@ -43,8 +43,8 @@ class StackedInputData implements InputData
 
     public function get(string $name)
     {
-        foreach($this->stack as $input) {
-            if($input->has($name)) {
+        foreach ($this->stack as $input) {
+            if ($input->has($name)) {
                 return $input->get($name);
             }
         }
@@ -53,8 +53,8 @@ class StackedInputData implements InputData
 
     public function getOr(string $name, $default)
     {
-        foreach($this->stack as $input) {
-            if($input->has($name)) {
+        foreach ($this->stack as $input) {
+            if ($input->has($name)) {
                 return $input->get($name);
             }
         }
@@ -63,8 +63,8 @@ class StackedInputData implements InputData
 
     public function has($name): bool
     {
-        foreach($this->stack as $input) {
-            if($input->has($name)) {
+        foreach ($this->stack as $input) {
+            if ($input->has($name)) {
                 return true;
             }
         }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/GroupDecorator.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/GroupDecorator.php
@@ -22,7 +22,7 @@ namespace ILIAS\UI\Implementation\Component\Input\ViewControl;
 use ILIAS\UI\Component\Input\Group;
 use ILIAS\Refinery\Transformation;
 use ILIAS\Data\Result;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
 
 /**

--- a/components/ILIAS/UI/src/Implementation/Component/Modal/RoundTrip.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Modal/RoundTrip.php
@@ -26,6 +26,7 @@ use ILIAS\UI\Implementation\Component\Input\NameSource;
 use ILIAS\UI\Implementation\Component\ReplaceSignal;
 use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Component\Input\Container\Form\FormInput;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Component\Component;
 use ILIAS\UI\Component\Button;
 use ILIAS\UI\Component\Signal;
@@ -179,6 +180,13 @@ class RoundTrip extends Modal implements M\RoundTrip
     {
         $clone = clone $this;
         $clone->form = $clone->form->withRequest($request);
+        return $clone;
+    }
+
+    public function withInput(InputData $input_data): self
+    {
+        $clone = clone $this;
+        $clone->form = $clone->form->withInput($request);
         return $clone;
     }
 

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterTest.php
@@ -24,7 +24,7 @@ use ILIAS\UI\Implementation\Component as I;
 use ILIAS\UI\Implementation\Component\Input;
 use ILIAS\UI\Component\Input\Container\Filter\FilterInput;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\Input\Container\Filter\Filter;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\Data;
@@ -45,7 +45,7 @@ class FixedNameSourceFilter implements NameSource
 class ConcreteFilter extends Filter
 {
     public array $inputs;
-    public ?Input\InputData $input_data = null;
+    public ?InputData $input_data = null;
     protected Input\Field\Factory $input_factory;
     protected Group $input_group;
 
@@ -80,12 +80,12 @@ class ConcreteFilter extends Filter
         );
     }
 
-    public function _extractParamData(ServerRequestInterface $request): Input\InputData
+    public function _extractParamData(ServerRequestInterface $request): InputData
     {
         return $this->extractParamData($request);
     }
 
-    public function extractParamData(ServerRequestInterface $request): Input\InputData
+    public function extractParamData(ServerRequestInterface $request): InputData
     {
         if ($this->input_data !== null) {
             return $this->input_data;

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/FormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/FormTest.php
@@ -24,7 +24,7 @@ use ILIAS\UI\Implementation\Component as I;
 use ILIAS\UI\Implementation\Component\Input;
 use ILIAS\UI\Component\Input\Container\Form\FormInput;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\Input\Container\Form\Form;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\Data;
@@ -46,7 +46,7 @@ class FixedNameSource implements NameSource
 
 class ConcreteForm extends Form
 {
-    public ?Input\InputData $input_data = null;
+    public ?InputData $input_data = null;
     protected Input\Field\Factory $input_factory;
     protected Group $input_group;
     protected array $inputs;
@@ -57,12 +57,12 @@ class ConcreteForm extends Form
         parent::__construct($input_factory, $name_source, $inputs);
     }
 
-    public function _extractRequestData(ServerRequestInterface $request): Input\InputData
+    public function _extractRequestData(ServerRequestInterface $request): InputData
     {
         return $this->extractRequestData($request);
     }
 
-    public function extractRequestData(ServerRequestInterface $request): Input\InputData
+    public function extractRequestData(ServerRequestInterface $request): InputData
     {
         if ($this->input_data !== null) {
             return $this->input_data;

--- a/components/ILIAS/UI/tests/Component/Input/DynamicInputDataIteratorTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/DynamicInputDataIteratorTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Tests\UI\Component\Input;
 
 use ILIAS\UI\Implementation\Component\Input\DynamicInputDataIterator;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use PHPUnit\Framework\TestCase;
 use LogicException;
 use ILIAS\UI\Implementation\Component\Input\DynamicInputsNameSource;

--- a/components/ILIAS/UI/tests/Component/Input/Field/CheckboxInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/CheckboxInputTest.php
@@ -23,7 +23,7 @@ require_once(__DIR__ . "/../../../Base.php");
 require_once(__DIR__ . "/InputTest.php");
 require_once(__DIR__ . "/CommonFieldRendering.php");
 
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Component\Input\Field;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Data;

--- a/components/ILIAS/UI/tests/Component/Input/Field/GroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/GroupInputTest.php
@@ -26,7 +26,7 @@ require_once(__DIR__ . "/CommonFieldRendering.php");
 use ILIAS\UI\Implementation\Component\Input\Field\FormInput;
 use ILIAS\UI\Implementation\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Implementation\Component\Input\Field\Group;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data;
 use ILIAS\Refinery\Factory as Refinery;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/components/ILIAS/UI/tests/Component/Input/Field/InputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/InputTest.php
@@ -23,7 +23,7 @@ require_once(__DIR__ . "/../../../Base.php");
 
 use ILIAS\UI\Implementation\Component\Input\Field\FormInput;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Data\Result;
 use ILIAS\Refinery\Constraint;

--- a/components/ILIAS/UI/tests/Component/Input/Field/LinkInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/LinkInputTest.php
@@ -28,7 +28,7 @@ use ILIAS\UI\Component\Input\Field;
 use ILIAS\Data;
 use ILIAS\UI\Implementation\Component\Input\Field\Factory;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 
 class LinkInputTest extends ILIAS_UI_TestBase
 {

--- a/components/ILIAS/UI/tests/Component/Input/Field/MultiSelectInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/MultiSelectInputTest.php
@@ -24,7 +24,7 @@ require_once(__DIR__ . "/CommonFieldRendering.php");
 
 use ILIAS\UI\Implementation\Component as I;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
 use ILIAS\UI\Component\Input\Field;
 use ILIAS\Data;

--- a/components/ILIAS/UI/tests/Component/Input/Field/OptionalGroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/OptionalGroupInputTest.php
@@ -25,7 +25,7 @@ require_once(__DIR__ . "/CommonFieldRendering.php");
 use ILIAS\UI\Implementation\Component\Input\Field\OptionalGroup;
 use ILIAS\UI\Implementation\Component\Input\Field\FormInput;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data;
 use ILIAS\Refinery\Factory as Refinery;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/components/ILIAS/UI/tests/Component/Input/Field/PasswordInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/PasswordInputTest.php
@@ -25,7 +25,7 @@ require_once(__DIR__ . "/CommonFieldRendering.php");
 
 use ILIAS\UI\Implementation\Component as I;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data\Password as PWD;
 use ILIAS\UI\Component\Input\Field;
 use ILIAS\Data;

--- a/components/ILIAS/UI/tests/Component/Input/Field/SelectInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SelectInputTest.php
@@ -24,7 +24,7 @@ require_once(__DIR__ . "/CommonFieldRendering.php");
 use ILIAS\Data;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Implementation\Component as I;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 
 class SelectForTest extends ILIAS\UI\Implementation\Component\Input\Field\Select

--- a/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
@@ -26,7 +26,7 @@ use ILIAS\UI\Implementation\Component as I;
 use ILIAS\UI\Implementation\Component\Input\Field\SwitchableGroup;
 use ILIAS\UI\Implementation\Component\Input\Field\Group;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\Refinery\Factory as Refinery;

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlFieldSelectionTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlFieldSelectionTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 use ILIAS\UI\Implementation\Component\Input\ViewControl as Control;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Component\Signal;

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlGroupTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlGroupTest.php
@@ -23,7 +23,7 @@ use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\Data\Order;
 use ILIAS\Data\Range;
 use ILIAS\Data\Result;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 
 class ViewControlGroupTest extends ViewControlTestBase
 {

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlInputGenericTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlInputGenericTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 use ILIAS\UI\Implementation\Component\Input\ViewControl as Control;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Component\Signal;

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlNullTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlNullTest.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\UI\Implementation\Component\Input\ViewControl as Control;
 use ILIAS\Data\Result;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 
 class ViewControlNullTest extends ViewControlTestBase
 {

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlPaginationTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlPaginationTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 use ILIAS\UI\Implementation\Component\Input\ViewControl as Control;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Component\Signal;

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlSortationTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlSortationTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 use ILIAS\UI\Implementation\Component\Input\ViewControl as Control;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\UI\Implementation\Component\Input\NameSource;
-use ILIAS\UI\Implementation\Component\Input\InputData;
+use ILIAS\UI\Component\Input\InputData;
 use ILIAS\Data\Order;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\UI\Component\Signal;


### PR DESCRIPTION
Hi all,

this is something that came up when @jeph864 and I were discussing [Activitities](https://github.com/klees/ILIAS/tree/11/activities/components/ILIAS/Component/src/Activities) and webservices.

The current plan is to use the inputs from the UI framework as a description for the input to Activities. @jeph864 is looking how these Activities can be published via a json-via-http API and, for this purpose, will need a way to provide values to the input. At first we thought that we might want to teach the UI framework how to deal with JSON input in a `ServerRequestInterface`, but then we found this solution to be more flexible and also simpler. This could open up the inputs from the UI framework to even more forms of user interface, such as the CLI.

The implementation should be quite obvious, but I'll wait until I have approval from @Amstutz and @thibsy here.

What do you think?

Kind regards!