### PR TITLE
[Improvement] Check skipped major objective early on before updating the database

### DIFF
--- a/components/ILIAS/Database/classes/Setup/class.ilDatabaseUpdateStepsExecutedObjective.php
+++ b/components/ILIAS/Database/classes/Setup/class.ilDatabaseUpdateStepsExecutedObjective.php
@@ -18,6 +18,7 @@
 
 use ILIAS\Setup\Environment;
 use ILIAS\Setup\Objective;
+use ILIAS\Data;
 
 /**
  * This class attempt to achieve a set of database update steps. Look into the
@@ -67,6 +68,7 @@ class ilDatabaseUpdateStepsExecutedObjective implements Objective
     public function getPreconditions(Environment $environment): array
     {
         return [
+            new ilNoMajorVersionSkippedConditionObjective(new Data\Factory()),
             new ilDBStepExecutionDBExistsObjective(),
             new ilDatabaseUpdatedObjective(),
             new ilDBStepReaderExistsObjective()


### PR DESCRIPTION
Before executing update steps, check if a major version was skipped. Terminate early on so the database is not updated and the user can update to the next viable version.