### PR TITLE
Notifications: Remove individual/dynamic timings from toasts

### DIFF
--- a/Services/Awareness/classes/Provider/AwarenessToastProvider.php
+++ b/Services/Awareness/classes/Provider/AwarenessToastProvider.php
@@ -85,9 +85,7 @@ class AwarenessToastProvider extends AbstractToastProvider
                     $this->if->identifier(self::PROVIDER_KEY . '_' . $this->dic->user()->getId()),
                     $this->dic->language()->txt('awareness_now_online')
                 )
-                ->withIcon($this->dic->ui()->factory()->symbol()->icon()->standard(Standard::USR, ''))
-                ->withVanishTime((int) $setting->get('osd_vanish', (string) Toast::DEFAULT_VANISH_TIME))
-                ->withDelayTime((int) $setting->get('osd_delay', (string) Toast::DEFAULT_DELAY_TIME));
+                ->withIcon($this->dic->ui()->factory()->symbol()->icon()->standard(Standard::USR, ''));
             $links = [];
             foreach ($new_users as $user) {
                 $uname = "[" . $user['login'] . "]";

--- a/Services/Notifications/ROADMAP.md
+++ b/Services/Notifications/ROADMAP.md
@@ -8,11 +8,6 @@ It should have its own checkbox within the notification administration.
 * Get rid of time dependency in `\ILIAS\Notifications\Repository\ilNotificationOSDRepository`
   and `\ILIAS\Notifications\ilNotificationDatabaseHandler`, use `\ILIAS\Data\Clock\ClockFactory` interface instead
 
-### Update of Toast Interface
-
-`VanishTime` and `DelayTime` should be moved to the interface, if the values could be configured in the respective consumers.
-As long as this is not the case, they keep an implementation detail.
-
 ## Mid Term
 
 ## Long Term

--- a/Services/Notifications/classes/Provider/NotificationsToastProvider.php
+++ b/Services/Notifications/classes/Provider/NotificationsToastProvider.php
@@ -61,8 +61,6 @@ class NotificationsToastProvider extends AbstractToastProvider
                 )
                 ->withIcon($this->getIconByType($notification->getType()))
                 ->withDescription($notification->getObject()->shortDescription)
-                ->withVanishTime((int) $settings->get('osd_vanish', (string) Toast::DEFAULT_VANISH_TIME))
-                ->withDelayTime((int) $settings->get('osd_delay', (string) Toast::DEFAULT_DELAY_TIME))
                 ->withClosedCallable(static function () use ($osd_repository, $notification) {
                     $osd_repository->deleteOSDNotificationById($notification->getId());
                 });

--- a/Services/Notifications/classes/Setup/ilNotificationUpdateSteps.php
+++ b/Services/Notifications/classes/Setup/ilNotificationUpdateSteps.php
@@ -127,16 +127,6 @@ class ilNotificationUpdateSteps implements ilDatabaseUpdateSteps
 
     public function step_6(): void
     {
-        $this->db->insert('settings', [
-            'module' => [ilDBConstants::T_TEXT, 'notifications'],
-            'keyword' => [ilDBConstants::T_TEXT, 'osd_vanish'],
-            'value' => [ilDBConstants::T_INTEGER, 5]
-        ]);
-        $this->db->insert('settings', [
-            'module' => [ilDBConstants::T_TEXT, 'notifications'],
-            'keyword' => [ilDBConstants::T_TEXT, 'osd_delay'],
-            'value' => [ilDBConstants::T_INTEGER, 500]
-        ]);
     }
 
     public function step_7(): void
@@ -159,11 +149,6 @@ class ilNotificationUpdateSteps implements ilDatabaseUpdateSteps
             "UPDATE settings SET value = CONCAT(value , '000') WHERE keyword = %s",
             [ilDBConstants::T_TEXT],
             ['osd_interval']
-        );
-        $this->db->manipulateF(
-            "UPDATE settings SET value = CONCAT(value , '000') WHERE keyword = %s",
-            [ilDBConstants::T_TEXT],
-            ['osd_vanish']
         );
         $this->db->manipulateF(
             'UPDATE usr_pref SET keyword = %s WHERE keyword = %s',

--- a/Services/Notifications/classes/class.ilObjNotificationAdminGUI.php
+++ b/Services/Notifications/classes/class.ilObjNotificationAdminGUI.php
@@ -79,8 +79,6 @@ class ilObjNotificationAdminGUI extends ilObjectGUI
             } else {
                 $values['enable_osd'] = [
                     'osd_interval' => (int) $settings->get('osd_interval'),
-                    'osd_vanish' => (int) $settings->get('osd_vanish'),
-                    'osd_delay' => (int) $settings->get('osd_delay'),
                     'osd_play_sound' => (bool) $settings->get('osd_play_sound'),
                 ];
             }
@@ -109,16 +107,11 @@ class ilObjNotificationAdminGUI extends ilObjectGUI
                 $DIC->notifications()->system()->clear('osd');
                 $settings->set('enable_osd', '0');
                 $settings->delete('osd_interval');
-                $settings->delete('osd_vanish');
-                $settings->delete('osd_delay');
                 $settings->delete('osd_play_sound');
             } else {
                 $settings->set('enable_osd', '1');
                 $settings->set('osd_interval', ((string) $data['osd']['enable_osd']['osd_interval']));
-                $settings->set('osd_vanish', ((string) $data['osd']['enable_osd']['osd_vanish']));
-                $settings->set('osd_delay', ((string) $data['osd']['enable_osd']['osd_delay']));
                 $settings->set('osd_play_sound', ($data['osd']['enable_osd']['osd_play_sound']) ? '1' : '0');
-
             }
         }
         $this->showOSDSettings($form);
@@ -144,40 +137,13 @@ class ilObjNotificationAdminGUI extends ilObjectGUI
                         },
                         $this->lng->txt('osd_error_refresh_interval_too_small')
                     )),
-                'osd_vanish' => $this->dic->ui()->factory()->input()->field()->numeric(
-                    $this->lng->txt('osd_vanish'),
-                    $this->lng->txt('osd_vanish_desc')
-                )
-                    ->withRequired(true)
-                    ->withValue(5000)
-                    ->withAdditionalTransformation($this->dic->refinery()->custom()->constraint(
-                        static function ($value) {
-                            return $value >= 1000;
-                        },
-                        $this->lng->txt('osd_error_presentation_time_too_small')
-                    )),
-                'osd_delay' => $this->dic->ui()->factory()->input()->field()->numeric(
-                    $this->lng->txt('osd_delay'),
-                    $this->lng->txt('osd_delay_desc')
-                )
-                    ->withRequired(true)
-                    ->withValue(500),
                 'osd_play_sound' => $this->dic->ui()->factory()->input()->field()->checkbox(
                     $this->lng->txt('osd_play_sound'),
                     $this->lng->txt('osd_play_sound_desc')
                 )
             ],
             $this->lng->txt('enable_osd')
-        )->withByline(
-            $this->lng->txt('enable_osd_desc')
-        )->withAdditionalTransformation(
-            $this->dic->refinery()->custom()->constraint(
-                static function ($value) {
-                    return $value === null || ($value['osd_interval'] > $value['osd_delay'] + $value['osd_vanish']);
-                },
-                $this->lng->txt('osd_error_refresh_interval_smaller_than_delay_and_vanish_combined')
-            )
-        );
+        )->withByline($this->lng->txt('enable_osd_desc'));
 
         if ($values !== null) {
             $enable_osd = $enable_osd->withValue($values['enable_osd'] ?? null);

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -12792,18 +12792,12 @@ noti#:#noti_notification_deactivated#:#Benachrichtigungen sind deaktiviert
 notifications_adm#:#enable_osd#:#Pop-up-Benachrichtigungen aktivieren
 notifications_adm#:#enable_osd_desc#:#Wenn aktiviert, werden Benutzer durch ein Pop-up über neue Benachrichtigungen informiert.
 notifications_adm#:#notification_settings#:#Benachrichtigungseinstellungen
-notifications_adm#:#osd_delay#:#Anzeigeverzögerung
-notifications_adm#:#osd_delay_desc#:#Verzögerung der Anzeige der Benachrichtigungen in Millisekunden
-notifications_adm#:#osd_error_presentation_time_too_small#:#Die Anzeigedauer muss mindestens 1000 Millisekunden betragen.
-notifications_adm#:#osd_error_refresh_interval_smaller_than_delay_and_vanish_combined#:#Das Abfrageintervall muss größer sein als die Summe der Anzeigedauer und der Anzeigeverzögerung.
 notifications_adm#:#osd_error_refresh_interval_too_small#:#Das Abfrageintervall muss mindestens 3000 Millisekunden betragen.
 notifications_adm#:#osd_interval#:#Abfrageintervall
 notifications_adm#:#osd_interval_desc#:#Abfrageintervall für Nachrichten in Millisekunden.Eine geringere Zeit ermöglicht zeitnähere Benachrichtigungen, erhöht aber die Serverlast.
 notifications_adm#:#osd_play_sound#:#Ton abspielen
 notifications_adm#:#osd_play_sound_desc#:#Ton abspielen bei Erhalt einer neuen Benachrichtigung.
 notifications_adm#:#osd_settings#:#Pop-up-Benachrichtigungen
-notifications_adm#:#osd_vanish#:#Anzeigedauer
-notifications_adm#:#osd_vanish_desc#:#Dauer der Anzeige von Benachrichtigungen in Millisekunden
 obj#:#activation_visible_when_disabled#:#Sichtbarkeit
 obj#:#activation_visible_when_disabled_info#:#Die gewählten Objekte sind auch außerhalb des gewählten Zeitraums sichtbar, können aber nicht geöffnet werden.
 obj#:#availability_period_changed#:#Die zeitliche Verfügbarkeit wurde für die ausgewählten Objekte erfolgreich angepasst.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -12792,18 +12792,12 @@ noti#:#noti_notification_deactivated#:#Notification Deactivated
 notifications_adm#:#enable_osd#:#Enable Toasts
 notifications_adm#:#enable_osd_desc#:#If enabled, users are notified by a pop-up about new notifications.
 notifications_adm#:#notification_settings#:#Notification Settings
-notifications_adm#:#osd_delay#:#Presentation Delay
-notifications_adm#:#osd_delay_desc#:#Delay of the visible presentation in milliseconds.
-notifications_adm#:#osd_error_presentation_time_too_small#:#The Presentation Time has to be at least than 1000 miliseconds.
-notifications_adm#:#osd_error_refresh_interval_smaller_than_delay_and_vanish_combined#:#The Refresh Interval has to be greater than the Presentation Time and the Presentation Delay combined.
 notifications_adm#:#osd_error_refresh_interval_too_small#:#The Refresh Interval has to be at least than 3000 miliseconds.
 notifications_adm#:#osd_interval#:#Refresh interval
 notifications_adm#:#osd_interval_desc#:#Polling interval for checking of new notifications in miliseconds. A lower number will notify the user more quickly but increases the number of requests the web server must handle.
 notifications_adm#:#osd_play_sound#:#Play a Sound
 notifications_adm#:#osd_play_sound_desc#:#Play a sound when receiving a new notficiation.
 notifications_adm#:#osd_settings#:#Toasts
-notifications_adm#:#osd_vanish#:#Presentation Time
-notifications_adm#:#osd_vanish_desc#:#Visible time of a notification on the screen in miliseconds.
 obj#:#activation_visible_when_disabled#:#Visibility
 obj#:#activation_visible_when_disabled_info#:#The item is visible outside of the selected availability period, but it cannot be opened.
 obj#:#availability_period_changed#:#The availability period for the selected objects has been changed successfully.

--- a/src/GlobalScreen/Scope/Toast/Collector/Renderer/StandardToastRenderer.php
+++ b/src/GlobalScreen/Scope/Toast/Collector/Renderer/StandardToastRenderer.php
@@ -127,15 +127,6 @@ class StandardToastRenderer implements ToastRenderer
             $toast = $toast->withAdditionalLink($link);
         }
 
-        // Times (currently disbaled since these methods are not on the Interface of a Toast
-        if ($item->getVanishTime() !== null) {
-            // $toast = $toast->withVanishTime($item->getVanishTime());
-        }
-
-        if ($item->getDelayTime() !== null) {
-            // $toast = $toast->withDelayTime($item->getDelayTime());
-        }
-
         return $toast;
     }
 

--- a/src/GlobalScreen/Scope/Toast/Factory/StandardToastItem.php
+++ b/src/GlobalScreen/Scope/Toast/Factory/StandardToastItem.php
@@ -54,9 +54,6 @@ class StandardToastItem implements isStandardItem
     protected IdentificationInterface $provider_identification;
     protected ToastRenderer $renderer;
 
-    protected ?int $vanish_time = null;
-    protected ?int $delay_time = null;
-
     public function __construct(
         IdentificationInterface $provider_identification,
         ToastRenderer $renderer,
@@ -225,30 +222,6 @@ class StandardToastItem implements isStandardItem
     public function hasVanishedAction(): bool
     {
         return $this->handle_vanished !== null;
-    }
-
-    public function withVanishTime(int $miliseconds): isStandardItem
-    {
-        $clone = clone $this;
-        $clone->vanish_time = $miliseconds;
-        return $clone;
-    }
-
-    public function getVanishTime(): ?int
-    {
-        return $this->vanish_time;
-    }
-
-    public function withDelayTime(int $miliseconds): isStandardItem
-    {
-        $clone = clone $this;
-        $clone->delay_time = $miliseconds;
-        return $clone;
-    }
-
-    public function getDelayTime(): ?int
-    {
-        return $this->delay_time;
     }
 
     final public function getRenderer(): ToastRenderer

--- a/src/GlobalScreen/Scope/Toast/Factory/isStandardItem.php
+++ b/src/GlobalScreen/Scope/Toast/Factory/isStandardItem.php
@@ -102,13 +102,5 @@ interface isStandardItem extends isItem
      */
     public function hasVanishedAction(): bool;
 
-    public function withVanishTime(int $miliseconds): isStandardItem;
-
-    public function getVanishTime(): ?int;
-
-    public function withDelayTime(int $miliseconds): isStandardItem;
-
-    public function getDelayTime(): ?int;
-
     public function getRenderer(): ToastRenderer;
 }

--- a/src/UI/Implementation/Component/Toast/Renderer.php
+++ b/src/UI/Implementation/Component/Toast/Renderer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Toast;
 
@@ -59,8 +59,6 @@ class Renderer extends AbstractComponentRenderer
         }
         $tpl->setVariable("TITLE", $title);
 
-        $tpl->setVariable("TOAST_DELAY", $component->getDelayTime());
-        $tpl->setVariable("TOAST_VANISH", $component->getVanishTime());
         $tpl->setVariable("VANISH_ASYNC", $component->getAction());
 
         $desc = htmlentities($component->getDescription());
@@ -82,10 +80,7 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable("ICON", $default_renderer->render($component->getIcon()));
         $tpl->setVariable("CLOSE", $default_renderer->render($this->getUIFactory()->button()->close()));
 
-        $component = $component->withAdditionalOnLoadCode(fn ($id) => "
-                il.UI.toast.setToastSettings($id);
-                il.UI.toast.showToast($id);
-            ");
+        $component = $component->withAdditionalOnLoadCode(fn($id) => "il.UI.toast.showToast($id);");
 
         $tpl->setCurrentBlock("id");
         $tpl->setVariable('ID', $this->bindJavaScript($component));

--- a/src/UI/Implementation/Component/Toast/Toast.php
+++ b/src/UI/Implementation/Component/Toast/Toast.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Toast;
 
@@ -34,9 +34,6 @@ class Toast implements ComponentInterface\Toast
     use ComponentHelper;
     use JavaScriptBindable;
 
-    public const DEFAULT_VANISH_TIME = 5000;
-    public const DEFAULT_DELAY_TIME = 500;
-
     /**
      * @var string|Shy|Link
      */
@@ -48,8 +45,6 @@ class Toast implements ComponentInterface\Toast
     protected string $action = '';
     protected SignalGeneratorInterface $signal_generator;
     protected Signal $signal;
-    protected int $vanishTime = Toast::DEFAULT_VANISH_TIME;
-    protected int $delayTime = Toast::DEFAULT_DELAY_TIME;
 
     public function __construct($title, Icon $icon, SignalGeneratorInterface $signal_generator)
     {
@@ -125,29 +120,5 @@ class Toast implements ComponentInterface\Toast
     public function getShowSignal(): Signal
     {
         return $this->signal;
-    }
-
-    public function withVanishTime(int $vanishTime): Toast
-    {
-        $new = clone $this;
-        $new->vanishTime = $vanishTime;
-        return $new;
-    }
-
-    public function getVanishTime(): int
-    {
-        return $this->vanishTime;
-    }
-
-    public function withDelayTime(int $delayTime): Toast
-    {
-        $new = clone $this;
-        $new->delayTime = $delayTime;
-        return $new;
-    }
-
-    public function getDelayTime(): int
-    {
-        return $this->delayTime;
     }
 }

--- a/src/UI/templates/default/Toast/tpl.toast.html
+++ b/src/UI/templates/default/Toast/tpl.toast.html
@@ -1,4 +1,4 @@
-<div class="il-toast-wrapper" <!-- BEGIN id -->id="{ID}"<!-- END id --> data-vanishurl="{VANISH_ASYNC}" data-vanish="{TOAST_VANISH}" data-delay="{TOAST_DELAY}">
+<div class="il-toast-wrapper" <!-- BEGIN id -->id="{ID}"<!-- END id --> data-vanishurl="{VANISH_ASYNC}">
     <div class="il-toast" tabindex="0">
         <div class="icon">{ICON}</div>
         <div class="title">{TITLE}</div>

--- a/src/UI/templates/js/Toast/toast.js
+++ b/src/UI/templates/js/Toast/toast.js
@@ -1,18 +1,25 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 var il = il || {};
 il.UI = il.UI || {};
 il.UI.toast = ((UI) => {
     let vanishTime = 5000;
     let delayTime = 500;
     let queue = new WeakMap();
-
-    const setToastSettings = (element) => {
-        if (element.hasAttribute('data-vanish')) {
-            vanishTime = parseInt(element.dataset.vanish);
-        }
-        if (element.hasAttribute('data-delay')) {
-            delayTime = parseInt(element.dataset.delay);
-        }
-    }
 
     const showToast = (element) => {
         setTimeout(() => {appearToast(element);}, delayTime);
@@ -53,6 +60,5 @@ il.UI.toast = ((UI) => {
         showToast: showToast,
         closeToast: closeToast,
         appearToast: appearToast,
-        setToastSettings: setToastSettings,
     }
 })(il.UI)

--- a/tests/UI/Client/Toast/ToastTest.html
+++ b/tests/UI/Client/Toast/ToastTest.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <div class="il-toast-container" aria-live="polite">
-    <div class="il-toast-wrapper" data-vanishurl="https://www.ilias.de" data-vanish="5000" data-delay="500">
+    <div class="il-toast-wrapper" data-vanishurl="https://www.ilias.de">
       <div class="il-toast" tabindex="0">
         <div class="icon">
           <img class="icon mail small" src="./templates/default/images/standard/icon_mail.svg" alt="Test"/>

--- a/tests/UI/Client/Toast/toast.test.js
+++ b/tests/UI/Client/Toast/toast.test.js
@@ -1,3 +1,19 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 import {expect} from "chai";
 import {JSDOM} from 'jsdom';
 
@@ -41,28 +57,12 @@ describe('component available', () => {
 describe('showToast', () => {
     it ('before timeout', () => {
         il.UI.toast.showToast(element);
-        expect(last_timeout_time).to.be.equal(parseInt(element.dataset.delay));
         expect(toast.classList.contains('active')).to.be.false;
     })
     it ('after timeout', () => {
         il.UI.toast.showToast(element);
         last_timeout();
         expect(toast.classList.contains('active')).to.be.true;
-    })
-})
-
-describe('setToastSettings', () => {
-    it ('set delay time', () => {
-        element.dataset.delay = 123;
-        il.UI.toast.setToastSettings(element);
-        il.UI.toast.showToast(element);
-        expect(last_timeout_time).to.be.equal(123);
-    })
-    it ('set vanish time', () => {
-        element.dataset.vanish = 1111;
-        il.UI.toast.setToastSettings(element);
-        il.UI.toast.appearToast(element);
-        expect(last_timeout_time).to.be.equal(1111);
     })
 })
 

--- a/tests/UI/Component/Toast/ToastClientHtmlTest.php
+++ b/tests/UI/Component/Toast/ToastClientHtmlTest.php
@@ -65,8 +65,6 @@ class ToastClientHtmlTest extends ILIAS_UI_TestBase
                 'Title',
                 $this->getIconFactory()->standard('mail', 'Test')
             )
-                                    ->withVanishTime(5000)
-                                    ->withDelayTime(500)
                                     ->withDescription('Description')
                                     ->withAction('https://www.ilias.de')
         );

--- a/tests/UI/Component/Toast/ToastTest.php
+++ b/tests/UI/Component/Toast/ToastTest.php
@@ -55,20 +55,16 @@ class ToastTest extends ILIAS_UI_TestBase
     /**
      * @dataProvider getToastProvider
      */
-    public function testToast(string $title, string $description, int $vanish_time, int $delay_time, string $action): void
+    public function testToast(string $title, string $description, string $action): void
     {
         $toast = $this->getToastFactory()->standard($title, $this->getIconFactory()->standard('', ''))
                       ->withDescription($description)
-                      ->withVanishTime($vanish_time)
-                      ->withDelayTime($delay_time)
                       ->withAction($action)
                       ->withAdditionalLink($this->getLinkFactory()->standard('', ''));
 
         $this->assertNotNull($toast);
         $this->assertEquals($title, $toast->getTitle());
         $this->assertEquals($description, $toast->getDescription());
-        $this->assertEquals($vanish_time, $toast->getVanishTime());
-        $this->assertEquals($delay_time, $toast->getDelayTime());
         $this->assertEquals($action, $toast->getAction());
         $this->assertCount(1, $toast->getLinks());
         $this->assertInstanceOf(Link::class, $toast->getLinks()[0]);
@@ -79,7 +75,7 @@ class ToastTest extends ILIAS_UI_TestBase
     /**
      * @dataProvider getToastProvider
      */
-    public function testToastContainer(string $title, string $description, int $vanish_time): void
+    public function testToastContainer(string $title, string $description): void
     {
         $container = $this->getToastFactory()->container()->withAdditionalToast(
             $this->getToastFactory()->standard('', $this->getIconFactory()->standard('', ''))
@@ -94,9 +90,9 @@ class ToastTest extends ILIAS_UI_TestBase
     public function getToastProvider(): array
     {
         return [
-            ['title', 'description', 5000, 500, 'test.php'],
-            ['', '', -5000, -500, ''],
-            ['"/><script>alert("hack")</script>', '"/><script>alert("hack")</script>', PHP_INT_MAX, PHP_INT_MIN, 'test.php']
+            ['title', 'description', 'test.php'],
+            ['', '', ''],
+            ['"/><script>alert("hack")</script>', '"/><script>alert("hack")</script>', 'test.php']
         ];
     }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43471

Due to strong disagreements on this feature and a very complex discussion (see https://github.com/ILIAS-eLearning/ILIAS/pull/6164 and referring PRs), this PR proposes to remove the feature of dynamic toast timing entirely.

This will recreate a clean structure on toast and remove their internal inconsistency concerning this topic by removing any options and artifacts of individual timing from the toasts.

Based on this clean state interested groups may propose feature requests regarding the additional option for individual configurations of toast timings.