### PR TITLE
TinyMCE: Fix license warning when using TinyMCE editor

### DIFF
--- a/components/ILIAS/RTE/templates/default/tpl.tinymce.js
+++ b/components/ILIAS/RTE/templates/default/tpl.tinymce.js
@@ -95,6 +95,7 @@ var ilTinyMceInitCallbackRegistry = new _ilTinyMceInitCallbackRegistry();
 window.ilTinyMceInitCallbackRegistry = ilTinyMceInitCallbackRegistry;
 
 tinymce.init({
+    license_key: 'gpl',
     selector: "textarea.RTEditor",
     branding: false,
     language: "{LANG}",

--- a/components/ILIAS/RTE/templates/default/tpl.tinymce_frm_post.js
+++ b/components/ILIAS/RTE/templates/default/tpl.tinymce_frm_post.js
@@ -73,6 +73,7 @@ function ilTinyMceInitCallback(ed) {
 }
 
 tinymce.init({
+    license_key: 'gpl',
     selector: "textarea.RTEditor",
     branding: false,
     language: "{LANG}",

--- a/components/ILIAS/RTE/templates/default/tpl.usereditor.js
+++ b/components/ILIAS/RTE/templates/default/tpl.usereditor.js
@@ -5,6 +5,7 @@ function ilTinyMceInitCallback(ed) { // Add hook for onContextMenu so that Inser
 }
 
 tinymce.init({
+    license_key: 'gpl',
     menubar: false,
     branding: false,
     selector: "{SELECTOR}",


### PR DESCRIPTION
This PR fixes a "TinyMCE" v7 warning which I noticed in the browser console.

> TinyMCE is running in evaluation mode. Provide a valid license key or add license_key: 'gpl' to the init config to agree to the open source license terms. Read more at https://www.tiny.cloud/license-key/