### PR TITLE
Test: Fix Removal of Inline Images

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssHtmlPurifier.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssHtmlPurifier.php
@@ -41,6 +41,15 @@ abstract class ilAssHtmlPurifier extends ilHtmlPurifierAbstractLibWrapper
         $config->set('HTML.Doctype', 'XHTML 1.0 Strict');
         $config->set('HTML.AllowedElements', $this->getAllowedElements());
         $config->set('HTML.ForbiddenAttributes', 'div@style');
+        $config->autoFinalize = false;
+        $config->set(
+            'URI.AllowedSchemes',
+            array_merge(
+                $config->get('URI.AllowedSchemes'),
+                ['data' => true]
+            )
+        );
+        $config->autoFinalize = true;
         if ($def = $config->maybeGetRawHTMLDefinition()) {
             $def->addAttribute('a', 'target', 'Enum#_blank,_self,_target,_top');
         }


### PR DESCRIPTION
The fix https://github.com/ILIAS-eLearning/ILIAS/commit/fa0282e08e6f41311d4d2a85dc5b0b94242d6dbc added in the past by @kergomard is missing in ILIAS versions >= 9.

Causing the same issue as reported in the past: https://mantis.ilias.de/view.php?id=36264

If accepted, should be picked into ILIAS versions 10 & trunk as well.