### PR TITLE
fixed 44739: When exercises are deleted, submissions from deleted use…

### DIFF
--- a/Modules/Exercise/Service/classes/class.InternalDomainService.php
+++ b/Modules/Exercise/Service/classes/class.InternalDomainService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\Exercise;
 

--- a/Modules/Exercise/Service/classes/class.InternalDomainService.php
+++ b/Modules/Exercise/Service/classes/class.InternalDomainService.php
@@ -28,6 +28,7 @@ use ILIAS\Refinery\Logical\Not;
 use ILIAS\Exercise\InstructionFile\InstructionFileManager;
 use ILIAS\Exercise\Team\TeamManager;
 use ILIAS\Exercise\IndividualDeadline\IndividualDeadlineManager;
+use ILIAS\Exercise\User\UserEvent;
 
 class InternalDomainService
 {
@@ -105,4 +106,13 @@ class InternalDomainService
             $obj_id
         );
     }
+
+    public function userEvent(): UserEvent
+    {
+        return new UserEvent(
+            $this->repo,
+            $this
+        );
+    }
+
 }

--- a/Modules/Exercise/User/UserEvent.php
+++ b/Modules/Exercise/User/UserEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Exercise\User;
+
+class UserEvent
+{
+    public function __construct(
+        protected \ILIAS\Exercise\InternalRepoService $repo,
+        protected \ILIAS\Exercise\InternalDomainService $domain
+    ) {
+    }
+
+    public function handleDeletion(int $user_id): void
+    {
+        global $DIC;
+
+        // get all exercises the user has submitted to
+        // todo move to repo layer
+        $db = $DIC->database();
+        $set = $db->queryF(
+            "SELECT DISTINCT obj_id FROM exc_returned " .
+            " WHERE user_id = %s ",
+            ["integer"],
+            [$user_id]
+        );
+        // remove all user submissions from these exercises
+        while ($rec = $db->fetchAssoc($set)) {
+            $exc_id = (int) $rec['obj_id'];
+            \ilExSubmission::deleteUser($exc_id, $user_id);
+        }
+    }
+}

--- a/Modules/Exercise/classes/class.ilExerciseAppEventListener.php
+++ b/Modules/Exercise/classes/class.ilExerciseAppEventListener.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilExerciseAppEventListener
+{
+    public static function handleEvent(
+        string $a_component,
+        string $a_event,
+        array $a_parameter
+    ): void {
+        global $DIC;
+
+        switch ($a_component) {
+            case "Services/User":
+                switch ($a_event) {
+                    case "beforeUserDeletion":
+                        $DIC->exercise()->internal()->domain()->userEvent()->handleDeletion((int) $a_parameter["usr_id"]);
+                        break;
+                }
+                break;
+        }
+    }
+}

--- a/Modules/Exercise/classes/class.ilExerciseAppEventListener.php
+++ b/Modules/Exercise/classes/class.ilExerciseAppEventListener.php
@@ -30,7 +30,7 @@ class ilExerciseAppEventListener
         switch ($a_component) {
             case "Services/User":
                 switch ($a_event) {
-                    case "beforeUserDeletion":
+                    case "deleteUser":
                         $DIC->exercise()->internal()->domain()->userEvent()->handleDeletion((int) $a_parameter["usr_id"]);
                         break;
                 }

--- a/Modules/Exercise/module.xml
+++ b/Modules/Exercise/module.xml
@@ -38,7 +38,8 @@
 		<event type="raise" id="createAssignment" />
 		<event type="raise" id="updateAssignment" />
 		<event type="raise" id="deleteAssignment" />		
-		<event type="raise" id="delete" />		
+		<event type="raise" id="delete" />
+		<event type="listen" id="Services/User" />
 	</events>
 	<web_access_checker>
 		<secure_path path="ilExercise" checking-class="ilObjExerciseAccess" />

--- a/Services/User/classes/class.ilObjUser.php
+++ b/Services/User/classes/class.ilObjUser.php
@@ -1097,6 +1097,14 @@ class ilObjUser extends ilObject
         $rbacadmin = $DIC->rbac()->admin();
         $ilDB = $this->db;
 
+        $ilAppEventHandler = $DIC['ilAppEventHandler'];
+        $ilAppEventHandler->raise(
+            'Services/User',
+            'beforeUserDeletion',
+            ['usr_id' => $this->getId()]
+        );
+
+
         // deassign from ldap groups
         $mapping = ilLDAPRoleGroupMapping::_getInstance();
         $mapping->deleteUser($this->getId());

--- a/Services/User/classes/class.ilObjUser.php
+++ b/Services/User/classes/class.ilObjUser.php
@@ -1100,10 +1100,9 @@ class ilObjUser extends ilObject
         $ilAppEventHandler = $DIC['ilAppEventHandler'];
         $ilAppEventHandler->raise(
             'Services/User',
-            'beforeUserDeletion',
+            'deleteUser',
             ['usr_id' => $this->getId()]
         );
-
 
         // deassign from ldap groups
         $mapping = ilLDAPRoleGroupMapping::_getInstance();
@@ -1189,16 +1188,6 @@ class ilObjUser extends ilObject
 
         // Reset owner
         $this->resetOwner();
-
-        // Trigger deleteUser Event
-        global $DIC;
-
-        $ilAppEventHandler = $DIC['ilAppEventHandler'];
-        $ilAppEventHandler->raise(
-            'Services/User',
-            'deleteUser',
-            ['usr_id' => $this->getId()]
-        );
 
         // delete object data
         parent::delete();

--- a/Services/User/service.xml
+++ b/Services/User/service.xml
@@ -16,7 +16,6 @@
 	</objects>
 	<events>		
 		<event type="raise" id="afterUpdate" />
-		<event type="raise" id="beforeUserDeletion" />
 		<event type="raise" id="deleteUser" />
 		<event type="raise" id="afterCreate" />
 		<event type="raise" id="onUserFieldAttributesChanged" />

--- a/Services/User/service.xml
+++ b/Services/User/service.xml
@@ -16,6 +16,7 @@
 	</objects>
 	<events>		
 		<event type="raise" id="afterUpdate" />
+		<event type="raise" id="beforeUserDeletion" />
 		<event type="raise" id="deleteUser" />
 		<event type="raise" id="afterCreate" />
 		<event type="raise" id="onUserFieldAttributesChanged" />


### PR DESCRIPTION
…rs are not deleted

The bug adresses the deletion of user related data in exercises when a user is being deleted.

There are two options:
a) adding more method calls to ilObjUser->delete (pretty sure we do not want that).
b) using events.

There is already a deleteUser event in place in the user service. However this event is called when most of the user data is already deleted. It is not possible to create instances of ilObjUser with the correspoding IDs at this time anymore.

This makes it impossible to re-use and domain level logic that relies on these instances. It makes it also impossible to create foreign key constraints to usr_data imo. (I did not try that)

Manytimes you want to delete data in dependent components, before the user "object" is finally deleted.

Thus this PR suggests to add a new event "beforeUserDeletion".