### PR TITLE
Component/Plugins: 43587, addendum - use absolute path for PLUGIN_BASE_PATH

### DIFF
--- a/components/ILIAS/Component/classes/class.ilComponentRepository.php
+++ b/components/ILIAS/Component/classes/class.ilComponentRepository.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
  */
 interface ilComponentRepository
 {
-    public const PLUGIN_BASE_PATH = "Customizing/plugins";
+    public const PLUGIN_BASE_PATH = __DIR__ . '/../../../../public/Customizing/plugins';
 
     /**
      * Check if a component exists.

--- a/components/ILIAS/Component/classes/class.ilPlugin.php
+++ b/components/ILIAS/Component/classes/class.ilPlugin.php
@@ -299,7 +299,7 @@ abstract class ilPlugin
         $lng = $DIC->language();
 
         $dbupdate = new ilPluginDBUpdate(
-            $this->db,
+            $ilDB,
             $this->getPluginInfo()
         );
 

--- a/components/ILIAS/Component/classes/class.ilPluginDBUpdate.php
+++ b/components/ILIAS/Component/classes/class.ilPluginDBUpdate.php
@@ -49,7 +49,7 @@ class ilPluginDBUpdate extends ilDBUpdate
         $this->db = $db;
         $this->plugin = $plugin;
 
-        $this->db_update_file = $this->PATH . $this->getDBUpdateScriptName();
+        $this->db_update_file = $this->getDBUpdateScriptName();
 
         $this->current_version = $plugin->getCurrentDBVersion() ?? 0;
 


### PR DESCRIPTION
following https://github.com/ILIAS-eLearning/ILIAS/pull/8837, https://mantis.ilias.de/view.php?id=43587
There is a difference in using path from GUI and cli; using absolute path resolves this.