### PR TITLE
Session: disallow timing-action for objects on info screen (43327)

### DIFF
--- a/components/ILIAS/Session/classes/class.ilObjSessionGUI.php
+++ b/components/ILIAS/Session/classes/class.ilObjSessionGUI.php
@@ -277,11 +277,6 @@ class ilObjSessionGUI extends ilObjectGUI implements ilDesktopItemHandling
         $this->addHeaderAction();
     }
 
-    protected function renderObject(): void
-    {
-        $this->infoScreenObject();
-    }
-
     protected function membersObject(): void
     {
         $this->ctrl->redirectByClass('ilSessionMembershipGUI', 'participants');

--- a/components/ILIAS/Session/classes/class.ilSessionObjectListGUIFactory.php
+++ b/components/ILIAS/Session/classes/class.ilSessionObjectListGUIFactory.php
@@ -56,6 +56,7 @@ class ilSessionObjectListGUIFactory
         if (!$item_list_gui instanceof ilObjectListGUI) {
             return null;
         }
+        $item_list_gui->enableTimings(false);
         $item_list_gui->enableDelete(false);
         $item_list_gui->enableCut(false);
         $item_list_gui->enableCopy(false);

--- a/components/ILIAS/Session/classes/class.ilSessionObjectListGUIFactory.php
+++ b/components/ILIAS/Session/classes/class.ilSessionObjectListGUIFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  ********************************************************************
  */
+
+declare(strict_types=1);
 
 /**
  * @classDescription List GUI factory for session materials in session objects


### PR DESCRIPTION
This PR 'fixes' [43327](https://mantis.ilias.de/view.php?id=43327) by removing the broken action from the object list. It also removes `ilObjSessionGUI::renderObject`, since that method was only added to make the action work.