### PR TITLE
T&A 44580: Fixes wrong learning progress determination when passing second - Nth attempt/pass

### DIFF
--- a/Modules/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
+++ b/Modules/Test/classes/class.ilCronFinishUnfinishedTestPasses.php
@@ -185,7 +185,7 @@ class ilCronFinishUnfinishedTestPasses extends ilCronJob
                 if ($this->test_ending_times[$test_id]['enable_processing_time'] == 1) {
                     $this->log->info('Test (' . $test_id . ') has processing time (' . $this->test_ending_times[$test_id]['processing_time'] . ')');
                     $obj_id = $this->test_ending_times[$test_id]['obj_fi'];
-                    if(ilObject::_exists($obj_id)) {
+                    if (ilObject::_exists($obj_id)) {
                         $test_obj = new ilObjTest($obj_id, false);
                         $startingTime = $test_obj->getStartingTimeOfUser($data['active_id']);
                         $max_processing_time = $test_obj->isMaxProcessingTimeReached($startingTime, $data['active_id']);
@@ -217,7 +217,7 @@ class ilCronFinishUnfinishedTestPasses extends ilCronJob
         $test_session = new ilTestSession($this->db, $this->user);
         $test_session->loadFromDb($active_id);
 
-        if(ilObject::_exists($obj_id)) {
+        if (ilObject::_exists($obj_id)) {
             $test = new ilObjTest($obj_id, false);
 
             $test->updateTestPassResults(
@@ -228,8 +228,7 @@ class ilCronFinishUnfinishedTestPasses extends ilCronJob
                 $obj_id
             );
 
-            $pass_finisher = new ilTestPassFinishTasks($test_session, $obj_id);
-            $pass_finisher->performFinishTasks($processLocker);
+            (new ilTestPassFinishTasks($test_session, $test))->performFinishTasks($processLocker);
 
             $this->log->info('Test session with active id (' . $active_id . ') and obj_id (' . $obj_id . ') is now finished.');
         } else {

--- a/Modules/Test/classes/class.ilTestEvaluationGUI.php
+++ b/Modules/Test/classes/class.ilTestEvaluationGUI.php
@@ -1928,7 +1928,7 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
             $this->object->getId()
         );
 
-        $this->finishTestPass($active_id, $this->object->getId());
+        $this->finishTestPass($active_id);
 
         $this->redirectBackToParticipantsScreen();
     }
@@ -2000,18 +2000,21 @@ class ilTestEvaluationGUI extends ilTestServiceGUI
                 $this->object->getId()
             );
 
-            $this->finishTestPass($participant->getActiveId(), $this->object->getId());
+            $this->finishTestPass($participant->getActiveId());
         }
 
 
         $this->redirectBackToParticipantsScreen();
     }
 
-    protected function finishTestPass(int $active_id, int $obj_id)
+    protected function finishTestPass(int $active_id)
     {
         $process_locker = $this->processLockerFactory->withContextId($active_id)->getLocker();
 
-        $test_pass_finisher = new ilTestPassFinishTasks($this->testSessionFactory->getSession($active_id), $obj_id);
+        $test_pass_finisher = new ilTestPassFinishTasks(
+            $this->testSessionFactory->getSession($active_id),
+            $this->object,
+        );
         $test_pass_finisher->performFinishTasks($process_locker);
     }
 

--- a/Modules/Test/classes/class.ilTestPassFinishTasks.php
+++ b/Modules/Test/classes/class.ilTestPassFinishTasks.php
@@ -25,8 +25,8 @@ declare(strict_types=1);
 class ilTestPassFinishTasks
 {
     public function __construct(
-        private ilTestSession $test_session,
-        private int $obj_id
+        private readonly ilTestSession $test_session,
+        private readonly ilObjTest $obj_test,
     ) {
     }
 
@@ -53,23 +53,26 @@ class ilTestPassFinishTasks
             }
         });
 
+        $this->obj_test->updateTestResultCache($this->test_session->getActiveId(), null);
+
         $this->updateLearningProgressAfterPassFinishedIsWritten();
     }
 
     protected function updateLearningProgressAfterPassFinishedIsWritten()
     {
+        $obj_id = $this->obj_test->getId();
         ilLPStatusWrapper::_updateStatus(
-            $this->obj_id,
+            $obj_id,
             ilObjTestAccess::_getParticipantId($this->test_session->getActiveId())
         );
 
         $caller = $this->getCaller();
-        $lp = ilLPStatus::_lookupStatus($this->obj_id, $this->test_session->getUserId());
+        $lp = ilLPStatus::_lookupStatus($obj_id, $this->test_session->getUserId());
         $debug = "finPass={$this->test_session->getLastFinishedPass()} / Lp={$lp}";
 
         ilObjAssessmentFolder::_addLog(
             $this->test_session->getUserId(),
-            $this->obj_id,
+            $obj_id,
             "updateLearningProgressAfterPassFinishedIsWritten has been called from {$caller} ({$debug})",
             true
         );
@@ -77,12 +80,6 @@ class ilTestPassFinishTasks
 
     protected function getCaller()
     {
-        try {
-            throw new Exception();
-        } catch (Exception $e) {
-            $trace = $e->getTrace();
-        }
-
-        return $trace[3]['class'];
+        return (new Exception())->getTrace()[3]['class'];
     }
 }

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -711,12 +711,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 
     protected function performTestPassFinishedTasks(): void
     {
-        $finishTasks = new ilTestPassFinishTasks(
-            $this->test_session,
-            $this->object->getId()
-        );
-        $finishTasks->performFinishTasks($this->processLocker);
-        $this->object->updateTestResultCache($this->test_session->getActiveId(), null);
+        (new ilTestPassFinishTasks($this->test_session, $this->object))->performFinishTasks($this->processLocker);
 
         $this->sendNewPassFinishedNotificationEmailIfActivated(
             $this->test_session->getActiveId(),

--- a/Modules/Test/test/ilTestPassFinishTasksTest.php
+++ b/Modules/Test/test/ilTestPassFinishTasksTest.php
@@ -30,7 +30,10 @@ class ilTestPassFinishTasksTest extends ilTestBaseTestCase
     {
         parent::setUp();
 
-        $this->testObj = new ilTestPassFinishTasks($this->createMock(ilTestSession::class), 0, 0);
+        $this->testObj = new ilTestPassFinishTasks(
+            $this->createMock(ilTestSession::class),
+            $this->createMock(ilObjTest::class),
+        );
     }
 
     public function test_instantiateObject_shouldReturnInstance(): void


### PR DESCRIPTION
This PR attempts to solve the issue described in [Mantis #44580](https://mantis.ilias.de/view.php?id=44580).

When a random test with one question synced from a question pool is completed for the 2nd - Nth time, the learning progress is incorrectly calculated and shows `failed`, even if the user scores 100%.

This happens because the learning progress is calculated based on cached test results. Following the code execution order, the cache is updated **after** the learning progress is calculated. As a result, the learning progress is determined using outdated data that still has a `failed` status.

To fix this, I moved the `updateTestResultCache` function into the `performFinishTasks` function, placing it between setting the test as finished and updating the learning progress.

Kind regards,  
@bidzanaaron  