### PR TITLE
UICore: Fix implicit nullable parameter in unit test

### DIFF
--- a/components/ILIAS/UICore/tests/ilTemplateTest.php
+++ b/components/ILIAS/UICore/tests/ilTemplateTest.php
@@ -34,7 +34,7 @@ class ilTemplateTest extends TestCase
             public function __construct()
             {
             }
-            public function _getTemplatePath(string $a_tplname, string $a_in_module = null): string
+            public function _getTemplatePath(string $a_tplname, ?string $a_in_module = null): string
             {
                 return $this->getTemplatePath($a_tplname, $a_in_module);
             }


### PR DESCRIPTION
This PR fixes an error with PHP 8.4. Implicit NULL-able parameters are not allowed anymore.