### PR TITLE
Add `jquery` as npm Dependency for ILIAS 11

### DIFF
--- a/components/ILIAS/jQuery/jQuery.php
+++ b/components/ILIAS/jQuery/jQuery.php
@@ -36,8 +36,8 @@ class jQuery implements Component\Component
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\NodeModule("jquery-migrate/dist/jquery-migrate.min.js");
         */
-        /* $contribute[Component\Resource\PublicAsset::class] = fn() =>
-            new Component\Resource\NodeModule("jquery/dist/jquery.js"); */
+        $contribute[Component\Resource\PublicAsset::class] = fn() =>
+            new Component\Resource\NodeModule("jquery/dist/jquery.js");
         /* This library was missing after discussing dependencies for ILIAS 10
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\NodeModule("jquery-ui-dist/jquery-ui.js");

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@yaireo/tagify": "^4.32.1",
         "chart.js": "^4.4.7",
         "dropzone": "^5.9.3",
+        "jquery": "^3.7.1",
         "linkify-element": "^4.1.3",
         "linkifyjs": "^4.1.3",
         "mathjax": "^3.2.2",
@@ -2008,6 +2009,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@yaireo/tagify": "^4.32.1",
     "chart.js": "^4.4.7",
     "dropzone": "^5.9.3",
+    "jquery": "^3.7.1",
     "linkify-element": "^4.1.3",
     "linkifyjs": "^4.1.3",
     "mathjax": "^3.2.2",
@@ -120,6 +121,13 @@
       "developer": "thibsy",
       "purpose": "JS Module Bundler",
       "last-update-for-ilias": "11.0"
+    },
+    "jquery": {
+      "introduction-date": null,
+      "approved-by": "Jour Fixe",
+      "developer": null,
+      "purpose": "We still use jQuery for many JS-related actions in ILIAS, unfortunately.",
+      "last-update-for-ilias": "10.0"
     }
   }
 }


### PR DESCRIPTION
This PR adds `jQuery` as NPM dependency.

Usage:
* In many components, searching for `$(` results in 3700+ occurrences

Wrapped By:
* Not applicable

Reasoning:
* `jQuery` has been introduced many years ago as a DOM abstraction and utility (XMLHttpRequest, Event Handling etc.) library. Nowadays, many of this functions could be replaced by the "Vanilla JS" API. Nevertheless, I doubt that we could tackle the migration in a timely manner for ILIAS 11 and most likely 12 either. It is unlikely to remove this dependency for all components outside of a big project with according funding and organisational resources.

Maintenance:
* `jQuery` is actively maintained and has an existing security policy (https://github.com/jquery/jquery/blob/e06ff08849057cd099365bf43598c8952fe9956d/SECURITY.md).

**Important:** It might be necessary to also include `"jquery-migrate": "^3.0.0",`, maybe the developer who introduced this can explain this further.

Links:
* NPM: https://www.npmjs.com/package/jquery
* GitHub: https://github.com/jquery/jquery
* Documentation: https://api.jquery.com/