### PR TITLE
Refinery: Fix `phpunit` issues

### DIFF
--- a/components/ILIAS/Refinery/tests/ByTrying/ByTryingTransformTest.php
+++ b/components/ILIAS/Refinery/tests/ByTrying/ByTryingTransformTest.php
@@ -22,6 +22,7 @@ use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Tests\Refinery\TestCase;
 use ILIAS\Data\Factory as DataFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 require_once("./components/ILIAS/Refinery/tests/TestCase.php");
 
@@ -55,12 +56,8 @@ class ByTryingTransformTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider NullOrNumericDataProvider
-     * @param mixed $value
-     * @param mixed $expected
-     */
-    public function testNullOrNumeric($value, $expected): void
+    #[DataProvider('NullOrNumericDataProvider')]
+    public function testNullOrNumeric(mixed $value, mixed $expected): void
     {
         $transformation = $this->refinery->byTrying([
             $this->refinery->numeric()->isNumeric(),
@@ -87,12 +84,8 @@ class ByTryingTransformTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider NullOrNumericOrStringDataProvider
-     * @param mixed $value
-     * @param mixed $expected
-     */
-    public function testNullOrNumericOrString($value, $expected): void
+    #[DataProvider('NullOrNumericOrStringDataProvider')]
+    public function testNullOrNumericOrString(mixed $value, mixed $expected): void
     {
         $transformation = $this->refinery->byTrying([
             $this->refinery->kindlyTo()->null(),
@@ -118,12 +111,8 @@ class ByTryingTransformTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider StringOrNullDataProvider
-     * @param mixed $value
-     * @param mixed $expected
-     */
-    public function testStringOrNull($value, $expected): void
+    #[DataProvider('StringOrNullDataProvider')]
+    public function testStringOrNull(mixed $value, mixed $expected): void
     {
         $transformation = $this->refinery->byTrying([
             $this->refinery->to()->string(),

--- a/components/ILIAS/Refinery/tests/Encode/Transformation/HTMLAttributeValueTest.php
+++ b/components/ILIAS/Refinery/tests/Encode/Transformation/HTMLAttributeValueTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\Encode\Transformation\HTMLAttributeValue;
 use ValueError;
 use TypeError;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 require_once __DIR__ . '/ProvideUTF8CodepointRange.php';
 
@@ -36,9 +37,7 @@ class HTMLAttributeValueTest extends TestCase
         $this->assertInstanceOf(HTMLAttributeValue::class, new HTMLAttributeValue());
     }
 
-    /**
-     * @dataProvider provideTransformData
-     */
+    #[DataProvider('provideTransformData')]
     public function testTransform(string $exptected, string $in, string $method): void
     {
         $this->$method($exptected, (new HTMLAttributeValue())->transform($in));

--- a/components/ILIAS/Refinery/tests/Encode/Transformation/HTMLSpecialCharsAsEntitiesTest.php
+++ b/components/ILIAS/Refinery/tests/Encode/Transformation/HTMLSpecialCharsAsEntitiesTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\Encode\Transformation\HTMLSpecialCharsAsEntities;
 use ValueError;
 use TypeError;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class HTMLSpecialCharsAsEntitiesTest extends TestCase
 {
@@ -32,9 +33,7 @@ class HTMLSpecialCharsAsEntitiesTest extends TestCase
         $this->assertInstanceOf(HTMLSpecialCharsAsEntities::class, new HTMLSpecialCharsAsEntities());
     }
 
-    /**
-     * @dataProvider provideTransformData
-     */
+    #[DataProvider('provideTransformData')]
     public function testTransform(string $exptected, string $in): void
     {
         $this->assertSame($exptected, (new HTMLSpecialCharsAsEntities())->transform($in));

--- a/components/ILIAS/Refinery/tests/Encode/Transformation/JsonTest.php
+++ b/components/ILIAS/Refinery/tests/Encode/Transformation/JsonTest.php
@@ -23,6 +23,7 @@ namespace ILIAS\Tests\Refinery\Encode\Transformation;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\Encode\Transformation\Json;
 use JsonException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 require_once __DIR__ . '/ProvideUTF8CodepointRange.php';
 
@@ -35,9 +36,7 @@ class JsonTest extends TestCase
         $this->assertInstanceOf(Json::class, new Json());
     }
 
-    /**
-     * @dataProvider provideTransformData
-     */
+    #[DataProvider('provideTransformData')]
     public function testTransform(string $exptected, string $in, string $method): void
     {
         $this->$method($exptected, (new Json())->transform($in));

--- a/components/ILIAS/Refinery/tests/Encode/Transformation/URLTest.php
+++ b/components/ILIAS/Refinery/tests/Encode/Transformation/URLTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\Encode\Transformation\URL;
 use ValueError;
 use TypeError;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class URLTest extends TestCase
 {
@@ -32,9 +33,7 @@ class URLTest extends TestCase
         $this->assertInstanceOf(URL::class, new URL());
     }
 
-    /**
-     * @dataProvider provideTransformData
-     */
+    #[DataProvider('provideTransformData')]
     public function testTransform(string $exptected, string $in): void
     {
         $this->assertSame($exptected, (new URL())->transform($in));

--- a/components/ILIAS/Refinery/tests/KindlyTo/Transformation/BooleanTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/KindlyTo/Transformation/BooleanTransformationTest.php
@@ -23,6 +23,7 @@ namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 use ILIAS\Refinery\KindlyTo\Transformation\BooleanTransformation;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\ConstraintViolationException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BooleanTransformationTest extends TestCase
 {
@@ -33,23 +34,16 @@ class BooleanTransformationTest extends TestCase
         $this->transformation = new BooleanTransformation();
     }
 
-    /**
-     * @dataProvider BooleanTestDataProvider
-     * @param mixed $originVal
-     * @param bool $expectedVal
-     */
-    public function testBooleanTransformation($originVal, bool $expectedVal): void
+    #[DataProvider('BooleanTestDataProvider')]
+    public function testBooleanTransformation(mixed $originVal, bool $expectedVal): void
     {
         $transformedValue = $this->transformation->transform($originVal);
         $this->assertIsBool($transformedValue);
         $this->assertSame($expectedVal, $transformedValue);
     }
 
-    /**
-     * @dataProvider TransformationFailureDataProvider
-     * @param mixed $failingValue
-     */
-    public function testTransformIsInvalid($failingValue): void
+    #[DataProvider('TransformationFailureDataProvider')]
+    public function testTransformIsInvalid(mixed $failingValue): void
     {
         $this->expectException(ConstraintViolationException::class);
         $this->transformation->transform($failingValue);

--- a/components/ILIAS/Refinery/tests/KindlyTo/Transformation/DateTimeTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/KindlyTo/Transformation/DateTimeTransformationTest.php
@@ -25,6 +25,7 @@ use DateTimeInterface;
 use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Refinery\KindlyTo\Transformation\DateTimeTransformation;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DateTimeTransformationTest extends TestCase
 {
@@ -35,12 +36,8 @@ class DateTimeTransformationTest extends TestCase
         $this->transformation = new DateTimeTransformation();
     }
 
-    /**
-     * @dataProvider DateTimeTransformationDataProvider
-     * @param mixed $originVal
-     * @param DateTimeImmutable $expectedVal
-     */
-    public function testDateTimeISOTransformation($originVal, DateTimeImmutable $expectedVal): void
+    #[DataProvider('DateTimeTransformationDataProvider')]
+    public function testDateTimeISOTransformation(mixed $originVal, DateTimeImmutable $expectedVal): void
     {
         $transformedValue = $this->transformation->transform($originVal);
         $this->assertIsObject($transformedValue);
@@ -48,10 +45,7 @@ class DateTimeTransformationTest extends TestCase
         $this->assertEquals($expectedVal, $transformedValue);
     }
 
-    /**
-     * @dataProvider TransformationFailureDataProvider
-     * @param string$failingValue
-     */
+    #[DataProvider('TransformationFailureDataProvider')]
     public function testTransformIsInvalid(string $failingValue): void
     {
         $this->expectException(ConstraintViolationException::class);

--- a/components/ILIAS/Refinery/tests/KindlyTo/Transformation/DictionaryTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/KindlyTo/Transformation/DictionaryTransformationTest.php
@@ -25,14 +25,15 @@ use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
 use ILIAS\Refinery\ConstraintViolationException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DictionaryTransformationTest extends TestCase
 {
     /**
-     * @dataProvider DictionaryTransformationDataProvider
      * @param array $originVal
      * @param array $expectedVal
      */
+    #[DataProvider('DictionaryTransformationDataProvider')]
     public function testDictionaryTransformation(array $originVal, array $expectedVal): void
     {
         $transformation = new DictionaryTransformation(new StringTransformation());
@@ -41,11 +42,8 @@ class DictionaryTransformationTest extends TestCase
         $this->assertEquals($expectedVal, $transformedValue);
     }
 
-    /**
-     * @dataProvider TransformationFailingDataProvider
-     * @param mixed $failingVal
-     */
-    public function testTransformationFailures($failingVal): void
+    #[DataProvider('TransformationFailingDataProvider')]
+    public function testTransformationFailures(mixed $failingVal): void
     {
         $this->expectException(ConstraintViolationException::class);
         $transformation = new DictionaryTransformation(new StringTransformation());

--- a/components/ILIAS/Refinery/tests/KindlyTo/Transformation/FloatTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/KindlyTo/Transformation/FloatTransformationTest.php
@@ -23,6 +23,7 @@ namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Refinery\KindlyTo\Transformation\FloatTransformation;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FloatTransformationTest extends TestCase
 {
@@ -33,23 +34,16 @@ class FloatTransformationTest extends TestCase
         $this->transformation = new FloatTransformation();
     }
 
-    /**
-     * @dataProvider FloatTestDataProvider
-     * @param mixed $originVal
-     * @param float $expectedVal
-     */
-    public function testFloatTransformation($originVal, float $expectedVal): void
+    #[DataProvider('FloatTestDataProvider')]
+    public function testFloatTransformation(mixed $originVal, float $expectedVal): void
     {
         $transformedValue = $this->transformation->transform($originVal);
         $this->assertIsFloat($transformedValue);
         $this->assertEquals($expectedVal, $transformedValue);
     }
 
-    /**
-     * @dataProvider FailingTransformationDataProvider
-     * @param mixed $failingVal
-     */
-    public function testFailingTransformations($failingVal): void
+    #[DataProvider('FailingTransformationDataProvider')]
+    public function testFailingTransformations(mixed $failingVal): void
     {
         $this->expectNotToPerformAssertions();
         try {

--- a/components/ILIAS/Refinery/tests/KindlyTo/Transformation/IntegerTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/KindlyTo/Transformation/IntegerTransformationTest.php
@@ -23,6 +23,7 @@ namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Refinery\KindlyTo\Transformation\IntegerTransformation;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class IntegerTransformationTest extends TestCase
 {
@@ -33,23 +34,16 @@ class IntegerTransformationTest extends TestCase
         $this->transformation = new IntegerTransformation();
     }
 
-    /**
-     * @dataProvider IntegerTestDataProvider
-     * @param mixed $originVal
-     * @param int $expectedVal
-     */
-    public function testIntegerTransformation($originVal, int $expectedVal): void
+    #[DataProvider('IntegerTestDataProvider')]
+    public function testIntegerTransformation(mixed $originVal, int $expectedVal): void
     {
         $transformedValue = $this->transformation->transform($originVal);
         $this->assertIsInt($transformedValue);
         $this->assertEquals($expectedVal, $transformedValue);
     }
 
-    /**
-     * @dataProvider TransformationFailureDataProvider
-     * @param mixed $failingValue
-     */
-    public function testTransformIsInvalid($failingValue): void
+    #[DataProvider('TransformationFailureDataProvider')]
+    public function testTransformIsInvalid(mixed $failingValue): void
     {
         $this->expectException(ConstraintViolationException::class);
         $this->transformation->transform($failingValue);

--- a/components/ILIAS/Refinery/tests/KindlyTo/Transformation/ListTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/KindlyTo/Transformation/ListTransformationTest.php
@@ -24,15 +24,12 @@ use ILIAS\Refinery\KindlyTo\Transformation\ListTransformation;
 use ILIAS\Refinery\To\Transformation\StringTransformation;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ListTransformationTest extends TestCase
 {
-    /**
-     * @dataProvider ArrayToListTransformationDataProvider
-     * @param mixed $originValue
-     * @param mixed $expectedValue
-     */
-    public function testListTransformation($originValue, $expectedValue): void
+    #[DataProvider('ArrayToListTransformationDataProvider')]
+    public function testListTransformation(mixed $originValue, mixed $expectedValue): void
     {
         $transformList = new ListTransformation(new StringTransformation());
         $transformedValue = $transformList->transform($originValue);
@@ -40,11 +37,8 @@ class ListTransformationTest extends TestCase
         $this->assertEquals($expectedValue, $transformedValue);
     }
 
-    /**
-     * @dataProvider ArrayFailureDataProvider
-     * @param mixed $origValue
-     */
-    public function testFailingTransformations($origValue): void
+    #[DataProvider('ArrayFailureDataProvider')]
+    public function testFailingTransformations(mixed $origValue): void
     {
         $this->expectException(UnexpectedValueException::class);
         $transformList = new ListTransformation(new StringTransformation());

--- a/components/ILIAS/Refinery/tests/KindlyTo/Transformation/NullTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/KindlyTo/Transformation/NullTransformationTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 use ILIAS\Refinery\KindlyTo\Transformation\NullTransformation;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\ConstraintViolationException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class NullTransformationTest extends TestCase
 {
@@ -48,13 +49,8 @@ class NullTransformationTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider NullTestDataProvider
-     * @param mixed $value
-     * @param bool $valid
-     * @throws Exception
-     */
-    public function testNullTransformation($value, bool $valid): void
+    #[DataProvider('NullTestDataProvider')]
+    public function testNullTransformation(mixed $value, bool $valid): void
     {
         if (!$valid) {
             $this->expectException(ConstraintViolationException::class);

--- a/components/ILIAS/Refinery/tests/KindlyTo/Transformation/RecordTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/KindlyTo/Transformation/RecordTransformationTest.php
@@ -25,6 +25,7 @@ use ILIAS\Refinery\KindlyTo\Transformation\IntegerTransformation;
 use ILIAS\Refinery\KindlyTo\Transformation\RecordTransformation;
 use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RecordTransformationTest extends TestCase
 {
@@ -33,10 +34,10 @@ class RecordTransformationTest extends TestCase
     private const SECOND_INT_KEY = 'integerKey2';
 
     /**
-     * @dataProvider RecordTransformationDataProvider
      * @param array $originVal
      * @param array $expectedVal
      */
+    #[DataProvider('RecordTransformationDataProvider')]
     public function testRecordTransformationIsValid(array $originVal, array $expectedVal): void
     {
         $recTransform = new RecordTransformation(
@@ -51,9 +52,9 @@ class RecordTransformationTest extends TestCase
     }
 
     /**
-     * @dataProvider RecordFailureDataProvider
      * @param array $origVal
      */
+    #[DataProvider('RecordFailureDataProvider')]
     public function testRecordTransformationFailures(array $origVal): void
     {
         $this->expectNotToPerformAssertions();
@@ -89,9 +90,9 @@ class RecordTransformationTest extends TestCase
     }
 
     /**
-     * @dataProvider RecordValueInvalidDataProvider
      * @param array $originalValue
      */
+    #[DataProvider('RecordValueInvalidDataProvider')]
     public function testInvalidValueDoesNotMatch(array $originalValue): void
     {
         $this->expectNotToPerformAssertions();

--- a/components/ILIAS/Refinery/tests/KindlyTo/Transformation/StringTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/KindlyTo/Transformation/StringTransformationTest.php
@@ -23,6 +23,7 @@ namespace ILIAS\Tests\Refinery\KindlyTo\Transformation;
 use ILIAS\Refinery\KindlyTo\Transformation\StringTransformation;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class StringTransformationTest extends TestCase
 {
@@ -33,12 +34,8 @@ class StringTransformationTest extends TestCase
         $this->transformation = new StringTransformation();
     }
 
-    /**
-     * @dataProvider StringTestDataProvider
-     * @param mixed $originVal
-     * @param string $expectedVal
-     */
-    public function testStringTransformation($originVal, string $expectedVal): void
+    #[DataProvider('StringTestDataProvider')]
+    public function testStringTransformation(mixed $originVal, string $expectedVal): void
     {
         $transformedValue = $this->transformation->transform($originVal);
         $this->assertIsString($transformedValue);

--- a/components/ILIAS/Refinery/tests/KindlyTo/Transformation/TupleTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/KindlyTo/Transformation/TupleTransformationTest.php
@@ -24,16 +24,17 @@ use ILIAS\Refinery\ConstraintViolationException;
 use ILIAS\Refinery\KindlyTo\Transformation\IntegerTransformation;
 use ILIAS\Refinery\KindlyTo\Transformation\TupleTransformation;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TupleTransformationTest extends TestCase
 {
     private const TUPLE_KEY = 'hello';
 
     /**
-     * @dataProvider TupleTransformationDataProvider
      * @param array $originVal
      * @param array $expectedVal
      */
+    #[DataProvider('TupleTransformationDataProvider')]
     public function testTupleTransformation(array $originVal, array $expectedVal): void
     {
         $transformation = new TupleTransformation(
@@ -48,9 +49,9 @@ class TupleTransformationTest extends TestCase
     }
 
     /**
-     * @dataProvider TupleFailingTransformationDataProvider
      * @param array $failingVal
      */
+    #[DataProvider('TupleFailingTransformationDataProvider')]
     public function testNewTupleIsIncorrect(array $failingVal): void
     {
         $this->expectNotToPerformAssertions();
@@ -70,9 +71,9 @@ class TupleTransformationTest extends TestCase
     }
 
     /**
-     * @dataProvider TupleTooManyValuesDataProvider
      * @param array $tooManyValues
      */
+    #[DataProvider('TupleTooManyValuesDataProvider')]
     public function testTupleTooManyValues(array $tooManyValues): void
     {
         $this->expectNotToPerformAssertions();

--- a/components/ILIAS/Refinery/tests/Logical/Constraint/LogicalOrTest.php
+++ b/components/ILIAS/Refinery/tests/Logical/Constraint/LogicalOrTest.php
@@ -22,28 +22,19 @@ use ILIAS\Data\Factory as DataFactory;
 use ILIAS\Refinery\Factory as Refinery;
 use ILIAS\Refinery\Logical\LogicalOr;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LogicalOrTest extends TestCase
 {
-    /**
-     * @dataProvider constraintsProvider
-     * @param LogicalOr $constraint
-     * @param mixed $okValue
-     * @param mixed $errorValue
-     */
-    public function testAccept(LogicalOr $constraint, $okValue, $errorValue): void
+    #[DataProvider('constraintsProvider')]
+    public function testAccept(LogicalOr $constraint, mixed $okValue, mixed $errorValue): void
     {
         $this->assertTrue($constraint->accepts($okValue));
         $this->assertFalse($constraint->accepts($errorValue));
     }
 
-    /**
-     * @dataProvider constraintsProvider
-     * @param LogicalOr $constraint
-     * @param mixed $okValue
-     * @param mixed $errorValue
-     */
-    public function testCheck(LogicalOr $constraint, $okValue, $errorValue): void
+    #[DataProvider('constraintsProvider')]
+    public function testCheck(LogicalOr $constraint, mixed $okValue, mixed $errorValue): void
     {
         $raised = false;
 
@@ -65,25 +56,15 @@ class LogicalOrTest extends TestCase
         $this->assertFalse($raised);
     }
 
-    /**
-     * @dataProvider constraintsProvider
-     * @param LogicalOr $constraint
-     * @param mixed $okValue
-     * @param mixed $errorValue
-     */
-    public function testProblemWith(LogicalOr $constraint, $okValue, $errorValue): void
+    #[DataProvider('constraintsProvider')]
+    public function testProblemWith(LogicalOr $constraint, mixed $okValue, mixed $errorValue): void
     {
         $this->assertNull($constraint->problemWith($okValue));
         $this->assertIsString($constraint->problemWith($errorValue));
     }
 
-    /**
-     * @dataProvider constraintsProvider
-     * @param LogicalOr $constraint
-     * @param mixed $okValue
-     * @param mixed $errorValue
-     */
-    public function testRestrict(LogicalOr $constraint, $okValue, $errorValue): void
+    #[DataProvider('constraintsProvider')]
+    public function testRestrict(LogicalOr $constraint, mixed $okValue, mixed $errorValue): void
     {
         $rf = new DataFactory();
         $ok = $rf->ok($okValue);
@@ -100,13 +81,8 @@ class LogicalOrTest extends TestCase
         $this->assertSame($error, $result);
     }
 
-    /**
-     * @dataProvider constraintsProvider
-     * @param LogicalOr $constraint
-     * @param mixed $okValue
-     * @param mixed $errorValue
-     */
-    public function testWithProblemBuilder(LogicalOr $constraint, $okValue, $errorValue): void
+    #[DataProvider('constraintsProvider')]
+    public function testWithProblemBuilder(LogicalOr $constraint, mixed $okValue, mixed $errorValue): void
     {
         $new_constraint = $constraint->withProblemBuilder(static function (): string {
             return "This was a vault";

--- a/components/ILIAS/Refinery/tests/Parser/ABNF/BrickTest.php
+++ b/components/ILIAS/Refinery/tests/Parser/ABNF/BrickTest.php
@@ -28,6 +28,7 @@ use ILIAS\Refinery\Parser\ABNF\Brick;
 use ILIAS\Refinery\Parser\ABNF\Intermediate;
 use ILIAS\Refinery\Transformation;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BrickTest extends TestCase
 {
@@ -154,9 +155,7 @@ class BrickTest extends TestCase
         $this->assertEquals('d', $result->value()['second']);
     }
 
-    /**
-     * @dataProvider repeatProvider
-     */
+    #[DataProvider('repeatProvider')]
     public function testRepeat(int $min, ?int $max, array $succeed, array $fail): void
     {
         $brick = new Brick();
@@ -185,9 +184,7 @@ class BrickTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider characterProvider
-     */
+    #[DataProvider('characterProvider')]
     public function testCharacters(string $method, string $input, bool $isOk): void
     {
         $brick = new Brick();
@@ -239,9 +236,7 @@ class BrickTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider emptyStringProvider
-     */
+    #[DataProvider('emptyStringProvider')]
     public function testEmptyString(string $input, bool $isOk): void
     {
         $brick = new Brick();

--- a/components/ILIAS/Refinery/tests/Parser/ABNF/IntermediateTest.php
+++ b/components/ILIAS/Refinery/tests/Parser/ABNF/IntermediateTest.php
@@ -26,6 +26,7 @@ use ILIAS\Refinery\Parser\ABNF\Intermediate;
 use ILIAS\Refinery\Parser\ABNF\Character;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use PHPUnit\Framework\Attributes\Depends;
 
 class IntermediateTest extends TestCase
 {
@@ -40,21 +41,19 @@ class IntermediateTest extends TestCase
     {
         $intermediate = new Intermediate('input');
 
-        $this->assertEquals(ord('i'), $intermediate->value());
+        $this->assertEquals(\ord('i'), $intermediate->value());
     }
 
-    /**
-     * @depends testValue
-     */
+    #[Depends('testValue')]
     public function testAccept(): void
     {
         $intermediate = new Intermediate('input');
 
-        $this->assertEquals(ord('i'), $intermediate->value());
+        $this->assertEquals(\ord('i'), $intermediate->value());
 
         $next = $intermediate->accept();
         $this->assertTrue($next->isOK());
-        $this->assertEquals(ord('n'), $next->value()->value());
+        $this->assertEquals(\ord('n'), $next->value()->value());
     }
 
     public function testReject(): void
@@ -65,17 +64,15 @@ class IntermediateTest extends TestCase
         $this->assertFalse($next->isOK());
     }
 
-    /**
-     * @depends testValue
-     * @depends testAccept
-     */
+    #[Depends('testValue')]
+    #[Depends('testAccept')]
     public function testAccepted(): void
     {
         $expected = 'in';
         $intermediate = new Intermediate('input');
         $this->assertEquals([], $intermediate->accepted());
         $accepted = $intermediate->accept()->value()->accept()->value()->accepted();
-        $this->assertTrue(is_array($accepted));
+        $this->assertIsArray($accepted);
         $actual = '';
         foreach ($accepted as $character) {
             $this->assertInstanceOf(Character::class, $character);
@@ -84,9 +81,7 @@ class IntermediateTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @depends testAccept
-     */
+    #[Depends('testAccept')]
     public function testDone(): void
     {
         $intermediate = new Intermediate('ab');
@@ -94,22 +89,17 @@ class IntermediateTest extends TestCase
         $this->assertTrue($intermediate->accept()->value()->accept()->value()->done());
     }
 
-    /**
-     * @depends testAccepted
-     * @depends testAccepted
-     * @depends testValue
-     */
+    #[Depends('testAccepted')]
+    #[Depends('testValue')]
     public function testOnlyTodo(): void
     {
         $intermediate = new Intermediate('ab');
         $intermediate = $intermediate->accept()->value()->onlyTodo();
         $this->assertEmpty($intermediate->accepted());
-        $this->assertEquals(ord('b'), $intermediate->value());
+        $this->assertEquals(\ord('b'), $intermediate->value());
     }
 
-    /**
-     * @depends testAccept
-     */
+    #[Depends('testAccept')]
     public function testTransformOnlyWithCharacters(): void
     {
         $intermediate = new Intermediate('hej');
@@ -125,9 +115,7 @@ class IntermediateTest extends TestCase
         $this->assertEquals($ok, $result);
     }
 
-    /**
-     * @depends testAccepted
-     */
+    #[Depends('testAccepted')]
     public function testPush(): void
     {
         $intermediate = new Intermediate('hej');
@@ -136,10 +124,8 @@ class IntermediateTest extends TestCase
         $this->assertEquals([$value], $intermediate->push([$value])->accepted());
     }
 
-    /**
-     * @depends testPush
-     * @depends testAccept
-     */
+    #[Depends('testPush')]
+    #[Depends('testAccept')]
     public function testTransformWithTransformedValues(): void
     {
         $intermediate = new Intermediate('hej');
@@ -151,7 +137,7 @@ class IntermediateTest extends TestCase
         $intermediate = $intermediate->push([$dummy]);
 
         $result = $intermediate->transform(function (array $accepted) use ($dummy, $ok): Result {
-            $this->assertEquals(2, count($accepted));
+            $this->assertCount(2, $accepted);
             $this->assertInstanceOf(Character::class, $accepted[0]);
             $this->assertEquals('h', $accepted[0]->value());
             $this->assertEquals($dummy, $accepted[1]);

--- a/components/ILIAS/Refinery/tests/Parser/ABNF/TransformTest.php
+++ b/components/ILIAS/Refinery/tests/Parser/ABNF/TransformTest.php
@@ -29,6 +29,7 @@ use ILIAS\Refinery\Parser\ABNF\Intermediate;
 use ILIAS\Refinery\Transformation;
 use Closure;
 use stdClass;
+use PHPUnit\Framework\Attributes\Depends;
 
 class TransformTest extends TestCase
 {
@@ -37,9 +38,7 @@ class TransformTest extends TestCase
         $this->assertInstanceOf(Transform::class, new Transform());
     }
 
-    /**
-     * @depends testConstruct
-     */
+    #[Depends('testConstruct')]
     public function testTo(): void
     {
         $transform = new Transform();
@@ -64,9 +63,7 @@ class TransformTest extends TestCase
         $this->assertEquals($end, $x->value());
     }
 
-    /**
-     * @depends testConstruct
-     */
+    #[Depends('testConstruct')]
     public function testFailedToTransform(): void
     {
         $transform = new Transform();
@@ -90,9 +87,7 @@ class TransformTest extends TestCase
         $this->assertEquals($end, $x->value());
     }
 
-    /**
-     * @depends testConstruct
-     */
+    #[Depends('testConstruct')]
     public function testFailedToParse(): void
     {
         $transform = new Transform();

--- a/components/ILIAS/Refinery/tests/Password/Constraint/PasswordContraintsTest.php
+++ b/components/ILIAS/Refinery/tests/Password/Constraint/PasswordContraintsTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use ILIAS\Refinery\Constraint;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PasswordContraintsTest extends TestCase
 {
@@ -82,11 +83,11 @@ class PasswordContraintsTest extends TestCase
     }
 
     /**
-     * @dataProvider constraintsProvider
      * @param Constraint $constraint
      * @param ILIAS\Data\Password[] $ok_values
      * @param ILIAS\Data\Password[] $error_values
      */
+    #[DataProvider('constraintsProvider')]
     public function testAccept(Constraint $constraint, array $ok_values, array $error_values): void
     {
         foreach ($ok_values as $ok_value) {

--- a/components/ILIAS/Refinery/tests/String/Encoding/EncodingTest.php
+++ b/components/ILIAS/Refinery/tests/String/Encoding/EncodingTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ILIAS\Refinery\String\Encoding;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class EncodingTest extends TestCase
 {
@@ -47,9 +48,7 @@ class EncodingTest extends TestCase
         return $strings;
     }
 
-    /**
-     * @dataProvider latin1StringProvider
-     */
+    #[DataProvider('latin1StringProvider')]
     public function testLatin1ToUTF8(
         string $latin_1_string,
         string $expected_utf8
@@ -75,9 +74,7 @@ class EncodingTest extends TestCase
         return $strings;
     }
 
-    /**
-     * @dataProvider asciiStringProvider
-     */
+    #[DataProvider('asciiStringProvider')]
     public function testAsciiToUTF8(
         string $latin_1_string,
         string $expected_utf8

--- a/components/ILIAS/Refinery/tests/String/EstimatedReadingTimeTest.php
+++ b/components/ILIAS/Refinery/tests/String/EstimatedReadingTimeTest.php
@@ -28,6 +28,7 @@ use ILIAS\Language\Language;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class EstimatedReadingTimeTest extends TestCase
 {
@@ -93,11 +94,8 @@ EOT;
         ]);
     }
 
-    /**
-     * @dataProvider inputProvider
-     * @param mixed $from
-     */
-    public function testExceptionIsRaisedIfInputIsNotAString($from): void
+    #[DataProvider('inputProvider')]
+    public function testExceptionIsRaisedIfInputIsNotAString(mixed $from): void
     {
         $this->expectException(InvalidArgumentException::class);
         $readingTimeTrafo = $this->refinery->string()->estimatedReadingTime(true);
@@ -165,10 +163,7 @@ EOT;
         );
     }
 
-    /**
-     * @dataProvider unsupportedButKnownEntitiesProvider
-     * @param string $text
-     */
+    #[DataProvider('unsupportedButKnownEntitiesProvider')]
     public function testNoExceptionIsRaisedIfHtmlContainsUnsupportedEntities(string $text): void
     {
         $reading_time_trafo = $this->refinery->string()->estimatedReadingTime(true);

--- a/components/ILIAS/Refinery/tests/String/MakeClickableTest.php
+++ b/components/ILIAS/Refinery/tests/String/MakeClickableTest.php
@@ -23,6 +23,7 @@ namespace ILIAS\Tests\Refinery\String;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\String\MakeClickable;
 use ILIAS\Refinery\ConstraintViolationException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class MakeClickableTest extends TestCase
 {
@@ -39,18 +40,14 @@ class MakeClickableTest extends TestCase
         $clickable->transform(3);
     }
 
-    /**
-     * @dataProvider provideInputInNewTab
-     */
+    #[DataProvider('provideInputInNewTab')]
     public function testTransformSuccessInNewTab(string $expected, string $input): void
     {
         $clickable = new MakeClickable();
         $this->assertEquals($expected, $clickable->transform($input));
     }
 
-    /**
-     * @dataProvider provideInputWithoutAttributes
-     */
+    #[DataProvider('provideInputWithoutAttributes')]
     public function testTransformSuccess(string $expected, string $input): void
     {
         $clickable = new MakeClickable(false);

--- a/components/ILIAS/Refinery/tests/String/MarkdownFormattingToHTMLTest.php
+++ b/components/ILIAS/Refinery/tests/String/MarkdownFormattingToHTMLTest.php
@@ -25,6 +25,7 @@ use ILIAS\Refinery\String\Group;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Language\Language;
 use ILIAS\Refinery\Transformation;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class MarkdownFormattingToHTMLTest extends TestCase
 {
@@ -57,9 +58,7 @@ class MarkdownFormattingToHTMLTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider stringProvider
-     */
+    #[DataProvider('stringProvider')]
     public function testTransformationToHTML(
         string $markdown_string,
         string $expected_html,

--- a/components/ILIAS/Refinery/tests/String/UTFNormalTest.php
+++ b/components/ILIAS/Refinery/tests/String/UTFNormalTest.php
@@ -25,6 +25,7 @@ use ILIAS\Refinery\String\Group;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\String\Transformation\UTFNormalTransformation;
 use ILIAS\Refinery\Transformation;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UTFNormalTest extends TestCase
 {
@@ -62,9 +63,7 @@ class UTFNormalTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider stringProvider
-     */
+    #[DataProvider('stringProvider')]
     public function testNormalization(
         string $string,
         string $expected_form_c,

--- a/components/ILIAS/Refinery/tests/To/Transformation/InArrayTransformationTest.php
+++ b/components/ILIAS/Refinery/tests/To/Transformation/InArrayTransformationTest.php
@@ -25,6 +25,7 @@ use ILIAS\Refinery\To\Transformation\InArrayTransformation;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Language\Language;
 use UnexpectedValueException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class InArrayTransformationTest extends TestCase
 {
@@ -34,9 +35,7 @@ class InArrayTransformationTest extends TestCase
         $this->assertInstanceOf(InArrayTransformation::class, new InArrayTransformation([], $language));
     }
 
-    /**
-     * @dataProvider memberProvider
-     */
+    #[DataProvider('memberProvider')]
     public function testAccept(string $value, bool $successful): void
     {
         $language = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();
@@ -45,9 +44,7 @@ class InArrayTransformationTest extends TestCase
         $this->assertSame($successful, $transformation->accepts($value));
     }
 
-    /**
-     * @dataProvider memberProvider
-     */
+    #[DataProvider('memberProvider')]
     public function testTransform(string $value, bool $successful): void
     {
         if (!$successful) {
@@ -60,9 +57,7 @@ class InArrayTransformationTest extends TestCase
         $this->assertSame($value, $transformation->transform($value));
     }
 
-    /**
-     * @dataProvider memberProvider
-     */
+    #[DataProvider('memberProvider')]
     public function testApplyTo(string $value, bool $successful): void
     {
         $language = $this->getMockBuilder(Language::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
This PR suggests to remove deprecated PHPDoc
annotations for `phpunit`. Instead, native
PHP attributes are used.