### PR TITLE
PRG: 43301, mail: use specific dic to keep context

### DIFF
--- a/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeMembersGUI.php
+++ b/Modules/StudyProgramme/classes/class.ilObjStudyProgrammeMembersGUI.php
@@ -1029,7 +1029,7 @@ class ilObjStudyProgrammeMembersGUI
 
     protected function mailToSelectedUsers(): void
     {
-        $dic = ilStudyProgrammeDIC::dic();
+        $dic = ilStudyProgrammeDIC::specificDicFor($this->object);
         $gui = $dic['ilStudyProgrammeMailMemberSearchGUI'];
 
         $selected = $this->getPostPrgsIds();


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43301

The bug is originally in ilPRGPermissionsHelper having a context (prg_ref_id) of -1 when constructed w/o a current PRG.
it then continues over ilOrgUnitPositionAccess::filterUserIdsByPositionOfUser and ilOrgUnitPositionAccess::getTypeForRefId - which is empty.