### PR TITLE
LSO: fix component names in export tail dependencies (44084)

### DIFF
--- a/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceExporter.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceExporter.php
@@ -103,7 +103,7 @@ class ilLearningSequenceExporter extends ilXmlExporter
         foreach ($a_ids as $id) {
             if (ilContainerPage::_exists(LSOPageType::INTRO->value, (int) $id)) {
                 $res[] = [
-                    "component" => "Services/COPage",
+                    "component" => "components/ILIAS/COPage",
                     "entity" => "pg",
                     "ids" => [LSOPageType::INTRO->value . ":" . $id]
                 ];
@@ -111,7 +111,7 @@ class ilLearningSequenceExporter extends ilXmlExporter
 
             if (ilContainerPage::_exists(LSOPageType::EXTRO->value, (int) $id)) {
                 $res[] = [
-                    "component" => "Services/COPage",
+                    "component" => "components/ILIAS/COPage",
                     "entity" => "pg",
                     "ids" => [LSOPageType::EXTRO->value . ":" . $id]
                 ];


### PR DESCRIPTION
This PR fixes [44084](https://mantis.ilias.de/view.php?id=44084), looks like a component revision related mixup.