### PR TITLE
T&A 44644: Fixes taxonomy filtering issue in question pool table

### DIFF
--- a/src/UI/templates/js/Input/Container/dist/filter.js
+++ b/src/UI/templates/js/Input/Container/dist/filter.js
@@ -1,3 +1,21 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ * this script wraps dropzone.js library for inputs of
+ * ILIAS\UI\Component\Input\Field\File.
+ **/
+
 var filter = function($) {
 
   //Init the Filter
@@ -249,16 +267,18 @@ var filter = function($) {
     //Remove Input Field from Filter
     $el.parents(".il-popover-container").hide();
 
-    //Clear Input Field (Text, Numeric, Select) when it is removed
     var input_element = searchInputElement($el);
-    input_element.val("");
-
-    //Clear Multi Select Input Field when it is removed
-    var checkboxes = searchInputElementMultiSelect($el);
-    checkboxes.each(function () {
-      $(this).prop("checked", false);
-    });
-    checkboxes.parents(".il-popover-container").find(".il-filter-field").html("");
+    if (input_element.length === 1) {
+      //Clear Input Field (Text, Numeric, Select) when it is removed
+      input_element.val("");
+    } else {
+      //Clear Multi Select Input Field when it is removed
+      var checkboxes = searchInputElementMultiSelect($el);
+      checkboxes.each(function () {
+        $(this).prop("checked", false);
+      });
+      checkboxes.parents(".il-popover-container").find(".il-filter-field").html("");
+    }
 
     //Add Input Field to Add-Button
     var label = $el.parents(".input-group").find(".input-group-addon.leftaddon").html();

--- a/src/UI/templates/js/Input/Container/src/filter.main.js
+++ b/src/UI/templates/js/Input/Container/src/filter.main.js
@@ -1,3 +1,21 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ * this script wraps dropzone.js library for inputs of
+ * ILIAS\UI\Component\Input\Field\File.
+ **/
+
 var filter = function($) {
 
   //Init the Filter
@@ -249,16 +267,18 @@ var filter = function($) {
     //Remove Input Field from Filter
     $el.parents(".il-popover-container").hide();
 
-    //Clear Input Field (Text, Numeric, Select) when it is removed
     var input_element = searchInputElement($el);
-    input_element.val("");
-
-    //Clear Multi Select Input Field when it is removed
-    var checkboxes = searchInputElementMultiSelect($el);
-    checkboxes.each(function () {
-      $(this).prop("checked", false);
-    });
-    checkboxes.parents(".il-popover-container").find(".il-filter-field").html("");
+    if (input_element.length === 1) {
+      //Clear Input Field (Text, Numeric, Select) when it is removed
+      input_element.val("");
+    } else {
+      //Clear Multi Select Input Field when it is removed
+      var checkboxes = searchInputElementMultiSelect($el);
+      checkboxes.each(function () {
+        $(this).prop("checked", false);
+      });
+      checkboxes.parents(".il-popover-container").find(".il-filter-field").html("");
+    }
 
     //Add Input Field to Add-Button
     var label = $el.parents(".input-group").find(".input-group-addon.leftaddon").html();


### PR DESCRIPTION
[Mantis: 44644](https://mantis.ilias.de/view.php?id=44644)

These changes aim to fix an issue caused when removing, readding and than submitting the taxonomy filter form.  I believe that the `input_element.val("");` call causes the value of the select to be removed, when removing the filter instead of just hiding it. For other input types, it is an expected behaviour but not for a select.