### PR TITLE
T&A: 43407: Fix missing StatusOfAttempt

### DIFF
--- a/components/ILIAS/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
+++ b/components/ILIAS/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\Test\Results\Data\StatusOfAttempt;
 use ILIAS\Test\Scoring\Marks\MarkSchema;
 
 /**
@@ -150,6 +151,12 @@ class ilTestEvaluationFactory
                 $attempt->setExamId((string) $row['exam_id']);
                 $attempt->setRequestedHintsCount($row['hint_count']);
                 $attempt->setDeductedHintPoints($row['hint_points']);
+
+                $attempt->setStatusOfAttempt(
+                    !isset($row['finalized_by']) || $row['finalized_by'] === null
+                    ? StatusOfAttempt::RUNNING
+                    : StatusOfAttempt::from($row['finalized_by'])
+                );
             }
 
             if ($row['question_fi'] !== null) {

--- a/components/ILIAS/Test/classes/Evaluation/class.ilTestEvaluationPassData.php
+++ b/components/ILIAS/Test/classes/Evaluation/class.ilTestEvaluationPassData.php
@@ -43,7 +43,6 @@ class ilTestEvaluationPassData
     private ?float $deductedHintPoints = null;
     private string $exam_id = '';
     private ?StatusOfAttempt $status_of_attempt = null;
-    private bool $unfinished_attempt = false;
 
     public function __sleep()
     {
@@ -243,25 +242,11 @@ class ilTestEvaluationPassData
             return $this->status_of_attempt;
         }
 
-        if ($this->unfinished_attempt) {
-            return StatusOfAttempt::RUNNING;
-        }
-
         return StatusOfAttempt::FINISHED_BY_UNKNOWN;
     }
 
     public function setStatusOfAttempt(?StatusOfAttempt $status_of_attempt): void
     {
         $this->status_of_attempt = $status_of_attempt;
-    }
-
-    public function isUnfinishedAttempt(): bool
-    {
-        return $this->unfinished_attempt;
-    }
-
-    public function setUnfinishedAttempt(bool $unfinished_attempt): void
-    {
-        $this->unfinished_attempt = $unfinished_attempt;
     }
 }


### PR DESCRIPTION
Hi everyone, 

this PR refers to the ticket [43407](https://mantis.ilias.de/view.php?id=43407), which describes an incorrect display of the Status Of Attempts.

The behavior described can be traced back to the fact that the object's properties are not set at any point, which I have added. Setting `StatusOfAttempt::RUNNING` at this point may look irritating. When debugging, however, I was able to determine that the `getAttemptOverviewInformation()` method is not executed if there is no pass. Accordingly, it can be assumed that the status at this point is at least _Running_ or that the test run has already been completed.

I look forward to your feedback and am open to suggestions or questions. This PR was co-authored and internally reviewed by @thojou.

Best,
@lukas-heinrich 