### PR TITLE
Doc/CI: Fix branch for CI badge in README.md (ILIAS 9.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![checks](https://github.com/ILIAS-eLearning/ILIAS/actions/workflows/checks.yml/badge.svg?branch=trunk)](https://github.com/ILIAS-eLearning/ILIAS/actions/workflows/checks.yml)
+[![checks](https://github.com/ILIAS-eLearning/ILIAS/actions/workflows/checks.yml/badge.svg?branch=release_9)](https://github.com/ILIAS-eLearning/ILIAS/actions/workflows/checks.yml)
 [![Supported PHP Version](https://img.shields.io/badge/php-8.1%20%7C%208.2-8892BF.svg)](https://php.net/)
 
 # ILIAS


### PR DESCRIPTION
This PR fixes the branch used for the CI check badge in our README.md file.