### PR TITLE
Fix value presentation and allow combination input types

### DIFF
--- a/Services/Form/classes/class.ilPropertyFormGUI.php
+++ b/Services/Form/classes/class.ilPropertyFormGUI.php
@@ -658,7 +658,7 @@ class ilPropertyFormGUI extends ilFormGUI
             $multi_values = $item->getMultiValues();
             if (is_array($multi_values) && sizeof($multi_values) > 1) {
                 $multi_value = new ilHiddenInputGUI("ilMultiValues~" . $item->getPostVar());
-                $multi_value->setValue(implode("~", $multi_values));
+                $multi_value->setValue(base64_encode(json_encode($multi_values)));
                 $this->addItem($multi_value);
             }
             //$cfg["multi_values"] = $multi_values;

--- a/Services/Form/js/ServiceFormMulti.js
+++ b/Services/Form/js/ServiceFormMulti.js
@@ -1,6 +1,19 @@
 /**
- * Handle multi values for select and text input fields
- */
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 var ilMultiFormValues = {
 	
 	// 
@@ -48,7 +61,7 @@ var ilMultiFormValues = {
 	 */
 	addEvent: function(e) {
 		var id = $(e.delegateTarget).attr('id').split('~');
-		ilMultiFormValues.add(id[1], id[2], '');
+		ilMultiFormValues.add(id[1], id[2], []);
 	},
 
 	/**
@@ -221,12 +234,8 @@ var ilMultiFormValues = {
 		element_id = element_id[1];
 
 		// add element for each additional value
-		var values = $(element).attr('value').split('~');	
-		$(values).each(function(i) {
-			// 1st value can be ignored
-			if(i > 0) {
-				ilMultiFormValues.add(element_id, i-1, this);		
-			}
+		JSON.parse(atob($(element).attr('value'))).slice(1).forEach(function(value, i) {
+			ilMultiFormValues.add(element_id, i, (typeof value === 'object') ? value : [value]);
 		});	
 	},
 
@@ -260,14 +269,20 @@ var ilMultiFormValues = {
 
 
 		// try to set value 
-		if(preset != '') {
-			$(element).find('select[id*="' + group_id + '"] option[value="' + il.Form.escapeSelector(preset) + '"]').attr('selected', true);
-			$(element).find('input:text[id*="' + group_id + '"]').attr('value', preset);
-		}
-		else {
-			$(element).find('select[id*="' + group_id + '"] option:selected').removeAttr('selected');
-			$(element).find('input:text[id*="' + group_id + '"]').val('');
-		}
+		$(element).find('select[id*="' + group_id + '"],input:text[id*="' + group_id + '"]').each(function (i) {
+			const value = preset[Object.keys(preset)[i]];
+			$(this).find('option:selected').removeAttr('selected');
+			if(value !== undefined && value != '') {
+				$(this).find('option[value="' + il.Form.escapeSelector(String(value)) + '"]').attr('selected', true);
+				if (this.tagName === 'INPUT') {
+					$(this).attr('value', value);
+				}
+			} else {
+				if (this.tagName === 'INPUT') {
+					$(this).val('');
+				}
+			}
+		});
 
 		// non-editable value
 		$(element).find('span[id*="' + group_id + '"]').html(preset);


### PR DESCRIPTION
Resolves https://mantis.ilias.de/view.php?id=38015
Resolves https://mantis.ilias.de/view.php?id=38017

### Initial Problem

Values of a multi input fields are transmitted to the Form/JS but string concatination and are therefore susceptible for a lot of context related issues of the form value.
This causes all input field of that kind to misfunction on specific input value and makes this feature unusable for some input types (event if it is enabled for those atm).

### Solution

This PR encodes the values to a context unrelated format (base64) before transmitting them to the JS where they are decoded and proper handled. Through that the inputs are preserved similar in every case, not matter of their semantically value.
Further this increases the support of that feature to all input types as long as their value is a multi scalar type and therefore makes it usable not only for all current types where its enabled, but for upcoming and custom types of any kind, too.

### Conflicts

- Performance: The transformation causes a slight increase in workload and space. However, these changes are negligible in relation to the overall performance. A form where this increase would be noticeable would already struggle with displaying such large information via a user interface.
- Current persisted values: The internal persistence of input values is not affected by those changes therefore all current occurrences will stay the same. Also this feature has only 1 current usage wich isn't scalar (ilOrgUnitPositionFormGUI =>  ilOrgUnitGenericMultiInputGUI)

If there is any struggle or concern with the proposed changes please leave me a feedback.

Greetings,
@iszmais 

(Ported from ILIAS7: https://github.com/ILIAS-eLearning/ILIAS/pull/6538)