### PR TITLE
LTI: Fix - Display only allowed breadcrumbs

### DIFF
--- a/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
+++ b/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
 use ILIAS\GlobalScreen\Scope\Layout\Provider\PagePart\PagePartProvider;
 use ILIAS\Refinery\Factory as RefineryFactory;
 
@@ -32,7 +50,7 @@ class CustomBreadcrumbPagePartProvider implements PagePartProvider
         if ($breadcrumbs === null) {
             return null;
         }
-        if(!isset($_SESSION["ref_id"])){
+        if (!isset($_SESSION["ref_id"])) {
             return $breadcrumbs;
         }
 
@@ -42,7 +60,7 @@ class CustomBreadcrumbPagePartProvider implements PagePartProvider
 
         foreach ($breadcrumbs->getItems() as $crumb) {
             if (method_exists($crumb, 'getAction') && str_contains($crumb->getAction(), 'goto.php')) {
-                if(str_contains($crumb->getAction(), $ref_id) && !str_contains($crumb->getAction(), 'root')) {
+                if (str_contains($crumb->getAction(), $ref_id) && !str_contains($crumb->getAction(), 'root')) {
                     $goto_crumbs[] = $crumb;
                 }
             } else {

--- a/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
+++ b/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
@@ -1,0 +1,124 @@
+<?php
+
+use ILIAS\GlobalScreen\Scope\Layout\Provider\PagePart\PagePartProvider;
+use ILIAS\Refinery\Factory as RefineryFactory;
+
+class CustomBreadcrumbPagePartProvider implements PagePartProvider
+{
+    private PagePartProvider $original;
+    private RefineryFactory $refinery;
+
+    public function __construct(PagePartProvider $original)
+    {
+        global $DIC;
+        $this->refinery = $DIC->refinery();
+        $this->original = $original;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->original->getTitle();
+    }
+
+    public function getDescription(): string
+    {
+        return $this->original->getDescription();
+    }
+
+    public function getBreadCrumbs(): ?\ILIAS\UI\Component\Breadcrumbs\Breadcrumbs
+    {
+        global $DIC;
+        $breadcrumbs = $this->original->getBreadCrumbs();
+        if ($breadcrumbs === null) {
+            return null;
+        }
+        if(!isset($_SESSION["ref_id"])){
+            return $breadcrumbs;
+        }
+
+        $goto_crumbs = [];
+        $non_goto_crumbs = [];
+        $ref_id = $_SESSION["ref_id"];
+
+        foreach ($breadcrumbs->getItems() as $crumb) {
+            if (method_exists($crumb, 'getAction') && str_contains($crumb->getAction(), 'goto.php')) {
+                if(str_contains($crumb->getAction(), $ref_id) && !str_contains($crumb->getAction(), 'root')) {
+                    $goto_crumbs[] = $crumb;
+                }
+            } else {
+                $non_goto_crumbs[] = $crumb;
+            }
+        }
+        $last_goto = array_slice($goto_crumbs, -1);
+
+        $final_crumbs = array_merge($last_goto, $non_goto_crumbs);
+
+        return $DIC->ui()->factory()->breadcrumbs($final_crumbs);
+
+    }
+
+    public function getMeta(): array
+    {
+        return $this->original->getMeta();
+    }
+
+    public function getActions(): array
+    {
+        return $this->original->getActions();
+    }
+
+    public function getContent(): ?\ILIAS\UI\Component\Legacy\Legacy
+    {
+        return $this->original->getContent();
+    }
+
+    public function getMetaBar(): ?\ILIAS\UI\Component\MainControls\MetaBar
+    {
+        return $this->original->getMetaBar();
+    }
+
+    public function getMainBar(): ?\ILIAS\UI\Component\MainControls\MainBar
+    {
+        return $this->original->getMainBar();
+    }
+
+    public function getLogo(): ?\ILIAS\UI\Component\Image\Image
+    {
+        return $this->original->getLogo();
+    }
+
+    public function getResponsiveLogo(): ?\ILIAS\UI\Component\Image\Image
+    {
+        return $this->original->getResponsiveLogo();
+    }
+
+    public function getFaviconPath(): string
+    {
+        return $this->original->getFaviconPath();
+    }
+
+    public function getSystemInfos(): array
+    {
+        return $this->original->getSystemInfos();
+    }
+
+    public function getFooter(): ?\ILIAS\UI\Component\MainControls\Footer
+    {
+        return $this->original->getFooter();
+    }
+
+    public function getShortTitle(): string
+    {
+        return $this->original->getShortTitle();
+    }
+
+    public function getViewTitle(): string
+    {
+        return $this->original->getViewTitle();
+    }
+
+    public function getToastContainer(): ?\ILIAS\UI\Component\Toast\Container
+    {
+        return $this->original->getToastContainer();
+    }
+}

--- a/components/ILIAS/LTIProvider/classes/Screen/LtiViewLayoutProvider.php
+++ b/components/ILIAS/LTIProvider/classes/Screen/LtiViewLayoutProvider.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ILIAS\LTI\Screen;
 
+use CustomBreadcrumbPagePartProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\PagePart\PagePartProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\AbstractModificationProvider;
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
@@ -68,13 +69,12 @@ class LtiViewLayoutProvider extends AbstractModificationProvider implements Modi
                              ->withModification(
                                  function (PagePartProvider $parts): Page {
                                      $p = new StandardPageBuilder();
-                                     $page = $p->build($parts);
-
+                                     $customParts = new CustomBreadcrumbPagePartProvider($parts);
+                                     $page = $p->build($customParts);
                                      $mv_modeinfo = MemberViewLayoutProvider::getMemberViewModeInfo($this->dic);
                                      if ($mv_modeinfo) {
                                          $page = $page->withModeInfo($mv_modeinfo);
                                      }
-
                                      return $page->withNoFooter();
                                  }
                              )


### PR DESCRIPTION
These changes correct the view of all breadcrumbs within an LTI-provided resource.
Fixes the problem reported in mantis:
https://mantis.ilias.de/view.php?id=44732