### PR TITLE
UI/Form: 43303, describedby not allowed on form, role='form' superflous

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Form/Renderer.php
@@ -81,15 +81,8 @@ class Renderer extends AbstractComponentRenderer
     protected function maybeAddError(Form\Form $component, Template $tpl): void
     {
         if (null !== ($error = $component->getError())) {
-            $tpl->setCurrentBlock("error");
-            $error_id = $this->createId();
             $tpl->setVariable("ERROR", $error);
-            $tpl->setVariable("ERROR_ID", $error_id);
             $tpl->setVariable("ERROR_LABEL", $this->txt("ui_error"));
-            $tpl->parseCurrentBlock();
-            $tpl->setCurrentBlock("reference_error");
-            $tpl->setVariable("ERROR_ID", $error_id);
-            $tpl->parseCurrentBlock();
         }
     }
 

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.standard.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.standard.html
@@ -1,4 +1,4 @@
-<form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data"<!-- BEGIN reference_error --> describedby="{ERROR_ID}"<!-- END reference_error --> {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post">
+<form class="c-form c-form--horizontal" enctype="multipart/form-data" {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post">
 	<div class="c-form__header">
 		<div class="c-form__actions">{BUTTONS_TOP}</div>
 		<!-- BEGIN required_text_top -->
@@ -8,7 +8,7 @@
 		<!-- END required_text_top -->
 	</div>
 	<!-- BEGIN error -->
-	<div class="c-form__error-msg alert alert-danger" id="{ERROR_ID}"><span class="sr-only">{ERROR_LABEL}: </span>{ERROR}</div>
+	<div class="c-form__error-msg alert alert-danger"><span class="sr-only">{ERROR_LABEL}: </span>{ERROR}</div>
 	<!-- END error -->
 	{INPUTS}
 	<div class="c-form__footer">

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.viewcontrol_container.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.viewcontrol_container.html
@@ -1,4 +1,4 @@
-<form role="form" class="il-viewcontrols-form l-bar__space-keeper" method="get" id="{ID}">
+<form class="il-viewcontrols-form l-bar__space-keeper" method="get" id="{ID}">
 	{INPUTS}
 	<!-- BEGIN param -->
     <input  type="hidden" name="{PARAM_NAME}" value="{VALUE}" />

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.without_submit_buttons.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.without_submit_buttons.html
@@ -1,6 +1,6 @@
-<form id="{ID}" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data"<!-- BEGIN reference_error --> describedby="{ERROR_ID}"<!-- END reference_error --> {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post">
+<form id="{ID}" class="c-form c-form--horizontal" enctype="multipart/form-data" {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post">
 	<!-- BEGIN error -->
-	<div class="c-form__error-msg alert alert-danger" id="{ERROR_ID}"><span class="sr-only">{ERROR_LABEL}: </span>{ERROR}</div>
+	<div class="c-form__error-msg alert alert-danger"><span class="sr-only">{ERROR_LABEL}: </span>{ERROR}</div>
 	<!-- END error -->
 
 	{INPUTS}

--- a/components/ILIAS/UI/tests/Component/Dropzone/File/StandardTest.php
+++ b/components/ILIAS/UI/tests/Component/Dropzone/File/StandardTest.php
@@ -47,7 +47,7 @@ class StandardTest extends FileTestBase
 			<div class="modal-content">
 				<div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>
 				<div class="modal-body">
-					<form id="id_2" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post">' . $this->input->getCanonicalName() . '</form>
+					<form id="id_2" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post">' . $this->input->getCanonicalName() . '</form>
 				</div>
 				<div class="modal-footer"><form><button class="btn btn-default" id="id_3">save</button><button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button></form></div>
 			</div>
@@ -116,7 +116,7 @@ class StandardTest extends FileTestBase
 			<div class="modal-content">
 				<div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>
 				<div class="modal-body">
-					<form id="id_2" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post">' . $this->input->getCanonicalName() . '</form>
+					<form id="id_2" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post">' . $this->input->getCanonicalName() . '</form>
 				</div>
 				<div class="modal-footer"><form><button class="btn btn-default" id="id_3">save</button><button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button></form></div>
 			</div>

--- a/components/ILIAS/UI/tests/Component/Dropzone/File/WrapperTest.php
+++ b/components/ILIAS/UI/tests/Component/Dropzone/File/WrapperTest.php
@@ -43,7 +43,7 @@ class WrapperTest extends FileTestBase
             <div class="modal-content">
                 <div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>
                 <div class="modal-body">
-                    <form id="id_2" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post">File Field Input</form>
+                    <form id="id_2" class="c-form c-form--horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post">File Field Input</form>
                 </div>
                 <div class="modal-footer"><form><button class="btn btn-default" id="id_3">save</button><button formmethod="dialog" class="btn btn-default" data-dismiss="modal">cancel</button></form></div>
             </div>

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/FormWithoutSubmitButtonsTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/FormWithoutSubmitButtonsTest.php
@@ -94,7 +94,7 @@ class FormWithoutSubmitButtonsTest extends \ILIAS_UI_TestBase
         );
 
         $expected_html =
-            "<form id=\"id_1\" role=\"form\" class=\"c-form c-form--horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\">" .
+            "<form id=\"id_1\" class=\"c-form c-form--horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\">" .
             $dummy_input->getCanonicalName() .
             "</form>";
 
@@ -124,7 +124,7 @@ class FormWithoutSubmitButtonsTest extends \ILIAS_UI_TestBase
         );
 
         $expected_html =
-            "<form id=\"id_1\" role=\"form\" class=\"c-form c-form--horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\">" .
+            "<form id=\"id_1\" class=\"c-form c-form--horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\">" .
             $dummy_input->getCanonicalName()
             . "<div class=\"c-form__footer\">"
             . "<div class=\"c-form__required\"><span class=\"asterisk\">*</span><span class=\"small\"> $required_lang_var</span></div>"
@@ -173,8 +173,8 @@ class FormWithoutSubmitButtonsTest extends \ILIAS_UI_TestBase
         $data = $form->getData();
 
         $expected_html = <<<EOT
-<form id="id_2" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" describedby="id_1" action="$post_url" method="post">
-    <div class="c-form__error-msg alert alert-danger" id="id_1"><span class="sr-only">$error_lang_var:</span>$error_lang_var_in_group
+<form id="id_1" class="c-form c-form--horizontal" enctype="multipart/form-data" action="$post_url" method="post">
+    <div class="c-form__error-msg alert alert-danger"><span class="sr-only">$error_lang_var:</span>$error_lang_var_in_group
     </div>{$dummy_input->getCanonicalName()}
 </form>
 EOT;

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/StandardFormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/StandardFormTest.php
@@ -129,7 +129,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $html = $this->getDefaultRenderer()->render($form);
 
         $expected = $this->brutallyTrimHTML('
-        <form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" action="MY_URL" method="post">
+        <form class="c-form c-form--horizontal" enctype="multipart/form-data" action="MY_URL" method="post">
            <div class="c-form__header">
               <div class="c-form__actions"><button class="btn btn-default" data-action="">save</button></div>
            </div>'
@@ -174,7 +174,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($form));
 
         $expected = $this->brutallyTrimHTML('
-        <form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" action="MY_URL" method="post">
+        <form class="c-form c-form--horizontal" enctype="multipart/form-data" action="MY_URL" method="post">
            <div class="c-form__header">
               <div class="c-form__actions"><button class="btn btn-default" data-action="">create</button></div>
            </div>'
@@ -201,7 +201,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($form));
 
         $expected = $this->brutallyTrimHTML('
-        <form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" method="post">
+        <form class="c-form c-form--horizontal" enctype="multipart/form-data" method="post">
             <div class="c-form__header">
                 <div class="c-form__actions">
                     <button class="btn btn-default" data-action="">save</button>
@@ -261,19 +261,19 @@ class StandardFormTest extends ILIAS_UI_TestBase
 
         $html = $this->brutallyTrimHTML($r->render($form));
         $expected = $this->brutallyTrimHTML('
-<form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" describedby="id_1" method="post">
+<form class="c-form c-form--horizontal" enctype="multipart/form-data" method="post">
     <div class="c-form__header">
         <div class="c-form__actions">
             <button class="btn btn-default" data-action="">save</button>
         </div>
     </div>
-    <div class="c-form__error-msg alert alert-danger" id="id_1"><span class="sr-only">ui_error:</span>testing error
+    <div class="c-form__error-msg alert alert-danger"><span class="sr-only">ui_error:</span>testing error
         message
     </div>
     <fieldset class="c-input" data-il-ui-component="text-field-input" data-il-ui-input-name="form_0/input_1"
-              aria-describedby="id_3"><label for="id_2">label</label>
-        <div class="c-input__field"><input id="id_2" type="text" name="form_0/input_1" class="c-field-text" /></div>
-        <div class="c-input__error-msg alert alert-danger" id="id_3"><span class="sr-only">ui_error:</span>This is
+              aria-describedby="id_2"><label for="id_1">label</label>
+        <div class="c-input__field"><input id="id_1" type="text" name="form_0/input_1" class="c-field-text" /></div>
+        <div class="c-input__error-msg alert alert-danger" id="id_2"><span class="sr-only">ui_error:</span>This is
             invalid...
         </div>
         <div class="c-input__help-byline">byline</div>
@@ -328,20 +328,20 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $field_html = $this->getFormWrappedHtml(
             'text-field-input',
             'label',
-            '<input id="id_2" type="text" name="form_0/input_1" class="c-field-text"/>',
+            '<input id="id_1" type="text" name="form_0/input_1" class="c-field-text"/>',
             'byline',
-            'id_2',
+            'id_1',
             null,
             'form_0/input_1'
         );
 
         $html = $this->brutallyTrimHTML($r->render($form));
         $expected = $this->brutallyTrimHTML('
-            <form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" describedby="id_1" method="post">
+            <form class="c-form c-form--horizontal" enctype="multipart/form-data" method="post">
                 <div class="c-form__header">
                     <div class="c-form__actions"><button class="btn btn-default" data-action="">save</button></div>
                 </div>
-                <div class="c-form__error-msg alert alert-danger" id="id_1"><span class="sr-only">ui_error:</span>This is a fail on form.</div>
+                <div class="c-form__error-msg alert alert-danger"><span class="sr-only">ui_error:</span>This is a fail on form.</div>
                 ' . $field_html . '
                 <div class="c-form__footer">
                     <div class="c-form__actions"><button class="btn btn-default" data-action="">save</button></div>
@@ -373,7 +373,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         );
 
         $expected = $this->brutallyTrimHTML('
-<form role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" action="MY_URL" method="post">
+<form class="c-form c-form--horizontal" enctype="multipart/form-data" action="MY_URL" method="post">
     <div class="c-form__header">
         <div class="c-form__actions"><button class="btn btn-default" data-action="">save</button></div>
         <div class="c-form__required">

--- a/components/ILIAS/UI/tests/Component/Launcher/LauncherInlineTest.php
+++ b/components/ILIAS/UI/tests/Component/Launcher/LauncherInlineTest.php
@@ -229,7 +229,7 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
                         <h1 class="modal-title">different label</h1>
                     </div>
                     <div class="modal-body">$msg_html
-                        <form id="id_3" role="form" class="c-form c-form--horizontal" enctype="multipart/form-data" action="http://localhost/ilias.php" method="post">
+                        <form id="id_3" class="c-form c-form--horizontal" enctype="multipart/form-data" action="http://localhost/ilias.php" method="post">
                             <fieldset class="c-input" data-il-ui-component="checkbox-field-input" data-il-ui-input-name="form/input_0">
                                 <label for="id_2">Understood</label>
                                 <div class="c-input__field">


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43303
Removes attributes 'role' and 'decribedby' from form, which are unnecessary/forbidden according to w3c.
I also could not see any difference using a screenreader.