### PR TITLE
ErrorHandling: Throw `RuntimeException` instead of `E_USER_ERROR` (PHP 8.4)

### DIFF
--- a/components/ILIAS/Init/classes/class.ilErrorHandling.php
+++ b/components/ILIAS/Init/classes/class.ilErrorHandling.php
@@ -187,8 +187,7 @@ class ilErrorHandling
             $log->write($message);
         }
         if ($code === $this->FATAL) {
-            trigger_error(stripslashes($message), E_USER_ERROR);
-            exit();
+            throw new RuntimeException(stripslashes($message));
         }
 
         if ($code === $this->WARNING) {


### PR DESCRIPTION
This PR suggests to throw an exception when exponential expression cannot be converted, instead of using the deprecated `E_USER_ERROR`.

See: https://www.php.net/manual/en/migration84.deprecated.php