### PR TITLE
Fix regression error: use PHP core randomizer

### DIFF
--- a/components/ILIAS/Init/classes/class.ilErrorHandling.php
+++ b/components/ILIAS/Init/classes/class.ilErrorHandling.php
@@ -272,8 +272,8 @@ class ilErrorHandling
             global $DIC;
 
             $session_id = substr(session_id(), 0, 5);
-            $random = new ilRandom();
-            $err_num = $random->int(1, 9999);
+            $r = new \Random\Randomizer();
+            $err_num = $r->getInt(1, 9999);
             $file_name = $session_id . '_' . $err_num;
 
             $logger = ilLoggingErrorSettings::getInstance();


### PR DESCRIPTION
Merge PR [#9111](https://github.com/ILIAS-eLearning/ILIAS/pull/9111) introduced a regression error going back to the old ILIAS Randomizer instead of the PHP core Randomizer(ilErrorHandling). This PR fixes this. If accepted please merge into trunk. 