### PR TITLE
Object: read out timings from crs timing view correctly (41946)

### DIFF
--- a/Services/Object/classes/class.ilObjectActivation.php
+++ b/Services/Object/classes/class.ilObjectActivation.php
@@ -235,8 +235,12 @@ class ilObjectActivation
 
         $item['timing_type'] = $item_array['timing_type'] ?? 0;
 
-        if (($item_array['changeable'] ?? false) &&
-            $item_array['timing_type'] == self::TIMINGS_PRESETTING) {
+        if ($item_array['timing_type'] == self::TIMINGS_PRESETTING &&
+            (
+                ($item_array['changeable'] ?? false) ||
+                ilObjCourse::lookupTimingMode(ilObject::_lookupObjId($item['parent'])) === ilCourseConstants::IL_CRS_VIEW_TIMING_RELATIVE
+            )
+        ) {
             // cognos-blu-patch: begin
             $user_data = new ilTimingUser((int) $item['ref_id'], $ilUser->getId());
             if ($user_data->isScheduled()) {


### PR DESCRIPTION
This PR fixes [41946](https://mantis.ilias.de/view.php?id=41946) by reading out timings correctly in `ilObjectActivation`. `ilTimingsUser` is relevant when the timings can vary user by user. This includes changeable timings, but also relative timings, and the latter are currently ignored.

As this code is used for building object lists, performance is a concern, so I resorted to using static methods directly wired to the database. It's not the prettiest fix, but I don't have any better ideas that don't involve rewriting the whole activation/timing mess.

Cheers, @schmitz-ilias 