### PR TITLE
T&A 42475: Fixes performance issues in question table

### DIFF
--- a/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
@@ -126,6 +126,9 @@ class ilTestQuestionBrowserTableGUI
 
     private function getQuestionsBrowserTable(string $parent_title = ''): QuestionsBrowserTable
     {
+        $question_list = new ilAssQuestionList($this->db, $this->lng, $this->refinery, $this->component_repository);
+        $question_list = $this->addModeParametersToQuestionList($question_list);
+
         return new QuestionsBrowserTable(
             (string) $this->test_obj->getId(),
             $this->current_user,
@@ -134,10 +137,9 @@ class ilTestQuestionBrowserTableGUI
             $this->lng,
             $this->ctrl,
             $this->data_factory,
-            new ilAssQuestionList($this->db, $this->lng, $this->refinery, $this->component_repository),
+            $question_list,
             $this->test_obj,
             $this->tree,
-            $this->testrequest,
             $this->taxonomy,
             $parent_title
         );
@@ -160,8 +162,11 @@ class ilTestQuestionBrowserTableGUI
         }
 
         if (in_array('ALL_OBJECTS', $selected_array, true)) {
-            $filters = $this->ui_service->filter()->getData($this->getQuestionsBrowserFilterComponent()) ?? [];
-            $selected_array = array_keys($this->getQuestionsBrowserTable()->loadRecords($filters));
+            $selected_array = array_keys(
+                $this->getQuestionsBrowserTable()->loadRecords(
+                    $this->ui_service->filter()->getData($this->getQuestionsBrowserFilterComponent()) ?? []
+                )
+            );
         }
 
         array_map(
@@ -211,5 +216,43 @@ class ilTestQuestionBrowserTableGUI
             $this->test_obj,
             $this->questionrepository
         ))->getQuestionSetConfig();
+    }
+
+    private function addModeParametersToQuestionList(ilAssQuestionList $question_list): ilAssQuestionList
+    {
+        if ($this->testrequest->raw(self::MODE_PARAMETER) === self::MODE_BROWSE_TESTS) {
+            $question_list->setParentObjectType('tst');
+            $question_list->setQuestionInstanceTypeFilter(\ilAssQuestionList::QUESTION_INSTANCE_TYPE_ALL);
+            $question_list->setExcludeQuestionIdsFilter($this->test_obj->getQuestions());
+            return $question_list;
+        }
+
+        $question_list->setParentObjIdsFilter($this->getQuestionParentObjIds(self::REPOSITORY_ROOT_NODE_ID));
+        $question_list->setQuestionInstanceTypeFilter(\ilAssQuestionList::QUESTION_INSTANCE_TYPE_ORIGINALS);
+        $question_list->setExcludeQuestionIdsFilter($this->test_obj->getExistingQuestions());
+        return $question_list;
+    }
+
+    private function getQuestionParentObjIds(int $repositoryRootNode): array
+    {
+        $parents = $this->tree->getSubTree(
+            $this->tree->getNodeData($repositoryRootNode),
+            true,
+            ['qpl']
+        );
+
+        $parentIds = [];
+
+        foreach ($parents as $nodeData) {
+            if ((int) $nodeData['obj_id'] === $this->test_obj->getId()) {
+                continue;
+            }
+
+            $parentIds[$nodeData['obj_id']] = $nodeData['obj_id'];
+        }
+
+        $parentIds = array_map('intval', array_values($parentIds));
+        $available_pools = array_map('intval', array_keys(\ilObjQuestionPool::_getAvailableQuestionpools(true)));
+        return array_intersect($parentIds, $available_pools);
     }
 }

--- a/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
@@ -138,8 +138,6 @@ class ilTestQuestionBrowserTableGUI
             $this->ctrl,
             $this->data_factory,
             $question_list,
-            $this->test_obj,
-            $this->tree,
             $this->taxonomy,
             $parent_title
         );

--- a/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
+++ b/components/ILIAS/Test/classes/Tables/class.ilTestQuestionBrowserTableGUI.php
@@ -160,11 +160,8 @@ class ilTestQuestionBrowserTableGUI
         }
 
         if (in_array('ALL_OBJECTS', $selected_array, true)) {
-            $selected_array = array_keys(
-                $this->getQuestionsBrowserTable()->loadRecords(
-                    $this->ui_service->filter()->getData($this->getQuestionsBrowserFilterComponent())
-                )
-            );
+            $filters = $this->ui_service->filter()->getData($this->getQuestionsBrowserFilterComponent()) ?? [];
+            $selected_array = array_keys($this->getQuestionsBrowserTable()->loadRecords($filters));
         }
 
         array_map(

--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsBrowserTable.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsBrowserTable.php
@@ -43,16 +43,16 @@ class QuestionsBrowserTable implements DataRetrieval
     public function __construct(
         protected readonly string $table_id,
         private readonly \ilObjUser $current_user,
-        protected UIFactory $ui_factory,
-        protected UIRenderer $ui_renderer,
-        protected \ilLanguage $lng,
-        protected \ilCtrl $ctrl,
-        protected DataFactory $data_factory,
-        protected \ilAssQuestionList $question_list,
-        protected \ilObjTest $test_obj,
-        protected \ilTree $tree,
-        protected TaxonomyService $taxonomy,
-        protected string $parent_title
+        protected readonly UIFactory $ui_factory,
+        protected readonly UIRenderer $ui_renderer,
+        protected readonly \ilLanguage $lng,
+        protected readonly \ilCtrl $ctrl,
+        protected readonly DataFactory $data_factory,
+        protected readonly \ilAssQuestionList $question_list,
+        protected readonly \ilObjTest $test_obj,
+        protected readonly \ilTree $tree,
+        protected readonly TaxonomyService $taxonomy,
+        protected readonly string $parent_title
     ) {
     }
 

--- a/components/ILIAS/Test/src/Questions/Presentation/QuestionsBrowserTable.php
+++ b/components/ILIAS/Test/src/Questions/Presentation/QuestionsBrowserTable.php
@@ -41,18 +41,16 @@ class QuestionsBrowserTable implements DataRetrieval
     public const ACTION_INSERT = 'insert';
 
     public function __construct(
-        protected readonly string $table_id,
+        private readonly string $table_id,
         private readonly \ilObjUser $current_user,
-        protected readonly UIFactory $ui_factory,
-        protected readonly UIRenderer $ui_renderer,
-        protected readonly \ilLanguage $lng,
-        protected readonly \ilCtrl $ctrl,
-        protected readonly DataFactory $data_factory,
-        protected readonly \ilAssQuestionList $question_list,
-        protected readonly \ilObjTest $test_obj,
-        protected readonly \ilTree $tree,
-        protected readonly TaxonomyService $taxonomy,
-        protected readonly string $parent_title
+        private readonly UIFactory $ui_factory,
+        private readonly UIRenderer $ui_renderer,
+        private readonly \ilLanguage $lng,
+        private readonly \ilCtrl $ctrl,
+        private readonly DataFactory $data_factory,
+        private readonly \ilAssQuestionList $question_list,
+        private readonly TaxonomyService $taxonomy,
+        private readonly string $parent_title
     ) {
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -55,20 +55,15 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
     public const ANSWER_STATUS_FILTER_NON_ANSWERED_ONLY = 'nonAnswered';
     public const ANSWER_STATUS_FILTER_WRONG_ANSWERED_ONLY = 'wrongAnswered';
 
-    private $answerStatusFilter = null;
+    private string $answerStatusFilter = '';
 
     public const QUESTION_INSTANCE_TYPE_ORIGINALS = 'QST_INSTANCE_TYPE_ORIGINALS';
     public const QUESTION_INSTANCE_TYPE_DUPLICATES = 'QST_INSTANCE_TYPE_DUPLICATES';
     public const QUESTION_INSTANCE_TYPE_ALL = 'QST_INSTANCE_TYPE_ALL';
     private string $questionInstanceTypeFilter = self::QUESTION_INSTANCE_TYPE_ORIGINALS;
 
-    private $includeQuestionIdsFilter = null;
-    private $excludeQuestionIdsFilter = null;
-
-    public const QUESTION_COMPLETION_STATUS_COMPLETE = 'complete';
-    public const QUESTION_COMPLETION_STATUS_INCOMPLETE = 'incomplete';
-    public const QUESTION_COMPLETION_STATUS_BOTH = 'complete/incomplete';
-    private string $questionCompletionStatusFilter = self::QUESTION_COMPLETION_STATUS_BOTH;
+    private array $includeQuestionIdsFilter = [];
+    private array $excludeQuestionIdsFilter = [];
 
     public const QUESTION_COMMENTED_ONLY = '1';
     public const QUESTION_COMMENTED_EXCLUDED = '2';
@@ -93,19 +88,9 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         $this->order = $order;
     }
 
-    public function getOrder(): ?Order
-    {
-        return $this->order;
-    }
-
     public function setRange(?Range $range = null): void
     {
         $this->range = $range;
-    }
-
-    public function getRange(): ?Range
-    {
-        return $this->range;
     }
 
     public function getParentObjId(): ?int
@@ -113,75 +98,37 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->parentObjId;
     }
 
-    public function setParentObjId($parentObjId): void
+    public function setParentObjId(?int $parentObjId): void
     {
         $this->parentObjId = $parentObjId;
     }
 
-    public function getParentObjectType(): string
-    {
-        return $this->parentObjType;
-    }
-
-    public function setParentObjectType($parentObjType): void
+    public function setParentObjectType(string $parentObjType): void
     {
         $this->parentObjType = $parentObjType;
     }
 
-    public function getParentObjIdsFilter(): array
-    {
-        return $this->parentObjIdsFilter;
-    }
-
-    /**
-     * @param array $parentObjIdsFilter
-     */
-    public function setParentObjIdsFilter($parentObjIdsFilter): void
+    public function setParentObjIdsFilter(array $parentObjIdsFilter): void
     {
         $this->parentObjIdsFilter = $parentObjIdsFilter;
     }
 
-    public function setQuestionInstanceTypeFilter($questionInstanceTypeFilter): void
+    public function setQuestionInstanceTypeFilter(?string $questionInstanceTypeFilter): void
     {
         $this->questionInstanceTypeFilter = (string) $questionInstanceTypeFilter;
     }
 
-    public function getQuestionInstanceTypeFilter()
-    {
-        return $this->questionInstanceTypeFilter;
-    }
-
-    public function setIncludeQuestionIdsFilter($questionIdsFilter): void
+    public function setIncludeQuestionIdsFilter(array $questionIdsFilter): void
     {
         $this->includeQuestionIdsFilter = $questionIdsFilter;
     }
 
-    public function getIncludeQuestionIdsFilter()
-    {
-        return $this->includeQuestionIdsFilter;
-    }
-
-    public function getExcludeQuestionIdsFilter()
-    {
-        return $this->excludeQuestionIdsFilter;
-    }
-
-    public function setExcludeQuestionIdsFilter($excludeQuestionIdsFilter): void
+    public function setExcludeQuestionIdsFilter(array $excludeQuestionIdsFilter): void
     {
         $this->excludeQuestionIdsFilter = $excludeQuestionIdsFilter;
     }
 
-    public function getQuestionCompletionStatusFilter(): string
-    {
-        return $this->questionCompletionStatusFilter;
-    }
-
-    public function setQuestionCompletionStatusFilter($questionCompletionStatusFilter): void
-    {
-        $this->questionCompletionStatusFilter = $questionCompletionStatusFilter;
-    }
-
-    public function addFieldFilter($fieldName, $fieldValue): void
+    public function addFieldFilter(string $fieldName, mixed $fieldValue): void
     {
         $this->fieldFilters[$fieldName] = $fieldValue;
     }
@@ -198,64 +145,37 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         $this->taxFiltersExcludeAnyObjectsWithTaxonomies = $flag;
     }
 
-    public function setAvailableTaxonomyIds($availableTaxonomyIds): void
+    public function setAvailableTaxonomyIds(array $availableTaxonomyIds): void
     {
         $this->availableTaxonomyIds = $availableTaxonomyIds;
     }
 
-    public function getAvailableTaxonomyIds(): array
-    {
-        return $this->availableTaxonomyIds;
-    }
-
-    public function setAnswerStatusActiveId($answerStatusActiveId): void
+    public function setAnswerStatusActiveId(?int $answerStatusActiveId): void
     {
         $this->answerStatusActiveId = $answerStatusActiveId;
     }
 
-    public function getAnswerStatusActiveId(): ?int
-    {
-        return $this->answerStatusActiveId;
-    }
-
-    public function setAnswerStatusFilter($answerStatusFilter): void
+    public function setAnswerStatusFilter(string $answerStatusFilter): void
     {
         $this->answerStatusFilter = $answerStatusFilter;
     }
 
-    public function getAnswerStatusFilter(): ?string
-    {
-        return $this->answerStatusFilter;
-    }
-
     /**
      * Set if object data table should be joined
-     *
-     * @param bool $a_val join object_data
      */
-    public function setJoinObjectData($a_val): void
+    public function setJoinObjectData(bool $a_val): void
     {
         $this->join_obj_data = $a_val;
-    }
-
-    /**
-     * Get if object data table should be joined
-     *
-     * @return bool join object_data
-     */
-    public function getJoinObjectData(): bool
-    {
-        return $this->join_obj_data;
     }
 
     private function getParentObjFilterExpression(): ?string
     {
         if ($this->getParentObjId()) {
-            return 'qpl_questions.obj_fi = ' . $this->db->quote($this->getParentObjId(), 'integer');
+            return "qpl_questions.obj_fi = {$this->db->quote($this->getParentObjId(), ilDBConstants::T_INTEGER)}";
         }
 
-        if (count($this->getParentObjIdsFilter())) {
-            return $this->db->in('qpl_questions.obj_fi', $this->getParentObjIdsFilter(), false, 'integer');
+        if (!empty($this->parentObjIdsFilter)) {
+            return $this->db->in('qpl_questions.obj_fi', $this->parentObjIdsFilter, false, ilDBConstants::T_INTEGER);
         }
 
         return null;
@@ -271,39 +191,25 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
                 case 'description':
                 case 'author':
                 case 'lifecycle':
-
-                    $expressions[] = $this->db->like('qpl_questions.' . $fieldName, 'text', "%%$fieldValue%%");
+                    $expressions[] = $this->db->like("qpl_questions.$fieldName", ilDBConstants::T_TEXT, "%%$fieldValue%%");
                     break;
-
                 case 'type':
-
-                    $expressions[] = "qpl_qst_type.type_tag = {$this->db->quote($fieldValue, 'text')}";
+                    $expressions[] = "qpl_qst_type.type_tag = {$this->db->quote($fieldValue, ilDBConstants::T_TEXT)}";
                     break;
-
                 case 'question_id':
-                    if ($fieldValue != "" && !is_array($fieldValue)) {
+                    if ($fieldValue !== '' && !is_array($fieldValue)) {
                         $fieldValue = [$fieldValue];
                     }
-                    $expressions[] = $this->db->in("qpl_questions.question_id", $fieldValue, false, "integer");
+                    $expressions[] = $this->db->in('qpl_questions.question_id', $fieldValue, false, ilDBConstants::T_INTEGER);
                     break;
-
                 case 'parent_title':
                     if ($this->join_obj_data) {
-                        $expressions[] = $this->db->like('object_data.title', 'text', "%%$fieldValue%%");
-                    }
-                    break;
-                case 'feedback':
-                    if ($fieldValue === 'false') {
-                        $expressions[] = 'qpl_fb_generic.question_fi IS NULL';
-                    }
-                    break;
-                case 'hints':
-                    if ($fieldValue === 'false') {
-                        $expressions[] = 'qpl_hints.qht_question_fi IS NULL';
+                        $expressions[] = $this->db->like('object_data.title', ilDBConstants::T_TEXT, "%%$fieldValue%%");
                     }
                     break;
             }
         }
+
 
         return $expressions;
     }
@@ -317,10 +223,8 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         };
 
         if (isset($feedback_join)) {
-            $SQL = $feedback_join . ' JOIN qpl_fb_generic ON qpl_fb_generic.question_fi = qpl_questions.question_id ';
-            if (!str_contains($tableJoin, $SQL)) {
-                $tableJoin .= $SQL;
-            }
+            $SQL = "$feedback_join JOIN qpl_fb_generic ON qpl_fb_generic.question_fi = qpl_questions.question_id ";
+            $tableJoin .= !str_contains($tableJoin, $SQL) ? $SQL : '';
         }
 
         return $tableJoin;
@@ -335,10 +239,8 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         };
 
         if (isset($feedback_join)) {
-            $SQL = $feedback_join . ' JOIN qpl_hints ON qpl_hints.qht_question_fi = qpl_questions.question_id ';
-            if (!str_contains($tableJoin, $SQL)) {
-                $tableJoin .= $SQL;
-            }
+            $SQL = "$feedback_join JOIN qpl_hints ON qpl_hints.qht_question_fi = qpl_questions.question_id ";
+            $tableJoin .= !str_contains($tableJoin, $SQL) ? $SQL : '';
         }
 
         return $tableJoin;
@@ -347,55 +249,69 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
     private function getTaxonomyFilterExpressions(): array
     {
         $expressions = [];
+
         if ($this->taxFiltersExcludeAnyObjectsWithTaxonomies) {
             $expressions[] = 'question_id NOT IN (SELECT DISTINCT item_id FROM tax_node_assignment)';
+        } else {
+            foreach ($this->taxFilters as $taxId => $taxNodes) {
+                $questionIds = [];
+
+                $forceBypass = true;
+
+                foreach ($taxNodes as $taxNode) {
+                    $forceBypass = false;
+
+                    $taxItemsByTaxParent = $this->getTaxItems(
+                        $this->taxParentTypes[$taxId],
+                        $this->taxParentIds[$taxId],
+                        $taxId,
+                        $taxNode
+                    );
+
+                    $taxItemsByParent = $this->getTaxItems(
+                        $this->parentObjType,
+                        $this->parentObjId,
+                        $taxId,
+                        $taxNode
+                    );
+
+                    $taxItems = array_merge($taxItemsByTaxParent, $taxItemsByParent);
+                    foreach ($taxItems as $taxItem) {
+                        $questionIds[$taxItem['item_id']] = $taxItem['item_id'];
+                    }
+                }
+
+                if (!$forceBypass) {
+                    $expressions[] = $this->db->in('question_id', $questionIds, false, ilDBConstants::T_INTEGER);
+                }
+            }
+        }
+
+        $taxonomy_title = $this->fieldFilters['taxonomy_title'] ?? '';
+        $taxonomy_node_title = $this->fieldFilters['taxonomy_node_title'] ?? '';
+
+        if ($taxonomy_title === '' && $taxonomy_node_title === '') {
             return $expressions;
         }
 
-        foreach ($this->taxFilters as $taxId => $taxNodes) {
-            $questionIds = [];
+        $base = 'SELECT DISTINCT item_id FROM tax_node_assignment';
 
-            $forceBypass = true;
+        $like_taxonomy_title = $taxonomy_title !== ''
+            ? "AND {$this->db->like('object_data.title', ilDBConstants::T_TEXT, "%$taxonomy_title%", false)}"
+            : '';
+        $like_taxonomy_node_title = $taxonomy_node_title !== ''
+            ? "AND {$this->db->like('tax_node.title', ilDBConstants::T_TEXT, "%$taxonomy_node_title%", false)}"
+            : '';
 
-            foreach ($taxNodes as $taxNode) {
-                $forceBypass = false;
+        $inner_join_object_data = "INNER JOIN object_data ON (object_data.obj_id = tax_node_assignment.tax_id AND object_data.type = 'tax' $like_taxonomy_title)";
+        $inner_join_tax_node = "INNER JOIN tax_node ON (tax_node.tax_id = tax_node_assignment.tax_id AND tax_node.type = 'taxn' AND tax_node_assignment.node_id = tax_node.obj_id $like_taxonomy_node_title)";
 
-                $taxItemsByTaxParent = $this->getTaxItems(
-                    $this->taxParentTypes[$taxId],
-                    $this->taxParentIds[$taxId],
-                    $taxId,
-                    $taxNode
-                );
-
-                $taxItemsByParent = $this->getTaxItems(
-                    $this->parentObjType,
-                    $this->parentObjId,
-                    $taxId,
-                    $taxNode
-                );
-
-                $taxItems = array_merge($taxItemsByTaxParent, $taxItemsByParent);
-                foreach ($taxItems as $taxItem) {
-                    $questionIds[$taxItem['item_id']] = $taxItem['item_id'];
-                }
-            }
-
-            if (!$forceBypass) {
-                $expressions[] = $this->db->in('question_id', $questionIds, false, 'integer');
-            }
-        }
+        $expressions[] = "qpl_questions.question_id IN ($base $inner_join_object_data $inner_join_tax_node)";
 
         return $expressions;
     }
 
-    /**
-     * @param string $parentType
-     * @param int $parentObjId
-     * @param int $taxId
-     * @param int $taxNode
-     * @return array
-     */
-    protected function getTaxItems($parentType, $parentObjId, $taxId, $taxNode): array
+    protected function getTaxItems(string $parentType, int $parentObjId, int $taxId, int $taxNode): array
     {
         $taxTree = new ilTaxonomyTree($taxId);
 
@@ -414,45 +330,35 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 
     private function getQuestionInstanceTypeFilterExpression(): ?string
     {
-        switch ($this->getQuestionInstanceTypeFilter()) {
-            case self::QUESTION_INSTANCE_TYPE_ORIGINALS:
-                return 'qpl_questions.original_id IS NULL';
-            case self::QUESTION_INSTANCE_TYPE_DUPLICATES:
-                return 'qpl_questions.original_id IS NOT NULL';
-            case self::QUESTION_INSTANCE_TYPE_ALL:
-            default:
-                return null;
-        }
-
-        return null;
+        return match ($this->questionInstanceTypeFilter) {
+            self::QUESTION_INSTANCE_TYPE_ORIGINALS => 'qpl_questions.original_id IS NULL',
+            self::QUESTION_INSTANCE_TYPE_DUPLICATES => 'qpl_questions.original_id IS NOT NULL',
+            default => null
+        };
     }
 
     private function getQuestionIdsFilterExpressions(): array
     {
         $expressions = [];
 
-        if (is_array($this->getIncludeQuestionIdsFilter())) {
+        if (!empty($this->includeQuestionIdsFilter)) {
             $expressions[] = $this->db->in(
                 'qpl_questions.question_id',
-                $this->getIncludeQuestionIdsFilter(),
+                $this->includeQuestionIdsFilter,
                 false,
-                'integer'
+                ilDBConstants::T_INTEGER
             );
         }
 
-        if (is_array($this->getExcludeQuestionIdsFilter())) {
+        if (!empty($this->excludeQuestionIdsFilter)) {
             $IN = $this->db->in(
                 'qpl_questions.question_id',
-                $this->getExcludeQuestionIdsFilter(),
+                $this->excludeQuestionIdsFilter,
                 true,
-                'integer'
+                ilDBConstants::T_INTEGER
             );
 
-            if ($IN == ' 1=2 ') {
-                $IN = ' 1=1 ';
-            } // required for ILIAS < 5.0
-
-            $expressions[] = $IN;
+            $expressions[] = $IN === ' 1=2 ' ? ' 1=1 ' : $IN; // required for ILIAS < 5.0
         }
 
         return $expressions;
@@ -460,68 +366,55 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 
     private function getParentObjectIdFilterExpression(): ?string
     {
-        if ($this->parentObjId) {
-            return "qpl_questions.obj_fi = {$this->db->quote($this->parentObjId, 'integer')}";
-        }
-
-        return null;
+        return $this->parentObjId
+            ? "qpl_questions.obj_fi = {$this->db->quote($this->parentObjId, ilDBConstants::T_INTEGER)}"
+            : null;
     }
 
     private function getAnswerStatusFilterExpressions(): array
     {
-        $expressions = [];
-
-        switch ($this->getAnswerStatusFilter()) {
-            case self::ANSWER_STATUS_FILTER_ALL_NON_CORRECT:
-
-                $expressions[] = '
-					(tst_test_result.question_fi IS NULL OR tst_test_result.points < qpl_questions.points)
-				';
-                break;
-
-            case self::ANSWER_STATUS_FILTER_NON_ANSWERED_ONLY:
-
-                $expressions[] = 'tst_test_result.question_fi IS NULL';
-                break;
-
-            case self::ANSWER_STATUS_FILTER_WRONG_ANSWERED_ONLY:
-
-                $expressions[] = 'tst_test_result.question_fi IS NOT NULL';
-                $expressions[] = 'tst_test_result.points < qpl_questions.points';
-                break;
-        }
-
-        return $expressions;
+        return match ($this->answerStatusFilter) {
+            self::ANSWER_STATUS_FILTER_ALL_NON_CORRECT => ['
+                (tst_test_result.question_fi IS NULL OR tst_test_result.points < qpl_questions.points)
+            '],
+            self::ANSWER_STATUS_FILTER_NON_ANSWERED_ONLY => ['tst_test_result.question_fi IS NULL'],
+            self::ANSWER_STATUS_FILTER_WRONG_ANSWERED_ONLY => [
+                'tst_test_result.question_fi IS NOT NULL',
+                'tst_test_result.points < qpl_questions.points'
+            ],
+            default => [],
+        };
     }
 
     private function getTableJoinExpression(): string
     {
-        $tableJoin = "
+        $tableJoin = '
 			INNER JOIN	qpl_qst_type
 			ON			qpl_qst_type.question_type_id = qpl_questions.question_type_fi
-		";
+		';
 
         if ($this->join_obj_data) {
-            $tableJoin .= "
+            $tableJoin .= '
 				INNER JOIN	object_data
 				ON			object_data.obj_id = qpl_questions.obj_fi
-			";
+			';
         }
 
-        if ($this->getParentObjectType() === 'tst'
-            && $this->getQuestionInstanceTypeFilter() === self::QUESTION_INSTANCE_TYPE_ALL
+        if (
+            $this->parentObjType === 'tst'
+            && $this->questionInstanceTypeFilter === self::QUESTION_INSTANCE_TYPE_ALL
         ) {
-            $tableJoin .= "INNER JOIN tst_test_question tstquest ON tstquest.question_fi = qpl_questions.question_id";
+            $tableJoin .= 'INNER JOIN tst_test_question tstquest ON tstquest.question_fi = qpl_questions.question_id';
         }
 
         $tableJoin = $this->handleFeedbackJoin($tableJoin);
         $tableJoin = $this->handleHintJoin($tableJoin);
 
-        if ($this->getAnswerStatusActiveId()) {
+        if ($this->answerStatusActiveId) {
             $tableJoin .= "
 				LEFT JOIN	tst_test_result
 				ON			tst_test_result.question_fi = qpl_questions.question_id
-				AND			tst_test_result.active_fi = {$this->db->quote($this->getAnswerStatusActiveId(), 'integer')}
+				AND			tst_test_result.active_fi = {$this->db->quote($this->answerStatusActiveId, ilDBConstants::T_INTEGER)}
 			";
         }
 
@@ -530,36 +423,35 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 
     private function getConditionalFilterExpression(): string
     {
-        $CONDITIONS = [];
+        $conditions = [];
 
         if ($this->getQuestionInstanceTypeFilterExpression() !== null) {
-            $CONDITIONS[] = $this->getQuestionInstanceTypeFilterExpression();
+            $conditions[] = $this->getQuestionInstanceTypeFilterExpression();
         }
 
         if ($this->getParentObjFilterExpression() !== null) {
-            $CONDITIONS[] = $this->getParentObjFilterExpression();
+            $conditions[] = $this->getParentObjFilterExpression();
         }
 
         if ($this->getParentObjectIdFilterExpression() !== null) {
-            $CONDITIONS[] = $this->getParentObjectIdFilterExpression();
+            $conditions[] = $this->getParentObjectIdFilterExpression();
         }
 
-        $CONDITIONS = array_merge(
-            $CONDITIONS,
+        $conditions = array_merge(
+            $conditions,
             $this->getQuestionIdsFilterExpressions(),
             $this->getFieldFilterExpressions(),
             $this->getTaxonomyFilterExpressions(),
-            $this->getTaxonomyFilterExpression(),
             $this->getAnswerStatusFilterExpressions()
         );
 
-        $CONDITIONS = implode(' AND ', $CONDITIONS);
-        return $CONDITIONS !== '' ? 'AND ' . $CONDITIONS : '';
+        $conditions = implode(' AND ', $conditions);
+        return $conditions !== '' ? "AND $conditions" : '';
     }
 
     private function getSelectFieldsExpression(): string
     {
-        $selectFields = [
+        $select_fields = [
             'qpl_questions.*',
             'qpl_qst_type.type_tag',
             'qpl_qst_type.plugin',
@@ -568,12 +460,12 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         ];
 
         if ($this->join_obj_data) {
-            $selectFields[] = 'object_data.title parent_title';
+            $select_fields[] = 'object_data.title parent_title';
         }
 
-        if ($this->getAnswerStatusActiveId()) {
-            $selectFields[] = 'tst_test_result.points reached_points';
-            $selectFields[] = "CASE
+        if ($this->answerStatusActiveId) {
+            $select_fields[] = 'tst_test_result.points reached_points';
+            $select_fields[] = "CASE
 					WHEN tst_test_result.points IS NULL THEN '" . self::QUESTION_ANSWER_STATUS_NON_ANSWERED . "'
 					WHEN tst_test_result.points < qpl_questions.points THEN '" . self::QUESTION_ANSWER_STATUS_WRONG_ANSWERED . "'
 					ELSE '" . self::QUESTION_ANSWER_STATUS_CORRECT_ANSWERED . "'
@@ -581,15 +473,15 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 			";
         }
 
-        $selectFields[] = $this->generateFeedbackSubQuery();
-        $selectFields[] = $this->generateHintSubquery();
-        $selectFields[] = $this->generateTaxonomySubquery();
+        $select_fields[] = $this->generateFeedbackSubquery();
+        $select_fields[] = $this->generateHintSubquery();
+        $select_fields[] = $this->generateTaxonomySubquery();
 
-        $selectFields = implode(', ', $selectFields);
-        return "SELECT $selectFields";
+        $select_fields = implode(', ', $select_fields);
+        return "SELECT DISTINCT $select_fields";
     }
 
-    private function generateFeedbackSubQuery(): string
+    private function generateFeedbackSubquery(): string
     {
         $cases = [];
         $tables = ['qpl_fb_generic', 'qpl_fb_specific'];
@@ -602,7 +494,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         $page_object_table = 'page_object';
         foreach ($tables as $table) {
             $subquery = sprintf(
-                "SELECT 1 FROM $table JOIN $page_object_table ON $page_object_table.page_id = $table.feedback_id WHERE $page_object_table.parent_type IN ('%s', '%s') AND $page_object_table.lang = '-' AND $page_object_table.is_empty <> 1 AND $table.question_fi = qpl_questions.question_id",
+                "SELECT 1 FROM $table JOIN $page_object_table ON $page_object_table.page_id = $table.feedback_id WHERE $page_object_table.parent_type IN ('%s', '%s') AND $page_object_table.is_empty <> 1 AND $table.question_fi = qpl_questions.question_id",
                 \ilAssQuestionFeedback::PAGE_OBJECT_TYPE_GENERIC_FEEDBACK,
                 \ilAssQuestionFeedback::PAGE_OBJECT_TYPE_SPECIFIC_FEEDBACK,
             );
@@ -631,9 +523,35 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return "{$this->getSelectFieldsExpression()} FROM qpl_questions {$this->getTableJoinExpression()} WHERE qpl_questions.tstamp > 0";
     }
 
+    private function getHavingFilterExpression(): string
+    {
+        $expressions = [];
+
+        foreach ($this->fieldFilters as $fieldName => $fieldValue) {
+            if ($fieldName ==='feedback') {
+                $fieldValue = strtoupper($fieldValue);
+                if (in_array($fieldValue, ['TRUE', 'FALSE'], true)) {
+                    $expressions[] = "feedback IS $fieldValue";
+                }
+                continue;
+
+            }
+
+            if ($fieldName ==='hints') {
+                $fieldValue = strtoupper($fieldValue);
+                if (in_array($fieldValue, ['TRUE', 'FALSE'], true)) {
+                    $expressions[] = "hints IS $fieldValue";
+                }
+            }
+        }
+
+        $having = implode(' AND ', $expressions);
+        return $having !== '' ? "HAVING $having" : '';
+    }
+
     private function buildOrderQueryExpression(): string
     {
-        $order = $this->getOrder();
+        $order = $this->order;
         if ($order === null) {
             return '';
         }
@@ -653,35 +571,15 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 
     private function buildLimitQueryExpression(): string
     {
-        $range = $this->getRange();
-        return $range === null
-            ? ''
-            : ' LIMIT ' . ((int) max($range->getLength(), 0)) . ' OFFSET ' . ((int) max($range->getStart(), 0));
-    }
-
-    private function getTaxonomyFilterExpression(): array
-    {
-        $taxonomy_title = (string) ($this->fieldFilters['taxonomy_title'] ?? '');
-        $taxonomy_node_title = (string) ($this->fieldFilters['taxonomy_node_title'] ?? '');
-
-        if (empty($taxonomy_title) && empty($taxonomy_node_title)) {
-            return [];
+        $range = $this->range;
+        if ($range === null) {
+            return '';
         }
 
-        $base = 'SELECT DISTINCT item_id FROM tax_node_assignment';
+        $limit = max($range->getLength(), 0);
+        $offset = max($range->getStart(), 0);
 
-        $like_taxonomy_title = empty($taxonomy_title)
-            ? ''
-            : 'AND' . $this->db->like('object_data.title', ilDBConstants::T_TEXT, "%$taxonomy_title%", false);
-        $like_taxonomy_node_title = empty($taxonomy_node_title)
-            ? ''
-            : 'AND' . $this->db->like('tax_node.title', ilDBConstants::T_TEXT, "%$taxonomy_node_title%", false);
-
-        $inner_join_object_data = "INNER JOIN object_data ON (object_data.obj_id = tax_node_assignment.tax_id AND object_data.type = 'tax' $like_taxonomy_title)";
-        $inner_join_tax_node = "INNER JOIN tax_node ON (tax_node.tax_id = tax_node_assignment.tax_id AND tax_node.type = 'taxn' AND tax_node_assignment.node_id = tax_node.obj_id $like_taxonomy_node_title)";
-
-
-        return ["qpl_questions.question_id IN ($base $inner_join_object_data $inner_join_tax_node)"];
+        return " LIMIT $limit OFFSET $offset";
     }
 
     private function buildQuery(): string
@@ -689,6 +587,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return implode(PHP_EOL, array_filter([
             $this->buildBasicQuery(),
             $this->getConditionalFilterExpression(),
+            $this->getHavingFilterExpression(),
             $this->buildOrderQueryExpression(),
             $this->buildLimitQueryExpression(),
         ]));
@@ -714,18 +613,18 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             $row['author'] = $tags_trafo->transform($row['author']);
             $row['taxonomies'] = $this->loadTaxonomyAssignmentData($row['obj_fi'], $row['question_id']);
             $row['ttype'] = $this->lng->txt($row['type_tag']);
-            $row['feedback'] = (bool) $row['feedback'];
-            $row['hints'] = (bool) $row['hints'];
+            $row['feedback'] = $row['feedback'] === 1;
+            $row['hints'] = $row['hints'] === 1;
             $row['comments'] = $this->getNumberOfCommentsForQuestion($row['question_id']);
 
             if (
-                ($this->filter_comments === self::QUESTION_COMMENTED_ONLY && $row['comments'] === 0)
-                || ($this->filter_comments === self::QUESTION_COMMENTED_EXCLUDED && $row['comments'] > 0)
+                $this->filter_comments === self::QUESTION_COMMENTED_ONLY && $row['comments'] === 0
+                || $this->filter_comments === self::QUESTION_COMMENTED_EXCLUDED && $row['comments'] > 0
             ) {
                 continue;
             }
 
-            $this->questions[ $row['question_id'] ] = $row;
+            $this->questions[$row['question_id']] = $row;
         }
     }
 
@@ -752,7 +651,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->notes_service->domain()->getNrOfCommentsForContext($notes_context);
     }
 
-    public function setCommentFilter(int $commented = null)
+    public function setCommentFilter(?int $commented = null): void
     {
         $this->filter_comments = $commented;
     }
@@ -762,7 +661,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         int $question_id
     ): array {
         $tax_assignment_data = [];
-        foreach ($this->getAvailableTaxonomyIds() as $tax_id) {
+        foreach ($this->availableTaxonomyIds as $tax_id) {
             $tax_tree = new ilTaxonomyTree($tax_id);
 
             $tax_assignment = new ilTaxNodeAssignment('qpl', $parent_obj_id, 'quest', $tax_id);
@@ -792,28 +691,24 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             return true;
         }
 
-        if (!isset($questionData['plugin_name'])
+        if (
+            !isset($questionData['plugin_name'])
             || !$this->component_repository->getComponentByTypeAndName(
                 ilComponentInfo::TYPE_MODULES,
                 'TestQuestionPool'
-            )->getPluginSlotById('qst')->hasPluginName($questionData['plugin_name'])) {
+            )->getPluginSlotById('qst')->hasPluginName($questionData['plugin_name'])
+        ) {
             return false;
         }
 
         return $this->component_repository
-            ->getComponentByTypeAndName(
-                ilComponentInfo::TYPE_MODULES,
-                'TestQuestionPool'
-            )
-            ->getPluginSlotById(
-                'qst'
-            )
-            ->getPluginByName(
-                $questionData['plugin_name']
-            )->isActive();
+            ->getComponentByTypeAndName(ilComponentInfo::TYPE_MODULES, 'TestQuestionPool')
+            ->getPluginSlotById('qst')
+            ->getPluginByName($questionData['plugin_name'])
+            ->isActive();
     }
 
-    public function getDataArrayForQuestionId($questionId)
+    public function getDataArrayForQuestionId(int $questionId)
     {
         return $this->questions[$questionId];
     }
@@ -823,7 +718,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         return $this->questions;
     }
 
-    public function isInList($questionId): bool
+    public function isInList(int $questionId): bool
     {
         return isset($this->questions[$questionId]);
     }
@@ -839,20 +734,16 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
      */
     public function getTitle(string $a_comp_id, string $a_item_type, int $a_item_id): string
     {
-        if ($a_comp_id != 'qpl' || $a_item_type != 'quest' || !$a_item_id) {
+        if ($a_comp_id !== 'qpl' || $a_item_type !== 'quest' || !$a_item_id) {
             return '';
         }
 
-        if (!isset($this->questions[$a_item_id])) {
-            return '';
-        }
-
-        return $this->questions[$a_item_id]['title'];
+        return $this->questions[$a_item_id]['title'] ?? '';
     }
 
     private function checkFilters(): void
     {
-        if ($this->getAnswerStatusFilter() !== null && !$this->getAnswerStatusActiveId()) {
+        if ($this->answerStatusFilter !== '' && !$this->answerStatusActiveId) {
             throw new ilTestQuestionPoolException(
                 'No active id given! You cannot use the answer status filter without giving an active id.'
             );

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -275,42 +275,40 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 
     private function getFilterByAssignedTaxonomyIdsExpression(): array
     {
-        $expressions = [];
-
         if ($this->taxFiltersExcludeAnyObjectsWithTaxonomies) {
-            $expressions[] = 'question_id NOT IN (SELECT DISTINCT item_id FROM tax_node_assignment)';
-            return $expressions;
+            return ['question_id NOT IN (SELECT DISTINCT item_id FROM tax_node_assignment)'];
         }
 
-        foreach ($this->taxFilters as $taxId => $taxNodes) {
-            $questionIds = [];
+        $expressions = [];
+        foreach ($this->taxFilters as $tax_id => $tax_nodes) {
+            $question_ids = [];
 
-            foreach ($taxNodes as $taxNode) {
-                $taxItemsByTaxParent = $this->getTaxItems(
-                    $this->taxParentTypes[$taxId],
-                    $this->taxParentIds[$taxId],
-                    $taxId,
-                    $taxNode
-                );
-
-                $taxItemsByParent = $this->getTaxItems(
-                    $this->parentObjType,
-                    $this->parentObjId,
-                    $taxId,
-                    $taxNode
-                );
-
-                $taxItems = array_merge($taxItemsByTaxParent, $taxItemsByParent);
-                foreach ($taxItems as $taxItem) {
-                    $questionIds[$taxItem['item_id']] = $taxItem['item_id'];
-                }
-            }
-
-            if ($taxNodes === []) {
+            if ($tax_nodes === []) {
                 continue;
             }
 
-            $expressions[] = $this->db->in('question_id', $questionIds, false, ilDBConstants::T_INTEGER);
+            foreach ($tax_nodes as $tax_node) {
+                $tax_items_by_tax_parent = $this->getTaxItems(
+                    $this->taxParentTypes[$tax_id],
+                    $this->taxParentIds[$tax_id],
+                    $tax_id,
+                    $tax_node
+                );
+
+                $tax_items_by_parent = $this->getTaxItems(
+                    $this->parentObjType,
+                    $this->parentObjId,
+                    $tax_id,
+                    $tax_node
+                );
+
+                $tax_items = array_merge($tax_items_by_tax_parent, $tax_items_by_parent);
+                foreach ($tax_items as $tax_item) {
+                    $question_ids[$tax_item['item_id']] = $tax_item['item_id'];
+                }
+            }
+
+            $expressions[] = $this->db->in('question_id', $question_ids, false, ilDBConstants::T_INTEGER);
         }
 
         return $expressions;

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -210,7 +210,6 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             }
         }
 
-
         return $expressions;
     }
 
@@ -528,7 +527,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         $expressions = [];
 
         foreach ($this->fieldFilters as $fieldName => $fieldValue) {
-            if ($fieldName ==='feedback') {
+            if ($fieldName === 'feedback') {
                 $fieldValue = strtoupper($fieldValue);
                 if (in_array($fieldValue, ['TRUE', 'FALSE'], true)) {
                     $expressions[] = "feedback IS $fieldValue";
@@ -537,7 +536,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
 
             }
 
-            if ($fieldName ==='hints') {
+            if ($fieldName === 'hints') {
                 $fieldValue = strtoupper($fieldValue);
                 if (in_array($fieldValue, ['TRUE', 'FALSE'], true)) {
                     $expressions[] = "hints IS $fieldValue";


### PR DESCRIPTION
[Mantis: 42475](https://mantis.ilias.de/view.php?id=42475)

There are a couple of performance issues regarding the "Add from Pool" & "Add from other Test" tables. With many records the loading times become very noticeable.

I analyzed the underlying code and believe to have found the possible causes. One problem seems to be that the ordering and limiting of the records happens in PHP instead of in the database. This means that no matter how many records should be displayed to the user (partially filtered) all records get returned from the database and get ordered and limited in PHP which could get quite slow. Another problem is that for every record returned more queries are sent to the database to check whether the question has feedback, hints or taxonomies. This can cause an exponential growth of queries. Also the main query is executed multiple times throughout the execution process. For example once to count all found records (pagination) and once with all found records limited to the page size. Overall this approach results in an overhead of queries.

The idea was to move the filtering, ordering and limiting components directly to the database. The database is much more efficient at doing these tasks. This also simplifies the handling on the PHP side, so the found records can be (more or less) directly passed to the user. Due to the higher complexity of some of the relations between tables, the current query increased in size and so did the overall performance.



> To put the code up to a test I duplicated a question inside a test 4600+ times. In another test I went to the "Add from other Test" table and tested the loading times.
> 
> Without the code it takes about 6.2 sec with no filtering, no sorting and unlimited elements per page.
> With the code it takes about 5 sec with no filtering, no sorting and unlimited elements per page.
> Average of 24% performance increase.
> 
> Without the code it takes about 6.8 sec with some filtering, sorting and unlimited elements per page.
> With the code it takes about 5.8 sec with some filtering, sorting and unlimited elements per page.
> Average of 17% performance increase.
> 
> Please keep in mind that this test is meant to show the extreme test case. The regular user will probably limit the amount of elements significantly. This would bring the loading times well below 1 sec.



If this general idea gets welcomed, may I propose going forward to try to put the filtering, ordering and limiting onto the database side? This should increase performance and lower the code complexity.  Although I do not know, if this would overwhelm the databases for bigger ILIAS Installations, in the long run.

I would be glad to know your opinions on this matter.

A not directly related issue: 
[Mantis: 43093](https://mantis.ilias.de/view.php?id=43093)
As a quick note. If ordering logic would to be moved to the database, the Collation would automatically perform the correct Ordering of German (An some others) special characters.