### PR TITLE
Auth: Prevent and log duplicate `session_start`

### DIFF
--- a/Services/Authentication/classes/class.ilAuthSession.php
+++ b/Services/Authentication/classes/class.ilAuthSession.php
@@ -67,6 +67,12 @@ class ilAuthSession
      */
     public function init(): bool
     {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            $this->getLogger()->error(__METHOD__ . ' called with active session.');
+            $this->getLogger()->logStack(ilLogLevel::ERROR);
+            return false;
+        }
+
         session_start();
 
         $this->setId(session_id());


### PR DESCRIPTION
This PR prevents subsequent calls of `session_start(...)` if a session is still active and logs an error to the ILIAS log.

If approved, this has to be merged to all maintained branches.