### PR TITLE
[FIX] #44019: provide `Input\UploadLimitResolver`

### DIFF
--- a/components/ILIAS/Init/Init.php
+++ b/components/ILIAS/Init/Init.php
@@ -120,6 +120,7 @@ class Init implements Component\Component
                 $pull[\ILIAS\UI\Implementation\Component\Progress\Factory::class],
                 $pull[\ILIAS\UI\Implementation\Component\Progress\State\Factory::class],
                 $pull[\ILIAS\UI\Implementation\Component\Progress\State\Bar\Factory::class],
+                $pull[\ILIAS\UI\Implementation\Component\Input\UploadLimitResolver::class],
             );
     }
 }

--- a/components/ILIAS/Init/src/AllModernComponents.php
+++ b/components/ILIAS/Init/src/AllModernComponents.php
@@ -91,6 +91,7 @@ class AllModernComponents implements \ILIAS\Component\EntryPoint
         protected \ILIAS\UI\Implementation\Component\Progress\Factory $ui_progress_factory,
         protected \ILIAS\UI\Implementation\Component\Progress\State\Factory $ui_progress_state_factory,
         protected \ILIAS\UI\Implementation\Component\Progress\State\Bar\Factory $ui_progress_state_bar_factory,
+        protected \ILIAS\UI\Implementation\Component\Input\UploadLimitResolver $ui_upload_limit_resolver,
     ) {
     }
 
@@ -163,6 +164,7 @@ class AllModernComponents implements \ILIAS\Component\EntryPoint
         $DIC['ui.factory.input.container.form'] = fn() => $this->ui_factory_input_container_form;
         $DIC['ui.factory.input.container.filter'] = fn() => $this->ui_factory_input_container_filter;
         $DIC['ui.factory.input.field'] = fn() => $this->ui_factory_input_field;
+        $DIC['ui.upload_limit_resolver'] = fn() => $this->ui_upload_limit_resolver;
         $DIC['ui.factory'] = fn() => $this->ui_factory;
         $DIC['ui.renderer'] = fn() => $this->ui_renderer;
     }

--- a/components/ILIAS/UI/UI.php
+++ b/components/ILIAS/UI/UI.php
@@ -165,6 +165,8 @@ class UI implements Component\Component
             $internal[UI\Implementation\Component\Prompt\Factory::class];
         $provide[UI\Implementation\Component\Prompt\State\Factory::class] = static fn() =>
             $internal[UI\Implementation\Component\Prompt\State\Factory::class];
+        $provide[UI\Implementation\Component\Input\UploadLimitResolver::class] = static fn() =>
+            $internal[UI\Implementation\Component\Input\UploadLimitResolver::class];
         // =================================================================================
 
         $internal[UI\Implementation\Factory::class] = static fn() =>


### PR DESCRIPTION
Hey guys,

This fixes https://mantis.ilias.de/view.php?id=44019, by adding `UI\Implementation\Component\Input\UploadLimitResolver` to `$DIC` via `Init\AllModernComponents` bridge.

Kind regards,
@thibsy 