### PR TITLE
[FIX] respect upload policies in MediaObjects (and maybe other locations)

### DIFF
--- a/Services/Repository/Service/Form/class.FormAdapterGUI.php
+++ b/Services/Repository/Service/Form/class.FormAdapterGUI.php
@@ -450,8 +450,8 @@ class FormAdapterGUI
             $this->upload_handler[$key],
             $title,
             $description
-        )
-            ->withMaxFileSize((int) \ilFileUtils::getPhpUploadSizeLimitInBytes());
+        );
+
         if (!is_null($max_files)) {
             $field = $field->withMaxFiles($max_files);
         }


### PR DESCRIPTION
@alex40724 From my point of view, you can drop the explicit setting of the maximum size here, because the upload_limit_resolver already calculates this correctly. Furthermore, this would enable the upload policies (custom limits), especially in the MediaObjects, where they probably make a lot of sense.