### PR TITLE
UI Components, fix validate issue, remove dialog from modal role 43609

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.interruptive.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.interruptive.html
@@ -1,4 +1,4 @@
-<dialog class="c-modal c-modal--interruptive" tabindex="-1" role="dialog" id="{ID}">
+<dialog class="c-modal c-modal--interruptive" tabindex="-1" id="{ID}">
 	<div class="modal-dialog" role="document">
 		<form action="{FORM_ACTION}" method="POST">
 			<div class="modal-content">

--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
@@ -1,4 +1,4 @@
-<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-{COLOR_SCHEME}" tabindex="-1" role="dialog" id="{ID}">
+<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-{COLOR_SCHEME}" tabindex="-1" id="{ID}">
 	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content il-modal-lightbox-page">
 			<div class="modal-header">

--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.roundtrip.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.roundtrip.html
@@ -1,4 +1,4 @@
-<dialog class="c-modal il-modal-roundtrip" tabindex="-1" role="dialog" id="{ID}">
+<dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="{ID}">
 	<div class="modal-dialog" role="document" data-replace-marker="component">
 		<div class="modal-content">
 			<div class="modal-header">

--- a/components/ILIAS/UI/src/templates/default/Prompt/tpl.prompt.html
+++ b/components/ILIAS/UI/src/templates/default/Prompt/tpl.prompt.html
@@ -1,5 +1,5 @@
 <div class="il-prompt" id="{ID}">
-    <dialog role="dialog" aria-labelledby="{ID}_title"> 
+    <dialog aria-labelledby="{ID}_title">
         <div class="il-prompt__header">
             <form>
                 <button formmethod="dialog" class="close" aria-label="{CLOSE_LABEL}">

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.datatable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.datatable.html
@@ -56,7 +56,7 @@
 
 	<div class="c-table-data__async_modal_container"></div>
 
-	<dialog class="c-table-data__async_message c-modal" role="dialog" id="{ID}_msgmodal">
+	<dialog class="c-table-data__async_message c-modal" id="{ID}_msgmodal">
 		<div class="modal-dialog" role="document">
 			<div class="modal-content">
 				<div class="modal-header">

--- a/components/ILIAS/UI/tests/Component/Dropzone/File/StandardTest.php
+++ b/components/ILIAS/UI/tests/Component/Dropzone/File/StandardTest.php
@@ -42,7 +42,7 @@ class StandardTest extends FileTestBase
 
         $expected_html = $this->brutallyTrimHTML('
 <div id="id_4" class="ui-dropzone ">
-    <dialog class="c-modal il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
+    <dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1">
 		<div class="modal-dialog" role="document" data-replace-marker="component">
 			<div class="modal-content">
 				<div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>
@@ -111,7 +111,7 @@ class StandardTest extends FileTestBase
 
         $expected_html = $this->brutallyTrimHTML('
 <div id="id_4" class="ui-dropzone ui-dropzone-bulky">
-	<dialog class="c-modal il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
+	<dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1">
 		<div class="modal-dialog" role="document" data-replace-marker="component">
 			<div class="modal-content">
 				<div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>

--- a/components/ILIAS/UI/tests/Component/Dropzone/File/WrapperTest.php
+++ b/components/ILIAS/UI/tests/Component/Dropzone/File/WrapperTest.php
@@ -38,7 +38,7 @@ class WrapperTest extends FileTestBase
         $expected_html = $this->brutallyTrimHTML(
             '
 <div id="id_4" class="ui-dropzone ui-dropzone-wrapper">
-    <dialog class="c-modal il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
+    <dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1">
         <div class="modal-dialog" role="document" data-replace-marker="component">
             <div class="modal-content">
                 <div class="modal-header"><form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form><h1 class="modal-title">' . $expected_title . ' </h1></div>

--- a/components/ILIAS/UI/tests/Component/Launcher/LauncherInlineTest.php
+++ b/components/ILIAS/UI/tests/Component/Launcher/LauncherInlineTest.php
@@ -221,7 +221,7 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
     </div>
     <button class="btn btn-bulky" id="id_5" disabled="disabled"><span class="glyph" role="img"><span class="glyphicon glyphicon-launch" aria-hidden="true"></span></span><span class="bulky-label">different label</span></button>
     <div class="c-launcher__form">
-        <dialog class="c-modal il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
+        <dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1">
             <div class="modal-dialog" role="document" data-replace-marker="component">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/components/ILIAS/UI/tests/Component/Modal/InterruptiveTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/InterruptiveTest.php
@@ -113,7 +113,7 @@ class InterruptiveTest extends ModalBase
     protected function getExpectedHTML(bool $with_items = false): string
     {
         $expected_start = <<<EOT
-<dialog class="c-modal c-modal--interruptive" tabindex="-1" role="dialog" id="id_1">
+<dialog class="c-modal c-modal--interruptive" tabindex="-1" id="id_1">
 	<div class="modal-dialog" role="document">
 		<form action="myAction.php" method="POST">
 			<div class="modal-content">

--- a/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
@@ -90,7 +90,7 @@ class LightboxTest extends ModalBase
     protected static function getExpectedTextPageHTML(): string
     {
         return <<<EOT
-<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-bright" tabindex="-1" role="dialog" id="id_1">
+<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-bright" tabindex="-1" id="id_1">
 	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content il-modal-lightbox-page">
 			<div class="modal-header">
@@ -119,7 +119,7 @@ EOT;
     protected static function getExpectedImagePageHTML(): string
     {
         return <<<EOT
-<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-dark" tabindex="-1" role="dialog" id="id_1">
+<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-dark" tabindex="-1" id="id_1">
 	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content il-modal-lightbox-page">
 			<div class="modal-header">
@@ -153,7 +153,7 @@ EOT;
     protected static function getExpectedMixedPagesHTML(): string
     {
         return <<<EOT
-<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-dark" tabindex="-1" role="dialog" id="id_1">
+<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-dark" tabindex="-1" id="id_1">
 	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content il-modal-lightbox-page">
 			<div class="modal-header">
@@ -205,7 +205,7 @@ EOT;
     private static function getExpectedCardPageHTML(): string
     {
         return <<<EOT
-<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-bright" tabindex="-1" role="dialog" id="id_1">
+<dialog class="c-modal c-modal--lightbox il-modal-lightbox il-modal-lightbox-bright" tabindex="-1" id="id_1">
 	<div class="modal-dialog modal-lg" role="document">
 		<div class="modal-content il-modal-lightbox-page">
 			<div class="modal-header">

--- a/components/ILIAS/UI/tests/Component/Modal/RoundTripTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/RoundTripTest.php
@@ -82,7 +82,7 @@ class RoundTripTest extends ModalBase
     protected function getExpectedHTML(): string
     {
         return <<<EOT
-<dialog class="c-modal il-modal-roundtrip" tabindex="-1" role="dialog" id="id_1">
+<dialog class="c-modal il-modal-roundtrip" tabindex="-1" id="id_1">
    <div class="modal-dialog" role="document" data-replace-marker="component">
       <div class="modal-content">
          <div class="modal-header">

--- a/components/ILIAS/UI/tests/Component/Table/DataRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/DataRendererTest.php
@@ -294,7 +294,7 @@ class DataRendererTest extends TableTestBase
     </div>
     <div class="c-table-data__async_modal_container"></div>
 
-    <dialog class="c-table-data__async_message c-modal" role="dialog" id="{ID}_msgmodal">
+    <dialog class="c-table-data__async_message c-modal" id="{ID}_msgmodal">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
@@ -368,7 +368,7 @@ EOT;
 
     <div class="c-table-data__async_modal_container"></div>
 
-    <dialog class="c-table-data__async_message c-modal" role="dialog" id="{ID}_msgmodal">
+    <dialog class="c-table-data__async_message c-modal" id="{ID}_msgmodal">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">


### PR DESCRIPTION
Another issue related to https://mantis.ilias.de/view.php?id=43609.

The role dialog is not needed if the element is a dialog. This should not be shown as an error, but a warning from my understanding. However, https://validator.w3.org/nu/ shows this as error, which is what most of our testers use. 

See also: https://github.com/validator/validator/issues/1299

I would therefore propose to just remove it, since I do not see any immediate benefit.