### PR TITLE
LTI: Manage session in the LTI Protocol

### DIFF
--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -691,6 +691,15 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         );
         $frontend->authenticate();
 
+        setcookie(session_name(), session_id(), [
+            'expires' => 0,
+            'path' => rtrim(IL_COOKIE_PATH, '/'),
+            'domain' => IL_COOKIE_DOMAIN,
+            'secure' => true,
+            'httponly' => true,
+            'samesite' => 'None'
+        ]);
+
         switch ($status->getStatus()) {
             case ilAuthStatus::STATUS_AUTHENTICATED:
                 ilLoggerFactory::getLogger('auth')->debug('Authentication successful; Redirecting to starting page.');


### PR DESCRIPTION
After careful examination of the LTI protocol and its operation in ILIAS, we have detected certain errors in the current implementation that prevent a session from being initiated when accessing via an embedded window (iFrame) in a scenario where the LTI communication is established between two servers that are in different domains.
It also occurs when launching the LTI consumer via a new window or its own window.
This problem occurs specifically when ILIAS acts as a provider, and occurs when consuming from both another ILIAS platform and a Moodle platform. 
It is due to the behaviour of browsers when dealing with cookies, as by default the ILIAS session cookie (PHPSESSID) is set with the ‘SameSite’ parameter in Lax.
This problem prevents the user session from being established, as the browser detects this cookie as a ‘Third-party cookie’ and blocks it, preventing it from working.

Once the problem was detected, we tried to find a solution to correct this behaviour without modifying the files outside the LTI component. Indeed, following @fneumann indications, we found a possibility: Set the ‘SameSite’ parameter to None from the `launch` method in the `ilLTIConsumerContentGUI` class.

The problem with this solution is that it only fixes the error in cases where the content is displayed in the same window or in a new one, and the error persists in cases where we use an iFrame. After encountering this obstacle we have investigated and the specific point where we must set the session cookie with the ‘SameSite’ parameter to None is in the `doLTIAuthentication` method belonging to the `ilStartUpGUI` class, since due to the flow in the code, modifying this parameter at an earlier point, within the methods of the LTI classes, implies setting the session cookie of the provider in the consumer, so the browser detects this cookie as a third party cookie and it is blocked. However, at the point where we intend to set the cookie we are at the provider so the problem no longer exists.

After digging into the ILIAS code, we have observed that the `doLTIAuthentication` method is only used in those cases in which the platform is accessed through LTI, so we understand that it should not imply any kind of setback in the behaviour of the platform when it is being consumed through LTI.

Additionally, we set the base path for the cookie to ‘/’ so that it can be accessed from the provider platform and the session is established correctly.