### PR TITLE
Add public/data/ to .gitignore to prevent overwriting by an older rel…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ phpstan-baseline.neon
 # File Delivery
 override.php
 components/ILIAS/FileHandlingDemo
+public/data/


### PR DESCRIPTION
This is my first PR. I hope, I did it well. This is my claim:
echo "public/data/" >> .gitignore
git add .gitignore

I dont want the public/data directory in ILIAS 10 to be deleted if anyone accidentaly checkouts release_9