### PR TITLE
[FIX] #44148 UI: `Field\SwitchableGroup::withValue()` in all contexts

### DIFF
--- a/components/ILIAS/UI/src/examples/Input/Field/SwitchableGroup/with_value.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/SwitchableGroup/with_value.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\SwitchableGroup;
+
+/**
+ * ---
+ * description: >
+ *   Example showing two Switchable Group Fields provided with existing value(s).
+ *
+ * expected output: >
+ *   ILIAS shows two Switchable Group Fields. The first (above) one has the "Group 2" option
+ *   selected with the "Item 2" Field having NO value. The second (below) one has the "Group 2"
+ *   option selected with the "Item 2" Field having "some existing text value" as a value.
+ * ---
+ */
+function with_value(): string
+{
+    global $DIC;
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $group_one = $factory->input()->field()->group([$factory->input()->field()->text("Item 1", "Just some field")], "Group 1");
+    $group_two = $factory->input()->field()->group([$factory->input()->field()->text("Item 2", "Just some field")], "Group 2");
+
+    $switchable_group = $factory->input()->field()->switchableGroup(
+        [$group_one, $group_two],
+        "Switchable Group with existing value(s)",
+    );
+
+    // tells the input only which option is selected
+    $direct_value = $switchable_group->withValue(1);
+
+    // tells the input which option is selected and what value(s) it has
+    $nested_value = $switchable_group->withValue([1, ['some existing text value']]);
+
+    $form = $factory->input()->container()->form()->standard('#', [$direct_value, $nested_value]);
+
+    return $renderer->render($form);
+}

--- a/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
@@ -39,6 +39,10 @@ class Group1 extends Group
 
 class Group2 extends Group
 {
+    public function isClientSideValueOk($value): bool
+    {
+        return parent::isClientSideValueOk($value);
+    }
 }
 
 class SwitchableGroupInputTest extends ILIAS_UI_TestBase
@@ -185,12 +189,15 @@ class SwitchableGroupInputTest extends ILIAS_UI_TestBase
             ->expects($this->never())
             ->method("withValue");
         $this->child2
+            ->method('isClientSideValueOk')
+            ->willReturn(true);
+        $this->child2
             ->expects($this->once())
             ->method("withValue")
-            ->with(2)
+            ->with([2])
             ->willReturn($this->child2);
 
-        $new_group = $this->switchable_group->withValue(["child2", 2]);
+        $new_group = $this->switchable_group->withValue(["child2", [2]]);
 
         $this->assertEquals(["child1" => $this->child1, "child2" => $this->child2], $new_group->getInputs());
         $this->assertInstanceOf(SwitchableGroup::class, $new_group);


### PR DESCRIPTION
Hi folks, 

This PR fixes https://mantis.ilias.de/view.php?id=44148, by making `Field\SwitchableGroup::withValue()` call `isClientSideValueOK()` as well. Up till now this only happened when the input was nested in a `Field\Group` or similar, which lead to different behaviour depending on its context.

I let you decide how far down you want to pick this fix; the issue exists in all maintained versions.

Kind regards,
@thibsy 