### PR TITLE
[FIX] #43712, #43711 UI: `Dropzone\File` test case descriptions.

### DIFF
--- a/components/ILIAS/UI/src/examples/Dropzone/File/Standard/base.php
+++ b/components/ILIAS/UI/src/examples/Dropzone/File/Standard/base.php
@@ -13,7 +13,7 @@ namespace ILIAS\UI\examples\Dropzone\File\Standard;
  *   ILIAS shows a white box with a dashed border. You can see a text "Upload files" (displayed as a link) on the left
  *   side and on the right side the text "Drag files in here to upload them". Clicking onto the link or dragging a file
  *   into the box opens a small window with the buttons "Save" and "Cancel". If you dragged a file into the box you can
- *   see the file in said small window, too. You can upload any number of files. The window will be closed if you click
+ *   see the file in said small window, too. You can upload only one of file. The window will be closed if you click
  *   onto the "Save" button. An upload doesn't happen in this example. If a file got listed after saving your selection
  *   you can remove the file by clicking the "X" on the right side.
  * ---

--- a/components/ILIAS/UI/src/examples/Dropzone/File/Wrapper/with_clear_button.php
+++ b/components/ILIAS/UI/src/examples/Dropzone/File/Wrapper/with_clear_button.php
@@ -12,7 +12,7 @@ namespace ILIAS\UI\examples\Dropzone\File\Wrapper;
  * expected output: >
  *   ILIAS shows a base file wrapper. If you drag a file into the box a small window opens
  *   including three buttons named "Save","Close" and "Clear files!". Clicking the clear button will remove the file.
- *   The upload process works as in the base file wrapper example.
+ *   The upload process will not upload any files and an empty array becomes visible.
  * ---
  */
 function with_clear_button()


### PR DESCRIPTION
Hey guys,

This PR fixes two issues:
- https://mantis.ilias.de/view.php?id=43712, and 
- https://mantis.ilias.de/view.php?id=43711

I bundled them together because they should actually fix the test case descriptions. I assume we need to generate another import file for this? Or would this be too much overhead? We can also adjust the test cases directly.

Let me know how to proceed here.

Kind regards,
@thibsy