### PR TITLE
#44852 Log missing language module without halting the import process

### DIFF
--- a/Services/Language/classes/class.ilObjLanguageExt.php
+++ b/Services/Language/classes/class.ilObjLanguageExt.php
@@ -459,6 +459,10 @@ class ilObjLanguageExt extends ilObjLanguage
                 $ilDB->quote($module, "text")
             ));
             $row = $ilDB->fetchAssoc($set);
+            if (!$row) {
+                $DIC->logger()->lang()->warning("Language module '{$module}' not found for language {$a_lang_key}.");
+                continue;
+            }
 
             $arr = unserialize($row["lang_array"], ["allowed_classes" => false]);
             if (is_array($arr)) {

--- a/Services/Language/classes/class.ilObjLanguageExt.php
+++ b/Services/Language/classes/class.ilObjLanguageExt.php
@@ -460,7 +460,7 @@ class ilObjLanguageExt extends ilObjLanguage
             ));
             $row = $ilDB->fetchAssoc($set);
             if (!$row) {
-                $DIC->logger()->lang()->warning("Language module '{$module}' not found for language {$a_lang_key}.");
+                $DIC->logger()->root()->warning("Language module '{$module}' not found for language {$a_lang_key}.");
                 continue;
             }
 


### PR DESCRIPTION
If I export the global language file from an ILIAS installation with some plugins, and I try to import it on another ILIAS that misses one of those plugins, I get the error message "Trying to access array offset on value of type null" with no logs anywhere else.
With this PR those modules (plugins) will be skipped from the import process, adding the information in the ILIAS log file.