### PR TITLE
T&A 43423: Addition of optional working time column in participants table

### DIFF
--- a/components/ILIAS/Test/src/Participants/ParticipantTable.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTable.php
@@ -106,6 +106,7 @@ class ParticipantTable implements DataRetrieval
                 'name' => $this->test_object->buildName($record->getUserId(), $record->getLastname(), $record->getFirstname()),
                 'login' => $record->getLogin(),
                 'matriculation' => $record->getMatriculation(),
+                'total_time_on_task' => $record->getAttemptOverviewInformation()?->getHumanReadableTotalTimeOnTask() ?? '',
                 'status_of_attempt' => $this->lng->txt($status_of_attempt->value),
                 'id_of_attempt' => $record->getAttemptOverviewInformation()?->getExamId(),
                 'ip_range' => $record->getClientIpTo() !== '' || $record->getClientIpFrom() !== ''
@@ -354,6 +355,8 @@ class ParticipantTable implements DataRetrieval
                 $this->lng->txt('tst_attempt_started'),
                 $this->current_user->getDateTimeFormat()
             )->withIsSortable(true),
+            'total_time_on_task' => $column_factory->text($this->lng->txt('working_time'))
+                ->withIsOptional(true, false),
             'total_attempts' => $column_factory->number($this->lng->txt('total_attempts'))
                 ->withIsOptional(true, false)
                 ->withIsSortable(true),
@@ -455,7 +458,7 @@ class ParticipantTable implements DataRetrieval
         return $this->limitRecords(
             $this->sortRecords(
                 $this->filterRecords(
-                    $records = $this->results_data_factory->addAttemptOverviewInformationToParticipants(
+                    $this->results_data_factory->addAttemptOverviewInformationToParticipants(
                         $this->results_presentation_settings,
                         $this->test_object,
                         $this->loadRecords($filter_data, $order)

--- a/components/ILIAS/Test/src/Results/Data/AttemptOverview.php
+++ b/components/ILIAS/Test/src/Results/Data/AttemptOverview.php
@@ -41,6 +41,7 @@ class AttemptOverview
         private readonly int $nr_of_questions_in_attempt = 0,
         private readonly ?int $requested_hints_count = null,
         private readonly int $time_on_task = 0,
+        private readonly int $total_time_on_task = 0,
         private readonly ?\DateTimeImmutable $attempt_started_date = null,
         private readonly ?\DateTimeImmutable $last_access = null,
         private readonly int $nr_of_attempts = 0,
@@ -153,6 +154,11 @@ class AttemptOverview
                 $lng->txt('tst_stat_result_rank_participant') => (string) $this->rank
             ]
         );
+    }
+
+    public function getHumanReadableTotalTimeOnTask(): string
+    {
+        return $this->buildHumanReadableTime($this->total_time_on_task);
     }
 
     private function buildHumanReadableTime(int $time): string

--- a/components/ILIAS/Test/src/Results/Data/Factory.php
+++ b/components/ILIAS/Test/src/Results/Data/Factory.php
@@ -119,6 +119,7 @@ class Factory
             $attempt_data->getQuestionCount(),
             $attempt_data->getRequestedHintsCount(),
             $attempt_data->getWorkingTime(),
+            $participant_data->getTimeOnTask(),
             $attempt_data->getStartTime(),
             $attempt_data->getLastAccessTime(),
             $participant_data->getPassCount(),


### PR DESCRIPTION
This PR aims to implement the proposed feature in https://mantis.ilias.de/view.php?id=43423.

An optional but not initially visible working time column has been added to the participants table in tests. It shows the time that a participant's attempt took in a human-readable format.

Kind regards,
@bidzanaaron 