### PR TITLE
File: Fix undefined Variable

### DIFF
--- a/components/ILIAS/FileDelivery/src/Delivery/StreamDelivery.php
+++ b/components/ILIAS/FileDelivery/src/Delivery/StreamDelivery.php
@@ -173,6 +173,7 @@ final class StreamDelivery extends BaseDelivery
                 $this->notFound($r);
             }
             $file_inside_zip_uri = $file_inside_ZIP->getMetadata()['uri'];
+            $file_inside_zip_stream = fopen($file_inside_zip_uri, 'rb');
 
             if ($file_inside_zip_stream === false) {
                 $this->notFound($r);


### PR DESCRIPTION
Hi @chfsx 

There is an undefined variable in `StreamDelivery`, the corresponding definition seems to have been removed by accident with [this commit](https://github.com/ILIAS-eLearning/ILIAS/commit/95a12d6c3f8ceb33e113d8a08c8da66e32863e9b).

The corresponding issue is here: https://mantis.ilias.de/view.php?id=43818

Best.
@kergomard 