### PR TITLE
[FIX] #44176 UI: add support for all `Field\File` metadata inputs.

### DIFF
--- a/components/ILIAS/File/classes/class.ilObjFileGUI.php
+++ b/components/ILIAS/File/classes/class.ilObjFileGUI.php
@@ -422,6 +422,7 @@ class ilObjFileGUI extends ilObject2GUI
         $inputs[self::PARAM_FILES] = $this->ui->factory()->input()->field()->file(
             $this->upload_handler,
             $this->lng->txt('upload_files'),
+            null,
             $this->ui->factory()->input()->field()->group([
                 self::PARAM_TITLE => $this->ui->factory()->input()->field()->text(
                     $this->lng->txt('title')
@@ -484,14 +485,14 @@ class ilObjFileGUI extends ilObject2GUI
 
         $errors = false;
         foreach ($files as $file_data) {
-            $rid = $this->storage->manage()->find($file_data[$this->upload_handler->getFileIdentifierParameterName()]);
+            $rid = $this->storage->manage()->find($file_data[0]);
             if (null !== $rid) {
                 try {
                     $processor->process(
                         $rid,
-                        $file_data[self::PARAM_TITLE] ?? null,
-                        $file_data[self::PARAM_DESCRIPTION] ?? null,
-                        $data[self::PARAM_COPYRIGHT_ID] ?? $data[1] ?? null
+                        $file_data[1][self::PARAM_TITLE] ?? null,
+                        $file_data[1][self::PARAM_DESCRIPTION] ?? null,
+                        $data[self::PARAM_COPYRIGHT_ID] ?? null
                     );
                 } catch (Throwable $t) {
                     $errors = true;

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
@@ -136,6 +136,7 @@ class Factory implements I\Factory
             $this->data_factory,
             $this->refinery,
             $this->upload_limit_resolver,
+            $this,
             $handler,
             $label,
             $metadata_input,

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/File.php
@@ -55,6 +55,7 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
         DataFactory $data_factory,
         Refinery $refinery,
         UploadLimitResolver $upload_limit_resolver,
+        Factory $field_factory,
         C\Input\Field\UploadHandler $handler,
         string $label,
         ?FormInput $metadata_input,
@@ -73,7 +74,7 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
             $data_factory,
             $refinery,
             $label,
-            $this->createDynamicInputsTemplate($metadata_input),
+            $this->createDynamicInputsTemplate($field_factory, $metadata_input),
             $byline
         );
     }
@@ -142,9 +143,8 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
         $this->checkArg("value", $this->isClientSideValueOk($value), "Display value does not match input type.");
 
         $clone = clone $this;
-        $identifier_key = $clone->upload_handler->getFileIdentifierParameterName();
         foreach ($value as $data) {
-            $file_id = ($clone->hasMetadataInputs()) ? $data[$identifier_key] : $data;
+            $file_id = ($clone->hasMetadataInputs()) ? $data[0] : $data;
 
             // that was not implicitly intended, but mapping dynamic inputs
             // to the file-id is also a duplicate protection.
@@ -210,53 +210,26 @@ class File extends HasDynamicInputsBase implements C\Input\Field\File
             if (!is_string($data) && !$this->hasMetadataInputs()) {
                 return false;
             }
-
-            if ($this->hasMetadataInputs()) {
-                // if a dynamic input template was provided, the values
-                // must all contain the file-id as an array entry.
-                if (!array_key_exists($this->upload_handler->getFileIdentifierParameterName(), $data)) {
-                    return false;
-                }
-
-                // if a dynamic input template was provided, the values
-                // must be valid for the template input.
-                if (!$this->dynamic_input_template->isClientSideValueOk($data)) {
-                    return false;
-                }
+            // if a dynamic input template was provided, the values
+            // must be valid for the template input.
+            if ($this->hasMetadataInputs() && !$this->dynamic_input_template->isClientSideValueOk($data)) {
+                return false;
             }
         }
 
         return true;
     }
 
-    protected function createDynamicInputsTemplate(?FormInput $metadata_input): FormInput
+    protected function createDynamicInputsTemplate(Factory $field_factory, ?FormInput $metadata_input): FormInput
     {
-        $default_metadata_input = new Hidden(
-            $this->data_factory,
-            $this->refinery
-        );
+        $file_id_input = $field_factory->hidden();
 
         if (null === $metadata_input) {
-            return $default_metadata_input;
+            return $file_id_input;
         }
 
-        $inputs = ($metadata_input instanceof C\Input\Field\Group) ?
-            $metadata_input->getInputs() : [
-                $metadata_input,
-            ];
-
-        // map the file-id input to the UploadHandlers identifier key.
-        $inputs[$this->upload_handler->getFileIdentifierParameterName()] = $default_metadata_input;
-
-        // tell the input that it contains actual metadata inputs.
         $this->has_metadata_inputs = true;
 
-        return new Group(
-            $this->data_factory,
-            $this->refinery,
-            $this->language,
-            $inputs,
-            ''
-        );
+        return $field_factory->group([$file_id_input, $metadata_input]);
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -764,14 +764,13 @@ class Renderer extends AbstractComponentRenderer
         return $this->wrapInFormContext($component, $component->getLabel(), $tpl->get(), $label_id);
     }
 
-    protected function renderFileField(FI\File $input, RendererInterface $default_renderer): string
+    protected function renderFileField(F\File $input, RendererInterface $default_renderer): string
     {
         $template = $this->getTemplate('tpl.file.html', true, true);
         foreach ($input->getDynamicInputs() as $metadata_input) {
             $file_info = null;
             if (null !== ($data = $metadata_input->getValue())) {
-                $file_id = (!$input->hasMetadataInputs()) ?
-                    $data : $data[$input->getUploadHandler()->getFileIdentifierParameterName()] ?? null;
+                $file_id = (!$input->hasMetadataInputs()) ? $data : $data[0] ?? null;
 
                 if (null !== $file_id) {
                     $file_info = $input->getUploadHandler()->getInfoResult($file_id);

--- a/components/ILIAS/UI/src/examples/Input/Field/File/with_metadata.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/File/with_metadata.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Input\Field\File;
+
+/**
+ * ---
+ * description: >
+ *   Example of how to create and render a File Field with ab additional metadata Field
+ *   and attach it to a form. This example does not show any processing.
+ *
+ * expected output: >
+ *   ILIAS shows the File Field inside a Standard Form. Its label and byline are correctly
+ *   rendered next to and underneath the actual input, which is displayed as a Shy Button
+ *   inside a discernible box. You can choose a file by dragging it onto this box, or by
+ *   clicking Shy Button inside it, which opens a file browser window. Once you have choosen
+ *   a file, a new file entry above the discernible box will show appear. Clicking the Glyph
+ *   next to the name of your file will expand the entry further. Another Field becomes
+ *   visible, which can be used to provide more information about the file. Submitting the
+ *   Standard Form has no effect because the example does not implement any processing.
+ * ---
+ */
+function with_metadata(): string
+{
+    global $DIC;
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $file_input = $factory->input()->field()->file(
+        new \ilUIDemoFileUploadHandlerGUI(),
+        "Upload File",
+        "After choosing the file you can add additional metadata.",
+        $factory->input()->field()->switchableGroup([
+            $factory->input()->field()->group([$factory->input()->field()->text('New filename')], 'Yes'),
+            $factory->input()->field()->group([], 'No'),
+        ], 'Change filename?'),
+    );
+
+    $form = $factory->input()->container()->form()->standard("#", [$file_input]);
+
+    return $renderer->render($form);
+}

--- a/components/ILIAS/UI/tests/Component/Input/Field/FileInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/FileInputTest.php
@@ -279,7 +279,7 @@ class FileInputTest extends ILIAS_UI_TestBase
             $metadata_input
         )->withValue([
             [
-                $u->getFileIdentifierParameterName() => "file_id",
+                "file_id",
                 ""
             ]
         ])->withNameFrom($this->name_source);
@@ -291,40 +291,28 @@ class FileInputTest extends ILIAS_UI_TestBase
             <div class="ui-input-file">
                 <div class="ui-input-file-input-list">
                     <div class="ui-input-file-input">
-                        <div class="ui-input-file-info">
-                            <span data-action="expand">
-                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content">
-                                    <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-action="collapse">
-                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content">
-                                    <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-dz-name></span>
-                            <span data-dz-size></span>
-                            <span data-action="remove">
-                                <a tabindex="0" class="glyph" href="#" aria-label="close">
-                                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                        </div>
-                        <div class="ui-input-file-metadata" style="display: none;">
-                            <fieldset class="c-input" data-il-ui-component="text-field-input" data-il-ui-input-name="name_0[input_1][]">
-                                <label for="id_1">text_input</label>
-                                <div class="c-input__field">
-                                    <input id="id_1" type="text" name="name_0[input_1][]" class="c-field-text"/>
-                                </div>
+                        <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph" href="#"
+                                    aria-label="expand_content"><span class="glyphicon glyphicon-triangle-right"
+                                        aria-hidden="true"></span></a></span><span data-action="collapse"><a tabindex="0"
+                                    class="glyph" href="#" aria-label="collapse_content"><span
+                                        class="glyphicon glyphicon-triangle-bottom"
+                                        aria-hidden="true"></span></a></span><span data-dz-name></span><span
+                                data-dz-size></span><span data-action="remove"><a tabindex="0" class="glyph" href="#"
+                                    aria-label="close"><span class="glyphicon glyphicon-remove"
+                                        aria-hidden="true"></span></a></span><span class="ui-input-file-input-error-msg"
+                                data-dz-error-msg></span></div>
+                        <div class="ui-input-file-metadata" style="display: none;"><input id="id_1" type="hidden"
+                                name="name_0[input_1][]" value="file_id" />
+                            <fieldset class="c-input" data-il-ui-component="text-field-input"
+                                data-il-ui-input-name="name_0[input_2][]"><label for="id_2">text_input</label>
+                                <div class="c-input__field"><input id="id_2" type="text" name="name_0[input_2][]"
+                                        class="c-field-text" /></div>
                             </fieldset>
-                            <input id="id_2" type="hidden" name="name_0[input_2][]" value="file_id"/>
                         </div>
                         <div class="ui-input-file-input-progress-container">
                             <div class="ui-input-file-input-progress-indicator"></div>
                         </div>
-                    </div>
-                    <template>
+                    </div><template>
                         <div class="ui-input-file-input">
                             <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph"
                                         href="#" aria-label="expand_content"><span
@@ -337,12 +325,13 @@ class FileInputTest extends ILIAS_UI_TestBase
                                         aria-label="close"><span class="glyphicon glyphicon-remove"
                                             aria-hidden="true"></span></a></span><span class="ui-input-file-input-error-msg"
                                     data-dz-error-msg></span></div>
-                            <div class="ui-input-file-metadata" style="display: none;">
+                            <div class="ui-input-file-metadata" style="display: none;"><input id="id_3" type="hidden"
+                                    name="name_0[input_1][]" value="" />
                                 <fieldset class="c-input" data-il-ui-component="text-field-input"
-                                    data-il-ui-input-name="name_0[input_1][]"><label for="id_3">text_input</label>
-                                    <div class="c-input__field"><input id="id_3" type="text" name="name_0[input_1][]"
+                                    data-il-ui-input-name="name_0[input_2][]"><label for="id_4">text_input</label>
+                                    <div class="c-input__field"><input id="id_4" type="text" name="name_0[input_2][]"
                                             class="c-field-text" /></div>
-                                </fieldset><input id="id_4" type="hidden" name="name_0[input_2][]" value="" />
+                                </fieldset>
                             </div>
                             <div class="ui-input-file-input-progress-container">
                                 <div class="ui-input-file-input-progress-indicator"></div>
@@ -350,10 +339,9 @@ class FileInputTest extends ILIAS_UI_TestBase
                         </div>
                     </template>
                 </div>
-                <div class="ui-input-file-input-dropzone">
-                    <button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button>
-                    <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                </div>
+                <div class="ui-input-file-input-dropzone"><button class="btn btn-link" data-action="#"
+                        id="id_5">select_files_from_computer</button><span class="ui-input-file-input-error-msg"
+                        data-dz-error-msg></span></div>
                 <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1</div>
             </div>
             ',
@@ -385,7 +373,7 @@ class FileInputTest extends ILIAS_UI_TestBase
             $metadata_input
         )->withValue([
             [
-                $u->getFileIdentifierParameterName() => $test_file_id,
+                $test_file_id,
                 "test",
             ]
         ])->withNameFrom($this->name_source);
@@ -398,64 +386,47 @@ class FileInputTest extends ILIAS_UI_TestBase
             <div class="ui-input-file">
                 <div class="ui-input-file-input-list">
                     <div class="ui-input-file-input">
-                        <div class="ui-input-file-info">
-                            <span data-action="expand">
-                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content">
-                                    <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-action="collapse">
-                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content">
-                                    <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-dz-name>test file name 1</span>
-                            <span data-dz-size>1 MB</span>
-                            <span data-action="remove">
-                                <a tabindex="0" class="glyph" href="#" aria-label="close">
-                                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                        </div>
-                        <div class="ui-input-file-metadata" style="display: none;">
-                            <fieldset class="c-input" data-il-ui-component="text-field-input" data-il-ui-input-name="name_0[input_1][]">
-                                <label for="id_1">text_input</label>
-                                <div class="c-input__field">
-                                    <input id="id_1" type="text" value="test" name="name_0[input_1][]" class="c-field-text"/>
-                                </div>
+                        <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph" href="#"
+                                    aria-label="expand_content"><span class="glyphicon glyphicon-triangle-right"
+                                        aria-hidden="true"></span></a></span><span data-action="collapse"><a tabindex="0"
+                                    class="glyph" href="#" aria-label="collapse_content"><span
+                                        class="glyphicon glyphicon-triangle-bottom"
+                                        aria-hidden="true"></span></a></span><span data-dz-name>test file name 1</span><span
+                                data-dz-size>1 MB</span><span data-action="remove"><a tabindex="0" class="glyph" href="#"
+                                    aria-label="close"><span class="glyphicon glyphicon-remove"
+                                        aria-hidden="true"></span></a></span><span class="ui-input-file-input-error-msg"
+                                data-dz-error-msg></span></div>
+                        <div class="ui-input-file-metadata" style="display: none;"><input id="id_1" type="hidden"
+                                name="name_0[input_1][]" value="test_file_id_1" />
+                            <fieldset class="c-input" data-il-ui-component="text-field-input"
+                                data-il-ui-input-name="name_0[input_2][]"><label for="id_2">text_input</label>
+                                <div class="c-input__field"><input id="id_2" type="text" value="test"
+                                        name="name_0[input_2][]" class="c-field-text" /></div>
                             </fieldset>
-                            <input id="id_2" type="hidden" name="name_0[input_2][]" value="test_file_id_1"/>
                         </div>
                         <div class="ui-input-file-input-progress-container">
                             <div class="ui-input-file-input-progress-indicator"></div>
                         </div>
-                    </div>
-                    <template>
+                    </div><template>
                         <div class="ui-input-file-input">
-                            <div class="ui-input-file-info">
-                            <span data-action="expand">
-                                <a tabindex="0" class="glyph" href="#" aria-label="expand_content">
-                                    <span class="glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-action="collapse">
-                                <a tabindex="0" class="glyph" href="#" aria-label="collapse_content">
-                                    <span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span>
-                                </a>
-                            </span>
-                            <span data-dz-name></span>
-                            <span data-dz-size></span>
-                            <span
-                                    data-action="remove"><a tabindex="0" class="glyph" href="#" aria-label="close"><span
-                                            class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></span><span
-                                    class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
-                            <div class="ui-input-file-metadata" style="display: none;">
+                            <div class="ui-input-file-info"><span data-action="expand"><a tabindex="0" class="glyph"
+                                        href="#" aria-label="expand_content"><span
+                                            class="glyphicon glyphicon-triangle-right"
+                                            aria-hidden="true"></span></a></span><span data-action="collapse"><a
+                                        tabindex="0" class="glyph" href="#" aria-label="collapse_content"><span
+                                            class="glyphicon glyphicon-triangle-bottom"
+                                            aria-hidden="true"></span></a></span><span data-dz-name></span><span
+                                    data-dz-size></span><span data-action="remove"><a tabindex="0" class="glyph" href="#"
+                                        aria-label="close"><span class="glyphicon glyphicon-remove"
+                                            aria-hidden="true"></span></a></span><span class="ui-input-file-input-error-msg"
+                                    data-dz-error-msg></span></div>
+                            <div class="ui-input-file-metadata" style="display: none;"><input id="id_3" type="hidden"
+                                    name="name_0[input_1][]" value="" />
                                 <fieldset class="c-input" data-il-ui-component="text-field-input"
-                                data-il-ui-input-name="name_0[input_1][]"><label for="id_3">text_input</label>
-                                <div class="c-input__field"><input id="id_3" type="text" name="name_0[input_1][]"
-                                        class="c-field-text" /></div>
-                                </fieldset><input id="id_4" type="hidden" name="name_0[input_2][]" value="" />
+                                    data-il-ui-input-name="name_0[input_2][]"><label for="id_4">text_input</label>
+                                    <div class="c-input__field"><input id="id_4" type="text" name="name_0[input_2][]"
+                                            class="c-field-text" /></div>
+                                </fieldset>
                             </div>
                             <div class="ui-input-file-input-progress-container">
                                 <div class="ui-input-file-input-progress-indicator"></div>
@@ -463,10 +434,9 @@ class FileInputTest extends ILIAS_UI_TestBase
                         </div>
                     </template>
                 </div>
-                <div class="ui-input-file-input-dropzone">
-                    <button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button>
-                    <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
-                </div>
+                <div class="ui-input-file-input-dropzone"><button class="btn btn-link" data-action="#"
+                        id="id_5">select_files_from_computer</button><span class="ui-input-file-input-error-msg"
+                        data-dz-error-msg></span></div>
                 <div class="help-block"> file_notice 0 B | ui_file_upload_max_nr 1</div>
             </div>
             ',


### PR DESCRIPTION
Hi folks,
    
This PR fixes https://mantis.ilias.de/view.php?id=44176, by removing the mechanism that merged the `Field\Hidden` dynamic inputs template with existing nested inputs of `Field\Group` inputs provided for metadata. This leads to a change in behaviour when handling file uploads, where a metadata input is provided, because it will be nested an additional time now. I have also decided not ti map the file-id value to the `Field\UploadHandler::getFileIdentifierParameterName()` key anymore, since this was only necessary because due to the merger of said inputs.

@chfsx this PR also contains a commit to address the changed behaviour in file upload handling. The `ilObjFile` was the only place where I could find usages of the `Field\File` input with a metadata input.

Kind regards,
@thibsy 