### PR TITLE
[Fix] LTI: Cast added to ref_id in the handling of Breadcrumbs

### DIFF
--- a/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
+++ b/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
@@ -59,9 +59,9 @@ class CustomBreadcrumbPagePartProvider implements PagePartProvider
         $ref_id = $_SESSION["ref_id"];
 
         foreach ($breadcrumbs->getItems() as $crumb) {
-            $action = (string)$crumb->getAction();
+            $action = (string) $crumb->getAction();
             if (method_exists($crumb, 'getAction') && str_contains($action, 'goto.php')) {
-                if (str_contains($action, (string)$ref_id) && !str_contains($action, 'root')) {
+                if (str_contains($action, (string) $ref_id) && !str_contains($action, 'root')) {
                     $goto_crumbs[] = $crumb;
                 }
             } else {

--- a/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
+++ b/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
@@ -59,8 +59,9 @@ class CustomBreadcrumbPagePartProvider implements PagePartProvider
         $ref_id = $_SESSION["ref_id"];
 
         foreach ($breadcrumbs->getItems() as $crumb) {
-            if (method_exists($crumb, 'getAction') && str_contains($crumb->getAction(), 'goto.php')) {
-                if (str_contains($crumb->getAction(), $ref_id) && !str_contains($crumb->getAction(), 'root')) {
+            $action = (string)$crumb->getAction();
+            if (method_exists($crumb, 'getAction') && str_contains($action, 'goto.php')) {
+                if (str_contains($action, (string)$ref_id) && !str_contains($action, 'root')) {
                     $goto_crumbs[] = $crumb;
                 }
             } else {


### PR DESCRIPTION
This change cast that value to string to skip possible fails