### PR TITLE
SOAP: Fix user is logged out when copying courses (in fallback mode)

### DIFF
--- a/webservice/soap/classes/class.ilSoapAdministration.php
+++ b/webservice/soap/classes/class.ilSoapAdministration.php
@@ -138,8 +138,6 @@ class ilSoapAdministration
 
     protected function initAuth(string $sid): void
     {
-        global $DIC;
-
         [$sid, $client] = $this->explodeSid($sid);
 
         if (session_status() === PHP_SESSION_ACTIVE && $sid === session_id()) {
@@ -151,6 +149,12 @@ class ilSoapAdministration
         }
 
         session_id($sid);
+
+        if (ilContext::getType() !== ilContext::CONTEXT_SOAP) {
+            require_once("Services/Init/classes/class.ilInitialisation.php");
+            ilInitialisation::reInitUser();
+            ilUtil::setCookie(session_name(), $sid);
+        }
     }
 
     protected function initIlias(): void


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=43882

If approved, this has to be picked to all maintained branches.