### PR TITLE
T&A 43575: Removes additional time, when removing participant data

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -1178,7 +1178,7 @@ class ilObjTest extends ilObject
                 static fn($active_id) => $participant_data->getUserIdByActiveId($active_id),
                 $participant_data->getAnonymousActiveIds(),
             );
-            $this->removeAdditionalTimesByUserIds($user_ids);
+            $this->participant_repository->removeExtraTimeByUserId($this->getTestId(), $user_ids);
         }
 
         if ($participant_data->getUserIds() !== []) {
@@ -1189,7 +1189,7 @@ class ilObjTest extends ilObject
                 $test_lp->resetLPDataForUserIds($participant_data->getUserIds(), false);
             }
 
-            $this->removeAdditionalTimesByUserIds($participant_data->getUserIds());
+            $this->participant_repository->removeExtraTimeByUserId($this->getTestId(), $participant_data->getUserIds());
         }
 
         if ($participant_data->getActiveIds() !== []) {
@@ -1199,7 +1199,7 @@ class ilObjTest extends ilObject
                 static fn($active_id) => $participant_data->getUserIdByActiveId($active_id),
                 $participant_data->getActiveIds(),
             );
-            $this->removeAdditionalTimesByUserIds($user_ids);
+            $this->participant_repository->removeExtraTimeByUserId($this->getTestId(), $user_ids);
         }
 
         if ($this->logger->isLoggingEnabled()) {
@@ -1215,17 +1215,6 @@ class ilObjTest extends ilObject
                 )
             );
         }
-    }
-
-    private function removeAdditionalTimesByUserIds(array $user_ids): void
-    {
-        $in_user_fis = $this->db->in(
-            'user_fi',
-            $user_ids,
-            false,
-            ilDBConstants::T_INTEGER,
-        );
-        $this->db->manipulate("DELETE FROM tst_addtime WHERE test_fi = {$this->getTestId()} AND $in_user_fis");
     }
 
     public function removeTestResultsByUserIds(array $user_ids): void

--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -1169,10 +1169,16 @@ class ilObjTest extends ilObject
         }
     }
 
-    public function removeTestResults(ilTestParticipantData $participant_data)
+    public function removeTestResults(ilTestParticipantData $participant_data): void
     {
         if ($participant_data->getAnonymousActiveIds() !== []) {
             $this->removeTestResultsByActiveIds($participant_data->getAnonymousActiveIds());
+
+            $user_ids = array_map(
+                static fn($active_id) => $participant_data->getUserIdByActiveId($active_id),
+                $participant_data->getAnonymousActiveIds(),
+            );
+            $this->removeAdditionalTimesByUserIds($user_ids);
         }
 
         if ($participant_data->getUserIds() !== []) {
@@ -1182,10 +1188,18 @@ class ilObjTest extends ilObject
                 $test_lp->setTestObject($this);
                 $test_lp->resetLPDataForUserIds($participant_data->getUserIds(), false);
             }
+
+            $this->removeAdditionalTimesByUserIds($participant_data->getUserIds());
         }
 
         if ($participant_data->getActiveIds() !== []) {
             $this->removeTestActives($participant_data->getActiveIds());
+
+            $user_ids = array_map(
+                static fn($active_id) => $participant_data->getUserIdByActiveId($active_id),
+                $participant_data->getActiveIds(),
+            );
+            $this->removeAdditionalTimesByUserIds($user_ids);
         }
 
         if ($this->logger->isLoggingEnabled()) {
@@ -1203,7 +1217,18 @@ class ilObjTest extends ilObject
         }
     }
 
-    public function removeTestResultsByUserIds($user_ids)
+    private function removeAdditionalTimesByUserIds(array $user_ids): void
+    {
+        $in_user_fis = $this->db->in(
+            'user_fi',
+            $user_ids,
+            false,
+            ilDBConstants::T_INTEGER,
+        );
+        $this->db->manipulate("DELETE FROM tst_addtime WHERE test_fi = {$this->getTestId()} AND $in_user_fis");
+    }
+
+    public function removeTestResultsByUserIds(array $user_ids): void
     {
         $participantData = new ilTestParticipantData($this->db, $this->lng);
         $participantData->setUserIdsFilter($user_ids);
@@ -1221,7 +1246,7 @@ class ilObjTest extends ilObject
         }
     }
 
-    private function removeTestResultsByActiveIds($active_ids)
+    private function removeTestResultsByActiveIds(array $active_ids): void
     {
         $in_active_ids = $this->db->in('active_fi', $active_ids, false, 'integer');
 

--- a/components/ILIAS/Test/src/Participants/Participant.php
+++ b/components/ILIAS/Test/src/Participants/Participant.php
@@ -31,7 +31,7 @@ class Participant
         private readonly int $user_id,
         private readonly ?int $active_id = null,
         private readonly ?int $test_id = null,
-        private readonly ?int $anonymous_id = null,
+        private readonly ?string $anonymous_id = null,
         private readonly string $firstname = '',
         private readonly string $lastname = '',
         private readonly string $login = '',
@@ -65,7 +65,7 @@ class Participant
         return $this->test_id;
     }
 
-    public function getAnonymousId(): ?int
+    public function getAnonymousId(): ?string
     {
         return $this->anonymous_id;
     }

--- a/components/ILIAS/Test/src/Participants/ParticipantRepository.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantRepository.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\Test\Participants;
 
+use ilDBConstants;
 use ILIAS\Data\Order;
 use ILIAS\Data\Range;
 
@@ -416,5 +417,16 @@ class ParticipantRepository
             AND         tinvited.user_fi = ta.user_fi
 			WHERE		tinvited.test_fi = %s AND ta.active_id IS NULL
         ";
+    }
+
+    public function removeExtraTimeByUserId(int $test_id, array $user_ids): void
+    {
+        $in_user_fis = $this->database->in(
+            'user_fi',
+            $user_ids,
+            false,
+            ilDBConstants::T_INTEGER,
+        );
+        $this->database->manipulate("DELETE FROM tst_addtime WHERE test_fi = $test_id AND $in_user_fis");
     }
 }

--- a/components/ILIAS/Test/src/Participants/ParticipantRepository.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantRepository.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace ILIAS\Test\Participants;
 
-use ilDBConstants;
 use ILIAS\Data\Order;
 use ILIAS\Data\Range;
 
@@ -425,7 +424,7 @@ class ParticipantRepository
             'user_fi',
             $user_ids,
             false,
-            ilDBConstants::T_INTEGER,
+            \ilDBConstants::T_INTEGER,
         );
         $this->database->manipulate("DELETE FROM tst_addtime WHERE test_fi = $test_id AND $in_user_fis");
     }

--- a/components/ILIAS/Test/src/Participants/ParticipantTableExtraTimeAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableExtraTimeAction.php
@@ -154,7 +154,7 @@ class ParticipantTableExtraTimeAction implements TableAction
 
     public function allowActionForRecord(Participant $record): bool
     {
-        return true;
+        return $record->getUserId() !== ANONYMOUS_USER_ID;
     }
 
     private function resolveInfoMessage(


### PR DESCRIPTION
When deleting the participant data for a speicifc test, the additinal time a user has is not deleted. This causes the user to retain that additional time when doing the test again.

Whenever the delete participant data method is called, it is also checked whether the user has any entries in the additional time table. If that is the case, they also get delted.

INFO: If you give a anonymous user additional time, all anonymous users in that test get the extra time. To keep in mind. If you remove a anonymous users data from the test, the extra time gets deleted for all anonymous users, since there is a single entry for all of them (user 13).

Also, the property `anonymous_id` in `Participant` probably should be a string instead of int. Otherwise I got an error when trying to start the test as an anonymous user.

[Mantis: 43575](https://mantis.ilias.de/view.php?id=43575)