### PR TITLE
T&A 43537: Fixes permission error when editing a question in page editor

### DIFF
--- a/components/ILIAS/COPage/PC/Question/class.ilPCQuestionGUI.php
+++ b/components/ILIAS/COPage/PC/Question/class.ilPCQuestionGUI.php
@@ -301,11 +301,8 @@ class ilPCQuestionGUI extends ilPageContentGUI
             $ilCtrl->setParameterByClass("ilQuestionEditGUI", "q_id", $q_id);
             $ilCtrl->redirectByClass(array(get_class($this->pg_obj) . "GUI", "ilQuestionEditGUI"), "editQuestion");
         } else {	// behaviour in question pool
-            $q_gui = assQuestionGUI::_getQuestionGUI(
-                "",
-                $this->request->getInt("q_id")
-            );
-            $this->ctrl->redirectByClass(array("ilobjquestionpoolgui", get_class($q_gui)), "editQuestion");
+            $q_gui = assQuestionGUI::_getQuestionGUI('', $this->request->getInt('q_id'));
+            $this->ctrl->redirectByClass($q_gui::class, 'editQuestion');
         }
     }
 


### PR DESCRIPTION
When clicking on a question in the page editor the user gets a "Permission denied" despite having correct permissions.

I believe this is a simple routing error, that can be fixed by removing a GUI class from the redirect chain.

[Mantis: 43537](https://mantis.ilias.de/view.php?id=43537)