### PR TITLE
Search: fix links in main menu search, get rid of search_last_class

### DIFF
--- a/components/ILIAS/Search/classes/ObjGUI/class.ilObjSearchLuceneSettingsFormGUI.php
+++ b/components/ILIAS/Search/classes/ObjGUI/class.ilObjSearchLuceneSettingsFormGUI.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\DI\UIServices;
@@ -135,7 +136,6 @@ class ilObjSearchLuceneSettingsFormGUI
                 $this->coordinator->refreshLuceneSettings();
             }
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('settings_saved'), true);
-            ilSession::clear('search_last_class');
             $this->ctrl->redirect($this, 'edit');
         } catch (Exception $exception) {
             $this->tpl->setOnScreenMessage('failure', $exception->getMessage());

--- a/components/ILIAS/Search/classes/ObjGUI/class.ilObjSearchSettingsFormGUI.php
+++ b/components/ILIAS/Search/classes/ObjGUI/class.ilObjSearchSettingsFormGUI.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\HTTP\GlobalHttpState;
 use ILIAS\DI\UIServices;
@@ -136,7 +137,6 @@ class ilObjSearchSettingsFormGUI
                 $this->coordinator->refreshLuceneSettings();
             }
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('settings_saved'), true);
-            ilSession::clear('search_last_class');
             $this->ctrl->redirect($this, 'edit');
         } catch (Exception $exception) {
             $this->tpl->setOnScreenMessage('failure', $exception->getMessage());


### PR DESCRIPTION
This PR adapts Search to the ilCtrl refactorings, by shifting the logic for selecting the correct GUI class from `ilSearchControllerGUI::executeCommand` to `ilMainMenuSearchGUI` where the links into Search are build. Additionally, it get rids of the `search_last_class` mechanism, which did not seem to be working.