### PR TITLE
[FIX]: Reorder CmiXapi getLaunchData Parameters for PHP 8 Compatibility

### DIFF
--- a/components/ILIAS/CmiXapi/classes/class.ilCmiXapiLaunchGUI.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilCmiXapiLaunchGUI.php
@@ -309,7 +309,7 @@ class ilCmiXapiLaunchGUI
         $defaultStatementsUrl = $defaultLrs . "/statements";
 
         // launchedStatement
-        $launchData = json_encode($this->object->getLaunchData($this->cmixUser, $DIC->language()->txt('cmiexit')));
+        $launchData = json_encode($this->object->getLaunchData($DIC->language()->txt('cmiexit'), $this->cmixUser));
         $launchedStatement = $this->object->getLaunchedStatement($this->cmixUser);
         $launchedStatementParams = [];
         $launchedStatementParams['statementId'] = $launchedStatement['id'];

--- a/components/ILIAS/CmiXapi/classes/class.ilObjCmiXapi.php
+++ b/components/ILIAS/CmiXapi/classes/class.ilObjCmiXapi.php
@@ -1391,7 +1391,7 @@ class ilObjCmiXapi extends ilObject2
      * LMS.LaunchData
      * @return array<string, mixed>
      */
-    public function getLaunchData(?ilCmiXapiUser $cmixUser = null, string $exitText): array
+    public function getLaunchData(string $exitText, ?ilCmiXapiUser $cmixUser = null): array
     {
         if (null === $cmixUser) {
             $cmixUser = $this->getCurrentCmixUser();


### PR DESCRIPTION
In versions equal or higher than PHP 8, defining a method with optional parameters before the mandatory ones generates an exception of greater or lesser severity depending on the PHP version. For this reason, the order in which the arguments of the ```getLaunchData``` method are introduced has been modified.

This change fixes the following mantis ticket related to the LTI module:
https://mantis.ilias.de/view.php?id=44838