### PR TITLE
UI: Remove leftover parameter in Form\Factory test

### DIFF
--- a/tests/UI/Component/Input/Container/Form/FormFactoryTest.php
+++ b/tests/UI/Component/Input/Container/Form/FormFactoryTest.php
@@ -47,8 +47,7 @@ class FormFactoryTest extends AbstractFactoryTest
                 $df,
                 new Factory($df, $language),
                 $language
-            ),
-            new DefNamesource()
+            )
         );
     }
 


### PR DESCRIPTION
This just removes a leftover parameter from the Form\Factory test that is not needed anymore. 