### PR TITLE
Mantis 44187: add excludePattern to RoleFilter

### DIFF
--- a/xml/SchemaValidation/ilias_otpl_9.xsd
+++ b/xml/SchemaValidation/ilias_otpl_9.xsd
@@ -67,7 +67,8 @@
     <xs:element name="roleFilter">
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="includePattern" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="includePattern" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="excludePattern" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             <xs:attribute name="source" type="xs:string" use="required"/>
         </xs:complexType>
@@ -76,6 +77,12 @@
     <xs:element name="includePattern">
         <xs:complexType>
             <xs:attribute name="preg" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="excludePattern">
+        <xs:complexType>
+            <xs_attribute name="preg" type="xs:string" use="required"/>
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
This is an approach for af Fix for Mantis 44187. 
From the documentation in ILIAS docu platform I saw, that includePatterns may occur multiple times, but exclude can only be used once. 
This approach allows that no pattern is present (I found no way to allow multiple includes in another way)
I could not yet test this modification (sorry), so this is just a suggestion.