### PR TITLE
UI/Input/Pagination: 38501/38505, use buttons with symbols for rocker navigation

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
@@ -294,31 +294,29 @@ class Renderer extends AbstractComponentRenderer
                 }
             }
 
-            $icon_left = $ui_factory->symbol()->glyph()->back();
+            $signal = null;
             if ($current > 0 && count($entries) > 1) {
                 $range = $ranges[$current - 1];
                 $signal = clone $internal_signal;
                 $signal->addOption('offset', $range->getStart());
                 $signal->addOption('limit', $limit);
-                $icon_left = $icon_left ->withOnClick($signal);
-            } else {
-                $icon_left = $icon_left->withUnavailableAction();
-                $tpl->touchBlock('left_disabled');
             }
-            $tpl->setVariable("LEFT", $default_renderer->render($icon_left));
+            $btn_left = $ui_factory->button()->shy('', $signal ?? '#')
+                ->withSymbol($ui_factory->symbol()->glyph()->back())
+                ->withUnavailableAction($signal === null);
+            $tpl->setVariable("LEFT_ROCKER", $default_renderer->render($btn_left));
 
-            $icon_right = $ui_factory->symbol()->glyph()->next();
+            $signal = null;
             if ($current < count($ranges) - 1) {
                 $range = $ranges[$current + 1];
                 $signal = clone $internal_signal;
                 $signal->addOption('offset', $range->getStart());
                 $signal->addOption('limit', $limit);
-                $icon_right = $icon_right ->withOnClick($signal);
-            } else {
-                $icon_right = $icon_right->withUnavailableAction();
-                $tpl->touchBlock('right_disabled');
             }
-            $tpl->setVariable("RIGHT", $default_renderer->render($icon_right));
+            $btn_right = $ui_factory->button()->shy('', $signal ?? '#')
+                ->withSymbol($ui_factory->symbol()->glyph()->next())
+                ->withUnavailableAction($signal === null);
+            $tpl->setVariable("RIGHT_ROCKER", $default_renderer->render($btn_right));
         }
 
         foreach ($component->getLimitOptions() as $option) {

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.viewcontrol_pagination.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.viewcontrol_pagination.html
@@ -4,14 +4,14 @@
     <!-- BEGIN section_part -->
     <div class="dropdown il-viewcontrol-pagination__sectioncontrol">
             <!-- BEGIN selection -->
-                <div class="btn btn-ctrl browse previous<!-- BEGIN left_disabled --> disabled<!-- END left_disabled -->">{LEFT}</div>
+                {LEFT_ROCKER}
                 <!-- BEGIN entry -->
                     <!-- BEGIN spacer -->
                     <span class="il-viewcontrol-pagination__spacer">...</span>
                     <!-- END spacer -->
                     {ENTRY}
                 <!-- END entry -->
-                <div class="btn btn-ctrl browse next<!-- BEGIN right_disabled --> disabled<!-- END right_disabled -->">{RIGHT}</div>
+                {RIGHT_ROCKER}
             <!-- END selection -->
             <!-- BEGIN input -->
                 {INPUT}

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlPaginationTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlPaginationTest.php
@@ -171,11 +171,9 @@ class ViewControlPaginationTest extends ViewControlTestBase
         $expected = $this->brutallyTrimHTML('
 <div class="il-viewcontrol il-viewcontrol-pagination l-bar__element" id="id_13">
     <div class="dropdown il-viewcontrol-pagination__sectioncontrol">
-            <div class="btn btn-ctrl browse previous">
-                <a tabindex="0" class="glyph" aria-label="back" id="id_8">
-                    <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-                </a>
-            </div>
+        <button class="btn btn-link" id="id_8">
+            <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+        </button>
 
         <button class="btn btn-link" id="id_1">1</button>
         <span class="il-viewcontrol-pagination__spacer">...</span>
@@ -187,11 +185,9 @@ class ViewControlPaginationTest extends ViewControlTestBase
         <span class="il-viewcontrol-pagination__spacer">...</span>
         <button class="btn btn-link" id="id_7">21</button>
 
-        <div class="btn btn-ctrl browse next">
-            <a tabindex="0" class="glyph" aria-label="next" id="id_9">
-                <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-            </a>
-        </div>
+        <button class="btn btn-link" id="id_9">
+            <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
+        </button>
     </div>
 
     <div class="dropdown il-viewcontrol-pagination__num-of-items">


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=38501
https://mantis.ilias.de/view.php?id=38505

Replace glyphs in the pagination's nav with buttons + symbol.

(Does not apply for 9, where symbols  cannot be used on buttons, yet)