### PR TITLE
LDAP: Make user defined pattern matching more robust if pattern contains RegEx delimiter

### DIFF
--- a/Services/Authentication/classes/class.ilAuthModeDetermination.php
+++ b/Services/Authentication/classes/class.ilAuthModeDetermination.php
@@ -113,11 +113,26 @@ class ilAuthModeDetermination
                     //#17731
                     $pattern = str_replace('*', '.*?', $server->getUsernameFilter());
 
-                    if (preg_match('/^' . $pattern . '$/', $a_username)) {
-                        $this->logger->debug('Filter matches for ' . $a_username);
-                        array_unshift($sorted, $auth_key);
-                        continue;
+                    foreach (ilAuthUtils::REGEX_DELIMITERS as $delimiter) {
+                        $this->logger->debug('Trying pattern to match username:' . $pattern . ' => ' . $a_username);
+                        set_error_handler(static function (int $severity, string $message, string $file, int $line): never {
+                            throw new ErrorException($message, $severity, $severity, $file, $line);
+                        });
+
+                        try {
+                            if (preg_match($delimiter . "^" . $pattern . '$' . $delimiter . 'i', $a_username) === 1) {
+                                $this->logger->debug('Filter matches for ' . $a_username);
+                                array_unshift($sorted, $auth_key);
+                                continue 2;
+                            }
+                            break;
+                        } catch (Exception $ex) {
+                            $this->logger->warning('Error occurred in preg_match Ex.: ' . $ex->getMessage());
+                        } finally {
+                            restore_error_handler();
+                        }
                     }
+
                     $this->logger->debug('Filter matches not for ' . $a_username . ' <-> ' . $server->getUsernameFilter());
                 }
             }

--- a/Services/Authentication/classes/class.ilAuthUtils.php
+++ b/Services/Authentication/classes/class.ilAuthUtils.php
@@ -86,6 +86,7 @@ class ilAuthUtils
     private const AUTH_USER_TIME_LIMIT_EXCEEDED = -602;
     private const AUTH_USER_SIMULTANEOUS_LOGIN = -603;
 
+    /** @var list<string> */
     public const REGEX_DELIMITERS = ['/', '~', '@', ';', '%', '`', '#'];
 
     /**

--- a/Services/Authentication/classes/class.ilAuthUtils.php
+++ b/Services/Authentication/classes/class.ilAuthUtils.php
@@ -86,6 +86,8 @@ class ilAuthUtils
     private const AUTH_USER_TIME_LIMIT_EXCEEDED = -602;
     private const AUTH_USER_SIMULTANEOUS_LOGIN = -603;
 
+    public const REGEX_DELIMITERS = ['/', '~', '@', ';', '%', '`', '#'];
+
     /**
      * Check if authentication is should be forced.
      */

--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  *
@@ -38,8 +38,8 @@ class ilLDAPRoleAssignmentRule
     private int $rule_id;
 
     private int $server_id = 0;
-    private bool$add_on_update = false;
-    private bool$remove_on_update = false;
+    private bool $add_on_update = false;
+    private bool $remove_on_update = false;
     private int $plugin_id = 0;
     private string $attribute_value = '';
     private string $attribute_name = '';
@@ -125,9 +125,26 @@ class ilLDAPRoleAssignmentRule
     protected function wildcardCompare(string $a_str1, string $a_str2): bool
     {
         $pattern = str_replace('*', '.*?', $a_str1);
-        $this->logger->debug(': Replace pattern:' . $pattern . ' => ' . $a_str2);
-        return preg_match('/^' . $pattern . '$/i', $a_str2) === 1;
+
+        foreach (ilAuthUtils::REGEX_DELIMITERS as $delimiter) {
+            $this->logger->debug('Trying pattern to match attribute value:' . $pattern . ' => ' . $a_str2);
+
+            set_error_handler(static function (int $severity, string $message, string $file, int $line): never {
+                throw new ErrorException($message, $severity, $severity, $file, $line);
+            });
+
+            try {
+                return preg_match($delimiter . "^" . $pattern . '$' . $delimiter . 'i', $a_str2) === 1;
+            } catch (Exception $ex) {
+                $this->logger->warning('Error occurred in preg_match Ex.: ' . $ex->getMessage());
+            } finally {
+                restore_error_handler();
+            }
+        }
+
+        return false;
     }
+
 
     /**
      * Check if user is member of specific group


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=30083.

If accepted should be picked into **release_10** & **trunk**.