### PR TITLE
LTI: Fix - Add redirection endpoint to access after the user accepts the "Terms of Service"

### DIFF
--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -700,6 +700,14 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             'samesite' => 'None'
         ]);
 
+        $lti_context_ids = ilSession::get("lti_context_ids");
+
+        if (is_array($lti_context_ids) && isset($lti_context_ids[0])) {
+            $ref_id = $lti_context_ids[0];
+            $obj_type = ilObject::_lookupType($ref_id, true);
+            ilSession::set('orig_request_target', "goto.php?target=" . $obj_type . "_" . $ref_id  . "&lti_context_id=" . $ref_id);
+        }
+
         switch ($status->getStatus()) {
             case ilAuthStatus::STATUS_AUTHENTICATED:
                 ilLoggerFactory::getLogger('auth')->debug('Authentication successful; Redirecting to starting page.');

--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -705,7 +705,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         if (is_array($lti_context_ids) && isset($lti_context_ids[0])) {
             $ref_id = $lti_context_ids[0];
             $obj_type = ilObject::_lookupType($ref_id, true);
-            ilSession::set('orig_request_target', "goto.php?target=" . $obj_type . "_" . $ref_id  . "&lti_context_id=" . $ref_id);
+            ilSession::set('orig_request_target', "goto.php?target=" . $obj_type . "_" . $ref_id . "&lti_context_id=" . $ref_id);
         }
 
         switch ($status->getStatus()) {


### PR DESCRIPTION
Using the information from the Mantis report https://mantis.ilias.de/view.php?id=39629, we identified the correct way to fix the redirection bug, which occurs when the provider platform requires acceptance of usage terms, and screens such as password change or similar.

Initially, we attempted to apply the fix only within the LTI-related files. However, we discovered that the logic also needs to be added in ```ilStartUpGUI```, because the method ```$frontend->authenticate()``` sets the session variable ```orig_request_target``` as empty. Therefore, this is the only suitable place where the bug can be effectively resolved.