### PR TITLE
T&A 44463: Fixes test exporting dates using incorrect timezone

### DIFF
--- a/Modules/Test/classes/MainSettings/ilObjTestSettingsAccess.php
+++ b/Modules/Test/classes/MainSettings/ilObjTestSettingsAccess.php
@@ -70,31 +70,15 @@ class ilObjTestSettingsAccess extends TestSettings
         array $environment = null
     ): Group {
         $constraint = $refinery->custom()->constraint(
-            static function (array $vs): bool {
-                if ($vs['start_time'] === null
-                    || $vs['end_time'] === null) {
-                    return true;
-                }
-                return $vs['start_time'] < $vs['end_time'];
-            },
+            static fn (array $vs) =>
+                $vs['start_time'] === null || $vs['end_time'] === null || $vs['start_time'] < $vs['end_time'],
             $lng->txt('duration_end_must_not_be_earlier_than_start')
         );
 
         $trafo = $refinery->custom()->transformation(
             static function (array $vs): array {
-                if ($vs['start_time'] === null) {
-                    $vs['start_time_enabled'] = false;
-                } else {
-                    $vs['start_time_enabled'] = true;
-                    $vs['start_time'] = $vs['start_time'];
-                }
-
-                if ($vs['end_time'] === null) {
-                    $vs['end_time_enabled'] = false;
-                    return $vs;
-                }
-
-                $vs['end_time_enabled'] = true;
+                $vs['start_time_enabled'] = $vs['start_time'] !== null;
+                $vs['end_time_enabled'] = $vs['end_time'] !== null;
                 return $vs;
             }
         );

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -3650,10 +3650,13 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
         if ($this->getScoreSettings()->getResultSummarySettings()->getReportingDate() !== null) {
             $a_xml_writer->xmlStartTag("qtimetadatafield");
             $a_xml_writer->xmlElement("fieldlabel", null, "reporting_date");
-            $reporting_date = $this->buildPeriodFromFormatedDateString(
-                $this->getScoreSettings()->getResultSummarySettings()->getReportingDate()->format('Y-m-d H:i:s')
+            $a_xml_writer->xmlElement(
+                "fieldentry",
+                null,
+                $this->buildIso8601PeriodFromUnixTimeForExportCompatibility(
+                    $this->getScoreSettings()->getResultSummarySettings()->getReportingDate()->getTimestamp(),
+                ),
             );
-            $a_xml_writer->xmlElement("fieldentry", null, $reporting_date);
             $a_xml_writer->xmlEndTag("qtimetadatafield");
         }
         // number of tries
@@ -3900,19 +3903,25 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
 
 
         // starting time
-        if ($this->getStartingTime()) {
+        if ($this->getStartingTime() > 0) {
             $a_xml_writer->xmlStartTag("qtimetadatafield");
             $a_xml_writer->xmlElement("fieldlabel", null, "starting_time");
-            $backward_compatibility_format = $this->buildIso8601PeriodFromUnixtimeForExportCompatibility($this->getStartingTime());
-            $a_xml_writer->xmlElement("fieldentry", null, $backward_compatibility_format);
+            $a_xml_writer->xmlElement(
+                "fieldentry",
+                null,
+                $this->buildIso8601PeriodFromUnixTimeForExportCompatibility($this->getStartingTime()),
+            );
             $a_xml_writer->xmlEndTag("qtimetadatafield");
         }
         // ending time
-        if ($this->getEndingTime()) {
+        if ($this->getEndingTime() > 0) {
             $a_xml_writer->xmlStartTag("qtimetadatafield");
             $a_xml_writer->xmlElement("fieldlabel", null, "ending_time");
-            $backward_compatibility_format = $this->buildIso8601PeriodFromUnixtimeForExportCompatibility($this->getEndingTime());
-            $a_xml_writer->xmlElement("fieldentry", null, $backward_compatibility_format);
+            $a_xml_writer->xmlElement(
+                "fieldentry",
+                null,
+                $this->buildIso8601PeriodFromUnixTimeForExportCompatibility($this->getEndingTime()),
+            );
             $a_xml_writer->xmlEndTag("qtimetadatafield");
         }
 
@@ -4042,21 +4051,12 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
         return $xml;
     }
 
-    /**
-     * @param $unix_timestamp
-     * @return string
-     */
-    protected function buildIso8601PeriodFromUnixtimeForExportCompatibility($unix_timestamp): string
+    protected function buildIso8601PeriodFromUnixTimeForExportCompatibility(int $unix_timestamp): string
     {
-        $date_time_unix = new ilDateTime($unix_timestamp, IL_CAL_UNIX);
-        $date_time = $date_time_unix->get(IL_CAL_DATETIME);
-        return $this->buildPeriodFromFormatedDateString($date_time);
-    }
-
-    protected function buildPeriodFromFormatedDateString(string $date_time): string
-    {
-        preg_match("/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/", $date_time, $matches);
-        return sprintf("P%dY%dM%dDT%dH%dM%dS", $matches[1], $matches[2], $matches[3], $matches[4], $matches[5], $matches[6]);
+        $date_time = (new DateTime('now', new DateTimeZone('UTC')))->setTimestamp($unix_timestamp);
+        $minutes_without_leading_zeros = (int) $date_time->format('i');
+        $seconds_without_leading_zeros = (int) $date_time->format('s');
+        return "{$date_time->format('\PY\Yn\Mj\D\TG\H')}{$minutes_without_leading_zeros}M{$seconds_without_leading_zeros}S";
     }
 
     protected function buildDateTimeImmutableFromPeriod(?string $period): ?DateTimeImmutable

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -3653,7 +3653,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             $a_xml_writer->xmlElement(
                 "fieldentry",
                 null,
-                $this->buildIso8601PeriodFromUnixTimeForExportCompatibility(
+                $this->buildIso8601PeriodForExportCompatibility(
                     $this->getScoreSettings()->getResultSummarySettings()->getReportingDate(),
                 ),
             );
@@ -3909,7 +3909,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             $a_xml_writer->xmlElement(
                 "fieldentry",
                 null,
-                $this->buildIso8601PeriodFromUnixTimeForExportCompatibility(
+                $this->buildIso8601PeriodForExportCompatibility(
                     (new DateTimeImmutable())->setTimestamp($this->getStartingTime()),
                 ),
             );
@@ -3922,7 +3922,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             $a_xml_writer->xmlElement(
                 "fieldentry",
                 null,
-                $this->buildIso8601PeriodFromUnixTimeForExportCompatibility(
+                $this->buildIso8601PeriodForExportCompatibility(
                     (new DateTimeImmutable())->setTimestamp($this->getEndingTime()),
                 ),
             );
@@ -4055,7 +4055,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
         return $xml;
     }
 
-    protected function buildIso8601PeriodFromUnixTimeForExportCompatibility(DateTimeImmutable $date_time): string
+    protected function buildIso8601PeriodForExportCompatibility(DateTimeImmutable $date_time): string
     {
         return $date_time->setTimezone(new DateTimeZone('UTC'))->format('\PY\Yn\Mj\D\TG\Hi\Ms\S');
     }

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -3654,7 +3654,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
                 "fieldentry",
                 null,
                 $this->buildIso8601PeriodFromUnixTimeForExportCompatibility(
-                    $this->getScoreSettings()->getResultSummarySettings()->getReportingDate()->getTimestamp(),
+                    $this->getScoreSettings()->getResultSummarySettings()->getReportingDate(),
                 ),
             );
             $a_xml_writer->xmlEndTag("qtimetadatafield");
@@ -3909,7 +3909,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             $a_xml_writer->xmlElement(
                 "fieldentry",
                 null,
-                $this->buildIso8601PeriodFromUnixTimeForExportCompatibility($this->getStartingTime()),
+                $this->buildIso8601PeriodFromUnixTimeForExportCompatibility(
+                    (new DateTimeImmutable())->setTimestamp($this->getStartingTime()),
+                ),
             );
             $a_xml_writer->xmlEndTag("qtimetadatafield");
         }
@@ -3920,7 +3922,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             $a_xml_writer->xmlElement(
                 "fieldentry",
                 null,
-                $this->buildIso8601PeriodFromUnixTimeForExportCompatibility($this->getEndingTime()),
+                $this->buildIso8601PeriodFromUnixTimeForExportCompatibility(
+                    (new DateTimeImmutable())->setTimestamp($this->getEndingTime()),
+                ),
             );
             $a_xml_writer->xmlEndTag("qtimetadatafield");
         }
@@ -4051,12 +4055,9 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
         return $xml;
     }
 
-    protected function buildIso8601PeriodFromUnixTimeForExportCompatibility(int $unix_timestamp): string
+    protected function buildIso8601PeriodFromUnixTimeForExportCompatibility(DateTimeImmutable $date_time): string
     {
-        $date_time = (new DateTime('now', new DateTimeZone('UTC')))->setTimestamp($unix_timestamp);
-        $minutes_without_leading_zeros = (int) $date_time->format('i');
-        $seconds_without_leading_zeros = (int) $date_time->format('s');
-        return "{$date_time->format('\PY\Yn\Mj\D\TG\H')}{$minutes_without_leading_zeros}M{$seconds_without_leading_zeros}S";
+        return $date_time->setTimezone(new DateTimeZone('UTC'))->format('\PY\Yn\Mj\D\TG\Hi\Ms\S');
     }
 
     protected function buildDateTimeImmutableFromPeriod(?string $period): ?DateTimeImmutable


### PR DESCRIPTION
[Mantis: 44463](https://mantis.ilias.de/view.php?id=44463)

When exporting a test, the starting and ending time where exported in the systems timezone. Importing it in a system with a different timezone causes the time to not be alligned correctly.

By always exporting timestamps in the UTC-0 timezone and displaying it to the user in their prefered timezone this issue can be mitigated and timestamps can be directly compared to eachother.