### PR TITLE
T&A 44764: Fixes end datetime of availability period in test settings being rese…

### DIFF
--- a/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
+++ b/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
@@ -539,17 +539,23 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
 
     private function saveAvailabilitySettingsSection(array $section): void
     {
-        $time_based_availability = $section['timebased_availability'];
+        [
+            'is_activation_limited' => $is_activation_limited,
+            'activation_starting_time' => $activation_starting_time,
+            'activation_ending_time' => $activation_ending_time,
+            'activation_visibility' => $activation_visibility
+        ] = $section['timebased_availability'];
 
+        $participant_data_exists = $this->test_object->participantDataExist();
         $this->test_object->storeActivationSettings(
-            $this->test_object->participantDataExist()
+            $participant_data_exists
                 ? $this->test_object->isActivationLimited()
-                : $time_based_availability['is_activation_limited'],
-            $this->test_object->participantDataExist()
+                : $is_activation_limited,
+            $participant_data_exists
                 ? $this->test_object->getActivationStartingTime()
-                : $time_based_availability['activation_starting_time'],
-            $this->test_object->getActivationEndingTime(),
-            $this->test_object->getActivationVisibility(),
+                : $activation_starting_time,
+            $activation_ending_time,
+            $activation_visibility,
         );
         $this->test_object->getObjectProperties()->storePropertyIsOnline($section['is_online']);
     }

--- a/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
+++ b/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
@@ -539,23 +539,18 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
 
     private function saveAvailabilitySettingsSection(array $section): void
     {
-        [
-            'is_activation_limited' => $is_activation_limited,
-            'activation_starting_time' => $activation_starting_time,
-            'activation_ending_time' => $activation_ending_time,
-            'activation_visibility' => $activation_visibility
-        ] = $section['timebased_availability'];
+        $time_based_availability = $section['timebased_availability'];
 
         $participant_data_exists = $this->test_object->participantDataExist();
         $this->test_object->storeActivationSettings(
             $participant_data_exists
                 ? $this->test_object->isActivationLimited()
-                : $is_activation_limited,
+                : $time_based_availability['is_activation_limited'],
             $participant_data_exists
                 ? $this->test_object->getActivationStartingTime()
-                : $activation_starting_time,
-            $activation_ending_time,
-            $activation_visibility,
+                : $time_based_availability['activation_starting_time'],
+            $time_based_availability['activation_ending_time'],
+            $time_based_availability['activation_visibility']
         );
         $this->test_object->getObjectProperties()->storePropertyIsOnline($section['is_online']);
     }


### PR DESCRIPTION
[Mantis: 44764](https://mantis.ilias.de/view.php?id=44764)

The `activation_ending_time` setting in a test was always being overwritten with the date `01.01.1970` (timestamp 0). The error seems to be caused by never applying the data from the form.