### PR TITLE
T&A 43349: Allow empty values in modal to make an anonymous test available without login

### DIFF
--- a/Modules/Test/classes/TestScreen/class.ilTestScreenGUI.php
+++ b/Modules/Test/classes/TestScreen/class.ilTestScreenGUI.php
@@ -410,7 +410,6 @@ class ilTestScreenGUI
                         if ($anonymous && !empty($value)) {
                             $this->test_session->setAccessCodeToSession($value);
                         } else {
-                            $conditions_met = false;
                             $this->test_session->unsetAccessCodeInSession();
                         }
                         break;

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1378,7 +1378,7 @@ assessment#:#tst_eval_total_passed_average_points#:#Durchschnittliche Punktezahl
 assessment#:#tst_eval_total_passed_average_time#:#Mittlere Bearbeitungsdauer aller bestandenen Tests
 assessment#:#tst_eval_total_persons#:#Gesamtzahl der Personen, die den Test gestartet haben
 assessment#:#tst_exam_access_code#:#Zugangscode
-assessment#:#tst_exam_access_code_label#:#Geben Sie den Zugangscode ein, um Ihren bereits begonnenen Test fortzusetzen.
+assessment#:#tst_exam_access_code_label#:#Geben Sie den Zugangscode ein, um Ihren bereits begonnenen Test fortzusetzen. Lassen Sie das Feld leer, um einen neuen Testdurchlauf zu starten.
 assessment#:#tst_exam_conditions#:#Prüfungsbedingungen
 assessment#:#tst_exam_conditions_label#:#Ankreuzen, um die Bedingungen zu akzeptieren.
 assessment#:#tst_exam_conditions_not_checked_message#:#Sie müssen die Prüfungsbedingungen akzeptieren!

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1378,7 +1378,7 @@ assessment#:#tst_eval_total_passed_average_points#:#Average points of passed tes
 assessment#:#tst_eval_total_passed_average_time#:#Average processing time of all passed tests
 assessment#:#tst_eval_total_persons#:#Total number of participants who started the test
 assessment#:#tst_exam_access_code#:#Access Code
-assessment#:#tst_exam_access_code_label#:#Enter access code to continue your already started test.
+assessment#:#tst_exam_access_code_label#:#Enter access code to continue your already started test. Leave the field empty to start a new test run.
 assessment#:#tst_exam_conditions#:#Exam Conditions
 assessment#:#tst_exam_conditions_label#:#Check to accept the conditions.
 assessment#:#tst_exam_conditions_not_checked_message#:#You need to accept the exam conditions!


### PR DESCRIPTION
Hi everyone, 

this PR refers to the ticket [43349](https://mantis.ilias.de/view.php?id=43349).  I am looking forward to your feedback.

Best,
@lukas-heinrich 