### PR TITLE
Cache: ILIAS 9 add TTL back to set function

### DIFF
--- a/src/Cache/Adaptor/Memcached.php
+++ b/src/Cache/Adaptor/Memcached.php
@@ -60,7 +60,7 @@ class Memcached extends BaseAdaptor implements Adaptor
 
     public function set(string $container, string $key, string $value, int $ttl): void
     {
-        $this->server->set($this->buildKey($container, $key), $value);
+        $this->server->set($this->buildKey($container, $key), $value, $ttl);
     }
 
     public function delete(string $container, string $key): void

--- a/src/Cache/Container/ActiveContainer.php
+++ b/src/Cache/Container/ActiveContainer.php
@@ -211,16 +211,20 @@ final class ActiveContainer implements Container
         return $this->buildFinalTransformation($transformation)->transform($unpacked_values);
     }
 
-    public function set(string $key, string|int|array|bool|null $value): void
+    public function set(string $key, string|int|array|bool|null $value, int $ttl = null): void
     {
         if ($this->isLocked()) {
             return;
         }
+        if ($ttl === null) {
+            $ttl = $this->config->getDefaultTTL();
+        }
+
         $this->adaptor->set(
             $this->request->getContainerKey(),
             $key,
             $this->pack($value),
-            $this->config->getDefaultTTL()
+            $ttl
         );
     }
 

--- a/src/Cache/Container/ActiveContainer.php
+++ b/src/Cache/Container/ActiveContainer.php
@@ -211,14 +211,12 @@ final class ActiveContainer implements Container
         return $this->buildFinalTransformation($transformation)->transform($unpacked_values);
     }
 
-    public function set(string $key, string|int|array|bool|null $value, int $ttl = null): void
+    public function set(string $key, string|int|array|bool|null $value, ?int $ttl = null): void
     {
         if ($this->isLocked()) {
             return;
         }
-        if ($ttl === null) {
-            $ttl = $this->config->getDefaultTTL();
-        }
+        $ttl = $ttl ?? $this->config->getDefaultTTL();
 
         $this->adaptor->set(
             $this->request->getContainerKey(),

--- a/src/Cache/Container/Container.php
+++ b/src/Cache/Container/Container.php
@@ -54,7 +54,7 @@ interface Container
     /**
      * Sets the value for the given key
      */
-    public function set(string $key, string|int|array|bool|null $value, int $ttl = null): void;
+    public function set(string $key, string|int|array|bool|null $value, ?int $ttl = null): void;
 
     /**
      * Deletes the value for the given key

--- a/src/Cache/Container/Container.php
+++ b/src/Cache/Container/Container.php
@@ -54,7 +54,7 @@ interface Container
     /**
      * Sets the value for the given key
      */
-    public function set(string $key, string|int|array|bool|null $value): void;
+    public function set(string $key, string|int|array|bool|null $value, int $ttl = null): void;
 
     /**
      * Deletes the value for the given key

--- a/src/Cache/Container/VoidContainer.php
+++ b/src/Cache/Container/VoidContainer.php
@@ -54,7 +54,7 @@ final class VoidContainer implements Container
         return null;
     }
 
-    public function set(string $key, array|bool|int|string|null $value, int $ttl = null): void
+    public function set(string $key, array|bool|int|string|null $value, ?int $ttl = null): void
     {
         // nothing to do
     }

--- a/src/Cache/Container/VoidContainer.php
+++ b/src/Cache/Container/VoidContainer.php
@@ -54,7 +54,7 @@ final class VoidContainer implements Container
         return null;
     }
 
-    public function set(string $key, array|bool|int|string|null $value): void
+    public function set(string $key, array|bool|int|string|null $value, int $ttl = null): void
     {
         // nothing to do
     }


### PR DESCRIPTION
@chfsx This pull request re-adds the possibility to set the TTL if adding an entry to the cache. If nothing is set, the default TTL from the cache config will be used.