### PR TITLE
The (int) cast on $course caused a fatal error because $course is an …

### DIFF
--- a/components/ILIAS/WebServices/ECS/classes/Course/class.ilECSCourseCreationHandler.php
+++ b/components/ILIAS/WebServices/ECS/classes/Course/class.ilECSCourseCreationHandler.php
@@ -200,7 +200,7 @@ class ilECSCourseCreationHandler
         foreach ($matching_rules as $matching_rule) {
             $this->logger->debug('Handling matching rule: ' . $matching_rule);
             $parent_refs = ilECSCourseMappingRule::doMappings(
-                (int) $course,
+                $course,
                 $this->getServer()->getServerId(),
                 $this->getMid(),
                 $matching_rule


### PR DESCRIPTION
…object.

The (int) cast on $course caused a fatal error because $course is an object.