### PR TITLE
T&A 43538: highlight a tab

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -1279,7 +1279,7 @@ abstract class assQuestionGUI
             }
             $changeoutput = $formchange->getHTML();
         }
-
+        $this->tabs_gui->activateTab('suggested_solution');
         $this->tpl->setVariable('ADM_CONTENT', $changeoutput . $output);
     }
 


### PR DESCRIPTION
This will fix https://mantis.ilias.de/view.php?id=43538, where the tab for "Content for Recapitulation" is not highlighted.
This problem also happened when selecting "File download". 

Best wishes 
Olivia