### PR TITLE
T&A 44808: Fixes type mismatch when creating a test object inside a question

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -701,11 +701,8 @@ abstract class assQuestion
         }
 
         // update test pass results
-        $test = new ilObjTest(
-            $this->getObjId(),
-            false
-        );
-        $test->updateTestPassResults($active_id, $pass, $obligationsEnabled, $this->getProcessLocker());
+        (new ilObjTest(ilObjTest::_lookupTestObjIdForQuestionId($this->getId()), false))
+            ->updateTestPassResults($active_id, $pass, $obligationsEnabled, $this->getProcessLocker());
         ilCourseObjectiveResult::_updateObjectiveResult($this->current_user->getId(), $active_id, $this->getId());
     }
 


### PR DESCRIPTION
[Mantis: 44808](https://mantis.ilias.de/view.php?id=44808)

The issue seems to be that the wrong identifier is used. In the specific case mentioned in the Mantis issue, it was a `QuestionPool` that had the certain identifier but I believe it could have been any other object as well. By strictly using a `Test` identifier we should not have the problem.