### PR TITLE
_10/UI/Chart/ProgressMeeter-match-goal-arrow-and-bar_43602

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Chart/ProgressMeter/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Chart/ProgressMeter/Renderer.php
@@ -113,6 +113,8 @@ class Renderer extends AbstractComponentRenderer
         $hasComparison = false
     ): Template {
         $main_percentage = $component->getMainValueAsPercent();
+        // in some cases, bar needs be adjusted because of a large rounded linecap to visually hit 50% mark exactly
+        $visual_percentage = $main_percentage;
 
         if ($hasComparison) {
             // multicircle
@@ -124,7 +126,7 @@ class Renderer extends AbstractComponentRenderer
             }
             $tpl->setVariable('COLOR_ONE_CLASS', $color_one_class);
             // set width for first process bar
-            $tpl->setVariable('BAR_ONE_WIDTH', $main_percentage);
+            $tpl->setVariable('BAR_ONE_WIDTH', $visual_percentage);
 
             // set second progress bar color class
             $color_two_class = 'active';
@@ -139,6 +141,11 @@ class Renderer extends AbstractComponentRenderer
         } else {
             // monocircle
             $tpl->setCurrentBlock('monocircle');
+            // because line endcap is so large, bar value needs to be shorter to visually hit 50% mark
+            $visual_percentage = $main_percentage - 4;
+            if ($visual_percentage < 0) {
+                $visual_percentage = 0;
+            }
             // set progress bar color class
             $color_class = 'no-success';
             if ($this->getIsReached($main_percentage, $component->getRequiredAsPercent())) {
@@ -146,7 +153,7 @@ class Renderer extends AbstractComponentRenderer
             }
             $tpl->setVariable('COLOR_ONE_CLASS', $color_class);
             // set width for process bars
-            $tpl->setVariable('BAR_ONE_WIDTH', $main_percentage);
+            $tpl->setVariable('BAR_ONE_WIDTH', $visual_percentage);
 
             $tpl->parseCurrentBlock();
         }
@@ -158,7 +165,11 @@ class Renderer extends AbstractComponentRenderer
         $needle_class = 'no-needle';
         if ($component->getRequired() != $component->getMaximum()) {
             $needle_class = '';
-            $tpl->setVariable('ROTATE_ONE', (276 / 100 * $component->getRequiredAsPercent() - 138));
+            $needle_value = (270 / 100 * $component->getRequiredAsPercent() - 133);
+            // because meter is squashed, rotation needs to be gradually modified the further away we get from 0 degrees
+            // 0 degress is the 50% mark at which this compensation equals 0
+            $compensated_needle_value = $needle_value - (7 * (1 - (2 * $main_percentage / 100)));
+            $tpl->setVariable('ROTATE_ONE', $compensated_needle_value);
         }
         $tpl->setVariable('NEEDLE_ONE_CLASS', $needle_class);
 
@@ -201,7 +212,9 @@ class Renderer extends AbstractComponentRenderer
      */
     protected function getMarkerPos(int $percentage): float
     {
-        return round((230 / 100 * ($percentage * 1)) - 115, 2, PHP_ROUND_HALF_UP);
+        $needle_value = round((230 / 100 * ($percentage * 1)) - 115, 2, PHP_ROUND_HALF_UP);
+        $compensated_needle_value = $needle_value - (16 * (1 - (2 * $percentage / 100)));
+        return $compensated_needle_value;
     }
 
     /**

--- a/components/ILIAS/UI/tests/Component/Chart/ProgressMeter/ChartProgressMeterTest.php
+++ b/components/ILIAS/UI/tests/Component/Chart/ProgressMeter/ChartProgressMeterTest.php
@@ -125,7 +125,7 @@ class ChartProgressMeterTest extends ILIAS_UI_TestBase
             '<text class="text-comparision" x="25" y="31">80 %</text>' .
             '<text class="text-comparision-info" x="25" y="34"></text>' .
             '</g>' .
-            '<g class="il-chart-progressmeter-needle " style="transform: rotate(82.8deg)">' .
+            '<g class="il-chart-progressmeter-needle " style="transform: rotate(86.5deg)">' .
             '<polygon class="il-chart-progressmeter-needle-border" points="23.5,0.1 25,2.3 26.5,0.1"></polygon>' .
             '<polygon class="il-chart-progressmeter-needle-fill" points="23.5,0 25,2.2 26.5,0"></polygon>' .
             '</g>' .
@@ -153,7 +153,7 @@ class ChartProgressMeterTest extends ILIAS_UI_TestBase
             '<path class="il-chart-progressmeter-circle-bg" stroke-dasharray="100, 100" ' .
             'd="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>' .
             '<g class="il-chart-progressmeter-monocircle">' .
-            '<path class="il-chart-progressmeter-circle no-success" stroke-dasharray="75, 100" ' .
+            '<path class="il-chart-progressmeter-circle no-success" stroke-dasharray="71, 100" ' .
             'd="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>' .
             '</g>' .
             '<g class="il-chart-progressmeter-text">' .
@@ -162,7 +162,7 @@ class ChartProgressMeterTest extends ILIAS_UI_TestBase
             '<text class="text-comparision" x="25" y="31">80 %</text>' .
             '<text class="text-comparision-info" x="25" y="34"></text>' .
             '</g>' .
-            '<g class="il-chart-progressmeter-needle " style="transform: rotate(82.8deg)">' .
+            '<g class="il-chart-progressmeter-needle " style="transform: rotate(86.5deg)">' .
             '<polygon class="il-chart-progressmeter-needle-border" points="23.5,0.1 25,2.3 26.5,0.1"></polygon>' .
             '<polygon class="il-chart-progressmeter-needle-fill" points="23.5,0 25,2.2 26.5,0"></polygon>' .
             '</g>' .
@@ -192,7 +192,7 @@ class ChartProgressMeterTest extends ILIAS_UI_TestBase
             '<path class="il-chart-progressmeter-circle no-success" stroke-dasharray="54.495, 100" ' .
             'd="M9,35 q-4.3934,-4.3934 -4.3934,-10.6066 a1,1 0 1,1 40,0 q0,6.2132 -4.3934,10.6066"></path>' .
             '<path class="il-chart-progressmeter-needle " stroke-dasharray="100, 100" d="M25,10 l0,15" ' .
-            'style="transform: rotate(57.5deg)"></path>' .
+            'style="transform: rotate(65.5deg)"></path>' .
             '</svg>' .
             '</div>' .
             '</div>';

--- a/components/ILIAS/UI/tests/Component/Item/ItemTest.php
+++ b/components/ILIAS/UI/tests/Component/Item/ItemTest.php
@@ -398,7 +398,7 @@ EOT;
 		            <svg viewBox="0 0 50 40" class="il-chart-progressmeter-viewbox">
 		                <path class="il-chart-progressmeter-circle-bg" stroke-dasharray="100, 100" d="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>
                         <g class="il-chart-progressmeter-monocircle">
-                            <path class="il-chart-progressmeter-circle no-success" stroke-dasharray="75, 100" d="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>
+                            <path class="il-chart-progressmeter-circle no-success" stroke-dasharray="71, 100" d="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>
                         </g>
                         <g class="il-chart-progressmeter-text">
                             <text class="text-score-info" x="25" y="16"></text>
@@ -450,7 +450,7 @@ EOT;
 		            <svg viewBox="0 0 50 40" class="il-chart-progressmeter-viewbox">
 		                <path class="il-chart-progressmeter-circle-bg" stroke-dasharray="100, 100" d="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>
                         <g class="il-chart-progressmeter-monocircle">
-                            <path class="il-chart-progressmeter-circle no-success" stroke-dasharray="75, 100" d="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>
+                            <path class="il-chart-progressmeter-circle no-success" stroke-dasharray="71, 100" d="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>
                         </g>
                         <g class="il-chart-progressmeter-text">
                             <text class="text-score-info" x="25" y="16"></text>
@@ -502,7 +502,7 @@ EOT;
 		            <svg viewBox="0 0 50 40" class="il-chart-progressmeter-viewbox">
 		                <path class="il-chart-progressmeter-circle-bg" stroke-dasharray="100, 100" d="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>
                         <g class="il-chart-progressmeter-monocircle">
-                            <path class="il-chart-progressmeter-circle no-success" stroke-dasharray="75, 100" d="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>
+                            <path class="il-chart-progressmeter-circle no-success" stroke-dasharray="71, 100" d="M10.4646,37.0354 q-5.858,-5.858 -5.858,-14.142 a1,1 0 1,1 40,0 q0,8.284 -5.858,14.142"></path>
                         </g>
                         <g class="il-chart-progressmeter-text">
                             <text class="text-score-info" x="25" y="16"></text>


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=43602

# Issue

Meter needles and bars do not match. For example, a 50% bar extends beyond a 52% needle.

![image](https://github.com/user-attachments/assets/1a7e4478-be23-4d19-b6fc-ff1b7008bc40)

# Changes

Wow, this was much more tricky than I initially thought and the code looks like someone was already battling with this before me. The problem is that the mathematically correct position of the bar and the needle arrow are both off for two reasons:
- line ends in vector svgs are perfectly straight and when the line ends they are capped off with a half circle that extends beyond their actual length. This buttcap adds another +4% visually.
- the meter is not a circle but slightly squashed. This means that just rotating the needle is off the further you get away from 0 degrees.

So I had to add two compensations:
1. subtract 4% from the length value of the bar (monocircle only)
2. the further left and right you go from 50%, some degrees of rotation are added or subtracted respectively. This needed to be done for both the needle arrow and the mini meter pointer.

![image](https://github.com/user-attachments/assets/e7c76ff5-cfaf-4575-a80a-ef73f6309dc4)
