### PR TITLE
SCORM/Certificate: Fix float value provided for placeholder

### DIFF
--- a/Modules/ScormAicc/classes/Certificate/class.ilScormPlaceholderValues.php
+++ b/Modules/ScormAicc/classes/Certificate/class.ilScormPlaceholderValues.php
@@ -104,7 +104,7 @@ class ilScormPlaceholderValues implements ilCertificatePlaceholderValues
         }
 
         $max_points = $object->getMaxPoints();
-        $txtMaxPoints = $max_points;
+        $txtMaxPoints = (string) $max_points;
         if (is_null($max_points)) {
             $txtMaxPoints = $this->language->txt('certificate_points_notavailable');
         } elseif ($max_points != floor($max_points)) {


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=44365

If approved, this must be picked to `release_10` and `trunk`. Please note that this file has been moved with ILIAS 10.x.

Location: components/ILIAS/ScormAicc/classes/Certificate/class.ilScormPlaceholderValues.php