### PR TITLE
[FIX] Style: remove `GeSHi` usage and syntax-highlighting.

### DIFF
--- a/components/ILIAS/Style/System/classes/Documentation/class.ilKSDocumentationEntryGUI.php
+++ b/components/ILIAS/Style/System/classes/Documentation/class.ilKSDocumentationEntryGUI.php
@@ -117,9 +117,7 @@ class ilKSDocumentationEntryGUI
                 }
                 $content_part_1 = $this->f->legacy()->content($example);
                 $code = str_replace('<?php\n', '', file_get_contents($path));
-                $geshi = new GeSHi($code, 'php');
-                //@Todo: we need a code container UI Component
-                $code_html = "<div class='code-container'>" . $geshi->parse_code() . '</div>';
+                $code_html = "<div class='code-container'><pre><code>" . htmlspecialchars($code) . '</code></pre></div>';
                 $content_part_2 = $this->f->legacy()->content($code_html);
                 $content = [$content_part_1, $content_part_2];
                 $sub_panels[] = $this->f->panel()->sub($title, $content);


### PR DESCRIPTION
Hi @Amstutz,

When proposing the `geshi/geshi` composer package I noticed it was EOL. The code also may not be PHP 8.4 compatible - or at least their website is not working because of it anymore :). This PR simply removes this usage and therefore syntax-highlighting from the Kitchensink Docu.

Unfortunately, there is no alternative exactly like `geshi/geshi`. They all require to load additional assets (js/css) in order to work, thus adding unneeded/unwanted complexity. Let me know how you feel about having no syntax-highlighting in the browser anymore.

Kind regards,
@thibsy 