### PR TITLE
LTI Form Handling and Validation Updates

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerGradeServiceScores.php
@@ -115,7 +115,7 @@ class ilLTIConsumerGradeServiceScores extends ilLTIConsumerResourceBase
                 $score->scoreGiven = null;
             }
         }
-        $result = (float)$score->scoreGiven / (float)$score->scoreMaximum;
+        $result = (float) $score->scoreGiven / (float) $score->scoreMaximum;
         ilObjLTIConsumer::getLogger()->debug("result: " . $result);
 
         $ltiObjRes = new ilLTIConsumerResultService();


### PR DESCRIPTION
- `saveObject` on ilObjLTIConsumerGUI's parent was expecting a single form but was receiving an array of forms. This caused the method to fail. Added a new method `saveObject` to handle the array
- Style corrections