### PR TITLE
Fix missing method getTitleForHTMLOutput on ilObject in ilObjTestGUI (#44772)

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -2421,7 +2421,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
             $max_points += $question_gui->object->getMaximumPoints();
         }
 
-        $template->setVariable("TITLE", strip_tags($this->object->getTitleForHTMLOutput(), ilObjectGUI::ALLOWED_TAGS_IN_TITLE_AND_DESCRIPTION));
+        $template->setVariable("TITLE", strip_tags(htmlspecialchars($this->object->getTitle()), ilObjectGUI::ALLOWED_TAGS_IN_TITLE_AND_DESCRIPTION));
         $template->setVariable("PRINT_TEST", ilLegacyFormElementsUtil::prepareFormOutput($this->lng->txt("tst_print")));
         $template->setVariable("TXT_PRINT_DATE", ilLegacyFormElementsUtil::prepareFormOutput($this->lng->txt("date")));
         $template->setVariable(


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=44772

TL;DR: Fixes copy-paste issue in https://github.com/ILIAS-eLearning/ILIAS/commit/7fa3eaaa98cca0e167470a0c87839096fcfa9ff7