### PR TITLE
LegalDocuments: Change submit buttons to refresh page when readonly

### DIFF
--- a/components/ILIAS/DataProtection/classes/Settings.php
+++ b/components/ILIAS/DataProtection/classes/Settings.php
@@ -81,6 +81,9 @@ final class Settings implements SettingsInterface
         return $this->select->typed('dpro_last_reset_date', fn(Marshal $m) => $m->dateTime());
     }
 
+    /**
+     * @return Setting<bool>
+     */
     public function noAcceptance(): Setting
     {
         return $this->select->typed('dpro_no_acceptance', $this->boolean(...));

--- a/components/ILIAS/DataProtection/classes/class.ilObjDataProtectionGUI.php
+++ b/components/ILIAS/DataProtection/classes/class.ilObjDataProtectionGUI.php
@@ -205,6 +205,13 @@ final class ilObjDataProtectionGUI extends ilObject2GUI
             ['enabled' => $enabled]
         );
 
+        if (!$this->config->editable()) {
+            $form = $form->withSubmitLabel($this->lng->txt('refresh'));
+            return $this->legal_documents->admin()->withFormData($form, function () {
+                $this->ctrl->redirect($this, 'settings');
+            });
+        }
+
         return $this->legal_documents->admin()->withFormData($form, function (array $data) use ($no_documents): void {
             if ($no_documents && isset($data['enabled'])) {
                 $this->tpl->setOnScreenMessage('failure', $this->ui->txt('no_documents_exist_cant_save'), true);

--- a/components/ILIAS/TermsOfService/classes/class.ilObjTermsOfServiceGUI.php
+++ b/components/ILIAS/TermsOfService/classes/class.ilObjTermsOfServiceGUI.php
@@ -153,7 +153,10 @@ class ilObjTermsOfServiceGUI extends ilObject2GUI
         );
 
         if ($read_only) {
-            return $form;
+            $form = $form->withSubmitLabel($this->lng->txt('refresh'));
+            return $this->legal_documents->admin()->withFormData($form, function () {
+                $this->ctrl->redirect($this, 'settings');
+            });
         }
 
         return $this->legal_documents->admin()->withFormData($form, function (array $data) use ($no_documents): void {


### PR DESCRIPTION
This PR addresses Mantis Bug: https://mantis.ilias.de/view.php?id=43948

Similar to PR #8982 this PR changes the submit button labels to "Refresh" and just reloads the page when clicked if the user has no write access.