### PR TITLE
Export: Fixes in migration of export files to IRSS, ...

### DIFF
--- a/components/ILIAS/Export/Export.php
+++ b/components/ILIAS/Export/Export.php
@@ -20,11 +20,10 @@ declare(strict_types=1);
 
 namespace ILIAS;
 
-use ILIAS\MetaData\Elements\Set;
-use ILIAS\Setup\Agent as SetupAgent;
-use ILIAS\Refinery\Factory as RefineryFactory;
-use ILIAS\Export\Setup\Agent as ilExportSetupAgent;
+use ilExportSetupAgent;
 use ILIAS\Export\HTML;
+use ILIAS\Refinery\Factory as RefineryFactory;
+use ILIAS\Setup\Agent as SetupAgent;
 
 class Export implements Component\Component
 {

--- a/components/ILIAS/Export/classes/Setup/ilExportFilesToIRSSMigration.php
+++ b/components/ILIAS/Export/classes/Setup/ilExportFilesToIRSSMigration.php
@@ -18,23 +18,11 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\Export\Setup;
-
-use ilDatabaseInitializedObjective;
-use ilDatabaseUpdatedObjective;
-use ilDBConstants;
-use ilDBInterface;
-use ilFileUtils;
-use ILIAS\Setup\Migration;
-use ILIAS\Setup\Environment;
-use ILIAS\Filesystem\Stream\Streams;
 use ILIAS\Export\ExportHandler\Repository\Stakeholder\Handler as ResourceStakeholder;
-use ilIniFilesLoadedObjective;
-use ilObject;
-use ilResourceStorageMigrationHelper;
-use InvalidArgumentException;
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Migration;
 
-class FilesToIRSSMigration implements Migration
+class ilExportFilesToIRSSMigration implements Migration
 {
     protected ilDBInterface $db;
 
@@ -72,13 +60,19 @@ class FilesToIRSSMigration implements Migration
         );
         $row_export_file_info = $res_export_file_info->fetchAssoc();
         if (is_null($row_export_file_info)) {
+            dump("return");
             return;
         }
+        $obj_id = (int) $row_export_file_info['obj_id'];
+        $export_type = $row_export_file_info['export_type'];
+        $filename = $row_export_file_info['filename'];
         $res_object_data = $this->db->query(
             "SELECT type FROM object_data WHERE obj_id = " . $this->db->quote((int) $row_export_file_info['obj_id'], ilDBConstants::T_INTEGER)
         );
         $row_object_data = $res_object_data->fetchAssoc();
+        # Export does not exist anymore, mark as migrated
         if (is_null($row_object_data)) {
+            $this->updateMigrated($obj_id, $export_type, $filename);
             return;
         }
         $res_il_object_def = $this->db->query(
@@ -94,9 +88,6 @@ class FilesToIRSSMigration implements Migration
             $plugin_ids[] = $row_il_plugin['plugin_id'];
         }
         $classname = $row_il_object_def['class_name'];
-        $obj_id = (int) $row_export_file_info['obj_id'];
-        $export_type = $row_export_file_info['export_type'];
-        $filename = $row_export_file_info['filename'];
         $create_date = $row_export_file_info['create_date'];
         $type = $row_object_data['type'];
         $component_for_type = $row_il_object_def['component'];
@@ -112,6 +103,11 @@ class FilesToIRSSMigration implements Migration
             $type
         );
         $file_path = $export_dir . DIRECTORY_SEPARATOR . $filename;
+        # Export file was deleted, mark as migrated
+        if (!file_exists($file_path)) {
+            $this->updateMigrated($obj_id, $export_type, $filename);
+            return;
+        }
         $irss_helper = new ilResourceStorageMigrationHelper(new ResourceStakeholder(), $environment);
         $rid = $irss_helper->movePathToStorage($file_path, 6, null, null, false);
         if (is_null($rid)) {
@@ -124,12 +120,8 @@ class FilesToIRSSMigration implements Migration
             . $this->db->quote(6, ilDBConstants::T_INTEGER) . ", "
             . $this->db->quote($create_date, ilDBConstants::T_DATE) . ")"
         );
-        $this->db->manipulate(
-            "UPDATE export_file_info SET migrated = 1 WHERE"
-            . " obj_id = " . $this->db->quote($obj_id, ilDBConstants::T_INTEGER)
-            . " AND export_type = " . $this->db->quote($export_type, ilDBConstants::T_TEXT)
-            . " AND filename = " . $this->db->quote($filename, ilDBConstants::T_TEXT)
-        );
+        # Export file was moved to irss, mark as migrated
+        $this->updateMigrated($obj_id, $export_type, $filename);
     }
 
     public function getRemainingAmountOfSteps(): int
@@ -141,6 +133,19 @@ class FilesToIRSSMigration implements Migration
             return 0;
         }
         return (int) $row['count'];
+    }
+
+    protected function updateMigrated(
+        int $obj_id,
+        string $export_type,
+        string $filename
+    ): void {
+        $this->db->manipulate(
+            "UPDATE export_file_info SET migrated = 1 WHERE"
+            . " obj_id = " . $this->db->quote($obj_id, ilDBConstants::T_INTEGER)
+            . " AND export_type = " . $this->db->quote($export_type, ilDBConstants::T_TEXT)
+            . " AND filename = " . $this->db->quote($filename, ilDBConstants::T_TEXT)
+        );
     }
 
     protected function getExportDirectory(

--- a/components/ILIAS/Export/classes/Setup/ilExportFilesToIRSSMigration.php
+++ b/components/ILIAS/Export/classes/Setup/ilExportFilesToIRSSMigration.php
@@ -60,7 +60,6 @@ class ilExportFilesToIRSSMigration implements Migration
         );
         $row_export_file_info = $res_export_file_info->fetchAssoc();
         if (is_null($row_export_file_info)) {
-            dump("return");
             return;
         }
         $obj_id = (int) $row_export_file_info['obj_id'];

--- a/components/ILIAS/Export/classes/Setup/ilExportSetupAgent.php
+++ b/components/ILIAS/Export/classes/Setup/ilExportSetupAgent.php
@@ -18,20 +18,15 @@
 
 declare(strict_types=1);
 
-namespace ILIAS\Export\Setup;
-
-use ilDatabaseUpdateStepsExecutedObjective;
-use ilDatabaseUpdateStepsMetricsCollectedObjective;
+use ILIAS\Export\Setup\BuildExportOptionsMapObjective as ilExportSetupBuildOptionsMapObjective;
+use ILIAS\Export\Setup\DBUpdateSteps10 as ilExportSetupDBUpdateSteps10;
 use ILIAS\Setup\Agent\NullAgent;
-use ILIAS\Setup\ObjectiveCollection;
-use ILIAS\Setup\Objective;
 use ILIAS\Setup\Config;
 use ILIAS\Setup\Metrics\Storage;
-use ILIAS\Export\Setup\DBUpdateSteps10 as ilExportSetupDBUpdateSteps10;
-use ILIAS\Export\Setup\FilesToIRSSMigration as ilExportSetupFilesToIRSSMigration;
-use ILIAS\Export\Setup\BuildExportOptionsMapObjective as ilExportSetupBuildOptionsMapObjective;
+use ILIAS\Setup\Objective;
+use ILIAS\Setup\ObjectiveCollection;
 
-class Agent extends NullAgent
+class ilExportSetupAgent extends NullAgent
 {
     public function getUpdateObjective(Config $config = null): Objective
     {
@@ -53,7 +48,7 @@ class Agent extends NullAgent
 
     public function getMigrations(): array
     {
-        return [new ilExportSetupFilesToIRSSMigration()];
+        return [new ilExportFilesToIRSSMigration()];
     }
 
     public function getBuildObjective(): Objective


### PR DESCRIPTION
mark export file info table entry as migrated if the corresponding export files no longer exists. Also remove namespaces from the setup agent and the migration, otherwise executing the migration leads to an error.

LINK: https://mantis.ilias.de/view.php?id=44427