### PR TITLE
File: fix export paths

### DIFF
--- a/components/ILIAS/File/classes/class.ilFileExporter.php
+++ b/components/ILIAS/File/classes/class.ilFileExporter.php
@@ -69,22 +69,32 @@ class ilFileExporter extends ilXmlExporter
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
         $xml = '';
-        if (ilObject::_lookupType($a_id) == "file") {
+        if (ilObject::_lookupType($a_id) == 'file') {
             $file = new ilObjFile($a_id, false);
             $writer = new ilFileXMLWriter();
             $writer->setFile($file);
             $writer->setOmitHeader(true);
             $writer->setAttachFileContents(ilFileXMLWriter::$CONTENT_ATTACH_COPY);
-            ilFileUtils::makeDirParents($this->getAbsoluteExportDirectory());
-            $writer->setFileTargetDirectories(
-                $this->getRelativeExportDirectory(),
-                $this->getAbsoluteExportDirectory()
-            );
+            $this->prepareExportDirectories($writer);
             $writer->start();
             $xml = $writer->getXml();
         }
-
         return $xml;
+    }
+
+    protected function prepareExportDirectories(
+        ilFileXMLWriter $writer
+    ): void {
+        $path = str_replace('\\', '/', $this->exp->getExportDirInContainer());
+        $segments = explode('/', $path);
+        array_shift($segments);
+        $target_dir_relative = implode('/', $segments) . '/expDir_1';
+        $target_dir_absolute = rtrim($this->getAbsoluteExportDirectory(), '/') . '/' . $target_dir_relative;
+        ilFileUtils::makeDirParents($target_dir_absolute);
+        $writer->setFileTargetDirectories(
+            $target_dir_relative,
+            $target_dir_absolute
+        );
     }
 
     /**

--- a/components/ILIAS/File/classes/class.ilFileExporter.php
+++ b/components/ILIAS/File/classes/class.ilFileExporter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -14,6 +15,8 @@
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Exporter class for files
@@ -69,8 +72,8 @@ class ilFileExporter extends ilXmlExporter
     public function getXmlRepresentation(string $a_entity, string $a_schema_version, string $a_id): string
     {
         $xml = '';
-        if (ilObject::_lookupType($a_id) == 'file') {
-            $file = new ilObjFile($a_id, false);
+        if (ilObject::_lookupType((int) $a_id) == 'file') {
+            $file = new ilObjFile((int) $a_id, false);
             $writer = new ilFileXMLWriter();
             $writer->setFile($file);
             $writer->setOmitHeader(true);


### PR DESCRIPTION
Link: https://mantis.ilias.de/view.php?id=43545

This PR recreates the old path-structure/functionality of file paths used by ilFileXMLWriter.

With ILIAS 10 the return values of the following methods have changed:
- `ilExport::getRelativeExportDirectory`
- `ilExport::getAbsoluteExportDirectory`

`ilExport::getRelativeExportDirectory` returns the root folder name of the export (the name of the export archive).
`ilExport::getAbsoluteExportDirectory` returns the path on the system to the root folder of the export including the name of the export archive.

The new Method `ilExporter::getExportDirInContainer` was added, wich returns the path inside the export archive to the sub folder of the export. This method can be used to recreate the old path-structure.

Starting with ILIAS 10 it is also possible to add resources directly from the IRSS to the export. This method uses the ExportWriter[0]. The ExportWriter can be aquired in ilXMLExporter and its subclasses with `$exp->getExportWriter()`.

For example to add a resource to the export, the method `ExportWriter::writeFilesByResourceId` can be used:

`$this->exp->getExportWriter()->writeFilesByResourceId($resource_id_serialized, $path_in_container);`

[0]: ILIAS\Export\ExportHandler\I\Consumer\ExportWriter\HandlerInterface as ExportWriter