### PR TITLE
T&A 35875: Prevents a multiple choice question to give negative points when answered fully correctly

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -483,7 +483,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      */
     public function getMaximumPoints(): float
     {
-        $total_max_points = 0;
+        $total_max_points = 0.0;
         foreach ($this->getAnswers() as $answer) {
             $total_max_points += max($answer->getPointsChecked(), $answer->getPointsUnchecked());
         }

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -136,11 +136,11 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
     */
     public function isComplete(): bool
     {
-        if (strlen($this->title) and ($this->author) and ($this->question) and (count($this->answers)) and ($this->getMaximumPoints() > 0)) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->title !== ''
+            && $this->author !== ''
+            && $this->question !== ''
+            && $this->getAnswerCount() > 0
+            && $this->getMaximumPoints() >= 0;
     }
 
     /**
@@ -483,16 +483,11 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
      */
     public function getMaximumPoints(): float
     {
-        $points = 0;
-        $allpoints = 0;
-        foreach ($this->answers as $key => $value) {
-            if ($value->getPoints() > $value->getPointsUnchecked()) {
-                $allpoints += $value->getPoints();
-            } else {
-                $allpoints += $value->getPointsUnchecked();
-            }
+        $total_max_points = 0;
+        foreach ($this->getAnswers() as $answer) {
+            $total_max_points += max($answer->getPointsChecked(), $answer->getPointsUnchecked());
         }
-        return $allpoints;
+        return $total_max_points;
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -136,7 +136,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
             $form->getItemByPostVar('selection_limit')->setMaxValue(count((array) $_POST['choice']['answer']));
 
             $form->setValuesByPost();
-            $errors = !$form->checkInput();
+            $errors = $this->handleMaxPointsNotNegative($form) || !$form->checkInput();
             if ($errors) {
                 $checkonly = false;
             }
@@ -146,6 +146,28 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
             $this->tpl->setVariable("QUESTION_DATA", $form->getHTML());
         }
         return $errors;
+    }
+
+    private function handleMaxPointsNotNegative(ilPropertyFormGUI $form): bool
+    {
+        $choice = $form->getItemByPostVar('choice');
+        if (!$choice instanceof ilMultipleChoiceWizardInputGUI) {
+            return true;
+        }
+
+        $answers = $choice->getValues();
+        $total_max_points = 0;
+        /** @var ASS_AnswerMultipleResponseImage $answer */
+        foreach ($answers as $answer) {
+            $total_max_points += max($answer->getPointsChecked(), $answer->getPointsUnchecked());
+        }
+
+        if ($total_max_points < 0) {
+            $choice->setAlert($this->lng->txt('total_max_points_cannot_be_negative'));
+            return true;
+        }
+
+        return false;
     }
 
     public function addBasicQuestionFormProperties(ilPropertyFormGUI $form): void

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -136,7 +136,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
             $form->getItemByPostVar('selection_limit')->setMaxValue(count((array) $_POST['choice']['answer']));
 
             $form->setValuesByPost();
-            $errors = $this->handleMaxPointsNotNegative($form) || !$form->checkInput();
+            $errors = !$this->checkMaxPointsNotNegative($form) || !$form->checkInput();
             if ($errors) {
                 $checkonly = false;
             }
@@ -148,7 +148,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         return $errors;
     }
 
-    private function handleMaxPointsNotNegative(ilPropertyFormGUI $form): bool
+    private function checkMaxPointsNotNegative(ilPropertyFormGUI $form): bool
     {
         $choice = $form->getItemByPostVar('choice');
         if (!$choice instanceof ilMultipleChoiceWizardInputGUI) {
@@ -164,10 +164,10 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
 
         if ($total_max_points < 0) {
             $choice->setAlert($this->lng->txt('total_max_points_cannot_be_negative'));
-            return true;
+            return false;
         }
 
-        return false;
+        return true;
     }
 
     public function addBasicQuestionFormProperties(ilPropertyFormGUI $form): void

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1258,6 +1258,7 @@ assessment#:#toplist_col_percentage#:#Prozentwert
 assessment#:#toplist_col_rank#:#Platz
 assessment#:#toplist_col_score#:#Punktzahl
 assessment#:#toplist_col_wtime#:#Bearbeitungszeit
+assessment#:#total_max_points_cannot_be_negative#:#Die maximale Anzahl von erreichbaren Punkten kann nich negativ sein.
 assessment#:#true#:#Wahr
 assessment#:#tst_access_code_created#:#Damit Sie dauerhaften Zugriff auf Ihre Testergebnisse haben und einen unterbrochenen Test wieder aufnehmen können, wurde für Sie ein persönlicher Zugangsschlüssel erzeugt. Bitte notieren Sie sich den nachfolgenden Code, um später den Test fortführen zu können.
 assessment#:#tst_activate_skill_service#:#Kompetenzen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1258,6 +1258,7 @@ assessment#:#toplist_col_percentage#:#Percentage
 assessment#:#toplist_col_rank#:#Rank
 assessment#:#toplist_col_score#:#Score
 assessment#:#toplist_col_wtime#:#Working Time
+assessment#:#total_max_points_cannot_be_negative#:#The maximum amount of reachable points cannot be negative.
 assessment#:#true#:#True
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please make a note of this code so that you can continue the test later.
 assessment#:#tst_activate_skill_service#:#Competence Service


### PR DESCRIPTION
[Mantis: 35875](https://mantis.ilias.de/view.php?id=35875)

A possible fix for the generall issue is to prevent a multiple choice question to have a negative total of maxium points. In case you answer a question perfectly (highest possible scores) you shouldn't be able to get negative points. On the other hand if you do not answer it quiet "perfect" you should be able to receive negative points for the question.

The inputs cannot be validated on their own, because there combination is what has to be evaluated.

For future reference: When the forms get refactored to the new UIForms this should be changed into a transformation/validation.