### PR TITLE
Object: fix id mapping on import (44072)

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectDataSet.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectDataSet.php
@@ -382,7 +382,7 @@ class ilObjectDataSet extends ilDataSet
         }
         if (!$new_id) {
             foreach ($mapping->getAllMappings() as $k => $m) {
-                if (substr($k, 0, 8) == 'components/ILIAS/') {
+                if (substr($k, 0, 17) == 'components/ILIAS/') {
                     foreach ($m as $type => $map) {
                         if (!$new_id) {
                             if ($objDefinition->isRBACObject($type)) {


### PR DESCRIPTION
Just a small fix for the ID mapping in `ilObjectDataSet`. In specific circumstances it failed, leading to object properties not getting imported, see [44072](https://mantis.ilias.de/view.php?id=44072).