### PR TITLE
Fix page editor plugin export in T&A

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -4170,6 +4170,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             $page_object = new ilAssQuestionPage($question_id);
             $page_object->buildDom();
             $page_object->insertInstIntoIDs((string) $inst);
+            ilPageComponentPluginExportImportStore::getInstance()->extractPluginProperties($page_object);
             $mob_ids = $page_object->collectMediaObjects(false);
             $file_ids = ilPCFileList::collectFileItems($page_object, $page_object->getDomDoc());
             $xml = $page_object->getXMLFromDom(false, false, false, "", true);

--- a/Modules/Test/classes/class.ilTestExporter.php
+++ b/Modules/Test/classes/class.ilTestExporter.php
@@ -35,6 +35,7 @@ class ilTestExporter extends ilXmlExporter
     private ilCtrl $ctrl;
     private ilComponentRepository $component_repository;
     private QuestionInfoService $questioninfo;
+    private ilPageComponentPluginExportImportStore $pc_plugin_store;
 
     public function __construct()
     {
@@ -45,6 +46,7 @@ class ilTestExporter extends ilXmlExporter
         $this->ctrl = $DIC['ilCtrl'];
         $this->component_repository = $DIC['component.repository'];
         $this->questioninfo = $DIC->testQuestionPool()->questionInfo();
+        $this->pc_plugin_store = ilPageComponentPluginExportImportStore::getInstance();
 
         parent::__construct();
     }
@@ -143,6 +145,8 @@ class ilTestExporter extends ilXmlExporter
                 'entity' => 'common',
                 'ids' => $a_ids
             ];
+
+            $deps = array_merge($deps, $this->pc_plugin_store->getPluginDependencies());
 
             return $deps;
         }

--- a/Modules/Test/classes/class.ilTestImporter.php
+++ b/Modules/Test/classes/class.ilTestImporter.php
@@ -34,12 +34,14 @@ class ilTestImporter extends ilXmlImporter
 
     private ilLogger $log;
     private ilDBInterface $db;
+    private ilPageComponentPluginExportImportStore $pc_plugin_store;
 
     public function __construct()
     {
         global $DIC;
         $this->log = $DIC['ilLog'];
         $this->db = $DIC['ilDB'];
+        $this->pc_plugin_store = ilPageComponentPluginExportImportStore::getInstance();
 
         parent::__construct();
     }
@@ -160,6 +162,14 @@ class ilTestImporter extends ilXmlImporter
                 (string) $oldQuestionId,
                 (string) $newQuestionId
             );
+
+            // needed for the import of page component plugins
+            $mapping->addMapping(
+                "Services/COPage",
+                "pg",
+                'qpl:' . $oldQuestionId,
+                'qpl:' . $newQuestionId
+            );
         }
 
         return $mapping;
@@ -172,6 +182,15 @@ class ilTestImporter extends ilXmlImporter
      */
     public function finalProcessing(ilImportMapping $a_mapping): void
     {
+        $page_map = $a_mapping->getMappingsOfEntity("Services/COPage", "pg");
+        foreach ($page_map as $new_page_id) {
+            $parts = explode(":", $new_page_id);
+            $page = ilPageObjectFactory::getInstance($parts[0], (int) $parts[1], 0, '-');
+            if ($this->pc_plugin_store->replacePluginProperties($page)) {
+                $page->update(false, true);
+            }
+        }
+
         $maps = $a_mapping->getMappingsOfEntity("Modules/Test", "tst");
 
         foreach ($maps as $old => $new) {

--- a/Modules/Test/test/ilTestImporterTest.php
+++ b/Modules/Test/test/ilTestImporterTest.php
@@ -30,6 +30,8 @@ class ilTestImporterTest extends ilTestBaseTestCase
     {
         parent::setUp();
 
+        $this->addGlobal_ilComponentRepository();
+
         $this->testObj = new ilTestImporter();
     }
 

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPool.php
@@ -440,6 +440,7 @@ class ilObjQuestionPool extends ilObject
             $page_object = new ilAssQuestionPage($question_id);
             $page_object->buildDom();
             $page_object->insertInstIntoIDs($a_inst);
+            ilPageComponentPluginExportImportStore::getInstance()->extractPluginProperties($page_object);
             $mob_ids = $page_object->collectMediaObjects(false);
             $file_ids = ilPCFileList::collectFileItems($page_object, $page_object->getDomDoc());
             $xml = $page_object->getXMLFromDom(false, false, false, '', true);

--- a/Modules/TestQuestionPool/classes/class.ilQuestionPageParser.php
+++ b/Modules/TestQuestionPool/classes/class.ilQuestionPageParser.php
@@ -81,6 +81,7 @@ class ilQuestionPageParser extends ilMDSaxParser
     protected string $cur_qid = "";
     protected string $chr_data = "";
     protected bool $in_media_item = false;
+    protected ilPageComponentPluginExportImportStore $pc_plugin_store;
 
     public function __construct(
         ilObject $a_content_object,
@@ -120,6 +121,7 @@ class ilQuestionPageParser extends ilMDSaxParser
         $this->qst_mapping = [];
         $this->coType = $this->content_object->getType();
         $this->metadata_parsing_disabled = false;
+        $this->pc_plugin_store = ilPageComponentPluginExportImportStore::getInstance();
 
         if (($this->coType != "tst") && ($this->coType != "qpl")) {
             $this->lm_tree = new ilLMTree($this->content_object->getId());
@@ -975,6 +977,7 @@ class ilQuestionPageParser extends ilMDSaxParser
                             if ($this->page_object->needsImportParsing()) {
                                 $this->pages_to_parse["qpl:" . $page->getId()] = "qpl:" . $page->getId();
                             }
+                            $this->pc_plugin_store->extractPluginProperties($page);
                             unset($page);
                         }
                         if ($ids["test"] > 0) {
@@ -990,6 +993,7 @@ class ilQuestionPageParser extends ilMDSaxParser
                             if ($this->page_object->needsImportParsing()) {
                                 $this->pages_to_parse["qpl:" . $page->getId()] = "qpl:" . $page->getId();
                             }
+                            $this->pc_plugin_store->extractPluginProperties($page);
                             unset($page);
                         }
                     }

--- a/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolExporter.php
+++ b/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolExporter.php
@@ -26,12 +26,14 @@
 class ilTestQuestionPoolExporter extends ilXmlExporter
 {
     private $ds;
+    private ilPageComponentPluginExportImportStore $pc_plugin_store;
 
     /**
      * Initialisation
      */
     public function init(): void
     {
+        $this->pc_plugin_store = ilPageComponentPluginExportImportStore::getInstance();
     }
 
     /**
@@ -90,6 +92,8 @@ class ilTestQuestionPoolExporter extends ilXmlExporter
                     'ids' => $taxIds
                 );
             }
+
+            $deps = array_merge($deps, $this->pc_plugin_store->getPluginDependencies());
 
             return $deps;
         }

--- a/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
+++ b/Modules/TestQuestionPool/classes/class.ilTestQuestionPoolImporter.php
@@ -30,6 +30,12 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
      * @var ilObjQuestionPool
      */
     private $poolOBJ;
+    private ilPageComponentPluginExportImportStore $pc_plugin_store;
+
+    public function __construct()
+    {
+        $this->pc_plugin_store = ilPageComponentPluginExportImportStore::getInstance();
+    }
 
     /**
      * Import XML
@@ -125,6 +131,14 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
                     $oldQuestionId,
                     $newQuestionId
                 );
+
+                // needed for the import of page component plugins
+                $a_mapping->addMapping(
+                    "Services/COPage",
+                    "pg",
+                    'qpl:' . $oldQuestionId,
+                    'qpl:' . $newQuestionId
+                );
             }
         }
 
@@ -144,6 +158,15 @@ class ilTestQuestionPoolImporter extends ilXmlImporter
      */
     public function finalProcessing(ilImportMapping $a_mapping): void
     {
+        $page_map = $a_mapping->getMappingsOfEntity("Services/COPage", "pg");
+        foreach ($page_map as $new_page_id) {
+            $parts = explode(":", $new_page_id);
+            $page = ilPageObjectFactory::getInstance($parts[0], (int) $parts[1], 0, '-');
+            if ($this->pc_plugin_store->replacePluginProperties($page)) {
+                $page->update(false, true);
+            }
+        }
+
         $maps = $a_mapping->getMappingsOfEntity("Modules/TestQuestionPool", "qpl");
         foreach ($maps as $old => $new) {
             if ($old != "new_id" && (int) $old > 0) {

--- a/Services/COPage/classes/class.ilCOPageExporter.php
+++ b/Services/COPage/classes/class.ilCOPageExporter.php
@@ -24,33 +24,13 @@ class ilCOPageExporter extends ilXmlExporter
 {
     private ilCOPageDataSet $ds;
     protected ilExportConfig $config;
-
-    /**
-     * List of dependencies for page component plugins with an own exporter
-     *
-     * The list of ids in the dependency definition has the following format:
-     * 		<parent_type>:<page_id>:<lang>:<pc_id>
-     *
-     * The implementation assumes the following call sequence of methods
-     * to avoid a multiple instatiation of page objects
-     * 1. init()
-     * 2. getXmlRepresentation()
-     * 3. getXmlExportTailDependencies()
-     *
-     *
-     * @var array  	plugin_name => depencency definition array
-     */
-    protected array $plugin_dependencies = array();
+    private ilPageComponentPluginExportImportStore $plugin_store;
 
     /**
      * Initialisation
      */
     public function init(): void
     {
-        global $DIC;
-        /** @var ilComponentRepository $component_repository */
-        $component_repository = $DIC["component.repository"];
-
         $this->ds = new ilCOPageDataSet();
         $this->ds->setExportDirectories($this->dir_relative, $this->dir_absolute);
         $this->ds->setDSPrefix("ds");
@@ -59,20 +39,7 @@ class ilCOPageExporter extends ilXmlExporter
             $this->ds->setMasterLanguageOnly(true);
         }
 
-        // collect all page component plugins that have their own exporter
-        foreach ($component_repository->getPluginSlotById("pgcp")->getActivePlugins() as $plugin) {
-            $plugin_name = $plugin->getName();
-            if ($plugin->supportsExport()) {
-                require_once('Customizing/global/plugins/Services/COPage/PageComponent/'
-                    . $plugin_name . '/classes/class.il' . $plugin_name . 'Exporter.php');
-
-                $this->plugin_dependencies[$plugin_name] = array(
-                    "component" => "Plugins/" . $plugin_name,
-                    "entity" => "pgcp",
-                    "ids" => array()
-                );
-            }
-        }
+        $this->plugin_store = ilPageComponentPluginExportImportStore::getInstance();
     }
 
     public function getXmlExportHeadDependencies(
@@ -144,12 +111,7 @@ class ilCOPageExporter extends ilXmlExporter
                 );
         }
 
-        if (!empty($this->plugin_dependencies)) {
-            // use numeric keys instead plugin names
-            return array_values($this->plugin_dependencies);
-        }
-
-        return array();
+        return $this->plugin_store->getPluginDependencies();
     }
 
     public function getXmlRepresentation(
@@ -175,7 +137,7 @@ class ilCOPageExporter extends ilXmlExporter
                 $page_object = ilPageObjectFactory::getInstance($id[0], $id[1], 0, $l);
                 $page_object->buildDom();
                 $page_object->insertInstIntoIDs(IL_INST_ID);
-                $this->extractPluginProperties($page_object);
+                $this->plugin_store->extractPluginProperties($page_object);
                 $pxml = $page_object->getXMLFromDom(false, false, false, "", true);
                 $pxml = str_replace("&", "&amp;", $pxml);
                 $a_media = ($this->config->getIncludeMedia())
@@ -224,57 +186,5 @@ class ilCOPageExporter extends ilXmlExporter
             );
         }
         return [];
-    }
-
-    /**
-     * Extract the properties of the plugged page contents
-     * The page XML is scanned for plugged contents with own exporters
-     * Their ids are added as dependencies
-     *
-     * Called from getXmlRepresentation() for each handled page object
-     * Extracted data is used by dependent exporters afterwards
-     */
-    protected function extractPluginProperties(
-        ilPageObject $a_page
-    ): void {
-        if (empty($this->plugin_dependencies)) {
-            return;
-        }
-
-        $a_page->buildDom();
-        $domdoc = $a_page->getDomDoc();
-        $xpath = new DOMXPath($domdoc);
-        $nodes = $xpath->query("//PageContent[child::Plugged]");
-
-        /** @var DOMElement $pcnode */
-        foreach ($nodes as $pcnode) {
-            // page content id (unique in the page)
-            $pc_id = $pcnode->getAttribute('PCID');
-            $plnode = $pcnode->childNodes->item(0);
-            $plugin_name = $plnode->getAttribute('PluginName');
-            $plugin_version = $plnode->getAttribute('PluginVersion');
-
-            // dependency should be exported
-            if (isset($this->plugin_dependencies[$plugin_name])) {
-                // construct a unique dependency id of the plugged page content
-                $id = $a_page->getParentType()
-                    . ':' . $a_page->getId()
-                    . ':' . $a_page->getLanguage()
-                    . ':' . $pc_id;
-
-                $properties = array();
-                /** @var DOMElement $child */
-                foreach ($plnode->childNodes as $child) {
-                    $properties[$child->getAttribute('Name')] = $child->nodeValue;
-                }
-
-                // statical provision of content to the exporter classes
-                ilPageComponentPluginExporter::setPCVersion($id, $plugin_version);
-                ilPageComponentPluginExporter::setPCProperties($id, $properties);
-
-                // each plugin exporter gets only the ids of its own content
-                $this->plugin_dependencies[$plugin_name]['ids'][] = $id;
-            }
-        }
     }
 }

--- a/Services/COPage/classes/class.ilCOPageImporter.php
+++ b/Services/COPage/classes/class.ilCOPageImporter.php
@@ -25,8 +25,7 @@ class ilCOPageImporter extends ilXmlImporter
     protected ilImportConfig $config;
     protected ilLogger $log;
     protected ilCOPageDataSet $ds;
-    // Names of active plugins with own importers for additional data
-    protected array $importer_plugins = array();
+    private ilPageComponentPluginExportImportStore $plugin_store;
 
     public function init(): void
     {
@@ -40,16 +39,7 @@ class ilCOPageImporter extends ilXmlImporter
 
         $this->log = ilLoggerFactory::getLogger('copg');
 
-        // collect all page component plugins that have their own exporter
-        foreach ($component_repository->getPluginSlotById("pgcp")->getActivePlugins() as $plugin) {
-            $plugin_name = $plugin->getName();
-            if ($plugin->supportsExport()) {
-                require_once('Customizing/global/plugins/Services/COPage/PageComponent/'
-                    . $plugin_name . '/classes/class.il' . $plugin_name . 'Importer.php');
-
-                $this->importer_plugins[] = $plugin_name;
-            }
-        }
+        $this->plugin_store = ilPageComponentPluginExportImportStore::getInstance();
     }
 
     public function importXmlRepresentation(
@@ -99,7 +89,7 @@ class ilCOPageImporter extends ilXmlImporter
                             $page->setImportMode(true);
                             $page->setXMLContent($next_xml);
                             $page->updateFromXML();
-                            $this->extractPluginProperties($page);
+                            $this->plugin_store->extractPluginProperties($page);
                         } else {
                             // #31937, #39229 (added lang === "-")
                             if ($lstr === "-" && ilPageObject::_exists($id[0], (int) $id[1], "-", true)) {
@@ -122,7 +112,7 @@ class ilCOPageImporter extends ilXmlImporter
                             $new_page->setActivationEnd($page_data["ActivationEnd"]);
                             $new_page->setShowActivationInfo((string) $page_data["ShowActivationInfo"]);
                             $new_page->createFromXML();
-                            $this->extractPluginProperties($new_page);
+                            $this->plugin_store->extractPluginProperties($new_page);
                         }
 
                         $a_xml = substr($a_xml, $p);
@@ -162,7 +152,7 @@ class ilCOPageImporter extends ilXmlImporter
                         $il = $new_page->resolveIntLinks();
                         $this->log->debug("resolve internal link for page " . $id[0] . "-" . $id[1] . "-" . $id[2]);
                     }
-                    $plug = $this->replacePluginProperties($new_page);
+                    $plug = $this->plugin_store->replacePluginProperties($new_page);
                     if ($med || $fil || $il || $plug || $res) {
                         $new_page->update(false, true);
                     }
@@ -175,115 +165,5 @@ class ilCOPageImporter extends ilXmlImporter
     public function afterContainerImportProcessing(
         ilImportMapping $a_mapping
     ): void {
-    }
-
-    /**
-     * Extract the properties of the plugged page contents
-     * The page XML is scanned for plugged contents with own importers
-     *
-     * Called from importXmlRepresentation() for each handled page object
-     * Extracted data is used by plugin importers afterwards
-     */
-    protected function extractPluginProperties(
-        ilPageObject $a_page
-    ): void {
-        if (empty($this->importer_plugins)) {
-            return;
-        }
-
-        $a_page->buildDom();
-        $domdoc = $a_page->getDomDoc();
-        $xpath = new DOMXPath($domdoc);
-        $nodes = $xpath->query("//PageContent[child::Plugged]");
-
-        /** @var DOMElement $pcnode */
-        foreach ($nodes as $pcnode) {
-            // page content id (unique in the page)
-            $pc_id = $pcnode->getAttribute('PCID');
-            $plnode = $pcnode->childNodes->item(0);
-            $plugin_name = $plnode->getAttribute('PluginName');
-            $plugin_version = $plnode->getAttribute('PluginVersion');
-
-            // additional data will be imported
-            if (in_array($plugin_name, $this->importer_plugins)) {
-                // get the id of the mapped plugged page content
-                $id = $a_page->getParentType()
-                    . ':' . $a_page->getId()
-                    . ':' . $a_page->getLanguage()
-                    . ':' . $pc_id;
-
-                $properties = array();
-                /** @var DOMElement $child */
-                foreach ($plnode->childNodes as $child) {
-                    $properties[$child->getAttribute('Name')] = $child->nodeValue;
-                }
-
-                // statical provision of content to the pluged importer classes
-                ilPageComponentPluginImporter::setPCVersion($id, $plugin_version);
-                ilPageComponentPluginImporter::setPCProperties($id, $properties);
-            }
-        }
-    }
-
-    /**
-     * Replace the properties of the plugged page contents
-     * The page XML is scanned for plugged contents with own importers
-     * The pluged content is replace
-     *
-     * Called finalProcessing() for each handled page
-     * Extracted data is used by dependent plugin importers afterwards
-     */
-    public function replacePluginProperties(
-        ilPageObject $a_page
-    ): bool {
-        if (empty($this->importer_plugins)) {
-            return false;
-        }
-
-        $a_page->buildDom();
-        $domdoc = $a_page->getDomDoc();
-        $xpath = new DOMXPath($domdoc);
-        $nodes = $xpath->query("//PageContent[child::Plugged]");
-
-        $modified = false;
-
-        /** @var DOMElement $pcnode */
-        foreach ($nodes as $pcnode) {
-            // page content id (unique in the page)
-            $pc_id = $pcnode->getAttribute('PCID');
-            $plnode = $pcnode->childNodes->item(0);
-            $plugin_name = $plnode->getAttribute('PluginName');
-
-            // get the id of the mapped plugged page content
-            $id = $a_page->getParentType()
-                . ':' . $a_page->getId()
-                . ':' . $a_page->getLanguage()
-                . ':' . $pc_id;
-
-            $plugin_version = ilPageComponentPluginImporter::getPCVersion($id);
-            $properties = ilPageComponentPluginImporter::getPCProperties($id);
-
-            // update the version if modified by the plugin importer
-            if (isset($plugin_version)) {
-                $plnode->setAttribute('PluginVersion', $plugin_version);
-                $modified = true;
-            }
-
-            // update the properties if modified by the plugin importer
-            if (is_array($properties)) {
-                /** @var DOMElement $child */
-                foreach ($plnode->childNodes as $child) {
-                    $plnode->removeChild($child);
-                }
-                foreach ($properties as $name => $value) {
-                    $child = new DOMElement('PluggedProperty', $value);
-                    $plnode->appendChild($child);
-                    $child->setAttribute('Name', $name);
-                }
-                $modified = true;
-            }
-        }
-
-        return $modified;
     }
 }

--- a/Services/COPage/classes/class.ilPageComponentPluginExportImportStore.php
+++ b/Services/COPage/classes/class.ilPageComponentPluginExportImportStore.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+class ilPageComponentPluginExportImportStore
+{
+    private static ?self $instance;
+    public static function getInstance()
+    {
+        global $DIC;
+        return self::$instance ??= new self(
+            $DIC["component.repository"]
+        );
+    }
+
+    private array $plugin_dependencies = [];
+    private $pc_versions = [];
+    private $pc_properties = [];
+
+    public function __construct(
+        ilComponentRepository $component_repository,
+    ) {
+        foreach ($component_repository->getPluginSlotById("pgcp")->getActivePlugins() as $plugin) {
+            $plugin_name = $plugin->getName();
+            if ($plugin->supportsExport()) {
+
+                $this->plugin_dependencies[$plugin_name] = [
+                    "component" => "Plugins/" . $plugin_name,
+                    "entity" => "pgcp",
+                    "ids" => []
+                ];
+            }
+        }
+    }
+
+    /**
+     * Build the store id of a page content
+     */
+    public function buildContentId(
+        string $parent_type,
+        int $page_id,
+        string $language,
+        string $pc_id
+    ) {
+        return $parent_type . ':' . $page_id . ':' . $language . ':' . $pc_id;
+    }
+
+    /**
+     * Get the store id of the mapped page content
+     */
+    public function getMappedContentId(string $id, ilImportMapping $mapping): string
+    {
+        $parts = explode(':', $id);
+        $old_page_id = $parts[0] . ':' . $parts[1];
+        $new_page_id = $mapping->getMapping("Services/COPage", 'pg', $old_page_id);
+
+        return $new_page_id . ':' . $parts[2] . ':' . $parts[3];
+    }
+
+    public function getPluginDependencies(): array
+    {
+        return array_values($this->plugin_dependencies);
+    }
+
+    public function setPluginDependency(string $id, string $plugin_name): void
+    {
+        $this->plugin_dependencies[$plugin_name]['ids'][] = $id;
+    }
+
+    public function hasExportablePlugins(): bool
+    {
+        return !empty($this->plugin_dependencies);
+    }
+
+    public function isPluginExportable(string $plugin_name): bool
+    {
+        return isset($this->plugin_dependencies[$plugin_name]);
+    }
+
+    /**
+     * Store the properties of a plugged page content
+     * This method is used by ilCOPageExporter to provide the properties
+     */
+    public function setPCProperties(string $id, array $properties): void
+    {
+        $this->pc_properties[$id] = $properties;
+    }
+
+    /**
+     * Get the properties of a plugged page content
+     */
+    public function getPCProperties(string $id): ?array
+    {
+        return $this->pc_properties[$id] ?? null;
+    }
+
+    /**
+     * Store the version of a plugged page content
+     */
+    public function setPCVersion(string $id, string $version): void
+    {
+        $this->pc_versions[$id] = $version;
+    }
+
+    /**
+     * Get the stored version of a plugged page content
+     */
+    public function getPCVersion(string $id)
+    {
+        return $this->pc_versions[$id] ?? null;
+    }
+
+    /**
+     * Extract the properties of the plugged page contents
+     * The page XML is scanned for plugged contents with own exporters
+     * Their ids are added as dependencies
+     *
+     * Called from getXmlRepresentation() for each handled page object
+     * Extracted data is used by dependent exporters afterward
+     */
+    public function extractPluginProperties(
+        ilPageObject $a_page
+    ): void {
+        if (empty($this->plugin_dependencies)) {
+            return;
+        }
+
+        $a_page->buildDom();
+        $domdoc = $a_page->getDomDoc();
+        $xpath = new DOMXPath($domdoc);
+        $nodes = $xpath->query("//PageContent[child::Plugged]");
+
+        /** @var DOMElement $pcnode */
+        foreach ($nodes as $pcnode) {
+            // page content id (unique in the page)
+            $pc_id = $pcnode->getAttribute('PCID');
+            $plnode = $pcnode->childNodes->item(0);
+            $plugin_name = $plnode->getAttribute('PluginName');
+            $plugin_version = $plnode->getAttribute('PluginVersion');
+
+            // dependency should be exported
+            if ($this->isPluginExportable($plugin_name)) {
+                $properties = [];
+                /** @var DOMElement $child */
+                foreach ($plnode->childNodes as $child) {
+                    $properties[$child->getAttribute('Name')] = $child->nodeValue;
+                }
+
+                $id = $this->buildContentId($a_page->getParentType(), $a_page->getId(), $a_page->getLanguage(), $pc_id);
+                $this->setPCVersion($id, $plugin_version);
+                $this->setPCProperties($id, $properties);
+                $this->setPluginDependency($id, $plugin_name);
+            }
+        }
+    }
+
+    /**
+     * Replace the properties of the plugged page contents
+     * The page XML is scanned for plugged contents with own importers
+     * The plugged content is replaced
+     *
+     * Called by finalProcessing() for each handled page
+     * Extracted data is used by dependent plugin importers afterward
+     * return true if page content is modified
+     */
+    public function replacePluginProperties(
+        ilPageObject $a_page
+    ): bool {
+        if (!$this->hasExportablePlugins()) {
+            return false;
+        }
+
+        $a_page->buildDom();
+        $domdoc = $a_page->getDomDoc();
+        $xpath = new DOMXPath($domdoc);
+        $nodes = $xpath->query("//PageContent[child::Plugged]");
+
+        $modified = false;
+
+        /** @var DOMElement $pcnode */
+        foreach ($nodes as $pcnode) {
+            // page content id (unique in the page)
+            $pc_id = $pcnode->getAttribute('PCID');
+            $plnode = $pcnode->childNodes->item(0);
+            $plugin_name = $plnode->getAttribute('PluginName');
+
+            $id = $this->buildContentId($a_page->getParentType(), $a_page->getId(), $a_page->getLanguage(), $pc_id);
+
+            $plugin_version = $this->getPCVersion($id);
+            $properties = $this->getPCProperties($id);
+
+            // update the version if modified by the plugin importer
+            if ($plugin_version !== null) {
+                $plnode->setAttribute('PluginVersion', $plugin_version);
+                $modified = true;
+            }
+
+            // update the properties if modified by the plugin importer
+            if (is_array($properties)) {
+                /** @var DOMElement $child */
+                foreach ($plnode->childNodes as $child) {
+                    $plnode->removeChild($child);
+                }
+                foreach ($properties as $name => $value) {
+                    $child = new DOMElement('PluggedProperty', (string) $value);
+                    $plnode->appendChild($child);
+                    $child->setAttribute('Name', $name);
+                }
+                $modified = true;
+            }
+        }
+
+        return $modified;
+    }
+}

--- a/Services/COPage/classes/class.ilPageComponentPluginExporter.php
+++ b/Services/COPage/classes/class.ilPageComponentPluginExporter.php
@@ -23,22 +23,14 @@
 abstract class ilPageComponentPluginExporter extends ilXmlExporter
 {
     /**
-     * Properties of exportable plugged page contents
-     * The id has the following format:
-     * 		<parent_type>:<page_id>:<lang>:<pc_id>
-     * This format, however, should be irrelevant to child classes
-     *
-     * @var array $pc_properties  id => [ name => value, ... ]
+     * @deprecated
      */
     protected static array $pc_properties = array();
 
     /**
-     * Plugin versions of exportable plugged page contents
-     *
-     * @var array $pc_version	id => version
+     * @deprecated
      */
     protected static array $pc_version = array();
-
 
     /**
      * Set the properties of a plugged page content
@@ -48,7 +40,7 @@ abstract class ilPageComponentPluginExporter extends ilXmlExporter
         string $a_id,
         array $a_properties
     ): void {
-        self::$pc_properties[$a_id] = $a_properties;
+        ilPageComponentPluginExportImportStore::getInstance()->setPCProperties($a_id, $a_properties);
     }
 
     /**
@@ -56,7 +48,7 @@ abstract class ilPageComponentPluginExporter extends ilXmlExporter
      */
     public static function getPCProperties(string $a_id): ?array
     {
-        return self::$pc_properties[$a_id] ?? null;
+        return ilPageComponentPluginExportImportStore::getInstance()->getPCProperties($a_id);
     }
 
     /**
@@ -67,7 +59,7 @@ abstract class ilPageComponentPluginExporter extends ilXmlExporter
         string $a_id,
         string $a_version
     ): void {
-        self::$pc_version[$a_id] = $a_version;
+        ilPageComponentPluginExportImportStore::getInstance()->setPCVersion($a_id, $a_version);
     }
 
     /**
@@ -75,6 +67,6 @@ abstract class ilPageComponentPluginExporter extends ilXmlExporter
      */
     public static function getPCVersion(string $a_id): ?string
     {
-        return self::$pc_version[$a_id] ?? null;
+        return ilPageComponentPluginExportImportStore::getInstance()->getPCVersion($a_id);
     }
 }

--- a/Services/COPage/classes/class.ilPageComponentPluginImporter.php
+++ b/Services/COPage/classes/class.ilPageComponentPluginImporter.php
@@ -24,22 +24,14 @@
 abstract class ilPageComponentPluginImporter extends ilXmlImporter
 {
     /**
-     * Properties of exportable plugged page contents
-     * The id has the following format:
-     * 		<parent_type>:<page_id>:<lang>:<pc_id>
-     * This format, however, should be irrelevant to child classes
-     *
-     * @var array $pc_properties  id => [ name => value, ... ]
+     * @deprecated
      */
     protected static array $pc_properties = array();
 
     /**
-     * Plugin versions of exportable plugged page contents
-     *
-     * @var array $pc_version	id => version
+     * @deprecated
      */
     protected static array $pc_version = array();
-
 
     /**
      * Set the properties of a plugged page content
@@ -49,7 +41,7 @@ abstract class ilPageComponentPluginImporter extends ilXmlImporter
         string $a_id,
         array $a_properties
     ): void {
-        self::$pc_properties[$a_id] = $a_properties;
+        ilPageComponentPluginExportImportStore::getInstance()->setPCProperties($a_id, $a_properties);
     }
 
     /**
@@ -57,7 +49,7 @@ abstract class ilPageComponentPluginImporter extends ilXmlImporter
      */
     public static function getPCProperties(string $a_id): ?array
     {
-        return self::$pc_properties[$a_id] ?? null;
+        return ilPageComponentPluginExportImportStore::getInstance()->getPCProperties($a_id);
     }
 
     /**
@@ -68,7 +60,7 @@ abstract class ilPageComponentPluginImporter extends ilXmlImporter
         string $a_id,
         string $a_version
     ): void {
-        self::$pc_version[$a_id] = $a_version;
+        ilPageComponentPluginExportImportStore::getInstance()->setPCVersion($a_id, $a_version);
     }
 
     /**
@@ -76,22 +68,17 @@ abstract class ilPageComponentPluginImporter extends ilXmlImporter
      */
     public static function getPCVersion(string $a_id): ?string
     {
-        return self::$pc_version[$a_id] ?? null;
+        return ilPageComponentPluginExportImportStore::getInstance()->getPCVersion($a_id);
     }
-
 
     /**
      * Get the id of the mapped page content
      * The id structure should be irrelevant to child classes
-     * The mapped ID shold be used both for getPCProperties() and setPCProperties()
+     * The mapped ID should be used both for getPCProperties() and setPCProperties()
      * when being called in their importXmlRepresentation()
      */
     public static function getPCMapping(string $a_id, ilImportMapping $a_mapping): string
     {
-        $parts = explode(':', $a_id);
-        $old_page_id = $parts[0] . ':' . $parts[1];
-        $new_page_id = $a_mapping->getMapping("Services/COPage", 'pg', $old_page_id);
-
-        return $new_page_id . ':' . $parts[2] . ':' . $parts[3];
+        return ilPageComponentPluginExportImportStore::getInstance()->getMappedContentId($a_id, $a_mapping);
     }
 }


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=44719

This pull request solves the issue by providing the handling of page editor plugins from the COPage service also in the Test and TestQuestionPool components. 

To avoid code duplication, functions from ilCOPageExporter and ilCOPageImporter are moved to a new class `ilPageComponentPluginExportImportStore`, which is used by the export and import in the CoPage, TestQuestionPool and Test components. 

The static functions provided in `ilPageComponentPluginExporter` and `ilPageComponentPluginImporter` are rewritten to use the new class as a store, but currently they must be kept for compatibility with existing plugins.