### PR TITLE
T&A Bugfix: 44350: highlight tab after analyzing ErrorText Question

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assErrorTextGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assErrorTextGUI.php
@@ -221,6 +221,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         $this->writePostData(true);
         $this->saveTaxonomyAssignments();
         $this->object->setErrorsFromParsedErrorText();
+        $this->tabs->activateTab('edit_question');
         $this->editQuestion();
     }
 


### PR DESCRIPTION
This PR will fix https://mantis.ilias.de/view.php?id=44350
The tab "Edit Question" will be highligted after clicking "Analyze Error Text"

Thank you