### PR TITLE
T&A 43093: Fixes sorting of questionpool questions table

### DIFF
--- a/components/ILIAS/TestQuestionPool/src/Presentation/QuestionTable.php
+++ b/components/ILIAS/TestQuestionPool/src/Presentation/QuestionTable.php
@@ -390,7 +390,7 @@ class QuestionTable extends \ilAssQuestionList implements Table\DataRetrieval
                 $aspect_b = $b[$aspect];
             }
 
-            return strcmp($aspect_a, $aspect_b);
+            return strcoll($aspect_a, $aspect_b);
         });
 
         if ($direction === $order::DESC) {


### PR DESCRIPTION
[Mantis: 43093](https://mantis.ilias.de/view.php?id=43093)

This change should resolve the issue with wrong sorting of questions in the questionpool.

It utilizes `strcoll` which respects the `locale` setting from the ilias administration.