### PR TITLE
T&A 44021: Redirects to test tab instead of info tab when maximum available time is reached in test

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/components/ILIAS/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -253,7 +253,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
         if (!$executable['executable']) {
             $this->tpl->setOnScreenMessage('info', $executable['errormessage'], true);
-            $this->ctrl->redirectByClass([ilRepositoryGUI::class, ilObjTestGUI::class, ilInfoScreenGUI::class]);
+            $this->ctrl->redirectByClass([ilRepositoryGUI::class, ilObjTestGUI::class, TestScreenGUI::class]);
         }
     }
 


### PR DESCRIPTION
[Mantis: 44021](https://mantis.ilias.de/view.php?id=44021)

This also affects other behaviour such as:
- When the starting time is not reached yet
- **When the ending time is reached**
- When maximum processing time is reached
- When maximum number of tries is reached
- When test is already passed and it is blocked to retake it
- When waiting for next pass

As of right now, all of these would also bo affected. They would redirect to the test tab, instead of info tab.