### PR TITLE
T&A 28142: Failed test: Übertragung von Änderungen einer Frage

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionSkillAssignmentsGUI.php
@@ -476,7 +476,6 @@ class ilAssQuestionSkillAssignmentsGUI
 
         $form->setManipulationEnabled(
             $this->isAssignmentEditingEnabled()
-            && $question->getOriginalId() === null
         );
 
         $form->build();

--- a/Modules/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilAssQuestionSkillAssignmentsTableGUI.php
@@ -217,7 +217,7 @@ class ilAssQuestionSkillAssignmentsTableGUI extends ilTable2GUI
             ilAssQuestionSkillAssignmentsGUI::CMD_SHOW_SKILL_QUEST_ASSIGN_PROPERTIES_FORM
         );
 
-        if ($this->isManipulationAllowedForQuestion($assignment->getQuestionId())) {
+        if ($this->manipulationsEnabled) {
             $label = $this->lng->txt('tst_edit_competence_assign');
         } else {
             $label = $this->lng->txt('tst_view_competence_assign');


### PR DESCRIPTION
Hi everyone,

This PR adresses ticket [28142](https://mantis.ilias.de/view.php?id=28142#c112790) and introduces the change that it should still be possible to edit competencies of a question from a QPL via the 'Edit Assignment Properties' link. 

I look forward to your feedback. As usual, these changes will be approved by @thojou  in an internal review.

Best
@lukas-heinrich 