### PR TITLE
T&A: Ghost Attempts & correct detection of unfinished test passes

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -5621,16 +5621,12 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             && $active_id > 0
             && ($starting_time = $this->getStartingTimeOfUser($active_id)) !== false
             && $this->isMaxProcessingTimeReached($starting_time, $active_id)) {
-            if ($allow_pass_increase
-                    && $this->getResetProcessingTime()
-                    && (($this->getNrOfTries() === 0)
-                || ($this->getNrOfTries() > (self::_getPass($active_id) + 1)))) {
+            if ($allow_pass_increase && $this->getResetProcessingTime()) {
                 // a test pass was quitted because the maximum processing time was reached, but the time
                 // will be resetted for future passes, so if there are more passes allowed, the participant may
                 // start the test again.
                 // This code block is only called when $allowPassIncrease is TRUE which only happens when
                 // the test info page is opened. Otherwise this will lead to unexpected results!
-                $test_session->increasePass();
                 $test_session->setLastSequence(0);
                 $test_session->saveToDb();
             } else {

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -5621,18 +5621,8 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             && $active_id > 0
             && ($starting_time = $this->getStartingTimeOfUser($active_id)) !== false
             && $this->isMaxProcessingTimeReached($starting_time, $active_id)) {
-            if ($allow_pass_increase && $this->getResetProcessingTime()) {
-                // a test pass was quitted because the maximum processing time was reached, but the time
-                // will be resetted for future passes, so if there are more passes allowed, the participant may
-                // start the test again.
-                // This code block is only called when $allowPassIncrease is TRUE which only happens when
-                // the test info page is opened. Otherwise this will lead to unexpected results!
-                $test_session->setLastSequence(0);
-                $test_session->saveToDb();
-            } else {
-                $result["executable"] = false;
-                $result["errormessage"] = $this->lng->txt("detail_max_processing_time_reached");
-            }
+            $result["executable"] = false;
+            $result["errormessage"] = $this->lng->txt("detail_max_processing_time_reached");
             return $result;
         }
 


### PR DESCRIPTION
Hi everyone,

with this PR, I propose a change to correctly recognize unfinished test attempts. Originally this is a fix for [28447](https://mantis.ilias.de/view.php?id=28447), but I was able to find some other places that should be fixed with this change:

- https://mantis.ilias.de/view.php?id=42856
- https://mantis.ilias.de/view.php?id=27077
- Incorrect number of test attempts in the results view
- Blank test results in the detailed test view and man scoring
![image](https://github.com/user-attachments/assets/5cb3c0b9-d165-431f-b9af-aa2ee742ce9d)

### Reproduction
To reproduce the behavior, make sure that the test has at least the following settings:

- **Overview of Answers Given**: checked
- Set Time Limit for Completing Test \> **Maximum Time Available**: e.g. 1 min
- Set Time Limit for Completing Test \> **Reset Time Limit for All Test Attempts**: checked

### Cause of the behavior

- The fundamental problem is that when resetting the Processing Time, the pass is incremented by one ([`\ilObjTest::isExecutable`](https://github.com/ILIAS-eLearning/ILIAS/blob/release_8/Modules/Test/classes/class.ilObjTest.php#L7467C1-L7467C58))
- This is why `self::_getPass($active_id)` returns a pass that doesn't exist
- When finishing the attempt via the button or cron job, the pass is incremented again (see ` \ilTestPassFinishTasks::performFinishTasks`)

### Tests

To verify this change, I tested the following scenarios and checked whether the number of passes and the unfinished passes are shown as expected.

- Attempt completed
- Attempt not completed
- First attempt completed, second attempt completed
- First attempt completed, second attempt not completed

I ran these four cases both for a test without a time limit and for a test with a limit, both with and without a reset. I also checked the database to see if there are any ghost passes.


I am looking forward to your feedback and comments. This PR was internally reviewed by @thojou .
Best,
@lukas-heinrich 