### PR TITLE
Adds monolog dependency

### DIFF
--- a/composer_new.json
+++ b/composer_new.json
@@ -49,6 +49,7 @@
 		"ext-xml": "*",
 		"ext-zip": "*",
 		"ext-imagick": "*",
+		"monolog/monolog": "^3.9"
 	},
 	"require-dev": {
 	},


### PR DESCRIPTION
This PR suggests adding `monolog/monolog` (v. `3.9`) as composer dependency.

General Information:
* [X] this dependency was already used in ILIAS.
* [X] License: MIT License

Usage:
* `components/ILIAS/Logging`

Wrapped By:
* `\ilLineFormatter` (extends `LineFormatter`)
* `\ilLoggerFactory`

Reasoning:
* `Monolog` is well-documented and widely adopted in the PHP community, ensuring excellent support and continuous updates.

Maintenance:
* `Monolog` is actively maintained by multiple contributors (see: https://github.com/Seldaek/monolog/graphs/contributors). There is recent activity
* Pull requests (https://github.com/Seldaek/monolog/pulls) are regularly processed: 3 open vs 1100 closed.
* According to https://github.com/Seldaek/monolog/security security relevant issues should be reported as private mail to maintainer.

Links:
* Packagist: https://packagist.org/packages/monolog/
* GitHub: https://github.com/Seldaek/monolog
* Documentation: https://github.com/Seldaek/monolog/tree/main/doc