### PR TITLE
Mantis #38284: Force local auth mode in local registration when not the default

### DIFF
--- a/Services/Registration/classes/class.ilAccountRegistrationGUI.php
+++ b/Services/Registration/classes/class.ilAccountRegistrationGUI.php
@@ -358,6 +358,9 @@ class ilAccountRegistrationGUI
         }
 
         $this->userObj = new ilObjUser();
+        if ((int) $this->settings->get('auth_mode') !== ilAuthUtils::AUTH_LOCAL) {
+            $this->userObj->setAuthMode('local');
+        }
 
         $this->user_profile->skipGroup("preferences");
         $this->user_profile->skipGroup("settings");


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38284

If accepted should be picked into **release_10** & **trunk**