### PR TITLE
Move soap internal config into ilias ini

### DIFF
--- a/components/ILIAS/WebServices/classes/Setup/class.ilWebServicesConfigStoredObjective.php
+++ b/components/ILIAS/WebServices/classes/Setup/class.ilWebServicesConfigStoredObjective.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
-/* Copyright (c) 2020 Daniel Weise <daniel.weise@concepts-and-training.de> Extended GPL, see docs/LICENSE */
+declare(strict_types=1);
 
 use ILIAS\Setup;
 
@@ -55,10 +69,28 @@ class ilWebServicesConfigStoredObjective implements Setup\Objective
         $settings->set("rpc_server_host", $this->config->getRPCServerHost());
         $settings->set("rpc_server_port", (string) $this->config->getRPCServerPort());
 
-        $settings->set('soap_internal_wsdl_path', (string) $this->config->getSoapInternalWsdlPath());
-        $settings->set('soap_internal_wsdl_verify_peer', (string) $this->config->getSoapInternalWsdlVerifyPeer());
-        $settings->set('soap_internal_wsdl_verify_peer_name', (string) $this->config->getSoapInternalWsdlVerifyPeerName());
-        $settings->set('soap_internal_wsdl_allow_self_signed', (string) $this->config->getSoapInternalWsdlAllowSelfSigned());
+        $ilias_ini = $environment->getResource(Setup\Environment::RESOURCE_ILIAS_INI);
+        $ilias_ini->setVariable(
+            'webservices',
+            'soap_internal_wsdl_path',
+            $this->config->getSoapInternalWsdlPath()
+        );
+        $ilias_ini->setVariable(
+            'webservices',
+            'soap_internal_wsdl_verify_peer',
+            (string) $this->config->getSoapInternalWsdlVerifyPeer()
+        );
+        $ilias_ini->setVariable(
+            'webservices',
+            'soap_internal_wsdl_verify_peer_name',
+            (string) $this->config->getSoapInternalWsdlVerifyPeerName()
+        );
+        $ilias_ini->setVariable(
+            'webservices',
+            'soap_internal_wsdl_allow_self_signed',
+            (string) $this->config->getSoapInternalWsdlAllowSelfSigned()
+        );
+        $ilias_ini->write();
 
         return $environment;
     }

--- a/components/ILIAS/soap/classes/class.ilNusoapUserAdministrationAdapter.php
+++ b/components/ILIAS/soap/classes/class.ilNusoapUserAdministrationAdapter.php
@@ -43,7 +43,7 @@ class ilNusoapUserAdministrationAdapter
 {
     public soap_server $server;
 
-    public function __construct(bool $a_use_wsdl = true)
+    public function __construct(bool $a_use_wsdl = true, ?ilIniFile $ilias_ini_file = null)
     {
         define('SERVICE_NAME', 'ILIASSoapWebservice');
         define('SERVICE_NAMESPACE', 'urn:ilUserAdministration');
@@ -55,7 +55,7 @@ class ilNusoapUserAdministrationAdapter
 
         if ($a_use_wsdl) {
             global $DIC;
-            $this->enableWSDL($DIC->settings());
+            $this->enableWSDL($ilias_ini_file);
         }
 
         $this->registerMethods();
@@ -68,10 +68,10 @@ class ilNusoapUserAdministrationAdapter
         exit();
     }
 
-    private function enableWSDL(ilSetting $setting): void
+    private function enableWSDL(?ilIniFile $ilias_ini_file): void
     {
         $this->server->configureWSDL(SERVICE_NAME, SERVICE_NAMESPACE);
-        $internal_path = $setting->get('soap_internal_wsdl_path', '');
+        $internal_path = $ilias_ini_file?->readVariable('webservices', 'soap_internal_wsdl_path');
         if ($internal_path) {
             $this->server->addInternalPort(SERVICE_NAME, $internal_path);
         }

--- a/components/ILIAS/soap/nusoapserver.php
+++ b/components/ILIAS/soap/nusoapserver.php
@@ -27,5 +27,10 @@ if (!defined('ILIAS_MODULE') || ILIAS_MODULE !== 'components/ILIAS/soap') {
     define('IL_SOAPMODE', IL_SOAPMODE_NUSOAP);
 }
 
-$server = new ilNusoapUserAdministrationAdapter(true);
+if (!isset($ilIliasIniFile)) {
+    $ilIliasIniFile = new ilIniFile(__DIR__ . "/../../../ilias.ini.php");
+    $ilIliasIniFile->read();
+}
+
+$server = new ilNusoapUserAdministrationAdapter(true, $ilIliasIniFile);
 $server->start();

--- a/components/ILIAS/soap/resources/soap/server.php
+++ b/components/ILIAS/soap/resources/soap/server.php
@@ -25,14 +25,14 @@ const ILIAS_MODULE = 'components/ILIAS/soap';
 
 chdir('../..');
 
-require_once 'vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../../vendor/composer/vendor/autoload.php';
 
 // Initialize the error_reporting level, until it will be overwritte when ILIAS gets initialized
 error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 
 ilContext::init(ilContext::CONTEXT_SOAP);
 
-$ilIliasIniFile = new ilIniFile('./ilias.ini.php');
+$ilIliasIniFile = new ilIniFile(__DIR__ . '/../../ilias.ini.php');
 $ilIliasIniFile->read();
 
 if ($ilIliasIniFile->readVariable('https', 'auto_https_detect_enabled')) {
@@ -47,7 +47,7 @@ if ($ilIliasIniFile->readVariable('https', 'auto_https_detect_enabled')) {
 
 if (strcasecmp($_SERVER['REQUEST_METHOD'], 'post') === 0) {
     // This is a SOAP request
-    require_once './components/ILIAS/soap/include/inc.soap_functions.php';
+    require_once __DIR__ . '/../../components/ILIAS/soap/include/inc.soap_functions.php';
     $uri = ilSoapFunctions::buildHTTPPath(false) . '/server.php';
     if (isset($_GET['client_id'])) {
         $uri .= '?client_id=' . $_GET['client_id'];
@@ -61,6 +61,5 @@ if (strcasecmp($_SERVER['REQUEST_METHOD'], 'post') === 0) {
     $soapServer->handle();
 } else {
     // This is a request to display the available SOAP methods or WSDL...
-    ilInitialisation::initILIAS();
-    require './components/ILIAS/soap/nusoapserver.php';
+    require __DIR__ . '/../../components/ILIAS/soap/nusoapserver.php';
 }


### PR DESCRIPTION
Our suggestion is to move the configuration for the internal SOAP communication to the ilias ini. This means that a complete initialization of ILIAS is no longer necessary.
In addition, we have changed the paths to absolute paths.