### PR TITLE
LTI: Correction of invalid parameters and loading of the RSA-Key in the form of LTI 1.3

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumeProviderFormGUI.php
@@ -150,6 +150,7 @@ class ilLTIConsumeProviderFormGUI extends ilPropertyFormGUI
         $keyType->addOption($keyRsa);
         $publicKey = new ilTextAreaInputGUI($lng->txt('lti_con_key_type_rsa_public_key'), 'public_key');
         $publicKey->setRows(6);
+        $publicKey->setValue($this->provider->getPublicKey());
         $publicKey->setRequired(true);
         $publicKey->setInfo($lng->txt('lti_con_key_type_rsa_public_key_info'));
         $keyRsa->addSubItem($publicKey);

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -879,9 +879,9 @@ class ilObjLTIConsumer extends ilObject2
             "context_label" => $contextType . " " . $contextId,
             "launch_presentation_locale" => $this->lng->getLangKey(),
             "launch_presentation_document_target" => $documentTarget,
-            "launch_presentation_width" => "",
+            //"launch_presentation_width" => "",
             //recommended
-            "launch_presentation_height" => "",
+            //"launch_presentation_height" => "",
             //recommended
             "launch_presentation_return_url" => $returnUrl,
             "tool_consumer_instance_guid" => $toolConsumerInstanceGuid,

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -733,6 +733,7 @@ class ilObjLTIConsumer extends ilObject2
             $toolConsumerInstanceGuid .= implode(".", array_reverse(explode("/", $parseIliasUrl["path"])));
         }
         $toolConsumerInstanceGuid .= $parseIliasUrl["host"];
+
         $launch_vars = [
             "lti_message_type" => "basic-lti-launch-request",
             "lti_version" => "LTI-1p0",
@@ -752,9 +753,9 @@ class ilObjLTIConsumer extends ilObject2
             "context_label" => $contextType . " " . $contextId,
             "launch_presentation_locale" => $this->lng->getLangKey(),
             "launch_presentation_document_target" => $documentTarget,
-            "launch_presentation_width" => "",
+            //"launch_presentation_width" => "",
             //recommended
-            "launch_presentation_height" => "",
+            //"launch_presentation_height" => "",
             //recommended
             "launch_presentation_return_url" => $returnUrl,
             "tool_consumer_instance_guid" => $toolConsumerInstanceGuid,


### PR DESCRIPTION
- The parameters ‘launch_presentation_width’ and ‘launch_presentation_height’ which broke the launch of the JWT have been omitted and are not being used.
- Implemented loading of the RSA-Key value in the LTI 1.3 form to display the saved value.