### PR TITLE
T&A 44619: Fixes error on kprim question correction statistics page

### DIFF
--- a/Modules/TestQuestionPool/classes/tables/class.ilKprimChoiceAnswerFreqStatTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilKprimChoiceAnswerFreqStatTableGUI.php
@@ -26,33 +26,21 @@
  */
 class ilKprimChoiceAnswerFreqStatTableGUI extends ilAnswerFrequencyStatisticTableGUI
 {
-    protected function getTrueOptionLabel()
+    private function getTrueOptionLabel(): string
     {
-        global $DIC; /* @var ILIAS\DI\Container $DIC */
-
-        return $this->question->getTrueOptionLabelTranslation(
-            $DIC->language(),
-            $this->question->getOptionLabel()
-        );
+        return $this->question->getTrueOptionLabelTranslation($this->language, $this->question->getOptionLabel());
     }
 
-    protected function getFalseOptionLabel()
+    private function getFalseOptionLabel(): string
     {
-        global $DIC; /* @var ILIAS\DI\Container $DIC */
-
-        return $this->question->getFalseOptionLabelTranslation(
-            $DIC->language(),
-            $this->question->getOptionLabel()
-        );
+        return $this->question->getFalseOptionLabelTranslation($this->language, $this->question->getOptionLabel());
     }
-
 
     public function initColumns(): void
     {
-        $lng = $this->DIC->language();
-        $this->addColumn($lng->txt('tst_corr_answ_stat_tbl_header_answer'), '');
-        $this->addColumn($lng->txt('tst_corr_answ_stat_tbl_header_frequency') . ': ' . $this->getTrueOptionLabel(), '');
-        $this->addColumn($lng->txt('tst_corr_answ_stat_tbl_header_frequency') . ': ' . $this->getFalseOptionLabel(), '');
+        $this->addColumn($this->language->txt('tst_corr_answ_stat_tbl_header_answer'), '');
+        $this->addColumn($this->language->txt('tst_corr_answ_stat_tbl_header_frequency') . ': ' . $this->getTrueOptionLabel(), '');
+        $this->addColumn($this->language->txt('tst_corr_answ_stat_tbl_header_frequency') . ': ' . $this->getFalseOptionLabel(), '');
 
         foreach ($this->getData() as $row) {
             if (isset($row['addable'])) {


### PR DESCRIPTION
[Mantis: 44619](https://mantis.ilias.de/view.php?id=44619)

A possible fix is to access the `language` property directly since it is already available because of the parent class.