### PR TITLE
T&A 43837: allow multi select to finish pass only if processing time resett…

### DIFF
--- a/components/ILIAS/Test/src/Participants/ParticipantTableFinishTestAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableFinishTestAction.php
@@ -126,6 +126,20 @@ class ParticipantTableFinishTestAction implements TableAction
             $this->user
         );
 
+        // If reset processing time is disabled it's not allowed to finish multiple attempts at once while one is still running
+        if (!$this->test_obj->getResetProcessingTime() && count($selected_participants) > 1) {
+            foreach ($selected_participants as $participant) {
+                if ($participant->hasUnfinishedAttempts()) {
+                    $this->tpl->setOnScreenMessage(
+                        \ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                        $this->lng->txt('finish_test_more_than_one_selected'),
+                        true
+                    );
+                    return null;
+                }
+            }
+        }
+
         foreach ($selected_participants as $participant) {
             $process_locker = $this->process_locker_factory->withContextId($participant->getActiveId())->getLocker();
 

--- a/components/ILIAS/Test/src/Participants/ParticipantTableFinishTestAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableFinishTestAction.php
@@ -119,14 +119,6 @@ class ParticipantTableFinishTestAction implements TableAction
             return null;
         }
 
-        // This is required here because of late test object binding
-        $test_session_factory = new \ilTestSessionFactory(
-            $this->test_obj,
-            $this->db,
-            $this->user
-        );
-
-        // If reset processing time is disabled it's not allowed to finish multiple attempts at once while one is still running
         if (!$this->test_obj->getResetProcessingTime() && count($selected_participants) > 1) {
             foreach ($selected_participants as $participant) {
                 if ($participant->hasUnfinishedAttempts()) {
@@ -139,6 +131,13 @@ class ParticipantTableFinishTestAction implements TableAction
                 }
             }
         }
+
+        // This is required here because of late test object binding
+        $test_session_factory = new \ilTestSessionFactory(
+            $this->test_obj,
+            $this->db,
+            $this->user
+        );
 
         foreach ($selected_participants as $participant) {
             $process_locker = $this->process_locker_factory->withContextId($participant->getActiveId())->getLocker();

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -745,6 +745,7 @@ assessment#:#finish_pass_for_user_confirmation#:#Wollen Sie den Test Durchlauf f
 assessment#:#finish_pass_for_user_in_processing_time#:#WARNUNG: die Bearbeitungszeit für diesen Benutzer ist noch nicht vorbei! Sie sollten den Testlauf nur bei zwingendem Grund (z.B. Ausschluss vom Test) beenden.
 assessment#:#finish_test#:#Test beenden
 assessment#:#finish_test_all#:#Sind Sie sicher, dass die den Testdurchlauf für alle Teilnehmer beenden möchten?
+assessment#:#finish_test_more_than_one_selected#:#Wenn der Test nur einen Durchgang zulässt, darf nur ein einziger Teilnehmer ausgewählt werden, um den Durchgang zu beenden.
 assessment#:#finish_test_multiple#:#Sind Sie sicher, dass Sie den Testdurchlauf für folgende Teilnehmer beenden möchten?
 assessment#:#finish_test_no_valid_participants_selected#:#Für die gewählten Teilnehmer gibt es keine aktiven Testdurchläufe und können daher nicht beendet werden.
 assessment#:#finish_test_single#:#Sind Sie sicher, dass Sie den Testdurchlauf für den Teilnehmer "%s" beenden möchten?

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -745,6 +745,7 @@ assessment#:#finish_pass_for_user_confirmation#:#Are you sure you want to finish
 assessment#:#finish_pass_for_user_in_processing_time#:#WARNING: the processing time for this user is not over yet! You should only end the test run if there is a compelling reason (e.g. exclusion from the test).
 assessment#:#finish_test#:#Finish Test
 assessment#:#finish_test_all#:#Are you sure you want to finish the test attempts for all users?
+assessment#:#finish_test_more_than_one_selected#:#Only a single participant may be selected to finish the pass if the test allows only one pass.
 assessment#:#finish_test_multiple#:#Are you sure you want to finish the test attempts for the following participants?
 assessment#:#finish_test_no_valid_participants_selected#:#There are no active test runs for the selected participants, so they cannot be completed.
 assessment#:#finish_test_single#:#Are you sure you want to finish the test attempt for the participant "%s"?


### PR DESCRIPTION
Hi everyone,

this PR is related to [43837](https://mantis.ilias.de/view.php?id=43837). With this change, it is no longer possible to end multiple test passes simultaneously if the test only allows a single test pass.

I look forward to your feedback, thank you in advance! These changes were reviewed in an internal process by @thojou  .

Best,
@lukas-heinrich 

