### PR TITLE
Fix typo in ilias_de.lang (ILIAS v9)

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -9497,7 +9497,7 @@ exc#:#exc_reminder_feedback_start#:#Start vor Peer-Feedback-Termin
 exc#:#exc_reminder_frequency#:#Häufigkeit
 exc#:#exc_reminder_grade_body#:#Die folgende Übungseinheit wurde noch nicht bewertet
 exc#:#exc_reminder_grade_setting#:#Erinnerung an notwendige Bewertung
-exc#:#exc_reminder_grade_subject#:#Übungseinheit „%s“ wurde nicht berwertet
+exc#:#exc_reminder_grade_subject#:#Übungseinheit „%s“ wurde nicht bewertet
 exc#:#exc_reminder_link#:#URL
 exc#:#exc_reminder_mail_no_tpl#:#Keine Mail-Vorlage verwenden
 exc#:#exc_reminder_mail_template#:#Mail-Vorlage


### PR DESCRIPTION
Fixes minor typo for reminder email title, see diff. (Fix for release_9)

See also for
- v8: https://github.com/ILIAS-eLearning/ILIAS/pull/8927
- v9: https://github.com/ILIAS-eLearning/ILIAS/pull/8935
- v10: https://github.com/ILIAS-eLearning/ILIAS/pull/8936