### PR TITLE
T&A 25064: Fixes conceptual issue where users can estimate their result when viewing their learning progress in a test

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -452,8 +452,25 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                 if ((!$this->access->checkAccess("read", "", $this->testrequest->getRefId()))) {
                     $this->redirectAfterMissingRead();
                 }
+
                 $this->prepareOutput();
                 $this->addHeaderAction();
+
+                $test_object = $this->getTestObject();
+                if ($test_object === null) {
+                    $this->redirectToInfoScreenObject();
+                    break;
+                }
+
+                $test_session = $this->test_session_factory->getSessionByUserId($this->user->getId());
+                if (!$test_object->canShowTestResults($test_session)) {
+                    $this->tpl->setOnScreenMessage(
+                        'info',
+                        $this->lng->txt('tst_res_tab_msg_no_lp_access'),
+                    );
+                    break;
+                }
+
                 $this->tabs_gui->activateTab(ilTestTabsManager::TAB_ID_LEARNING_PROGRESS);
                 $new_gui = new ilLearningProgressGUI(ilLearningProgressGUI::LP_CONTEXT_REPOSITORY, $this->object->getRefId());
                 $this->ctrl->forwardCommand($new_gui);

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1763,6 +1763,7 @@ assessment#:#tst_res_jump_to_participant_hint_opt#:#Zu Teilnehmer springen
 assessment#:#tst_res_lo_objectives_header#:#Relevante Lernziele
 assessment#:#tst_res_lo_try_header#:#Versuch
 assessment#:#tst_res_lo_try_n#:#%s. Versuch
+assessment#:#tst_res_tab_msg_no_lp_access#:#Sie dürfen aktuell nicht auf Ihren Lernfortschritt zugreifen, da der Zugriff auf die Testresultate nicht freigegeben ist.
 assessment#:#tst_res_tab_msg_res_after_date#:#Die Testergebnisse werden Ihnen hier zu folgendem Datum präsentiert: %s
 assessment#:#tst_res_tab_msg_res_after_date_no_res#:#Wenn Sie den Test durchführen werden Ihnen hier zu folgendem Datum die Testergebnisse präsentiert: %s
 assessment#:#tst_res_tab_msg_res_after_finish_test#:#Wenn Sie den Test abgeschlossen haben werden Ihnen hier die Testergebnisse präsentiert.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1763,6 +1763,7 @@ assessment#:#tst_res_jump_to_participant_hint_opt#:#Jump to Participant
 assessment#:#tst_res_lo_objectives_header#:#Relevant Learning Objectives
 assessment#:#tst_res_lo_try_header#:#Attempt
 assessment#:#tst_res_lo_try_n#:#Attempt %s
+assessment#:#tst_res_tab_msg_no_lp_access#:#You are currently not allowed to access your Learning Progress, as you are not allowed to see your test results.
 assessment#:#tst_res_tab_msg_res_after_date#:#Your test results will be shown here after: %s
 assessment#:#tst_res_tab_msg_res_after_date_no_res#:#Once you have taken the test your results will be shown here after: %s
 assessment#:#tst_res_tab_msg_res_after_finish_test#:#After finishing the test your results will be shown here.


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=25064

This PR attempts to solve the conceptual issue mentioned. Previously, participants of a test with the learning progress feature enabled could estimate their result by looking at the learning progress percentage, even if the date after which results should be shown is in the future.

I have now added a check to see if the participant trying to access their learning progress can view their test result before showing them their learning progress. This now gives the same feedback to the user as if they were trying to view their results under the “Result” tab.

Kind regards,
@bidzanaaron 