### PR TITLE
T&A 43482: Fixes test export with user results and adds user file upload question file uploads to export and import

### DIFF
--- a/Modules/Test/classes/class.ilTestExport.php
+++ b/Modules/Test/classes/class.ilTestExport.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\ResourceStorage\Services as ResourceStorage;
+
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
 
 /**
@@ -52,6 +54,7 @@ abstract class ilTestExport
     protected ILIAS $ilias;
 
     protected string $inst_id;
+    private ResourceStorage $irss;
 
     public function __construct(
         public ilObjTest $test_obj,
@@ -63,6 +66,7 @@ abstract class ilTestExport
         $this->db = $DIC['ilDB'];
         $this->lng = $DIC['lng'];
         $this->bench = $DIC['ilBench'];
+        $this->irss = $DIC['resource_storage'];
 
         $this->inst_id = (string) IL_INST_ID;
 
@@ -243,7 +247,13 @@ abstract class ilTestExport
         $this->bench->stop("TestExport", "buildExportFile_dumpToFile");
 
         if ($this->isResultExportingEnabledForTestExport()) {
-            $resultwriter = new ilTestResultsToXML($this->test_obj->getTestId(), $this->db, $this->test_obj->getAnonymity());
+            $resultwriter = new ilTestResultsToXML(
+                $this->test_obj->getTestId(),
+                $this->db,
+                $this->irss,
+                $this->export_dir . "/" . $this->subdir . "/objects",
+                $this->test_obj->getAnonymity()
+            );
             $resultwriter->setIncludeRandomTestQuestionsEnabled($this->test_obj->isRandomTest());
             $this->bench->start("TestExport", "buildExportFile_results");
             $resultwriter->xmlDumpFile($this->export_dir . "/" . $this->subdir . "/" . $this->resultsfile, false);

--- a/Modules/Test/classes/class.ilTestImporter.php
+++ b/Modules/Test/classes/class.ilTestImporter.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\ResourceStorage\Services as ResourceStorage;
+
 /**
  * Importer class for files
  *
@@ -34,12 +36,14 @@ class ilTestImporter extends ilXmlImporter
 
     private ilLogger $log;
     private ilDBInterface $db;
+    private ResourceStorage $irss;
 
     public function __construct()
     {
         global $DIC;
         $this->log = $DIC['ilLog'];
         $this->db = $DIC['ilDB'];
+        $this->irss = $DIC['resource_storage'];
 
         parent::__construct();
     }
@@ -121,7 +125,7 @@ class ilTestImporter extends ilXmlImporter
         $results_file_path = ilSession::get("tst_import_results_file");
         // import test results
         if ($results_file_path !== null && file_exists($results_file_path)) {
-            $results = new ilTestResultsImportParser($results_file_path, $new_obj, $this->db, $this->log);
+            $results = new ilTestResultsImportParser($results_file_path, $new_obj, $this->db, $this->log, $this->irss);
             $results->setQuestionIdMapping($a_mapping->getMappingsOfEntity('Modules/Test', 'quest'));
             $results->setSrcPoolDefIdMapping($a_mapping->getMappingsOfEntity('Modules/Test', 'rnd_src_pool_def'));
             $results->startParsing();

--- a/Modules/Test/classes/class.ilTestResultsImportParser.php
+++ b/Modules/Test/classes/class.ilTestResultsImportParser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +18,9 @@
 
 declare(strict_types=1);
 
+use ILIAS\Filesystem\Stream\Stream;
+use ILIAS\ResourceStorage\Services as ResourceStorage;
+
 class ilTestResultsImportParser extends ilSaxParser
 {
     private $table;
@@ -27,6 +31,7 @@ class ilTestResultsImportParser extends ilSaxParser
     private bool $user_criteria_checked = false;
 
     protected $src_pool_def_id_mapping;
+    private string $import_directory;
 
     /**
     * Constructor
@@ -35,14 +40,15 @@ class ilTestResultsImportParser extends ilSaxParser
         ?string $a_xml_file,
         private ilObjTest $test_obj,
         private ilDBInterface $db,
-        private ilLogger $log
+        private ilLogger $log,
+        private ResourceStorage $irss
     ) {
         parent::__construct($a_xml_file, true);
         $this->table = '';
         $this->active_id_mapping = [];
         $this->question_id_mapping = [];
-        $this->user_criteria_checked = false;
         $this->src_pool_def_id_mapping = [];
+        $this->import_directory = dirname($a_xml_file);
     }
 
     /**
@@ -226,7 +232,7 @@ class ilTestResultsImportParser extends ilSaxParser
                             "solution_id" => array("integer", $next_id),
                             "active_fi" => array("integer", $this->active_id_mapping[$a_attribs['active_fi']]),
                             "question_fi" => array("integer", $this->question_id_mapping[$a_attribs['question_fi']]),
-                            "value1" => array("clob", (strlen($a_attribs['value1'])) ? $a_attribs['value1'] : null),
+                            "value1" => array("clob", $this->importParticipantsUploadedFiles($a_attribs)),
                             "value2" => array("clob", (strlen($a_attribs['value2'])) ? $a_attribs['value2'] : null),
                             "pass" => array("integer", $a_attribs['pass']),
                             "tstamp" => array("integer", $a_attribs['tstamp'])
@@ -312,5 +318,41 @@ class ilTestResultsImportParser extends ilSaxParser
         }
 
         return null;
+    }
+
+    /**
+     * @param array{value1: string, value2: string} $a_attribs
+     * @return string
+     */
+    private function importParticipantsUploadedFiles(array $a_attribs): ?string
+    {
+        ['value1' => $value1, 'value2' => $value2] = $a_attribs;
+
+        if ($value2 !== 'rid') {
+            return $value1 ?: null;
+        }
+
+        $resource_directory = "$this->import_directory/objects/resources/$value1";
+        $file_name = $this->getFirstFileName($resource_directory);
+        if (!is_string($file_name)) {
+            return $value1 ?: null;
+        }
+
+        $file_path = "$resource_directory/$file_name";
+        $new_rid = $this->irss->manage()->stream(
+            new Stream(fopen($file_path, 'rwb')),
+            new assFileUploadStakeholder(),
+            basename($file_path),
+        );
+        return $new_rid->serialize();
+    }
+
+    private function getFirstFileName(string $resource_directory): mixed
+    {
+        $entries = array_filter(
+            scandir($resource_directory),
+            static fn(string $entry): bool => is_file("$resource_directory/$entry") && !in_array($entry, ['.', '..']),
+        );
+        return array_shift($entries);
     }
 }

--- a/Modules/Test/classes/class.ilTestResultsToXML.php
+++ b/Modules/Test/classes/class.ilTestResultsToXML.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\ResourceStorage\Services as ResourceStorage;
+
 class ilTestResultsToXML extends ilXmlWriter
 {
     private $active_ids;
@@ -27,7 +29,9 @@ class ilTestResultsToXML extends ilXmlWriter
     public function __construct(
         private int $test_id,
         private ilDBInterface $db,
-        private bool $anonymized = false
+        private ResourceStorage $irss,
+        private string $objects_export_directory,
+        private bool $anonymized = false,
     ) {
         parent::__construct();
     }
@@ -200,18 +204,50 @@ class ilTestResultsToXML extends ilXmlWriter
         $result = $this->db->query($query);
         $this->xmlStartTag('tst_test_result', null);
         while ($row = $this->db->fetchAssoc($result)) {
+            $active_fi = $row['active_fi'];
+            $pass = $row['pass'] ?? '';
             $attrs = [
                 'test_result_id' => $row['test_result_id'],
-                'active_fi' => $row['active_fi'],
+                'active_fi' => $active_fi,
                 'question_fi' => $row['question_fi'],
                 'points' => $row['points'] ?? '',
-                'pass' => $row['pass'] ?? '',
+                'pass' => $pass,
                 'manual' => $row['manual'] ?? '',
                 'tstamp' => $row['tstamp'] ?? ''
             ];
+
+            if (($question = assQuestion::instantiateQuestion($row['question_fi'])) instanceof assFileUpload) {
+                $this->exportParticipantUploadedFiles($question->getUploadedFiles($active_fi, $pass));
+            }
+
             $this->xmlElement('row', $attrs);
         }
         $this->xmlEndTag('tst_test_result');
+    }
+
+    /**
+     * @param array{value1: string, value2: string} $uploaded_files
+     */
+    protected function exportParticipantUploadedFiles(array $uploaded_files): void
+    {
+        foreach ($uploaded_files as $uploaded_file) {
+            if ($uploaded_file['value2'] !== 'rid') {
+                continue;
+            }
+
+            $rid_string = $uploaded_file['value1'];
+            $rid = $this->irss->manage()->find($rid_string);
+            if ($rid === null) {
+                continue;
+            }
+
+            $target_dir = "$this->objects_export_directory/resources/$rid_string";
+            ilFileUtils::makeDirParents($target_dir);
+            file_put_contents(
+                "$target_dir/{$this->irss->manage()->getCurrentRevision($rid)->getTitle()}",
+                $this->irss->consume()->stream($rid)->getStream(),
+            );
+        }
     }
 
     protected function exportTestTimes(): void

--- a/Modules/Test/test/ilTestBaseTestCase.php
+++ b/Modules/Test/test/ilTestBaseTestCase.php
@@ -27,6 +27,7 @@ use ILIAS\HTTP\Services;
 use ILIAS\UI\Implementation\Factory;
 use ILIAS\Refinery\Factory as RefineryFactory;
 use ILIAS\Refinery\Random\Group as RandomGroup;
+use ILIAS\ResourceStorage\Services as ResourceStorage;
 
 /**
  * Class ilTestBaseClass
@@ -60,6 +61,7 @@ class ilTestBaseTestCase extends TestCase
         $this->addGlobal_ilComponentFactory();
         $this->addGlobal_uiFactory();
         $this->addGlobal_uiRenderer();
+        $this->addGlobal_resourceStorage();
 
         $this->getMockBuilder(\ILIAS\DI\LoggingServices::class)->disableOriginalConstructor()->getMock();
 
@@ -331,6 +333,11 @@ class ilTestBaseTestCase extends TestCase
         $object_mock = $this->getMockBuilder(\ilObjectService::class)->disableOriginalConstructor()->getMock();
 
         $this->setGlobalVariable("object", $object_mock);
+    }
+
+    protected function addGlobal_resourceStorage(): void
+    {
+        $this->setGlobalVariable("resource_storage", $this->createMock(ResourceStorage::class));
     }
 
     protected function getTestObjMock(): ilObjTest

--- a/Modules/Test/test/ilTestResultsImportParserTest.php
+++ b/Modules/Test/test/ilTestResultsImportParserTest.php
@@ -32,7 +32,7 @@ class ilTestResultsImportParserTest extends ilTestBaseTestCase
         $this->addGlobal_ilLog();
 
         $testObject = $this->createMock(ilObjTest::class);
-        $this->testObj = new ilTestResultsImportParser("", $testObject, $DIC['ilDB'], $DIC['ilLog']);
+        $this->testObj = new ilTestResultsImportParser("", $testObject, $DIC['ilDB'], $DIC['ilLog'], $DIC['resource_storage']);
     }
 
     public function test_instantiateObject_shouldReturnInstance(): void

--- a/Modules/Test/test/ilTestResultsToXMLTest.php
+++ b/Modules/Test/test/ilTestResultsToXMLTest.php
@@ -34,6 +34,8 @@ class ilTestResultsToXMLTest extends ilTestBaseTestCase
         $this->testObj = new ilTestResultsToXML(
             0,
             $DIC['ilDB'],
+            $DIC['resource_storage'],
+            '',
             false
         );
     }


### PR DESCRIPTION
[Mantis: 43482](https://mantis.ilias.de/view.php?id=43482)

When exporint a test with participant data, the file uploads from file upload questions do not get exported. This causes the files to be missing on import and preventing a manual correction if the question.

I believe this should fix this issue, by including the participants file uploads in the export and importing them on import into the systems storage.