### PR TITLE
9/object/fix icons

### DIFF
--- a/Modules/File/classes/ObjectProperties/FileObjectPropertyProviders.php
+++ b/Modules/File/classes/ObjectProperties/FileObjectPropertyProviders.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\Object\Properties\ObjectTypeSpecificProperties\ilObjectTypeSpecificPropertyProviders;
 use ILIAS\Object\Properties\CoreProperties\TileImage\ilObjectTileImageFlavourDefinition;
-use ILIAS\UI\Component\Symbol\Icon\Icon;
+use ILIAS\UI\Component\Symbol\Icon\Custom as CustomIcon;
 use ILIAS\UI\Component\Symbol\Icon\Factory as IconFactory;
 use ILIAS\UI\Component\Image\Image;
 use ILIAS\UI\Component\Image\Factory as ImageFactory;
@@ -28,18 +28,23 @@ use ILIAS\ResourceStorage\Services as StorageService;
 use ILIAS\ResourceStorage\Flavour\Flavour;
 use ILIAS\ResourceStorage\Flavour\Definition\FlavourDefinition;
 use ILIAS\Modules\File\Preview\Settings;
+use ILIAS\File\Icon\IconDatabaseRepository;
 
 class FileObjectPropertyProviders implements ilObjectTypeSpecificPropertyProviders
 {
     private FlavourDefinition $crop_definition;
     private FlavourDefinition $extract_definition;
     private Settings $settings;
+    private IconDatabaseRepository $icons;
+    private ilObjFileInfoRepository $info;
 
     public function __construct()
     {
         $this->crop_definition = new ilObjectTileImageFlavourDefinition();
         $this->extract_definition = new FirstPageToTileImageFlavourDefinition();
         $this->settings = new Settings();
+        $this->info = new ilObjFileInfoRepository();
+        $this->icons = new IconDatabaseRepository();
     }
 
     public function getObjectTypeSpecificTileImage(
@@ -101,11 +106,17 @@ class FileObjectPropertyProviders implements ilObjectTypeSpecificPropertyProvide
         )['image'];
     }
 
-    public function getObjectTypeSpecificCustomIcon(
+    public function getObjectTypeSpecificIcon(
         int $obj_id,
         IconFactory $icon_factory,
         StorageService $irss
-    ): ?Icon {
+    ): ?CustomIcon {
+        $info = $this->info->getByObjectId($obj_id);
+        $path = $this->icons->getIconFilePathBySuffix($info->getSuffix());
+        if (($path !== '' && $path !== '0')) {
+            return $icon_factory->custom($path, $info->getSuffix());
+        }
+
         return null;
     }
 }

--- a/Services/Object/classes/Properties/AdditionalProperties/Icon/ilObjectPropertyIcon.php
+++ b/Services/Object/classes/Properties/AdditionalProperties/Icon/ilObjectPropertyIcon.php
@@ -22,6 +22,9 @@ use ILIAS\Object\Properties\ObjectTypeSpecificProperties\ilObjectTypeSpecificPro
 use ILIAS\UI\Component\Input\Field\Factory as FieldFactory;
 use ILIAS\UI\Component\Input\Field\File;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\UI\Component\Symbol\Icon\Custom as CustomIcon;
+use ILIAS\UI\Component\Symbol\Icon\Factory as IconFactory;
+use ILIAS\ResourceStorage\Services as StorageService;
 use ILIAS\FileUpload\MimeType;
 
 /**
@@ -42,9 +45,20 @@ class ilObjectPropertyIcon implements ilObjectProperty
     ) {
     }
 
-    public function getIcon(): ?ilObjectCustomIcon
+    public function getObjectTypeSpecificItem(
+        int $object_id,
+        IconFactory $factory,
+        StorageService $irss
+    ): ?CustomIcon {
+        if ($this->object_type_specific_property_providers === null) {
+            return null;
+        }
+        return $this->object_type_specific_property_providers->getObjectTypeSpecificIcon($object_id, $factory, $irss);
+    }
+
+    public function getCustomIcon(): ?ilObjectCustomIcon
     {
-        return $this->custom_icon;
+        return $this->custom_icons_enabled ? $this->custom_icon : null;
     }
 
     public function getDeletedFlag(): bool

--- a/Services/Object/classes/Properties/AdditionalProperties/Icon/ilObjectPropertyIcon.php
+++ b/Services/Object/classes/Properties/AdditionalProperties/Icon/ilObjectPropertyIcon.php
@@ -45,7 +45,7 @@ class ilObjectPropertyIcon implements ilObjectProperty
     ) {
     }
 
-    public function getObjectTypeSpecificItem(
+    public function getObjectTypeSpecificIcon(
         int $object_id,
         IconFactory $factory,
         StorageService $irss

--- a/Services/Object/classes/Properties/AdditionalProperties/ilObjectAdditionalPropertiesLegacyRepository.php
+++ b/Services/Object/classes/Properties/AdditionalProperties/ilObjectAdditionalPropertiesLegacyRepository.php
@@ -159,11 +159,11 @@ class ilObjectAdditionalPropertiesLegacyRepository implements ilObjectAdditional
     private function storeIcon(ilObjectPropertyIcon $property_icon): void
     {
         if ($property_icon->getDeletedFlag()) {
-            $property_icon->getIcon()->remove();
+            $property_icon->getCustomIcon()->remove();
         }
 
         if ($property_icon->getTempFileName()) {
-            $property_icon->getIcon()->saveFromTempFileName($property_icon->getTempFileName());
+            $property_icon->getCustomIcon()->saveFromTempFileName($property_icon->getTempFileName());
         }
     }
 }

--- a/Services/Object/classes/Properties/AdditionalProperties/ilObjectAdditonalProperties.php
+++ b/Services/Object/classes/Properties/AdditionalProperties/ilObjectAdditonalProperties.php
@@ -96,7 +96,7 @@ class ilObjectAdditionalProperties
         return $clone;
     }
 
-    public function getPropertyIcon(): ilObjectProperty
+    public function getPropertyIcon(): ilObjectPropertyIcon
     {
         return $this->property_icon;
     }

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -19,7 +19,6 @@
 declare(strict_types=1);
 
 use ILIAS\Object\ilObjectDIC;
-use ILIAS\Object\Properties\ObjectReferenceProperties\ObjectReferenceProperties;
 
 /**
  * Class ilObject
@@ -1847,10 +1846,11 @@ class ilObject
         string $type = "",
         bool $offline = false
     ): string {
+        /** @var ILIAS\DI\Container $DIC */
         global $DIC;
-
-        $ilSetting = $DIC->settings();
-        $objDefinition = $DIC["objDefinition"];
+        $objDefinition = $DIC['objDefinition'];
+        $icon_factory = $DIC['ui.factory']->symbol()->icon();
+        $irss = $DIC['resource_storage'];
 
         if ($obj_id == "" && $type == "") {
             return "";
@@ -1864,16 +1864,19 @@ class ilObject
             $size = "big";
         }
 
-        if ($obj_id && $ilSetting->get('custom_icons')) {
-            $customIconFactory = $DIC['object.customicons.factory'];
-            $customIcon = $customIconFactory->getPresenterByObjId($obj_id, $type);
-            if ($customIcon->exists()) {
-                $filename = $customIcon->getFullPath();
-                return $filename . '?tmp=' . filemtime($filename);
-            }
-        }
-
         if ($obj_id) {
+            /** @var ilObjectPropertyIcon $property_icon */
+            $property_icon = ilObjectDIC::dic()['additional_properties_repository']->getFor($obj_id)->getPropertyIcon();
+            $custom_icon = $property_icon->getCustomIcon();
+            if ($custom_icon?->exists()) {
+                return $custom_icon->getFullPath() . '?tmp=' . filemtime($custom_icon->getFullPath());
+            }
+
+            $file_type_specific_icon = $property_icon->getObjectTypeSpecificItem($obj_id, $icon_factory, $irss);
+            if ($file_type_specific_icon !== null) {
+                return $file_type_specific_icon->getIconPath();
+            }
+
             $dtpl_icon_factory = ilDidacticTemplateIconFactory::getInstance();
             if ($ref_id) {
                 $path = $dtpl_icon_factory->getIconPathForReference($ref_id);

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -1872,7 +1872,7 @@ class ilObject
                 return $custom_icon->getFullPath() . '?tmp=' . filemtime($custom_icon->getFullPath());
             }
 
-            $file_type_specific_icon = $property_icon->getObjectTypeSpecificItem($obj_id, $icon_factory, $irss);
+            $file_type_specific_icon = $property_icon->getObjectTypeSpecificIcon($obj_id, $icon_factory, $irss);
             if ($file_type_specific_icon !== null) {
                 return $file_type_specific_icon->getIconPath();
             }

--- a/Services/Object/classes/class.ilObjectListGUI.php
+++ b/Services/Object/classes/class.ilObjectListGUI.php
@@ -2698,14 +2698,7 @@ class ilObjectListGUI
             }
 
             $this->tpl->setCurrentBlock('icon');
-            if (!$this->obj_definition->isPlugin($this->getIconImageType())) {
-                $this->tpl->setVariable('ALT_ICON', $this->lng->txt('obj_' . $this->getIconImageType()));
-            } else {
-                $this->tpl->setVariable(
-                    'ALT_ICON',
-                    ilObjectPlugin::lookupTxtById($this->getIconImageType(), 'obj_' . $this->getIconImageType())
-                );
-            }
+            $this->tpl->setVariable('ALT_ICON', $this->buildTranslatedType());
 
             $this->tpl->setVariable(
                 'SRC_ICON',
@@ -3153,13 +3146,6 @@ class ilObjectListGUI
 
         $def_command = $this->getDefaultCommand();
 
-        $icon = $this->ui->factory()
-            ->symbol()
-            ->icon()
-            ->custom(ilObject::_getIcon($obj_id), $this->lng->txt('icon') . ' ' . $this->lng->txt('obj_' . $type))
-            ->withSize('medium');
-
-
         if ($def_command['link'] ?? false) {
             list($def_command['link'], $def_command['frame']) =
                 $this->modifySAHSlaunch($def_command['link'], $def_command['frame']);
@@ -3176,7 +3162,13 @@ class ilObjectListGUI
         if ($description != '') {
             $list_item = $list_item->withDescription($description);
         }
-        $list_item = $list_item->withActions($dropdown)->withLeadIcon($icon);
+        $list_item = $list_item->withActions($dropdown)->withLeadIcon(
+            $this->ui->factory()->symbol()->icon()->custom(
+                $this->getTypeIcon(),
+                $this->buildTranslatedType(),
+                'medium'
+            )
+        );
 
 
         $l = [];
@@ -3209,7 +3201,7 @@ class ilObjectListGUI
     ): ?RepositoryObject {
         $ui = $this->ui;
 
-         $title = htmlspecialchars(addslashes($title));
+        $title = htmlspecialchars(addslashes($title));
         // even b tag produced bugs, see #32304
         $description = strip_tags($description);
 
@@ -3272,8 +3264,6 @@ class ilObjectListGUI
 
         $image = $this->getTileImage();
 
-
-
         if ($def_cmd_link != '') {    // #24256
             if ($def_cmd_frame !== '' && ($modified_link === $def_cmd_link)) {
                 $signal = (new SignalGenerator())->create();
@@ -3309,27 +3299,11 @@ class ilObjectListGUI
             ) . $title;
         }
 
-        $icon = $this->ui
-            ->factory()
-            ->symbol()
-            ->icon()
-            ->standard($type, $this->lng->txt('obj_' . $type))
-        ;
-
-
-
-        if ($this->obj_definition->isActivePluginType($type)) {
-            $class_name = 'il' . $this->obj_definition->getClassName($type) . 'Plugin';
-            if ($class_name !== 'ilPlugin'
-            && method_exists($class_name, '_getIcon')) {
-                $pl = ilObjectPlugin::getPluginObjectByType($type);
-                $icon = $this->ui
-                    ->factory()
-                    ->symbol()
-                    ->icon()
-                    ->custom(call_user_func([$class_name, '_getIcon'], $type, 'small', $obj_id), $pl->txt('obj_' . $type));
-            }
-        }
+        $icon = $this->ui->factory()->symbol()->icon()->custom(
+            $this->getTypeIcon(),
+            $this->buildTranslatedType(),
+            'medium'
+        );
 
         // card title action
         $card_title_action = '';
@@ -3509,5 +3483,14 @@ class ilObjectListGUI
                 $this->lng->txt('listaction_learning_progress_settings')
             );
         }
+    }
+
+    private function buildTranslatedType(): string
+    {
+        if ($this->obj_definition->isPlugin($this->getIconImageType())) {
+            return ilObjectPlugin::lookupTxtById($this->getIconImageType(), 'obj_' . $this->getIconImageType());
+        }
+
+        return $this->lng->txt('obj_' . $this->getIconImageType());
     }
 }

--- a/Services/Object/interfaces/Properties/ObjectTypeSpecificProperties/ilObjectTypeSpecificPropertyProviders.php
+++ b/Services/Object/interfaces/Properties/ObjectTypeSpecificProperties/ilObjectTypeSpecificPropertyProviders.php
@@ -20,7 +20,7 @@ namespace ILIAS\Object\Properties\ObjectTypeSpecificProperties;
 
 use ILIAS\UI\Component\Image\Image;
 use ILIAS\UI\Component\Image\Factory as ImageFactory;
-use ILIAS\UI\Component\Symbol\Icon\Icon;
+use ILIAS\UI\Component\Symbol\Icon\Custom as CustomIcon;
 use ILIAS\UI\Component\Symbol\Icon\Factory as IconFactory;
 use ILIAS\ResourceStorage\Services as StorageService;
 
@@ -36,9 +36,9 @@ interface ilObjectTypeSpecificPropertyProviders
         ImageFactory $factory,
         StorageService $irss
     ): ?Image;
-    public function getObjectTypeSpecificCustomIcon(
+    public function getObjectTypeSpecificIcon(
         int $object_id,
         IconFactory $factory,
         StorageService $irss
-    ): ?Icon;
+    ): ?CustomIcon;
 }


### PR DESCRIPTION
Hi @chfsx 

As discussed this is the backport of the fix for object specific types back to ILIAS 9. Changes in Object are clearly fine with me. Feel free to merge, no picking needed.

See: https://mantis.ilias.de/view.php?id=42146

Best,
@kergomard 