### PR TITLE
_10/UI/scss-docs clarifications about compiling and custom system styles

### DIFF
--- a/templates/Guidelines_SCSS-Coding.md
+++ b/templates/Guidelines_SCSS-Coding.md
@@ -1,7 +1,6 @@
 # General
 
-*Please note, that you need to provide a Pull Request for all CSS related changes done in this folder. The CSS Coordinators
-will then review the PR and give you feedback and/or merge your changes.*
+*Please note, that you need to provide a Pull Request for all CSS related changes done in this folder. The CSS Authorities will then review the PR and give you feedback and/or merge your changes.*
 
 This section of the codebase defines the design and layout of ILIAS. All CSS code is build here. HTML templates can be found elsewhere (see section "HTML").
 
@@ -22,30 +21,49 @@ Sass extends the CSS language, adding features that allow advanced variables, mi
 
 The Sass pre-processor compiles the entry point delos.scss and all connected files to the one delos.css file which can then be rendered by the browser.
 
-Please use the most recent **Dart Sass** version (**not** Ruby Sass) that is included as NPM package in the package.json (see: devDependencies).
+**You MUST use the exact SASS version referenced in the package.json (see devDependencies) that is installed in your local environment by executing 'npm install' at the root.**
+
+From the root directory, you can compile your SCSS as a source file that will be committed to the git repository:
+
+```bash
+node_modules/.bin/sass templates/default/delos.scss templates/default/delos.css
+```
+
+To see current css changes in your running environment, this css file also needs to be copied to the public folder 'public/assets/css/delos.css' (this happens automatically when you install ILIAS and, more specifically, execute `composer dump-autoload`). This is the file that is actually being used in the frontend by the browser.
+
+During development, you may want SCSS changes continuously updated the CSS in the public folder whenever you change any SCSS file to instantly see any changes:
+
+```bash
+node_modules/.bin/sass templates/default/delos.scss public/assets/css/delos.css --watch
+```
+
+However, do not forget to also update the delos.css file in templates/default when you commit your code.
+
+If you observe that there are changes appearing in your css output other than the ones to be expected, please first make sure that you are using the correct SASS version.
+
+If you have any questions about style code and how to contribute in the most optimal way, please contact the maintenance coordinators or ask in the CSS Squad channel on the official ILIAS Discord server.
 
 You should consult the [official Sass Documentation](https://sass-lang.com/documentation/) to make use of the advantages of Sass.
 
 ### Guidelines
 * Style code MUST be written in the SCSS syntax of the Sass pre-processer.
 * All colors, font sizes, spacings, offsets, gaps, as well as the proportions of the basic layout MUST be defined by Sass/CSS.
-* When contributing style code to the ILIAS repository, you MUST first compile the Sass code to CSS using the latest released version of Dart Sass: https://github.com/sass/dart-sass/releases
+* When contributing style code to the ILIAS repository, you MUST first compile the SCSS code to CSS using the version of SASS that is set as a development dependency in package.json.
 * We currently follow a **desktop first approach** on the Sass level. This means, that we handle all mobile cases as special cases and the desktop as the default.
 * You MUST NOT make changes to the compiled delos.css manually.
 * Delos.scss MUST only contain imports and no other Sass logic at all.
 * The Sass compiler automatically creates a CSS map called delos.css.map, which tells the developer tools of a browser which line of CSS belongs to which SCSS file and line. This map MUST NOT be committed as it causes merge conflicts and contains paths of your local file system and is therefor listed in the .gitignore file.
 
-If you are interested, you can read more about why we switched preprocessors from LESS to Sass here.
-
 ## HTML
 
-HTML templates are only responsible for a well structured HTML document, which displays the bare content of the website and nothing else.
+HTML templates are only responsible for a well-structured HTML document, which displays the bare content of the website and nothing else.
 
 They can be found in `ILIAS/UI/templates/default` for modern UI components or in other components in `components/ILIAS/` for legacy components.
 
 ### Guidelines
 * New class names MUST follow the naming convention outlined in this document.
 * You MUST NOT use style attributes like style, align, border, cellpadding, cellspacing font, nowrap, valign, width, height and similar in HTML templates.
+* If you use JavaScript to change the visibility of an HTML Element you MAY use `style="display: none;"` to set an initial state. For setting the visible state in JavaScript, you SHOULD consider removing the `style="display: ..."` attribute completely from the HTML element using `htmlElement.style.removeProperty('display');` (instead of setting `display: block;`) to honor whatever display property is set by CSS.
 * You MUST NOT use `&nbsp;`, `<br>`, `<br/>` or similar means to create space.
 
 
@@ -138,7 +156,7 @@ Guidelines
 * If the Bootstrap inspired classes, tools, layout systems and mixins in our codebase can help you to get your desired output, you SHOULD use them whenever possible.
 * Don't expect them to work exactly the same as they would in an unmodified version of Bootstrap. They may have been heavily reduced to only cover the needs specific to ILIAS.
 * You MAY add needed functionality to existing Bootstrap inspired systems making them more specific to our requirements, while cutting parts that we do not need.
-* If a need isn't covered yet that has got a well-thought out solution in Bootstrap 3 or 5 (or another framework with an appropriate license), you MAY after careful consideration merge it into an appropriate place on our ITCSS layers - but you SHOULD customize, shorten and modernize the code to be more ILIAS specific (e.g. color variations are often not needed). 
+* If a need isn't covered yet that has got a well-thought out solution in Bootstrap 3 or 5 (or another framework with an appropriate license), you MAY (after careful) consideration merge it into an appropriate place on our ITCSS layers - but you SHOULD customize, shorten and modernize the code to be more ILIAS specific (e.g. color variations are often not needed). 
 * If you copy several lines of code from Bootstrap 3 or 5 into our stylecode you MUST give one line credit at the beginning and end of the section like this
 
 ``` SCSS
@@ -433,7 +451,7 @@ CSS](https://rhodesmill.org/brandon/2011/concentric-css/)):
 # SASS best practices
 
 ## Importing files
-Keep in mind that paths in CSS are relative to the compiled CSS file at templates/default/. Paths in Sass @use, @forward or @import (deprecated) are relative to the Sass file.
+Keep in mind that paths in CSS are relative to the compiled CSS file starting in public/assets/css/. Paths in Sass @use, @forward or @import (deprecated) are relative to the SCSS file.
 * You MUST include partials with @use and/or @forward.
 * You MUST NOT use the deprecated @import.
 * When including a file with @use you SHOULD utilize a namespace. You MAY use the one generated by default or define a custom namespace.
@@ -450,17 +468,3 @@ Keep in mind that paths in CSS are relative to the compiled CSS file at template
 ## Deprecated slash division
 
 Division with a slash (e.g. "10px / 2") outside of calc() is deprecated and MUST NOT be used. You MUST use math.div() instead or multiplication (e.g. "$il-padding-small / 2" could be substituted with "$il-padding-small * 0.5")
-
-## CSS Guideline
-
-CSS is obtained by using the latest Dart Sass compiler on delos.scss, e.g. like so:
-
-```
-./node_modules/sass/sass.js templates/default/delos.scss templates/default/delos.css
-```
-
-Note that the output heavily depends on the used sass version. You MUST use the latest release version of Dart Sass: https://github.com/sass/dart-sass/releases
-
-If you observe that there are changes appearing in your css output other than the ones to be expected, please first make sure that you are using the latest Sass version. 
-
-If you have any questions about style code and how to contribute in the most optimal way, please contact the maintenance coordinators or ask in the CSS Squad channel on the official ILIAS Discord server.

--- a/templates/Readme.md
+++ b/templates/Readme.md
@@ -12,30 +12,34 @@ System Styles may be customized by creating custom System Styles. Custom styles 
 to be placed in the `./public/Customizing/skin` directory to be active. One may have
 multiple substyles which may be active for different branches of the repository.
 
-A GitHub Repo for a custom System Style based on the default Delos will be available
-soon.
-
 ### Tools
 
-You may directly use the Sass version shipped with ILIAS.
+The ILIAS default system style called Delos is written in SCSS, which has to be
+compiled using the SASS pre-processor to a CSS file that the browser can read.
 
-If you want to use your own version, first install the necessary tools to your
-server. These tools include nodejs and the node packet manager. After that you
-can install the sass compiler that is used to turn SCSS into CSS using:
+For any larger scale styling project, we recommend that you consider using SASS as
+well. This way, you can build on and modify all the work that has been done by the
+community to style the many views and components used in ILIAS.
 
-```
-npm install -g sass
-```
+You may want to use the same version of SASS that is referenced in the NPM
+package.json and automatically installed to `node_modules/` when using `npm install`.
+This specific SASS version can be executed like this from the ILIAS root:
+`node_modules/.bin/sass`
 
-or
+Alternatively, you can install the latest version of SASS globally with
+`npm install sass -g`.
 
-Download [Dart SASS from Github](https://github.com/sass/dart-sass/releases/) and add it to the machine's PATH.
+You can find a starting point for a custom System Style based on the default Delos
+system style here: [Delos Repository](https://github.com/ILIAS-eLearning/delos)
+
+At the point of writing, it does require modification to be recognized as a custom
+System Style as outlined later in this document.
 
 ### Access available Styles through Frontend
 
 1. Navigate to "Administration -> Layout and Styles" of you ILIAS Installation.
 2. In a table you see all available System Styles. 
-3. You may assigne users to styles via Actions Dropdown
+3. You may assign users to styles via Actions Dropdown
 4. You may set Sub Styles for certain sections of the repository via Actions Dropdown
 
 ### How-To 
@@ -43,10 +47,7 @@ Download [Dart SASS from Github](https://github.com/sass/dart-sass/releases/) an
 #### Step 1: Create skin directory
 
 To create a new skin, first add a new subdirectory to directory
-`./public/Customizing/skin`, e.g. `./public/Customizing/skin`.
-
-In the future, we will provide a base System Style based on the
-default Delos that you can download from Github and place here.
+`./public/Customizing/skin`, e.g. `./public/Customizing/skin/myskin/`.
 
 #### Step 2: Create template.xml File
 
@@ -61,55 +62,64 @@ One file that must exist in every skin is the file template.xml. E.g.
 ```
 
 Every skin can contain multiple styles. This example defines one style called
-MyStyle. This skin/style combination will be listed as MySkin/MyStyle in the
-ILIAS Style and Layout administration. The ILIAS administration is the place
-where you can activate/deactivate styles, and where you can assign users from
-one skin to another.
+MyStyle.
 
-#### Step 3: Create main CSS File
+This skin/style combination will be listed as MySkin/MyStyle in the
+ILIAS Style and Layout administration. The style's files are now expected
+to be located in `./public/Customizing/skin/myskin/mystyle/`:
+
+The ILIAS administration is the place where you can activate/deactivate styles,
+and where you can assign users from one skin to another.
+
+#### Step 3.1: Create main CSS File
 
 The `id` attribute of the style tag defines the name of the corresponding style
-sheet (CSS) file. This CSS file must also be added to the skin directory (here:
-`./public/Customizing/skin/myskin/mystyle/mystyle.css`). You should start with a copy of
-the default CSS file located at `templates/default/delos.css`. The best way to
-see which styles are used on a given ILIAS screen is to open the HTML source of
-the screen. Probably import delos in the top line of your css like so: `@import url("../../../../assets/css/delos.css");`
+sheet (CSS) file, in our example `./public/Customizing/skin/myskin/mystyle/mystyle.css`.
+
+The easiest (but not recommended) ways to get a working skin quickly are to
+* copy and rename the default CSS file located at `templates/default/delos.css`
+  to `./public/Customizing/skin/myskin/mystyle/mystyle.css`
+* or create `./public/Customizing/skin/myskin/mystyle/` and import delos in the
+  top line of your css like so: `@import url("../../../../assets/css/delos.css");`
 
 If your CSS file contains references to (background) images, these images must
 be present at their defined locations. If you copied the default CSS file, the
 image paths will not be correct anymore. You can either copy them to your skin
 directory, change the CSS definitions or provide your own image files.
 
-#### Step 3: Better Alternative
+#### Step 3.2: Better Alternative
 
 To have a working directory for your skin, you can also copy the complete folder
 templates/default of your ilias installation to a new folder below
-`./public/Customizing/skin/skin` within that directory, edit the file `template.xml` to
-have an unique Style Name and id. This is needed to identify the new skin in
-ILIAS' administration. Then copy the standard `delos.css` file to "your-id.css".
-Take care: the main CSS-File must reflect the id in its name (see above).
+`./public/Customizing/skin/myskin` within that directory, edit the file
+`template.xml` to have an unique Style Name and id. This is needed to identify the
+new skin in ILIAS' administration. Compile `delos.scss` or copy/rename the
+standard `delos.css` file to `./public/Customizing/skin/myskin/mystyle/mystyle.css`.
+Take care: the main CSS-File must reflect the style id in its name (see above).
 
 However, best use the stand alone skin [delos](https://github.com/ILIAS-eLearning/delos)
 git repo, which is always an up-to-date copy of the delos skin from the main repo.
-Clone it into your `./public/Customizing/skin` folder, make your changes and keep it always
-up-to-date for fixes from the main repo.
+Clone it into your `./public/Customizing/skin/myskin` folder, make your changes and
+merge important fixes and updates to delos into your skin.
 
-#### Step 3: Sass
+With this approach, you should not modify the css file, but work entirely in the scss files.
 
-Do not froget to re-compile the scss-file after each change. Switch to the delos scss folder and execute:
+#### Step 3.3 Sass
+
+Do not forget to re-compile the scss-file after each change. Switch to the root of your style 
+and execute:
 
 ```
-./node_modules/sass/sass.js delos.scss mystyle.css
+./node_modules/.bin/sass delos.scss mystyle.css
 ```
 
 or
 
 ```
-./node_modules/sass/sass.js --style=compressed delos.scss mystyle.css
+./node_modules/.bin/sass  --style=compressed delos.scss mystyle.css
 ```
 
 for a minified CSS version.
-
 
 #### Step 4: Add Icons (Optional)
 


### PR DESCRIPTION
# Issue

While fixing other issues (e.g. #8897 ) it came up that the instructions towards compiling delos from SASS scss to CSS are not up to date.

# Changes

This PR suggests updates to the SCSS Coding Guidelines and the Custom System Style Instructions to reflect the most recent best practices.

While the documentation for sure could be optimized and clarified even further, I feel like this is at least a good step towards more clarity and correctness.