### PR TITLE
UI Improvement: Link Arrows MessageBox

### DIFF
--- a/templates/default/070-components/UI-framework/MessageBox/_ui-component_messagebox.scss
+++ b/templates/default/070-components/UI-framework/MessageBox/_ui-component_messagebox.scss
@@ -7,6 +7,7 @@
 $il-messagebox-link-bullet: "\00BB \0020";
 $il-messagebox-margin-top: 10px;
 $il-messagebox-link-list-margin-top: 15px;
+$il-messagebox-link-list-padding-left: 26px;
 
 div.alert {
 	div {
@@ -15,13 +16,8 @@ div.alert {
 	ul {
 		margin-top: $il-messagebox-link-list-margin-top;
 		background-color: $il-main-dark-bg;
-		padding: $il-padding-large-vertical $il-padding-large-horizontal;
+		padding: $il-padding-large-vertical $il-messagebox-link-list-padding-left;
 		font-size: $il-font-size-small;
 		color: $il-text-light-color;
-		list-style-type: none;
-	}
-	ul > li:before {
-		content: $il-messagebox-link-bullet;
-		/* margin-left: -10px; */
 	}
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -7905,14 +7905,9 @@ div.alert div {
 div.alert ul {
   margin-top: 15px;
   background-color: #f9f9f9;
-  padding: 6px 12px;
+  padding: 6px 26px;
   font-size: 0.75rem;
   color: #6f6f6f;
-  list-style-type: none;
-}
-div.alert ul > li:before {
-  content: "» ";
-  /* margin-left: -10px; */
 }
 
 .c-modal,


### PR DESCRIPTION
This PR updates the Link Arrows inside the MessageBox as specified in the document [ILIAS/UI/docs/ilias-arrows.md.](https://github.com/ILIAS-eLearning/ILIAS/blob/ad8118f9d94d4ada9a0c37ea0ad5e840bdee1f6b/components/ILIAS/UI/docs/ilias-arrows.md)

The goal of the Links group is to standardize the use of the usual Unordered List Dot.
To achieve this, the double arrow has been replaced accordingly.