### PR TITLE
Test/FinishPassesCron: Fix object existence check + Migrate field type

### DIFF
--- a/components/ILIAS/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
+++ b/components/ILIAS/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
@@ -224,7 +224,7 @@ class ilCronFinishUnfinishedTestPasses extends ilCronJob
         $this->logger->info('Test (' . $test_id . ') has processing time (' . $this->test_ending_times[$test_id]['processing_time'] . ')');
         $obj_id = $this->test_ending_times[$test_id]['obj_fi'];
 
-        if (ilObject::_exists($obj_id)) {
+        if (!ilObject::_exists($obj_id)) {
             $this->logger->info('Test object with id (' . $obj_id . ') does not exist.');
             return false;
         }

--- a/components/ILIAS/Test/src/Setup/Test10DBUpdateSteps.php
+++ b/components/ILIAS/Test/src/Setup/Test10DBUpdateSteps.php
@@ -404,4 +404,25 @@ class Test10DBUpdateSteps implements \ilDatabaseUpdateSteps
             $this->db->dropTableColumn('tst_tests', 'author');
         }
     }
+
+    public function step_11(): void
+    {
+        if ($this->db->tableColumnExists('tst_tests', 'enable_processing_time')) {
+            $this->db->manipulateF(
+                'UPDATE tst_tests SET enable_processing_time = %s WHERE enable_processing_time IS NULL',
+                [\ilDBConstants::T_INTEGER],
+                [0]
+            );
+            $this->db->modifyTableColumn(
+                'tst_tests',
+                'enable_processing_time',
+                [
+                    'type' => \ilDBConstants::T_INTEGER,
+                    'length' => 1,
+                    'notnull' => true,
+                    'default' => 0
+                ]
+            );
+        }
+    }
 }


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=44237

I pushed **two** commits to the branch because there were two different issues here:

- Database field `enable_processing_time` was of type `varchar`, which resulted in `!== 1` checks being `true`. This PR suggests to migrate to `tiynint` for this boolean state.
- Aborting the process if the test object **existed** was simply wrong (no offense, it's just a forgotton `!`). It has to be aborted if the object does **not** exist.

If approved, these two commits must be picked to all other relevant branches.