### PR TITLE
OrgUnit: fix saving of adv md dates (43385)

### DIFF
--- a/components/ILIAS/OrgUnit/classes/class.ilObjOrgUnitGUI.php
+++ b/components/ILIAS/OrgUnit/classes/class.ilObjOrgUnitGUI.php
@@ -692,9 +692,8 @@ class ilObjOrgUnitGUI extends ilContainerGUI
             $this->object->getOrgUnitTypeId()
         );
         $gui->setPropertyForm($form);
-        $form->checkInput();
         $gui->parse();
-        if ($gui->importEditFormPostValues()) {
+        if ($form->checkInput() && $gui->importEditFormPostValues()) {
             $gui->writeEditForm();
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('settings_saved'), true);
             $this->ctrl->redirect($this, 'editAdvancedSettings');


### PR DESCRIPTION
This PR fixes [43385](https://mantis.ilias.de/view.php?id=43385), by basically swapping two lines. Not sure why that works exactly, legacy date inputs seem to be a bit finicky. It looks like this is also an issue in ILIAS 8 and 9, so this is not limited to the html-native datetime pickers.