### PR TITLE
LTI: Fix correct path to get files and xml data extraction

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
@@ -105,9 +105,16 @@ class ilLTIConsumerResultService
             $xml = simplexml_load_file('php://input');
             $logger->info('LTI Consumer Result Service: xml loaded');
             $this->message_ref_id = (string) $xml->imsx_POXHeader->imsx_POXRequestHeaderInfo->imsx_messageIdentifier;
-            $request = current($xml->imsx_POXBody->children());
+            $children = (array) $xml->imsx_POXBody->children();
+            $request = current($children);
+
+            $ns = $xml->getNamespaces(true);
+            $body = $xml->children($ns[''])->imsx_POXBody;
+
             $logger->info('LTI Consumer Result Service: request loaded');
             $this->operation = str_replace('Request', '', $request->getName());
+
+            $request = $body->replaceResultRequest;
             $logger->info("LTI Consumer Result Service: operation loaded ($this->operation)");
 
             $token = ilCmiXapiAuthToken::getInstanceByToken((string) $request->resultRecord->sourcedGUID->sourcedId);
@@ -263,7 +270,7 @@ class ilLTIConsumerResultService
      */
     protected function loadResponse($a_name): string
     {
-        return file_get_contents('./components/ILIAS/LTIConsumer/responses/' . $a_name);
+        return file_get_contents(__DIR__ . '/../responses/' . $a_name);
     }
 
 


### PR DESCRIPTION
Replaced deprecated ```Current``` method that prevented the handling of XML files and modified the XML access form by including a namespace.