### PR TITLE
Mantis 44181: add missing typecasts in class.ilCustomuserFieldsGUI

### DIFF
--- a/Services/User/classes/class.ilCustomUserFieldsGUI.php
+++ b/Services/User/classes/class.ilCustomUserFieldsGUI.php
@@ -363,7 +363,7 @@ class ilCustomUserFieldsGUI
                     break;
 
                 default:
-                    $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType($udf_type);
+                    $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType((string) $udf_type);
                     if ($plugin instanceof ilUDFDefinitionPlugin) {
                         $form->setTitle($plugin->getDefinitionUpdateFormTitle());
                     }
@@ -461,7 +461,7 @@ class ilCustomUserFieldsGUI
             $new_id = $user_field_definitions->add();
 
             if ($user_field_definitions->isPluginType()) {
-                $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType($user_field_definitions->getFieldType());
+                $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType((string) $user_field_definitions->getFieldType());
                 if ($plugin instanceof ilUDFDefinitionPlugin) {
                     $plugin->updateDefinitionFromForm($form, $new_id);
                 }
@@ -607,7 +607,7 @@ class ilCustomUserFieldsGUI
             $user_field_definitions->update($this->field_id);
 
             if ($user_field_definitions->isPluginType()) {
-                $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType($user_field_definitions->getFieldType());
+                $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType((string) $user_field_definitions->getFieldType());
                 if ($plugin instanceof ilUDFDefinitionPlugin) {
                     $plugin->updateDefinitionFromForm($form, $this->field_id);
                 }

--- a/Services/User/classes/class.ilCustomUserFieldsGUI.php
+++ b/Services/User/classes/class.ilCustomUserFieldsGUI.php
@@ -298,7 +298,7 @@ class ilCustomUserFieldsGUI
                     break;
 
                 default:
-                    $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType((string) $udf_type);
+                    $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType($udf_type);
                     if ($plugin instanceof ilUDFDefinitionPlugin) {
                         $plugin->addDefinitionTypeOptionsToRadioOption($op, $this->field_id);
                     }
@@ -363,7 +363,7 @@ class ilCustomUserFieldsGUI
                     break;
 
                 default:
-                    $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType((string) $udf_type);
+                    $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType($udf_type);
                     if ($plugin instanceof ilUDFDefinitionPlugin) {
                         $form->setTitle($plugin->getDefinitionUpdateFormTitle());
                     }
@@ -461,7 +461,7 @@ class ilCustomUserFieldsGUI
             $new_id = $user_field_definitions->add();
 
             if ($user_field_definitions->isPluginType()) {
-                $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType((string) $user_field_definitions->getFieldType());
+                $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType($user_field_definitions->getFieldType());
                 if ($plugin instanceof ilUDFDefinitionPlugin) {
                     $plugin->updateDefinitionFromForm($form, $new_id);
                 }
@@ -607,7 +607,7 @@ class ilCustomUserFieldsGUI
             $user_field_definitions->update($this->field_id);
 
             if ($user_field_definitions->isPluginType()) {
-                $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType((string) $user_field_definitions->getFieldType());
+                $plugin = ilCustomUserFieldsHelper::getInstance()->getPluginForType($user_field_definitions->getFieldType());
                 if ($plugin instanceof ilUDFDefinitionPlugin) {
                     $plugin->updateDefinitionFromForm($form, $this->field_id);
                 }

--- a/Services/User/classes/class.ilCustomUserFieldsHelper.php
+++ b/Services/User/classes/class.ilCustomUserFieldsHelper.php
@@ -65,7 +65,7 @@ class ilCustomUserFieldsHelper
     /**
      * Get plugin for udf type
      */
-    public function getPluginForType(string $a_type): ?ilUDFDefinitionPlugin
+    public function getPluginForType(int $a_type): ?ilUDFDefinitionPlugin
     {
         foreach ($this->getActivePlugins() as $plugin) {
             if ($plugin->getDefinitionType() == $a_type) {


### PR DESCRIPTION
possible fix for mantis 44181, typecasts are missing in 3 of 4 calls to getPluginForType