### PR TITLE
LearningModule: propagate change in title of page/chapter to LOM (43861)

### DIFF
--- a/components/ILIAS/LearningModule/Editing/class.EditSubObjectsGUI.php
+++ b/components/ILIAS/LearningModule/Editing/class.EditSubObjectsGUI.php
@@ -394,9 +394,18 @@ class EditSubObjectsGUI
     {
         $mt = $this->gui->mainTemplate();
         $lng = $this->domain->lng();
-        $form = $this->getEditTitleForm($this->request->getEditId());
+        $edit_id = $this->request->getEditId();
+        $form = $this->getEditTitleForm($edit_id);
         if ($form->isValid()) {
-            \ilLMObject::_writeTitle($this->request->getEditId(), $form->getData("title"));
+            $title = $form->getData("title");
+            \ilLMObject::_writeTitle($edit_id, $title);
+
+            $lom = $this->domain->learningObjectMetadata();
+            $lom->manipulate($this->lm_id, $edit_id, \ilLMObject::_lookupType($edit_id, $this->lm_id))
+                ->prepareCreateOrUpdate(
+                    $lom->paths()->title(),
+                    $title
+                )->execute();
         }
         $mt->setContent("success", $lng->txt("msg_obj_modified"), true);
         $this->gui->ctrl()->redirect($this, "list");


### PR DESCRIPTION
This PR fixes [43861](https://mantis.ilias.de/view.php?id=0043861), by having the `EditSubObjectsGUI` also update the title of pages and chapters in LOM.

`ilLMObject::update` (as well as `create` and `delete` and so on) already take care of keeping LOM up to date, but for changing the title `EditSubObjectsGUI` uses the static `ilLMObject::_writeTitle`.