### PR TITLE
Blog/MediaCast/MediaPool: create LOM sets for pre-existing objects (44066)

### DIFF
--- a/components/ILIAS/Blog/Setup/class.Agent.php
+++ b/components/ILIAS/Blog/Setup/class.Agent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -18,6 +16,8 @@ declare(strict_types=1);
  *
  *********************************************************************/
 
+declare(strict_types=1);
+
 namespace ILIAS\Blog\Setup;
 
 use ILIAS\Setup;
@@ -32,6 +32,11 @@ class Agent extends Setup\Agent\NullAgent
     public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
     {
         return new \ilDatabaseUpdateStepsExecutedObjective(new BlogDBUpdateSteps());
+    }
+
+    public function getMigrations(): array
+    {
+        return [new InitLOMForBlogMigration()];
     }
 
     public function getStatusObjective(Metrics\Storage $storage): Objective

--- a/components/ILIAS/Blog/Setup/class.InitLOMForBlogMigration.php
+++ b/components/ILIAS/Blog/Setup/class.InitLOMForBlogMigration.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Blog\Setup;
+
+use ILIAS\MetaData\Setup\InitLOMForObjectTypeMigration;
+
+class InitLOMForBlogMigration extends InitLOMForObjectTypeMigration
+{
+    protected function objectType(): string
+    {
+        return 'blog';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Creates LOM sets for pre-existing Blogs.';
+    }
+}

--- a/components/ILIAS/MediaCast/classes/Setup/class.Agent.php
+++ b/components/ILIAS/MediaCast/classes/Setup/class.Agent.php
@@ -32,6 +32,11 @@ class Agent extends Setup\Agent\NullAgent
         return new \ilDatabaseUpdateStepsExecutedObjective(new ilMediaCastDBUpdateSteps());
     }
 
+    public function getMigrations(): array
+    {
+        return [new InitLOMForMediaCastMigration()];
+    }
+
     public function getStatusObjective(Metrics\Storage $storage): Objective
     {
         return new \ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilMediaCastDBUpdateSteps());

--- a/components/ILIAS/MediaCast/classes/Setup/class.InitLOMForMediaCastMigration.php
+++ b/components/ILIAS/MediaCast/classes/Setup/class.InitLOMForMediaCastMigration.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\MediaCast\Setup;
+
+use ILIAS\MetaData\Setup\InitLOMForObjectTypeMigration;
+
+class InitLOMForMediaCastMigration extends InitLOMForObjectTypeMigration
+{
+    protected function objectType(): string
+    {
+        return 'mcst';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Creates LOM sets for pre-existing Media Casts.';
+    }
+}

--- a/components/ILIAS/MediaPool/MediaPool.php
+++ b/components/ILIAS/MediaPool/MediaPool.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS;
 
+use ILIAS\MediaPool\Setup\Agent;
+
 class MediaPool implements Component\Component
 {
     public function init(
@@ -32,6 +34,10 @@ class MediaPool implements Component\Component
         array | \ArrayAccess &$pull,
         array | \ArrayAccess &$internal,
     ): void {
+        $contribute[\ILIAS\Setup\Agent::class] = static fn() =>
+        new Agent(
+            $pull[\ILIAS\Refinery\Factory::class]
+        );
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "ilMediaPool.js");
     }

--- a/components/ILIAS/MediaPool/Setup/class.Agent.php
+++ b/components/ILIAS/MediaPool/Setup/class.Agent.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\MediaPool\Setup;
+
+use ILIAS\Setup;
+
+class Agent extends Setup\Agent\NullAgent
+{
+    public function getMigrations(): array
+    {
+        return [new InitLOMForMediaPoolMigration()];
+    }
+}

--- a/components/ILIAS/MediaPool/Setup/class.InitLOMForMediaPoolMigration.php
+++ b/components/ILIAS/MediaPool/Setup/class.InitLOMForMediaPoolMigration.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\MediaPool\Setup;
+
+use ILIAS\MetaData\Setup\InitLOMForObjectTypeMigration;
+
+class InitLOMForMediaPoolMigration extends InitLOMForObjectTypeMigration
+{
+    protected function objectType(): string
+    {
+        return 'mep';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Creates LOM sets for pre-existing Media Pools.';
+    }
+}


### PR DESCRIPTION
This PR fixes [44066](https://mantis.ilias.de/view.php?id=44066) by adding a migration that creates LOM sets for pre-existing objects of those types that support LOM since ILIAS 10. Empty LOM sets for these objects leads to problems in export/import, and probably also in other places.