### PR TITLE
Correct numeric sorting of column reached_points in T&A result table

### DIFF
--- a/Modules/Test/classes/tables/class.ilParticipantsTestResultsTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilParticipantsTestResultsTableGUI.php
@@ -92,7 +92,7 @@ class ilParticipantsTestResultsTableGUI extends ilTable2GUI
     public function numericOrdering(string $a_field): bool
     {
         return in_array($a_field, array(
-            'scored_pass', 'answered_questions', 'points', 'percent_result'
+            'scored_pass', 'answered_questions', 'reached_points', 'percent_result'
         ));
     }
 


### PR DESCRIPTION
fix: changed numeric ordering from unused points - to correct reached_points column (mantis id: 28433)