### PR TITLE
T&A Bugfix: Import of Tests with Images takes exponentially longer than normal

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assQuestionImport.php
+++ b/components/ILIAS/TestQuestionPool/classes/import/qti12/class.assQuestionImport.php
@@ -374,6 +374,10 @@ class assQuestionImport
             return $this->object->getThumbSize();
         }
 
+        if ($size < $this->object->getMinimumThumbSize()) {
+            return $this->object->getMinimumThumbSize();
+        }
+
         if ($size > $this->object->getMaximumThumbSize()) {
             return $this->object->getMaximumThumbSize();
         }


### PR DESCRIPTION
Solves the issue that came along with https://mantis.ilias.de/view.php?id=42016

The Problem with Test Imports and Images was that the thumbnails that were generated were always generated with Maximum Thumb Size. This would make all Images in the imported test scaled to much higher than 8k (8192x8192)

```php
        if ($size < $this->object->getMaximumThumbSize() // 8192) {
            return $this->object->getMaximumThumbSize();
        }
```

@kergomard solved this unintentionally with commit https://github.com/ILIAS-eLearning/ILIAS/commit/8b66c0cdf2127cecd8caf5b39cace0f37e1d2665 which removed the line.
But since this line was faulty and could be fixed by removing the logic typo i re-added the line (now correctly)
which should also still work with the Bugfix addressed by the commit.

Best @fhelfer 