### PR TITLE
UICore: 44208, reset parameter to relative path for Template

### DIFF
--- a/components/ILIAS/UICore/classes/class.ilTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilTemplate.php
@@ -315,63 +315,61 @@ class ilTemplate extends HTML_Template_ITX
             );
     }
 
+
+    protected function getCurrentSkin(): ?string
+    {
+        // use ilStyleDefinition instead of account to get the current skin
+        return ilStyleDefinition::getCurrentSkin();
+    }
+
+    protected function getCurrentStyle(): ?string
+    {
+        return ilStyleDefinition::getCurrentStyle();
+    }
+
+    protected function fileExistsInSkin(string $path): bool
+    {
+        return file_exists($path);
+    }
+
     /**
      * @throws ilSystemStyleException
      */
     protected function getTemplatePath(string $a_tplname, string $a_in_module = null): string
     {
         $ilias_root = realpath(__DIR__ . '/../../../../') . '/';
+
         if (str_starts_with($a_in_module, $ilias_root)) {
             $a_in_module = str_replace($ilias_root, '', $a_in_module);
         }
 
-        $fname = "";
-        if (strpos($a_tplname, "/") === false) {
-            $module_path = "";
-
-            if ($a_in_module !== "") {
-                $module_path = $a_in_module . "/";
-            }
-
-            // use ilStyleDefinition instead of account to get the current skin
-            if (ilStyleDefinition::getCurrentSkin() !== "default") {
-                $style = ilStyleDefinition::getCurrentStyle();
-
-                $fname = "./Customizing/global/skin/" .
-                    ilStyleDefinition::getCurrentSkin() . "/" . $style . "/" . $module_path
-                    . basename($a_tplname);
-
-                if ($fname === "" || !file_exists($fname)) {
-                    $fname = "./Customizing/global/skin/" .
-                        ilStyleDefinition::getCurrentSkin() . "/" . $module_path . basename($a_tplname);
-                }
-            }
-
-            if ($fname === "" || !file_exists($fname)) {
-                $fname = $module_path . "templates/default/" . basename($a_tplname);
-            }
-
-        } elseif (strpos($a_tplname, "components/ILIAS/UI") === 0) {
-            if (class_exists("ilStyleDefinition") // for testing
-                && ilStyleDefinition::getCurrentSkin() != "default") {
-                $style = ilStyleDefinition::getCurrentStyle();
-                $skin = ilStyleDefinition::getCurrentSkin();
-                $base_path = "./Customizing/global/skin/";
-                $ui_path = "/" . str_replace("components/ILIAS/UI/src/templates/default", "UI", $a_tplname);
-                $fname = $base_path . ilStyleDefinition::getCurrentSkin() . "/" . $style . "/" . $ui_path;
-
-                if (!file_exists($fname)) {
-                    $fname = $base_path . $skin . "/" . $ui_path;
-                }
-            }
-
-            if ($fname == "" || !file_exists($fname)) {
-                $fname = $a_tplname;
-            }
-        } else {
-            $fname = $a_tplname;
+        if (str_ends_with($a_in_module, '/')) {
+            $a_in_module = rtrim($a_in_module, '/');
         }
-        return $ilias_root . $fname;
+
+        if (str_starts_with($a_tplname, 'components/ILIAS/UI/')) {
+            $a_in_module = 'components/ILIAS/UI/src';
+            $a_tplname = str_replace('components/ILIAS/UI/src/templates/default/', '', $a_tplname);
+        }
+
+        $base_path = $ilias_root;
+        $default = $base_path . $a_in_module . '/templates/default/' . $a_tplname;
+
+        $skin = $this->getCurrentSkin();
+        if ($skin === 'default') {
+            return $default;
+        }
+
+        $style = $this->getCurrentStyle();
+        $base_path .= 'public/Customizing/skin/' . $skin . '/' . $style;
+
+        if ($a_in_module === 'components/ILIAS/UI/src') {
+            $a_in_module = 'UI';
+        }
+
+        $from_skin = $base_path . '/' . $a_in_module . '/' . $a_tplname;
+
+        return $this->fileExistsInSkin($from_skin) ? $from_skin : $default;
     }
 
     /**

--- a/components/ILIAS/UICore/classes/class.ilTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilTemplate.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 require_once __DIR__ . '/../lib/html-it/IT.php';
 require_once __DIR__ . '/../lib/html-it/ITX.php';
@@ -320,6 +320,11 @@ class ilTemplate extends HTML_Template_ITX
      */
     protected function getTemplatePath(string $a_tplname, string $a_in_module = null): string
     {
+        $ilias_root = realpath(__DIR__ . '/../../../../') . '/';
+        if (str_starts_with($a_in_module, $ilias_root)) {
+            $a_in_module = str_replace($ilias_root, '', $a_in_module);
+        }
+
         $fname = "";
         if (strpos($a_tplname, "/") === false) {
             $module_path = "";
@@ -343,8 +348,9 @@ class ilTemplate extends HTML_Template_ITX
             }
 
             if ($fname === "" || !file_exists($fname)) {
-                $fname = "./" . $module_path . "templates/default/" . basename($a_tplname);
+                $fname = $module_path . "templates/default/" . basename($a_tplname);
             }
+
         } elseif (strpos($a_tplname, "components/ILIAS/UI") === 0) {
             if (class_exists("ilStyleDefinition") // for testing
                 && ilStyleDefinition::getCurrentSkin() != "default") {
@@ -365,7 +371,7 @@ class ilTemplate extends HTML_Template_ITX
         } else {
             $fname = $a_tplname;
         }
-        return __DIR__ . '/../../../../' . $fname;
+        return $ilias_root . $fname;
     }
 
     /**

--- a/components/ILIAS/UICore/tests/ilTemplateTest.php
+++ b/components/ILIAS/UICore/tests/ilTemplateTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class ilTemplateTest extends TestCase
+{
+    protected ilTemplate $il_template;
+    protected string $il_root;
+
+    public function setUp(): void
+    {
+        $this->il_template = new class () extends ilTemplate {
+            protected string $style = 'delos';
+            protected string $skin = 'default';
+            protected bool $file_exists = true;
+            public function __construct()
+            {
+            }
+            public function _getTemplatePath(string $a_tplname, string $a_in_module = null): string
+            {
+                return $this->getTemplatePath($a_tplname, $a_in_module);
+            }
+            protected function getCurrentStyle(): ?string
+            {
+                return $this->style;
+            }
+            public function withStyle(string $style)
+            {
+                $clone = clone $this;
+                $clone->style = $style;
+                return $clone;
+            }
+            public function withSkin(string $skin)
+            {
+                $clone = clone $this;
+                $clone->skin = $skin;
+                return $clone;
+            }
+            protected function getCurrentSkin(): ?string
+            {
+                return $this->skin;
+            }
+            protected function fileExistsInSkin(string $path): bool
+            {
+                return $this->file_exists;
+            }
+            public function withFileExists(bool $file_exists)
+            {
+                $clone = clone $this;
+                $clone->file_exists = $file_exists;
+                return $clone;
+            }
+        };
+        $this->il_root = realpath(__DIR__ . '/../../../../');
+
+    }
+
+
+    public static function templatePathDataProvider(): array
+    {
+        $il_root = realpath(__DIR__ . '/../../../../');
+        return [
+            'standard component template' => [
+                'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
+                'tpl_filename' => 'tpl.appointment_panel.html',
+                'component' => 'components/ILIAS/Calendar',
+                'expected' => $il_root . '/components/ILIAS/Calendar/templates/default/tpl.appointment_panel.html'
+            ],
+            'plugin template' => [
+                'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
+                'tpl_filename' => 'tpl.test.html',
+                 //ilPlugin::getDirectory() will return something like this:
+                'component' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/plugins/UIComponent/UserInterfaceHook/EditorAsMode',
+                'expected' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/plugins/UIComponent/UserInterfaceHook/EditorAsMode/templates/default/tpl.test.html',
+            ],
+            'custom skin' => [
+                'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => true,
+                'tpl_filename' => 'tpl.external_settings.html',
+                'component' => 'components/ILIAS/Administration',
+                'expected' => $il_root . '/public/Customizing/skin/mySkin/myStyle/components/ILIAS/Administration/tpl.external_settings.html',
+            ],
+            'custom skin, unaltered file' => [
+                'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => false,
+                'tpl_filename' => 'tpl.external_settings.html',
+                'component' => 'components/ILIAS/Administration',
+                'expected' => $il_root . '/components/ILIAS/Administration/templates/default/tpl.external_settings.html',
+            ],
+            'ui template' => [
+                'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
+                'tpl_filename' => 'components/ILIAS/UI/src/templates/default/Input/tpl.standard.html',
+                'component' => '',
+                'expected' => $il_root . '/components/ILIAS/UI/src/templates/default/Input/tpl.standard.html',
+            ],
+            'ui template from skin' => [
+                'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => true,
+                'tpl_filename' => 'components/ILIAS/UI/src/templates/default/Input/tpl.standard.html',
+                'component' => '',
+                'expected' => $il_root . '/public/Customizing/skin/mySkin/myStyle/UI/Input/tpl.standard.html',
+            ],
+            'ui template from skin, unaltered' => [
+                'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => false,
+                'tpl_filename' => 'components/ILIAS/UI/src/templates/default/Input/tpl.standard.html',
+                'component' => '',
+                'expected' => $il_root . '/components/ILIAS/UI/src/templates/default/Input/tpl.standard.html',
+            ],
+            'trailing slash' => [
+                'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
+                'tpl_filename' => 'tpl.test.html',
+                'component' => 'components/ILIAS/Test/',
+                'expected' => $il_root . '/components/ILIAS/Test/templates/default/tpl.test.html',
+            ],
+
+        ];
+    }
+
+    /**
+     * @dataProvider templatePathDataProvider
+     */
+    public function testGetTemplatePath(
+        string $skin,
+        string $style,
+        bool $file_exists,
+        string $tpl_filename,
+        string $component,
+        string $expected
+    ): void {
+        $path = $this->il_template
+            ->withSkin($skin)
+            ->withStyle($style)
+            ->withFileExists($file_exists)
+            ->_getTemplatePath($tpl_filename, $component);
+
+        $this->assertEquals($expected, $path);
+    }
+
+}


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44208

with https://github.com/ILIAS-eLearning/ILIAS/pull/8873,  $plugin->getDirectory() will return an absolute path,
ilTemplate expects a relative path, though.
This has ilTemplate accept both. 
