### PR TITLE
T&A 43838: Redirects user to test tab when test attempt gets finished by administrator

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -215,7 +215,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
                     if (!$testPassesSelector->openPassExists()) {
                         $this->tpl->setOnScreenMessage('info', $this->lng->txt('tst_pass_finished'), true);
-                        $this->ctrl->redirectByClass([ilRepositoryGUI::class, ilObjTestGUI::class, ilInfoScreenGUI::class]);
+                        $this->ctrl->redirectByClass([ilRepositoryGUI::class, ilObjTestGUI::class, TestScreenGUI::class]);
                     }
                 }
 


### PR DESCRIPTION
[Mantis: 43838](https://mantis.ilias.de/view.php?id=43838)

When a administrator finishes a test attempt, while the user ist still taking the test, the user gets redirected to the info tab of the test. The user should get redirected to the test tab instead.