### PR TITLE
Logging: Fix monolog 3.9 compatibility issues

### DIFF
--- a/components/ILIAS/Logging/classes/extensions/class.ilLineFormatter.php
+++ b/components/ILIAS/Logging/classes/extensions/class.ilLineFormatter.php
@@ -35,9 +35,11 @@ class ilLineFormatter extends LineFormatter
     public function format(LogRecord $record): string
     {
         if (isset($record["extra"]["trace"])) {
+            $trace = $record["extra"]["trace"];
+            unset($record["extra"]["trace"]);
             $record = $record->with(
-                message: $record["extra"]["trace"] . " " . $record["message"],
-                extra: []
+                message: $trace . " " . $record["message"],
+                extra: $record["extra"]
             );
         }
 

--- a/components/ILIAS/Logging/classes/extensions/class.ilTraceProcessor.php
+++ b/components/ILIAS/Logging/classes/extensions/class.ilTraceProcessor.php
@@ -17,6 +17,9 @@
  *********************************************************************/
 
 declare(strict_types=1);
+
+use Monolog\LogRecord;
+
 /**
  * Logging factory
  *
@@ -40,7 +43,7 @@ class ilTraceProcessor
     /**
      * @todo fix shifting calls
      */
-    public function __invoke(array $record): array
+    public function __invoke(LogRecord $record): LogRecord
     {
         if ($record['level'] < $this->level) {
             return $record;

--- a/components/ILIAS/Logging/classes/public/class.ilLoggerFactory.php
+++ b/components/ILIAS/Logging/classes/public/class.ilLoggerFactory.php
@@ -36,7 +36,7 @@ use Monolog\Processor\PsrLogMessageProcessor;
  */
 class ilLoggerFactory
 {
-    protected const DEFAULT_FORMAT = "[%suid%] [%datetime%] %channel%.%level_name%: %message% %context% %extra%\n";
+    protected const DEFAULT_FORMAT = "[%extra.suid%] [%datetime%] %channel%.%level_name%: %message% %context% %extra%\n";
 
     protected const ROOT_LOGGER = 'root';
     protected const COMPONENT_ROOT = 'log_root';
@@ -242,7 +242,7 @@ class ilLoggerFactory
 
         // suid log
         $logger->pushProcessor(function ($record) {
-            $record['suid'] = substr(session_id(), 0, 5);
+            $record['extra']['suid'] = substr(session_id(), 0, 5);
             return $record;
         });
 


### PR DESCRIPTION
This PR fixes Monolog 3.9 incompatibilities:
- The processors are given a `Monolog\LogRecord` instead of an array now.
- Move `suid` record entry to `extra` as you cannot add arbitrary keys to the `Monolog\LogRecord` directly.

Mantis Issue: https://mantis.ilias.de/view.php?id=44782