### PR TITLE
T&A 44512: Fixes issue with pool_title column in tst_rnd_quest_set_qpls not being able to fit all data in some cases

### DIFF
--- a/Modules/TestQuestionPool/classes/Setup/class.ilTestQuestionPool9DBUpdateSteps.php
+++ b/Modules/TestQuestionPool/classes/Setup/class.ilTestQuestionPool9DBUpdateSteps.php
@@ -85,4 +85,17 @@ class ilTestQuestionPool9DBUpdateSteps implements ilDatabaseUpdateSteps
             ['type' => 'text', 'length' => 124]
         );
     }
+
+    public function step_7(): void
+    {
+        $table = 'tst_rnd_quest_set_qpls';
+        $table_column = 'pool_title';
+        if ($this->db->tableColumnExists($table, $table_column)) {
+            $this->db->modifyTableColumn(
+                $table,
+                $table_column,
+                ['type' => ilDBConstants::T_TEXT, 'length' => 255],
+            );
+        }
+    }
 }


### PR DESCRIPTION
[Mantis: 44512](https://mantis.ilias.de/view.php?id=44512)

The question pool title is stored in (atleast) two tables. The `object_data` table column `title` allows up to `255` characters and the  `tst_rnd_quest_set_qpls` table column `pool_title` currently only allows up to `128` characters. This can causes issues on updated platforms when opening older random tests.

Since we have already allowed the title to be up to `255` characters we cannot decrease it and probably should increase it on the other side to match that limit.