### PR TITLE
DataCollection: add migration to create LOM sets for pre-existing Data Collections (44066)

### DIFF
--- a/components/ILIAS/DataCollection/classes/Setup/class.ilDataCollectionInitLOMMigration.php
+++ b/components/ILIAS/DataCollection/classes/Setup/class.ilDataCollectionInitLOMMigration.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\MetaData\Setup\InitLOMForObjectTypeMigration;
+
+class ilDataCollectionInitLOMMigration extends InitLOMForObjectTypeMigration
+{
+    protected function objectType(): string
+    {
+        return 'dcl';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Creates LOM sets for pre-existing Data Collections.';
+    }
+}

--- a/components/ILIAS/DataCollection/classes/Setup/class.ilDataCollectionSetupAgent.php
+++ b/components/ILIAS/DataCollection/classes/Setup/class.ilDataCollectionSetupAgent.php
@@ -35,7 +35,8 @@ class ilDataCollectionSetupAgent implements Setup\Agent
     public function getMigrations(): array
     {
         return [
-            new ilDataCollectionStorageMigration()
+            new ilDataCollectionStorageMigration(),
+            new ilDataCollectionInitLOMMigration()
         ];
     }
 


### PR DESCRIPTION
This PR adds a migration that creates LOM sets for pre-existing Data Collections. Empty LOM sets for Data Collections could lead to problems in export/import, and probably also in other places, see [44066](https://mantis.ilias.de/view.php?id=44066).