### PR TITLE
10/contentPage/right-column panel breakpoints 44276

### DIFF
--- a/templates/default/050-layout/_layout_container-query.scss
+++ b/templates/default/050-layout/_layout_container-query.scss
@@ -14,10 +14,8 @@
 /// @prop {Numbers} wide-card switch to slightly condensed card/item design (e.g. for 2 column grid) below
 /// @prop {Numbers} toolbar switch an entire toolbar to a condensed design below
 $container-query-contexts: (
-    compact-card: 300px,
     sidebar: l.$il-standard-page-slate-width,
-    wide-card: 600px,
-    toolbar: 600px,
+    wide-content: 600px,
 );
 
 $_error-invalid-query-context: "Must pick valid container query name from map of allowed contexts: #{map.keys($container-query-contexts)}";

--- a/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
+++ b/templates/default/070-components/UI-framework/Layout/_ui-component_standardpage.scss
@@ -1,7 +1,8 @@
 @use "../../../010-settings/"as *;
 @use "../../../050-layout/basics"as *;
 @use "../../../050-layout/layout_breakpoints" as *;
-@use "../../../050-layout/standardpage"as *;
+@use "../../../050-layout/standardpage" as *;
+@use "../../../050-layout/layout_container-query" as container-query;
 
 //== Standard Page
 $il-standard-page-small-mainbar-height-w-bottom-safe-area: calc($il-standard-page-small-mainbar-height + 1.2 * env(safe-area-inset-bottom));
@@ -175,6 +176,16 @@ main {
     	width: 100%;
 	}
 }
+#il_center_col {
+	.panel-viewcontrols {
+		@include container-query.set-container-context(wide-content);
+		@include container-query.style-in-context(wide-content) {
+			.il-viewcontrol-sortation .label {
+				display: none;
+			}
+		}
+	}
+}
 
 /*
 **************************************************************
@@ -182,31 +193,12 @@ main {
 **************************************************************
 */
 
-// Sidepanel in right column under content
-//
-#il_right_col {
-	@media (min-width: $il-grid-float-breakpoint) {
-		padding-left: 0; //See: #https://mantis.ilias.de/view.php?id=27109
-	}
-}
-@media only screen and (max-width: ($screen-lg-desktop - 1px)) {
-	.il-layout-page.with-mainbar-slates-engaged {
-		#il_right_col {
-			padding-left: 15px;
-		}
-	}
-}
 
 @media only screen and (max-width: ($screen-lg-desktop - 1px)) {
-	.il-layout-page.with-mainbar-slates-engaged {
-		#il_center_col.col-sm-9{
-			padding-right: 15px;
-		}
-		#il_center_col.col-sm-9,
-		#il_right_col.col-sm-3 {
-			float: none !important;
-			width: 100% !important;
-		}
+	#il_center_col.col-sm-9,
+	#il_right_col.col-sm-3 {
+		float: none !important;
+		width: 100% !important;
 	}
 }
 

--- a/templates/default/070-components/UI-framework/Panel/_ui-component_panel.scss
+++ b/templates/default/070-components/UI-framework/Panel/_ui-component_panel.scss
@@ -24,7 +24,7 @@
 		border-bottom: 1px solid transparent;
 		border: none;
 		@include border-top-radius((ls.$il-panel-border-radius - 1));
-	
+
 		>.dropdown .dropdown-toggle {
 			color: $il-btn-standard-color;
 		}
@@ -93,7 +93,6 @@
 		gap: $il-margin-base-horizontal;
 	}
 	.panel-title{
-		flex-shrink: 0;
 		order: 1;
 	}
 	.panel-controls {

--- a/templates/default/070-components/UI-framework/ViewControl/_ui-component_viewcontrol.scss
+++ b/templates/default/070-components/UI-framework/ViewControl/_ui-component_viewcontrol.scss
@@ -140,10 +140,4 @@ $il-vc-pagination-btn-active-bg: $il-main-bg;
 // container queries - change design when viewcontrol is in a narrow toolbar
 .panel-viewcontrols {
 	z-index: $il-z-index-content;
-	@include container-query.set-container-context(toolbar);
-	@include container-query.style-in-context(toolbar) {
-		.il-viewcontrol-sortation .label {
-			display: none;
-		}
-	}
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -5293,28 +5293,24 @@ main {
   width: 100%;
 }
 
+#il_center_col .panel-viewcontrols {
+  container-name: wide-content;
+  container-type: inline-size;
+}
+@container wide-content (width <= 600px) {
+  #il_center_col .panel-viewcontrols .il-viewcontrol-sortation .label {
+    display: none;
+  }
+}
+
 /*
 **************************************************************
        mobile Layout
 **************************************************************
 */
-@media (min-width: 768px) {
-  #il_right_col {
-    padding-left: 0;
-  }
-}
-
 @media only screen and (max-width: 1199px) {
-  .il-layout-page.with-mainbar-slates-engaged #il_right_col {
-    padding-left: 15px;
-  }
-}
-@media only screen and (max-width: 1199px) {
-  .il-layout-page.with-mainbar-slates-engaged #il_center_col.col-sm-9 {
-    padding-right: 15px;
-  }
-  .il-layout-page.with-mainbar-slates-engaged #il_center_col.col-sm-9,
-  .il-layout-page.with-mainbar-slates-engaged #il_right_col.col-sm-3 {
+  #il_center_col.col-sm-9,
+  #il_right_col.col-sm-3 {
     float: none !important;
     width: 100% !important;
   }
@@ -8293,7 +8289,6 @@ div.alert ul > li:before {
   gap: 9px;
 }
 .panel-flex .panel-title {
-  flex-shrink: 0;
   order: 1;
 }
 .panel-flex .panel-controls {
@@ -10929,13 +10924,6 @@ td.c-table-data__cell--highlighted {
 
 .panel-viewcontrols {
   z-index: 994;
-  container-name: toolbar;
-  container-type: inline-size;
-}
-@container toolbar (width <= 600px) {
-  .panel-viewcontrols .il-viewcontrol-sortation .label {
-    display: none;
-  }
 }
 
 /* Component parts from old delos.scss */


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44276
https://mantis.ilias.de/view.php?id=43744
https://mantis.ilias.de/view.php?id=44394

# Issue

Break behavior in panels inside sidebars is not optimal. Viewcontrols and titles extend over panel borders. Side panels do not stack under content on mobile.

# Changes

Stringed container query up higher on the center_col, so both header and viewcontrols are inside of the container. Thinned out code.

![Dashboard_Content-Breaks](https://github.com/user-attachments/assets/8dfd5bbb-646d-4abe-aeb0-2095081d0e47)

# Lessons learned

Container Query containers should never be expected to push elements around them or grow and shrink with the content inside them. They don't do either because they are their own independent DOM context. Neither DOM context can effect anything outside or inside the other.

The solution is to define containers as high up as possible (e.g. main content and sidebar are fine as containers but panel-viewcontrols are not).