### PR TITLE
[FIX] GS: use legacy initialisation adapter for endpoints.

### DIFF
--- a/components/ILIAS/GlobalScreen/resources/callback_handler.php
+++ b/components/ILIAS/GlobalScreen/resources/callback_handler.php
@@ -1,10 +1,28 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 namespace ILIAS\GlobalScreen\Client;
 
 /** @noRector  */
 require_once(__DIR__ . '/../vendor/composer/vendor/autoload.php');
+require_once(__DIR__ . '/../artifacts/bootstrap_default.php');
 
 if (php_sapi_name() !== 'cli') {
+    entry_point('ILIAS Legacy Initialisation Adapter');
     (new CallbackHandler())->run();
 }

--- a/components/ILIAS/GlobalScreen/resources/gs_content.php
+++ b/components/ILIAS/GlobalScreen/resources/gs_content.php
@@ -19,6 +19,7 @@
 namespace ILIAS\GlobalScreen\Client;
 
 require_once(__DIR__ . '/../vendor/composer/vendor/autoload.php');
+require_once(__DIR__ . '/../artifacts/bootstrap_default.php');
 
 use ILIAS\GlobalScreen\Scope\MainMenu\Collector\Renderer\Hasher;
 use ILIAS\GlobalScreen\Scope\MainMenu\Factory\Item\Lost;
@@ -29,8 +30,6 @@ class ContentRenderer
 
     public function run()
     {
-        \ilContext::init(\ilContext::CONTEXT_WAC);
-        \ilInitialisation::initILIAS();
         global $DIC;
 
         $GS = $DIC->globalScreen();
@@ -58,5 +57,7 @@ class ContentRenderer
 }
 
 if (php_sapi_name() !== 'cli') {
+    \ilContext::init(\ilContext::CONTEXT_WAC);
+    entry_point('ILIAS Legacy Initialisation Adapter');
     (new ContentRenderer())->run();
 }

--- a/components/ILIAS/GlobalScreen/resources/notify.php
+++ b/components/ILIAS/GlobalScreen/resources/notify.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -15,14 +14,17 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *********************************************************************/
-/**
+ *********************************************************************
+ *
  * Entry Point for Async calls from the Notification Center
  */
+
+declare(strict_types=1);
 
 namespace ILIAS\GlobalScreen\Client;
 
 /** @noRector  */
 require_once(__DIR__ . '/../vendor/composer/vendor/autoload.php');
-\ilInitialisation::initILIAS();
+require_once __DIR__ . '/../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 (new Notifications())->run();

--- a/components/ILIAS/GlobalScreen/src/Client/CallbackHandler.php
+++ b/components/ILIAS/GlobalScreen/src/Client/CallbackHandler.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\GlobalScreen\Client;
 
@@ -40,7 +41,6 @@ class CallbackHandler
 
     public function __construct()
     {
-        ilInitialisation::initILIAS();
         global $DIC;
         $this->ctrl = $DIC->ctrl();
         $this->wrapper = $DIC->http()->wrapper();


### PR DESCRIPTION
Hi @chfsx,

I noticed that the endpoints of the global screen are still using the legacy initialisation directly, instead of the new adapter. Since #7969 we can no longer call `ilInitialisation::initILIAS()` directly, because already bootstrapped components would be missing (such as UI). This should fix some errors with the main menu.

Kind regards
@thibsy 