### PR TITLE
Administration: Raise intead of throw error on permission denied

### DIFF
--- a/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
+++ b/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
@@ -76,6 +76,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
     protected int $requested_obj_id = 0;
     protected AdminGUIRequest $request;
     protected ilObjectGUI $gui_obj;
+    private readonly ilErrorHandling $error;
 
     public function __construct()
     {
@@ -98,6 +99,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
         $this->rbacsystem = $rbacsystem;
         $this->objDefinition = $objDefinition;
         $this->ctrl = $ilCtrl;
+        $this->error = $DIC['ilErr'];
 
         $context = $DIC->globalScreen()->tool()->context();
         $context->claim()->administration();
@@ -142,7 +144,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
         // permission checks
         if (!$rbacsystem->checkAccess("visible", SYSTEM_FOLDER_ID) &&
                 !$rbacsystem->checkAccess("read", SYSTEM_FOLDER_ID)) {
-            throw new ilPermissionException($this->lng->txt('permission_denied'));
+            $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
         // check creation mode


### PR DESCRIPTION
This PR fixes Mantis Bug: https://mantis.ilias.de/view.php?id=43548

With this change the user will be redirected to a public page and shown the error message instead of throwing a hard error.