### PR TITLE
ErrorHandling/SOAP: Use SOAP exception handler for HTTP POST only

### DIFF
--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -114,11 +114,12 @@ class ilErrorHandling
      */
     public function getHandler(): HandlerInterface
     {
-        if (ilContext::getType() === ilContext::CONTEXT_SOAP) {
+        if (ilContext::getType() === ilContext::CONTEXT_SOAP &&
+            strcasecmp($_SERVER['REQUEST_METHOD'] ?? '', 'post') === 0) {
             return new ilSoapExceptionHandler();
         }
 
-        // TODO: There might be more specific execution contexts (WebDAV, REST, etc.) that need specific error handling. 
+        // TODO: There might be more specific execution contexts (WebDAV, REST, etc.) that need specific error handling.
 
         if ($this->isDevmodeActive()) {
             return $this->devmodeHandler();
@@ -393,7 +394,7 @@ class ilErrorHandling
     protected function loggingHandler(): HandlerInterface
     {
         /**
-         * @var 
+         * @var
          */
         return new CallbackHandler(function ($exception, Inspector $inspector, Run $run) {
             /**
@@ -409,15 +410,15 @@ class ilErrorHandling
                 $previous = $exception->getPrevious();
                 while ($previous) {
                     $message .= "\n\nCaused by\n" . sprintf(
-                            '%s: %s in file %s on line %d',
-                            get_class($previous),
-                            $previous->getMessage(),
-                            $previous->getFile(),
-                            $previous->getLine()
-                        );
+                        '%s: %s in file %s on line %d',
+                        get_class($previous),
+                        $previous->getMessage(),
+                        $previous->getFile(),
+                        $previous->getLine()
+                    );
                     $previous = $previous->getPrevious();
                 }
-                
+
                 $ilLog->error($exception->getCode() . ' ' . $message);
             }
 


### PR DESCRIPTION
The SOAP exception handler should only be used for HTTP POST requests, even if `ilContextSoap` is given

See: https://mantis.ilias.de/view.php?id=44363

If approved, this must be picked to `release_10` and `trunk`.