### PR TITLE
Init: Fix `phpunit` issues

### DIFF
--- a/components/ILIAS/Init/tests/HttpPathBuilderTest.php
+++ b/components/ILIAS/Init/tests/HttpPathBuilderTest.php
@@ -73,9 +73,9 @@ class HttpPathBuilderTest extends TestCase
     }
 
     /**
-     * @dataProvider environmentProvider
      * @param array<string, mixed>|ArrayAccess<string, mixed> $server_data
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('environmentProvider')]
     public function testValidHostsTriggerNoExceptions(
         array|ArrayAccess $server_data,
         string $http_path,


### PR DESCRIPTION
This PR suggests to remove deprecated PHPDoc
annotations for `phpunit`. Instead, native
PHP attributes are used.