### PR TITLE
10/UI/Input/Section mobil layout shift 42785

### DIFF
--- a/templates/default/070-components/UI-framework/Input/_ui-component_optionalgroups.scss
+++ b/templates/default/070-components/UI-framework/Input/_ui-component_optionalgroups.scss
@@ -36,7 +36,7 @@
 			@include c-input_switch-bg-hover(none, s.$il-main-darker-bg);
 		}
 	}
-							
+
 	> .c-input__help-byline {
 		grid-area: group-help;
 	}
@@ -96,7 +96,7 @@
 }
 
 @include brk.on-screen-size(small) {
-	.c-form .c-input[data-il-ui-component="switchable-group-field-input"],
+	.c-form .c-input[data-il-ui-component="switchable-group-field-input"] > .c-input__field > .c-input,
 	.c-form .c-input[data-il-ui-component="optional-group-field-input"] {
 		grid-template-columns: 100%;
 		grid-template-areas:  "group-head"

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -4670,12 +4670,12 @@ hr.il-divider-with-label {
 }
 
 @media screen and (max-width: 768px) {
-  .c-form .c-input[data-il-ui-component=switchable-group-field-input],
+  .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input,
   .c-form .c-input[data-il-ui-component=optional-group-field-input] {
     grid-template-columns: 100%;
     grid-template-areas: "group-head" "error" "group-help" "group";
   }
-  .c-form .c-input[data-il-ui-component=switchable-group-field-input] > label,
+  .c-form .c-input[data-il-ui-component=switchable-group-field-input] > .c-input__field > .c-input > label,
   .c-form .c-input[data-il-ui-component=optional-group-field-input] > label {
     grid-template-columns: 100%;
     grid-template-areas: "group-label" "group-field";


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42785

# Issue

Broken layout of Switchable Group on mobile screen breakpoint.

![image](https://github.com/user-attachments/assets/dd437a61-6310-46d1-9e8d-b6f44bc82f3a)

# Change

The class targeting for the grid was incorrect. The nesting for Switchable Groups is different compared to Optional Groups.

![image](https://github.com/user-attachments/assets/98920902-0e3b-48b5-b3b2-79bf25a96b09)
