### PR TITLE
T&A Mantis #0044579: Participant Data are skipped during Excel Statistic Export

### DIFF
--- a/Modules/Test/classes/class.ilExcelTestExport.php
+++ b/Modules/Test/classes/class.ilExcelTestExport.php
@@ -51,16 +51,26 @@ class ilExcelTestExport extends ilTestExportAbstract
 
         $datarows = $this->getDatarows($this->test_obj);
         foreach ($datarows as $row => $data) {
-            if ($this->scoredonly && $row % 2 === 0) {
-                for ($col = 0, $colMax = count($header_row); $col < $colMax; $col++) {
-                    $data[$col] = "";
-                }
-                foreach ($data as $col => $value) {
-                    if ($value !== "") {
-                        $this->worksheet->setFormattedExcelTitle(
-                            $this->worksheet->getColumnCoord($col) . $row + 1,
-                            $value
-                        );
+            if ($this->test_obj->isRandomTest()) {
+                if ($row % 2 === 0) {
+                    foreach ($data as $col => $value) {
+                        if ($value !== "" && $col >= count($header_row)) {
+                            $this->worksheet->setFormattedExcelTitle(
+                                $this->worksheet->getColumnCoord($col) . $row + 1,
+                                $value
+                            );
+                        } else {
+                            $this->worksheet->setCellByCoordinates($this->worksheet->getColumnCoord($col) . $row + 1, $value);
+                        }
+                    }
+                } elseif ($row % 2 === 1) {
+                    if ($row !== 1) {
+                        for ($col = 0, $colMax = count($header_row); $col < $colMax - 1; $col++) {
+                            $data[$col] = "";
+                        }
+                    }
+                    foreach ($data as $col => $value) {
+                        $this->worksheet->setCellByCoordinates($this->worksheet->getColumnCoord($col) . $row + 1, $value);
                     }
                 }
             } else {

--- a/Modules/Test/classes/class.ilTestExportAbstract.php
+++ b/Modules/Test/classes/class.ilTestExportAbstract.php
@@ -144,6 +144,12 @@ abstract class ilTestExportAbstract
                 $datarow2[] = $userdata->getLastPass() + 1;
             }
             $shown_pass = 0;
+            if ($counter >= 2 && $test_obj->isRandomTest()) {
+                $datarow = $datarow2;
+                $datarow[] = '';
+                $datarow2 = array_map(static fn($entry) => '', $datarow2);
+            }
+
             for ($pass = 0; $pass <= $userdata->getLastPass(); $pass++) {
                 $finishdate = ilObjTest::lookupPassResultsUpdateTimestamp($active_id, $pass);
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44579

The Statistic Export for Random Tests has an additional row for each pass, containing the question titles.
 These lines are printed bold, which requires the if-conditions in ilExcelTestExport. This part was incorrect and caused participant data to be replaced with empty strings in lines of the export for fixed tests.

In addition to this, the Export for Random Tests had the lines for questions titles and participant results not in order with. The changes to ilTestExportAbstract switch the two arrays, so Participant data is the first line matched with the question titles to the first pass.

Let me know if you see any errors to this

Best @fhelfer 