### PR TITLE
AssignCourseMember: add more fields(notification, contact, blocked)

### DIFF
--- a/components/ILIAS/soap/classes/class.ilNusoapUserAdministrationAdapter.php
+++ b/components/ILIAS/soap/classes/class.ilNusoapUserAdministrationAdapter.php
@@ -250,14 +250,17 @@ class ilNusoapUserAdministrationAdapter
             array('sid' => 'xsd:string',
                   'course_id' => 'xsd:int',
                   'user_id' => 'xsd:int',
-                  'type' => 'xsd:string'
+                  'type' => 'xsd:string',
+                  'notification' => 'xsd:int',
+                  'contact_person' => 'xsd:int',
+                  'blocked' => 'xsd:int'
             ),
             array('success' => 'xsd:boolean'),
             SERVICE_NAMESPACE,
             SERVICE_NAMESPACE . '#assignCourseMember',
             SERVICE_STYLE,
             SERVICE_USE,
-            'ILIAS assignCourseMember(). Assigns an user to an existing course. Type should be "Admin", "Tutor" or "Member"'
+            'ILIAS assignCourseMember(). Assigns an user to an existing course. Type should be "Admin", "Tutor" or "Member". Notification, contact_person and blocked should be either 1 or 0.'
         );
 
         // excludeCourseMember()

--- a/components/ILIAS/soap/include/inc.soap_functions.php
+++ b/components/ILIAS/soap/include/inc.soap_functions.php
@@ -79,10 +79,18 @@ class ilSoapFunctions
     /**
      * @return bool|soap_fault|SoapFault|null
      */
-    public static function assignCourseMember(string $sid, int $course_id, int $user_id, string $type)
+    public static function assignCourseMember(
+        string $sid,
+        int $course_id,
+        int $user_id,
+        string $type,
+        ?bool $notification =  null,
+        ?bool $contact_person = null,
+        ?bool $blocked = null
+    )
     {
         $sca = new ilSoapCourseAdministration();
-        return $sca->assignCourseMember($sid, $course_id, $user_id, $type);
+        return $sca->assignCourseMember($sid, $course_id, $user_id, $type, $notification, $contact_person, $blocked);
     }
 
     /**


### PR DESCRIPTION

As per https://docu.ilias.de/go/wiki/wpage_8587_1357 , the   assignCourseMember SOAP Method does not yet support setting the options “Notification” and “Contact Person” (formerly “Tutorielle Betreuung” before ILIAS 9). While these options can already be set manually via the ILIAS UI, there is no way to enable them through SOAP. 
This PR implements these options.