### PR TITLE
LTI: Fixed static calls to delos and jQuery files in the ilLTIConsumerContentGUI class

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
@@ -307,8 +307,8 @@ class ilLTIConsumerContentGUI
             }
 
             $v = DEVMODE ? '?vers=' . time() : '?vers=' . ILIAS_VERSION_NUMERIC;
-            $tpl->setVariable("DELOS_CSS_HREF", 'templates/default/delos.css' . $v);
-            $tpl->setVariable("JQUERY_SRC", 'public/node_modules/jquery/dist/jquery.js' . $v);
+            $tpl->setVariable("DELOS_CSS_HREF", 'assets/css/delos.css' . $v);
+            $tpl->setVariable("JQUERY_SRC", 'assets/js/jquery.js' . $v);
 
             $tpl->setVariable("LOADER_ICON_SRC", ilUtil::getImagePath("media/loader.svg"));
             $tpl->setVariable('LAUNCH_URL', $this->object->getProvider()->getProviderUrl());


### PR DESCRIPTION
This commit solves a problem that prevented loading an external provider on an LTI consumer in an embedded way.