### PR TITLE
introduce catamorphism for ui components

### DIFF
--- a/components/ILIAS/UI/src/Component/Component.php
+++ b/components/ILIAS/UI/src/Component/Component.php
@@ -30,4 +30,32 @@ interface Component
      * Get the canonical name of the component.
      */
     public function getCanonicalName(): string;
+
+    /**
+     * This implements the catamorphism (https://en.wikipedia.org/wiki/Catamorphism)
+     * for components, which is a clever way to implement a generalized fold over
+     * data structures.
+     *
+     * The scheme starts at the leaves of the structure and applys the function to
+     * each leave and moves up the tree recursively. The return value of the function
+     * is put into the "sub structure" to be consumed when the function is applied
+     * to the upper levels. By using this method, the structure can be broken down
+     * completely or it can be modified.
+     */
+    public function foldWith(callable $f): mixed;
+
+    /**
+     * This contains the sub structure of the component to support `foldWith`. For
+     * pristine Components, it shall return all Components that are contained in
+     * the component. When applying `foldWith` it will contain the results of the
+     * function for these sub components. A component might contain no substructure
+     * whatsoever, hence this might return null;
+     *
+     * Implementations of Component shall simply pass back their sub components,
+     * and, most probably, use the implementation of foldWith from the trait
+     * ComponentHelper and overwrite "getSubComponents" according to their requirements.
+     *
+     * @return ?array<mixed>
+     */
+    public function getSubStructure(): ?array;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Container.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Container.php
@@ -149,4 +149,9 @@ abstract class Container implements C\Input\Container\Container
      * since different containers may allow different request methods.
      */
     abstract protected function extractRequestData(ServerRequestInterface $request): InputData;
+
+    public function getSubComponents(): array
+    {
+        return $this->getInputs();
+    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Group.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Group.php
@@ -157,4 +157,9 @@ class Group extends FormInput implements C\Input\Field\Group, GroupInternal
     {
         return $this->_isClientSideValueOk($value);
     }
+
+    protected function getSubComponents(): ?array
+    {
+        return $this->getInputs();
+    }
 }

--- a/components/ILIAS/UI/src/examples/Input/Container/Form/Standard/catamorph.php
+++ b/components/ILIAS/UI/src/examples/Input/Container/Form/Standard/catamorph.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Container\Form\Standard;
+
+/**
+ * ---
+ * description: >
+ *   Example showing catamorphism with Form to factor out classes and structure as JSON.
+ *
+ * expected output: >
+ *   ILIAS shows a JSON like that:
+ *   {
+ *    "Standard Form Container Input": [
+ *        {
+ *            "Section Field Input": [
+ *                "Text Field Input"
+ *            ]
+ *        },
+ *        {
+ *            "Section Field Input": [
+ *                "Text Field Input"
+ *            ]
+ *        },
+ *        "Text Field Input"
+ *    ]
+ *   }
+ * ---
+ */
+function catamorph()
+{
+    global $DIC;
+    $ui = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $text_input = $ui->input()->field()
+        ->text("Required Input", "User needs to fill this field")
+        ->withRequired(true);
+
+    $section = $ui->input()->field()->section(
+        [$text_input],
+        "Section with required field",
+        "The Form should show an explaining hint at the bottom"
+    );
+
+    $form = $ui->input()->container()->form()->standard("", [$section, $section, $text_input]);
+
+    $array = $form->foldWith(
+        function ($c) {
+            $subs = $c->getSubStructure();
+            if ($subs !== null) {
+                return [$c->getCanonicalName() => $subs];
+            } else {
+                return $c->getCanonicalName();
+            }
+        }
+    );
+
+    return $renderer->render(
+        $ui->legacy()->content('<pre>' . print_r(json_encode($array, JSON_PRETTY_PRINT), true) . '</pre>')
+    );
+}

--- a/components/ILIAS/UI/src/examples/Input/Container/ViewControl/Standard/catamorph.php
+++ b/components/ILIAS/UI/src/examples/Input/Container/ViewControl/Standard/catamorph.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Container\ViewControl\Standard;
+
+use ILIAS\Data\Order;
+use ILIAS\UI\Implementation\Component\Input\ViewControl\Pagination;
+
+/**
+ * ---
+ * expected output: >
+ *   ILIAS shows a JSON like that:
+ *   {
+ *       "Standard View Control Container Input": [
+ *           "Pagination View Control Input",
+ *           "Sortation View Control Input",
+ *           "Field Selection View Control Input"
+ *       ]
+ *   }
+ * ---
+ */
+function catamorph()
+{
+    global $DIC;
+    $f = $DIC->ui()->factory();
+    $r = $DIC->ui()->renderer();
+
+    $vcs = [
+        $f->input()->viewControl()->pagination(),
+        $f->input()->viewControl()->sortation([
+                'Field 1, ascending' => new Order('field1', 'ASC'),
+                'Field 1, descending' => new Order('field1', 'DESC'),
+                'Field 2, descending' => new Order('field2', 'ASC')
+            ]),
+        $f->input()->viewControl()->fieldSelection([
+                'field1' => 'Feld 1',
+                'field2' => 'Feld 2'
+            ], 'shown columns', 'apply'),
+    ];
+
+    $vc_container = $f->input()->container()->viewControl()->standard($vcs);
+
+
+    $array = $vc_container->foldWith(
+        function ($c) {
+            $subs = $c->getSubStructure();
+            if ($subs !== null) {
+                return [$c->getCanonicalName() => $subs];
+            } else {
+                return $c->getCanonicalName();
+            }
+        }
+    );
+
+    return $r->render([
+        $f->legacy()->content('<pre>' . print_r(json_encode($array, JSON_PRETTY_PRINT), true) . '</pre>')
+    ]);
+}

--- a/components/ILIAS/UI/tests/Base.php
+++ b/components/ILIAS/UI/tests/Base.php
@@ -40,6 +40,7 @@ use PHPUnit\Framework\TestCase;
 use ILIAS\UI\Implementation\Component\SignalGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
 use ILIAS\UI\Component\Component;
+use ILIAS\UI\Implementation\Component\ComponentHelper;
 use ILIAS\Data\Factory as DataFactory;
 use ILIAS\UI\HelpTextRetriever;
 use ILIAS\UI\Help;
@@ -319,6 +320,8 @@ class SignalGeneratorMock extends SignalGenerator
 
 class DummyComponent implements IComponent
 {
+    use ComponentHelper;
+
     public function getCanonicalName(): string
     {
         return "DummyComponent";

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterTest.php
@@ -476,7 +476,9 @@ class FilterTest extends ILIAS_UI_TestBase
                 "withOnUpdate",
                 "appendOnUpdate",
                 "withResetTriggeredSignals",
-                "getTriggeredSignals"
+                "getTriggeredSignals",
+                "foldWith",
+                "getSubStructure"
             ])
             ->setMockClassName("Mock_InputNo" . ($no++))
             ->getMock();

--- a/components/ILIAS/UI/tests/Component/Input/Container/Form/FormTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Form/FormTest.php
@@ -461,7 +461,9 @@ class FormTest extends ILIAS_UI_TestBase
                 "withOnUpdate",
                 "appendOnUpdate",
                 "withResetTriggeredSignals",
-                "getTriggeredSignals"
+                "getTriggeredSignals",
+                "foldWith",
+                "getSubStructure"
             ])
             ->setMockClassName("Mock_InputNo" . ($no++))
             ->getMock();

--- a/components/ILIAS/UI/tests/Component/Modal/InterruptiveTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/InterruptiveTest.php
@@ -178,6 +178,8 @@ EOT;
 
 class InterruptiveItemMock implements C\Modal\InterruptiveItem\InterruptiveItem
 {
+    use I\Component\ComponentHelper;
+
     protected string $canonical_name;
 
     public function __construct(string $canonical_name = '')

--- a/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
@@ -27,6 +27,8 @@ use ILIAS\UI\Implementation\Component\SignalGenerator;
 
 class ComponentDummy implements C\Component
 {
+    use I\Component\ComponentHelper;
+
     protected string $id;
 
     public function __construct($id = "")


### PR DESCRIPTION
UI Components inductively built upon each other, i.e. components will contain other components.
It is, for some components, possible to access their substructure, but always in a specific manner; there is no generic way to get from the containing component to its children.

Now, @jeph864 is working on Activities and the idea arose to use forms/inputs to publish APIs (see https://github.com/ILIAS-eLearning/ILIAS/pull/8746). What's missing right now is a simple way to fold down the inputs into e.g. some json-object, and while at it, this is true for all components.

Therefore, I implemented a mechanism on the componentHelper to walk down the object tree and apply operations to the components, storing the result in a property. This result does not need to stay a component, and you can see its effect quite clearly in the examples included here.  Also, modification of the components' instances are perfectly feasible.

Components need to implement `getSubStructure(): array ` to participate in the catamorphism; if they don't or return an empty array, recursion just stops and the component is considered a leaf-node.

This implementation comes with Container and Field\Group for now, but is explicitely meant for all UI Components.
I fiddled around wit the Panel, e.g., and it behaves just alike.

