### PR TITLE
T&A9 43838: Redirects user to test tab when test attempt gets finished by administrator

### DIFF
--- a/Modules/Test/classes/class.ilTestOutputGUI.php
+++ b/Modules/Test/classes/class.ilTestOutputGUI.php
@@ -189,7 +189,7 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
 
                     if (!$testPassesSelector->openPassExists()) {
                         $this->tpl->setOnScreenMessage('info', $this->lng->txt('tst_pass_finished'), true);
-                        $this->ctrl->redirectByClass("ilobjtestgui", "infoScreen");
+                        $this->ctrl->redirectByClass([ilRepositoryGUI::class, ilObjTestGUI::class, ilTestScreenGUI::class]);
                     }
                 }
 


### PR DESCRIPTION
[Mantis: 43838](https://mantis.ilias.de/view.php?id=43838)

When a administrator finishes a test attempt, while the user ist still taking the test, the user gets redirected to the info tab of the test. The user should get redirected to the test tab instead.