### PR TITLE
PRG: 43335: leftover JS in async calls

### DIFF
--- a/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeAutoMembershipsGUI.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeAutoMembershipsGUI.php
@@ -49,7 +49,7 @@ class ilObjStudyProgrammeAutoMembershipsGUI
     private const CMD_DELETE = 'delete';
     private const CMD_DELETE_CONFIRMATION = 'deleteConfirmation';
     public const CMD_GET_ASYNC_MODAL_OUTPUT = 'getAsynchModalOutput';
-    private const CMD_NEXT_STEP = 'nextStep';
+    public const CMD_NEXT_STEP = 'nextStep';
     private const CMD_ENABLE = 'enable';
     private const CMD_DISABLE = 'disable';
     private const CMD_PROFILE_NOT_PUBLIC = 'profile_not_public';

--- a/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilObjStudyProgrammeGUI.php
@@ -53,6 +53,11 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI
     private const TAB_MEMBERS = "members";
     private const TAB_METADATA = "edit_advanced_settings";
     private const SUBTAB_PAGE_EDIT = "page";
+    private const ASYNC_CALLS = [
+        ilObjStudyProgrammeAutoCategoriesGUI::CMD_GET_ASYNC_MODAL,
+        ilObjStudyProgrammeAutoMembershipsGUI::CMD_GET_ASYNC_MODAL_OUTPUT,
+        ilObjStudyProgrammeAutoMembershipsGUI::CMD_NEXT_STEP,
+    ];
 
     protected ilLocatorGUI $ilLocator;
     protected ilComponentLogger $ilLog;
@@ -116,10 +121,7 @@ class ilObjStudyProgrammeGUI extends ilContainerGUI
         $cmd = $this->ctrl->getCmd(self::SUBTAB_VIEW_MANAGE);
         $next_class = $this->ctrl->getNextClass($this);
 
-        if (!in_array($cmd, [
-            ilObjStudyProgrammeAutoCategoriesGUI::CMD_GET_ASYNC_MODAL,
-            ilObjStudyProgrammeAutoMembershipsGUI::CMD_GET_ASYNC_MODAL_OUTPUT
-        ])) {
+        if (!in_array($cmd, self::ASYNC_CALLS)) {
             $this->addToNavigationHistory();
             parent::prepareOutput();
             $this->addHeaderAction();


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43335
https://mantis.ilias.de/view.php?id=43825
https://mantis.ilias.de/view.php?id=43743
and close to 
https://mantis.ilias.de/view.php?id=43817 (https://github.com/ILIAS-eLearning/ILIAS/pull/8914)

Async calls have to bypass prepareOutput/addHeaderAction