### PR TITLE
Http: Make lists of hosts configurable in setup (ILIAS >= 10.x)

### DIFF
--- a/components/ILIAS/Http_/classes/Setup/class.ilHttpConfigStoredObjective.php
+++ b/components/ILIAS/Http_/classes/Setup/class.ilHttpConfigStoredObjective.php
@@ -1,20 +1,25 @@
 <?php
 
-use ILIAS\Setup;
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+
 class ilHttpConfigStoredObjective implements Setup\Objective
 {
     protected \ilHttpSetupConfig $config;
@@ -92,6 +97,12 @@ class ilHttpConfigStoredObjective implements Setup\Objective
         $settings->set("proxy_host", (string) $this->config->getProxyHost());
         $settings->set("proxy_port", (string) $this->config->getProxyPort());
 
+        if (is_array($this->config->getAllowedHosts()) && $this->config->getAllowedHosts() !== []) {
+            $settings->set('allowed_hosts', implode(',', $this->config->getAllowedHosts()));
+        } else {
+            $settings->delete('allowed_hosts');
+        }
+
         return $environment;
     }
 
@@ -115,7 +126,8 @@ class ilHttpConfigStoredObjective implements Setup\Objective
             $ini->readVariable(ilHTTPS::SETTINGS_GROUP_HTTPS, ilHTTPS::SETTING_AUTO_HTTPS_DETECT_HEADER_VALUE) !== $this->config->getHeaderValue() ||
             $settings->get("proxy_status") !== (int) $this->config->isProxyEnabled() ||
             $settings->get("proxy_host") !== $this->config->getProxyHost() ||
-            $settings->get("proxy_port") !== $this->config->getProxyPort()
+            $settings->get("proxy_port") !== $this->config->getProxyPort() ||
+            $settings->get('allowed_hosts', '') !== implode(',', $this->config->getAllowedHosts() ?? [])
         ;
     }
 }

--- a/components/ILIAS/Http_/classes/Setup/class.ilHttpMetricsCollectedObjective.php
+++ b/components/ILIAS/Http_/classes/Setup/class.ilHttpMetricsCollectedObjective.php
@@ -1,20 +1,23 @@
 <?php
 
-use ILIAS\Setup;
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+use ILIAS\Setup;
+
 class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
 {
     /**
@@ -110,6 +113,25 @@ class ilHttpMetricsCollectedObjective extends Setup\Metrics\CollectedObjective
                 "proxy",
                 false,
                 "Does the server use a proxy for outgoing connections?"
+            );
+        }
+
+        if ($settings->get('allowed_hosts')) {
+            $storage->store(
+                'allowed_hosts',
+                new Setup\Metrics\Metric(
+                    Setup\Metrics\Metric::STABILITY_CONFIG,
+                    Setup\Metrics\Metric::TYPE_COLLECTION,
+                    array_map(
+                        static fn(string $host) => new Setup\Metrics\Metric(
+                            Setup\Metrics\Metric::STABILITY_CONFIG,
+                            Setup\Metrics\Metric::TYPE_TEXT,
+                            $host
+                        ),
+                        explode(',', $settings->get('allowed_hosts'))
+                    ),
+                    'Collection of configured allowed hosts.'
+                )
             );
         }
     }

--- a/components/ILIAS/Http_/classes/Setup/class.ilHttpSetupAgent.php
+++ b/components/ILIAS/Http_/classes/Setup/class.ilHttpSetupAgent.php
@@ -1,25 +1,26 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 use ILIAS\Setup;
 use ILIAS\Refinery;
-use ILIAS\Data;
-use ILIAS\UI;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 class ilHttpSetupAgent implements Setup\Agent
 {
     use Setup\Agent\HasNoNamedObjective;
@@ -63,6 +64,7 @@ class ilHttpSetupAgent implements Setup\Agent
                 (isset($data["proxy"]) && $data["proxy"])
                     ? $data["proxy"]["port"]
                     : null,
+                $data['allowed_hosts'] ?? null
             );
         });
     }

--- a/components/ILIAS/Http_/classes/Setup/class.ilHttpSetupConfig.php
+++ b/components/ILIAS/Http_/classes/Setup/class.ilHttpSetupConfig.php
@@ -1,20 +1,23 @@
 <?php
 
-use ILIAS\Setup;
-
-/******************************************************************************
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
+use ILIAS\Setup;
+
 class ilHttpSetupConfig implements Setup\Config
 {
     protected string $http_path;
@@ -25,8 +28,12 @@ class ilHttpSetupConfig implements Setup\Config
     protected bool $proxy_enabled;
     protected ?string $proxy_host;
     protected ?string $proxy_port;
+    /** @var list<string>|null */
+    protected ?array $allowed_hosts = null;
 
-
+    /**
+     * @param list<string>|null  $allowed_hosts
+     */
     public function __construct(
         string $http_path,
         bool $autodetection_enabled,
@@ -35,7 +42,8 @@ class ilHttpSetupConfig implements Setup\Config
         ?string $header_value,
         bool $proxy_enabled,
         ?string $proxy_host,
-        ?string $proxy_port
+        ?string $proxy_port,
+        ?array $allowed_hosts
     ) {
         if ($autodetection_enabled && (!$header_name || !$header_value)) {
             throw new \InvalidArgumentException(
@@ -55,6 +63,10 @@ class ilHttpSetupConfig implements Setup\Config
         $this->proxy_enabled = $proxy_enabled;
         $this->proxy_host = $proxy_host;
         $this->proxy_port = $proxy_port;
+
+        if (is_array($allowed_hosts)) {
+            $this->allowed_hosts = array_values(array_filter(array_map(strval(...), $allowed_hosts)));
+        }
     }
 
 
@@ -96,5 +108,13 @@ class ilHttpSetupConfig implements Setup\Config
     public function getProxyPort(): ?string
     {
         return $this->proxy_port;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    public function getAllowedHosts(): ?array
+    {
+        return $this->allowed_hosts;
     }
 }

--- a/components/ILIAS/Init/src/Environment/HttpPathBuilder.php
+++ b/components/ILIAS/Init/src/Environment/HttpPathBuilder.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Init\Environment;
+
+final class HttpPathBuilder
+{
+    /**
+     * @param array<string, mixed>|\ArrayAccess<string, mixed> $server_data
+     */
+    public function __construct(
+        private readonly \ILIAS\Data\Factory $df,
+        private readonly \ilSetting $settings,
+        private readonly \ilHTTPS $https,
+        private readonly \ilIniFile $ini,
+        private readonly array|\ArrayAccess $server_data
+    ) {
+    }
+
+    public function build(): \ILIAS\Data\URI
+    {
+        $protocol = 'http://';
+        if ($this->https->isDetected()) {
+            $protocol = 'https://';
+        }
+        $host = $this->server_data['HTTP_HOST'];
+        $request_uri = strip_tags($this->server_data['REQUEST_URI']);
+
+        // security fix: this failed, if the URI contained "?" and following "/"
+        // -> we remove everything after "?"
+        if (\is_int($pos = strpos($request_uri, '?'))) {
+            $request_uri = substr($request_uri, 0, $pos);
+        }
+
+        if (\defined('ILIAS_MODULE')) {
+            // if in module remove module name from HTTP_PATH
+            $path = \dirname($request_uri);
+
+            // dirname cuts the last directory from a directory path e.g content/classes return content
+            $module = \ilFileUtils::removeTrailingPathSeparators(ILIAS_MODULE);
+
+            $dirs = explode('/', $module);
+            $uri = $path;
+            $uri = \dirname($uri, \count($dirs));
+        } else {
+            $path = pathinfo($request_uri);
+            if (($path['extension'] ?? null) !== '') {
+                $uri = \dirname($request_uri);
+            } else {
+                $uri = $request_uri;
+            }
+        }
+
+        $ilias_http_path = \ilContext::modifyHttpPath(implode('', [$protocol, $host, $uri]));
+
+        // remove everything after the first .php in the path
+        $ilias_http_path = preg_replace('@(http|https)(://)(.*?/.*?\.php).*@', '$1$2$3', $ilias_http_path);
+        $ilias_http_path = preg_replace('@goto.php/$@', '', $ilias_http_path);
+        $ilias_http_path = preg_replace('/goto.php$/', '', $ilias_http_path);
+        $ilias_http_path = preg_replace('@go/.*$@', '', $ilias_http_path);
+
+        $uri = $this->df->uri(\ilFileUtils::removeTrailingPathSeparators($ilias_http_path));
+
+        $ini_uri = $this->df->uri($this->ini->readVariable('server', 'http_path'));
+        $allowed_hosts = [
+            'localhost',
+            $ini_uri->getHost()
+        ];
+
+        if ($this->settings->get('soap_wsdl_path')) {
+            $soap_wsdl_uri = $this->df->uri($this->settings->get('soap_wsdl_path'));
+            $allowed_hosts = array_merge(
+                [$soap_wsdl_uri->getHost()],
+                $allowed_hosts
+            );
+        }
+
+        $allowed_hosts = array_merge(
+            array_filter(explode(',', $this->settings->get('allowed_hosts', ''))),
+            $allowed_hosts
+        );
+
+        if (!\in_array($uri->getHost(), $allowed_hosts, true)) {
+            throw new \RuntimeException('Request rejected, the given HTTP host is not in the "allowed_hosts" list');
+        }
+
+        return $uri;
+    }
+}

--- a/components/ILIAS/Init/tests/HttpPathBuilderTest.php
+++ b/components/ILIAS/Init/tests/HttpPathBuilderTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class HttpPathBuilderTest extends TestCase
+{
+    /**
+     * @return Generator<string, array{
+     *     server_data: array<string, mixed>|ArrayAccess<string, mixed>,
+     *     http_path: string,
+     *     wsdl_path: string,
+     *     allowed_hosts: string
+     * }>
+     */
+    public static function environmentProvider(): Generator
+    {
+        yield 'Host matches configured HTTP path (no `allowed_hosts` configuration)' => [
+            'server_data' => [
+                'HTTP_HOST' => 'localhost',
+                'REQUEST_URI' => '/login.php',
+            ],
+            'http_path' => 'http://localhost',
+            'wsdl_path' => 'https://localhost/soap/server.php?wsdl=1',
+            'allowed_hosts' => '',
+        ];
+
+        yield 'Host matches configured WSDL path (no `allowed_hosts` configuration)' => [
+            'server_data' => [
+                'HTTP_HOST' => 'soap.ilias.de',
+                'REQUEST_URI' => '/login.php',
+            ],
+            'http_path' => 'https://test.ilias.de',
+            'wsdl_path' => 'https://soap.ilias.de/soap/server.php?wsdl=1',
+            'allowed_hosts' => '',
+        ];
+
+        yield 'Localhost is always allowed (no `allowed_hosts` configuration)' => [
+            'server_data' => [
+                'HTTP_HOST' => 'localhost',
+                'REQUEST_URI' => '/login.php',
+            ],
+            'http_path' => 'https://test.ilias.de',
+            'wsdl_path' => 'https://test.ilias.de/soap/server.php?wsdl=1',
+            'allowed_hosts' => '',
+        ];
+
+        yield 'Host is in `allowed_hosts` list' => [
+            'server_data' => [
+                'HTTP_HOST' => 'test2.ilias.de',
+                'REQUEST_URI' => '/login.php',
+            ],
+            'http_path' => 'https://test.ilias.de',
+            'wsdl_path' => 'https://test.ilias.de/soap/server.php?wsdl=1',
+            'allowed_hosts' => 'test2.ilias.de',
+        ];
+    }
+
+    /**
+     * @dataProvider environmentProvider
+     * @param array<string, mixed>|ArrayAccess<string, mixed> $server_data
+     */
+    public function testValidHostsTriggerNoExceptions(
+        array|ArrayAccess $server_data,
+        string $http_path,
+        string $wsdl_path,
+        string $allowed_hosts
+    ): void {
+        $path_builder = new \ILIAS\Init\Environment\HttpPathBuilder(
+            new \ILIAS\Data\Factory(),
+            $this->getSettingsMock($wsdl_path, $allowed_hosts),
+            $this->getHttpsMock(),
+            $this->getIniMock($http_path),
+            $server_data
+        );
+
+        $this->assertNotEmpty((string) $path_builder->build());
+    }
+
+    public function testUnknownHostWillRaiseException(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $path_builder = new \ILIAS\Init\Environment\HttpPathBuilder(
+            new \ILIAS\Data\Factory(),
+            $this->getSettingsMock('https://test.ilias.de/soap/server.php?wsdl=1', 'test.ilias.de'),
+            $this->getHttpsMock(),
+            $this->getIniMock('https://test.ilias.de'),
+            [
+                'HTTP_HOST' => 'phishing.ilias.de',
+                'REQUEST_URI' => '/login.php',
+            ]
+        );
+
+        $path_builder->build();
+    }
+
+    private function getSettingsMock(
+        string $wsdl_path,
+        string $allowed_hosts
+    ): ilSetting&\PHPUnit\Framework\MockObject\MockObject {
+        $settings = $this
+            ->getMockBuilder(ilSetting::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get'])
+            ->getMock();
+        $settings->method('get')->willReturnCallback(
+            static fn(string $key, ?string $default = null): ?string => match ($key) {
+                'soap_wsdl_path' => $wsdl_path,
+                'allowed_hosts' => $allowed_hosts,
+                default => $default
+            }
+        );
+
+        return $settings;
+    }
+
+    private function getHttpsMock(): ilHttps&\PHPUnit\Framework\MockObject\MockObject
+    {
+        $https = $this
+            ->getMockBuilder(ilHTTPS::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['isDetected'])
+            ->getMock();
+        $https->method('isDetected')->willReturn(true);
+
+        return $https;
+    }
+
+    private function getIniMock(string $http_path): ilIniFile&\PHPUnit\Framework\MockObject\MockObject
+    {
+        $ini = $this
+            ->getMockBuilder(ilIniFile::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['readVariable'])
+            ->getMock();
+        $ini->method('readVariable')->willReturnCallback(
+            static fn(string $group, string $variable): string => match ($variable) {
+                'http_path' => $http_path,
+                default => ''
+            }
+        );
+
+        return $ini;
+    }
+}

--- a/components/ILIAS/setup_/README.md
+++ b/components/ILIAS/setup_/README.md
@@ -349,7 +349,12 @@ are printed bold**, all other fields might be omitted. A minimal example is
 		"proxy" : {
 			"host" : "webproxy.ilias.de",
 			"port" : "8088"
-		}
+		},
+		"allowed_hosts" : [
+			"red.ilias.de",
+			"blue.ilias.de",
+			"www.ilias.de"
+		]
     },
     ```
   * **path** (type: string) to your installation on the internet
@@ -360,6 +365,13 @@ are printed bold**, all other fields might be omitted. A minimal example is
   * *proxy* (type: object) for outgoing http connections
     * *host* (type: string) the proxy runs on
     * *port* (type: string or number) the proxy listens on
+  * *allowed_hosts* (type: an `array`/list of strings, or `null`) A list of valid hosts which is used to
+    validate the `HTTP_HOST` header of incoming web requests. If the host header does not match any of
+    the allowed hosts, the request is rejected. If `null` is set or an empty list is provided, the host
+    header is only validated against the host of the `path` setting
+    (stored in the "ilias.ini.php" as `http_path`), which is always considered allowed.
+    This also applies for the optionally configurable host used for the WSDL path definition
+    in the SOAP web service configuration and for "localhost".
 * *logging* (type: object) configuration if logging should be used
     ```
 	"logging" : {


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=43902

If approved, this must be picked to `trunk` as well.