### PR TITLE
T&A 43576: Allows sorting of a tests participant list by matriculation number and test id

### DIFF
--- a/components/ILIAS/Test/src/Participants/ParticipantTable.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTable.php
@@ -237,7 +237,7 @@ class ParticipantTable implements DataRetrieval
             'id_of_attempt' => static fn(
                 Participant $a,
                 Participant $b
-            ) => $a->getMatriculation() <=> $b->getMatriculation()
+            ) => $a->getAttemptOverviewInformation()?->getExamId() <=> $b->getAttemptOverviewInformation()?->getExamId()
         ];
     }
 

--- a/components/ILIAS/Test/src/Participants/ParticipantTable.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTable.php
@@ -229,8 +229,15 @@ class ParticipantTable implements DataRetrieval
             'mark' => static fn(
                 Participant $a,
                 Participant $b
-            ) => $a->getAttemptOverviewInformation()?->getMark() <=> $b->getAttemptOverviewInformation()?->getMark()
-
+            ) => $a->getAttemptOverviewInformation()?->getMark() <=> $b->getAttemptOverviewInformation()?->getMark(),
+            'matriculation' => static fn(
+                Participant $a,
+                Participant $b
+            ) => $a->getMatriculation() <=> $b->getMatriculation(),
+            'id_of_attempt' => static fn(
+                Participant $a,
+                Participant $b
+            ) => $a->getMatriculation() <=> $b->getMatriculation()
         ];
     }
 
@@ -337,7 +344,7 @@ class ParticipantTable implements DataRetrieval
         $columns += [
             'matriculation' => $column_factory->text($this->lng->txt('matriculation'))
                 ->withIsOptional(true, false)
-                ->withIsSortable(false),
+                ->withIsSortable(true),
             'ip_range' => $column_factory->text($this->lng->txt('client_ip_range'))
                 ->withIsOptional(true, false)
                 ->withIsSortable(true),
@@ -365,7 +372,7 @@ class ParticipantTable implements DataRetrieval
         if ($this->test_object->getMainSettings()->getTestBehaviourSettings()->getExamIdInTestAttemptEnabled()) {
             $columns['id_of_attempt'] = $column_factory->text($this->lng->txt('exam_id_of_attempt'))
                 ->withIsOptional(true, false)
-                ->withIsSortable(false);
+                ->withIsSortable(true);
         }
 
         if ($this->test_access->checkParticipantsResultsAccess()) {


### PR DESCRIPTION
I believe this will allow the sorting by matriculation number and test id in the test participant list view.
[Mantis: 43576](https://mantis.ilias.de/view.php?id=43576)