### PR TITLE
42276 - SCORM HTTP context

### DIFF
--- a/components/ILIAS/Context/classes/class.ilContextScorm.php
+++ b/components/ILIAS/Context/classes/class.ilContextScorm.php
@@ -35,7 +35,7 @@ class ilContextScorm implements ilContextTemplate
 
     public static function usesHTTP(): bool
     {
-        return false;
+        return true;
     }
 
     public static function hasHTML(): bool


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42276

Solving error with message:
Error: Undefined constant "ILIAS\Repository\Form\ILIAS_HTTP_PATH" in file /var/www/ilias/9x/Services/Repository/Service/Form/class.FormAdapterGUI.php on line 95

The problem is that the "storeScorm" script, which requests asynchronously when storing SCORM learning progress, does not initialize the ILIAS_HTTP_PATH config.