### PR TITLE
UI Improvement: Hierarchy Arrows Learning Progress

### DIFF
--- a/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfSettingsGUI.php
+++ b/components/ILIAS/Tracking/classes/repository_statistics/class.ilLPListOfSettingsGUI.php
@@ -555,6 +555,10 @@ class ilLPListOfSettingsGUI extends ilLearningProgressBaseGUI
                     $params["gotolp"] = 1;
                 }
 
+                $tpl->setVariable("EXPAND_GLYPH", $this->ui_renderer->render(
+                    $this->ui_factory->symbol()->glyph()->expand()->withUnavailableAction()
+                ));
+
                 if ($this->access->checkAccess("read", "", $parent_ref_id) &&
                     $parent_ref_id != $ref_id) { // #17170
                     $tpl->setCurrentBlock("parent_link_bl");

--- a/components/ILIAS/Tracking/templates/default/tpl.lp_obj_settings_tree_info.html
+++ b/components/ILIAS/Tracking/templates/default/tpl.lp_obj_settings_tree_info.html
@@ -1,6 +1,6 @@
 <!-- BEGIN parent_usage_bl -->
 <div style="margin-left:{MARGIN}px">
-	&raquo;
+	{EXPAND_GLYPH}
 	<img class="ilListItemIcon" src="{PARENT_TYPE_URL}" alt="{PARENT_TYPE_ALT}" title="{PARENT_TYPE_ALT}" />
 	<!-- BEGIN parent_nolink_bl -->
 	<span{PARENT_STYLE}>{PARENT_NOLINK_TITLE}</span>


### PR DESCRIPTION
This PR updates the arrows in the Learning Progress Hierarchy to align them with the Hierarchy Arrows group, as specified in the document [ILIAS/UI/docs/ilias-arrows.md.](https://github.com/ILIAS-eLearning/ILIAS/blob/ad8118f9d94d4ada9a0c37ea0ad5e840bdee1f6b/components/ILIAS/UI/docs/ilias-arrows.md)

The goal of the Hierarchy Arrows group is to standardize the use of the Hierarchy Arrow Marker (triangle-right ["\e606"] across the platform.
To achieve this, the double arrow in LP has been changed accordingly, to a disabled Expand Glyph