### PR TITLE
Test: Remove Option to Disable Taxonomies from QPL

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/Setup/class.ilTestQuestionPool10DBUpdateSteps.php
+++ b/components/ILIAS/TestQuestionPool/classes/Setup/class.ilTestQuestionPool10DBUpdateSteps.php
@@ -40,4 +40,11 @@ class ilTestQuestionPool10DBUpdateSteps implements ilDatabaseUpdateSteps
         $this->db->modifyTableColumn('qpl_questions', 'lifecycle', ['notnull' => 1, 'default' => 'draft']);
         $this->db->modifyTableColumn('qpl_questions', 'complete', ['notnull' => 1, 'default' => '1']);
     }
+
+    public function step_2(): void
+    {
+        if ($this->db->tableColumnExists('qpl_questionpool', 'show_taxonomies')) {
+            $this->db->dropTableColumn('qpl_questionpool', 'show_taxonomies');
+        }
+    }
 }

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPool.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPool.php
@@ -37,7 +37,6 @@ class ilObjQuestionPool extends ilObject
 
     private array $mob_ids;
     private array $file_ids;
-    private ?bool $show_taxonomies = null;
     private bool $skill_service_enabled;
     private GeneralQuestionPropertiesRepository $questionrepository;
 
@@ -171,7 +170,6 @@ class ilObjQuestionPool extends ilObject
         );
         if ($result->numRows() == 1) {
             $row = $this->db->fetchAssoc($result);
-            $this->setShowTaxonomies((bool) $row['show_taxonomies']);
             $this->setSkillServiceEnabled((bool) $row['skill_service']);
         }
     }
@@ -188,7 +186,6 @@ class ilObjQuestionPool extends ilObject
             $result = $this->db->update(
                 'qpl_questionpool',
                 [
-                    'show_taxonomies' => ['integer', (int) $this->getShowTaxonomies()],
                     'skill_service' => ['integer', (int) $this->isSkillServiceEnabled()],
                     'tstamp' => ['integer', time()]
                 ],
@@ -201,7 +198,6 @@ class ilObjQuestionPool extends ilObject
 
             $result = $this->db->insert('qpl_questionpool', [
                 'id_questionpool' => ['integer', $next_id],
-                'show_taxonomies' => ['integer', (int) $this->getShowTaxonomies()],
                 'skill_service' => ['integer', (int) $this->isSkillServiceEnabled()],
                 'tstamp' => ['integer', time()],
                 'obj_fi' => ['integer', $this->getId()]
@@ -320,10 +316,7 @@ class ilObjQuestionPool extends ilObject
     private function exportXMLSettings($xmlWriter): void
     {
         $xmlWriter->xmlStartTag('Settings');
-
-        $xmlWriter->xmlElement('ShowTaxonomies', null, (int) $this->getShowTaxonomies());
         $xmlWriter->xmlElement('SkillService', null, (int) $this->isSkillServiceEnabled());
-
         $xmlWriter->xmlEndTag('Settings');
     }
 
@@ -652,16 +645,6 @@ class ilObjQuestionPool extends ilObject
         );
         $row = $ilDB->fetchAssoc($result);
         return $row['question_count'];
-    }
-
-    public function setShowTaxonomies(bool $show_taxonomies): void
-    {
-        $this->show_taxonomies = $show_taxonomies;
-    }
-
-    public function getShowTaxonomies(): ?bool
-    {
-        return $this->show_taxonomies;
     }
 
     /**
@@ -1032,7 +1015,6 @@ class ilObjQuestionPool extends ilObject
         $new_obj->update();
 
         $new_obj->setSkillServiceEnabled($this->isSkillServiceEnabled());
-        $new_obj->setShowTaxonomies($this->getShowTaxonomies());
         $new_obj->saveToDb();
 
         // clone the questions in the question pool

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -1711,13 +1711,12 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             $this->lng->txt('qpl_settings_subtab_general'),
             $this->ctrl->getLinkTargetByClass(ilObjQuestionPoolSettingsGeneralGUI::class),
         );
-        if ($this->object->getShowTaxonomies()) {
-            $tabs->addSubTab(
-                'tax_settings',
-                $this->lng->txt('qpl_settings_subtab_taxonomies'),
-                $this->ctrl->getLinkTargetByClass(ilTaxonomySettingsGUI::class, ''),
-            );
-        }
+
+        $tabs->addSubTab(
+            'tax_settings',
+            $this->lng->txt('qpl_settings_subtab_taxonomies'),
+            $this->ctrl->getLinkTargetByClass(ilTaxonomySettingsGUI::class, ''),
+        );
     }
 
     public function infoScreenObject(): void
@@ -1804,7 +1803,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
             $this->component_repository,
             $this->rbac_system,
             $this->user,
-            $this->object->getShowTaxonomies() ? $this->taxonomy->domain() : null,
+            $this->taxonomy->domain(),
             $this->notes_service,
             $this->object->getId(),
             $this->request_data_collector->getRefId()

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolXMLParser.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPoolXMLParser.php
@@ -78,7 +78,6 @@ class ilObjQuestionPoolXMLParser extends ilSaxParser
                 $this->inSettingsTag = true;
                 break;
 
-            case 'ShowTaxonomies':
             case 'NavTaxonomy':
             case 'SkillService':
                 if ($this->inSettingsTag) {
@@ -119,11 +118,6 @@ class ilObjQuestionPoolXMLParser extends ilSaxParser
 
             case 'Settings':
                 $this->inSettingsTag = false;
-                break;
-
-            case 'ShowTaxonomies':
-                $this->poolOBJ->setShowTaxonomies((bool) $this->cdata);
-                $this->cdata = '';
                 break;
 
             case 'SkillService':

--- a/components/ILIAS/TestQuestionPool/classes/tables/class.ilQuestionBrowserTableGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/tables/class.ilQuestionBrowserTableGUI.php
@@ -327,15 +327,13 @@ class ilQuestionBrowserTableGUI extends ilTable2GUI
         $si->readFromSession();
         $this->filter["type"] = $si->getValue();
 
-        if ($this->parent_obj->getObject()->getShowTaxonomies()) {
-            foreach ($this->taxIds as $taxId) {
-                $postvar = "tax_$taxId";
+        foreach ($this->taxIds as $taxId) {
+            $postvar = "tax_$taxId";
 
-                $inp = new ilTaxSelectInputGUI($taxId, $postvar, true);
-                $this->addFilterItem($inp);
-                $inp->readFromSession();
-                $this->filter[$postvar] = $inp->getValue();
-            }
+            $inp = new ilTaxSelectInputGUI($taxId, $postvar, true);
+            $this->addFilterItem($inp);
+            $inp->readFromSession();
+            $this->filter[$postvar] = $inp->getValue();
         }
 
         // comments

--- a/components/ILIAS/TestQuestionPool/src/Presentation/QuestionTable.php
+++ b/components/ILIAS/TestQuestionPool/src/Presentation/QuestionTable.php
@@ -48,16 +48,14 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
         protected \ilComponentRepository $component_repository,
         protected \ilRbacSystem $rbac,
         protected \ilObjUser $current_user,
-        protected ?TaxonomyService $taxonomy,
+        protected TaxonomyService $taxonomy,
         protected NotesService $notes_service,
         protected int $parent_obj_id,
         protected int $request_ref_id
     ) {
         $lng->loadLanguageModule('qpl');
         parent::__construct($db, $lng, $refinery, $component_repository, $notes_service);
-        if ($this->taxonomy) {
-            $this->setAvailableTaxonomyIds($taxonomy->getUsageOfObject($parent_obj_id));
-        }
+        $this->setAvailableTaxonomyIds($taxonomy->getUsageOfObject($parent_obj_id));
     }
 
     public function getTable(): Table\Data
@@ -105,34 +103,32 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
             )
         ];
 
-        if ($this->taxonomy) {
-            $taxs = $this->taxonomy->getUsageOfObject($this->parent_obj_id, true);
-            $tax_filter_options = [
-                'null' => '<b>' . $this->lng->txt('tax_filter_notax') . '</b>'
-            ];
+        $taxs = $this->taxonomy->getUsageOfObject($this->parent_obj_id, true);
+        $tax_filter_options = [
+            'null' => '<b>' . $this->lng->txt('tax_filter_notax') . '</b>'
+        ];
 
-            foreach ($taxs as $tax_entry) {
-                $tax = new \ilObjTaxonomy($tax_entry['tax_id']);
-                $tax_tree = $tax->getTree();
-                $sortfield = $tax->getSortingMode() === \ilObjTaxonomy::SORT_ALPHABETICAL ? 'title' : 'order_nr';
-                $children = $this->taxNodeReader($tax_tree, $sortfield, $tax_tree->readRootId());
-                $nodes = implode('-', array_map(fn($node) => $node['obj_id'], $children));
+        foreach ($taxs as $tax_entry) {
+            $tax = new \ilObjTaxonomy($tax_entry['tax_id']);
+            $tax_tree = $tax->getTree();
+            $sortfield = $tax->getSortingMode() === \ilObjTaxonomy::SORT_ALPHABETICAL ? 'title' : 'order_nr';
+            $children = $this->taxNodeReader($tax_tree, $sortfield, $tax_tree->readRootId());
+            $nodes = implode('-', array_map(fn($node) => $node['obj_id'], $children));
 
-                $tax_id = $tax_entry['tax_id'] . '-0-' . $nodes;
-                $tax_title = '<b>' . $tax_entry['title'] . '</b>';
-                $tax_filter_options[$tax_id] = $tax_title;
+            $tax_id = $tax_entry['tax_id'] . '-0-' . $nodes;
+            $tax_title = '<b>' . $tax_entry['title'] . '</b>';
+            $tax_filter_options[$tax_id] = $tax_title;
 
-                foreach ($children as $subtax) {
-                    $stax_id = $subtax['tax_id'] . '-' . $subtax['obj_id'];
-                    $stax_title = str_repeat('&nbsp; ', ($subtax['depth'] - 2) * 2)
-                        . ' &boxur;&HorizontalLine; '
-                        . $subtax['title'];
+            foreach ($children as $subtax) {
+                $stax_id = $subtax['tax_id'] . '-' . $subtax['obj_id'];
+                $stax_title = str_repeat('&nbsp; ', ($subtax['depth'] - 2) * 2)
+                    . ' &boxur;&HorizontalLine; '
+                    . $subtax['title'];
 
-                    $tax_filter_options[$stax_id] = $stax_title;
-                }
+                $tax_filter_options[$stax_id] = $stax_title;
             }
-            $filter_inputs['taxonomies'] = $field_factory->multiSelect($this->lng->txt("tax_filter"), $tax_filter_options);
         }
+        $filter_inputs['taxonomies'] = $field_factory->multiSelect($this->lng->txt("tax_filter"), $tax_filter_options);
 
         $active = array_fill(0, count($filter_inputs), true);
 
@@ -155,18 +151,14 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
         $icon_yes = $this->ui_factory->symbol()->icon()->custom(\ilUtil::getImagePath('standard/icon_checked.svg'), 'yes');
         $icon_no = $this->ui_factory->symbol()->icon()->custom(\ilUtil::getImagePath('standard/icon_unchecked.svg'), 'no');
 
-        $cols = [
+        return [
             'title' => $f->link($this->lng->txt('title')),
             'description' => $f->text($this->lng->txt('description'))->withIsOptional(true, true),
             'ttype' => $f->text($this->lng->txt('question_type'))->withIsOptional(true, true),
             'points' => $f->number($this->lng->txt('points'))->withIsOptional(true, true),
             'author' => $f->text($this->lng->txt('author'))->withIsOptional(true, true),
             'lifecycle' => $f->text($this->lng->txt('qst_lifecycle'))->withIsOptional(true, true),
-        ];
-        if ($this->taxonomy) {
-            $cols['taxonomies'] = $f->text($this->lng->txt('qpl_settings_subtab_taxonomies'))->withIsOptional(true, true);
-        }
-        $cols = array_merge($cols, [
+            'taxonomies' => $f->text($this->lng->txt('qpl_settings_subtab_taxonomies'))->withIsOptional(true, true),
             'feedback' => $f->boolean($this->lng->txt('feedback'), $icon_yes, $icon_no)->withIsOptional(true, true),
             'hints' => $f->boolean($this->lng->txt('hints'), $icon_yes, $icon_no)->withIsOptional(true, true),
             'created' => $f->date(
@@ -178,8 +170,7 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
                 $this->current_user->getDateTimeFormat()
             )->withIsOptional(true, true),
             'comments' => $f->number($this->lng->txt('comments'))->withIsOptional(true, false),
-        ]);
-        return $cols;
+        ];
     }
 
     private function treeify(&$pointer, $stack)
@@ -307,9 +298,7 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
                 $title .= ' (' . $this->lng->txt('warning_question_not_complete') . ')';
             }
             $record['title'] = $this->ui_factory->link()->standard($title, $to_question);
-            if ($this->taxonomy) {
-                $record['taxonomies'] = $this->taxonomyRepresentation($record['taxonomies']);
-            }
+            $record['taxonomies'] = $this->taxonomyRepresentation($record['taxonomies']);
 
             yield $row_builder->buildDataRow($row_id, $record)
                 ->withDisabledAction('move', $no_write_access)

--- a/components/ILIAS/TestQuestionPool/tests/ilQuestionBrowserTableGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilQuestionBrowserTableGUITest.php
@@ -48,11 +48,6 @@ class ilQuestionBrowserTableGUITest extends assBaseTestCase
                     {
                         return 0;
                     }
-
-                    public function getShowTaxonomies(): bool
-                    {
-                        return false;
-                    }
                 };
             }
 


### PR DESCRIPTION
Hi all

The option to disable taxonomies in the question pool is actually very problematic and we would like to remove it. The problem is that taxonomies could be used in tests as a criterion to select questions. Currently this criterion is independent of the setting in the pool, but this leads to a situation where you might use taxonomies as a criterion to select questions from a pool where taxonomies are disabled and this does not make much sense. So we could actually make the selection by taxonomies depend on the taxonomies being enabled in the question pool, but this again would lead to problems when the taxonomies are enabled or disabled in a linked question pool.

We thus suggest to simply remove this option from ILIAS 10 and above. Taxonomies will thus always be enabled.

Best,
@kergomard 