### PR TITLE
Potential Fix mantis: 44591 Course members from campus management are only adde…

### DIFF
--- a/Services/WebServices/ECS/classes/Course/class.ilECSCourseMemberAssignment.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCourseMemberAssignment.php
@@ -113,7 +113,7 @@ class ilECSCourseMemberAssignment
         $ilDB = $DIC['ilDB'];
 
         if (is_null($a_cms_sub_id)) {
-            $cms_sub_id_query = 'AND cms_sub_id IS NULL ';
+            $cms_sub_id_query = 'AND cms_sub_id IS NULL OR cms_sub_id = 0 ';
         } else {
             $cms_sub_id_query = 'AND cms_sub_id = ' . $ilDB->quote($a_cms_sub_id, 'integer') . ' ';
         }
@@ -141,7 +141,7 @@ class ilECSCourseMemberAssignment
         $ilDB = $DIC['ilDB'];
 
         if (is_null($a_cms_sub_id)) {
-            $cms_sub_id_query = 'AND cms_sub_id IS NULL ';
+            $cms_sub_id_query = 'AND cms_sub_id IS NULL OR cms_sub_id = 0 ';
         } else {
             $cms_sub_id_query = 'AND cms_sub_id = ' . $ilDB->quote($a_cms_sub_id, 'integer') . ' ';
         }


### PR DESCRIPTION
…d to courses but not removed

Course members were not being removed from ILIAS when they no longer appeared in the CMS JSON. This was due to a mismatch in the SQL query condition, which only checked for cms_sub_id IS NULL, while in our case, cms_sub_id was 0. The fix extends the condition to also check for cms_sub_id = 0, ensuring proper removal of members.