### PR TITLE
LearningModule: fix export option lang var, export option was not displayed because the lang var had the same name as the standard export

### DIFF
--- a/components/ILIAS/LearningModule/Export/class.ilLearningModuleExportOptionXML.php
+++ b/components/ILIAS/LearningModule/Export/class.ilLearningModuleExportOptionXML.php
@@ -63,7 +63,7 @@ class ilLearningModuleExportOptionXML extends ilLegacyExportOption
     public function getLabel(): string
     {
         $this->lng->loadLanguageModule('exp');
-        return $this->lng->txt("exp_format_dropdown-xml");
+        return $this->lng->txt("exp_format_dropdown-xml") . " (" . $this->lng->txt('cont_master_language_only_no_media') . ")";
     }
 
     public function onExportOptionSelected(\ILIAS\Export\ExportHandler\I\Consumer\Context\HandlerInterface $context): void


### PR DESCRIPTION
LINK: https://mantis.ilias.de/view.php?id=43418