### PR TITLE
UI Improvement: MessageBox Implements IsPromptContentInternal

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/MessageBox/MessageBox.php
+++ b/components/ILIAS/UI/src/Implementation/Component/MessageBox/MessageBox.php
@@ -22,8 +22,9 @@ namespace ILIAS\UI\Implementation\Component\MessageBox;
 
 use ILIAS\UI\Component as C;
 use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Implementation\Component\Prompt\IsPromptContentInternal;
 
-class MessageBox implements C\MessageBox\MessageBox
+class MessageBox implements C\MessageBox\MessageBox, IsPromptContentInternal
 {
     use ComponentHelper;
 


### PR DESCRIPTION
The `MessageBox` class should implement the `IsPromptContentInternal` interface from `Implementation\Component\Prompt`.
It already includes the necessary methods and will now be formally linked to this functionality through the interface.