### PR TITLE
T&A 44486: Fixes umlaute not being displayed correctly in correction tab of text subset question

### DIFF
--- a/Modules/Test/classes/class.ilTestCorrectionsGUI.php
+++ b/Modules/Test/classes/class.ilTestCorrectionsGUI.php
@@ -132,9 +132,7 @@ class ilTestCorrectionsGUI
 
         $this->setCorrectionTabsContext($questionGUI, 'question');
 
-        if ($form === null) {
-            $form = $this->buildQuestionCorrectionForm($questionGUI);
-        }
+        $form ??= $this->buildQuestionCorrectionForm($questionGUI);
 
         $this->populatePageTitleAndDescription($questionGUI);
         $this->main_tpl->setContent($form->getHTML());
@@ -574,17 +572,11 @@ class ilTestCorrectionsGUI
      */
     protected function allowedInAdjustment(\assQuestionGUI $question_object): bool
     {
-        $setting = new ilSetting('assessment');
-        $types = explode(',', $setting->get('assessment_scoring_adjustment'));
-        $type_def = array();
-        foreach ($types as $type) {
+        $type_def = [];
+        foreach (explode(',', (new ilSetting('assessment'))->get('assessment_scoring_adjustment', '')) as $type) {
             $type_def[$type] = ilObjQuestionPool::getQuestionTypeByTypeId($type);
         }
 
-        $type = $question_object->getQuestionType();
-        if (in_array($type, $type_def)) {
-            return true;
-        }
-        return false;
+        return in_array($question_object->getQuestionType(), $type_def);
     }
 }

--- a/Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php
@@ -239,7 +239,7 @@ class assTextSubsetGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
                     }
                 }
                 $template->setCurrentBlock("textsubset_row");
-                $template->setVariable("SOLUTION", $this->escapeTemplatePlaceholders($user_solutions[$i]['value1']));
+                $template->setVariable("SOLUTION", $this->escapeTemplatePlaceholders(htmlspecialchars($user_solutions[$i]['value1'])));
                 $template->setVariable("COUNTER", $i + 1);
                 if ($result_output) {
                     $points = $user_solutions[$i]["points"];

--- a/Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php
@@ -348,8 +348,7 @@ class assTextSubsetGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
         // Delete all existing answers and create new answers from the form data
         $this->object->flushAnswers();
         foreach ($this->answers_from_post as $index => $answertext) {
-            $answertext = assQuestion::extendedTrim($answertext);
-            $this->object->addAnswer(htmlentities($answertext), $_POST['answers']['points'][$index], $index);
+            $this->object->addAnswer(assQuestion::extendedTrim($answertext), $_POST['answers']['points'][$index], $index);
         }
     }
 

--- a/Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assTextSubsetGUI.php
@@ -239,7 +239,17 @@ class assTextSubsetGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
                     }
                 }
                 $template->setCurrentBlock("textsubset_row");
-                $template->setVariable("SOLUTION", $this->escapeTemplatePlaceholders(htmlspecialchars($user_solutions[$i]['value1'])));
+                $template->setVariable(
+                    "SOLUTION",
+                    $this->escapeTemplatePlaceholders(
+                        htmlspecialchars(
+                            $user_solutions[$i]['value1'],
+                            ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401,
+                            null,
+                            false
+                        )
+                    )
+                );
                 $template->setVariable("COUNTER", $i + 1);
                 if ($result_output) {
                     $points = $user_solutions[$i]["points"];

--- a/Modules/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
@@ -399,10 +399,9 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         return "tpl.prop_answerwizardinput.html";
     }
 
-    public static function prepareFormOutput(float|string $input, bool $strip = false): string
+    protected function prepareFormOutput(float|string $input, bool $strip = false): string
     {
-        global $DIC;
-        $input = $DIC->refinery()->kindlyTo()->string()->transform($input);
+        $input = $this->refinery->kindlyTo()->string()->transform($input);
         $input = $strip ? ilUtil::stripSlashes($input) : $input;
         $input = htmlspecialchars($input, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, null, false);
         return str_replace(['{', '}', '\\'], ['&#123;', '&#125;', '&#92;'], $input);

--- a/Modules/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
@@ -398,4 +398,12 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
     {
         return "tpl.prop_answerwizardinput.html";
     }
+
+    public static function prepareFormOutput(int|string $input, bool $strip = false): string
+    {
+        $input = (string) $input;
+        $input = $strip ? ilUtil::stripSlashes($input) : $input;
+        $input = htmlspecialchars($input, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, null, false);
+        return str_replace(['{', '}', '\\'], ['&#123;', '&#125;', '&#92;'], $input);
+    }
 }

--- a/Modules/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
@@ -399,9 +399,10 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         return "tpl.prop_answerwizardinput.html";
     }
 
-    public static function prepareFormOutput(int|string $input, bool $strip = false): string
+    public static function prepareFormOutput(float|string $input, bool $strip = false): string
     {
-        $input = (string) $input;
+        global $DIC;
+        $input = $DIC->refinery()->kindlyTo()->string()->transform($input);
         $input = $strip ? ilUtil::stripSlashes($input) : $input;
         $input = htmlspecialchars($input, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, null, false);
         return str_replace(['{', '}', '\\'], ['&#123;', '&#125;', '&#92;'], $input);

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
@@ -125,12 +125,12 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
                 $tpl->setVariable("POST_VAR", $this->getPostVar());
                 $tpl->setVariable("ROW_NUMBER", $i);
                 $tpl->setVariable("POINTS_ID", $this->getPostVar() . "[points][$i]");
-                $tpl->setVariable("POINTS", self::prepareFormOutput($value->getPoints()));
+                $tpl->setVariable("POINTS", $this->prepareFormOutput($value->getPoints()));
                 $tpl->parseCurrentBlock();
             }
 
             $tpl->setCurrentBlock("row");
-            $tpl->setVariable("ANSWER", self::prepareFormOutput($value->getAnswertext()));
+            $tpl->setVariable("ANSWER", $this->prepareFormOutput($value->getAnswertext()));
             $tpl->parseCurrentBlock();
             $i++;
         }

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssAnswerCorrectionsInputGUI.php
@@ -125,12 +125,12 @@ class ilAssAnswerCorrectionsInputGUI extends ilAnswerWizardInputGUI
                 $tpl->setVariable("POST_VAR", $this->getPostVar());
                 $tpl->setVariable("ROW_NUMBER", $i);
                 $tpl->setVariable("POINTS_ID", $this->getPostVar() . "[points][$i]");
-                $tpl->setVariable("POINTS", ilLegacyFormElementsUtil::prepareFormOutput($value->getPoints()));
+                $tpl->setVariable("POINTS", self::prepareFormOutput($value->getPoints()));
                 $tpl->parseCurrentBlock();
             }
 
             $tpl->setCurrentBlock("row");
-            $tpl->setVariable("ANSWER", ilLegacyFormElementsUtil::prepareFormOutput($value->getAnswertext()));
+            $tpl->setVariable("ANSWER", self::prepareFormOutput($value->getAnswertext()));
             $tpl->parseCurrentBlock();
             $i++;
         }


### PR DESCRIPTION
[Mantis: 44486](https://mantis.ilias.de/view.php?id=44486)

I believe removing the `htmlentities` function call allows the data to be correctly persisted into the database.