### PR TITLE
streamlining for import/export; fixes for event handling

### DIFF
--- a/components/ILIAS/File/classes/class.ilFileExporter.php
+++ b/components/ILIAS/File/classes/class.ilFileExporter.php
@@ -55,7 +55,7 @@ class ilFileExporter extends ilXmlExporter
                 "ids" => $md_ids,
             ],
             [
-                "component" => "components/ILIAS/Object",
+                "component" => "components/ILIAS/ILIASObject",
                 "entity" => "common",
                 "ids" => $a_ids
             ]

--- a/components/ILIAS/Forum/classes/class.ilForumExporter.php
+++ b/components/ILIAS/Forum/classes/class.ilForumExporter.php
@@ -62,7 +62,7 @@ class ilForumExporter extends ilXmlExporter implements ilForumObjectConstants
 
         if ('frm' === $a_entity) {
             $deps[] = [
-                'component' => 'components/ILIAS/Object',
+                'component' => 'components/ILIAS/ILIASObject',
                 'entity' => 'common',
                 'ids' => $a_ids
             ];

--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -625,7 +625,6 @@ class ilObject
     {
         $this->getObjectProperties()->storeCoreProperties();
 
-
         $this->app_event_handler->raise(
             'components/ILIAS/ILIASObject',
             'update',

--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -625,6 +625,8 @@ class ilObject
     {
         $this->getObjectProperties()->storeCoreProperties();
 
+        ilLoggerFactory::getLogger('root')->warning("Raised");
+
         $this->app_event_handler->raise(
             'components/ILIAS/ILIASObject',
             'update',

--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -625,7 +625,6 @@ class ilObject
     {
         $this->getObjectProperties()->storeCoreProperties();
 
-        ilLoggerFactory::getLogger('root')->warning("Raised");
 
         $this->app_event_handler->raise(
             'components/ILIAS/ILIASObject',

--- a/components/ILIAS/IndividualAssessment/classes/class.ilIndividualAssessmentExporter.php
+++ b/components/ILIAS/IndividualAssessment/classes/class.ilIndividualAssessmentExporter.php
@@ -55,7 +55,7 @@ class ilIndividualAssessmentExporter extends ilXmlExporter
         if ($a_entity == "iass") {
             // service settings
             $res[] = [
-                "component" => "components/ILIAS/Object",
+                "component" => "components/ILIAS/ILIASObject",
                 "entity" => "common",
                 "ids" => $a_ids
             ];

--- a/components/ILIAS/IndividualAssessment/tests/ilIndividualAssessmentExporterTest.php
+++ b/components/ILIAS/IndividualAssessment/tests/ilIndividualAssessmentExporterTest.php
@@ -40,7 +40,7 @@ class ilIndividualAssessmentExporterTest extends TestCase
     public function test_getXmlExportTailDependencies_iass(): void
     {
         $expected[] = [
-            "component" => "components/ILIAS/Object",
+            "component" => "components/ILIAS/ILIASObject",
             "entity" => "common",
             "ids" => [12,13]
         ];

--- a/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceAppEventListener.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceAppEventListener.php
@@ -37,7 +37,7 @@ class ilLearningSequenceAppEventListener
                         break;
                 }
                 break;
-            case "components/ILIAS/Object":
+            case "components/ILIAS/ILIASObject":
                 switch ($event) {
                     case "beforeDeletion":
                         self::onObjectDeletion($parameter);

--- a/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceExporter.php
+++ b/components/ILIAS/LearningSequence/classes/class.ilLearningSequenceExporter.php
@@ -93,7 +93,7 @@ class ilLearningSequenceExporter extends ilXmlExporter
         if ($a_entity == "lso") {
             // service settings
             $res[] = [
-                "component" => "components/ILIAS/Object",
+                "component" => "components/ILIAS/ILIASObject",
                 "entity" => "common",
                 "ids" => $a_ids
             ];

--- a/components/ILIAS/LearningSequence/module.xml
+++ b/components/ILIAS/LearningSequence/module.xml
@@ -59,7 +59,7 @@
 
 	<events>
 		<event type="listen" id="components/ILIAS/Tracking" />
-		<event type="listen" id="components/ILIAS/Object" />
+		<event type="listen" id="components/ILIAS/ILIASObject" />
 		<event type="listen" id="components/ILIAS/LearningSequence" />
 	<!--
 		<event type="listen" id="components/ILIAS/AccessControl" />

--- a/components/ILIAS/Notification/classes/class.ilNotificationAppEventListener.php
+++ b/components/ILIAS/Notification/classes/class.ilNotificationAppEventListener.php
@@ -23,7 +23,7 @@ class ilNotificationAppEventListener implements ilAppEventListener
         string $a_event,
         array $a_parameter
     ): void {
-        if ($a_component === 'components/ILIAS/Object' && $a_event === 'delete') {
+        if ($a_component === 'components/ILIAS/ILIASObject' && $a_event === 'delete') {
             if ($a_parameter['obj_id'] > 0) {
                 $set = new ilObjNotificationSettings($a_parameter['obj_id']);
                 $set->delete();

--- a/components/ILIAS/Search/classes/class.ilSearchAppEventListener.php
+++ b/components/ILIAS/Search/classes/class.ilSearchAppEventListener.php
@@ -43,6 +43,8 @@ class ilSearchAppEventListener implements ilAppEventListener
             return;
         }
 
+        ilLoggerFactory::getLogger('root')->warning($a_component);
+
         // only for files in the moment
         if (!isset($a_parameter['obj_type'])) {
             $type = ilObject::_lookupType($a_parameter['obj_id']);
@@ -58,7 +60,7 @@ class ilSearchAppEventListener implements ilAppEventListener
                 break;
 
             case 'components/ILIAS/Help':
-            case 'components/ILIAS/Object':
+            case 'components/ILIAS/ILIASObject':
 
                 switch ($a_event) {
                     case 'undelete':

--- a/components/ILIAS/Search/classes/class.ilSearchAppEventListener.php
+++ b/components/ILIAS/Search/classes/class.ilSearchAppEventListener.php
@@ -43,7 +43,6 @@ class ilSearchAppEventListener implements ilAppEventListener
             return;
         }
 
-        ilLoggerFactory::getLogger('root')->warning($a_component);
 
         // only for files in the moment
         if (!isset($a_parameter['obj_type'])) {

--- a/components/ILIAS/Search/service.xml
+++ b/components/ILIAS/Search/service.xml
@@ -12,7 +12,7 @@
 	<events>
 		<event type="raise" id="contentChanged" />
 		<event type="listen" id="components/ILIAS/Search" />
-		<event type="listen" id="components/ILIAS/Object" />
+		<event type="listen" id="components/ILIAS/ILIASObject" />
 	</events>
 	<crons>
 		<cron id="src_lucene_indexer" class="ilLuceneIndexer" path="Services/Search/classes/Lucene/" />

--- a/components/ILIAS/Session/classes/class.ilSessionDataSet.php
+++ b/components/ILIAS/Session/classes/class.ilSessionDataSet.php
@@ -402,7 +402,7 @@ class ilSessionDataSet extends ilDataSet
 
                 $this->current_obj = $newObj;
                 $a_mapping->addMapping("components/ILIAS/Session", "sess", $a_rec["Id"], (string) $newObj->getId());
-                $a_mapping->addMapping('components/ILIAS/Object', 'objs', $a_rec['Id'], (string) $newObj->getId());
+                $a_mapping->addMapping('components/ILIAS/ILIASObject', 'objs', $a_rec['Id'], (string) $newObj->getId());
                 $a_mapping->addMapping('components/ILIAS/AdvancedMetaData', 'parent', $a_rec['Id'], (string) $newObj->getId());
                 $a_mapping->addMapping(
                     "components/ILIAS/MetaData",

--- a/components/ILIAS/Session/classes/class.ilSessionExporter.php
+++ b/components/ILIAS/Session/classes/class.ilSessionExporter.php
@@ -73,13 +73,13 @@ class ilSessionExporter extends ilXmlExporter
 
         // service settings
         $deps[] = array(
-            "component" => "components/ILIAS/Object",
+            "component" => "components/ILIAS/ILIASObject",
             "entity" => "service_settings",
             "ids" => $a_ids);
 
         // tile image
         $deps[] = array(
-            "component" => "components/ILIAS/Object",
+            "component" => "components/ILIAS/ILIASObject",
             "entity" => "tile",
             "ids" => $a_ids);
 

--- a/components/ILIAS/StudyProgramme/classes/class.ilStudyProgrammeAppEventListener.php
+++ b/components/ILIAS/StudyProgramme/classes/class.ilStudyProgrammeAppEventListener.php
@@ -63,7 +63,7 @@ class ilStudyProgrammeAppEventListener
                         break;
                 }
                 break;
-            case "components/ILIAS/Object":
+            case "components/ILIAS/ILIASObject":
                 switch ($event) {
                     case "delete":
                     case "toTrash":

--- a/components/ILIAS/StudyProgramme/module.xml
+++ b/components/ILIAS/StudyProgramme/module.xml
@@ -30,7 +30,7 @@
 		<event type="listen" id="components/ILIAS/User" />
 		<event type="listen" id="components/ILIAS/Tracking" />
 		<event type="listen" id="components/ILIAS/Tree" />
-		<event type="listen" id="components/ILIAS/Object" />
+		<event type="listen" id="components/ILIAS/ILIASObject" />
 		<event type="listen" id="components/ILIAS/ContainerReference" />
 		<event type="listen" id="components/ILIAS/AccessControl" />
 		<event type="listen" id="components/ILIAS/StudyProgramme" />

--- a/components/ILIAS/Test/classes/class.ilTestExporter.php
+++ b/components/ILIAS/Test/classes/class.ilTestExporter.php
@@ -92,7 +92,7 @@ class ilTestExporter extends ilXmlExporter
             }
 
             $deps[] = [
-                'component' => 'components/ILIAS/Object',
+                'component' => 'components/ILIAS/ILIASObject',
                 'entity' => 'common',
                 'ids' => $a_ids
             ];

--- a/components/ILIAS/Tracking/classes/class.ilTrackingAppEventListener.php
+++ b/components/ILIAS/Tracking/classes/class.ilTrackingAppEventListener.php
@@ -40,7 +40,7 @@ class ilTrackingAppEventListener implements ilAppEventListener
     ): void {
         $obj_id = $a_parameter['obj_id'] ?? null;
         switch ($a_component) {
-            case 'components/ILIAS/Object':
+            case 'components/ILIAS/ILIASObject':
                 switch ($a_event) {
                     case 'toTrash':
                         $olp = ilObjectLP::getInstance($obj_id);

--- a/components/ILIAS/Tracking/service.xml
+++ b/components/ILIAS/Tracking/service.xml
@@ -11,7 +11,7 @@
 	</objects>
 	<events>		
 		<event type="raise" id="updateStatus" />	
-		<event type="listen" id="components/ILIAS/Object" />
+		<event type="listen" id="components/ILIAS/ILIASObject" />
 		<event type="listen" id="components/ILIAS/Tree" />
 		<event type="listen" id="components/ILIAS/Course" />
 		<event type="listen" id="components/ILIAS/Group" />

--- a/components/ILIAS/User/classes/class.ilUserAppEventListener.php
+++ b/components/ILIAS/User/classes/class.ilUserAppEventListener.php
@@ -42,7 +42,7 @@ class ilUserAppEventListener implements ilAppEventListener
             $DIC['ilSetting']
         );
 
-        if ('components/ILIAS/Object' === $component && 'beforeDeletion' === $event) {
+        if ('components/ILIAS/ILIASObject' === $component && 'beforeDeletion' === $event) {
             if (isset($parameter['object']) && $parameter['object'] instanceof ilObjRole) {
                 $user_starting_point_repository->onRoleDeleted($parameter['object']);
             }

--- a/components/ILIAS/User/service.xml
+++ b/components/ILIAS/User/service.xml
@@ -19,7 +19,7 @@
 		<event type="raise" id="deleteUser" />
 		<event type="raise" id="afterCreate" />
 		<event type="raise" id="onUserFieldAttributesChanged" />
-		<event type="listen" id="components/ILIAS/Object" />
+		<event type="listen" id="components/ILIAS/ILIASObject" />
 		<event type="listen" id="components/ILIAS/TermsOfService" />
 	</events>
 	<crons>

--- a/components/ILIAS/WebResource/classes/class.ilWebResourceExporter.php
+++ b/components/ILIAS/WebResource/classes/class.ilWebResourceExporter.php
@@ -70,7 +70,7 @@ class ilWebResourceExporter extends ilXmlExporter
         $deps = [];
         // service settings
         $deps[] = [
-            "component" => "components/ILIAS/Object",
+            "component" => "components/ILIAS/ILIOASObject",
             "entity" => "common",
             "ids" => $a_ids
         ];

--- a/components/ILIAS/WebResource/classes/class.ilWebResourceExporter.php
+++ b/components/ILIAS/WebResource/classes/class.ilWebResourceExporter.php
@@ -70,7 +70,7 @@ class ilWebResourceExporter extends ilXmlExporter
         $deps = [];
         // service settings
         $deps[] = [
-            "component" => "components/ILIAS/ILIOASObject",
+            "component" => "components/ILIAS/ILIASObject",
             "entity" => "common",
             "ids" => $a_ids
         ];


### PR DESCRIPTION
This fixes some issues (not triggered event handling listeners, import/export mapping) caused by renaming of component ObJect to ILIASObject. 

https://mantis.ilias.de/view.php?id=43970