### PR TITLE
T&A 28142: prevent skill assignment for questions from a question pool (ILIAS 9)

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -473,7 +473,11 @@ class ilAssQuestionSkillAssignmentsGUI
 
         $form->setQuestion($question);
         $form->setAssignment($assignment);
-        $form->setManipulationEnabled($this->isAssignmentEditingEnabled());
+
+        $form->setManipulationEnabled(
+            $this->isAssignmentEditingEnabled()
+            && $question->getOriginalId() === null
+        );
 
         $form->build();
 
@@ -559,6 +563,7 @@ class ilAssQuestionSkillAssignmentsGUI
     {
         $table = new ilAssQuestionSkillAssignmentsTableGUI($this, self::CMD_SHOW_SKILL_QUEST_ASSIGNS, $this->ctrl, $this->lng);
         $table->setManipulationsEnabled($this->isAssignmentEditingEnabled());
+        $table->setManipulationAllowedList($this->buildManipulationAllowedList());
         $table->init();
 
         return $table;
@@ -570,6 +575,19 @@ class ilAssQuestionSkillAssignmentsGUI
         $assignmentList->setParentObjId($this->getQuestionContainerId());
 
         return $assignmentList;
+    }
+
+    /**
+     * Questions from a question pool may not be edited (JF 3 MAR 2024) and are filtered out here.
+     *
+     * @return array<int, bool>
+     */
+    private function buildManipulationAllowedList(): array
+    {
+        return array_map(
+            static fn(array $questionData) => $questionData['original_id'] === null,
+            $this->questionList->getQuestionDataArray()
+        );
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
@@ -42,7 +42,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
     /**
      * @var array<int, bool> Question ID => Manipulation allowed
      */
-    private array $manipulationsAllowedList;
+    private array $manipulations_allowed_list;
 
     public function setSkillQuestionAssignmentList(ilAssQuestionSkillAssignmentList $assignmentList): void
     {
@@ -50,26 +50,21 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
     }
 
     /**
-     * @param array<int, bool> $manipulationsAllowedList
+     * @param array<int, bool> $manipulations_allowed_list
      */
-    public function setManipulationAllowedList(array $manipulationsAllowedList): void
+    public function setManipulationAllowedList(array $manipulations_allowed_list): void
     {
-        $this->manipulationsAllowedList = $manipulationsAllowedList;
+        $this->manipulations_allowed_list = $manipulations_allowed_list;
     }
 
-    public function areManipulationsEnabled(): bool
+    private function areManipulationsPossible(): bool
     {
-        return $this->manipulationsEnabled;
+        return $this->manipulationsEnabled && array_filter($this->manipulations_allowed_list) !== [];
     }
 
-    public function areManipulationsPossible(): bool
+    private function isManipulationAllowedForQuestion(int $q_id): bool
     {
-        return $this->areManipulationsEnabled() && array_filter($this->manipulationsAllowedList) !== [];
-    }
-
-    public function isManipulationAllowedForQuestion(int $q_id): bool
-    {
-        return $this->areManipulationsEnabled() && $this->manipulationsAllowedList[$q_id];
+        return $this->manipulationsEnabled && $this->manipulations_allowed_list[$q_id];
     }
 
     public function setManipulationsEnabled(bool $manipulationsEnabled): void

--- a/Modules/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
@@ -39,23 +39,40 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
      */
     private $manipulationsEnabled;
 
+    /**
+     * @var array<int, bool> Question ID => Manipulation allowed
+     */
+    private array $manipulationsAllowedList;
+
     public function setSkillQuestionAssignmentList(ilAssQuestionSkillAssignmentList $assignmentList): void
     {
         $this->skillQuestionAssignmentList = $assignmentList;
     }
 
     /**
-     * @return boolean
+     * @param array<int, bool> $manipulationsAllowedList
      */
+    public function setManipulationAllowedList(array $manipulationsAllowedList): void
+    {
+        $this->manipulationsAllowedList = $manipulationsAllowedList;
+    }
+
     public function areManipulationsEnabled(): bool
     {
         return $this->manipulationsEnabled;
     }
 
-    /**
-     * @param boolean $manipulationsEnabled
-     */
-    public function setManipulationsEnabled($manipulationsEnabled): void
+    public function areManipulationsPossible(): bool
+    {
+        return $this->areManipulationsEnabled() && array_filter($this->manipulationsAllowedList) !== [];
+    }
+
+    public function isManipulationAllowedForQuestion(int $q_id): bool
+    {
+        return $this->areManipulationsEnabled() && $this->manipulationsAllowedList[$q_id];
+    }
+
+    public function setManipulationsEnabled(bool $manipulationsEnabled): void
     {
         $this->manipulationsEnabled = $manipulationsEnabled;
     }
@@ -83,7 +100,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
     {
         $this->initColumns();
 
-        if ($this->areManipulationsEnabled()) {
+        if ($this->areManipulationsPossible()) {
             $this->setFormAction($this->ctrl->getFormAction($this->parent_obj));
 
             $this->addCommandButton(
@@ -112,9 +129,10 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
 
     public function fillRow(array $a_set): void
     {
-        $assignments = $this->skillQuestionAssignmentList->getAssignmentsByQuestionId($a_set['question_id']);
+        $question_id = (int) $a_set['question_id'];
+        $assignments = $this->skillQuestionAssignmentList->getAssignmentsByQuestionId($question_id);
 
-        $this->ctrl->setParameter($this->parent_obj, 'question_id', $a_set['question_id']);
+        $this->ctrl->setParameter($this->parent_obj, 'question_id', $question_id);
 
         $this->tpl->setCurrentBlock('question_title');
         $this->tpl->setVariable('ROWSPAN', $this->getRowspan($assignments));
@@ -144,7 +162,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
                 $this->tpl->setVariable('SKILL_POINTS', $assignment->getMaxSkillPoints());
             }
 
-            if ($this->areManipulationsEnabled() || ($i + 1) < $numAssigns) {
+            if ($this->isManipulationAllowedForQuestion($question_id) || ($i + 1) < $numAssigns) {
                 $this->tpl->parseCurrentBlock();
 
                 $this->tpl->setCurrentBlock('tbl_content');
@@ -152,7 +170,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
             }
         }
 
-        if ($this->areManipulationsEnabled()) {
+        if ($this->isManipulationAllowedForQuestion($question_id)) {
             $this->tpl->setCurrentBlock('actions_col');
             $this->tpl->setVariable('ACTION', $this->getManageCompetenceAssignsActionLink());
             $this->tpl->parseCurrentBlock();
@@ -175,7 +193,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
             return 1;
         }
 
-        if ($this->areManipulationsEnabled()) {
+        if ($this->areManipulationsPossible()) {
             $cnt++;
         }
 
@@ -204,7 +222,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
             ilAssQuestionSkillAssignmentsGUI::CMD_SHOW_SKILL_QUEST_ASSIGN_PROPERTIES_FORM
         );
 
-        if ($this->areManipulationsEnabled()) {
+        if ($this->isManipulationAllowedForQuestion($assignment->getQuestionId())) {
             $label = $this->lng->txt('tst_edit_competence_assign');
         } else {
             $label = $this->lng->txt('tst_view_competence_assign');
@@ -280,7 +298,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
 
     private function isSkillPointInputRequired(ilAssQuestionSkillAssignment $assignment): bool
     {
-        if (!$this->areManipulationsEnabled()) {
+        if (!$this->isManipulationAllowedForQuestion($assignment->getQuestionId())) {
             return false;
         }
 


### PR DESCRIPTION
Hi everyone,

this PR relates to ticket [28142](https://mantis.ilias.de/view.php?id=28142). It prevents questions from a Question Pool in a test from having their competency schema modified.

I am looking forward to feedback.
Best
@lukas-heinrich 