### PR TITLE
Fix offset not in array if on last page and filter is applied.

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
@@ -255,6 +255,7 @@ class Renderer extends AbstractComponentRenderer
 
         list(Pagination::FNAME_OFFSET => $offset, Pagination::FNAME_LIMIT => $limit) = array_map('intval', $component->getValue());
         $limit = $limit > 0 ? $limit : reset($limit_options);
+        $offset = $offset > $total_count ? 0 : $offset;
 
         if (! $total_count) {
             $input = $ui_factory->input()->field()->numeric('offset')->withValue($offset);

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
@@ -128,9 +128,14 @@ class Data extends AbstractTable implements T\Data
             $view_controls = $this->applyValuesToViewcontrols($view_controls, $request);
             $data = $view_controls->getData();
             $range = $data[self::VIEWCONTROL_KEY_PAGINATION];
-            $range = ($range instanceof Range) ? $range->croppedTo($total_count ?? PHP_INT_MAX) : null;
+            $range = ($range instanceof Range) ? $range : null;
             $order = $data[self::VIEWCONTROL_KEY_ORDERING];
             $order = ($order instanceof Order) ? $order : null;
+
+            if ($range instanceof Range) {
+                $range = $range->withStart($range->getStart() <= $total_count ? $range->getStart() : 0);
+                $range = $range->croppedTo($total_count ?? PHP_INT_MAX);
+            }
 
             $table = $table
                 ->withRange($range)


### PR DESCRIPTION
Hey,

This PR addresses the issue described in Mantis Bug Tracker https://mantis.ilias.de/view.php?id=42959.

During debugging, it became clear that the problem was not limited to a specific table implementation, but affected all table implementations. Here’s a scenario to illustrate the problem:

If a table has multiple pages and the user navigates to the last page, applying a filter that reduces the total number of displayed pages by at least one will trigger the issue.
The root cause lies in how the data table range is cropped—this happens too late in the execution flow. To address this issue, the PR introduces two adjustments:

1. The `findCurrentPage` method now defaults to `0` instead of throwing a `LogicException` if no valid range is defined for the given offset.
2. Previously, the `croppedTo` method returned a zero-length range, which seemed counterintuitive. This is adjusted so that the method now returns to the interval of 0 to smaller user selection or standard configuration.

These changes are directed to resolve the data tables as a whole. 
Looking forward to your feedback and comments.

Best
@thojou