### PR TITLE
COPage Editor: Add entrypoint for custom functions

### DIFF
--- a/components/ILIAS/COPage/Editor/js/src/components/paragraph/actions/paragraph-action-types.js
+++ b/components/ILIAS/COPage/Editor/js/src/components/paragraph/actions/paragraph-action-types.js
@@ -12,7 +12,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ******************************************************************** */
+ *********************************************************************/
 
 const ACTIONS = {
 
@@ -57,5 +57,6 @@ const ACTIONS = {
   SPLIT_PARAGRAPH: 'par.split',
   MERGE_PREVIOUS: 'merge.previous',
   SECTION_CLASS: 'sec.class', // section format
+  INSERT_TEXT_TEMPLATE: 'insert.text.template',
 };
 export default ACTIONS;

--- a/components/ILIAS/COPage/Editor/js/src/components/paragraph/ui/paragraph-ui.js
+++ b/components/ILIAS/COPage/Editor/js/src/components/paragraph/ui/paragraph-ui.js
@@ -1,9 +1,3 @@
-import ACTIONS from '../actions/paragraph-action-types.js';
-import PAGE_ACTIONS from '../../page/actions/page-action-types.js';
-import TinyWrapper from './tiny-wrapper.js';
-import TINY_CB from './tiny-wrapper-cb-types.js';
-import AutoSave from './auto-save.js';
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,7 +12,13 @@ import AutoSave from './auto-save.js';
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ******************************************************************** */
+ *********************************************************************/
+
+import ACTIONS from '../actions/paragraph-action-types.js';
+import PAGE_ACTIONS from '../../page/actions/page-action-types.js';
+import TinyWrapper from './tiny-wrapper.js';
+import TINY_CB from './tiny-wrapper-cb-types.js';
+import AutoSave from './auto-save.js';
 
 /**
  * paragraph ui
@@ -998,6 +998,12 @@ export default class ParagraphUI {
           const url = char_button.dataset.copgEdParUrl;
           char_button.addEventListener('click', (event) => {
             dispatch.dispatch(ef.linkWikiSelection(url));
+          });
+          break;
+
+        case ACTIONS.INSERT_TEXT_TEMPLATE:
+          char_button.addEventListener('click', (event) => {
+            this.addBBCode(char_button.dataset.copgEdParContent, '')
           });
           break;
 

--- a/components/ILIAS/COPage/PC/Paragraph/class.ilPCParagraphEditorGUI.php
+++ b/components/ILIAS/COPage/PC/Paragraph/class.ilPCParagraphEditorGUI.php
@@ -30,7 +30,7 @@ class ilPCParagraphEditorGUI implements \ILIAS\COPage\Editor\Components\PageComp
         int $style_id
     ): array {
         $cfg = $page_gui->getPageConfig();
-        $menu = ilPageObjectGUI::getTinyMenu(
+        $menu = $page_gui->getTinyMenu(
             $page_type,
             $cfg->getEnableInternalLinks(),
             $cfg->getEnableWikiLinks(),

--- a/components/ILIAS/COPage/classes/class.ilPageConfig.php
+++ b/components/ILIAS/COPage/classes/class.ilPageConfig.php
@@ -492,4 +492,9 @@ abstract class ilPageConfig
     {
         return $this->section_protection_info;
     }
+
+    public function appendCustomFunctions(array $menu): array
+    {
+        return $menu;
+    }
 }

--- a/components/ILIAS/COPage/classes/class.ilPageObjectGUI.php
+++ b/components/ILIAS/COPage/classes/class.ilPageObjectGUI.php
@@ -1705,7 +1705,7 @@ class ilPageObjectGUI
     /**
      * Get Tiny Menu
      */
-    public static function getTinyMenu(
+    public function getTinyMenu(
         string $a_par_type,
         bool $a_int_links = false,
         bool $a_wiki_links = false,
@@ -1988,6 +1988,8 @@ class ilPageObjectGUI
         if ($a_anchors) {
             $menu["cont_more_functions"][] = ["text" => $lng->txt("cont_anchor"), "action" => "selection.anchor", "data" => []];
         }
+
+        $menu = $this->getPageConfig()->appendCustomFunctions($menu);
 
         $btpl = new ilTemplate("tpl.tiny_menu.html", true, true, "components/ILIAS/COPage");
 


### PR DESCRIPTION
In dependency of the implementation of 
https://docu.ilias.de/go/wiki/wpage_8375_1357 
this PR proposes an inherited function through which specific PageObject Editor can provide custom selectable placeholder function for their scope.

This change allows specific scopes to integrate their custom CO features into the Page editor itself instead of injecting them into the rendered HTML.

---

The features’ implementation can be found [here](https://github.com/ILIAS-eLearning/ILIAS/pull/8939) for better visualization