### PR TITLE
Glossary: add migration to delete LOM remnants of definitions

### DIFF
--- a/components/ILIAS/Glossary/ROADMAP.md
+++ b/components/ILIAS/Glossary/ROADMAP.md
@@ -2,14 +2,6 @@
 
 ## Short Term
 
-### Get rid of obsolete metadata entries
-
-See FR: https://docu.ilias.de/goto_docu_wiki_wpage_7360_1357.html
-
-Up to ILIAS 8, it was possible to define LOM for glossary definitions. Since multiple definitons per term are abandoned 
-from ILIAS 9 onwards, LOM for definitions have also been abandoned (see Jour Fixe decision in FR). Now, there is
-"dead metadata" in the corresponding database tables, which should be deleted.
-
 ### Remove Public Access Exports From DB
 
 In the table `glossary`, the following columns can be removed:

--- a/components/ILIAS/Glossary/classes/Setup/class.ilGlossaryDeleteLOMOfDefinitionsMigration.php
+++ b/components/ILIAS/Glossary/classes/Setup/class.ilGlossaryDeleteLOMOfDefinitionsMigration.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ********************************************************************
+ */
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+use ILIAS\Setup\Environment;
+use ILIAS\Setup\Migration;
+use ILIAS\MetaData\Setup\DeleteLOMForObjectTypeMigration;
+
+final class ilGlossaryDeleteLOMOfDefinitionsMigration extends DeleteLOMForObjectTypeMigration
+{
+    protected function objectType(): string
+    {
+        return 'gdf';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Remove remnants of Learning Object Metadata sets for Glossary Definitions from the database';
+    }
+}

--- a/components/ILIAS/Glossary/classes/Setup/class.ilGlossaryDeleteLOMOfDefinitionsMigration.php
+++ b/components/ILIAS/Glossary/classes/Setup/class.ilGlossaryDeleteLOMOfDefinitionsMigration.php
@@ -19,9 +19,6 @@
 
 declare(strict_types=1);
 
-use ILIAS\Setup;
-use ILIAS\Setup\Environment;
-use ILIAS\Setup\Migration;
 use ILIAS\MetaData\Setup\DeleteLOMForObjectTypeMigration;
 
 final class ilGlossaryDeleteLOMOfDefinitionsMigration extends DeleteLOMForObjectTypeMigration

--- a/components/ILIAS/Glossary/classes/Setup/class.ilGlossarySetupAgent.php
+++ b/components/ILIAS/Glossary/classes/Setup/class.ilGlossarySetupAgent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +14,9 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\Refinery;
 use ILIAS\Setup;

--- a/components/ILIAS/Glossary/classes/Setup/class.ilGlossarySetupAgent.php
+++ b/components/ILIAS/Glossary/classes/Setup/class.ilGlossarySetupAgent.php
@@ -63,7 +63,8 @@ final class ilGlossarySetupAgent implements Setup\Agent
     {
         return [
             new ilGlossaryDefinitionMigration(),
-            new ilGlossaryCollectionMigration()
+            new ilGlossaryCollectionMigration(),
+            new ilGlossaryDeleteLOMOfDefinitionsMigration()
         ];
     }
 }


### PR DESCRIPTION
This PR adds a migration to delete leftover LOM sets of Glossary definitions from the database. All the heavy lifting is done in a reusable abstract migration supplied by MetaData, see [here](https://github.com/ILIAS-eLearning/ILIAS/blob/release_10/components/ILIAS/MetaData/classes/Setup/DeleteLOMForObjectTypeMigration.php).