### PR TITLE
Calling ilObjTest->getActiveIdOfUser in a cron/cli enviroment as anonymous user no activeId is returned

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -1734,7 +1734,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
                 [$user_id, $this->test_id, $anonymous_id]
             );
         } else {
-            if ($this->user->getId() === ANONYMOUS_USER_ID) {
+            if ((int) $user_id === ANONYMOUS_USER_ID) {
                 return null;
             }
             $result = $this->db->queryF(


### PR DESCRIPTION
In a cron/cli enviroment without explicit user context the  `$this->user` is the anonymouos user not the passed user of the passed user_id. The fallback user_id is fetched in the first lines of the method so this `$user_id` should be used.

Mantis https://mantis.ilias.de/view.php?id=44475