### PR TITLE
Mantis #44126 ILIAS 9: Only show a generic error message on error after auth failure

### DIFF
--- a/Services/Authentication/classes/Frontend/class.ilAuthFrontend.php
+++ b/Services/Authentication/classes/Frontend/class.ilAuthFrontend.php
@@ -234,6 +234,7 @@ class ilAuthFrontend
     {
         $user = ilObjectFactory::getInstanceByObjId($this->getStatus()->getAuthenticatedUserId(), false);
 
+        $this->getStatus()->setReason('auth_err_invalid_user_account');
         // reset expired status
         $this->getAuthSession()->setExpired(false);
 
@@ -241,7 +242,6 @@ class ilAuthFrontend
             $this->logger->error('Cannot instantiate user account with id: ' . $this->getStatus()->getAuthenticatedUserId());
             $this->getStatus()->setStatus(ilAuthStatus::STATUS_AUTHENTICATION_FAILED);
             $this->getStatus()->setAuthenticatedUserId(ANONYMOUS_USER_ID);
-            $this->getStatus()->setReason('auth_err_invalid_user_account');
             return false;
         }
 
@@ -249,7 +249,6 @@ class ilAuthFrontend
             $this->logger->info('Authentication failed for inactive user with id and too may login attempts: ' . $this->getStatus()->getAuthenticatedUserId());
             $this->getStatus()->setStatus(ilAuthStatus::STATUS_AUTHENTICATION_FAILED);
             $this->getStatus()->setAuthenticatedUserId(ANONYMOUS_USER_ID);
-            $this->getStatus()->setReason('auth_err_login_attempts_deactivation');
             return false;
         }
 
@@ -257,7 +256,6 @@ class ilAuthFrontend
             $this->logger->info('Authentication failed for inactive user with id: ' . $this->getStatus()->getAuthenticatedUserId());
             $this->getStatus()->setStatus(ilAuthStatus::STATUS_AUTHENTICATION_FAILED);
             $this->getStatus()->setAuthenticatedUserId(ANONYMOUS_USER_ID);
-            $this->getStatus()->setReason('err_inactive');
             return false;
         }
 
@@ -273,7 +271,6 @@ class ilAuthFrontend
                 $this->getStatus()->setStatus(ilAuthStatus::STATUS_AUTHENTICATION_FAILED);
                 $this->getStatus()->setAuthenticatedUserId(ANONYMOUS_USER_ID);
             }
-            $this->getStatus()->setReason('time_limit_reached');
             return false;
         }
 
@@ -282,13 +279,6 @@ class ilAuthFrontend
             $this->logger->info('Authentication failed (wrong ip) for user with id: ' . $this->getStatus()->getAuthenticatedUserId());
             $this->getStatus()->setStatus(ilAuthStatus::STATUS_AUTHENTICATION_FAILED);
             $this->getStatus()->setAuthenticatedUserId(ANONYMOUS_USER_ID);
-
-            $this->getStatus()->setTranslatedReason(
-                sprintf(
-                    $this->lng->txt('wrong_ip_detected'),
-                    $_SERVER['REMOTE_ADDR']
-                )
-            );
             return false;
         }
 
@@ -298,7 +288,6 @@ class ilAuthFrontend
             $this->logger->info('Authentication failed: simultaneous logins forbidden for user: ' . $this->getStatus()->getAuthenticatedUserId());
             $this->getStatus()->setStatus(ilAuthStatus::STATUS_AUTHENTICATION_FAILED);
             $this->getStatus()->setAuthenticatedUserId(ANONYMOUS_USER_ID);
-            $this->getStatus()->setReason('simultaneous_login_detected');
             return false;
         }
 

--- a/Services/Authentication/classes/Frontend/class.ilAuthFrontend.php
+++ b/Services/Authentication/classes/Frontend/class.ilAuthFrontend.php
@@ -357,6 +357,7 @@ class ilAuthFrontend
                 'username' => $user->getLogin())
         );
 
+        $this->getStatus()->setReason('');
         return true;
     }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2017,7 +2017,6 @@ auth#:#auth_cron_destroy_expired_sessions_desc#:#Dieser Cron-Job löscht bereits
 auth#:#auth_err_expired#:#Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.
 auth#:#auth_err_invalid_user_account#:#Die Authentifizierung konnte wegen eines internen Fehlers nicht durchgeführt werden.
 auth#:#auth_err_ldap_exception#:#Die Authentifizierung konnte wegen eines Fehlers im Anmeldungsverfahren (LDAP) nicht durchgeführt werden.
-auth#:#auth_err_login_attempts_deactivation#:#Das ILIAS-Konto wurde wegen zu vieler falscher Login-Versuche deaktiviert.
 auth#:#auth_info_add#:#Wählen Sie diese Einstellung, falls Sie sich noch nie für ILIAS registriert haben. In diesem Fall wird ein neues ILIAS-Konto angelegt.
 auth#:#auth_info_migrate#:#Wenn Sie bereits ein ILIAS-Konto besitzen, geben Sie bitte den Anmeldenamen und das Passwort ein, um Ihre persönlichen Daten (Mails, Testergebnisse ...) zu übernehmen.
 auth#:#auth_ldap_server_ds#:#LDAP-Server
@@ -5634,7 +5633,6 @@ common#:#show_users_online#:#Aktive Benutzer anzeigen
 common#:#show_who_is_online#:#Zeig wer online ist
 common#:#side_frame#:#Rahmen Baumansicht
 common#:#signature#:#Signatur
-common#:#simultaneous_login_detected#:#Der Zugang zum System wird verweigert, da sich bereits ein Benutzer mit diesen Zugangsdaten in einer ILIAS-Sitzung befindet.
 common#:#size#:#Größe
 common#:#skills#:#Kompetenzen
 common#:#skin_style#:#Standard-Skin/-Style
@@ -6011,7 +6009,6 @@ common#:#withdrawal_sure_account_no_consent_yet#:#Sind Sie sicher, dass Sie Ihr 
 common#:#wizard_search_list#:#Ihre Suche ergab folgende Ergebnisse. Bitte wählen Sie eines aus.
 common#:#wizard_title_info#:#Geben Sie bitte den Titel ein, um das Objekt zu suchen, das Sie kopieren wollen. Auch Teile des Titels reichen aus. Klicken Sie auf „Suchen“, um die Treffer angezeigt zu bekommen.
 common#:#write#:#Schreiben
-common#:#wrong_ip_detected#:#Der Zugang zum System wird aufgrund einer falschen Client IP verweigert.<br>Ihre aktuelle IP-Adresse: %s<br>Bitte kontaktieren Sie die Technische Betreuung / Systemadministration.
 common#:#year#:#Jahr
 common#:#yearly#:#jährlich
 common#:#years#:#Jahre

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2017,7 +2017,6 @@ auth#:#auth_cron_destroy_expired_sessions_desc#:#This job deletes expires sessio
 auth#:#auth_err_expired#:#Your session has been deactivated due to inactivity.
 auth#:#auth_err_invalid_user_account#:#Authentication failed due to an internal failure.
 auth#:#auth_err_ldap_exception#:#Authentication failed due to an internal authentication failure (LDAP).
-auth#:#auth_err_login_attempts_deactivation#:#This user account has been deactivated due to too many incorrect login attempts.
 auth#:#auth_info_add#:#Choose this option if you have never registered to ILIAS. A new account will be created.
 auth#:#auth_info_migrate#:#If you have already an ILIAS account, enter username and password to migrate your personal data (mail, test results...).
 auth#:#auth_ldap_server_ds#:#LDAP-Server
@@ -5634,7 +5633,6 @@ common#:#show_users_online#:#Show active users
 common#:#show_who_is_online#:#Show who is online
 common#:#side_frame#:#Side Frame
 common#:#signature#:#Signature
-common#:#simultaneous_login_detected#:#Your access is denied because of a simultaneous login with the same account.
 common#:#size#:#Size
 common#:#skills#:#Competences
 common#:#skin_style#:#Default Skin / Style
@@ -6011,7 +6009,6 @@ common#:#withdrawal_sure_account_no_consent_yet#:#Are you sure that you do not w
 common#:#wizard_search_list#:#Your search produced the following hits. Please select one of them.
 common#:#wizard_title_info#:#Search for the object you want to duplicate. Please enter the object's title or a part of it and click on 'Continue' to get matching search results.
 common#:#write#:#Write
-common#:#wrong_ip_detected#:#Your access is denied because of a wrong client ip.<br>You are currently using this IP address: %s<br>Please contact the system administrator.
 common#:#year#:#Year
 common#:#yearly#:#yearly
 common#:#years#:#Years


### PR DESCRIPTION
This PR changes the error message presented on the login page.

See: https://mantis.ilias.de/view.php?id=44126