### PR TITLE
SOAP: Fix calling `getInstallationInfoXML`

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1604,6 +1604,10 @@ class ilInitialisation
      */
     protected static function replaceSuperGlobals(\ILIAS\DI\Container $container): void
     {
+        if (!ilContext::initClient()) {
+            return;
+        }
+
         /** @var ilIniFile $client_ini */
         $client_ini = $container['ilClientIniFile'];
 


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=44361

If approved, this must be picked to `release_10` and `trunk`.