### PR TITLE
ZIP: Don't read/write ZIP archive from/into identical file / PHP Memory Issue

### DIFF
--- a/src/Filesystem/Util/Archive/LegacyArchives.php
+++ b/src/Filesystem/Util/Archive/LegacyArchives.php
@@ -77,7 +77,7 @@ final class LegacyArchives
         $zip->addDirectory($directory_to_zip);
         $zip_stream = $zip->get();
 
-        return file_put_contents($path_to_output_zip, $zip_stream->getContents()) > 0;
+        return $zip_stream->getSize() > 0;
     }
 
     /**


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=44190

As written in the Mantis issue, the `$zip_stream` already encapsulates a stream of the ZIP archive we want create in `$path_to_output_zip`. 
`\ILIAS\Filesystem\Util\Archive\Zip::get` already calls `\ILIAS\Filesystem\Util\Archive\Zip::storeZIPtoFilesystem`, so in my opinion there is not need to read the complete stream contents and write it again in the same(!) file with:

```php
        return file_put_contents($path_to_output_zip, $zip_stream->getContents()) > 0;
````

If approved, please pick this to all relevant branches.

@chfsx I suggest to also check other consumers of `get`.