### PR TITLE
changes to security.md for patch application

### DIFF
--- a/docs/development/security.md
+++ b/docs/development/security.md
@@ -51,10 +51,10 @@ to the corresponding patch files to the issue manager through a secure channel.
 The following process MUST be followed to hand in a fix for a security issue:
 * Create one patch file per supported branch needing the fix. The patch file MUST
 be named "<ilias_version>_<title_of_fix>.patch" (e.g. "9_my-very-important-fix.patch").
-To create the patch use `git format-patch` with the option `--stdout`
-(e.g. `git format-patch latest-not-included-commit-id-of-current-branch --stdout > 9_my-very-important-fix.patch`)
+To create the patch use `git format-patch` with the option `--stdout` from the branch in which you made the fixes
+(e.g. `git format-patch release_9 --stdout > 9_my-very-important-fix.patch`)
 to ensure that all commits are in a single patch file, if multiple commits are
-needed to fix the issue. This writes only the changes after the chosen commit into the patch file. To make the application of the patches as easy as possible,
+needed to fix the issue. To make the application of the patches as easy as possible,
 **fixes for security issues MUST not contain any unrelated changes**.
 * Upload the patch files to the corresponding issue in the project "ILIAS Security"
 on our issue tracker. If you would like to provide a patch for an issue, but do

--- a/docs/development/security.md
+++ b/docs/development/security.md
@@ -52,9 +52,9 @@ The following process MUST be followed to hand in a fix for a security issue:
 * Create one patch file per supported branch needing the fix. The patch file MUST
 be named "<ilias_version>_<title_of_fix>.patch" (e.g. "9_my-very-important-fix.patch").
 To create the patch use `git format-patch` with the option `--stdout`
-(e.g. `git format-patch my-bug-fixing-branch --stdout > 9_my-very-important-fix.patch`)
+(e.g. `git format-patch latest-not-included-commit-id-of-current-branch --stdout > 9_my-very-important-fix.patch`)
 to ensure that all commits are in a single patch file, if multiple commits are
-needed to fix the issue. To make the application of the patches as easy as possible,
+needed to fix the issue. This writes only the changes after the chosen commit into the patch file. To make the application of the patches as easy as possible,
 **fixes for security issues MUST not contain any unrelated changes**.
 * Upload the patch files to the corresponding issue in the project "ILIAS Security"
 on our issue tracker. If you would like to provide a patch for an issue, but do


### PR DESCRIPTION
This should specify the git format-patch command. I think the current documentation is not correct since git can't know which commits are supposed to be chosen if you only input the branch name as a parameter.