### PR TITLE
OrgU: 42554, param handling when deleting position

### DIFF
--- a/components/ILIAS/StudyProgramme/classes/model/AutoMemberships/class.ilStudyProgrammeMembershipSourceReaderOrgu.php
+++ b/components/ILIAS/StudyProgramme/classes/model/AutoMemberships/class.ilStudyProgrammeMembershipSourceReaderOrgu.php
@@ -38,7 +38,7 @@ class ilStudyProgrammeMembershipSourceReaderOrgu implements ilStudyProgrammeMemb
     {
         $children[] = $this->src_id;
         if ($this->search_recursive) {
-            $children = array_unique(array_merge($children, $this->orgu_tree->getChildren($this->src_id)));
+            $children = array_unique(array_merge($children, $this->orgu_tree->getAllChildren($this->src_id)));
         }
         return $this->orgu_assignment_repo->getUsersByOrgUnits($children);
     }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -13108,7 +13108,7 @@ orgu#:#msg_confirm_deletion#:#Wollen Sie die folgende Position wirklich löschen
 orgu#:#msg_confirm_remove_user#:#Möchten Sie den folgenden Benutzer wirklich aus der Position %s entfernen?
 orgu#:#msg_deleted#:#Gelöscht
 orgu#:#msg_position_created#:#Position wurde erstellt.
-orgu#:#msg_position_udpated#:#Position updated
+orgu#:#msg_position_delete_fail#:#Position wurde nicht gefunden.
 orgu#:#msg_position_updated#:#Position wurde aktualisiert.
 orgu#:#msg_success_permission_saved#:#Rechte wurden gespeichert.
 orgu#:#no_assignment#:#Bitte prüfen Sie Ihre XML-Datei. Es konnte keine Benutzerzuweisung gefunden werden.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -13108,7 +13108,7 @@ orgu#:#msg_confirm_deletion#:#Would you really like to delete the following Posi
 orgu#:#msg_confirm_remove_user#:#Would you really like to remove the following User from the Position %s?
 orgu#:#msg_deleted#:#Deleted
 orgu#:#msg_position_created#:#Position created.
-orgu#:#msg_position_udpated#:#Position aktualisiert
+orgu#:#msg_position_delete_fail#:#Position wurde nicht gefunden.
 orgu#:#msg_position_updated#:#Position updated.
 orgu#:#msg_success_permission_saved#:#Permissions saved.
 orgu#:#no_assignment#:#Please check your XML-File. There is no User Assignment.


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42554

besides adjusting the paramter handling (its a post, no ids in query), I also removed the unused and apparently wrong lang_var msg_position_u**dp**ated. Finally, not really in OrgU, but closely related, the StudyProgrammeMembershipSourceReaderOrgu is triggered via event when deleting the position and threw due to getChildren beeing private on orguTree