### PR TITLE
T&A Bugfix: 44352 ErrorText Questions accept 0 for points

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilErrorTextWizardInputGUI.php
@@ -226,7 +226,7 @@ class ilErrorTextWizardInputGUI extends ilTextInputGUI
             return false;
         }
         foreach ($points as $point) {
-            if ($point < 0) {
+            if ($point <= 0) {
                 $this->setAlert($this->lng->txt('positive_numbers_required'));
                 return false;
             }


### PR DESCRIPTION
This PR will fix https://mantis.ilias.de/view.php?id=44352

If a user enters '0' for points, the message "Please enter only positive numbers." will pop up when trying to save.