### PR TITLE
Certificate Bugfix #0044668: Import deleteDir throws Error with NFS runnning

### DIFF
--- a/Services/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
+++ b/Services/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
@@ -37,7 +37,7 @@ class ilCertificateTemplateImportAction
         private readonly int $objectId,
         private readonly string $certificatePath,
         private readonly ilCertificatePlaceholderDescription $placeholderDescriptionObject,
-        ilLogger $logger,
+        private readonly ilLogger $logger,
         private readonly Filesystem $filesystem,
         ?ilCertificateTemplateRepository $templateRepository = null,
         ?ilCertificateObjectHelper $objectHelper = null,
@@ -92,7 +92,7 @@ class ilCertificateTemplateImportAction
 
         $clean_up_import_dir = function () use (&$importPath) {
             if ($this->filesystem->hasDir($importPath)) {
-                ilFileUtils::delDir($importPath);
+                $this->filesystem->deleteDir($importPath);
             }
         };
 
@@ -110,15 +110,11 @@ class ilCertificateTemplateImportAction
         );
 
         $unzipped = $unzip->extract();
-        $unzip->close();
         if (!$unzipped) {
             $clean_up_import_dir();
             return false;
         }
 
-        if ($this->filesystem->has($importPath . $filename)) {
-            $this->filesystem->delete($importPath . $filename);
-        }
 
         $xmlFiles = 0;
         $contents = $this->filesystem->listContents($importPath);

--- a/Services/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
+++ b/Services/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
@@ -92,7 +92,7 @@ class ilCertificateTemplateImportAction
 
         $clean_up_import_dir = function () use (&$importPath) {
             if ($this->filesystem->hasDir($importPath)) {
-                $this->filesystem->deleteDir($importPath);
+                ilFileUtils::delDir($importPath);
             }
         };
 
@@ -110,6 +110,7 @@ class ilCertificateTemplateImportAction
         );
 
         $unzipped = $unzip->extract();
+        $unzip->close();
         if (!$unzipped) {
             $clean_up_import_dir();
             return false;


### PR DESCRIPTION
Although this is a step back from abandoning ilFileUtils and using flysystem, the certificate import doesn't seem to work with NFS. There has to be a FileStream that isn't properly being closed. Until the actual error cannot be found this is the only fix I found so far for https://mantis.ilias.de/view.php?id=44668