### PR TITLE
UnitTests: Add fix for deprecated `cacheResultFile`

### DIFF
--- a/scripts/PHPUnit/phpunit.xml
+++ b/scripts/PHPUnit/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunAit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          bootstrap="../../vendor/composer/vendor/autoload.php"
          colors="true"
          beStrictAboutOutputDuringTests="true"
@@ -15,7 +15,7 @@
          displayDetailsOnTestsThatTriggerNotices="true"
          backupGlobals="true"
          executionOrder="random"
-         cacheResultFile=".phpunit.cache/test-results">
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="all">
             <directory>../../components/*/*/tests/</directory>


### PR DESCRIPTION
This PR suggests removing the `cacheResultFile` setting from our `phpunit` configuration file, since this is no longer supported. Instead, it is now possible to define a directory.

See: https://github.com/sebastianbergmann/phpunit/issues/4599