### PR TITLE
T&A 44781: Fallback to first page and reset offset and range if out of bounds after filter. (Backport)

### DIFF
--- a/src/UI/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/src/UI/Implementation/Component/Input/ViewControl/Renderer.php
@@ -258,6 +258,7 @@ class Renderer extends AbstractComponentRenderer
 
         list(Pagination::FNAME_OFFSET => $offset, Pagination::FNAME_LIMIT => $limit) = array_map('intval', $component->getValue());
         $limit = $limit > 0 ? $limit : reset($limit_options);
+        $offset = $offset > $total_count ? 0 : $offset;
 
         if (! $total_count) {
             $input = $ui_factory->input()->field()->numeric('offset')->withValue($offset);

--- a/src/UI/Implementation/Component/Table/Data.php
+++ b/src/UI/Implementation/Component/Table/Data.php
@@ -404,7 +404,13 @@ class Data extends Table implements T\Data, JSBindable
             # This retrieves container data from the request
             $data = $this->applyValuesToViewcontrols($view_controls, $request)->getData();
             $range = $data[self::VIEWCONTROL_KEY_PAGINATION];
-            $range = ($range instanceof Range) ? $range->croppedTo($total_count ?? PHP_INT_MAX) : null;
+            $range = $range instanceof Range ? $range : null;
+            if ($range instanceof Range) {
+                $range = $range
+                    ->withStart($range->getStart() <= $total_count ? $range->getStart() : 0)
+                    ->croppedTo($total_count ?? PHP_INT_MAX);
+            }
+
             $table = $table
                 ->withRange($range)
                 ->withOrder($data[self::VIEWCONTROL_KEY_ORDERING] ?? null)


### PR DESCRIPTION
[Mantis: 44781](https://mantis.ilias.de/view.php?id=44781)

This error was already reported to ILIAS 10 and fixed by @thojou in https://github.com/ILIAS-eLearning/ILIAS/pull/8829.
I just ported the changes to ILIAS 9.