### PR TITLE
BackgroundTasks Bugfix #0044856: Character Limit Bucket Descriptions

### DIFF
--- a/src/BackgroundTasks/Implementation/Bucket/BasicBucket.php
+++ b/src/BackgroundTasks/Implementation/Bucket/BasicBucket.php
@@ -205,7 +205,7 @@ class BasicBucket implements Bucket
 
     public function setDescription(string $description): void
     {
-        $this->description = $description;
+        $this->description = mb_substr($description, 0, 255);
     }
 
     /**


### PR DESCRIPTION
Fixes an Error when setting a description for Buckets longer than 255 chars.

Since there are no formal requirements specified for the description field, the consumer cannot know this constraint.
For example, changing the language variable for feedback via File in Exercises, creates a task with a description more than 255 chars, if language variable + exercise title are too long.
This approach ensures consistency for all components by explicitly truncating the input to 255 characters.

See https://mantis.ilias.de/view.php?id=44856