### PR TITLE
[MathJax] Fix "Read only" für Administration

### DIFF
--- a/components/ILIAS/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
+++ b/components/ILIAS/Administration/classes/class.ilObjExternalToolsSettingsGUI.php
@@ -235,7 +235,9 @@ class ilObjExternalToolsSettingsGUI extends ilObjectGUI
             case 'ilmathjaxsettingsgui':
                 $this->tabs_gui->setTabActive('settings');
                 $this->initSubTabs("editMathJax");
-                $this->ctrl->forwardCommand(new ilMathJaxSettingsGUI());
+                $this->ctrl->forwardCommand(new ilMathJaxSettingsGUI(
+                    $this->rbacsystem->checkAccess('write', $this->object->getRefId())
+                ));
                 break;
 
             case 'ilecssettingsgui':


### PR DESCRIPTION
Resolves https://mantis.ilias.de/view.php?id=44014

This disables all properties on the MathJax settings form if a user has only read access to the administration node. 

Unfortunately, the "Save" button of a UI form can't be omitted. So with "Read only" access, the button is renamed to "Reload" and the form is shown again.