### PR TITLE
Saml: Add level.logger migration note to readme

### DIFF
--- a/Services/Saml/README.md
+++ b/Services/Saml/README.md
@@ -90,6 +90,14 @@ ILIAS 9 uses simplesamlphp v2.0 (prior v1.9). For a complete list of all changes
 
 The following changes must be made in the `$ILI_DATA/auth/saml/config/config.php`:
 
+The namespace path for the key `logging.level` may need to be changed.
+This was already the case at least since ILIAS 6 but the old namespace pathes where still valid until ILIAS 9.
+So old installations may still have `_` instead of `\\`.
+```diff
+-    'logging.level' => SimpleSAML_Logger::DEBUG,
++    'logging.level' => SimpleSAML\Logger::DEBUG,
+```
+
 The key `debug` is now not a boolean but an array value instead. New installations will have this value as default.
 ```diff
 -    'debug' => true,


### PR DESCRIPTION
This PR adds a migration note for the `logger.level` option.
Even though configs for saml have out of the box `SimpleSAML\Logger::DEBUG` at least since ILIAS 6, the old class path seems to be kept for backwards compatibility in the simplesaml package until now, which causes issues for old installations which still have the old `SimpleSAML_Logger::DEBUG` option set.