### PR TITLE
UI Improvement: Sortation Arrows View Control

### DIFF
--- a/components/ILIAS/UI/src/templates/default/ViewControl/tpl.sortation.html
+++ b/components/ILIAS/UI/src/templates/default/ViewControl/tpl.sortation.html
@@ -1,5 +1,5 @@
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="{ID}">
-    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"<!-- BEGIN aria_label --> aria-label="{ARIA_LABEL}"<!-- END aria_label --> aria-haspopup="true" aria-expanded="false" aria-controls="{ID_MENU}"><span class="label">{LABEL}</span><span class="caret"></span></button>
+    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown"<!-- BEGIN aria_label --> aria-label="{ARIA_LABEL}"<!-- END aria_label --> aria-haspopup="true" aria-expanded="false" aria-controls="{ID_MENU}"><span class="label">{LABEL}</span><span class="glyphicon-sort"></span></button>
 
     <ul id="{ID_MENU}" class="dropdown-menu">
         <!-- BEGIN option -->

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
@@ -234,7 +234,7 @@ EOT;
             <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
                 <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
                     <span class="label">vc_sort B</span>
-                    <span class="caret"></span>
+                    <span class="glyphicon-sort"></span>
                 </button>
                 <ul id="id_1_ctrl" class="dropdown-menu">
                     <li><button class="btn btn-link" data-action="?sortation=a" id="id_2">A</button></li>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
@@ -192,7 +192,7 @@ EOT;
             <div class="dropdown il-viewcontrol  il-viewcontrol-sortation l-bar__element" id="id_1">
                 <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
                     <span class="label">vc_sort A</span>
-                    <span class="caret"></span>
+                    <span class="glyphicon-sort"></span>
                 </button>
                 <ul id="id_1_ctrl" class="dropdown-menu">
                     <li class="selected"><button class="btn btn-link" data-action="?sortation=a" id="id_2">A</button></li>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
@@ -478,7 +478,7 @@ EOT;
             <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
                 <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
                     <span class="label">vc_sort B</span>
-                    <span class="caret"></span>
+                    <span class="glyphicon-sort"></span>
                 </button>
                 <ul id="id_1_ctrl" class="dropdown-menu">
                    <li><button class="btn btn-link" data-action="?sortation=a" id="id_2">A</button></li>

--- a/components/ILIAS/UI/tests/Component/ViewControl/SortationTest.php
+++ b/components/ILIAS/UI/tests/Component/ViewControl/SortationTest.php
@@ -86,7 +86,7 @@ class SortationTest extends ILIAS_UI_TestBase
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
     <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
         <span class="label">vc_sort Most Recent</span>
-        <span class="caret"></span>
+        <span class="glyphicon-sort"></span>
     </button>
     <ul id="id_1_ctrl" class="dropdown-menu">
         <li><button class="btn btn-link" data-action="?sortation=internal_rating" id="id_2">Best</button></li>
@@ -110,7 +110,7 @@ EOT;
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element" id="id_1">
     <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="id_1_ctrl">
         <span class="label">vc_sort Most Recent</span>
-        <span class="caret"></span>
+        <span class="glyphicon-sort"></span>
     </button>
     <ul id="id_1_ctrl" class="dropdown-menu">
         <li><button class="btn btn-link" data-action="?sortation=internal_rating" id="id_2">Best</button></li>
@@ -146,7 +146,7 @@ EOT;
 <div class="dropdown il-viewcontrol il-viewcontrol-sortation l-bar__element"$id>
     <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-label="sortation" aria-haspopup="true" aria-expanded="false" aria-controls="{$id_ctrl}">
         <span class="label">vc_sort Best</span>
-        <span class="caret"></span>
+        <span class="glyphicon-sort"></span>
     </button>
     <ul id="{$id_ctrl}" class="dropdown-menu">
         <li class="selected"><button class="btn btn-link" data-action="?sortation=internal_rating" id="$button1_id">Best</button></li>


### PR DESCRIPTION
This PR updates the Sortation Arrows of the ViewControl to align them with the Sortation Arrows group, as specified in the document [ILIAS/UI/docs/ilias-arrows.md.](https://github.com/ILIAS-eLearning/ILIAS/blob/ad8118f9d94d4ada9a0c37ea0ad5e840bdee1f6b/components/ILIAS/UI/docs/ilias-arrows.md)

The goal of the Sortation Arrows group is to standardize the use of the Sortation (glyphicon-sort ["\e90b"])
To achieve this, the arrows in the ViewControl Sortation have been replaced accordingly, as it already is the case for the Input ViewControl Sortation