### PR TITLE
UI: 44282, add padding to .c-form in maincontrols-slate-content 

### DIFF
--- a/templates/default/070-components/UI-framework/MainControls/Slate/_ui-component_slate.scss
+++ b/templates/default/070-components/UI-framework/MainControls/Slate/_ui-component_slate.scss
@@ -131,6 +131,14 @@ $il-slate-tree-padding: $il-padding-small-vertical 0;
 	li.il-workflow-step {
 		padding: 0 $il-slate-content-spacing*2;
 	}
+
+	.il-slate-content {
+		> .c-form,
+		> #copg-editor-slate-content
+		> .c-form {
+			padding: $il-padding-xlarge-vertical $il-padding-base-horizontal;
+		}
+	}
 }
 
 .il-maincontrols-slate-close,

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -5898,6 +5898,10 @@ a[aria-disabled].il-link.link-bulky:hover {
 .il-maincontrols-slate-content li.il-workflow-step {
   padding: 0 4px;
 }
+.il-maincontrols-slate-content .il-slate-content > .c-form,
+.il-maincontrols-slate-content .il-slate-content > #copg-editor-slate-content > .c-form {
+  padding: 9px 9px;
+}
 
 .il-maincontrols-slate-close button,
 .il-maincontrols-slate-back button {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44282

### NOTE

> It is correct that ui-component classes like ".c-form" or ".c-input" do not get any padding. The padding has to be configured in the parent div. This happens with this PR.
> 
> But have in mind that these changes will also add more padding to all legacy UI implementations in the editor slate. 
> It was decided with @yvseiler  that we do not implement a special solution for that as the old legacy forms should get exchanged with the new UI elements in the future.

**Update of note above:** 
It was discussed today (by the CSS-Squat-Meeting participants) that we will set padding specifically for .c-form in .il-slate-content, as .c-form in #copg-editor-slate-content. 

ILIAS 11 will get another implementation. 