### PR TITLE
Setup: I want to allow plugins to have an Setup\Agent in src/ directory

### DIFF
--- a/components/ILIAS/Setup/src/AbstractOfFinder.php
+++ b/components/ILIAS/Setup/src/AbstractOfFinder.php
@@ -35,7 +35,6 @@ abstract class AbstractOfFinder
     protected array $ignore = [
         '.*/components/ILIAS/Setup/',
         '.*/components/ILIAS/GlobalScreen/',
-        '.*/Customizing/.*/src/',
         '.*/vendor/',
         '.*/components/ILIAS/App/tests/',
         '.*/components/ILIAS/BackgroundTasks/tests/',


### PR DESCRIPTION
I'm not quite sure why this is not allowed due to the ignore list in Setup\AbstractOfFinder.  

We want to gradually adapt our plugin to the ILIAS core and therefore move all classes that are in namespaces to the src/ folder. The SetupAgent is not found there due to an ignored path pattern. 