### PR TITLE
UI: 42802, remove the box-shadow from elements like file buttons as there…

### DIFF
--- a/templates/default/030-tools/_tool_focus-outline.scss
+++ b/templates/default/030-tools/_tool_focus-outline.scss
@@ -59,7 +59,6 @@ $il-focus-outline-outer-width: 2px;
 	$il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protection-color;
 	&:focus-within{
 		outline: $il-focus-outline-inner;
-		box-shadow: inset 0px 0px 0px $il-focus-outline-outer-width $il-focus-protection-color, 0px 0px 0px (($il-focus-outline-outer-width*2) + $il-focus-outline-inner-width) red; // $il-focus-protection-color
 		@if $clearAfter {
 			&::after {
 				content: none;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -17074,7 +17074,6 @@ div.ilHFormFooter .ilFormCmds {
 }
 .btn-file:focus-within {
   outline: 3px solid #0078D7;
-  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 7px red;
 }
 
 .btn-file input[type=file] {


### PR DESCRIPTION
…'s already a outline setting in use. As a result the second border in red is now removed and only the first border is visible. 

https://mantis.ilias.de/view.php?id=42802