### PR TITLE
[Bugfix 44735]Add prefix to cache key to prevent language mix-up across ILIAS tenants

### DIFF
--- a/src/Cache/Adaptor/BaseAdaptor.php
+++ b/src/Cache/Adaptor/BaseAdaptor.php
@@ -1,4 +1,4 @@
-<?php
+    <?php
 
 /**
  * This file is part of ILIAS, a powerful learning management system
@@ -40,6 +40,6 @@ abstract class BaseAdaptor implements Adaptor
 
     protected function buildContainerPrefix(string $container): string
     {
-        return $container . self::CONTAINER_PREFIX_SEPARATOR;
+        return getcwd() . self::CONTAINER_PREFIX_SEPARATOR . $container . self::CONTAINER_PREFIX_SEPARATOR;
     }
 }

--- a/src/Cache/Adaptor/BaseAdaptor.php
+++ b/src/Cache/Adaptor/BaseAdaptor.php
@@ -1,4 +1,4 @@
-    <?php
+<?php
 
 /**
  * This file is part of ILIAS, a powerful learning management system


### PR DESCRIPTION
Adding prefix in the cache key prevents cache conflicts when multiple ILIAS tenants run on the same PHP-FPM server. This avoids incorrect language assignments caused by shared cache entries.