### PR TITLE
UI Improvement: Navigation Arrows Survey

### DIFF
--- a/components/ILIAS/Survey/Execution/class.ilSurveyExecutionGUI.php
+++ b/components/ILIAS/Survey/Execution/class.ilSurveyExecutionGUI.php
@@ -698,7 +698,10 @@ class ilSurveyExecutionGUI
         if (is_null($prevpage)) {
             $stpl->setVariable("BTN_PREV", $this->lng->txt("survey_start"));
         } else {
-            $stpl->setVariable("BTN_PREV", $this->lng->txt("survey_previous"));
+            $stpl->setVariable(
+                "BTN_PREV",
+                '<span class="glyphicon glyphicon-chevron-left"></span>' . $this->lng->txt("previous")
+            );
         }
         $stpl->parseCurrentBlock();
         $nextpage = $this->object->getNextPage($page[0]["question_id"], 1);
@@ -706,7 +709,10 @@ class ilSurveyExecutionGUI
         if (is_null($nextpage)) {
             $stpl->setVariable("BTN_NEXT", $this->lng->txt("survey_finish"));
         } else {
-            $stpl->setVariable("BTN_NEXT", $this->lng->txt("survey_next"));
+            $stpl->setVariable(
+                "BTN_NEXT",
+                $this->lng->txt("next") . '<span class="glyphicon glyphicon-chevron-right"></span>'
+            );
         }
         $stpl->parseCurrentBlock();
     }

--- a/components/ILIAS/Survey/templates/default/tpl.il_svy_svy_content.html
+++ b/components/ILIAS/Survey/templates/default/tpl.il_svy_svy_content.html
@@ -9,7 +9,9 @@
 	<tr>
 	<td align="left" width="33%" class="submit">
 <!-- BEGIN top_prev -->
-		<input type="submit" id="prevButton" class="btn btn-default" name="cmd[previous]" value="{BTN_PREV}" />
+		<button type="submit" id="prevButton" class="btn btn-default" name="cmd[previous]">
+			{BTN_PREV}
+		</button>
 <!-- END top_prev -->
 	</td>
 	<td class="submit">
@@ -21,7 +23,9 @@
 	</td>
 	<td align="right" width="33%" class="submit">
 <!-- BEGIN top_next -->
-		<input type="submit" id="nextButton" class="btn btn-default btn-primary" name="cmd[next]" value="{BTN_NEXT}" />
+		<button type="submit" id="nextButton" class="btn btn-default btn-primary" name="cmd[next]">
+			{BTN_NEXT}
+		</button>
 <!-- END top_next -->
 	</td>
 	</tr>	
@@ -36,14 +40,18 @@
 	<tr>
 		<td align="left" width="33%" class="submit">
 <!-- BEGIN bottom_prev -->
-			<input type="submit" id="prevButtonBottom" class="btn btn-default" name="cmd[previous]" value="{BTN_PREV}" />
+			<button type="submit" id="prevButtonBottom" class="btn btn-default" name="cmd[previous]">
+				{BTN_PREV}
+			</button>
 <!-- END bottom_prev -->
 		</td>
 		<td align="left" width="1" class="submit">
 		</td>
 		<td align="right" width="33%" class="submit">
 <!-- BEGIN bottom_next -->
-			<input type="submit" id="nextButtonBottom" class="btn btn-default btn-primary" name="cmd[next]" value="{BTN_NEXT}" />
+			<button type="submit" id="nextButtonBottom" class="btn btn-default btn-primary" name="cmd[next]">
+				{BTN_NEXT}
+			</button>
 <!-- END bottom_next -->
 		</td>
 	</tr>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16653,7 +16653,6 @@ survey#:#survey_has_datasets_warning_page_view_link#:#Datensätze anzeigen
 survey#:#survey_introduction_info#:#Dieser Text wird dauerhaft auf dem Reiter „Info“ angezeigt.
 survey#:#survey_is_offline#:#Sie können die Umfrage nicht starten! Die Umfrage ist offline (nicht aktiviert).
 survey#:#survey_new_pool#:#Neuen Fragenpool anlegen
-survey#:#survey_next#:#Weiter →
 survey#:#survey_no_pool#:#Keinen Fragenpool verwenden
 survey#:#survey_not_available#:#n.a.
 survey#:#survey_notification_finished_introduction#:#eine Person hat die Umfrage beendet.
@@ -16672,7 +16671,6 @@ survey#:#survey_notification_tutor_setting#:#Eine E-Mail nachdem alle Befragten 
 survey#:#survey_notification_tutor_subject#:#Alle Befragten haben die Umfrage „%s“ beendet
 survey#:#survey_order#:#Sortierung
 survey#:#survey_pool_selection#:#Poolauswahl
-survey#:#survey_previous#:#← Zurück
 survey#:#survey_question_editor#:#Listenansicht
 survey#:#survey_question_obligatory#:#(Diese Frage ist eine Pflichtfrage. Sie muss beantwortet werden!)
 survey#:#survey_question_pool#:#Fragenpool

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16652,7 +16652,6 @@ survey#:#survey_has_datasets_warning_page_view_link#:#Edit Participants
 survey#:#survey_introduction_info#:#This message is permanently displayed on the ‘Info’-tab.
 survey#:#survey_is_offline#:#You cannot start the survey! The survey is currently offline.
 survey#:#survey_new_pool#:#Create new question pool
-survey#:#survey_next#:#Next >>
 survey#:#survey_no_pool#:#Do not use question pool
 survey#:#survey_not_available#:#n/a
 survey#:#survey_notification_finished_introduction#:#A participant has finished the survey.
@@ -16671,7 +16670,6 @@ survey#:#survey_notification_tutor_setting#:#One E-Mail after all Participants F
 survey#:#survey_notification_tutor_subject#:#All participants have finished the survey "%s"
 survey#:#survey_order#:#Sort Order
 survey#:#survey_pool_selection#:#Pool Selection
-survey#:#survey_previous#:#<< Previous
 survey#:#survey_question_editor#:#List View
 survey#:#survey_question_obligatory#:#This question is compulsory. You must answer the question!
 survey#:#survey_question_pool#:#Question Pool


### PR DESCRIPTION
This PR updates the arrows in the survey navigation to align them with the Navigation Arrows group, as specified in the document [ILIAS/UI/docs/ilias-arrows.md.](https://github.com/ILIAS-eLearning/ILIAS/blob/ad8118f9d94d4ada9a0c37ea0ad5e840bdee1f6b/components/ILIAS/UI/docs/ilias-arrows.md)

The goal of the Navigation Arrows group is to standardize the use of the "Next" glyph (chevron-right ["\e080"]) and the "Back" glyph (chevron-left ["\e079"]) across the platform.
To achieve this, the double chevron ">>" (or "→" in the german version) in the survey from the language variables have been removed and have been replaced accordingly.
The previous inputs have also been replaced with proper buttons.