### PR TITLE
LTI: Updated ilLTIConsumerContentGUI to remove an unnecessary setcookie and ilLTITool to specify authentication via get.

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
@@ -104,7 +104,7 @@ class ilLTIConsumerContentGUI
                         $this->dic->http()->close();
                     }
                 } elseif (!$this->object->isLaunchMethodEmbedded()) {
-                    setcookie('PHPSESSID', session_id(), [
+                    setcookie(session_name(), session_id(), [
                         'expires' => 0,
                         'path' => rtrim(IL_COOKIE_PATH, '/') . '/ltiauth.php',
                         'domain' => IL_COOKIE_DOMAIN,

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
@@ -104,15 +104,6 @@ class ilLTIConsumerContentGUI
                         $this->dic->http()->close();
                     }
                 } elseif (!$this->object->isLaunchMethodEmbedded()) {
-                    setcookie(session_name(), session_id(), [
-                        'expires' => 0,
-                        'path' => rtrim(IL_COOKIE_PATH, '/') . '/ltiauth.php',
-                        'domain' => IL_COOKIE_DOMAIN,
-                        'secure' => true,
-                        'httponly' => true,
-                        'samesite' => 'None'
-                    ]);
-
                     $this->dic->toolbar()->addText($this->getStartButtonTxt13());
                 }
             }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
@@ -84,15 +84,6 @@ class ilLTIConsumerContentGUI
             }
         } else {
 
-            setcookie('PHPSESSID', session_id(), [
-                'expires' => 0,
-                'path' => rtrim(IL_COOKIE_PATH, '/') . '/ltiauth.php',
-                'domain' => IL_COOKIE_DOMAIN,
-                'secure' => true,
-                'httponly' => true,
-                'samesite' => 'None'
-            ]);
-
             if ($this->object->isLaunchMethodEmbedded() && (ilSession::get('lti13_login_data') == null)) {
                 $tpl = new ilTemplate('tpl.lti_content.html', true, true, 'components/ILIAS/LTIConsumer');
                 $tpl->setVariable("EMBEDDED_IFRAME_SRC", $this->dic->ctrl()->getLinkTarget(
@@ -113,6 +104,15 @@ class ilLTIConsumerContentGUI
                         $this->dic->http()->close();
                     }
                 } else {
+                    setcookie('PHPSESSID', session_id(), [
+                        'expires' => 0,
+                        'path' => rtrim(IL_COOKIE_PATH, '/') . '/ltiauth.php',
+                        'domain' => IL_COOKIE_DOMAIN,
+                        'secure' => true,
+                        'httponly' => true,
+                        'samesite' => 'None'
+                    ]);
+
                     $this->dic->toolbar()->addText($this->getStartButtonTxt13());
                 }
             }

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerContentGUI.php
@@ -103,7 +103,7 @@ class ilLTIConsumerContentGUI
                         $this->dic->http()->sendResponse();
                         $this->dic->http()->close();
                     }
-                } else {
+                } elseif (!$this->object->isLaunchMethodEmbedded()) {
                     setcookie('PHPSESSID', session_id(), [
                         'expires' => 0,
                         'path' => rtrim(IL_COOKIE_PATH, '/') . '/ltiauth.php',

--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTITool.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTITool.php
@@ -98,6 +98,8 @@ class ilLTITool extends Tool
             $_SERVER['REQUEST_URI'] = rtrim(preg_replace('/([?&])client_id=[^&]+(&|$)/', '$1', $_SERVER['REQUEST_URI']), '?&');
         }
 
+        self::$authenticateUsingGet = true;
+
         parent::handleRequest($strictMode, $disableCookieCheck, $generateWarnings);
     }
 }


### PR DESCRIPTION
The ```ilLTIConsumerContentGUI``` file has been modified to remove a previously added setcookie that enabled LTI connection in new window or own window.
This setcookie did not work for embedded consumers and will be set in ```ilStartUpGUI```.

We have also modified a parameter of the ```Celtic LTI``` library to perform authentication via GET method.