### PR TITLE
UI: 43428, adjust rendering of breadcrumb title.

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Breadcrumbs/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Breadcrumbs/Renderer.php
@@ -38,11 +38,11 @@ class Renderer extends AbstractComponentRenderer
         $tpl = $this->getTemplate("tpl.breadcrumbs.html", true, true);
 
         $tpl->setVariable("ARIA_LABEL", $this->txt('breadcrumbs_aria_label'));
-
-        foreach ($component->getItems() as $crumb) {
+        foreach ($component->getItems() as $key => $crumb) {
             $tpl->setCurrentBlock("crumbs");
             $tpl->setVariable("CRUMB", $default_renderer->render($crumb));
-            if (!preg_match('/[a-zA-Z0-9\ ]$/', $crumb->getLabel())) {
+            if (!preg_match('/[a-zA-Z0-9\ ]$/', $crumb->getLabel())
+                && ($key === array_key_last($component->getItems()))) {
                 $tpl->setCurrentBlock("lrmmark");
                 $tpl->setVariable("LRMMARK", htmlspecialchars_decode("&lrm;", ENT_HTML5));
             }


### PR DESCRIPTION
Only decode special chars if the breadcrumb entry is the last entry, else don't decode the special chars as this step is not necessary in this case and to avoid loosing entries with double and single quotes.

https://mantis.ilias.de/view.php?id=43428