### PR TITLE
Re-introduce jQuery-UI and jQuery-migrate for ILIAS 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "chart.js": "^4.4.1",
     "dropzone": "^5.9.3",
     "jquery": "^3.6.0",
+    "jquery-migrate": "^3.5.2",
+    "jquery-ui": "^1.14.1",
     "jstree": "^3.3.16",
     "linkify-element": "^4.1.3",
     "linkifyjs": "^4.1.3",
@@ -51,6 +53,22 @@
       "developer": null,
       "purpose": "We use jQuery for most JS-related actions in ILIAS.",
       "last-update-for-ilias": "10.0"
+    },
+    "jquery-migrate": {
+      "introduction-date": null,
+      "approved-by": "Jour Fixe",
+      "developer": "oliver.samoila",
+      "purpose": "",
+      "last-update-for-ilias": "10.0",
+      "note": "used for user autocompletion"
+    },
+    "jquery-ui": {
+      "introduction-date": null,
+      "approved-by": "Jour Fixe",
+      "developer": "oliver.samoila",
+      "purpose": "",
+      "last-update-for-ilias": "10.0",
+      "note": "used for user autocompletion"
     },
     "moment": {
       "introduction-date": null,


### PR DESCRIPTION
This PR adds `jquery-ui` and `jquery-migrate` as NPM dependency.

Usage:

*   Used for requesting and auto-completing user searches. For example, for adding users to roles (including memberships), test participants, survey participants, chat participants and many more. 

Wrapped By:

*   Not applicable 

Reasoning:

*   Without this functionality, usability will be significantly worse in many places where users need to be located and identified by their surname / first name or email address. To use the remaining functions, you would always have to have correct/complete data about users with whom something is to be done. This lack can't be understood by any end user.
*   This libraries will be used for the last time with ILIAS 10, as we prefer a different solution in the UI framework from ILIAS 11 onwards.  
*   We are convinced that we still have so much jquery code that we still need `jquery-migrate`.

Maintenance `jquery-ui`:

*   The library has been stable for a long time.
*   The library is regularly updated and maintained (313 contributors)
*   License: MIT

Maintenance `jquery-migrate`:

*   The library has been stable for a long time.
*   The library is regularly updated and maintained (29 contributors)
*   License: MIT

Links:

*   NPM: [https://www.npmjs.com/package/jquery-ui](https://www.npmjs.com/package/jquery-ui)
*   GitHub: [github.com/jquery/jquery-ui](github.com/jquery/jquery-ui)
*   NPM: [https://www.npmjs.com/package/jquery-migrate](https://www.npmjs.com/package/jquery-migrate)
*   GitHub: [github.com/jquery/jquery-migrate](github.com/jquery/jquery-migrate)