### PR TITLE
Plugins: adjust path to public/Customizing/global/Services

### DIFF
--- a/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
+++ b/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
@@ -20,7 +20,7 @@ use ILIAS\Setup;
 
 class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactObjective
 {
-    protected const BASE_PATH = "./public/Customizing/plugins/";
+    protected const BASE_PATH = "./public/Customizing/global/plugins/";
     protected const PLUGIN_PHP = "plugin.php";
     protected const PLUGIN_CLASS_FILE = "classes/class.il%sPlugin.php";
 
@@ -30,40 +30,43 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
         return "plugin_data";
     }
 
-
     public function build(): Setup\Artifact
     {
         $data = [];
-
-        $components = $this->scanDir(static::BASE_PATH);
-        foreach ($components as $component) {
-            if ($this->isDotFile($component)
-                || ! $this->isDir(static::BASE_PATH . "$component")) {
+        foreach (['Modules', 'Services'] as $type) {
+            $base_path = static::BASE_PATH . $type . '/';
+            if (! $this->isDir($base_path)) {
                 continue;
             }
-            $slots = $this->scanDir(static::BASE_PATH . "$component");
-            foreach ($slots as $slot) {
-                if ($this->isDotFile($slot)
-                    || ! $this->isDir(static::BASE_PATH . "$component/$slot")) {
+            $components = $this->scanDir($base_path);
+            foreach ($components as $component) {
+                if ($this->isDotFile($component)
+                    || ! $this->isDir($base_path . "$component")) {
                     continue;
                 }
-                $plugins = $this->scanDir(static::BASE_PATH . "$component/$slot");
-                foreach ($plugins as $plugin) {
-                    if ($this->isDotFile($plugin)
-                        || ! $this->isDir(static::BASE_PATH . "$component/$slot/$plugin")) {
+                $slots = $this->scanDir($base_path . "$component");
+                foreach ($slots as $slot) {
+                    if ($this->isDotFile($slot)
+                        || ! $this->isDir($base_path . "$component/$slot")) {
                         continue;
                     }
-                    $this->addPlugin($data, $component, $slot, $plugin);
+                    $plugins = $this->scanDir($base_path . "$component/$slot");
+                    foreach ($plugins as $plugin) {
+                        if ($this->isDotFile($plugin)
+                            || ! $this->isDir($base_path . "$component/$slot/$plugin")) {
+                            continue;
+                        }
+                        $this->addPlugin($data, $type, $component, $slot, $plugin);
+                    }
                 }
             }
         }
-
         return new Setup\Artifact\ArrayArtifact($data);
     }
 
-    protected function addPlugin(array &$data, string $component, string $slot, string $plugin): void
+    protected function addPlugin(array &$data, string $type, string $component, string $slot, string $plugin): void
     {
-        $plugin_path = $this->buildPluginPath($component, $slot, $plugin);
+        $plugin_path = $this->buildPluginPath($type, $component, $slot, $plugin);
         $plugin_php = $plugin_path . static::PLUGIN_PHP;
         if (!$this->fileExists($plugin_php)) {
             throw new \RuntimeException(
@@ -141,8 +144,8 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
         return (substr($file, 0, 1) === '.');
     }
 
-    protected function buildPluginPath(string $component, string $slot, string $plugin): string
+    protected function buildPluginPath(string $type, string $component, string $slot, string $plugin): string
     {
-        return static::BASE_PATH . "$component/$slot/$plugin/";
+        return static::BASE_PATH . "$type/$component/$slot/$plugin/";
     }
 }

--- a/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
+++ b/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
@@ -102,7 +102,7 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
         }
 
         $data[$id] = [
-            \ilComponentInfo::TYPES[0],
+            $type,
             $component,
             $slot,
             $plugin,

--- a/components/ILIAS/Component/classes/class.ilArtifactComponentRepository.php
+++ b/components/ILIAS/Component/classes/class.ilArtifactComponentRepository.php
@@ -25,7 +25,6 @@ use ILIAS\Data;
  */
 class ilArtifactComponentRepository implements ilComponentRepositoryWrite
 {
-
     protected Data\Factory $data_factory;
     protected ilPluginStateDB $plugin_state_db;
     protected Data\Version $ilias_version;
@@ -93,12 +92,14 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
                 $supports_export,
                 $supports_cli_setup
             ] = $data;
-            if (!$this->hasComponent($type, $comp_name)) {
+
+            if (!$this->hasComponent('components/ILIAS', $comp_name)) {
                 throw new \InvalidArgumentException(
                     "Can't find component $type/$comp_name for plugin $plugin_name"
                 );
             }
-            $component = $this->getComponentByTypeAndName($type, $comp_name);
+
+            $component = $this->getComponentByTypeAndName('components/ILIAS', $comp_name);
             if (!$component->hasPluginSlotName($slot_name)) {
                 throw new \InvalidArgumentException(
                     "Can't find slot $type/$comp_name/$slot_name for plugin $plugin_name"
@@ -110,6 +111,7 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
                 $slot,
                 $plugin_id,
                 $plugin_name,
+                $type,
                 $this->plugin_state_db->isPluginActivated($plugin_id),
                 $this->plugin_state_db->getCurrentPluginVersion($plugin_id),
                 $this->plugin_state_db->getCurrentPluginDBVersion($plugin_id),
@@ -141,12 +143,14 @@ class ilArtifactComponentRepository implements ilComponentRepositoryWrite
      */
     public function hasComponent(string $type, string $name): bool
     {
-        if (!in_array($type, ilComponentInfo::TYPES)) {
+        $types = ilComponentInfo::TYPES;
+        $types[] = ilComponentInfo::TYPE_MODULES;
+        $types[] = ilComponentInfo::TYPE_SERVICES;
+        if (!in_array($type, $types)) {
             throw new \InvalidArgumentException(
                 "Unknown component type $type."
             );
         }
-
         return isset($this->component_id_by_type_and_name[$type][$name]);
     }
 

--- a/components/ILIAS/Component/classes/class.ilComponentInfo.php
+++ b/components/ILIAS/Component/classes/class.ilComponentInfo.php
@@ -25,8 +25,8 @@ class ilComponentInfo
 {
     // TODO: to be replaced with an enum for PHP 8.1...
     public const TYPES = ["components/ILIAS"];
-    public const TYPE_MODULES = "components/ILIAS";
-    public const TYPE_SERVICES = "components/ILIAS";
+    public const TYPE_MODULES = "Modules";
+    public const TYPE_SERVICES = "Services";
 
     protected string $id;
     protected string $type;

--- a/components/ILIAS/Component/classes/class.ilComponentRepository.php
+++ b/components/ILIAS/Component/classes/class.ilComponentRepository.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
  */
 interface ilComponentRepository
 {
-    public const PLUGIN_BASE_PATH = __DIR__ . '/../../../../public/Customizing/plugins';
+    public const PLUGIN_BASE_PATH = __DIR__ . '/../../../../public/Customizing/global/plugins';
 
     /**
      * Check if a component exists.

--- a/components/ILIAS/Component/classes/class.ilPluginInfo.php
+++ b/components/ILIAS/Component/classes/class.ilPluginInfo.php
@@ -29,6 +29,7 @@ class ilPluginInfo
     protected ilPluginSlotInfo $pluginslot;
     protected string $id;
     protected string $name;
+    protected string $type;
     protected bool $activated;
     protected ?Version $current_version;
     protected ?int $current_db_version;
@@ -46,6 +47,7 @@ class ilPluginInfo
         ilPluginSlotInfo $pluginslot,
         string $id,
         string $name,
+        string $type,
         bool $activated,
         ?Version $current_version,
         ?int $current_db_version,
@@ -68,6 +70,7 @@ class ilPluginInfo
         $this->pluginslot = $pluginslot;
         $this->id = $id;
         $this->name = $name;
+        $this->type = $type;
         $this->activated = $activated;
         $this->current_version = $current_version;
         $this->current_db_version = $current_db_version;
@@ -101,9 +104,20 @@ class ilPluginInfo
         return $this->name;
     }
 
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
     public function getPath(): string
     {
-        return $this->pluginslot->getPath() . "/" . $this->getName();
+        return implode('/', [
+            ilComponentRepository::PLUGIN_BASE_PATH,
+            $this->getType(),
+            $this->getComponent()->getName(),
+            $this->getPluginSlot()->getName(),
+            $this->getName()
+        ]);
     }
 
     public function getClassName(): string

--- a/components/ILIAS/Component/classes/class.ilPluginSlotInfo.php
+++ b/components/ILIAS/Component/classes/class.ilPluginSlotInfo.php
@@ -64,15 +64,6 @@ class ilPluginSlotInfo
         return $this->component->getQualifiedName() . "/" . $this->getName();
     }
 
-    public function getPath(): string
-    {
-        return implode('/', [
-            ilComponentRepository::PLUGIN_BASE_PATH,
-            $this->component->getName(),
-            $this->getName()
-        ]);
-    }
-
     /**
      * @return Iterator <ilPluginInfo>
      */

--- a/components/ILIAS/Component/tests/Setup/ilComponentBuildPluginInfoObjectiveTest.php
+++ b/components/ILIAS/Component/tests/Setup/ilComponentBuildPluginInfoObjectiveTest.php
@@ -62,22 +62,22 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
             {
                 return parent::isDotFile($file);
             }
-            protected function buildPluginPath(string $component, string $slot, string $plugin): string
+            protected function buildPluginPath(string $type, string $component, string $slot, string $plugin): string
             {
-                return $this->test->files[parent::buildPluginPath($component, $slot, $plugin)];
+                return $this->test->files[parent::buildPluginPath($type, $component, $slot, $plugin)];
             }
 
-            public function _buildPluginPath(string $component, string $slot, string $plugin): string
+            public function _buildPluginPath(string $type, string $component, string $slot, string $plugin): string
             {
-                return parent::buildPluginPath($component, $slot, $plugin);
+                return parent::buildPluginPath($type, $component, $slot, $plugin);
             }
-            protected function addPlugin(array &$data, string $component, string $slot, string $plugin): void
+            protected function addPlugin(array &$data, string $type, string $component, string $slot, string $plugin): void
             {
-                $this->test->added[] = "$component/$slot/$plugin";
+                $this->test->added[] = "$type/$component/$slot/$plugin";
             }
-            public function _addPlugin(array &$data, string $component, string $slot, string $plugin): void
+            public function _addPlugin(array &$data, string $type, string $component, string $slot, string $plugin): void
             {
-                parent::addPlugin($data, $component, $slot, $plugin);
+                parent::addPlugin($data, $type, $component, $slot, $plugin);
             }
         };
     }
@@ -86,7 +86,7 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     {
         $this->builder->build();
 
-        $expected = ["plugins/"];
+        $expected = ["plugins/Modules/", "plugins/Services/"];
         sort($expected);
         sort($this->scanned);
         $this->assertEquals($expected, $this->scanned);
@@ -95,15 +95,22 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     public function testScanningComplete(): void
     {
         $this->dirs = [
-            "plugins/" => ["Module1", "Module2"],
-            "plugins/Module1" => ["Slot1", "Slot2"],
-            "plugins/Module2" => []
+            "plugins/" => ["Services"],
+            "plugins/Services/" => ["Module1", "Module2"],
+            "plugins/Services/Module1" => ["Slot1", "Slot2"],
+            "plugins/Services/Module2" => []
         ];
 
         $this->builder->build();
 
-        $expected = ["plugins/", "plugins/Module1", "plugins/Module2",
-            "plugins/Module1/Slot1", "plugins/Module1/Slot2"];
+        $expected = [
+            "plugins/Modules/",
+            "plugins/Services/",
+            "plugins/Services/Module1",
+            "plugins/Services/Module1/Slot1",
+            "plugins/Services/Module1/Slot2",
+            "plugins/Services/Module2",
+        ];
         sort($expected);
         sort($this->scanned);
         $this->assertEquals($expected, $this->scanned);
@@ -112,16 +119,17 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     public function testPluginsAdded(): void
     {
         $this->dirs = [
-            "plugins/" => ["Module1"],
-            "plugins/Module1" => ["Slot1"],
-            "plugins/Module1/Slot1" => ["Plugin1", "Plugin2"]
+            "plugins/" => ["Services"],
+            "plugins/Services/" => ["Module1"],
+            "plugins/Services/Module1" => ["Slot1"],
+            "plugins/Services/Module1/Slot1" => ["Plugin1", "Plugin2"],
         ];
 
         $this->builder->build();
 
         $expected = [
-            "Module1/Slot1/Plugin1",
-            "Module1/Slot1/Plugin2"
+            "Services/Module1/Slot1/Plugin1",
+            "Services/Module1/Slot1/Plugin2"
         ];
         sort($expected);
         sort($this->added);
@@ -159,8 +167,8 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     public function testAddPlugins(): void
     {
         $data = [];
-        $this->files["plugins/Module1/Slot1/Plugin1/"] = __DIR__ . "/";
-        $this->builder->_addPlugin($data, "Module1", "Slot1", "Plugin1");
+        $this->files["plugins/Type1/Module1/Slot1/Plugin1/"] = __DIR__ . "/";
+        $this->builder->_addPlugin($data, "Type1", "Module1", "Slot1", "Plugin1");
 
         $expected = [
             "tstplg" => [
@@ -183,6 +191,6 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
 
     public function testBuildPluginPath(): void
     {
-        $this->assertEquals("plugins/COMPONENT/SLOT/PLUGIN/", $this->builder->_buildPluginPath("COMPONENT", "SLOT", "PLUGIN"));
+        $this->assertEquals("plugins/TYPE/COMPONENT/SLOT/PLUGIN/", $this->builder->_buildPluginPath("TYPE", "COMPONENT", "SLOT", "PLUGIN"));
     }
 }

--- a/components/ILIAS/Component/tests/Setup/ilComponentBuildPluginInfoObjectiveTest.php
+++ b/components/ILIAS/Component/tests/Setup/ilComponentBuildPluginInfoObjectiveTest.php
@@ -172,7 +172,7 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
 
         $expected = [
             "tstplg" => [
-                "components/ILIAS",
+                "Type1",
                 "Module1",
                 "Slot1",
                 "Plugin1",

--- a/components/ILIAS/Component/tests/ilArtifactComponentRepositoryTest.php
+++ b/components/ILIAS/Component/tests/ilArtifactComponentRepositoryTest.php
@@ -39,7 +39,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
 
     public static array $plugin_data = [
         "plg1" => [
-            "components/ILIAS",
+            "Type1",
             "Module1",
             "Slot1",
             "Plugin1",
@@ -53,7 +53,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
             null
         ],
         "plg2" => [
-            "components/ILIAS",
+            "Type2",
             "Service2",
             "Slot4",
             "Plugin2",
@@ -67,7 +67,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
             false
         ],
         "plg3" => [
-            "components/ILIAS",
+            "Type3",
             "Service2",
             "Slot4",
             "Plugin3",
@@ -164,6 +164,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
             $this->slt1,
             "plg1",
             "Plugin1",
+            "Type1",
             false,
             $this->data_factory->version("0.9.1"),
             13,
@@ -232,6 +233,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
             $this->slt4,
             "plg2",
             "Plugin2",
+            "Type2",
             false,
             $this->data_factory->version("0.9.1"),
             13,
@@ -251,6 +253,7 @@ class ilArtifactComponentRepositoryTest extends TestCase
             $this->slt4,
             "plg3",
             "Plugin3",
+            "Type3",
             true,
             $this->data_factory->version("0.9.1"),
             13,

--- a/components/ILIAS/Component/tests/ilPluginInfoTest.php
+++ b/components/ILIAS/Component/tests/ilPluginInfoTest.php
@@ -53,6 +53,7 @@ class ilPluginInfoTest extends TestCase
             $this->pluginslot,
             "plg1",
             "Plugin1",
+            "Type1",
             true,
             $this->data_factory->version("1.0.0"),
             12,
@@ -73,6 +74,7 @@ class ilPluginInfoTest extends TestCase
         $this->assertEquals($this->component, $this->plugin->getComponent());
         $this->assertEquals("plg1", $this->plugin->getId());
         $this->assertEquals("Plugin1", $this->plugin->getName());
+        $this->assertEquals("Type1", $this->plugin->getType());
         $this->assertTrue($this->plugin->isActivated());
         $this->assertEquals($this->data_factory->version("1.0.0"), $this->plugin->getCurrentVersion());
         $this->assertEquals(12, $this->plugin->getCurrentDBVersion());
@@ -98,6 +100,7 @@ class ilPluginInfoTest extends TestCase
             $this->pluginslot,
             "plg1",
             "Plugin1",
+            "Type1",
             true,
             null,
             null,
@@ -126,6 +129,7 @@ class ilPluginInfoTest extends TestCase
             $this->pluginslot,
             "plg1",
             "Plugin1",
+            "Type1",
             true,
             null,
             null,
@@ -149,6 +153,7 @@ class ilPluginInfoTest extends TestCase
             $this->pluginslot,
             "plg1",
             "Plugin1",
+            "Type1",
             true,
             $this->data_factory->version("2.0.0"),
             11,
@@ -174,6 +179,7 @@ class ilPluginInfoTest extends TestCase
             $this->pluginslot,
             "plg1",
             "Plugin1",
+            "Type1",
             true,
             $this->data_factory->version("1.0.0"),
             12,
@@ -193,6 +199,7 @@ class ilPluginInfoTest extends TestCase
             $this->pluginslot,
             "plg1",
             "Plugin1",
+            "Type1",
             true,
             $this->data_factory->version("1.2.2"),
             12,
@@ -218,6 +225,7 @@ class ilPluginInfoTest extends TestCase
             $this->pluginslot,
             "plg1",
             "Plugin1",
+            "Type1",
             true,
             $this->data_factory->version("1.2.2"),
             12,
@@ -246,7 +254,7 @@ class ilPluginInfoTest extends TestCase
     public function testGetPath(): void
     {
         $this->assertEquals(
-            ilComponentRepository::PLUGIN_BASE_PATH . "/Module1/Slot1/Plugin1",
+            ilComponentRepository::PLUGIN_BASE_PATH . "/Type1/Module1/Slot1/Plugin1",
             $this->plugin->getPath()
         );
     }

--- a/components/ILIAS/Component/tests/ilPluginSlotInfoTest.php
+++ b/components/ILIAS/Component/tests/ilPluginSlotInfoTest.php
@@ -45,7 +45,7 @@ class ilPluginSlotInfoTest extends TestCase
         );
 
         $v = $this->createMock(\ILIAS\Data\Version::class);
-        $this->plugin1 = new class ($v, $this->pluginslot, "plg1", "Plugin1", true, $v, 0, $v, $v, $v, "", "", false, false, false) extends ilPluginInfo {
+        $this->plugin1 = new class ($v, $this->pluginslot, "plg1", "Plugin1", "Type1", true, $v, 0, $v, $v, $v, "", "", false, false, false) extends ilPluginInfo {
             public function isActive(): bool
             {
                 return true;
@@ -53,7 +53,7 @@ class ilPluginSlotInfoTest extends TestCase
         };
         $plugins["plg1"] = $this->plugin1;
 
-        $this->plugin2 = new class ($v, $this->pluginslot, "plg2", "Plugin2", true, $v, 0, $v, $v, $v, "", "", false, false, false) extends ilPluginInfo {
+        $this->plugin2 = new class ($v, $this->pluginslot, "plg2", "Plugin2", "Type2", true, $v, 0, $v, $v, $v, "", "", false, false, false) extends ilPluginInfo {
             public function isActive(): bool
             {
                 return false;
@@ -115,14 +115,6 @@ class ilPluginSlotInfoTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->pluginslot->getPluginByName("Plugin3");
-    }
-
-    public function testGetPath(): void
-    {
-        $this->assertEquals(
-            ilComponentRepository::PLUGIN_BASE_PATH . "/Module1/Slot1",
-            $this->pluginslot->getPath()
-        );
     }
 
     public function testGetActivePlugins(): void

--- a/components/ILIAS/Repository/PluginSlot/class.ilRepositoryObjectPlugin.php
+++ b/components/ILIAS/Repository/PluginSlot/class.ilRepositoryObjectPlugin.php
@@ -60,7 +60,6 @@ abstract class ilRepositoryObjectPlugin extends ilPlugin
         }
 
         $d = $plugin->getPath();
-
         return $d . "/templates/images/" . $a_img;
     }
 
@@ -71,7 +70,7 @@ abstract class ilRepositoryObjectPlugin extends ilPlugin
         global $DIC;
         $component_repository = $DIC["component.repository"];
         return self::_getImagePath(
-            ilComponentInfo::TYPE_SERVICES,
+            ilComponentInfo::TYPES[0],
             "Repository",
             "robj",
             $component_repository->getPluginById($a_type)->getName(),

--- a/components/ILIAS/Setup/src/ImplementationOfAgentFinder.php
+++ b/components/ILIAS/Setup/src/ImplementationOfAgentFinder.php
@@ -95,7 +95,7 @@ class ImplementationOfAgentFinder implements AgentFinder
         // TODO: This seems to be something that rather belongs to Services/Component/
         // but we put it here anyway for the moment. This seems to be something that
         // could go away when we unify Services/Modules/Plugins to one common concept.
-        $path = "[/]public/Customizing/plugins/.*/.*/" . $name . "/.*";
+        $path = "[/]public/Customizing/global/plugins/.*/.*/" . $name . "/.*";
         $agent_classes = iterator_to_array($this->interface_finder->getMatchingClassNames(
             Agent::class,
             [],
@@ -160,13 +160,13 @@ class ImplementationOfAgentFinder implements AgentFinder
     {
         $directories =
             new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator(__DIR__ . "/../../../../public/Customizing/plugins/")
+                new \RecursiveDirectoryIterator(__DIR__ . "/../../../../public/Customizing/global/plugins/Services")
             );
         $names = [];
         foreach ($directories as $dir) {
             $groups = [];
-            if (preg_match("%^" . __DIR__ . "/[.][.]/[.][.]/[.][.]/[.][.]/public/Customizing/plugins/((\\w+/){2})([^/\.]+)(/|$)%", (string) $dir, $groups)) {
-                $name = $groups[3];
+            if (preg_match("%^" . __DIR__ . "/[.][.]/[.][.]/[.][.]/[.][.]/public/Customizing/global/plugins/(Services|Modules)/((\\w+/){2})([^/\.]+)(/|$)%", (string) $dir, $groups)) {
+                $name = $groups[4];
                 if (isset($names[$name])) {
                     continue;
                 }

--- a/components/ILIAS/Setup/src/ImplementationOfAgentFinder.php
+++ b/components/ILIAS/Setup/src/ImplementationOfAgentFinder.php
@@ -160,7 +160,7 @@ class ImplementationOfAgentFinder implements AgentFinder
     {
         $directories =
             new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator(__DIR__ . "/../../../../public/Customizing/global/plugins/Services")
+                new \RecursiveDirectoryIterator(__DIR__ . "/../../../../public/Customizing/global/plugins")
             );
         $names = [];
         foreach ($directories as $dir) {

--- a/components/ILIAS/UICore/classes/class.ilTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilTemplate.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 require_once __DIR__ . '/../lib/html-it/IT.php';
 require_once __DIR__ . '/../lib/html-it/ITX.php';

--- a/components/ILIAS/UICore/classes/class.ilTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilTemplate.php
@@ -315,57 +315,61 @@ class ilTemplate extends HTML_Template_ITX
             );
     }
 
+
+    protected function getCurrentSkin(): ?string
+    {
+        // use ilStyleDefinition instead of account to get the current skin
+        return ilStyleDefinition::getCurrentSkin();
+    }
+
+    protected function getCurrentStyle(): ?string
+    {
+        return ilStyleDefinition::getCurrentStyle();
+    }
+
+    protected function fileExistsInSkin(string $path): bool
+    {
+        return file_exists($path);
+    }
+
     /**
      * @throws ilSystemStyleException
      */
     protected function getTemplatePath(string $a_tplname, string $a_in_module = null): string
     {
-        $fname = "";
-        if (strpos($a_tplname, "/") === false) {
-            $module_path = "";
+        $ilias_root = realpath(__DIR__ . '/../../../../') . '/';
 
-            if ($a_in_module !== "") {
-                $module_path = $a_in_module . "/";
-            }
-
-            // use ilStyleDefinition instead of account to get the current skin
-            if (ilStyleDefinition::getCurrentSkin() !== "default") {
-                $style = ilStyleDefinition::getCurrentStyle();
-
-                $fname = "./Customizing/global/skin/" .
-                    ilStyleDefinition::getCurrentSkin() . "/" . $style . "/" . $module_path
-                    . basename($a_tplname);
-
-                if ($fname === "" || !file_exists($fname)) {
-                    $fname = "./Customizing/global/skin/" .
-                        ilStyleDefinition::getCurrentSkin() . "/" . $module_path . basename($a_tplname);
-                }
-            }
-
-            if ($fname === "" || !file_exists($fname)) {
-                $fname = "./" . $module_path . "templates/default/" . basename($a_tplname);
-            }
-        } elseif (strpos($a_tplname, "components/ILIAS/UI") === 0) {
-            if (class_exists("ilStyleDefinition") // for testing
-                && ilStyleDefinition::getCurrentSkin() != "default") {
-                $style = ilStyleDefinition::getCurrentStyle();
-                $skin = ilStyleDefinition::getCurrentSkin();
-                $base_path = "./Customizing/global/skin/";
-                $ui_path = "/" . str_replace("components/ILIAS/UI/src/templates/default", "UI", $a_tplname);
-                $fname = $base_path . ilStyleDefinition::getCurrentSkin() . "/" . $style . "/" . $ui_path;
-
-                if (!file_exists($fname)) {
-                    $fname = $base_path . $skin . "/" . $ui_path;
-                }
-            }
-
-            if ($fname == "" || !file_exists($fname)) {
-                $fname = $a_tplname;
-            }
-        } else {
-            $fname = $a_tplname;
+        if (str_starts_with($a_in_module, $ilias_root)) {
+            $a_in_module = str_replace($ilias_root, '', $a_in_module);
         }
-        return __DIR__ . '/../../../../' . $fname;
+
+        if (str_ends_with($a_in_module, '/')) {
+            $a_in_module = rtrim($a_in_module, '/');
+        }
+
+        if (str_starts_with($a_tplname, 'components/ILIAS/UI/')) {
+            $a_in_module = 'components/ILIAS/UI/src';
+            $a_tplname = str_replace('components/ILIAS/UI/src/templates/default/', '', $a_tplname);
+        }
+
+        $base_path = $ilias_root;
+        $default = $base_path . $a_in_module . '/templates/default/' . $a_tplname;
+
+        $skin = $this->getCurrentSkin();
+        if ($skin === 'default') {
+            return $default;
+        }
+
+        $style = $this->getCurrentStyle();
+        $base_path .= 'public/Customizing/skin/' . $skin . '/' . $style;
+
+        if ($a_in_module === 'components/ILIAS/UI/src') {
+            $a_in_module = 'UI';
+        }
+
+        $from_skin = $base_path . '/' . $a_in_module . '/' . $a_tplname;
+
+        return $this->fileExistsInSkin($from_skin) ? $from_skin : $default;
     }
 
     /**

--- a/components/ILIAS/UICore/tests/ilTemplateTest.php
+++ b/components/ILIAS/UICore/tests/ilTemplateTest.php
@@ -88,8 +88,8 @@ class ilTemplateTest extends TestCase
                 'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
                 'tpl_filename' => 'tpl.test.html',
                  //ilPlugin::getDirectory() will return something like this:
-                'component' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/plugins/UIComponent/UserInterfaceHook/EditorAsMode',
-                'expected' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/plugins/UIComponent/UserInterfaceHook/EditorAsMode/templates/default/tpl.test.html',
+                'component' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/EditorAsMode',
+                'expected' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/EditorAsMode/templates/default/tpl.test.html',
             ],
             'custom skin' => [
                 'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => true,

--- a/components/ILIAS/UICore/tests/ilTemplateTest.php
+++ b/components/ILIAS/UICore/tests/ilTemplateTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class ilTemplateTest extends TestCase
+{
+    protected ilTemplate $il_template;
+    protected string $il_root;
+
+    public function setUp(): void
+    {
+        $this->il_template = new class () extends ilTemplate {
+            protected string $style = 'delos';
+            protected string $skin = 'default';
+            protected bool $file_exists = true;
+            public function __construct()
+            {
+            }
+            public function _getTemplatePath(string $a_tplname, string $a_in_module = null): string
+            {
+                return $this->getTemplatePath($a_tplname, $a_in_module);
+            }
+            protected function getCurrentStyle(): ?string
+            {
+                return $this->style;
+            }
+            public function withStyle(string $style)
+            {
+                $clone = clone $this;
+                $clone->style = $style;
+                return $clone;
+            }
+            public function withSkin(string $skin)
+            {
+                $clone = clone $this;
+                $clone->skin = $skin;
+                return $clone;
+            }
+            protected function getCurrentSkin(): ?string
+            {
+                return $this->skin;
+            }
+            protected function fileExistsInSkin(string $path): bool
+            {
+                return $this->file_exists;
+            }
+            public function withFileExists(bool $file_exists)
+            {
+                $clone = clone $this;
+                $clone->file_exists = $file_exists;
+                return $clone;
+            }
+        };
+        $this->il_root = realpath(__DIR__ . '/../../../../');
+
+    }
+
+
+    public static function templatePathDataProvider(): array
+    {
+        $il_root = realpath(__DIR__ . '/../../../../');
+        return [
+            'standard component template' => [
+                'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
+                'tpl_filename' => 'tpl.appointment_panel.html',
+                'component' => 'components/ILIAS/Calendar',
+                'expected' => $il_root . '/components/ILIAS/Calendar/templates/default/tpl.appointment_panel.html'
+            ],
+            'plugin template' => [
+                'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
+                'tpl_filename' => 'tpl.test.html',
+                 //ilPlugin::getDirectory() will return something like this:
+                'component' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/plugins/UIComponent/UserInterfaceHook/EditorAsMode',
+                'expected' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/plugins/UIComponent/UserInterfaceHook/EditorAsMode/templates/default/tpl.test.html',
+            ],
+            'custom skin' => [
+                'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => true,
+                'tpl_filename' => 'tpl.external_settings.html',
+                'component' => 'components/ILIAS/Administration',
+                'expected' => $il_root . '/public/Customizing/skin/mySkin/myStyle/components/ILIAS/Administration/tpl.external_settings.html',
+            ],
+            'custom skin, unaltered file' => [
+                'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => false,
+                'tpl_filename' => 'tpl.external_settings.html',
+                'component' => 'components/ILIAS/Administration',
+                'expected' => $il_root . '/components/ILIAS/Administration/templates/default/tpl.external_settings.html',
+            ],
+            'ui template' => [
+                'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
+                'tpl_filename' => 'components/ILIAS/UI/src/templates/default/Input/tpl.standard.html',
+                'component' => '',
+                'expected' => $il_root . '/components/ILIAS/UI/src/templates/default/Input/tpl.standard.html',
+            ],
+            'ui template from skin' => [
+                'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => true,
+                'tpl_filename' => 'components/ILIAS/UI/src/templates/default/Input/tpl.standard.html',
+                'component' => '',
+                'expected' => $il_root . '/public/Customizing/skin/mySkin/myStyle/UI/Input/tpl.standard.html',
+            ],
+            'ui template from skin, unaltered' => [
+                'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => false,
+                'tpl_filename' => 'components/ILIAS/UI/src/templates/default/Input/tpl.standard.html',
+                'component' => '',
+                'expected' => $il_root . '/components/ILIAS/UI/src/templates/default/Input/tpl.standard.html',
+            ],
+            'trailing slash' => [
+                'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
+                'tpl_filename' => 'tpl.test.html',
+                'component' => 'components/ILIAS/Test/',
+                'expected' => $il_root . '/components/ILIAS/Test/templates/default/tpl.test.html',
+            ],
+
+        ];
+    }
+
+    /**
+     * @dataProvider templatePathDataProvider
+     */
+    public function testGetTemplatePath(
+        string $skin,
+        string $style,
+        bool $file_exists,
+        string $tpl_filename,
+        string $component,
+        string $expected
+    ): void {
+        $path = $this->il_template
+            ->withSkin($skin)
+            ->withStyle($style)
+            ->withFileExists($file_exists)
+            ->_getTemplatePath($tpl_filename, $component);
+
+        $this->assertEquals($expected, $path);
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 			"@php cli/setup.php build --yes"
 		],
 		"pre-install-cmd": [
-			"mkdir -p public/Customizing/plugins"
+			"mkdir -p public/Customizing/global/plugins"
 		],
 		"post-install-cmd": [
 			"@php vendor/composer/rmdirs.php"
@@ -90,7 +90,7 @@
 			"ILIAS\\Scripts\\" : "./scripts"
 		},
 		"classmap": [
-			"./public/Customizing/plugins",
+			"./public/Customizing/global/plugins",
 			"./components/ILIAS",
 			"./vendor/ilias",
 			"./components/ILIAS/soap",

--- a/docs/development/components-and-directories-process.md
+++ b/docs/development/components-and-directories-process.md
@@ -237,11 +237,13 @@ The following new structure won't implemented in the first PR / process step:
 
 -----------
 
-## 4. ./public/Customizing/plugins
+## 4. ./public/Customizing/global/plugins
 
-The plugin directory stays at `public/Customizing/plugins` for now and will later on moved to
-`components/{SERVICE_PROVIDER}`.
+The plugin directory is at `public/Customizing/global/plugins/(Services|Modules)` for now
+and will later on be removed; plugins will then be components in `components/{SERVICE_PROVIDER}`.
 The name {SERVICE_PROVIDER} will be a placeholder for unique provider, who will create their own plugins.
+For 10, you may move your (adjusted!) plugins from /Customizing/global/plugins
+to /public/Customizing/global/plugins
 
 -----------
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44596

includes https://github.com/ILIAS-eLearning/ILIAS/pull/9069 (for https://mantis.ilias.de/view.php?id=44208)
and fixes https://mantis.ilias.de/view.php?id=44425

Main issue was, that the Slot-providing component is in components/ILIAS whith no reference to "Services" or "Modules", while the plugin needs to know this path. 
I removed ilPluginSlotInfo::getPath and re-added the type to ilPluginInfo.