### PR TITLE
T&A 30750: Poor performance using "Corrections"

### DIFF
--- a/Modules/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
+++ b/Modules/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
@@ -125,22 +125,7 @@ class ilTestEvaluationFactory
 
     public function getCorrectionsEvaluationData(): ilTestEvaluationData
     {
-        return $this->buildEvaluationData(false);
-    }
-
-    public function getEvaluationData(): ilTestEvaluationData
-    {
-        return $this->buildEvaluationData(true);
-    }
-
-    /**
-     * @param bool $detailed If detailed is false the evaluation data will not contain the participant's visit times
-     *                          and only the answered questions will be included in the pass data.
-     */
-    private function buildEvaluationData(bool $detailed): ilTestEvaluationData
-    {
         $eval_data_rows = $this->queryEvaluationData($this->getAccessFilteredActiveIds());
-        $scoring_settings = $this->getPassScoringSettings();
         $participants = [];
         $current_user = null;
         $current_attempt = null;
@@ -149,82 +134,134 @@ class ilTestEvaluationFactory
             if ($current_user !== $row['active_id']) {
                 $current_user = $row['active_id'];
                 $current_attempt = null;
-
-                $user_eval_data = new ilTestEvaluationUserData($scoring_settings);
-
-                $user_eval_data->setName(
-                    $this->test_obj->buildName($row['usr_id'], $row['firstname'], $row['lastname'])
-                );
-
-                if ($row['login'] !== null) {
-                    $user_eval_data->setLogin($row['login']);
-                }
-                if ($row['usr_id'] !== null) {
-                    $user_eval_data->setUserID($row['usr_id']);
-                }
-                $user_eval_data->setSubmitted((bool) $row['submitted']);
-                $user_eval_data->setLastFinishedPass($row['last_finished_pass']);
-
-                if ($detailed) {
-                    $visitingTime = $this->getVisitTimeOfParticipant($row['active_id']);
-                    $user_eval_data->setFirstVisit($visitingTime['firstvisit']);
-                    $user_eval_data->setLastVisit($visitingTime['lastvisit']);
-                }
+                $user_eval_data = $this->buildBasicUserEvaluationDataFromDB($row);
             }
 
             if ($current_attempt !== $row['pass']) {
                 $current_attempt = $row['pass'];
-                $attempt = new \ilTestEvaluationPassData();
-                $attempt->setPass($row['pass']);
-                $attempt->setReachedPoints($row['points']);
-                $attempt->setObligationsAnswered((bool) $row['obligations_answered']);
-
-                if ($detailed) {
-                    if ($row['questioncount'] == 0) {
-                        list($count, $points) = array_values(
-                            $this->getQuestionCountAndPointsForPassOfParticipant($row['active_id'], $row['pass'])
-                        );
-                        $attempt->setMaxPoints($points);
-                        $attempt->setQuestionCount($count);
-                    } else {
-                        $attempt->setMaxPoints($row['maxpoints']);
-                        $attempt->setQuestionCount($row['questioncount']);
-                    }
-                }
-
-                $attempt->setNrOfAnsweredQuestions($row['answeredquestions']);
-                $attempt->setWorkingTime($row['workingtime']);
-                $attempt->setExamId((string) $row['exam_id']);
-                $attempt->setRequestedHintsCount($row['hint_count']);
-                $attempt->setDeductedHintPoints($row['hint_points']);
+                $attempt = $this->buildBasicAttemptEvaluationDataFromDB($row);
             }
 
-            if ($row['question_fi'] !== null) {
-                $attempt->addAnsweredQuestion(
-                    $row["question_fi"],
-                    $row["qpl_maxpoints"],
-                    $row["result_points"],
-                    (bool) $row['answered'],
-                    null,
-                    $row['manual']
+            $user_eval_data->addPass($row['pass'], $attempt);
+            $participants[$row['active_id']] = $user_eval_data;
+        }
+        return new ilTestEvaluationData($participants);
+    }
+
+    public function getEvaluationData(): ilTestEvaluationData
+    {
+        $eval_data_rows = $this->queryEvaluationData($this->getAccessFilteredActiveIds());
+        $participants = [];
+        $current_user = null;
+        $current_attempt = null;
+
+        foreach ($eval_data_rows as $row) {
+            if ($current_user !== $row['active_id']) {
+                $current_user = $row['active_id'];
+                $current_attempt = null;
+                $user_eval_data = $this->addVisitingTimeToUserEvalData(
+                    $this->buildBasicUserEvaluationDataFromDB($row),
+                    $row['active_id']
+                );
+            }
+
+            if ($current_attempt !== $row['pass']) {
+                $current_attempt = $row['pass'];
+                $attempt = $this->addPointsAndQuestionCountToAttempt(
+                    $this->buildBasicAttemptEvaluationDataFromDB($row),
+                    $row
                 );
             }
 
             $user_eval_data->addPass($row['pass'], $attempt);
-
             $participants[$row['active_id']] = $user_eval_data;
         }
 
-        if ($detailed) {
-            $evaluation_data = $this->addQuestionsToParticipantPasses(
-                new ilTestEvaluationData($participants)
-            );
-            return $this->addMarksToParticipants($evaluation_data);
-        } else {
-            return new ilTestEvaluationData($participants);
-        }
+        $evaluation_data = $this->addQuestionsToParticipantPasses(
+            new ilTestEvaluationData($participants)
+        );
+        return $this->addMarksToParticipants($evaluation_data);
     }
 
+    private function buildBasicUserEvaluationDataFromDB(array $row): ilTestEvaluationUserData
+    {
+        $user_data = new ilTestEvaluationUserData($this->getPassScoringSettings());
+
+        $user_data->setName(
+            $this->test_obj->buildName($row['usr_id'], $row['firstname'], $row['lastname'])
+        );
+
+        if ($row['login'] !== null) {
+            $user_data->setLogin($row['login']);
+        }
+        if ($row['usr_id'] !== null) {
+            $user_data->setUserID($row['usr_id']);
+        }
+        $user_data->setSubmitted((bool) $row['submitted']);
+        $user_data->setLastFinishedPass($row['last_finished_pass']);
+        return $user_data;
+    }
+
+    private function buildBasicAttemptEvaluationDataFromDB(array $row): ilTestEvaluationPassData
+    {
+        $attempt = new \ilTestEvaluationPassData();
+        $attempt->setPass($row['pass']);
+        $attempt->setReachedPoints($row['points']);
+        $attempt->setObligationsAnswered((bool) $row['obligations_answered']);
+        $attempt->setNrOfAnsweredQuestions($row['answeredquestions']);
+        $attempt->setWorkingTime($row['workingtime']);
+        $attempt->setExamId((string) $row['exam_id']);
+        $attempt->setRequestedHintsCount($row['hint_count']);
+        $attempt->setDeductedHintPoints($row['hint_points']);
+        return $this->addQuestionToAttempt($attempt, $row);
+    }
+
+    private function addVisitingTimeToUserEvalData(
+        ilTestEvaluationUserData $user_data,
+        int $active_id
+    ): ilTestEvaluationUserData {
+        $visitingTime = $this->getVisitTimeOfParticipant($active_id);
+        $user_data->setFirstVisit($visitingTime['firstvisit']);
+        $user_data->setLastVisit($visitingTime['lastvisit']);
+        return $user_data;
+    }
+
+    private function addPointsAndQuestionCountToAttempt(
+        ilTestEvaluationPassData $attempt,
+        array $row
+    ): ilTestEvaluationPassData {
+        if ($row['questioncount'] !== 0) {
+            $attempt->setMaxPoints($row['maxpoints']);
+            $attempt->setQuestionCount($row['questioncount']);
+            return $attempt;
+        }
+
+        list($count, $points) = array_values(
+            $this->getQuestionCountAndPointsForPassOfParticipant($row['active_id'], $row['pass'])
+        );
+        $attempt->setMaxPoints($points);
+        $attempt->setQuestionCount($count);
+        return $attempt;
+    }
+
+    private function addQuestionToAttempt(
+        ilTestEvaluationPassData $attempt,
+        array $row
+    ): ilTestEvaluationPassData {
+        if ($row['question_fi'] === null) {
+            return $attempt;
+        }
+
+        $attempt->addAnsweredQuestion(
+            $row["question_fi"],
+            $row["qpl_maxpoints"],
+            $row["result_points"],
+            (bool) $row['answered'],
+            null,
+            $row['manual']
+        );
+        return $attempt;
+    }
 
     protected function addQuestionsToParticipantPasses(ilTestEvaluationData $evaluation_data): ilTestEvaluationData
     {

--- a/Modules/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
+++ b/Modules/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
@@ -142,6 +142,7 @@ class ilTestEvaluationFactory
                 $attempt = $this->buildBasicAttemptEvaluationDataFromDB($row);
             }
 
+            $attempt = $this->addQuestionToAttempt($attempt, $row);
             $user_eval_data->addPass($row['pass'], $attempt);
             $participants[$row['active_id']] = $user_eval_data;
         }
@@ -173,6 +174,7 @@ class ilTestEvaluationFactory
                 );
             }
 
+            $attempt = $this->addQuestionToAttempt($attempt, $row);
             $user_eval_data->addPass($row['pass'], $attempt);
             $participants[$row['active_id']] = $user_eval_data;
         }
@@ -213,7 +215,7 @@ class ilTestEvaluationFactory
         $attempt->setExamId((string) $row['exam_id']);
         $attempt->setRequestedHintsCount($row['hint_count']);
         $attempt->setDeductedHintPoints($row['hint_points']);
-        return $this->addQuestionToAttempt($attempt, $row);
+        return $attempt;
     }
 
     private function addVisitingTimeToUserEvalData(

--- a/Modules/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
+++ b/Modules/Test/classes/Evaluation/class.ilTestEvaluationFactory.php
@@ -125,61 +125,19 @@ class ilTestEvaluationFactory
 
     public function getCorrectionsEvaluationData(): ilTestEvaluationData
     {
-        $eval_data_rows = $this->queryEvaluationData($this->getAccessFilteredActiveIds());
-        $scoring_settings = $this->getPassScoringSettings();
-        $participants = [];
-        $current_user = null;
-        $current_attempt = null;
-
-        foreach ($eval_data_rows as $row) {
-            if ($current_user !== $row['active_fi']) {
-                $current_user = $row['active_fi'];
-                $current_attempt = null;
-
-                $user_eval_data = new ilTestEvaluationUserData($scoring_settings);
-
-                $user_eval_data->setName(
-                    $this->buildName($row['usr_id'], $row['firstname'], $row['lastname'], $row['title'])
-                );
-
-                if ($row['login'] !== null) {
-                    $user_eval_data->setLogin($row['login']);
-                }
-                if ($row['usr_id'] !== null) {
-                    $user_eval_data->setUserID($row['usr_id']);
-                }
-                $user_eval_data->setSubmitted((bool) $row['submitted']);
-                $user_eval_data->setLastFinishedPass($row['last_finished_pass']);
-                $user_eval_data->setFirstVisit(-1);
-                $user_eval_data->setLastVisit(-1);
-            }
-
-            if ($current_attempt !== $row['pass']) {
-                $current_attempt = $row['pass'];
-                $attempt = new \ilTestEvaluationPassData();
-                $attempt->setPass($row['pass']);
-                $attempt->setReachedPoints($row['points']);
-            }
-
-            if ($row['question_fi'] !== null) {
-                $attempt->addAnsweredQuestion(
-                    $row["question_fi"],
-                    $row["qpl_maxpoints"],
-                    $row["result_points"],
-                    (bool) $row['answered'],
-                    null,
-                    $row['manual']
-                );
-            }
-
-            $user_eval_data->addPass($row['pass'], $attempt);
-            $participants[$row['active_fi']] = $user_eval_data;
-        }
-
-        return new ilTestEvaluationData($participants);
+        return $this->buildEvaluationData(false);
     }
 
     public function getEvaluationData(): ilTestEvaluationData
+    {
+        return $this->buildEvaluationData(true);
+    }
+
+    /**
+     * @param bool $detailed If detailed is false the evaluation data will not contain the participant's visit times
+     *                          and only the answered questions will be included in the pass data.
+     */
+    private function buildEvaluationData(bool $detailed): ilTestEvaluationData
     {
         $eval_data_rows = $this->queryEvaluationData($this->getAccessFilteredActiveIds());
         $scoring_settings = $this->getPassScoringSettings();
@@ -207,9 +165,11 @@ class ilTestEvaluationFactory
                 $user_eval_data->setSubmitted((bool) $row['submitted']);
                 $user_eval_data->setLastFinishedPass($row['last_finished_pass']);
 
-                $visitingTime = $this->getVisitTimeOfParticipant($row['active_id']);
-                $user_eval_data->setFirstVisit($visitingTime['firstvisit']);
-                $user_eval_data->setLastVisit($visitingTime['lastvisit']);
+                if ($detailed) {
+                    $visitingTime = $this->getVisitTimeOfParticipant($row['active_id']);
+                    $user_eval_data->setFirstVisit($visitingTime['firstvisit']);
+                    $user_eval_data->setLastVisit($visitingTime['lastvisit']);
+                }
             }
 
             if ($current_attempt !== $row['pass']) {
@@ -219,15 +179,17 @@ class ilTestEvaluationFactory
                 $attempt->setReachedPoints($row['points']);
                 $attempt->setObligationsAnswered((bool) $row['obligations_answered']);
 
-                if ($row['questioncount'] == 0) {
-                    list($count, $points) = array_values(
-                        $this->getQuestionCountAndPointsForPassOfParticipant($row['active_id'], $row['pass'])
-                    );
-                    $attempt->setMaxPoints($points);
-                    $attempt->setQuestionCount($count);
-                } else {
-                    $attempt->setMaxPoints($row['maxpoints']);
-                    $attempt->setQuestionCount($row['questioncount']);
+                if ($detailed) {
+                    if ($row['questioncount'] == 0) {
+                        list($count, $points) = array_values(
+                            $this->getQuestionCountAndPointsForPassOfParticipant($row['active_id'], $row['pass'])
+                        );
+                        $attempt->setMaxPoints($points);
+                        $attempt->setQuestionCount($count);
+                    } else {
+                        $attempt->setMaxPoints($row['maxpoints']);
+                        $attempt->setQuestionCount($row['questioncount']);
+                    }
                 }
 
                 $attempt->setNrOfAnsweredQuestions($row['answeredquestions']);
@@ -253,10 +215,14 @@ class ilTestEvaluationFactory
             $participants[$row['active_id']] = $user_eval_data;
         }
 
-        $evaluation_data = $this->addQuestionsToParticipantPasses(
-            new ilTestEvaluationData($participants)
-        );
-        return $this->addMarksToParticipants($evaluation_data);
+        if ($detailed) {
+            $evaluation_data = $this->addQuestionsToParticipantPasses(
+                new ilTestEvaluationData($participants)
+            );
+            return $this->addMarksToParticipants($evaluation_data);
+        } else {
+            return new ilTestEvaluationData($participants);
+        }
     }
 
 

--- a/Modules/Test/classes/class.ilTestCorrectionsGUI.php
+++ b/Modules/Test/classes/class.ilTestCorrectionsGUI.php
@@ -286,10 +286,12 @@ class ilTestCorrectionsGUI
         $this->main_tpl->parseCurrentBlock();
     }
 
-    protected function showAnswerStatistic()
+    protected function showAnswerStatistic($participant_results = null)
     {
         $questionGUI = $this->getQuestion((int) $this->testrequest->raw('qid'));
-        $solutions = $this->getSolutions($questionGUI->object);
+        $solutions = $participant_results
+            ? $this->getSolutionsByParticipantResults($questionGUI->object, $participant_results)
+            : $this->getSolutions($questionGUI->object);
 
         $this->setCorrectionTabsContext($questionGUI, 'answers');
 
@@ -346,10 +348,10 @@ class ilTestCorrectionsGUI
         $scoring = new ilTestScoring($this->testOBJ, $this->database);
         $scoring->setPreserveManualScores(true);
         $scoring->setQuestionId($question_id);
-        $scoring->recalculateSolutions();
+        $results = $scoring->recalculateSolutions();
 
         $this->main_tpl->setOnScreenMessage('success', $this->language->txt('saved_successfully'));
-        $this->showAnswerStatistic();
+        $this->showAnswerStatistic($results);
     }
 
     protected function confirmQuestionRemoval()
@@ -526,6 +528,24 @@ class ilTestCorrectionsGUI
         }
 
         return $solutionRows;
+    }
+
+    /**
+     * @param array<int, ilTestEvaluationUserData> $participant_results
+     */
+    protected function getSolutionsByParticipantResults(assQuestion $question, array $participant_results): array
+    {
+        $solutions = [];
+
+        foreach ($participant_results as $active_id => $result) {
+            foreach ($result->getPasses() as $pass) {
+                foreach ($question->getSolutionValues($active_id, $pass->getPass()) as $row) {
+                    $solutions[] = $row;
+                }
+            }
+        }
+
+        return $solutions;
     }
 
     /**

--- a/Modules/Test/classes/class.ilTestCorrectionsGUI.php
+++ b/Modules/Test/classes/class.ilTestCorrectionsGUI.php
@@ -345,6 +345,7 @@ class ilTestCorrectionsGUI
 
         $scoring = new ilTestScoring($this->testOBJ, $this->database);
         $scoring->setPreserveManualScores(true);
+        $scoring->setQuestionId($question_id);
         $scoring->recalculateSolutions();
 
         $this->main_tpl->setOnScreenMessage('success', $this->language->txt('saved_successfully'));

--- a/Modules/Test/classes/class.ilTestCorrectionsGUI.php
+++ b/Modules/Test/classes/class.ilTestCorrectionsGUI.php
@@ -286,7 +286,10 @@ class ilTestCorrectionsGUI
         $this->main_tpl->parseCurrentBlock();
     }
 
-    protected function showAnswerStatistic($participant_results = null)
+    /**
+     * @param null|array<int, ilTestEvaluationUserData> $participant_results
+     */
+    protected function showAnswerStatistic(?array $participant_results = null)
     {
         $questionGUI = $this->getQuestion((int) $this->testrequest->raw('qid'));
         $solutions = $participant_results

--- a/Modules/Test/classes/class.ilTestCorrectionsGUI.php
+++ b/Modules/Test/classes/class.ilTestCorrectionsGUI.php
@@ -287,7 +287,7 @@ class ilTestCorrectionsGUI
     }
 
     /**
-     * @param null|array<int, ilTestEvaluationUserData> $participant_results
+     * @param null|list<ilTestEvaluationUserData> $participant_results
      */
     protected function showAnswerStatistic(?array $participant_results = null)
     {
@@ -534,7 +534,7 @@ class ilTestCorrectionsGUI
     }
 
     /**
-     * @param array<int, ilTestEvaluationUserData> $participant_results
+     * @param list<ilTestEvaluationUserData> $participant_results
      */
     protected function getSolutionsByParticipantResults(assQuestion $question, array $participant_results): array
     {

--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -88,30 +88,21 @@ class ilTestScoring
         $this->question_id = $question_id;
     }
 
-    public function recalculateSolutions(): void
+    /**
+     * @return ilTestEvaluationUserData[]
+     */
+    public function recalculateSolutions(): array
     {
         $factory = new ilTestEvaluationFactory($this->db, $this->test);
         $this->participants = $factory->getCorrectionsEvaluationData()->getParticipants();
-        if (is_array($this->participants)) {
-            foreach ($this->participants as $active_id => $userdata) {
-                if (is_object($userdata) && is_array($userdata->getPasses())) {
-                    $this->recalculatePasses($userdata, $active_id);
-                }
+
+        foreach ($this->participants as $active_id => $userdata) {
+            if (is_object($userdata) && is_array($userdata->getPasses())) {
+                $this->recalculatePasses($userdata, $active_id);
             }
         }
-        $this->participants = [];
-    }
 
-    public function recalculateSolution(int $active_id, int $pass): void
-    {
-        $user_data = $this
-            ->test
-            ->getCompleteEvaluationData(false)
-            ->getParticipant($active_id)
-            ->getPass($pass);
-
-        $this->recalculatePass($user_data, $active_id, $pass);
-        $this->test->updateTestResultCache($active_id);
+        return $this->participants;
     }
 
     public function recalculatePasses(ilTestEvaluationUserData $userdata, int $active_id): void

--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -55,7 +55,8 @@ class ilTestScoring
      */
     protected array $participants = [];
 
-    protected string $initiator = '';
+    protected string $initiator_name;
+    protected int $initiator_id;
 
     public function __construct(
         private ilObjTest $test,
@@ -63,7 +64,8 @@ class ilTestScoring
     ) {
         global $DIC;
         $this->lng = $DIC->language();
-        $this->initiator = $DIC->user()->getFullname() . " (" . $DIC->user()->getLogin() . ")";
+        $this->initiator_name = $DIC->user()->getFullname() . " (" . $DIC->user()->getLogin() . ")";
+        $this->initiator_id = $DIC->user()->getId();
     }
 
     public function setPreserveManualScores(bool $preserve_manual_scores): void
@@ -217,13 +219,19 @@ class ilTestScoring
         ilCourseObjectiveResult::_updateObjectiveResult(ilObjTest::_getUserIdFromActiveId($active_id), $active_id, $question_id);
         if (ilObjAssessmentFolder::_enabledAssessmentLogging()) {
             $msg = $this->lng->txtlng('assessment', 'log_answer_changed_points', ilObjAssessmentFolder::_getLogLanguage());
-            assQuestion::logAction(sprintf(
+            $msg = sprintf(
                 $msg,
                 $this->participants[$active_id] ? $this->participants[$active_id]->getName() : '',
                 $old_points,
                 $points,
-                $this->initiator
-            ), $active_id, $question_id);
+                $this->initiator_name
+            );
+            ilObjAssessmentFolder::_addLog(
+                $this->initiator_id,
+                $this->test->getId(),
+                $msg,
+                $question_id
+            );
         }
     }
 

--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -77,7 +77,6 @@ class ilTestScoring
                 if (is_object($userdata) && is_array($userdata->getPasses())) {
                     $this->recalculatePasses($userdata, $active_id);
                 }
-                $this->test->updateTestResultCache($active_id);
             }
         }
     }

--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -43,6 +43,11 @@ class ilTestScoring
     private array $recalculated_passes = [];
     private int $question_id = 0;
 
+    /**
+     * @var array<int, assQuestionGUI> $question_cache
+     */
+    protected $question_cache = [];
+
     public function __construct(
         private ilObjTest $test,
         private ilDBInterface $db
@@ -112,12 +117,16 @@ class ilTestScoring
         $questions = $passdata->getAnsweredQuestions();
         if (is_array($questions)) {
             foreach ($questions as $questiondata) {
-                if ($this->getQuestionId() && $this->getQuestionId() != $questiondata['id']) {
+                $q_id = $questiondata['id'];
+                if ($this->getQuestionId() && $this->getQuestionId() != $q_id) {
                     continue;
                 }
 
-                $question_gui = $this->test->createQuestionGUI('', $questiondata['id']);
-                $this->recalculateQuestionScore($question_gui, $active_id, $pass, $questiondata);
+                if (!isset($this->question_cache[$q_id])) {
+                    $this->question_cache[$q_id] = $this->test->createQuestionGUI("", $q_id);
+                }
+
+                $this->recalculateQuestionScore($this->question_cache[$q_id], $active_id, $pass, $questiondata);
             }
         }
     }

--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -43,15 +43,27 @@ class ilTestScoring
     private array $recalculated_passes = [];
     private int $question_id = 0;
 
+    protected ilLanguage $lng;
+
     /**
      * @var array<int, assQuestionGUI> $question_cache
      */
-    protected $question_cache = [];
+    protected array $question_cache = [];
+
+    /**
+     * @var array<int, array{'login': string, 'name': string, 'fullname': string}> $participants
+     */
+    protected array $participants = [];
+
+    protected string $initiator = '';
 
     public function __construct(
         private ilObjTest $test,
         private ilDBInterface $db
     ) {
+        global $DIC;
+        $this->lng = $DIC->language();
+        $this->initiator = $DIC->user()->getFullname() . " (" . $DIC->user()->getLogin() . ")";
     }
 
     public function setPreserveManualScores(bool $preserve_manual_scores): void
@@ -76,6 +88,7 @@ class ilTestScoring
 
     public function recalculateSolutions(): void
     {
+        $this->participants = $this->test->getParticipants();
         $participants = $this->test->getCompleteEvaluationData(false)->getParticipants();
         if (is_array($participants)) {
             foreach ($participants as $active_id => $userdata) {
@@ -107,6 +120,7 @@ class ilTestScoring
                 $this->addRecalculatedPassByActive($active_id, $pass);
             }
         }
+        $this->test->updateTestResultCache($active_id);
     }
 
     public function recalculatePass(
@@ -116,46 +130,100 @@ class ilTestScoring
     ) {
         $questions = $passdata->getAnsweredQuestions();
         if (is_array($questions)) {
-            foreach ($questions as $questiondata) {
-                $q_id = $questiondata['id'];
-                if ($this->getQuestionId() && $this->getQuestionId() != $q_id) {
-                    continue;
+            foreach ($questions as $question_data) {
+                $q_id = $question_data['id'];
+                if (!$this->getQuestionId() || $this->getQuestionId() == $q_id) {
+                    $this->recalculateQuestionScore($q_id, $active_id, $pass, $question_data);
                 }
-
-                if (!isset($this->question_cache[$q_id])) {
-                    $this->question_cache[$q_id] = $this->test->createQuestionGUI("", $q_id);
-                }
-
-                $this->recalculateQuestionScore($this->question_cache[$q_id], $active_id, $pass, $questiondata);
             }
         }
     }
 
-    public function recalculateQuestionScore(
-        assQuestionGUI $question_gui,
-        int $active_id,
-        int $pass,
-        array $questiondata
-    ): void {
-        $reached = $question_gui->object->calculateReachedPoints($active_id, $pass);
-        $actual_reached = $question_gui->object->adjustReachedPointsByScoringOptions($reached, $active_id, $pass);
+    public function recalculateQuestionScore(int $q_id, $active_id, $pass, $questiondata)
+    {
+        if (!isset($this->question_cache[$q_id])) {
+            $this->question_cache[$q_id] = $this->test->createQuestionGUI("", $q_id)->object;
+        }
+        $question = $this->question_cache[$q_id];
+
+        $old_points = $question->getReachedPoints($active_id, $pass);
+        $reached = $question->calculateReachedPoints($active_id, $pass);
+        $actual_reached = $question->adjustReachedPointsByScoringOptions($reached, $active_id, $pass);
 
         if ($this->preserve_manual_scores == true && $questiondata['manual'] == '1') {
             // Do we need processing here?
         } else {
-            assQuestion::setForcePassResultUpdateEnabled(true);
-
-            assQuestion::_setReachedPoints(
+            $this->updateReachedPoints(
                 $active_id,
                 $questiondata['id'],
+                $old_points,
                 $actual_reached,
-                $question_gui->object->getMaximumPoints(),
+                $question->getMaximumPoints(),
                 $pass,
-                false,
-                true
             );
+        }
 
-            assQuestion::setForcePassResultUpdateEnabled(false);
+    }
+
+    /**
+     * This is an optimized version of \assQuestion::_setReachedPoints that only executes updates in the database if
+     * necessary. In addition, unlike the original, this method does NOT update the test cache, so this must also be called
+     * afterward.
+     *
+     * @see assQuestion::_setReachedPoints
+     */
+    public function updateReachedPoints(int $active_id, int $question_id, float $old_points, float $points, float $max_points, int $pass)
+    {
+        // Only update the test results if necessary
+        $has_changed = $old_points != $points;
+        if ($has_changed && $points <= $max_points) {
+            $this->db->update(
+                "tst_test_result",
+                [
+                    'points' => ['float', $points],
+                    'tstamp' => ['integer', time()],
+                ],
+                [
+                    'active_fi' => ['integer', $active_id],
+                    'question_fi' => ['integer', $question_id],
+                    'pass' => ['integer', $pass]
+                ]
+            );
+        }
+
+        // Always update the pass result as the maximum points might have changed
+        $data = ilObjTest::_getQuestionCountAndPointsForPassOfParticipant($active_id, $pass);
+        $values = [
+            'maxpoints' => ['float', $data['points']],
+            'tstamp' => ['integer', time()],
+        ];
+
+        if ($has_changed) {
+            $result = $this->db->queryF(
+                "SELECT SUM(points) reachedpoints FROM tst_test_result WHERE active_fi = %s AND pass = %s",
+                ['integer', 'integer'],
+                [$active_id, $pass]
+            );
+            $values['points'] = ['float', (float) $result->fetchAssoc()['reachedpoints'] || 0];
+        }
+
+        $this->db->update(
+            'tst_pass_result',
+            $values,
+            ['active_fi' => ['integer', $active_id], 'pass' => ['integer', $pass]]
+        );
+
+        ilCourseObjectiveResult::_updateObjectiveResult(ilObjTest::_getUserIdFromActiveId($active_id), $active_id, $question_id);
+        if (ilObjAssessmentFolder::_enabledAssessmentLogging()) {
+            $msg = $this->lng->txtlng('assessment', 'log_answer_changed_points', ilObjAssessmentFolder::_getLogLanguage());
+            $username = $this->participants[$active_id] ? $this->participants[$active_id]["name"] : "";
+            assQuestion::logAction(sprintf(
+                $msg,
+                $username,
+                $old_points,
+                $points,
+                $this->initiator
+            ), $active_id, $question_id);
         }
     }
 

--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -198,7 +198,7 @@ class ilTestScoring
                 ['integer', 'integer'],
                 [$active_id, $pass]
             );
-            $values['points'] = ['float', (float) $result->fetchAssoc()['reachedpoints'] || 0];
+            $values['points'] = ['float', (float) $result->fetchAssoc()['reachedpoints'] ?? 0.0];
         }
 
         $this->db->update(

--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -51,7 +51,7 @@ class ilTestScoring
     protected array $question_cache = [];
 
     /**
-     * @var ilTestEvaluationUserData[] $participants
+     * @var array<int, ilTestEvaluationUserData> $participants
      */
     protected array $participants = [];
 
@@ -89,7 +89,7 @@ class ilTestScoring
     }
 
     /**
-     * @return ilTestEvaluationUserData[]
+     * @return array<int, ilTestEvaluationUserData>
      */
     public function recalculateSolutions(): array
     {
@@ -103,6 +103,18 @@ class ilTestScoring
         }
 
         return $this->participants;
+    }
+
+    public function recalculateSolution(int $active_id, int $pass): void
+    {
+        $user_data = $this
+            ->test
+            ->getCompleteEvaluationData(false)
+            ->getParticipant($active_id)
+            ->getPass($pass);
+
+        $this->recalculatePass($user_data, $active_id, $pass);
+        $this->test->updateTestResultCache($active_id);
     }
 
     public function recalculatePasses(ilTestEvaluationUserData $userdata, int $active_id): void
@@ -123,17 +135,14 @@ class ilTestScoring
         int $pass
     ) {
         $questions = $passdata->getAnsweredQuestions();
-        if (is_array($questions)) {
-            foreach ($questions as $question_data) {
-                $q_id = $question_data['id'];
-                if (!$this->getQuestionId() || $this->getQuestionId() == $q_id) {
-                    $this->recalculateQuestionScore($q_id, $active_id, $pass, $question_data);
-                }
+        foreach ($questions as $question_data) {
+            if (!$this->getQuestionId() || $this->getQuestionId() === $question_data['id']) {
+                $this->recalculateQuestionScore($question_data['id'], $active_id, $pass, $question_data);
             }
         }
     }
 
-    public function recalculateQuestionScore(int $q_id, $active_id, $pass, $questiondata)
+    public function recalculateQuestionScore(int $q_id, int $active_id, int $pass, array $questiondata): void
     {
         if (!isset($this->question_cache[$q_id])) {
             $this->question_cache[$q_id] = $this->test->createQuestionGUI("", $q_id)->object;
@@ -141,22 +150,24 @@ class ilTestScoring
         $question = $this->question_cache[$q_id];
 
         $old_points = $question->getReachedPoints($active_id, $pass);
-        $reached = $question->calculateReachedPoints($active_id, $pass);
-        $actual_reached = $question->adjustReachedPointsByScoringOptions($reached, $active_id, $pass);
+        $reached = $question->adjustReachedPointsByScoringOptions(
+            $question->calculateReachedPoints($active_id, $pass),
+            $active_id,
+            $pass
+        );
 
-        if ($this->preserve_manual_scores == true && $questiondata['manual'] == '1') {
-            // Do we need processing here?
-        } else {
-            $this->updateReachedPoints(
-                $active_id,
-                $questiondata['id'],
-                $old_points,
-                $actual_reached,
-                $question->getMaximumPoints(),
-                $pass,
-            );
+        if ($this->preserve_manual_scores && $questiondata['manual'] == '1') {
+            return;
         }
 
+        $this->updateReachedPoints(
+            $active_id,
+            $questiondata['id'],
+            $old_points,
+            $reached,
+            $question->getMaximumPoints(),
+            $pass,
+        );
     }
 
     /**
@@ -166,13 +177,13 @@ class ilTestScoring
      *
      * @see assQuestion::_setReachedPoints
      */
-    public function updateReachedPoints(int $active_id, int $question_id, float $old_points, float $points, float $max_points, int $pass)
+    public function updateReachedPoints(int $active_id, int $question_id, float $old_points, float $points, float $max_points, int $pass): void
     {
         // Only update the test results if necessary
-        $has_changed = $old_points != $points;
+        $has_changed = $old_points !== $points;
         if ($has_changed && $points <= $max_points) {
             $this->db->update(
-                "tst_test_result",
+                'tst_test_result',
                 [
                     'points' => ['float', $points],
                     'tstamp' => ['integer', time()],
@@ -194,11 +205,11 @@ class ilTestScoring
 
         if ($has_changed) {
             $result = $this->db->queryF(
-                "SELECT SUM(points) reachedpoints FROM tst_test_result WHERE active_fi = %s AND pass = %s",
+                'SELECT SUM(points) reachedpoints FROM tst_test_result WHERE active_fi = %s AND pass = %s',
                 ['integer', 'integer'],
                 [$active_id, $pass]
             );
-            $values['points'] = ['float', (float) $result->fetchAssoc()['reachedpoints'] ?? 0.0];
+            $values['points'] = ['float', $result->fetchAssoc()['reachedpoints'] ?? 0.0];
         }
 
         $this->db->update(

--- a/Modules/Test/test/ilTestScoringTest.php
+++ b/Modules/Test/test/ilTestScoringTest.php
@@ -30,6 +30,7 @@ class ilTestScoringTest extends ilTestBaseTestCase
     {
         global $DIC;
         parent::setUp();
+        $this->addGlobal_ilUser();
 
         $this->testObj = new ilTestScoring(
             $this->createMock(ilObjTest::class),

--- a/Modules/TestQuestionPool/classes/class.assClozeTest.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeTest.php
@@ -891,7 +891,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         $assClozeGapCombinationObj = new assClozeGapCombination();
         $points = 0;
         $gaps_used_in_combination = [];
-        if ($assClozeGapCombinationObj->combinationExistsForQid($this->getId())) {
+        if ($this->gap_combinations_exists) {
             $points = $assClozeGapCombinationObj->getMaxPointsForCombination($this->getId());
             $gaps_used_in_combination = $assClozeGapCombinationObj->getGapsWhichAreUsedInCombination($this->getId());
         }
@@ -1869,7 +1869,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
 
         $assClozeGapCombinationObj = new assClozeGapCombination();
         $combinations[1] = [];
-        if ($assClozeGapCombinationObj->combinationExistsForQid($this->getId())) {
+        if ($this->gap_combinations_exists) {
             $combinations = $this->calculateCombinationResult($user_result);
             $points = $combinations[0];
         }

--- a/Modules/TestQuestionPool/classes/class.assClozeTest.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeTest.php
@@ -1953,7 +1953,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
             }
         }
 
-        return (float)$points;
+        return (float) $points;
     }
 
     public function calculateReachedPointsFromPreviewSession(ilAssQuestionPreviewSession $preview_session)

--- a/Modules/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -285,6 +285,7 @@ JS;
                     $_POST['gap_combination'],
                     $_POST['gap_combination_values']
                 );
+                $this->object->setGapCombinationsExists(true);
             }
         }
         if ($this->ctrl->getCmd() != 'createGaps') {
@@ -1824,5 +1825,6 @@ JS;
             $combinationPoints,
             $combinationValues
         );
+        $this->object->setGapCombinationsExists(true);
     }
 }


### PR DESCRIPTION
Hi everyone,

This PR addresses the issue described in [30750](https://mantis.ilias.de/view.php?id=30750) where the corrections process for adding an answer option in ILIAS is very slow. With this PR, I propose several changes to improve the process performance.

For reproduction, I worked with a test containing 11 questions (10 of them being Cloze Questions) that was completed by 500 participants to achieve approximately the same scale as described in the ticket and to conduct a better comparison.

As can be traced in the commit history, I implemented and tested each change separately step by step. Using comparison checks, I verified that my changes do not alter the expected processing results. This PR includes the following changes:

1. The "Add Answer" operation always explicitly refers to a specific question. However, during point recalculation, every question in the test is updated in the database. I could not identify any scenario where recalculating all questions affects the overall result calculation.
2. Updating the total results (*tst_result_cache*) only after the final recalculation instead of after each update
3. Creation of question objects once; I found that this method is called for each test attempt and rebuilds the same data each time. As far as I can tell, the object has no user state, so it's possible to create the object once and reuse it subsequently
4. Optimized method for updating points and querying all participant results only calculates information relevant to the post-correction process, thereby drastically reducing database queries
5. Optimization of database queries by caching parameters for logging and caching combinations for Cloze-Gaps


Through analysis using external tools, I measured the performance as follows:

- Current status in `release_9`: 103 seconds, ~235,000 database queries, 570MB peak memory
- Status after the last commit in this PR: 1.8 seconds, ~12,000 database queries, 52MB peak memory

The changes and measurement results have been documented in more detail in internal documentation. We can provide this document if needed.

Thank you in advance for the review, I look forward to feedback on these changes.

Best,
@lukas-heinrich 