### PR TITLE
User/Import: Use `isset(...)` instead `is_null(...)`

### DIFF
--- a/Services/User/classes/class.ilUserImportParser.php
+++ b/Services/User/classes/class.ilUserImportParser.php
@@ -578,7 +578,7 @@ class ilUserImportParser extends ilSaxParser
                 // if we have an object id, store it
                 $this->user_id = -1;
 
-                if (!is_null($a_attribs['Id']) && $this->getUserMappingMode() === self::IL_USER_MAPPING_ID) {
+                if (isset($a_attribs['Id']) && $this->getUserMappingMode() === self::IL_USER_MAPPING_ID) {
                     if (is_numeric($a_attribs['Id'])) {
                         $this->user_id = (int) $a_attribs['Id'];
                     } elseif (($id = (int) ilUtil::__extractId($a_attribs['Id'], (int) IL_INST_ID)) > 0) {
@@ -586,7 +586,7 @@ class ilUserImportParser extends ilSaxParser
                     }
                 }
 
-                $this->action = (is_null($a_attribs['Action'])) ? 'Insert' : $a_attribs['Action'];
+                $this->action = !isset($a_attribs['Action']) ? 'Insert' : $a_attribs['Action'];
                 if ($this->action !== 'Insert'
                 && $this->action !== 'Update'
                 && $this->action !== 'Delete') {


### PR DESCRIPTION
This PR makes the XML parser for user XML documents more robust against missing "Id" and "Action" attributes.

The same attributes are checked with `isset(...)` in other methods of this class, so I suggest streamlining the checks.