### PR TITLE
Fix: LTI icon in the menu for adding new repository objects.

### DIFF
--- a/components/ILIAS/UI/src/Component/Symbol/Icon/Standard.php
+++ b/components/ILIAS/UI/src/Component/Symbol/Icon/Standard.php
@@ -144,7 +144,7 @@ interface Standard extends Icon
     public const NOTS = 'nots';	//Notes
     public const LHTS = 'lhts';	//Learning History
     public const COMS = 'coms';	//Comments
-    public const LTIS = 'ltis';	//LTI
+    public const LTIS = 'lti';	//LTI
     public const CMIS = 'cmis';	//xAPI/cmi5
     public const REP = 'rep';	//Repository
     public const TASK = 'task';   //Task


### PR DESCRIPTION
Currently, when a user creates a new LTI Consumer Object, the icon is not displayed. With this change, ILIAS will correctly display the LTI icon in this menu.