### PR TITLE
10/UI/form/section headings html tags

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -739,7 +739,18 @@ class Renderer extends AbstractComponentRenderer
     protected function renderSection(F\Section $section, RendererInterface $default_renderer): string
     {
         $inputs_html = $default_renderer->render($section->getInputs());
-        return $this->wrapInFormContext($section, $section->getLabel(), $inputs_html);
+
+        $headline_tpl = $this->getTemplate("tpl.headlines.html", true, true);
+        $headline_tpl->setVariable("HEADLINE", $section->getLabel());
+        $nesting_level = $section->getNestingLevel() + 2;
+        if ($nesting_level > 6) {
+            $nesting_level = 6;
+        };
+        $headline_tpl->setVariable("LEVEL", $nesting_level);
+
+        $headline_html = $headline_tpl->get();
+
+        return $this->wrapInFormContext($section, $headline_html, $inputs_html);
     }
 
     protected function renderUrlField(F\Url $component, RendererInterface $default_renderer): string

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Section.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Section.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,10 +14,15 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *********************************************************************/
+ * @author Ferdinand Engländer <ferdinand.englaender@concepts-and-training.de>
+ */
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input\Field;
 
+use ILIAS\Data\Factory as DataFactory;
+use ILIAS\Language\Language;
 use ILIAS\UI\Component as C;
 
 /**
@@ -27,4 +30,44 @@ use ILIAS\UI\Component as C;
  */
 class Section extends Group implements C\Input\Field\Section
 {
+    protected int $nesting_level = 0;
+
+    public function __construct(
+        DataFactory $data_factory,
+        \ILIAS\Refinery\Factory $refinery,
+        Language $lng,
+        array $inputs,
+        string $label,
+        ?string $byline = null
+    ) {
+        parent::__construct($data_factory, $refinery, $lng, $inputs, $label, $byline);
+        $this->updateChildrenNestingLevels();
+    }
+
+    public function setNestingLevel(int $nesting_level): void
+    {
+        $this->nesting_level = $nesting_level;
+        $this->updateChildrenNestingLevels();
+    }
+
+    public function getNestingLevel(): int
+    {
+        return $this->nesting_level;
+    }
+
+    protected function setInputs(array $inputs): void
+    {
+        parent::setInputs($inputs);
+        $this->updateChildrenNestingLevels();
+    }
+
+    private function updateChildrenNestingLevels(): void
+    {
+        foreach ($this->getInputs() as $input) {
+            if ($input instanceof Section) {
+                $nesting_level = $this->getNestingLevel() + 1;
+                $input->setNestingLevel($nesting_level);
+            }
+        }
+    }
 }

--- a/components/ILIAS/UI/src/examples/Input/Field/Section/nested.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Section/nested.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\Section;
+
+/**
+ * ---
+ * description: >
+ *   Example showing how sections can be nested inside one another.
+ *
+ * expected output: >
+ *   The headline html tags should make this nested structure clear to screen readers (h2, h3, h4).
+ *   The nested sections should be visibly recognizable as being a sub-section of the parent section.
+ * ---
+ */
+function nested()
+{
+    // Step 0: Declare dependencies
+    global $DIC;
+    $ui = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    // Step 1: Define inputs for the innermost section
+    $text_input = $ui->input()->field()->text("Text Input", "Enter some text here.");
+    $multi_select = $ui->input()->field()->multiselect(
+        "Multi-Select",
+        [
+            "1" => "Option 1",
+            "2" => "Option 2",
+            "3" => "Option 3",
+        ],
+        "Choose one or more options"
+    );
+
+    $inner_section = $ui->input()->field()->section(
+        [$text_input, $multi_select],
+        "Inner Section",
+        "This is the innermost section."
+    )->withRequired(true);
+
+    // Step 2: Define inputs for the middle section
+    $dropdown = $ui->input()->field()->select(
+        "Dropdown",
+        [
+            "1" => "Choice 1",
+            "2" => "Choice 2",
+            "3" => "Choice 3",
+        ],
+        "Select a single choice"
+    );
+
+    $middle_section = $ui->input()->field()->section(
+        [$dropdown, $inner_section],
+        "Middle Section",
+        "This section contains the inner section and a dropdown."
+    );
+
+    // Step 3: Define the outer section
+    $number_input = $ui->input()->field()->numeric("Numeric Input", "Enter a number.");
+    $outer_section = $ui->input()->field()->section(
+        [$number_input, $middle_section],
+        "Outer Section",
+        "This is the top-level section containing all other sections."
+    );
+
+    // Step 4: Define the form and attach the outer section
+    $form = $ui->input()->container()->form()->standard("#", [$outer_section]);
+
+    // Step 5: Render the form (no submission or processing, purely for display)
+    return $renderer->render($form);
+}

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.headlines.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.headlines.html
@@ -1,0 +1,1 @@
+<h{LEVEL}>{HEADLINE}</h{LEVEL}>

--- a/components/ILIAS/UI/tests/Component/Input/Field/CommonFieldRendering.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/CommonFieldRendering.php
@@ -125,10 +125,17 @@ trait CommonFieldRendering
         $label_id = $label_id ? " for=\"$label_id\"" : '';
         $tab = $label_id ? '' : ' tabindex="0"';
         $js_id = $js_id ? " id=\"$js_id\"" : '';
+        if ($type === 'section-field-input') {
+            $headline_tag_open = "<h2>";
+            $headline_tag_close = "</h2>";
+        } else {
+            $headline_tag_open = "";
+            $headline_tag_close = "";
+        }
 
         $html = '
         <fieldset class="c-input" data-il-ui-component="' . $type . '" data-il-ui-input-name="' . $name . '"' . $js_id . $tab . '>
-            <label' . $label_id . '>' . $label . '</label>
+            <label' . $label_id . '>' . $headline_tag_open . $label . $headline_tag_close . '</label>
             <div class="c-input__field">';
         $html .= $payload_field;
         $html .= '

--- a/components/ILIAS/UI/tests/Component/Input/Field/SectionInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SectionInputTest.php
@@ -90,4 +90,23 @@ class SectionInputTest extends ILIAS_UI_TestBase
         $this->testWithDisabled($section);
         $this->testWithAdditionalOnloadCodeRendersId($section);
     }
+
+    public function testNestedSectionRendering(): void
+    {
+        $f = $this->getFieldFactory();
+        $inputs_level4 = [$f->text("input3", "input3 byline")];
+        $section_level4 = $f->section($inputs_level4, "Inner Section");
+
+        $inputs_level3 = [$f->text("input2", "input2 byline"), $section_level4];
+        $section_level3 = $f->section($inputs_level3, "Middle Section");
+
+        $inputs_level2 = [$f->text("input1", "input1 byline"), $section_level3];
+        $section_level2 = $f->section($inputs_level2, "Outermost Section");
+
+        $nested_sections_html = $this->render($section_level2);
+
+        $this->assertStringContainsString('<h2>Outermost Section</h2>', $nested_sections_html);
+        $this->assertStringContainsString('<h3>Middle Section</h3>', $nested_sections_html);
+        $this->assertStringContainsString('<h4>Inner Section</h4>', $nested_sections_html);
+    }
 }

--- a/templates/default/070-components/UI-framework/Input/_ui-component_section.scss
+++ b/templates/default/070-components/UI-framework/Input/_ui-component_section.scss
@@ -9,8 +9,9 @@
   > label {
     order: 1;
     width: 100%;
-    margin-bottom: l.$il-margin-xlarge-vertical;
-    font-size: s.$il-font-size-xxlarge;
+    h2, h3, h4, h5, h6 {
+      display: inline-block;
+    }
   }
 
   > .c-input__help-byline {
@@ -28,5 +29,7 @@
     width: 100%;
     order: 4;
   }
+
+
 }
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -4624,8 +4624,9 @@ hr.il-divider-with-label {
 .c-form .c-input[data-il-ui-component=section-field-input].c-input > label {
   order: 1;
   width: 100%;
-  margin-bottom: 9px;
-  font-size: 1.5rem;
+}
+.c-form .c-input[data-il-ui-component=section-field-input].c-input > label h2, .c-form .c-input[data-il-ui-component=section-field-input].c-input > label h3, .c-form .c-input[data-il-ui-component=section-field-input].c-input > label h4, .c-form .c-input[data-il-ui-component=section-field-input].c-input > label h5, .c-form .c-input[data-il-ui-component=section-field-input].c-input > label h6 {
+  display: inline-block;
 }
 .c-form .c-input[data-il-ui-component=section-field-input].c-input > .c-input__help-byline {
   width: 100%;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42226

# Issue

Sections no longer have heading tags.

![image](https://github.com/user-attachments/assets/cfb1a196-8444-4f29-9fd5-19e4f6d2aaed)

# Changes

Sections now assess their nesting level and html tags are rendered accordingly. ~~I also strengthened the visual difference of differently deep nesting levels.~~

UPDATE: @yvseiler and I decided against visual indents for now. The headline size already does a sufficient job to convey nesting and we don't have deeply nested sections yet. We might revisit this once we have the first use cases of triple+ nested sections (if ever)

UPDATED IMAGE:
![image](https://github.com/user-attachments/assets/88941d95-6c3f-49af-bd95-9f8ab1cc62e2)

# ~~Advice needed~~

~~Unit tests can currently only handle the first level expecting a h2. I will discuss a better solution with my colleagues.~~

Unit Tests now account for both the general form tests and a specific triple nested scenario.