### PR TITLE
11/Components/Plugins: adjust composer to mkdir public/Customizing/global/plugins

### DIFF
--- a/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
+++ b/components/ILIAS/Component/classes/Setup/class.ilComponentBuildPluginInfoObjective.php
@@ -20,7 +20,7 @@ use ILIAS\Setup;
 
 class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactObjective
 {
-    protected const BASE_PATH = "./public/Customizing/plugins/";
+    protected const BASE_PATH = "./public/Customizing/global/plugins/";
     protected const PLUGIN_PHP = "plugin.php";
     protected const PLUGIN_CLASS_FILE = "classes/class.il%sPlugin.php";
 
@@ -30,40 +30,43 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
         return "plugin_data";
     }
 
-
     public function build(): Setup\Artifact
     {
         $data = [];
-
-        $components = $this->scanDir(static::BASE_PATH);
-        foreach ($components as $component) {
-            if ($this->isDotFile($component)
-                || ! $this->isDir(static::BASE_PATH . "$component")) {
+        foreach (['Modules', 'Services'] as $type) {
+            $base_path = static::BASE_PATH . $type . '/';
+            if (! $this->isDir($base_path)) {
                 continue;
             }
-            $slots = $this->scanDir(static::BASE_PATH . "$component");
-            foreach ($slots as $slot) {
-                if ($this->isDotFile($slot)
-                    || ! $this->isDir(static::BASE_PATH . "$component/$slot")) {
+            $components = $this->scanDir($base_path);
+            foreach ($components as $component) {
+                if ($this->isDotFile($component)
+                    || ! $this->isDir($base_path . "$component")) {
                     continue;
                 }
-                $plugins = $this->scanDir(static::BASE_PATH . "$component/$slot");
-                foreach ($plugins as $plugin) {
-                    if ($this->isDotFile($plugin)
-                        || ! $this->isDir(static::BASE_PATH . "$component/$slot/$plugin")) {
+                $slots = $this->scanDir($base_path . "$component");
+                foreach ($slots as $slot) {
+                    if ($this->isDotFile($slot)
+                        || ! $this->isDir($base_path . "$component/$slot")) {
                         continue;
                     }
-                    $this->addPlugin($data, $component, $slot, $plugin);
+                    $plugins = $this->scanDir($base_path . "$component/$slot");
+                    foreach ($plugins as $plugin) {
+                        if ($this->isDotFile($plugin)
+                            || ! $this->isDir($base_path . "$component/$slot/$plugin")) {
+                            continue;
+                        }
+                        $this->addPlugin($data, $type, $component, $slot, $plugin);
+                    }
                 }
             }
         }
-
         return new Setup\Artifact\ArrayArtifact($data);
     }
 
-    protected function addPlugin(array &$data, string $component, string $slot, string $plugin): void
+    protected function addPlugin(array &$data, string $type, string $component, string $slot, string $plugin): void
     {
-        $plugin_path = $this->buildPluginPath($component, $slot, $plugin);
+        $plugin_path = $this->buildPluginPath($type, $component, $slot, $plugin);
         $plugin_php = $plugin_path . static::PLUGIN_PHP;
         if (!$this->fileExists($plugin_php)) {
             throw new \RuntimeException(
@@ -141,8 +144,8 @@ class ilComponentBuildPluginInfoObjective extends Setup\Artifact\BuildArtifactOb
         return (substr($file, 0, 1) === '.');
     }
 
-    protected function buildPluginPath(string $component, string $slot, string $plugin): string
+    protected function buildPluginPath(string $type, string $component, string $slot, string $plugin): string
     {
-        return static::BASE_PATH . "$component/$slot/$plugin/";
+        return static::BASE_PATH . "$type/$component/$slot/$plugin/";
     }
 }

--- a/components/ILIAS/Component/classes/class.ilComponentRepository.php
+++ b/components/ILIAS/Component/classes/class.ilComponentRepository.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
  */
 interface ilComponentRepository
 {
-    public const PLUGIN_BASE_PATH = __DIR__ . '/../../../../public/Customizing/plugins';
+    public const PLUGIN_BASE_PATH = __DIR__ . '/../../../../public/Customizing/global/plugins';
 
     /**
      * Check if a component exists.

--- a/components/ILIAS/Component/tests/Setup/ilComponentBuildPluginInfoObjectiveTest.php
+++ b/components/ILIAS/Component/tests/Setup/ilComponentBuildPluginInfoObjectiveTest.php
@@ -62,22 +62,22 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
             {
                 return parent::isDotFile($file);
             }
-            protected function buildPluginPath(string $component, string $slot, string $plugin): string
+            protected function buildPluginPath(string $type, string $component, string $slot, string $plugin): string
             {
-                return $this->test->files[parent::buildPluginPath($component, $slot, $plugin)];
+                return $this->test->files[parent::buildPluginPath($type, $component, $slot, $plugin)];
             }
 
-            public function _buildPluginPath(string $component, string $slot, string $plugin): string
+            public function _buildPluginPath(string $type, string $component, string $slot, string $plugin): string
             {
-                return parent::buildPluginPath($component, $slot, $plugin);
+                return parent::buildPluginPath($type, $component, $slot, $plugin);
             }
-            protected function addPlugin(array &$data, string $component, string $slot, string $plugin): void
+            protected function addPlugin(array &$data, string $type, string $component, string $slot, string $plugin): void
             {
-                $this->test->added[] = "$component/$slot/$plugin";
+                $this->test->added[] = "$type/$component/$slot/$plugin";
             }
-            public function _addPlugin(array &$data, string $component, string $slot, string $plugin): void
+            public function _addPlugin(array &$data, string $type, string $component, string $slot, string $plugin): void
             {
-                parent::addPlugin($data, $component, $slot, $plugin);
+                parent::addPlugin($data, $type, $component, $slot, $plugin);
             }
         };
     }
@@ -86,7 +86,7 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     {
         $this->builder->build();
 
-        $expected = ["plugins/"];
+        $expected = ["plugins/Modules/", "plugins/Services/"];
         sort($expected);
         sort($this->scanned);
         $this->assertEquals($expected, $this->scanned);
@@ -95,15 +95,22 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     public function testScanningComplete(): void
     {
         $this->dirs = [
-            "plugins/" => ["Module1", "Module2"],
-            "plugins/Module1" => ["Slot1", "Slot2"],
-            "plugins/Module2" => []
+            "plugins/" => ["Services"],
+            "plugins/Services/" => ["Module1", "Module2"],
+            "plugins/Services/Module1" => ["Slot1", "Slot2"],
+            "plugins/Services/Module2" => []
         ];
 
         $this->builder->build();
 
-        $expected = ["plugins/", "plugins/Module1", "plugins/Module2",
-            "plugins/Module1/Slot1", "plugins/Module1/Slot2"];
+        $expected = [
+            "plugins/Modules/",
+            "plugins/Services/",
+            "plugins/Services/Module1",
+            "plugins/Services/Module1/Slot1",
+            "plugins/Services/Module1/Slot2",
+            "plugins/Services/Module2",
+        ];
         sort($expected);
         sort($this->scanned);
         $this->assertEquals($expected, $this->scanned);
@@ -112,16 +119,17 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     public function testPluginsAdded(): void
     {
         $this->dirs = [
-            "plugins/" => ["Module1"],
-            "plugins/Module1" => ["Slot1"],
-            "plugins/Module1/Slot1" => ["Plugin1", "Plugin2"]
+            "plugins/" => ["Services"],
+            "plugins/Services/" => ["Module1"],
+            "plugins/Services/Module1" => ["Slot1"],
+            "plugins/Services/Module1/Slot1" => ["Plugin1", "Plugin2"],
         ];
 
         $this->builder->build();
 
         $expected = [
-            "Module1/Slot1/Plugin1",
-            "Module1/Slot1/Plugin2"
+            "Services/Module1/Slot1/Plugin1",
+            "Services/Module1/Slot1/Plugin2"
         ];
         sort($expected);
         sort($this->added);
@@ -159,8 +167,8 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
     public function testAddPlugins(): void
     {
         $data = [];
-        $this->files["plugins/Module1/Slot1/Plugin1/"] = __DIR__ . "/";
-        $this->builder->_addPlugin($data, "Module1", "Slot1", "Plugin1");
+        $this->files["plugins/Type1/Module1/Slot1/Plugin1/"] = __DIR__ . "/";
+        $this->builder->_addPlugin($data, "Type1", "Module1", "Slot1", "Plugin1");
 
         $expected = [
             "tstplg" => [
@@ -183,6 +191,6 @@ class ilComponentBuildPluginInfoObjectiveTest extends TestCase
 
     public function testBuildPluginPath(): void
     {
-        $this->assertEquals("plugins/COMPONENT/SLOT/PLUGIN/", $this->builder->_buildPluginPath("COMPONENT", "SLOT", "PLUGIN"));
+        $this->assertEquals("plugins/TYPE/COMPONENT/SLOT/PLUGIN/", $this->builder->_buildPluginPath("TYPE", "COMPONENT", "SLOT", "PLUGIN"));
     }
 }

--- a/components/ILIAS/Setup/src/ImplementationOfAgentFinder.php
+++ b/components/ILIAS/Setup/src/ImplementationOfAgentFinder.php
@@ -95,7 +95,7 @@ class ImplementationOfAgentFinder implements AgentFinder
         // TODO: This seems to be something that rather belongs to Services/Component/
         // but we put it here anyway for the moment. This seems to be something that
         // could go away when we unify Services/Modules/Plugins to one common concept.
-        $path = "[/]public/Customizing/plugins/.*/.*/" . $name . "/.*";
+        $path = "[/]public/Customizing/global/plugins/.*/.*/" . $name . "/.*";
         $agent_classes = iterator_to_array($this->interface_finder->getMatchingClassNames(
             Agent::class,
             [],
@@ -165,8 +165,8 @@ class ImplementationOfAgentFinder implements AgentFinder
         $names = [];
         foreach ($directories as $dir) {
             $groups = [];
-            if (preg_match("%^" . __DIR__ . "/[.][.]/[.][.]/[.][.]/[.][.]/public/Customizing/plugins/((\\w+/){2})([^/\.]+)(/|$)%", (string) $dir, $groups)) {
-                $name = $groups[3];
+            if (preg_match("%^" . __DIR__ . "/[.][.]/[.][.]/[.][.]/[.][.]/public/Customizing/global/plugins/(Services|Modules)/((\\w+/){2})([^/\.]+)(/|$)%", (string) $dir, $groups)) {
+                $name = $groups[4];
                 if (isset($names[$name])) {
                     continue;
                 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 			"@php cli/setup.php build --yes"
 		],
 		"pre-install-cmd": [
-			"mkdir -p public/Customizing/plugins"
+			"mkdir -p public/Customizing/global/plugins"
 		],
 		"post-install-cmd": [
 			"@php vendor/composer/rmdirs.php"
@@ -82,7 +82,7 @@
 			"ILIAS\\Scripts\\" : "./scripts"
 		},
 		"classmap": [
-			"./public/Customizing/plugins",
+			"./public/Customizing/global/plugins",
 			"./components/ILIAS",
 			"./vendor/ilias",
 			"./components/ILIAS/soap",


### PR DESCRIPTION
Actually, plugins should be just components, but for now and to ease stepping up: 
allow for plugins to reside in public/Customizing/global/plugins (https://mantis.ilias.de/view.php?id=44596)

adds 89e5bc7605759ef7bc31fdf6d6f8d1f90e4beec8 from 10