### PR TITLE
Test: Prevent "LOCK" situation for fixed questions

### DIFF
--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2432,6 +2432,7 @@ JS;
         $state = $question_gui->object->lookupForExistingSolutions($this->test_session->getActiveId(), $this->test_session->getPass());
         $config['isAnswered'] = $state['authorized'];
         $config['isAnswerChanged'] = $state['intermediate'] || $this->getAnswerChangedParameter();
+        $config['isAnswerFixed'] = $this->isParticipantsAnswerFixed($question_gui->object->getId());
         $config['saveOnTimeReachedUrl'] = str_replace('&amp;', '&', $this->ctrl->getFormAction($this, ilTestPlayerCommands::AUTO_SAVE_ON_TIME_LIMIT));
 
         $config['autosaveUrl'] = '';

--- a/Modules/Test/js/ilTestPlayerQuestionEditControl.js
+++ b/Modules/Test/js/ilTestPlayerQuestionEditControl.js
@@ -57,6 +57,7 @@ il.TestPlayerQuestionEditControl = new function() {
     var config = {
         isAnswered: false,                      // question is already answered
         isAnswerChanged: false,                 // question is already changed, e.g. after marking
+        isAnswerFixed: false,                   // question is already fixed, e.g. because instant feedback has been requested
         saveOnTimeReachedUrl: '',               // url for save at nd of working time
         autosaveUrl: '',                        // url for saving of intermediate solutions
         autosaveInterval: 0,                    // interval for saving of intermediate solutions
@@ -144,6 +145,11 @@ il.TestPlayerQuestionEditControl = new function() {
         if (config.isAnswerChanged) {
             answerChanged = true;
             stickyChanged = true;
+        }
+
+        if (config.isAnswered && config.isAnswerChanged && config.isAnswerFixed) {
+            answerChanged = false;
+            stickyChanged = false;
         }
 
         // adjust the display of status dependent elements


### PR DESCRIPTION
If questions are fixed (e.g. when requesting instant feedback) and there are multiple user solutions (one authorized, one not) for the same question in the same test pass, it might occur that the learner is caught in a "LOCK" situation, where she/he is not able to navigate to the next/previous question and not able to finish the test.
Every interaction results in a server request with `cmd=submitIntermediateSolution`, and the server responds with `ilTestException`.

This PR suggests a new state `isAnswerFixed` which is passed to the client/browser.
If the question is considered "answered" (authorized solution exists), "changed" (intermediate solution exists) and "fixed", the client-side states `answerChanged` and `stickyChanged` are set to `false`.
Doing this, the client does not set the `submitIntermediateSolution` command when interacting with the question navigation.

See: https://mantis.ilias.de/view.php?id=44467