### PR TITLE
[FIX] 0037444: Drop zones can be activated with subtabs, container ttles and others

### DIFF
--- a/src/UI/templates/js/Dropzone/File/dropzone.js
+++ b/src/UI/templates/js/Dropzone/File/dropzone.js
@@ -1,4 +1,19 @@
 /**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************
+ *
  * this script is responsible for the dropzone highlighting and
  * file processing.
  *
@@ -111,6 +126,21 @@ il.UI = il.UI || {};
             }
         }
 
+        let hasEventFiles = function (event) {
+            // check if "Files" is in the event.originalEvent.dataTransfer.types
+            if (event.originalEvent.dataTransfer.types.length === 0) {
+                return false;
+            }
+            let is_file = false;
+            for (let i = 0; i < event.originalEvent.dataTransfer.types.length; i++) {
+                if (event.originalEvent.dataTransfer.types[i] === 'Files') {
+                    is_file = true;
+                    break;
+                }
+            }
+            return is_file;
+        }
+
         let removeAllFilesFromQueue = function (dropzone_id) {
             if (typeof dropzones[dropzone_id] === 'undefined') {
                 console.error(`Error: tried accessing unknown dropzone '${dropzone_id}'.`);
@@ -123,6 +153,9 @@ il.UI = il.UI || {};
          * @param {Event} event
          */
         let highlightCurrentDropzoneHook = function (event) {
+            if(!hasEventFiles(event)) {
+                return;
+            }
             event.preventDefault();
             let current_dropzone = $(event.currentTarget);
             current_dropzone.addClass(CSS.highlight_current);
@@ -140,6 +173,10 @@ il.UI = il.UI || {};
          * @param {Event} event
          */
         let highlightPossibleDropzones = function (event) {
+            if(!hasEventFiles(event)) {
+                return;
+            }
+
             disableDefaultEventBehaviour(event);
             drag_enter_counter++;
 


### PR DESCRIPTION
This fixes Issue https://mantis.ilias.de/view.php?id=37444.

The dropzones react to anything that can be “dragged around”, for example, selected text, icons, etc. The PR adjusts the dropzones so that they only react to files that are dragged onto the browser.