### PR TITLE
T&A 43749: Fixes checkboxes of multiple choice question (multiple answers) not being checked in detailed evaluation view

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -221,20 +221,15 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         $show_question_text = true,
         bool $show_inline_feedback = true
     ): string {
-        // shuffle output
-        $user_solution = [];
-
         if ($active_id > 0 && !$show_correct_solution) {
-            $solutions = $this->object->getSolutionValues($active_id, $pass);
+            $user_solution = $this->object->getSolutionValues($active_id, $pass);
         } else {
-            // take the correct solution instead of the user solution
+            $user_solution = [];
             foreach ($this->object->answers as $index => $answer) {
                 $points_checked = $answer->getPointsChecked();
                 $points_unchecked = $answer->getPointsUnchecked();
-                if ($points_checked > $points_unchecked) {
-                    if ($points_checked > 0) {
-                        $user_solution[] = ['value1' => $index];
-                    }
+                if ($points_checked > $points_unchecked && $points_checked > 0) {
+                    $user_solution[] = ['value1' => $index];
                 }
             }
         }


### PR DESCRIPTION
[Mantis: 43749](https://mantis.ilias.de/view.php?id=43749)

In the detailed evaluation view the checkboxes of multiple choice (multiple answers) questions are partially shown incorrectly. This seems to be related to a variable being named differently in one spot, not passing the value further. Since it is correctly working in `release_10`, i copied the code from there and everything seems to work as expected. 