### PR TITLE
[FIX] Docs: enforce file extensions for ES6 import specifiers.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,6 +55,9 @@
         "devDependencies": true
       }
     ],
+    // enforce file extensions for Node.js compatibility
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
+    "import/extensions": ["error", "ignorePackages"],
     // allow to reassign argument properties for e.g. altering
     // HTMLElement styles and state.
     "no-param-reassign": [

--- a/docs/development/js-coding-style.md
+++ b/docs/development/js-coding-style.md
@@ -124,6 +124,13 @@ Airbnb does not allow to manipulate/reassign parameters completely. However, rea
 e.g. `HTMLElement`s is a common use-case, which has led to many unnecessary variables being initialised to work around
 this code-style rule. Therefore we allow the manipulation/reassignment of **parameter properties**.
 
+#### 5. Import File Extensions
+
+Airbnb does not allow file extensions in ES6 import statements. However, in the Node.js environment [file extensions are
+always necessary for relative specifiers](https://nodejs.org/api/esm.html#esm_import_specifiers). This leads to problems
+when e.g. building bundles with Rollup.js. Therefore we adjust this rule and **enforce all ES6 import specifiers to
+include their file extension, except for depencendies which are resolved by other tools (Node.js, Rollup.js).**
+
 ## Applying Code Style
 
 ILIAS is using [ESLint](https://eslint.org/) to automatically check and/or fix JavaScript code according to the


### PR DESCRIPTION
Hi folks,

Technically, it is not possible to create JavaScript bundles using Rollup.js right now, because our code-style disallows file extensions in ES6 import specifiers, but the module bundler requires them. This is due to the [Node.js specification of import specifiers](https://nodejs.org/api/esm.html#esm_import_specifiers), which states that a file extension is always necessary for relative specifiers. Since we are maintaining a repository and cannot use absolute specifiers, we need to make a code-style adjustment.

This PR therefore changes:

* the ESLint configuration to enforce file extensions in import statements, except for specifiers that are resolved by other tools like Node.js itself or Rollup.js
* the JavaScript code-style to document why the change is necessary

Kind regards,
@thibsy 