### PR TITLE
Chatroom: Add `mariadb`

### DIFF
--- a/components/ILIAS/Chatroom/chat/package_new.json
+++ b/components/ILIAS/Chatroom/chat/package_new.json
@@ -1,0 +1,8 @@
+{
+  "name": "ILIAS-Chat",
+  "description": "ILIAS CHAT",
+  "version": "2.0.0",
+  "dependencies": {
+    "mariadb": "^3.4.0"
+  }
+}


### PR DESCRIPTION
This PR adds `mariadb` as NPM dependency for the chatroom.

General Information:
- [ ] this dependency was already used in ILIAS.
- [X] License: LGPL

Usages:

- components/ILIAS/Chatroom/chat/Persistence/Database.js

To be Wrapped By:

- Database (see: components/ILIAS/Chatroom/chat/Persistence/Database.js)

Reasoning:

This dependency is a replacement for the `mysql` dependency, which was not updated since 2022, as noted in the dependency PR for ILIAS 10: #6773.

`mariadb` is a mysql driver for Node.js. It is used to communicate with a mysql (or mariadb) server.

Maintenance:

`mariadb` is actively maintained and regularly updated (The latest release is from 24.10.2024). And is developed by the mariadb corporation.

Links:

- NPM: https://www.npmjs.com/package/mariadb
- GitHub: https://github.com/mariadb-corporation/mariadb-connector-nodejs
- Documentation: https://github.com/mariadb-corporation/mariadb-connector-nodejs/tree/master/documentation