### PR TITLE
T&A 43539: Internal Server error - when copy and paste a question

### DIFF
--- a/Services/COPage/PC/Question/class.ilPCQuestion.php
+++ b/Services/COPage/PC/Question/class.ilPCQuestion.php
@@ -471,7 +471,12 @@ class ilPCQuestion extends ilPageContent
             $path = "//Question";
             $nodes = $dom_util->path($a_domdoc, $path);
             foreach ($nodes as $node) {
-                $node->parentNode->removeChild($node);
+                $parent_node = $node->parentNode;
+                if ($parent_node->parentNode) {
+                    $parent_node->parentNode->removeChild($parent_node);
+                } else {
+                    $parent_node->removeChild($node);
+                }
             }
         }
     }


### PR DESCRIPTION
Hi everyone,

this PR addresses ticket [43549](https://mantis.ilias.de/view.php?id=43539), which describes an exception when attempting to insert a question in the PE.

I was able to trace the problem back to the XML parser. When inserting a question, the question element is removed from the DOM since it apparently doesn't allow any insert operations. However, the parent element of the question element remains in the DOM since it isn't removed. The empty element cannot be read and the parser throws an exception. As a fix, I implemented that the parent element is also removed. For this, I followed the [implementation in Release 8](https://gitlab.databay.de/team-ilias-2/ilias/-/merge_requests/97).

I look forward to your feedback. Thank you in advance!

Best regards,
@lukas-heinrich 