### PR TITLE
UI Improvement: Navigation Arrows Lightbox Modal

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
+++ b/components/ILIAS/UI/src/templates/default/Modal/tpl.lightbox.html
@@ -31,14 +31,14 @@
 					</div>
 
 					<!-- BEGIN controls -->
-					<a class="left carousel-control" href="#{ID_CAROUSEL3}" role="button" data-slide="prev">
+					<button class="left carousel-control btn-link" href="#{ID_CAROUSEL3}" role="button" data-slide="prev">
 						<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 						<span class="sr-only">Previous</span>
-					</a>
-					<a class="right carousel-control" href="#{ID_CAROUSEL3}" role="button" data-slide="next">
+					</button>
+					<button class="right carousel-control btn-link" href="#{ID_CAROUSEL3}" role="button" data-slide="next">
 						<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 						<span class="sr-only">Next</span>
-					</a>
+					</button>
 					<!-- END controls -->
 
 				</div>

--- a/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
@@ -185,14 +185,14 @@ EOT;
 						</div>
 					</div>
 
-					<a class="left carousel-control" href="#id_1_carousel" role="button" data-slide="prev">
+					<button class="left carousel-control btn-link" href="#id_1_carousel" role="button" data-slide="prev">
 						<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 						<span class="sr-only">Previous</span>
-					</a>
-					<a class="right carousel-control" href="#id_1_carousel" role="button" data-slide="next">
+					</button>
+					<button class="right carousel-control btn-link" href="#id_1_carousel" role="button" data-slide="next">
 						<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 						<span class="sr-only">Next</span>
-					</a>
+					</button>
 
 				</div>
 			</div>


### PR DESCRIPTION
This PR updates the arrows in the lightbox modal navigation to align them with the Navigation Arrows group, as specified in the document [ILIAS/UI/docs/ilias-arrows.md.](https://github.com/ILIAS-eLearning/ILIAS/blob/ad8118f9d94d4ada9a0c37ea0ad5e840bdee1f6b/components/ILIAS/UI/docs/ilias-arrows.md)

The goal of the Navigation Arrows group is to standardize the use of the "Next" glyph (chevron-right ["\e080"]) and the "Back" glyph (chevron-left ["\e079"]) across the platform.
This PR only changes the previous Navigation Links to Buttons. Class .btn-link has been added to make the Button Outline invisible.