### PR TITLE
T&A 44733: Fixes invalid data types in assFormulaQuestionResult::getReachedPoints method

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
@@ -933,11 +933,12 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, ilAs
 
         $points = 0;
         foreach ($this->getResults() as $result) {
+            $unit_id = $user_solution[$result->getResult() . '_unit'] ?? null;
             $points += $result->getReachedPoints(
                 $this->getVariables(),
                 $this->getResults(),
                 $user_solution[$result->getResult()] ?? '',
-                $this->unitrepository->getUnit($user_solution[$result->getResult() . '_unit'] ?? 0),
+                $unit_id !== null ? $this->unitrepository->getUnit($unit_id) : null,
                 $this->unitrepository->getUnits()
             );
         }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
@@ -892,7 +892,7 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, ilAs
         }
         $solutions = $this->getSolutionValues($active_id, $pass, $authorizedSolution);
         $user_solution = array();
-        foreach ($solutions as $idx => $solution_value) {
+        foreach ($solutions as $solution_value) {
             if (preg_match("/^(\\\$v\\d+)$/", $solution_value["value1"], $matches)) {
                 $user_solution[$matches[1]] = $solution_value["value2"];
                 $varObj = $this->getVariable($solution_value["value1"]);
@@ -906,7 +906,9 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, ilAs
                 if (!array_key_exists($matches[1], $user_solution)) {
                     $user_solution[$matches[1]] = array();
                 }
-                $user_solution[$matches[1]]["unit"] = $solution_value["value2"];
+                $user_solution[$matches[1]]["unit"] = $this->unitrepository->getUnit(
+                    $this->refinery->kindlyTo()->int()->transform($solution_value["value2"]),
+                );
             }
         }
         //vd($this->getResults());
@@ -917,7 +919,7 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, ilAs
                 $this->getVariables(),
                 $this->getResults(),
                 $user_solution[$result->getResult()]["value"] ?? '',
-                $user_solution[$result->getResult()]["unit"] ?? '',
+                $user_solution[$result->getResult()]["unit"] ?? null,
                 $this->unitrepository->getUnits()
             );
         }
@@ -931,14 +933,11 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, ilAs
 
         $points = 0;
         foreach ($this->getResults() as $result) {
-            $v = isset($user_solution[$result->getResult()]) ? $user_solution[$result->getResult()] : null;
-            $u = isset($user_solution[$result->getResult() . '_unit']) ? $user_solution[$result->getResult() . '_unit'] : null;
-
             $points += $result->getReachedPoints(
                 $this->getVariables(),
                 $this->getResults(),
-                $v,
-                $u,
+                $user_solution[$result->getResult()] ?? '',
+                $this->unitrepository->getUnit($user_solution[$result->getResult() . '_unit'] ?? 0),
                 $this->unitrepository->getUnits()
             );
         }
@@ -1307,7 +1306,7 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, ilAs
                 $check_unit = false;
                 if (array_key_exists($result_name, $available_units) &&
                     $available_units[$result_name] !== null) {
-                    $check_unit = in_array($user_solution[$result_name]['unit'], $available_units[$result_name]);
+                    $check_unit = in_array($user_solution[$result_name]['unit'] ?? null, $available_units[$result_name]);
                 }
 
                 if ($check_unit == true) {

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionResult.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionResult.php
@@ -423,18 +423,10 @@ class assFormulaQuestionResult
             return $this->isCorrect($variables, $results, $value, $unit) ? $this->getPoints() : 0;
         }
 
-        $result = $this->evaluateResultAsFormula($variables, $results);
+        $result = $this->calculateResult($variables, $results);
 
         if ($unit instanceof assFormulaQuestionUnit) {
-            $value = $this->handleValueByResultType($value, $unit);
-        }
-
-        $result_unit = $this->getUnit();
-        if ($result_unit instanceof assFormulaQuestionUnit) {
-            /** @var float $result */
-            $result = $result_unit->getBaseUnit() !== -1
-                ? ilMath::_div($result, $result_unit->getFactor(), $this->getPrecision())
-                : ilMath::_mul($result, $result_unit->getFactor(), $this->getPrecision());
+            $value = $this->transformResultAccordingToType($value, $unit);
         }
 
         /** @var ?float $value */
@@ -444,11 +436,11 @@ class assFormulaQuestionResult
         ])->transform($value);
         $points = 0.0;
 
-        if (is_float($float_value) && $this->checkSign($result, $float_value)) {
+        if ($float_value !== null && $this->checkSign($result, $float_value)) {
             $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingSign(), 100));
         }
 
-        if (is_float($float_value) && $this->isInTolerance(abs($float_value), abs($result), $this->getTolerance())) {
+        if ($float_value !== null && $this->isInTolerance(abs($float_value), abs($result), $this->getTolerance())) {
             $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingValue(), 100));
         }
 
@@ -467,7 +459,7 @@ class assFormulaQuestionResult
         return $points;
     }
 
-    private function evaluateResultAsFormula(array $variables, array $results): float
+    private function calculateResult(array $variables, array $results): float
     {
         $formula = $this->substituteFormula($variables, $results);
 
@@ -487,12 +479,22 @@ class assFormulaQuestionResult
 
         $eval_math = new EvalMath();
         $eval_math->suppress_errors = true;
-        return $eval_math->evaluate($formula);
+        $result = $eval_math->evaluate($formula);
+
+        $result_unit = $this->getUnit();
+        if ($result_unit instanceof assFormulaQuestionUnit) {
+            /** @var float $result */
+            $result = $result_unit->getBaseUnit() !== -1
+                ? ilMath::_div($result, $result_unit->getFactor(), $this->getPrecision())
+                : ilMath::_mul($result, $result_unit->getFactor(), $this->getPrecision());
+        }
+
+        return $result;
     }
 
-    private function handleValueByResultType(string $value, assFormulaQuestionUnit $unit): mixed
+    private function transformResultAccordingToType(string $value, assFormulaQuestionUnit $unit): ?float
     {
-        $frac_value = '';
+        $frac_value = null;
         switch ($this->getResultType()) {
             case self::RESULT_DEC:
                 if (substr_count($value, '.') === 1 || substr_count($value, ',') === 1) {
@@ -520,7 +522,13 @@ class assFormulaQuestionResult
             default:
                 break;
         }
-        return ilMath::_mul($frac_value, $unit->getFactor(), 100);
+
+        /** @var ?float $float_value */
+        $float_value = $this->refinery->byTrying([
+            $this->refinery->kindlyTo()->float(),
+            $this->refinery->always(null),
+        ])->transform($frac_value !== null ? ilMath::_mul($frac_value, $unit->getFactor(), 100) : $value);
+        return $float_value;
     }
 
     public function getResultInfo($variables, $results, $value, $unit, $units): array

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionResult.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionResult.php
@@ -404,13 +404,9 @@ class assFormulaQuestionResult
             && $user_answer <= $upper_boundary;
     }
 
-    protected function checkSign($v1, $v2): bool
+    private function checkSign(float $v1, float $v2): bool
     {
-        if ((($v1 >= 0) && ($v2 >= 0)) || (($v1 <= 0) && ($v2 <= 0))) {
-            return true;
-        } else {
-            return false;
-        }
+        return ($v1 >= 0.0 && $v2 >= 0.0) || ($v1 <= 0.0 && $v2 <= 0.0);
     }
 
     /**
@@ -422,125 +418,109 @@ class assFormulaQuestionResult
         string $value,
         ?assFormulaQuestionUnit $unit,
         array $units
-    ) {
+    ): float {
         if ($this->getRatingSimple()) {
             return $this->isCorrect($variables, $results, $value, $unit) ? $this->getPoints() : 0;
-        } else {
-            $points = 0;
-            $formula = $this->substituteFormula($variables, $results);
-
-            if (preg_match_all("/(\\\$v\\d+)/ims", $formula, $matches)) {
-                foreach ($matches[1] as $variable) {
-                    $varObj = $variables[$variable];
-                    if (!is_object($varObj)) {
-                        continue;
-                    }
-                    if ($varObj->getUnit() != null) {
-                        //convert unit and value to baseunit
-                        if ($varObj->getUnit()->getBaseUnit() != -1) {
-                            $tmp_value = $varObj->getValue() * $varObj->getUnit()->getFactor();
-                        } else {
-                            $tmp_value = $varObj->getValue();
-                        }
-                    } else {
-                        $tmp_value = $varObj->getValue();
-                    }
-                    $formula = preg_replace("/\\\$" . substr($variable, 1) . "(?![0-9]+)/", "(" . $tmp_value . ")" . "\\1", $formula);
-                }
-            }
-
-            $math = new EvalMath();
-            $math->suppress_errors = true;
-            $result = $math->evaluate($formula);
-
-            // result_type extension
-            switch ($this->getResultType()) {
-                case assFormulaQuestionResult::RESULT_DEC:
-                    if ((substr_count($value, '.') == 1) || (substr_count($value, ',') == 1)) {
-                        $exp_val = $value;
-                        $frac_value = str_replace(',', '.', $exp_val);
-                    } else {
-                        $frac_value = $value;
-                    }
-                    $check_fraction = true;
-                    break;
-                case assFormulaQuestionResult::RESULT_FRAC:
-                    $exp_val = explode('/', $value);
-                    if (count($exp_val) == 1) {
-                        $frac_value = ilMath::_div($exp_val[0], 1, $this->getPrecision());
-                        if (ilMath::_equals(abs($frac_value), abs($result), $this->getPrecision())) {
-                            $check_fraction = true;
-                        } else {
-                            $check_fraction = false;
-                        }
-                    } else {
-                        $frac_value = ilMath::_div($exp_val[0], $exp_val[1], $this->getPrecision());
-                        if (ilMath::_equals(abs($frac_value), abs($result), $this->getPrecision())) {
-                            $check_fraction = true;
-                        }
-                    }
-                    break;
-                case assFormulaQuestionResult::RESULT_CO_FRAC:
-                    $exp_val = explode('/', $value);
-                    if (count($exp_val) == 1) {
-                        $check_fraction = false;
-                    } else {
-                        $frac_value = ilMath::_div($exp_val[0], $exp_val[1], $this->getPrecision());
-                        if (self::isCoprimeFraction($exp_val[0], $exp_val[1])) {
-                            $check_fraction = true;
-                        }
-                    }
-                    break;
-                case assFormulaQuestionResult::RESULT_NO_SELECTION:
-                default:
-                    $check_fraction = true;
-                    break;
-            }
-
-            // result unit!!
-            if ($this->getUnit() !== null) {
-                // if expected resultunit != baseunit convert to resultunit
-                if ($this->getUnit()->getBaseUnit() != -1) {
-                    $result = ilMath::_div($result, $this->getUnit()->getFactor(), $this->getPrecision());
-                } else {
-                    //if resultunit == baseunit calculate to get correct precision
-                    $result = ilMath::_mul($result, $this->getUnit()->getFactor(), $this->getPrecision());
-                }
-            }
-
-            if ($unit instanceof assFormulaQuestionUnit && isset($frac_value)) {
-                $value = ilMath::_mul($frac_value, $unit->getFactor(), 100);
-            }
-
-            /** @var ?float $value */
-            $value = $this->refinery->byTrying([
-                $this->refinery->kindlyTo()->float(),
-                $this->refinery->always(null),
-            ])->transform($value);
-
-            if ($this->checkSign($result, $value)) {
-                $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingSign(), 100));
-            }
-
-            if (is_numeric($value) && $this->isInTolerance(abs($value), abs($result), $this->getTolerance())) {
-                $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingValue(), 100));
-            }
-            if ($this->getUnit() !== null) {
-                $base1 = $unit;
-                if ($unit instanceof assFormulaQuestionUnit) {
-                    $base1 = $units[$unit->getBaseUnit()];
-                }
-                $base2 = $units[$this->getUnit()->getBaseUnit()];
-                if (
-                    $base1 instanceof assFormulaQuestionUnit
-                    && $base2 instanceof assFormulaQuestionUnit
-                    && $base1->getId() === $base2->getId()
-                ) {
-                    $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingUnit(), 100));
-                }
-            }
-            return $points;
         }
+
+        $result = $this->evaluateResultAsFormula($variables, $results);
+
+        if ($unit instanceof assFormulaQuestionUnit) {
+            $value = $this->handleValueByResultType($value, $unit);
+        }
+
+        $result_unit = $this->getUnit();
+        if ($result_unit instanceof assFormulaQuestionUnit) {
+            /** @var float $result */
+            $result = $result_unit->getBaseUnit() !== -1
+                ? ilMath::_div($result, $result_unit->getFactor(), $this->getPrecision())
+                : ilMath::_mul($result, $result_unit->getFactor(), $this->getPrecision());
+        }
+
+        /** @var ?float $value */
+        $float_value = $this->refinery->byTrying([
+            $this->refinery->kindlyTo()->float(),
+            $this->refinery->always(null),
+        ])->transform($value);
+        $points = 0.0;
+
+        if (is_float($float_value) && $this->checkSign($result, $float_value)) {
+            $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingSign(), 100));
+        }
+
+        if (is_float($float_value) && $this->isInTolerance(abs($float_value), abs($result), $this->getTolerance())) {
+            $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingValue(), 100));
+        }
+
+        if ($unit instanceof assFormulaQuestionUnit && $result_unit instanceof assFormulaQuestionUnit) {
+            $base1 = $units[$unit->getBaseUnit()] ?? null;
+            $base2 = $units[$result_unit->getBaseUnit()] ?? null;
+            if (
+                $base1 instanceof assFormulaQuestionUnit
+                && $base2 instanceof assFormulaQuestionUnit
+                && $base1->getId() === $base2->getId()
+            ) {
+                return $points + ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingUnit(), 100));
+            }
+        }
+
+        return $points;
+    }
+
+    private function evaluateResultAsFormula(array $variables, array $results): float
+    {
+        $formula = $this->substituteFormula($variables, $results);
+
+        if (preg_match_all("/(\\\$v\\d+)/im", $formula, $matches)) {
+            foreach ($matches[1] as $variable) {
+                $varObj = $variables[$variable];
+                if (!is_object($varObj)) {
+                    continue;
+                }
+
+                //convert unit and value to baseunit
+                $has_base_unit = $varObj->getUnit() !== null && $varObj->getUnit()->getBaseUnit() !== -1;
+                $tmp_value = $varObj->getValue() * ($has_base_unit ? $varObj->getUnit()->getFactor() : 1);
+                $formula = preg_replace("/\\\$" . substr($variable, 1) . "(?![0-9]+)/", "(" . $tmp_value . ")" . "\\1", $formula);
+            }
+        }
+
+        $eval_math = new EvalMath();
+        $eval_math->suppress_errors = true;
+        return $eval_math->evaluate($formula);
+    }
+
+    private function handleValueByResultType(string $value, assFormulaQuestionUnit $unit): mixed
+    {
+        $frac_value = '';
+        switch ($this->getResultType()) {
+            case self::RESULT_DEC:
+                if (substr_count($value, '.') === 1 || substr_count($value, ',') === 1) {
+                    $exp_val = $value;
+                    $frac_value = str_replace(',', '.', $exp_val);
+                } else {
+                    $frac_value = $value;
+                }
+                break;
+            case self::RESULT_FRAC:
+                $exp_val = explode('/', $value);
+                $frac_value = ilMath::_div(
+                    $exp_val[0],
+                    count($exp_val) === 1 ? 1 : $exp_val[1],
+                    $this->getPrecision()
+                );
+                break;
+            case self::RESULT_CO_FRAC:
+                $exp_val = explode('/', $value);
+                if (count($exp_val) > 1) {
+                    $frac_value = ilMath::_div($exp_val[0], $exp_val[1], $this->getPrecision());
+                }
+                break;
+            case self::RESULT_NO_SELECTION:
+            default:
+                break;
+        }
+        return ilMath::_mul($frac_value, $unit->getFactor(), 100);
     }
 
     public function getResultInfo($variables, $results, $value, $unit, $units): array

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionResult.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionResult.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Refinery\Factory as Refinery;
+
 /**
  * Formula Question Result
  * @author        Helmut Schottmüller <helmut.schottmueller@mac.com>
@@ -30,6 +32,7 @@ class assFormulaQuestionResult
     public const RESULT_CO_FRAC = 3;
 
     private \ilGlobalTemplateInterface $main_tpl;
+    private Refinery $refinery;
 
     private $available_units = [];
     private ?float $range_min = null;
@@ -52,6 +55,7 @@ class assFormulaQuestionResult
     ) {
         global $DIC;
         $this->main_tpl = $DIC->ui()->mainTemplate();
+        $this->refinery = $DIC->refinery();
         $this->setRangeMin($range_min_txt);
         $this->setRangeMax($range_max_txt);
 
@@ -409,16 +413,18 @@ class assFormulaQuestionResult
         }
     }
 
-    public function getReachedPoints($variables, $results, $value, $unit, $units)
-    {
-        global $DIC;
-        $ilLog = $DIC['ilLog'];
+    /**
+     * @param assFormulaQuestionUnit[] $units
+     */
+    public function getReachedPoints(
+        array $variables,
+        array $results,
+        string $value,
+        ?assFormulaQuestionUnit $unit,
+        array $units
+    ) {
         if ($this->getRatingSimple()) {
-            if ($this->isCorrect($variables, $results, $value, $units[$unit] ?? null)) {
-                return $this->getPoints();
-            } else {
-                return 0;
-            }
+            return $this->isCorrect($variables, $results, $value, $unit) ? $this->getPoints() : 0;
         } else {
             $points = 0;
             $formula = $this->substituteFormula($variables, $results);
@@ -502,26 +508,34 @@ class assFormulaQuestionResult
                 }
             }
 
-            if (is_object($unit)) {
-                if (isset($frac_value)) {
-                    $value = ilMath::_mul($frac_value, $unit->getFactor(), 100);
-                }
+            if ($unit instanceof assFormulaQuestionUnit && isset($frac_value)) {
+                $value = ilMath::_mul($frac_value, $unit->getFactor(), 100);
             }
+
+            /** @var ?float $value */
+            $value = $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->float(),
+                $this->refinery->always(null),
+            ])->transform($value);
 
             if ($this->checkSign($result, $value)) {
                 $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingSign(), 100));
             }
 
-            if ($this->isInTolerance(abs($value), abs($result), $this->getTolerance())) {
+            if (is_numeric($value) && $this->isInTolerance(abs($value), abs($result), $this->getTolerance())) {
                 $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingValue(), 100));
             }
             if ($this->getUnit() !== null) {
-                $base1 = $units[$unit] ?? null;
-                if (is_object($base1)) {
-                    $base1 = $units[$base1->getBaseUnit()];
+                $base1 = $unit;
+                if ($unit instanceof assFormulaQuestionUnit) {
+                    $base1 = $units[$unit->getBaseUnit()];
                 }
                 $base2 = $units[$this->getUnit()->getBaseUnit()];
-                if (is_object($base1) && is_object($base2) && $base1->getId() == $base2->getId()) {
+                if (
+                    $base1 instanceof assFormulaQuestionUnit
+                    && $base2 instanceof assFormulaQuestionUnit
+                    && $base1->getId() === $base2->getId()
+                ) {
                     $points += ilMath::_mul($this->getPoints(), ilMath::_div($this->getRatingUnit(), 100));
                 }
             }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeEvaluator.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeEvaluator.php
@@ -164,9 +164,10 @@ class ilAssLacCompositeEvaluator
                 $result = $solutions->getSolutionForKey($index);
                 $answer = $question->getAvailableAnswerOptions($index - 1);
 
+                $unit_repository = $question->getUnitrepository();
                 $unit = $solutions->getSolutionForKey($index . "_unit");
                 $key = isset($unit["value"])
-                    ? (new ilUnitConfigurationRepository(0))->getUnit((int) $unit["value"])
+                    ? $unit_repository->getUnit((int) $unit["value"])
                     : null;
 
                 $max_points = $answer->getPoints();
@@ -180,7 +181,7 @@ class ilAssLacCompositeEvaluator
                     $question->getResults(),
                     $result["value"] ?? "",
                     $key,
-                    $question->getUnitrepository()->getUnits()
+                    $unit_repository->getUnits()
                 );
 
                 $percentage = 0;

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeEvaluator.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeEvaluator.php
@@ -165,10 +165,9 @@ class ilAssLacCompositeEvaluator
                 $answer = $question->getAvailableAnswerOptions($index - 1);
 
                 $unit = $solutions->getSolutionForKey($index . "_unit");
-                $key = null;
-                if (is_array($unit)) {
-                    $key = $unit['value'];
-                }
+                $key = isset($unit["value"])
+                    ? (new ilUnitConfigurationRepository(0))->getUnit((int) $unit["value"])
+                    : null;
 
                 $max_points = $answer->getPoints();
                 // @PHP8-CR
@@ -176,7 +175,13 @@ class ilAssLacCompositeEvaluator
                 // to a later date and eventually task this to T&A TechSquad for analysis.
                 // Candidate:
                 //$points = $question->getReachedPoints($question->getVariables(), $question->getResults(), $result["value"], $key, $question->getUnitrepository()->getUnits());
-                $points = $answer->getReachedPoints($question->getVariables(), $question->getResults(), $result["value"], $key, $question->getUnitrepository()->getUnits());
+                $points = $answer->getReachedPoints(
+                    $question->getVariables(),
+                    $question->getResults(),
+                    $result["value"] ?? "",
+                    $key,
+                    $question->getUnitrepository()->getUnits()
+                );
 
                 $percentage = 0;
                 if ($max_points != 0) {

--- a/Modules/TestQuestionPool/test/assFormulaQuestionTest.php
+++ b/Modules/TestQuestionPool/test/assFormulaQuestionTest.php
@@ -16,6 +16,8 @@
  *
  *********************************************************************/
 
+use ILIAS\Refinery\Factory;
+
 /**
 * Unit tests
 *
@@ -77,7 +79,8 @@ class assFormulaQuestionTest extends assBaseTestCase
         $this->backup_dic = $DIC;
         $DIC = new ILIAS\DI\Container([
             'tpl' => $this->getMockBuilder(ilGlobalTemplateInterface::class)
-                          ->getMock()
+                          ->getMock(),
+            'refinery' => $this->getMockBuilder(Factory::class)->disableOriginalConstructor()->getMock(),
         ]);
         $points = 5;
         $precision = 2;


### PR DESCRIPTION
[Mantis: 44733](https://mantis.ilias.de/view.php?id=44733)

In some cases the values passed to the `assFormulaQuestionResult::getReachedPoints` method did have a incorrect (unusual) datatype. To resolve this issue, I tried to streamline the inputs to use more suitable datatypes.