### PR TITLE
[FIX] Notes: replace legacy `setCloseSignal()` usages.

### DIFF
--- a/components/ILIAS/Notes/Service/class.InternalGUIService.php
+++ b/components/ILIAS/Notes/Service/class.InternalGUIService.php
@@ -84,7 +84,7 @@ class InternalGUIService
         $tpl->addOnLoadCode("ilNotes.setAjaxUrl('" . $ajax_url . "');");
         $tpl->addOnLoadCode('ilNotes.setModalTemplate("' . addslashes(json_encode($modal_template["template"])) . '");');
         $tpl->addOnLoadCode("ilNotes.setShowSignal('" . $modal_template["show"] . "');");
-        $tpl->addOnLoadCode("ilNotes.setCloseSignal('" . $modal_template["close"] . "');");
+        $tpl->addOnLoadCode("ilNotes.setHideSignal('" . $modal_template["close"] . "');");
     }
 
     public function getModalTemplate(): array

--- a/components/ILIAS/Tagging/classes/class.ilTaggingGUI.php
+++ b/components/ILIAS/Tagging/classes/class.ilTaggingGUI.php
@@ -284,7 +284,7 @@ class ilTaggingGUI
         $tpl->addOnLoadCode("ilTagging.setAjaxUrl('" . $a_ajax_url . "');");
         $tpl->addOnLoadCode('ilTagging.setModalTemplate("' . addslashes(json_encode($modal_template["template"])) . '");');
         $tpl->addOnLoadCode("ilTagging.setShowSignal('" . $modal_template["show"] . "');");
-        $tpl->addOnLoadCode("ilTagging.setCloseSignal('" . $modal_template["close"] . "');");
+        $tpl->addOnLoadCode("ilTagging.setHideSignal('" . $modal_template["close"] . "');");
     }
 
     public static function getModalTemplate(): array


### PR DESCRIPTION
Hi @alex40724, could you have a look? Should be a trivial fix - some remnants of the old function. Thx!
Must be picked for `trunk` as well.