### PR TITLE
[FIX] UI: create client-side random ids in any context.

### DIFF
--- a/components/ILIAS/UI/resources/js/Core/dist/core.js
+++ b/components/ILIAS/UI/resources/js/Core/dist/core.js
@@ -12,7 +12,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  */
-(function (il, $, crypto) {
+(function (il, $) {
     'use strict';
 
     /**
@@ -299,11 +299,40 @@
      * https://www.ilias.de
      * https://github.com/ILIAS-eLearning
      *
+     * @author Thibeau Fuhrer <thibeau@sr.solutions>
+     */
+
+    /**
+     * Returns a random string which is NOT cryptographically secure.
+     * This can be used in contexts where Window.crypto is not available.
+     *
+     * @param {string} prefix
+     * @returns {string}
+     */
+    function createRandomString(prefix = '') {
+      const timestampString = Date.now().toString(36);
+      const randomString = Math.random().toString(36).substring(2);
+      return `${prefix}${timestampString}_${randomString}`;
+    }
+
+    /**
+     * This file is part of ILIAS, a powerful learning management system
+     * published by ILIAS open source e-Learning e.V.
+     *
+     * ILIAS is licensed with the GPL-3.0,
+     * see https://www.gnu.org/licenses/gpl-3.0.en.html
+     * You should have received a copy of said license along with the
+     * source code, too.
+     *
+     * If this is not the case or you just want to try ILIAS, you'll find
+     * us at:
+     * https://www.ilias.de
+     * https://github.com/ILIAS-eLearning
+     *
      ********************************************************************
      */
 
     const URLBuilderTokenSeparator = '_';
-    const URLBuilderTokenLength = 24;
 
     class URLBuilderToken {
       /**
@@ -336,7 +365,7 @@
         this.#parameterName = parameterName;
         this.#token = token;
         if (this.#token === null) {
-          this.#token = URLBuilderToken.createToken();
+          this.#token = createRandomString();
         }
         this.#name = this.#namespace.join(URLBuilderTokenSeparator) + URLBuilderTokenSeparator;
         this.#name += this.#parameterName;
@@ -354,19 +383,6 @@
          */
       getName() {
         return this.#name;
-      }
-
-      /**
-         * @returns {string}
-         */
-      static createToken() {
-        let token = '';
-        const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-        const charactersLength = characters.length;
-        while (token.length < URLBuilderTokenLength) {
-          token += characters.charAt(Math.floor(Math.random() * charactersLength));
-        }
-        return token;
       }
     }
 
@@ -683,13 +699,6 @@
     }
 
     /**
-     * @returns {string}
-     */
-    function createId() {
-      return crypto.randomUUID();
-    }
-
-    /**
      * @author Thibeau Fuhrer <thibeau@sr.solutions>
      */
     class TemplateRenderer {
@@ -727,7 +736,7 @@
         const elementIdMapping = new Map();
 
         newElement.querySelectorAll('[id]').forEach((element) => {
-          const newId = createId();
+          const newId = createRandomString('il_ui_fw_');
           elementIdMapping.set(element.id, newId);
           element.id = newId;
         });
@@ -775,4 +784,4 @@
     // @todo: remove this once file input is migrated.
     il.UI.core.TemplateRenderer = new TemplateRenderer(document);
 
-})(il, $, crypto);
+})(il, $);

--- a/components/ILIAS/UI/resources/js/Core/rollup.config.js
+++ b/components/ILIAS/UI/resources/js/Core/rollup.config.js
@@ -19,7 +19,6 @@ export default {
   external: [
     'il',
     'jquery',
-    'crypto',
   ],
   input: './src/core.js',
   output: {
@@ -29,7 +28,6 @@ export default {
     globals: {
       il: 'il',
       jquery: '$',
-      crypto: 'crypto',
     },
   },
 };

--- a/components/ILIAS/UI/resources/js/Core/src/TemplateRenderer.js
+++ b/components/ILIAS/UI/resources/js/Core/src/TemplateRenderer.js
@@ -13,8 +13,8 @@
  * https://github.com/ILIAS-eLearning
  */
 
-import crypto from 'crypto';
 import createDocumentFragment from './createDocumentFragment';
+import createRandomString from './createRandomString';
 
 /**
  * Updates all attribute values from an old element id to a new one.
@@ -32,13 +32,6 @@ function mapAttributeElementIds(parentElement, elementIdMapping, attributeName) 
     }
     child.setAttribute(attributeName, elementIdMapping.get(originalId));
   });
-}
-
-/**
- * @returns {string}
- */
-function createId() {
-  return crypto.randomUUID();
 }
 
 /**
@@ -79,7 +72,7 @@ export default class TemplateRenderer {
     const elementIdMapping = new Map();
 
     newElement.querySelectorAll('[id]').forEach((element) => {
-      const newId = createId();
+      const newId = createRandomString('il_ui_fw_');
       elementIdMapping.set(element.id, newId);
       element.id = newId;
     });

--- a/components/ILIAS/UI/resources/js/Core/src/core.URLBuilderToken.js
+++ b/components/ILIAS/UI/resources/js/Core/src/core.URLBuilderToken.js
@@ -14,9 +14,9 @@
  *
  ********************************************************************
  */
+import createRandomString from './createRandomString';
 
 const URLBuilderTokenSeparator = '_';
-const URLBuilderTokenLength = 24;
 
 export default class URLBuilderToken {
   /**
@@ -49,7 +49,7 @@ export default class URLBuilderToken {
     this.#parameterName = parameterName;
     this.#token = token;
     if (this.#token === null) {
-      this.#token = URLBuilderToken.createToken();
+      this.#token = createRandomString();
     }
     this.#name = this.#namespace.join(URLBuilderTokenSeparator) + URLBuilderTokenSeparator;
     this.#name += this.#parameterName;
@@ -67,18 +67,5 @@ export default class URLBuilderToken {
      */
   getName() {
     return this.#name;
-  }
-
-  /**
-     * @returns {string}
-     */
-  static createToken() {
-    let token = '';
-    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    const charactersLength = characters.length;
-    while (token.length < URLBuilderTokenLength) {
-      token += characters.charAt(Math.floor(Math.random() * charactersLength));
-    }
-    return token;
   }
 }

--- a/components/ILIAS/UI/resources/js/Core/src/createRandomString.js
+++ b/components/ILIAS/UI/resources/js/Core/src/createRandomString.js
@@ -1,0 +1,29 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ * @author Thibeau Fuhrer <thibeau@sr.solutions>
+ */
+
+/**
+ * Returns a random string which is NOT cryptographically secure.
+ * This can be used in contexts where Window.crypto is not available.
+ *
+ * @param {string} prefix
+ * @returns {string}
+ */
+export default function createRandomString(prefix = '') {
+  const timestampString = Date.now().toString(36);
+  const randomString = Math.random().toString(36).substring(2);
+  return `${prefix}${timestampString}_${randomString}`;
+}


### PR DESCRIPTION
Hi folks,

I have introduced the usage of [`crypto`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto) inside our new `TemplateRenderer` to generate random strings. We noticed however that this object is only available in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts), which is not always the case for ILIAS - especially during development.

We also noticed that the `URLBuilderToken` implements a random string generation, similar to the use case of our `TemplateRenderer`. I therefore decided to introduce a new `createRandomString()` function which covers both of these usages. These strings are not cryptographically secure, but they are random enough for what they are used for.

Kind regards,
@thibsy 