### PR TITLE
Export: Build export target with export object instead of obj id for standard and container export

### DIFF
--- a/components/ILIAS/Export/classes/ExportHandler/I/Manager/HandlerInterface.php
+++ b/components/ILIAS/Export/classes/ExportHandler/I/Manager/HandlerInterface.php
@@ -27,6 +27,7 @@ use ILIAS\Export\ExportHandler\I\Info\Export\Container\ObjectId\CollectionBuilde
 use ILIAS\Export\ExportHandler\I\Info\Export\Container\ObjectId\CollectionInterface as ilExportHandlerContainerExportInfoObjectIdCollectionInterface;
 use ILIAS\Export\ExportHandler\I\Info\Export\HandlerInterface as ilExportHandlerExportInfoInterface;
 use ILIAS\Export\ExportHandler\I\Repository\Element\HandlerInterface as ilExportHandlerRepositoryElementInterface;
+use ilObject;
 
 interface HandlerInterface
 {
@@ -43,6 +44,11 @@ interface HandlerInterface
 
     public function getExportInfo(
         ObjectId $object_id,
+        int $time_stamp
+    ): ilExportHandlerExportInfoInterface;
+
+    public function getExportInfoWithObject(
+        ilObject $export_object,
         int $time_stamp
     ): ilExportHandlerExportInfoInterface;
 

--- a/components/ILIAS/Export/classes/ExportHandler/Manager/Handler.php
+++ b/components/ILIAS/Export/classes/ExportHandler/Manager/Handler.php
@@ -64,6 +64,23 @@ class Handler implements ilExportHandlerManagerInterface
         $this->data_factory_wrapper = $data_factory_wrapper;
     }
 
+    protected function getExportTargetWithObject(
+        ilObject $export_object
+    ) {
+        $obj_id = $export_object->getId();
+        $type = $export_object->getType();
+        $class = ilImportExportFactory::getExporterClass($type);
+        $comp = ilImportExportFactory::getComponentForExport($type);
+        $v = explode(".", ILIAS_VERSION_NUMERIC);
+        $target_release = $v[0] . "." . $v[1] . ".0";
+        return $this->export_handler->target()->handler()
+            ->withTargetRelease($target_release)
+            ->withType($type)
+            ->withObjectIds([$obj_id])
+            ->withClassname($class)
+            ->withComponent($comp);
+    }
+
     protected function getExportTarget(
         ObjectId $object_id
     ): ilExportHandlerTargetInterface {
@@ -188,6 +205,14 @@ class Handler implements ilExportHandlerManagerInterface
     ): ilExportHandlerExportInfoInterface {
         return $this->export_handler->info()->export()->handler()
             ->withTarget($this->getExportTarget($object_id), $time_stamp);
+    }
+
+    public function getExportInfoWithObject(
+        ilObject $export_object,
+        int $time_stamp
+    ): ilExportHandlerExportInfoInterface {
+        return $this->export_handler->info()->export()->handler()
+            ->withTarget($this->getExportTargetWithObject($export_object), $time_stamp);
     }
 
     public function getContainerExportInfo(

--- a/components/ILIAS/Export/classes/class.ilExportGUI.php
+++ b/components/ILIAS/Export/classes/class.ilExportGUI.php
@@ -267,8 +267,8 @@ class ilExportGUI
     final protected function createXMLExport()
     {
         $manager = $this->export_handler->manager()->handler();
-        $export_info = $manager->getExportInfo(
-            $this->data_factory->objId($this->obj->getId()),
+        $export_info = $manager->getExportInfoWithObject(
+            $this->obj,
             time()
         );
         $element = $manager->createExport(
@@ -318,8 +318,8 @@ class ilExportGUI
         }
         $manager = $this->export_handler->manager()->handler();
         if (count($ref_ids_all) === 1) {
-            $export_info = $manager->getExportInfo(
-                $this->data_factory->objId($this->obj->getId()),
+            $export_info = $manager->getExportInfoWithObject(
+                $this->obj,
                 time()
             );
             $element = $manager->createExport(


### PR DESCRIPTION
Some Components change the object data with setters bevore the export and expect the export to honor these changes.

Bevore this PR the object data was read by using the object id of the export object. After this PR the object data is aquired from the export object directly.
