### PR TITLE
User: init js for actions in user gallery (43271)

### DIFF
--- a/components/ILIAS/User/classes/Gallery/class.ilUsersGalleryGUI.php
+++ b/components/ILIAS/User/classes/Gallery/class.ilUsersGalleryGUI.php
@@ -207,6 +207,7 @@ JS;
             $contact_btn_html = ilBuddySystemLinkButton::getInstanceByUserId($user->getId())->getHtml();
         }
 
+        $this->user_action_gui->init();
         $list_html = $this->user_action_gui->renderDropDown($user->getId());
 
         if ($contact_btn_html || $list_html) {


### PR DESCRIPTION
This PR fixes the last little bit of [43271](https://mantis.ilias.de/view.php?id=43271) by loading the required js for actions in the user gallery.

Note that this is only an issue when 'Add to Group' is deactivated for the 'Who is online' tool, otherwise the js already gets loaded there.