### PR TITLE
RTE: Fix Clean-Up of Existing Images

### DIFF
--- a/components/ILIAS/Forum/classes/Purifier/class.ilHtmlForumPostPurifier.php
+++ b/components/ILIAS/Forum/classes/Purifier/class.ilHtmlForumPostPurifier.php
@@ -28,7 +28,7 @@ class ilHtmlForumPostPurifier extends ilHtmlPurifierAbstractLibWrapper
     {
         $config = HTMLPurifier_Config::createDefault();
         $config->set('HTML.DefinitionID', 'ilias forum post');
-        $config->set('HTML.DefinitionRev', 1);
+        $config->set('HTML.DefinitionRev', 2);
         $config->set('Cache.SerializerPath', ilHtmlPurifierAbstractLibWrapper::_getCacheDirectory());
         $config->set('HTML.Doctype', 'XHTML 1.0 Strict');
 
@@ -38,6 +38,7 @@ class ilHtmlForumPostPurifier extends ilHtmlPurifierAbstractLibWrapper
         $config->set('HTML.ForbiddenAttributes', 'div@style');
 
         if (($def = $config->maybeGetRawHTMLDefinition()) !== null) {
+            $def->addAttribute('img', 'data-id', 'Number');
             $def->addAttribute('a', 'target', 'Enum#_blank,_self,_target,_top');
         }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssHtmlPurifier.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssHtmlPurifier.php
@@ -36,12 +36,13 @@ abstract class ilAssHtmlPurifier extends ilHtmlPurifierAbstractLibWrapper
     {
         $config = HTMLPurifier_Config::createDefault();
         $config->set('HTML.DefinitionID', $this->getPurifierType());
-        $config->set('HTML.DefinitionRev', 1);
+        $config->set('HTML.DefinitionRev', 2);
         $config->set('Cache.SerializerPath', ilHtmlPurifierAbstractLibWrapper::_getCacheDirectory());
         $config->set('HTML.Doctype', 'XHTML 1.0 Strict');
         $config->set('HTML.AllowedElements', $this->getAllowedElements());
         $config->set('HTML.ForbiddenAttributes', 'div@style');
         if ($def = $config->maybeGetRawHTMLDefinition()) {
+            $def->addAttribute('img', 'data-id', 'Number');
             $def->addAttribute('a', 'target', 'Enum#_blank,_self,_target,_top');
         }
 


### PR DESCRIPTION
Hi all

This tries to improve the situation for existing images in RTE. These images cannot be changed anymore (at least not easily), but with these changes the corresponding fields can at least be saved and imported without loosing the images.

@mjansenDatabay : Can I ask you to have a quick look at this?

See: https://mantis.ilias.de/view.php?id=42916

Thank you very much!
@kergomard 