### PR TITLE
fix ctrl-error

### DIFF
--- a/components/ILIAS/Dashboard/Achievements/classes/class.ilAchievementsGUI.php
+++ b/components/ILIAS/Dashboard/Achievements/classes/class.ilAchievementsGUI.php
@@ -19,7 +19,7 @@
 declare(strict_types=1);
 
 /**
- * @ilCtrl_Calls ilAchievementsGUI: ilPersonalSkillsGUI, ilBadgeProfileGUI, ilLearningHistoryGUI, ilLPPersonalGUI
+ * @ilCtrl_Calls ilAchievementsGUI: ilPersonalSkillsGUI, ilBadgeProfileGUI, ilLearningHistoryGUI, ilLPPersonalGUI, ilLearningProgressGUI
  */
 class ilAchievementsGUI
 {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43604

Had an error loggin into ilias11:

ilCtrlException thrown with message "Class 'ilLearningProgressGUI' is not a child of 'ilAchievementsGUI'."

Stacktrace:
#23 ilCtrlException in /var/www/html/components/ILIAS/UICore/classes/Path/class.ilCtrlArrayClassPath.php:72
#22 ilCtrlArrayClassPath:getCidPathByArray in /var/www/html/components/ILIAS/UICore/classes/Path/class.ilCtrlArrayClassPath.php:33
#21 ilCtrlArrayClassPath:__construct in /var/www/html/components/ILIAS/UICore/classes/Path/class.ilCtrlPathFactory.php:35
#20 ilCtrlPathFactory:find in /var/www/html/components/ILIAS/UICore/classes/class.ilCtrl.php:862
#19 ilCtrl:getTargetUrl in /var/www/html/components/ILIAS/UICore/classes/class.ilCtrl.php:342
#18 ilCtrl:getLinkTargetByClass in /var/www/html/components/ILIAS/Tracking/classes/Provider/LPMainBarProvider.php:62
#17 ILIAS\LearningProgress\LPMainBarProvider:getStaticSubItems in /var/www/html/components/ILIAS/GlobalScreen/src/Scope/MainMenu/Collector/MainMenuMainCollector.php:82