### PR TITLE
UI: remove indifferent aria label from viewcontrol

### DIFF
--- a/components/ILIAS/UI/src/Component/ViewControl/Factory.php
+++ b/components/ILIAS/UI/src/Component/ViewControl/Factory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\UI\Component\ViewControl;
 
@@ -46,7 +46,6 @@ interface Factory
      *   accessibility:
      *      1: The HTML container enclosing the buttons of the Mode View Control MUST cary the role-attribute "group".
      *      2: The HTML container enclosing the buttons of the Mode View Control MUST set an aria-label describing the element. Eg. "Mode View Control"
-     *      3: The Buttons of the Mode View Control MUST set an aria-label clearly describing what the button shows if clicked. E.g. "List View", "Month View", ...
      * ---
      * @param    array $labelled_actions Set of labelled actions (string|string)[]. The label of the action is used as key, the action itself as value.
      *          The first of the actions will be activated by default.

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
@@ -70,9 +70,7 @@ class Renderer extends AbstractComponentRenderer
         foreach ($component->getLabelledActions() as $label => $action) {
             $tpl->setCurrentBlock("view_control");
 
-            //At this point we don't have a specific text for the button aria label.
-            // component->getAriaLabel gets the main view control aria label.
-            $button = $f->button()->standard($label, $action)->withAriaLabel($label);
+            $button = $f->button()->standard($label, $action);
             if ($activate_first_item) {
                 $button = $button->withEngagedState(true);
                 $activate_first_item = false;

--- a/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
@@ -436,8 +436,8 @@ EOT;
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-viewcontrols l-bar__space-keeper">
             <div class="il-viewcontrol-mode l-bar__element" aria-label="Presentation Mode" role="group">
-                <button class="btn btn-default engaged" aria-label="A" aria-pressed="true" data-action="a" id="id_1">A</button>
-                <button class="btn btn-default" aria-label="B" aria-pressed="false" data-action="b" id="id_2">B</button>
+                <button class="btn btn-default engaged" aria-pressed="true" data-action="a" id="id_1">A</button>
+                <button class="btn btn-default" aria-pressed="false" data-action="b" id="id_2">B</button>
             </div>
         </div>
         <div class="panel-controls"></div>

--- a/components/ILIAS/UI/tests/Component/ViewControl/ViewControlTest.php
+++ b/components/ILIAS/UI/tests/Component/ViewControl/ViewControlTest.php
@@ -142,12 +142,12 @@ class ViewControlTest extends ILIAS_UI_TestBase
         $expected = "<div class=\"il-viewcontrol-mode l-bar__element\" aria-label=\"" . $this->aria_label . "\" role=\"" . $this->role . "\">";
         foreach ($this->actions as $label => $action) {
             if ($activate_first_item) {
-                $expected .= "<button class=\"btn btn-default engaged\" aria-label=\"$label\" aria-pressed=\"true\" data-action=\"$action\" id=\"id_1\">$label</button>";
+                $expected .= "<button class=\"btn btn-default engaged\" aria-pressed=\"true\" data-action=\"$action\" id=\"id_1\">$label</button>";
                 $activate_first_item = false;
             } elseif ($active == $label) {
-                $expected .= "<button class=\"btn btn-default engaged\" aria-label=\"$label\" aria-pressed=\"true\" data-action=\"$action\" id=\"id_1\">$label</button>";
+                $expected .= "<button class=\"btn btn-default engaged\" aria-pressed=\"true\" data-action=\"$action\" id=\"id_1\">$label</button>";
             } else {
-                $expected .= "<button class=\"btn btn-default\" aria-label=\"$label\" aria-pressed=\"false\" data-action=\"$action\" id=\"id_2\">$label</button>";
+                $expected .= "<button class=\"btn btn-default\" aria-pressed=\"false\" data-action=\"$action\" id=\"id_2\">$label</button>";
             }
         }
         $expected .= "</div>";


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43994

Alternatively, IMO an implementation which allows the provision of own buttons (with set aria-labels) would also be a sufficient solution.