### PR TITLE
T&A 43267: Fixes being able to save a question with no positive point answers (Matching question)

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/forms/class.ilAssMatchingPairCorrectionsInputGUI.php
@@ -54,8 +54,7 @@ class ilAssMatchingPairCorrectionsInputGUI extends ilMatchingPairWizardInputGUI
             return false;
         }
 
-        $sum = array_sum(array_filter($result, fn($points) => $points > 0));
-        if ($sum <= 0) {
+        if (max($result) <= 0) {
             $this->setAlert($this->lng->txt('enter_enough_positive_points'));
             return false;
         }

--- a/components/ILIAS/TestQuestionPool/classes/ilTestLegacyFormsHelper.php
+++ b/components/ILIAS/TestQuestionPool/classes/ilTestLegacyFormsHelper.php
@@ -75,11 +75,7 @@ class ilTestLegacyFormsHelper
             return $points;
         }
 
-        if (max($points) === 0.0) {
-            return 'enter_enough_positive_points';
-        }
-
-        return $points;
+        return max($points) <= 0 ? 'enter_enough_positive_points' : $points;
     }
 
     public function transformArray($data, string $key, Transformation $transformation): array


### PR DESCRIPTION
When editing a Matching question and setting all matches to give negative (incl. 0) points, the question get successfully saved but when looking in the question overview it says that the question is incomplete.

There error seems to be affected by the way how it is determined, whether the question has enough positive points assigned.

By checking what the highest point value is, you could determine if the question is solveable and if correctly solved even gives any points. Correctly solved questions should always give more than 0 points.

[Mantis: 43267](https://mantis.ilias.de/view.php?id=43267)