### PR TITLE
UnitTests: Migrate PHPDoc metadata to PHP attributes (whole codebase)

### DIFF
--- a/components/ILIAS/AuthApache/tests/ilWhiteListUrlValidatorTest.php
+++ b/components/ILIAS/AuthApache/tests/ilWhiteListUrlValidatorTest.php
@@ -60,9 +60,7 @@ final class ilWhiteListUrlValidatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider domainProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('domainProvider')]
     public function testValidator(string $domain, array $whitelist, bool $result): void
     {
         $this->assertSame((new ilWhiteListUrlValidator($domain, $whitelist))->isValid(), $result);

--- a/components/ILIAS/Component/tests/Dependencies/NameTest.php
+++ b/components/ILIAS/Component/tests/Dependencies/NameTest.php
@@ -25,18 +25,14 @@ use ILIAS\Component\Dependencies\Name;
 
 class NameTest extends TestCase
 {
-    /**
-     * @dataProvider properNames
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('properNames')]
     public function testProperNames(string $name): void
     {
         $n = new Name($name);
         $this->assertEquals($name, (string) $n);
     }
 
-    /**
-     * @dataProvider improperNames
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('improperNames')]
     public function testImproperNames(string $name): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/components/ILIAS/Component/tests/Dependencies/RendererTest.php
+++ b/components/ILIAS/Component/tests/Dependencies/RendererTest.php
@@ -39,9 +39,7 @@ class RendererTest extends TestCase
         $this->renderer = new Renderer();
     }
 
-    /**
-     * @dataProvider scenarios
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('scenarios')]
     public function testScenario($scenario_file, $result_file, $components)
     {
         require_once(__DIR__ . "/scenarios/$scenario_file");

--- a/components/ILIAS/Component/tests/Resource/PublicAssetManagerTest.php
+++ b/components/ILIAS/Component/tests/Resource/PublicAssetManagerTest.php
@@ -135,9 +135,7 @@ class PublicAssetManagerTest extends TestCase
         $this->manager->buildPublicFolder("/srv/demo10.ilias.de", "/public");
     }
 
-    /**
-     * @dataProvider provideInvalidFolderPathData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideInvalidFolderPathData')]
     public function testInvalidFolderPaths(string $ilias_base, string $target): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/components/ILIAS/Component/tests/Settings/ilPluginsOverviewTableTest.php
+++ b/components/ILIAS/Component/tests/Settings/ilPluginsOverviewTableTest.php
@@ -61,9 +61,7 @@ class ilPluginsOverviewTableTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider getImportantFieldData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getImportantFieldData')]
     public function testGetImportantFields(bool $installed, bool $active): void
     {
         $obj = new class ($this->parent_gui, $this->ctrl, $this->ui, $this->renderer, $this->lng, []) extends ilPluginsOverviewTable {

--- a/components/ILIAS/Component/tests/ilPluginInfoTest.php
+++ b/components/ILIAS/Component/tests/ilPluginInfoTest.php
@@ -214,9 +214,7 @@ class ilPluginInfoTest extends TestCase
         $this->assertTrue($plugin->isVersionToOld());
     }
 
-    /**
-     * @dataProvider versionCompliance
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('versionCompliance')]
     public function testIsCompliantToILIAS(Data\Version $version, bool $is_compliant): void
     {
         $plugin = new ilPluginInfo(
@@ -274,9 +272,7 @@ class ilPluginInfoTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider isActivationPossibleTruthTable
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('isActivationPossibleTruthTable')]
     public function testIsActivationPossible(
         bool $is_installed,
         bool $supports_current_ilias,
@@ -349,9 +345,7 @@ class ilPluginInfoTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider isActiveTruthTable
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('isActiveTruthTable')]
     public function testIsActive(
         bool $is_installed,
         bool $supports_current_ilias,
@@ -451,9 +445,7 @@ class ilPluginInfoTest extends TestCase
     }
 
 
-    /**
-     * @dataProvider inactivityReasonTable
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('inactivityReasonTable')]
     public function testGetReasonForInactivity(
         bool $is_installed,
         bool $supports_current_ilias,

--- a/components/ILIAS/Context/tests/ilContextTest.php
+++ b/components/ILIAS/Context/tests/ilContextTest.php
@@ -31,9 +31,7 @@ class ilContextTest extends TestCase
         require_once("components/ILIAS/Context/tests/class.ilContextExtended.php");
     }
 
-    /**
-     * @dataProvider contextProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('contextProvider')]
     public function testInit(string $context, string $className): void
     {
         $context_obj = ilContextExtended::init($context);

--- a/components/ILIAS/Course/tests/Certificate/ilCertificateCourseLearningProgressEvaluationTest.php
+++ b/components/ILIAS/Course/tests/Certificate/ilCertificateCourseLearningProgressEvaluationTest.php
@@ -402,9 +402,9 @@ class ilCertificateCourseLearningProgressEvaluationTest extends TestCase
     }
 
     /**
-     * @dataProvider globalLearningProgressStateProvder
      * @param array[] $template_recods
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('globalLearningProgressStateProvder')]
     public function testRetrievingCertificateTemplatesForCoursesWorksAsExpectedWhenUsingNonCachingRepository(
         bool $isGlobalLpEnabled,
         array $template_recods

--- a/components/ILIAS/DI/tests/HTTPServicesTest.php
+++ b/components/ILIAS/DI/tests/HTTPServicesTest.php
@@ -37,12 +37,11 @@ use ILIAS\HTTP\Duration\DurationFactory;
  * @author  Nicolas Schäfli <ns@studer-raimann.ch>
  *
  * @package                DI
- *
- * @runInSeparateProcess
- * @preserveGlobalState    disabled
- * @backupGlobals          disabled
- * @backupStaticAttributes disabled
  */
+#[\PHPUnit\Framework\Attributes\BackupGlobals(false)]
+#[\PHPUnit\Framework\Attributes\BackupStaticProperties(false)]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+#[\PHPUnit\Framework\Attributes\RunClassInSeparateProcess]
 class HTTPServicesTest extends PHPUnitTestCase
 {
     /**
@@ -85,9 +84,7 @@ class HTTPServicesTest extends PHPUnitTestCase
     }
 
 
-    /**
-     * @Test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function testRequestWhichShouldGenerateANewRequestOnce(): void
     {
         $expectedRequest = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
@@ -111,9 +108,7 @@ class HTTPServicesTest extends PHPUnitTestCase
     }
 
 
-    /**
-     * @Test
-     */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function testResponseWhichShouldGenerateANewResponseOnce(): void
     {
         $expectedResponse = $this->getMockBuilder(ResponseInterface::class)->getMock();

--- a/components/ILIAS/Exercise/tests/Certificate/ilCertificateSettingsExerciseRepositoryTest.php
+++ b/components/ILIAS/Exercise/tests/Certificate/ilCertificateSettingsExerciseRepositoryTest.php
@@ -96,9 +96,7 @@ class ilCertificateSettingsExerciseRepositoryTest extends TestCase
         $this->assertSame($formMock, $result);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testSave(): void
     {
         $object = $this->getMockBuilder(ilObject::class)

--- a/components/ILIAS/IndividualAssessment/tests/Members/ilIndividualAssessmentMemberTest.php
+++ b/components/ILIAS/IndividualAssessment/tests/Members/ilIndividualAssessmentMemberTest.php
@@ -308,9 +308,7 @@ class ilIndividualAssessmentMemberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider fileNamesDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('fileNamesDataProvider')]
     public function test_mayBeFinalized_file_required_filename_empty(?string $filename): void
     {
         $settings = $this->createMock(ilIndividualAssessmentSettings::class);
@@ -350,9 +348,7 @@ class ilIndividualAssessmentMemberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider positiveLPStatusDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('positiveLPStatusDataProvider')]
     public function test_mayBeFinalized_with_positive_lp_status(int $lp_status): void
     {
         $settings = $this->createMock(ilIndividualAssessmentSettings::class);
@@ -433,9 +429,7 @@ class ilIndividualAssessmentMemberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider negativeLPStatusDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('negativeLPStatusDataProvider')]
     public function test_mayBeFinalized_with_negative_lp_status(int $lp_status): void
     {
         $settings = $this->createMock(ilIndividualAssessmentSettings::class);

--- a/components/ILIAS/IndividualAssessment/tests/Members/ilIndividualAssessmentMembersStorageDBTest.php
+++ b/components/ILIAS/IndividualAssessment/tests/Members/ilIndividualAssessmentMembersStorageDBTest.php
@@ -683,9 +683,7 @@ class ilIndividualAssessmentMembersStorageDBTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataFor_getWhereFromFilter
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataFor_getWhereFromFilter')]
     public function test_getWhereFromFilter($filter, $result): void
     {
         $db = $this->createMock(ilDBInterface::class);

--- a/components/ILIAS/IndividualAssessment/tests/Settings/ilIndividualAssessmentSettingsTest.php
+++ b/components/ILIAS/IndividualAssessment/tests/Settings/ilIndividualAssessmentSettingsTest.php
@@ -21,9 +21,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use ILIAS\UI\Component\Input\Field\Section;
 
-/**
- * @backupGlobals disabled
- */
+#[\PHPUnit\Framework\Attributes\BackupGlobals(false)]
 class ilIndividualAssessmentSettingsTest extends TestCase
 {
     public function test_create_settings()

--- a/components/ILIAS/IndividualAssessment/tests/ilIndividualAssessmentUserGradingTest.php
+++ b/components/ILIAS/IndividualAssessment/tests/ilIndividualAssessmentUserGradingTest.php
@@ -22,9 +22,7 @@ use PHPUnit\Framework\TestCase;
 use ILIAS\UI\Component\Input\Field\Section;
 use ILIAS\FileUpload\Handler\AbstractCtrlAwareUploadHandler;
 
-/**
- * @backupGlobals disabled
- */
+#[\PHPUnit\Framework\Attributes\BackupGlobals(false)]
 class ilIndividualAssessmentUserGradingTest extends TestCase
 {
     public function test_create_instance()

--- a/components/ILIAS/KioskMode/tests/StateTest.php
+++ b/components/ILIAS/KioskMode/tests/StateTest.php
@@ -28,9 +28,7 @@ class StateTest extends TestCase
         return $state;
     }
 
-    /**
-     * @depends testGetNullValue
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testGetNullValue')]
     public function testValue(State $state): State
     {
         $key = 'key';
@@ -40,18 +38,14 @@ class StateTest extends TestCase
         return $state;
     }
 
-    /**
-     * @depends testValue
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testValue')]
     public function testSerialize(State $state): void
     {
         $expected = json_encode(['key' => 'value'], JSON_THROW_ON_ERROR);
         $this->assertEquals($expected, $state->serialize());
     }
 
-    /**
-     * @depends testValue
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testValue')]
     public function testRemoveValue(State $state): void
     {
         $state = $state->withValueFor('keep', 'this');

--- a/components/ILIAS/LearningSequence/tests/GlobalSettings/GlobalSettingsTest.php
+++ b/components/ILIAS/LearningSequence/tests/GlobalSettings/GlobalSettingsTest.php
@@ -33,9 +33,7 @@ class GlobalSettingsTest extends TestCase
         return $settings;
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testIntervalAttribute(LSGlobalSettings $settings): void
     {
         $interval = 2.0;

--- a/components/ILIAS/LearningSequence/tests/LSItems/LSItemTest.php
+++ b/components/ILIAS/LearningSequence/tests/LSItems/LSItemTest.php
@@ -65,9 +65,7 @@ class LSItemTest extends TestCase
         return $object;
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithOnline(LSItem $object): void
     {
         $new_obj = $object->withOnline(false);
@@ -91,9 +89,7 @@ class LSItemTest extends TestCase
         $this->assertEquals(self::REF_ID, $new_obj->getRefId());
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithOrderNumber(LSItem $object): void
     {
         $new_obj = $object->withOrderNumber(20);
@@ -117,9 +113,7 @@ class LSItemTest extends TestCase
         $this->assertEquals(self::REF_ID, $new_obj->getRefId());
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithPostCondition(LSItem $object): void
     {
         $pc = new ilLSPostCondition(555, 'always');

--- a/components/ILIAS/LearningSequence/tests/LearnerProgress/LSLearnerItemTest.php
+++ b/components/ILIAS/LearningSequence/tests/LearnerProgress/LSLearnerItemTest.php
@@ -69,27 +69,21 @@ class LSLearnerItemTest extends TestCase
         return $object;
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testTurnedOffWithPostCondition(LSItem $object): void
     {
         $this->expectException(LogicException::class);
         $object->withPostCondition($this->post_condition);
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testTurnedOffWithOrderNumber(LSItem $object): void
     {
         $this->expectException(LogicException::class);
         $object->withOrderNumber(self::ORDER_NUMBER);
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testTurnedOffWithOnline(LSItem $object): void
     {
         $this->expectException(LogicException::class);

--- a/components/ILIAS/LearningSequence/tests/Settings/LSSettingsTest.php
+++ b/components/ILIAS/LearningSequence/tests/Settings/LSSettingsTest.php
@@ -55,9 +55,7 @@ class LSSettingsTest extends TestCase
         return $object;
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithAbstract(ilLearningSequenceSettings $object)
     {
         $new_object = $object->withAbstract("teststring");
@@ -77,9 +75,7 @@ class LSSettingsTest extends TestCase
         $this->assertEquals($new_object->getMembersGallery(), self::TO_MEMBERS_GALLERY);
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithExtro(ilLearningSequenceSettings $object)
     {
         $new_object = $object->withExtro("teststring");
@@ -99,9 +95,7 @@ class LSSettingsTest extends TestCase
         $this->assertEquals($new_object->getMembersGallery(), self::TO_MEMBERS_GALLERY);
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithAbstractImage(ilLearningSequenceSettings $object)
     {
         $new_object = $object->withAbstractImage("teststring");
@@ -121,9 +115,7 @@ class LSSettingsTest extends TestCase
         $this->assertEquals($new_object->getMembersGallery(), self::TO_MEMBERS_GALLERY);
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithExtroImage(ilLearningSequenceSettings $object)
     {
         $new_object = $object->withExtroImage("teststring");
@@ -143,9 +135,7 @@ class LSSettingsTest extends TestCase
         $this->assertEquals($new_object->getMembersGallery(), self::TO_MEMBERS_GALLERY);
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithMembersGallery(ilLearningSequenceSettings $object)
     {
         $new_object = $object->withMembersGallery(false);

--- a/components/ILIAS/LearningSequence/tests/Settings/ilLearningSequenceSettingsTest.php
+++ b/components/ILIAS/LearningSequence/tests/Settings/ilLearningSequenceSettingsTest.php
@@ -51,9 +51,7 @@ class ilLearningSequenceSettingsTest extends TestCase
         return $object;
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithAbstract(ilLearningSequenceSettings $object): void
     {
         $new_object = $object->withAbstract("teststring");
@@ -73,9 +71,7 @@ class ilLearningSequenceSettingsTest extends TestCase
         $this->assertEquals(self::TO_MEMBERS_GALLERY, $new_object->getMembersGallery());
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithExtro(ilLearningSequenceSettings $object): void
     {
         $new_object = $object->withExtro("teststring");
@@ -95,9 +91,7 @@ class ilLearningSequenceSettingsTest extends TestCase
         $this->assertEquals(self::TO_MEMBERS_GALLERY, $new_object->getMembersGallery());
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithAbstractImage(ilLearningSequenceSettings $object): void
     {
         $new_object = $object->withAbstractImage("teststring");
@@ -117,9 +111,7 @@ class ilLearningSequenceSettingsTest extends TestCase
         $this->assertEquals(self::TO_MEMBERS_GALLERY, $new_object->getMembersGallery());
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithExtroImage(ilLearningSequenceSettings $object): void
     {
         $new_object = $object->withExtroImage("teststring");
@@ -139,9 +131,7 @@ class ilLearningSequenceSettingsTest extends TestCase
         $this->assertEquals(self::TO_MEMBERS_GALLERY, $new_object->getMembersGallery());
     }
 
-    /**
-     * @depends testCreate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testCreate')]
     public function testWithMembersGallery(ilLearningSequenceSettings $object): void
     {
         $new_object = $object->withMembersGallery(false);

--- a/components/ILIAS/Maps/tests/ilMapGUITest.php
+++ b/components/ILIAS/Maps/tests/ilMapGUITest.php
@@ -41,9 +41,7 @@ class ilMapGUITest extends TestCase
         };
     }
 
-    /**
-     * @dataProvider properties
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('properties')]
     public function testSettersAndGetters($name, $value): void
     {
         $set = "set$name";

--- a/components/ILIAS/Math/tests/ilMathBaseAdapterTestCase.php
+++ b/components/ILIAS/Math/tests/ilMathBaseAdapterTestCase.php
@@ -56,74 +56,58 @@ abstract class ilMathBaseAdapterTestCase extends TestCase
         $this->assertTrue($actual == $expected, $differ->diff($actual, $expected));
     }
 
-    /**
-     * @dataProvider addData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('addData')]
     public function testAdd(string $a, string $b, string $result, int $scale): void
     {
         $this->assertEqualNumbers($result, $this->mathAdapter->add($a, $b, $scale));
     }
 
-    /**
-     *  @dataProvider subData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('subData')]
     public function testSub(string $a, string $b, string $result, int $scale): void
     {
         $this->assertEqualNumbers($result, $this->mathAdapter->sub($a, $b, $scale));
     }
 
-    /**
-     *  @dataProvider mulData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('mulData')]
     public function testMul(string $a, string $b, string $result, int $scale): void
     {
         $this->assertEqualNumbers($result, $this->mathAdapter->mul($a, $b, $scale));
     }
 
-    /**
-     *  @dataProvider divData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('divData')]
     public function testDiv(string $a, string $b, string $result, int $scale): void
     {
         $this->assertEqualNumbers($result, $this->mathAdapter->div($a, $b, $scale));
     }
 
-    /**
-     *  @dataProvider sqrtData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('sqrtData')]
     public function testSqrt(string $a, string $result, ?int $scale): void
     {
         $this->assertEqualNumbers($result, $this->mathAdapter->sqrt($a, $scale));
     }
 
-    /**
-     *  @dataProvider powData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('powData')]
     public function testPow(string $a, string $b, string $result, ?int $scale): void
     {
         $this->assertEqualNumbers($result, $this->mathAdapter->pow($a, $b, $scale));
     }
 
     /**
-     * @dataProvider modData
      * @throws ilMathDivisionByZeroException
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('modData')]
     public function testMod(string $a, string $b, string $result): void
     {
         $this->assertEqualNumbers($result, $this->mathAdapter->mod($a, $b));
     }
 
-    /**
-     *  @dataProvider equalsData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('equalsData')]
     public function testEquals(string $a, string $b, bool $result, ?int $scale): void
     {
         $this->assertEqualNumbers($result, $this->mathAdapter->equals($a, $b, $scale));
     }
 
-    /**
-     *  @dataProvider calcData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('calcData')]
     public function testCalculation(string $formula, string $result, int $scale): void
     {
         $this->assertEqualNumbers($result, ilMath::_applyScale($this->evalMath->evaluate($formula), $scale));

--- a/components/ILIAS/Math/tests/ilMathTest.php
+++ b/components/ILIAS/Math/tests/ilMathTest.php
@@ -33,9 +33,7 @@ class ilMathTest extends TestCase
         $this->eval_math = new EvalMath();
     }
 
-    /**
-     * @dataProvider gcdData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('gcdData')]
     public function testGcd(string $a, string $b, string $result): void
     {
         $this->assertEquals($result, ilMath::getGreatestCommonDivisor($a, $b));

--- a/components/ILIAS/MathJax/tests/ilMathJaxTest.php
+++ b/components/ILIAS/MathJax/tests/ilMathJaxTest.php
@@ -30,10 +30,8 @@ class ilMathJaxTest extends ilMathJaxBaseTestCase
         $this->assertInstanceOf('ilMathJax', $mathjax);
     }
 
-    /**
-     * @depends testInstanceCanBeCreated
-     * @dataProvider clientSideData
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testInstanceCanBeCreated')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('clientSideData')]
     public function testClientSideRendering(int $limiter, string $input, ?string $start, ?string $end, string $expected): void
     {
         $config = $this->getEmptyConfig()->withClientEnabled(true)->withClientLimiter($limiter);
@@ -65,10 +63,8 @@ class ilMathJaxTest extends ilMathJaxBaseTestCase
         ];
     }
 
-    /**
-     * @depends testInstanceCanBeCreated
-     * @dataProvider serverSideData
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testInstanceCanBeCreated')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('serverSideData')]
     public function testServerSideRendering(string $purpose, ?string $imagefile, string $expected): void
     {
         $input = '[tex]f(x)=\int_{-\infty}^x e^{-t^2}dt[/tex]';

--- a/components/ILIAS/MetaData/tests/Vocabularies/Dispatch/Info/InfosTest.php
+++ b/components/ILIAS/MetaData/tests/Vocabularies/Dispatch/Info/InfosTest.php
@@ -118,9 +118,7 @@ class InfosTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider activeCountProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('activeCountProvider')]
     public function testIsDeactivatableStandard(
         int $active_controlled_vocabs,
         bool $is_standard_vocab_active,
@@ -151,9 +149,7 @@ class InfosTest extends TestCase
         $this->assertTrue($infos->isDeactivatable($vocab));
     }
 
-    /**
-     * @dataProvider activeCountProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('activeCountProvider')]
     public function testIsDeactivatableControlledVocabValue(
         int $active_controlled_vocabs,
         bool $is_standard_vocab_active,
@@ -264,9 +260,7 @@ class InfosTest extends TestCase
         $this->assertTrue($infos->canBeDeleted($vocab));
     }
 
-    /**
-     * @dataProvider activeCountProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('activeCountProvider')]
     public function testCanBeDeletedControlledVocabValue(
         int $active_controlled_vocabs,
         bool $is_standard_vocab_active,

--- a/components/ILIAS/MetaData/tests/Vocabularies/Dispatch/Presentation/PresentationTest.php
+++ b/components/ILIAS/MetaData/tests/Vocabularies/Dispatch/Presentation/PresentationTest.php
@@ -273,9 +273,7 @@ class PresentationTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider singleValueProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('singleValueProvider')]
     public function testPresentableLabels(
         string $value,
         bool $is_in_copyright,
@@ -314,9 +312,7 @@ class PresentationTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider singleValueProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('singleValueProvider')]
     public function testPresentableLabelsWithUnknownVocab(
         string $value,
         bool $is_in_copyright,

--- a/components/ILIAS/QTI/tests/ilQTIAssessmentcontrolTest.php
+++ b/components/ILIAS/QTI/tests/ilQTIAssessmentcontrolTest.php
@@ -31,18 +31,14 @@ class ilQTIAssessmentcontrolTest extends TestCase
         return $instance;
     }
 
-    /**
-     * @depends testConstruct
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruct')]
     public function testGetView(ilQTIAssessmentcontrol $instance): void
     {
         $this->assertEquals('All', $instance->getView());
     }
 
-    /**
-     * @dataProvider validViews
-     * @depends testGetView
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testGetView')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('validViews')]
     public function testSetViewValid(string $view): void
     {
         $instance = new ilQTIAssessmentcontrol();
@@ -50,9 +46,7 @@ class ilQTIAssessmentcontrolTest extends TestCase
         $this->assertEquals($view, $instance->getView());
     }
 
-    /**
-     * @depends testSetViewValid
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testSetViewValid')]
     public function testSetViewInvalid(): void
     {
         $instance = new ilQTIAssessmentcontrol();
@@ -60,10 +54,8 @@ class ilQTIAssessmentcontrolTest extends TestCase
         $this->assertEquals('All', $instance->getView());
     }
 
-    /**
-     * @dataProvider switches
-     * @depends testConstruct
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruct')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('switches')]
     public function testSwitchInitializeValue(string $suffix): void
     {
         $instance = new ilQTIAssessmentcontrol();
@@ -72,10 +64,8 @@ class ilQTIAssessmentcontrolTest extends TestCase
         $this->assertEquals('', $instance->$get());
     }
 
-    /**
-     * @dataProvider switches
-     * @depends testConstruct
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruct')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('switches')]
     public function testSwitchValuesConsideredAsYes(string $suffix): void
     {
         $instance = new ilQTIAssessmentcontrol();
@@ -90,10 +80,8 @@ class ilQTIAssessmentcontrolTest extends TestCase
     }
 
 
-    /**
-     * @dataProvider switches
-     * @depends testConstruct
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruct')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('switches')]
     public function testSwitchValuesConsideredAsNo(string $suffix): void
     {
         $instance = new ilQTIAssessmentcontrol();

--- a/components/ILIAS/QTI/tests/ilQTIDecvarTest.php
+++ b/components/ILIAS/QTI/tests/ilQTIDecvarTest.php
@@ -34,9 +34,7 @@ class ilQTIDecvarTest extends TestCase
         $this->assertEquals('Some input.', $instance->getVarname());
     }
 
-    /**
-     * @dataProvider vartypes
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('vartypes')]
     public function testSetGetVartype(string $input, ?string $expected): void
     {
         $instance = new ilQTIDecvar();

--- a/components/ILIAS/QTI/tests/ilQTIItemfeedbackTest.php
+++ b/components/ILIAS/QTI/tests/ilQTIItemfeedbackTest.php
@@ -27,10 +27,8 @@ class ilQTIItemfeedbackTest extends TestCase
         $this->assertInstanceOf(ilQTIItemfeedback::class, new ilQTIItemfeedback());
     }
 
-    /**
-     * @depends testConstruct
-     * @dataProvider views
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruct')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('views')]
     public function testSetGetView(string $input, ?string $expected): void
     {
         $instance = new ilQTIItemfeedback();

--- a/components/ILIAS/QTI/tests/ilQTIMattextTest.php
+++ b/components/ILIAS/QTI/tests/ilQTIMattextTest.php
@@ -55,9 +55,7 @@ class ilQTIMattextTest extends TestCase
         $this->assertEquals('Some input.', $instance->getUri());
     }
 
-    /**
-     * @dataProvider xmlSpaces
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('xmlSpaces')]
     public function testSetGetXmlspace(string $input, ?string $expected): void
     {
         $instance = new ilQTIMattext();

--- a/components/ILIAS/QTI/tests/ilQTIRenderFibTest.php
+++ b/components/ILIAS/QTI/tests/ilQTIRenderFibTest.php
@@ -41,9 +41,7 @@ class ilQTIRenderFibTest extends TestCase
         $this->assertEquals('Some input.', $instance->getMaxnumber());
     }
 
-    /**
-     * @dataProvider prompts
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('prompts')]
     public function testSetGetPrompt(string $input, ?string $expected): void
     {
         $instance = new ilQTIRenderFib();
@@ -51,9 +49,7 @@ class ilQTIRenderFibTest extends TestCase
         $this->assertEquals($expected, $instance->getPrompt());
     }
 
-    /**
-     * @dataProvider fibtypes
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('fibtypes')]
     public function testSetGetFibtype(string $input, ?string $expected): void
     {
         $instance = new ilQTIRenderFib();

--- a/components/ILIAS/QTI/tests/ilQTIRespconditionTest.php
+++ b/components/ILIAS/QTI/tests/ilQTIRespconditionTest.php
@@ -27,9 +27,7 @@ class ilQTIRespconditionTest extends TestCase
         $this->assertInstanceOf(ilQTIRespcondition::class, new ilQTIRespcondition());
     }
 
-    /**
-     * @dataProvider continues
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('continues')]
     public function testSetGetContinue(string $input, ?string $expected): void
     {
         $instance = new ilQTIRespcondition();

--- a/components/ILIAS/QTI/tests/ilQTIResponseLabelTest.php
+++ b/components/ILIAS/QTI/tests/ilQTIResponseLabelTest.php
@@ -27,9 +27,7 @@ class ilQTIResponseLabelTest extends TestCase
         $this->assertInstanceOf(ilQTIResponseLabel::class, new ilQTIResponseLabel());
     }
 
-    /**
-     * @dataProvider rshuffles
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('rshuffles')]
     public function testSetGetRshuffle(string $input, ?string $expected): void
     {
         $instance = new ilQTIResponseLabel();
@@ -37,9 +35,7 @@ class ilQTIResponseLabelTest extends TestCase
         $this->assertEquals($expected, $instance->getRshuffle());
     }
 
-    /**
-     * @dataProvider areas
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('areas')]
     public function testSetGetRarea(string $input, ?string $expected): void
     {
         $instance = new ilQTIResponseLabel();
@@ -47,9 +43,7 @@ class ilQTIResponseLabelTest extends TestCase
         $this->assertEquals($expected, $instance->getRarea());
     }
 
-    /**
-     * @dataProvider rranges
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('rranges')]
     public function testSetGetRrange(string $input, ?string $expected): void
     {
         $instance = new ilQTIResponseLabel();

--- a/components/ILIAS/QTI/tests/ilQTIResponseTest.php
+++ b/components/ILIAS/QTI/tests/ilQTIResponseTest.php
@@ -34,9 +34,7 @@ class ilQTIResponseTest extends TestCase
         $this->assertEquals('Some input.', $instance->getIdent());
     }
 
-    /**
-     * @dataProvider rtimings
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('rtimings')]
     public function testSetGetRtiming(string $input, ?string $expected): void
     {
         $instance = new ilQTIResponse();
@@ -44,9 +42,7 @@ class ilQTIResponseTest extends TestCase
         $this->assertEquals($expected, $instance->getRtiming());
     }
 
-    /**
-     * @dataProvider numtypes
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('numtypes')]
     public function testSetGetNumtype(string $input, ?string $expected): void
     {
         $instance = new ilQTIResponse();

--- a/components/ILIAS/QTI/tests/ilQTIResponseVarTest.php
+++ b/components/ILIAS/QTI/tests/ilQTIResponseVarTest.php
@@ -34,9 +34,7 @@ class ilQTIResponseVarTest extends TestCase
         $this->assertEquals('Some input.', $instance->getVartype());
     }
 
-    /**
-     * @dataProvider cases
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('cases')]
     public function testSetGetCase(string $input, ?string $expected): void
     {
         $instance = new ilQTIResponseVar('a');
@@ -58,9 +56,7 @@ class ilQTIResponseVarTest extends TestCase
         $this->assertEquals('Some input.', $instance->getIndex());
     }
 
-    /**
-     * @dataProvider setMatches
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('setMatches')]
     public function testSetGetSetmatch(string $input, ?string $expected): void
     {
         $instance = new ilQTIResponseVar('a');
@@ -68,9 +64,7 @@ class ilQTIResponseVarTest extends TestCase
         $this->assertEquals($expected, $instance->getSetmatch());
     }
 
-    /**
-     * @dataProvider areaTypes
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('areaTypes')]
     public function testSetGetAreatype(string $input, ?string $expected): void
     {
         $instance = new ilQTIResponseVar('a');

--- a/components/ILIAS/QTI/tests/ilQTISetvarTest.php
+++ b/components/ILIAS/QTI/tests/ilQTISetvarTest.php
@@ -27,9 +27,7 @@ class ilQTISetvarTest extends TestCase
         $this->assertInstanceOf(ilQTISetvar::class, new ilQTISetvar());
     }
 
-    /**
-     * @dataProvider actions
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('actions')]
     public function testSetGetAction(string $input, ?string $expected): void
     {
         $instance = new ilQTISetvar();

--- a/components/ILIAS/Setup/tests/Metrics/MetricTest.php
+++ b/components/ILIAS/Setup/tests/Metrics/MetricTest.php
@@ -31,9 +31,7 @@ use ILIAS\UI\Component\Panel\Report;
 
 class MetricTest extends TestCase
 {
-    /**
-     * @dataProvider metricProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('metricProvider')]
     public function testConstructMetric(string $stability, string $type, $value, string $description, bool $success): void
     {
         if (!$success) {
@@ -115,9 +113,7 @@ class MetricTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider typedMetricsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('typedMetricsProvider')]
     public function testToYAML(M $metric, string $expected): void
     {
         $this->assertEquals($expected, $metric->toYAML());
@@ -228,9 +224,7 @@ METRIC;
         $this->assertEquals($expected_rest, $rest);
     }
 
-    /**
-     * @dataProvider typedMetricsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('typedMetricsProvider')]
     public function testToArrayWithFlatValues(M $metric, string $expected): void
     {
         $this->assertEquals($expected, $metric->toArray());

--- a/components/ILIAS/StudyProgramme/tests/model/Assignments/ilStudyProgrammeProgressTest.php
+++ b/components/ILIAS/StudyProgramme/tests/model/Assignments/ilStudyProgrammeProgressTest.php
@@ -256,9 +256,7 @@ class ilStudyProgrammeProgressTest extends \PHPUnit\Framework\TestCase
         $pgs = (new ilPRGProgress(123))->withStatus(777);
     }
 
-    /**
-     * @dataProvider ilPRGProgressStatus
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('ilPRGProgressStatus')]
     public function testPRGProgressAllowedTransitionsForInProgress(int $status): void
     {
         $pgs = (new ilPRGProgress(123))->withStatus(ilPRGProgress::STATUS_IN_PROGRESS);
@@ -275,9 +273,7 @@ class ilStudyProgrammeProgressTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @dataProvider ilPRGProgressStatus
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('ilPRGProgressStatus')]
     public function testPRGProgressAllowedTransitionsForAccredited($status)
     {
         $pgs = (new ilPRGProgress(123))
@@ -296,9 +292,7 @@ class ilStudyProgrammeProgressTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @dataProvider ilPRGProgressStatus
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('ilPRGProgressStatus')]
     public function testPRGProgressAllowedTransitionsForCompleted($status)
     {
         $pgs = (new ilPRGProgress(123))
@@ -315,9 +309,7 @@ class ilStudyProgrammeProgressTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @dataProvider ilPRGProgressStatus
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('ilPRGProgressStatus')]
     public function testPRGProgressAllowedTransitionsForFailed($status)
     {
         $pgs = (new ilPRGProgress(123))
@@ -335,9 +327,7 @@ class ilStudyProgrammeProgressTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @dataProvider ilPRGProgressStatus
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('ilPRGProgressStatus')]
     public function testPRGProgressAllowedTransitionsForIrrelevant($status): void
     {
         $pgs = (new ilPRGProgress(123))->withStatus(ilPRGProgress::STATUS_NOT_RELEVANT);

--- a/components/ILIAS/StudyProgramme/tests/model/AutoCategories/ilStudyProgrammeAutoCategoryTest.php
+++ b/components/ILIAS/StudyProgramme/tests/model/AutoCategories/ilStudyProgrammeAutoCategoryTest.php
@@ -50,9 +50,7 @@ class ilStudyProgrammeAutoCategoryTest extends TestCase
         return $ac;
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetPrgObjId(ilStudyProgrammeAutoCategory $ac): void
     {
         $this->assertEquals(
@@ -61,9 +59,7 @@ class ilStudyProgrammeAutoCategoryTest extends TestCase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetCategoryRefId(ilStudyProgrammeAutoCategory $ac): void
     {
         $this->assertEquals(
@@ -72,9 +68,7 @@ class ilStudyProgrammeAutoCategoryTest extends TestCase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetLastEditorId(ilStudyProgrammeAutoCategory $ac): void
     {
         $this->assertEquals(
@@ -83,9 +77,7 @@ class ilStudyProgrammeAutoCategoryTest extends TestCase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetLastEdited(ilStudyProgrammeAutoCategory $ac): void
     {
         $this->assertEquals(

--- a/components/ILIAS/StudyProgramme/tests/model/AutoMemberships/ilStudyProgrammeAutoMembershipsSourceTest.php
+++ b/components/ILIAS/StudyProgramme/tests/model/AutoMemberships/ilStudyProgrammeAutoMembershipsSourceTest.php
@@ -57,9 +57,7 @@ class ilStudyProgrammeAutoMembershipsSourceTest extends TestCase
         return $ams;
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetPrgObjId(ilStudyProgrammeAutoMembershipSource $ams): void
     {
         $this->assertEquals(
@@ -68,9 +66,7 @@ class ilStudyProgrammeAutoMembershipsSourceTest extends TestCase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetSourceType(ilStudyProgrammeAutoMembershipSource $ams): void
     {
         $this->assertEquals(
@@ -78,9 +74,7 @@ class ilStudyProgrammeAutoMembershipsSourceTest extends TestCase
             $ams->getSourceType()
         );
     }
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetSourceId(ilStudyProgrammeAutoMembershipSource $ams): void
     {
         $this->assertEquals(
@@ -89,9 +83,7 @@ class ilStudyProgrammeAutoMembershipsSourceTest extends TestCase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetLastEditorId(ilStudyProgrammeAutoMembershipSource $ams): void
     {
         $this->assertEquals(
@@ -100,9 +92,7 @@ class ilStudyProgrammeAutoMembershipsSourceTest extends TestCase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetLastEdited(ilStudyProgrammeAutoMembershipSource $ams): void
     {
         $this->assertEquals(

--- a/components/ILIAS/StudyProgramme/tests/model/Settings/ilStudyProgrammeSettingsRepositoryTest.php
+++ b/components/ILIAS/StudyProgramme/tests/model/Settings/ilStudyProgrammeSettingsRepositoryTest.php
@@ -42,9 +42,7 @@ class ilStudyProgrammeSettingsRepositoryTest extends \PHPUnit\Framework\TestCase
         return $repo;
     }
 
-    /**
-     * @depends test_init
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('test_init')]
     public function testPRGRepoEditAndUpdate(ilStudyProgrammeSettingsDBRepository $repo)
     {
         $this->markTestSkipped('Failed for some unknown reason.');
@@ -125,9 +123,7 @@ class ilStudyProgrammeSettingsRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($set->getPoints(), 10);
     }
 
-    /**
-     * @depends testPRGRepoEditAndUpdate
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPRGRepoEditAndUpdate')]
     public function testPRGRepoDelete()
     {
         $this->expectException(\LogicException::class);

--- a/components/ILIAS/StudyProgramme/tests/model/Types/ilStudyProgrammeTypeTranslationTest.php
+++ b/components/ILIAS/StudyProgramme/tests/model/Types/ilStudyProgrammeTypeTranslationTest.php
@@ -27,9 +27,7 @@ class ilStudyProgrammeTypeTranslationTest extends \PHPUnit\Framework\TestCase
         return $tt;
     }
 
-    /**
-     * @depends test_init_and_id
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('test_init_and_id')]
     public function test_prg_type_id($tt)
     {
         $this->assertEquals(0, $tt->getPrgTypeId());
@@ -38,9 +36,7 @@ class ilStudyProgrammeTypeTranslationTest extends \PHPUnit\Framework\TestCase
     }
 
 
-    /**
-     * @depends test_init_and_id
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('test_init_and_id')]
     public function test_lang($tt)
     {
         $this->assertEquals('', $tt->getLang());
@@ -48,9 +44,7 @@ class ilStudyProgrammeTypeTranslationTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('de', $tt->getLang());
     }
 
-    /**
-     * @depends test_init_and_id
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('test_init_and_id')]
     public function test_member($tt)
     {
         $this->assertEquals('', $tt->getMember());
@@ -58,9 +52,7 @@ class ilStudyProgrammeTypeTranslationTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('a_member', $tt->getMember());
     }
 
-    /**
-     * @depends test_init_and_id
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('test_init_and_id')]
     public function test_value($tt)
     {
         $this->assertEquals('', $tt->getValue());

--- a/components/ILIAS/Test/tests/AccessFileUploadPreviewTest.php
+++ b/components/ILIAS/Test/tests/AccessFileUploadPreviewTest.php
@@ -63,9 +63,7 @@ class AccessFileUploadPreviewTest extends TestCase
         $this->assertFalse($result->value());
     }
 
-    /**
-     * @dataProvider types
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('types')]
     public function testWithTypes(?string $type, bool $permitted, ?string $requires_permission): void
     {
         $database = $this->getMockBuilder(ilDBInterface::class)->disableOriginalConstructor()->getMock();

--- a/components/ILIAS/Test/tests/AccessQuestionImageTest.php
+++ b/components/ILIAS/Test/tests/AccessQuestionImageTest.php
@@ -32,9 +32,7 @@ class AccessQuestionImageTest extends TestCase
         $this->assertInstanceOf(AccessQuestionImage::class, new AccessQuestionImage($readable));
     }
 
-    /**
-     * @dataProvider invalidPaths
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('invalidPaths')]
     public function testIsPermittedWithInvalidPath(string $path): void
     {
         $readable = $this->getMockBuilder(Readable::class)->disableOriginalConstructor()->getMock();
@@ -56,9 +54,7 @@ class AccessQuestionImageTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider isPermittedProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('isPermittedProvider')]
     public function testIsPermittedWithValidPath(bool $is_readable): void
     {
         $readable = $this->getMockBuilder(Readable::class)->disableOriginalConstructor()->getMock();

--- a/components/ILIAS/Test/tests/Certificate/CertificateSettingsTestFormRepositoryTest.php
+++ b/components/ILIAS/Test/tests/Certificate/CertificateSettingsTestFormRepositoryTest.php
@@ -83,9 +83,7 @@ class CertificateSettingsTestFormRepositoryTest extends TestCase
         $this->assertSame($form_mock, $result);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testSave(): void
     {
         $language = $this->getMockBuilder(\ilLanguage::class)

--- a/components/ILIAS/Test/tests/Exceptions/ilTestEvaluationExceptionTest.php
+++ b/components/ILIAS/Test/tests/Exceptions/ilTestEvaluationExceptionTest.php
@@ -18,9 +18,7 @@
 
 class ilTestEvaluationExceptionTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider constructDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('constructDataProvider')]
     public function testConstruct(array $input, array $output): void
     {
         $ilTestEvaluationException = isset($input['code'])
@@ -46,9 +44,7 @@ class ilTestEvaluationExceptionTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider exceptionDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('exceptionDataProvider')]
     public function testException(array $input, array $output): void
     {
         $this->expectException(ilTestEvaluationException::class);

--- a/components/ILIAS/Test/tests/Exceptions/ilTestExceptionTest.php
+++ b/components/ILIAS/Test/tests/Exceptions/ilTestExceptionTest.php
@@ -18,9 +18,7 @@
 
 class ilTestExceptionTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider constructDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('constructDataProvider')]
     public function testConstruct(array $input, array $output): void
     {
         $ilTestException = isset($input['code'])
@@ -46,9 +44,7 @@ class ilTestExceptionTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider exceptionDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('exceptionDataProvider')]
     public function testException(array $input, array $output): void
     {
         $this->expectException(ilTestException::class);

--- a/components/ILIAS/Test/tests/Exceptions/ilTestMissingQuestionPoolIdParameterExceptionTest.php
+++ b/components/ILIAS/Test/tests/Exceptions/ilTestMissingQuestionPoolIdParameterExceptionTest.php
@@ -18,9 +18,7 @@
 
 class ilTestMissingQuestionPoolIdParameterExceptionTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider constructDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('constructDataProvider')]
     public function testConstruct(array $input, array $output): void
     {
         $ilTestMissingQuestionPoolIdParameterException = isset($input['code'])
@@ -46,9 +44,7 @@ class ilTestMissingQuestionPoolIdParameterExceptionTest extends ilTestBaseTestCa
         ];
     }
 
-    /**
-     * @dataProvider exceptionDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('exceptionDataProvider')]
     public function testException(array $input, array $output): void
     {
         $this->expectException(ilTestMissingQuestionPoolIdParameterException::class);

--- a/components/ILIAS/Test/tests/Exceptions/ilTestMissingSourcePoolDefinitionParameterExceptionTest.php
+++ b/components/ILIAS/Test/tests/Exceptions/ilTestMissingSourcePoolDefinitionParameterExceptionTest.php
@@ -18,9 +18,7 @@
 
 class ilTestMissingSourcePoolDefinitionParameterExceptionTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider constructDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('constructDataProvider')]
     public function testConstruct(array $input, array $output): void
     {
         $ilTestMissingSourcePoolDefinitionParameterException = isset($input['code'])
@@ -46,9 +44,7 @@ class ilTestMissingSourcePoolDefinitionParameterExceptionTest extends ilTestBase
         ];
     }
 
-    /**
-     * @dataProvider exceptionDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('exceptionDataProvider')]
     public function testException(array $input, array $output): void
     {
         $this->expectException(ilTestMissingSourcePoolDefinitionParameterException::class);

--- a/components/ILIAS/Test/tests/Exceptions/ilTestNoNextRequestableHintExistsExceptionTest.php
+++ b/components/ILIAS/Test/tests/Exceptions/ilTestNoNextRequestableHintExistsExceptionTest.php
@@ -18,9 +18,7 @@
 
 class ilTestNoNextRequestableHintExistsExceptionTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider constructDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('constructDataProvider')]
     public function testConstruct(array $input, array $output): void
     {
         $ilTestNoNextRequestableHintExistsException = isset($input['code'])
@@ -46,9 +44,7 @@ class ilTestNoNextRequestableHintExistsExceptionTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider exceptionDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('exceptionDataProvider')]
     public function testException(array $input, array $output): void
     {
         $this->expectException(ilTestNoNextRequestableHintExistsException::class);

--- a/components/ILIAS/Test/tests/Exceptions/ilTestQuestionPoolNotAvailableAsSourcePoolExceptionTest.php
+++ b/components/ILIAS/Test/tests/Exceptions/ilTestQuestionPoolNotAvailableAsSourcePoolExceptionTest.php
@@ -23,9 +23,7 @@ use ilTestQuestionPoolNotAvailableAsSourcePoolException;
 
 class ilTestQuestionPoolNotAvailableAsSourcePoolExceptionTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider constructDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('constructDataProvider')]
     public function testConstruct(array $input, array $output): void
     {
         $ilTestQuestionPoolNotAvailableAsSourcePoolException = isset($input['code'])
@@ -50,9 +48,7 @@ class ilTestQuestionPoolNotAvailableAsSourcePoolExceptionTest extends ilTestBase
         ];
     }
 
-    /**
-     * @dataProvider exceptionDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('exceptionDataProvider')]
     public function testException(array $input, array $output): void
     {
         $this->expectException(ilTestQuestionPoolNotAvailableAsSourcePoolException::class);

--- a/components/ILIAS/Test/tests/Results/Data/AttemptResultTest.php
+++ b/components/ILIAS/Test/tests/Results/Data/AttemptResultTest.php
@@ -30,9 +30,7 @@ class AttemptResultTest extends \ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getActiveIdDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getActiveIdDataProvider')]
     public function testGetActiveId(int $IO): void
     {
         $ilTestPassResult = new AttemptResult(
@@ -52,9 +50,7 @@ class AttemptResultTest extends \ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getPassDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getPassDataProvider')]
     public function testGetAttempt(int $IO): void
     {
         $ilTestPassResult = new AttemptResult(
@@ -74,9 +70,7 @@ class AttemptResultTest extends \ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getQuestionResultsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getQuestionResultsDataProvider')]
     public function testGetQuestionResults(\Closure $IO): void
     {
         $IO = $IO($this);

--- a/components/ILIAS/Test/tests/Scoring/Marks/MarkSchemaTest.php
+++ b/components/ILIAS/Test/tests/Scoring/Marks/MarkSchemaTest.php
@@ -200,9 +200,7 @@ class MarkSchemaTest extends ilTestBaseTestCase
         );
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testSaveToDb_regular()
     {
         /*

--- a/components/ILIAS/Test/tests/Settings/MainSettings/MainSettingsTest.php
+++ b/components/ILIAS/Test/tests/Settings/MainSettings/MainSettingsTest.php
@@ -31,9 +31,7 @@ use ILIAS\Test\Settings\MainSettings\SettingsAdditional;
 
 class MainSettingsTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider throwOnDifferentTestIdDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('throwOnDifferentTestIdDataProvider')]
     public function testThrowOnDifferentTestId(int $IO): void
     {
         $test_settings = $this->createConfiguredMock(TestSettings::class, ['getTestId' => $IO]);
@@ -64,9 +62,7 @@ class MainSettingsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider throwOnDifferentTestIdExceptionDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('throwOnDifferentTestIdExceptionDataProvider')]
     public function testThrowOnDifferentTestIdException(array $input): void
     {
         $test_settings = $this->createMock(TestSettings::class);
@@ -96,9 +92,7 @@ class MainSettingsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithTestIdDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithTestIdDataProvider')]
     public function testGetAndWithTestId(int $IO): void
     {
         $main_settings = (new MainSettings(
@@ -152,9 +146,7 @@ class MainSettingsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithGeneralSettingsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithGeneralSettingsDataProvider')]
     public function testGetAndWithGeneralSettings(\Closure $IO): void
     {
         $IO = $IO($this);
@@ -183,9 +175,7 @@ class MainSettingsTest extends ilTestBaseTestCase
         ]];
     }
 
-    /**
-     * @dataProvider getAndWithIntroductionSettingsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithIntroductionSettingsDataProvider')]
     public function testGetAndWithIntroductionSettings(\Closure $IO): void
     {
         $IO = $IO($this);
@@ -214,9 +204,7 @@ class MainSettingsTest extends ilTestBaseTestCase
         ]];
     }
 
-    /**
-     * @dataProvider getAndWithAccessSettingsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithAccessSettingsDataProvider')]
     public function testGetAndWithAccessSettings(\Closure $IO): void
     {
         $IO = $IO($this);
@@ -245,9 +233,7 @@ class MainSettingsTest extends ilTestBaseTestCase
         ]];
     }
 
-    /**
-     * @dataProvider getAndWithTestBehaviourSettingsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithTestBehaviourSettingsDataProvider')]
     public function testGetAndWithTestBehaviourSettings(\Closure $IO): void
     {
         $IO = $IO($this);
@@ -276,9 +262,7 @@ class MainSettingsTest extends ilTestBaseTestCase
         ]];
     }
 
-    /**
-     * @dataProvider getAndWithQuestionBehaviourSettingsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithQuestionBehaviourSettingsDataProvider')]
     public function testGetAndWithQuestionBehaviourSettings(\Closure $IO): void
     {
         $IO = $IO($this);
@@ -307,9 +291,7 @@ class MainSettingsTest extends ilTestBaseTestCase
         ]];
     }
 
-    /**
-     * @dataProvider getAndWithParticipantFunctionalitySettingsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithParticipantFunctionalitySettingsDataProvider')]
     public function testGetAndWithParticipantFunctionalitySettings(\Closure $IO): void
     {
         $IO = $IO($this);
@@ -338,9 +320,7 @@ class MainSettingsTest extends ilTestBaseTestCase
         ]];
     }
 
-    /**
-     * @dataProvider getAndWithFinishingSettingsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithFinishingSettingsDataProvider')]
     public function testGetAndWithFinishingSettings(\Closure $IO): void
     {
         $IO = $IO($this);
@@ -369,9 +349,7 @@ class MainSettingsTest extends ilTestBaseTestCase
         ]];
     }
 
-    /**
-     * @dataProvider getAndWithAdditionalSettingsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithAdditionalSettingsDataProvider')]
     public function testGetAndWithAdditionalSettings(\Closure $IO): void
     {
         $IO = $IO($this);

--- a/components/ILIAS/Test/tests/Settings/MainSettings/SettingsAccessTest.php
+++ b/components/ILIAS/Test/tests/Settings/MainSettings/SettingsAccessTest.php
@@ -22,9 +22,7 @@ use ILIAS\Test\Settings\MainSettings\SettingsAccess;
 
 class SettingsAccessTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider getAndWithStartTimeEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithStartTimeEnabledDataProvider')]
     public function testGetAndWithStartTimeEnabled(bool $io): void
     {
         $settings_access = (new SettingsAccess(0))->withStartTimeEnabled($io);
@@ -41,9 +39,7 @@ class SettingsAccessTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithStartTimeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithStartTimeDataProvider')]
     public function testGetAndWithStartTime(?DateTimeImmutable $io): void
     {
         $settings_access = (new SettingsAccess(0))->withStartTime($io);
@@ -60,9 +56,7 @@ class SettingsAccessTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithEndTimeEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithEndTimeEnabledDataProvider')]
     public function testGetAndWithEndTimeEnabled(bool $io): void
     {
         $settings_access = (new SettingsAccess(0))->withEndTimeEnabled($io);
@@ -79,9 +73,7 @@ class SettingsAccessTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithEndTimeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithEndTimeDataProvider')]
     public function testGetAndWithEndTime(?DateTimeImmutable $io): void
     {
         $settings_access = (new SettingsAccess(0))->withEndTime($io);
@@ -98,9 +90,7 @@ class SettingsAccessTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithPasswordEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithPasswordEnabledDataProvider')]
     public function testGetAndWithPasswordEnabled(bool $io): void
     {
         $settings_access = (new SettingsAccess(0))->withPasswordEnabled($io);
@@ -117,9 +107,7 @@ class SettingsAccessTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithPasswordDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithPasswordDataProvider')]
     public function testGetAndWithPassword(?string $io): void
     {
         $settings_access = (new SettingsAccess(0))->withPassword($io);
@@ -137,9 +125,7 @@ class SettingsAccessTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithFixedParticipantsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithFixedParticipantsDataProvider')]
     public function testGetAndWithFixedParticipants(bool $io): void
     {
         $settings_access = (new SettingsAccess(0))->withFixedParticipants($io);

--- a/components/ILIAS/Test/tests/Settings/MainSettings/SettingsAdditionalTest.php
+++ b/components/ILIAS/Test/tests/Settings/MainSettings/SettingsAdditionalTest.php
@@ -22,9 +22,7 @@ use ILIAS\Test\Settings\MainSettings\SettingsAdditional;
 
 class SettingsAdditionalTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider getSkillsServiceEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getSkillsServiceEnabledDataProvider')]
     public function testGetAndWithSkillsServiceEnabled(bool $io): void
     {
         $settings_additional = (new SettingsAdditional(0))->withSkillsServiceEnabled($io);
@@ -41,9 +39,7 @@ class SettingsAdditionalTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getHideInfoTabDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getHideInfoTabDataProvider')]
     public function testGetAndWithHideInfoTab(bool $io): void
     {
         $settings_additional = (new SettingsAdditional(0))->withHideInfoTab($io);

--- a/components/ILIAS/Test/tests/Settings/MainSettings/SettingsFinishingTest.php
+++ b/components/ILIAS/Test/tests/Settings/MainSettings/SettingsFinishingTest.php
@@ -22,9 +22,7 @@ use ILIAS\Test\Settings\MainSettings\SettingsFinishing;
 
 class SettingsFinishingTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider getAndWithConcludingRemarksEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithConcludingRemarksEnabledDataProvider')]
     public function testGetAndWithShowAnswerOverview(bool $io): void
     {
         $settings_finishing = (new SettingsFinishing(0))->withShowAnswerOverview($io);
@@ -41,9 +39,7 @@ class SettingsFinishingTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithConcludingRemarksEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithConcludingRemarksEnabledDataProvider')]
     public function testGetAndWithConcludingRemarksEnabled(bool $io): void
     {
         $settings_finishing = (new SettingsFinishing(0))->withConcludingRemarksEnabled($io);
@@ -52,9 +48,7 @@ class SettingsFinishingTest extends ilTestBaseTestCase
         $this->assertEquals($io, $settings_finishing->getConcludingRemarksEnabled());
     }
 
-    /**
-     * @dataProvider getAndWithConcludingRemarksTextDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithConcludingRemarksTextDataProvider')]
     public function testGetAndWithConcludingRemarksText(?string $io): void
     {
         $settings_finishing = new SettingsFinishing(
@@ -76,9 +70,7 @@ class SettingsFinishingTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithConcludingRemarksPageIdDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithConcludingRemarksPageIdDataProvider')]
     public function testGetAndWithConcludingRemarksPageId(?int $io): void
     {
         $settings_finishing = (new SettingsFinishing(0))->withConcludingRemarksPageId($io);
@@ -97,9 +89,7 @@ class SettingsFinishingTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithRedirectionModeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithRedirectionModeDataProvider')]
     public function testGetAndWithRedirectionMode(int $io): void
     {
         $settings_finishing = (new SettingsFinishing(0))->withRedirectionMode($io);
@@ -117,9 +107,7 @@ class SettingsFinishingTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithRedirectionUrlDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithRedirectionUrlDataProvider')]
     public function testGetAndWithRedirectionUrl(?string $io): void
     {
         $settings_finishing = (new SettingsFinishing(0))->withRedirectionUrl($io);
@@ -137,9 +125,7 @@ class SettingsFinishingTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithMailNotificationContentTypeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithMailNotificationContentTypeDataProvider')]
     public function testGetAndWithMailNotificationContentType(int $io): void
     {
         $settings_finishing = (new SettingsFinishing(0))->withMailNotificationContentType($io);
@@ -157,9 +143,7 @@ class SettingsFinishingTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithAlwaysSendMailNotificationDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithAlwaysSendMailNotificationDataProvider')]
     public function testGetAndWithAlwaysSendMailNotification(bool $io): void
     {
         $settings_finishing = (new SettingsFinishing(0))->withAlwaysSendMailNotification($io);

--- a/components/ILIAS/Test/tests/Settings/MainSettings/SettingsGeneralTest.php
+++ b/components/ILIAS/Test/tests/Settings/MainSettings/SettingsGeneralTest.php
@@ -22,9 +22,7 @@ use ILIAS\Test\Settings\MainSettings\SettingsGeneral;
 
 class SettingsGeneralTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider getAndWithQuestionSetTypeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithQuestionSetTypeDataProvider')]
     public function testGetAndWithQuestionSetType(string $io): void
     {
         $Settings_general = (new SettingsGeneral(0))->withQuestionSetType($io);
@@ -41,9 +39,7 @@ class SettingsGeneralTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithAnonymityDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithAnonymityDataProvider')]
     public function testGetAndWithAnonymity(bool $io): void
     {
         $Settings_general = (new SettingsGeneral(0))->withAnonymity($io);

--- a/components/ILIAS/Test/tests/Settings/MainSettings/SettingsIntroductionTest.php
+++ b/components/ILIAS/Test/tests/Settings/MainSettings/SettingsIntroductionTest.php
@@ -22,9 +22,7 @@ use ILIAS\Test\Settings\MainSettings\SettingsIntroduction;
 
 class SettingsIntroductionTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider getAndWithIntroductionEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithIntroductionEnabledDataProvider')]
     public function testGetAndWithIntroductionEnabled(bool $io): void
     {
         $settings_introduction = (new SettingsIntroduction(0))->withIntroductionEnabled($io);
@@ -41,9 +39,7 @@ class SettingsIntroductionTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithIntroductionTextDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithIntroductionTextDataProvider')]
     public function testGetAndWithIntroductionText(string $io): void
     {
         $settings_introduction = (new SettingsIntroduction(0))->withIntroductionText($io);
@@ -60,9 +56,7 @@ class SettingsIntroductionTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithIntroductionPageIdDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithIntroductionPageIdDataProvider')]
     public function testGetAndWithIntroductionPageId(?int $io): void
     {
         $settings_introduction = (new SettingsIntroduction(0))->withIntroductionPageId($io);
@@ -81,9 +75,7 @@ class SettingsIntroductionTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithExamConditionsCheckboxEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithExamConditionsCheckboxEnabledDataProvider')]
     public function testGetAndWithExamConditionsCheckboxEnabled(bool $io): void
     {
         $settings_introduction = (new SettingsIntroduction(0))->withExamConditionsCheckboxEnabled($io);

--- a/components/ILIAS/Test/tests/Settings/MainSettings/SettingsParticipantFunctionalityTest.php
+++ b/components/ILIAS/Test/tests/Settings/MainSettings/SettingsParticipantFunctionalityTest.php
@@ -22,9 +22,7 @@ use ILIAS\Test\Settings\MainSettings\SettingsParticipantFunctionality;
 
 class SettingsParticipantFunctionalityTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider getAndWithUsePreviousAnswerAllowedDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithUsePreviousAnswerAllowedDataProvider')]
     public function testGetAndWithUsePreviousAnswerAllowed(bool $io): void
     {
         $Settings_participant_functionality = (new SettingsParticipantFunctionality(0))->withUsePreviousAnswerAllowed($io);
@@ -41,9 +39,7 @@ class SettingsParticipantFunctionalityTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithSuspendTestAllowedDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithSuspendTestAllowedDataProvider')]
     public function testGetAndWithSuspendTestAllowed(bool $io): void
     {
         $Settings_participant_functionality = (new SettingsParticipantFunctionality(0))->withSuspendTestAllowed($io);
@@ -60,9 +56,7 @@ class SettingsParticipantFunctionalityTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithPostponedQuestionsMoveToEndDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithPostponedQuestionsMoveToEndDataProvider')]
     public function testGetAndWithPostponedQuestionsMoveToEnd(bool $io): void
     {
         $Settings_participant_functionality = (new SettingsParticipantFunctionality(0))->withPostponedQuestionsMoveToEnd($io);
@@ -79,9 +73,7 @@ class SettingsParticipantFunctionalityTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithQuestionListEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithQuestionListEnabledDataProvider')]
     public function testGetAndWithQuestionListEnabled(bool $io): void
     {
         $Settings_participant_functionality = (new SettingsParticipantFunctionality(0))->withQuestionListEnabled($io);
@@ -98,9 +90,7 @@ class SettingsParticipantFunctionalityTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithUsrPassOverviewModeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithUsrPassOverviewModeDataProvider')]
     public function testGetAndWithUsrPassOverviewMode(int $io): void
     {
         $Settings_participant_functionality = (new SettingsParticipantFunctionality(0))->withUsrPassOverviewMode($io);
@@ -118,9 +108,7 @@ class SettingsParticipantFunctionalityTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithUsrPassOverviewEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithUsrPassOverviewEnabledDataProvider')]
     public function testGetAndWithQuestionMarkingEnabled(bool $io): void
     {
         $Settings_participant_functionality = (new SettingsParticipantFunctionality(0));

--- a/components/ILIAS/Test/tests/Settings/MainSettings/SettingsQuestionBehaviourTest.php
+++ b/components/ILIAS/Test/tests/Settings/MainSettings/SettingsQuestionBehaviourTest.php
@@ -42,9 +42,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         );
     }
 
-    /**
-     * @dataProvider getAndWithQuestionTitleOutputModeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithQuestionTitleOutputModeDataProvider')]
     public function testGetAndWithQuestionTitleOutputMode(int $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withQuestionTitleOutputMode($io);
@@ -62,9 +60,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithInstantFeedbackDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithInstantFeedbackDataProvider')]
     public function testGetAndWithAutosaveEnabled(bool $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withAutosaveEnabled($io);
@@ -81,9 +77,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithAutosaveIntervalDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithAutosaveIntervalDataProvider')]
     public function testGetAndWithAutosaveInterval(int $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withAutosaveInterval($io);
@@ -101,9 +95,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShuffleQuestionsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShuffleQuestionsDataProvider')]
     public function testGetAndWithShuffleQuestions(bool $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withShuffleQuestions($io);
@@ -120,9 +112,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithInstantFeedbackPointsEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithInstantFeedbackPointsEnabledDataProvider')]
     public function testGetAndWithInstantFeedbackPointsEnabled(bool $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withInstantFeedbackPointsEnabled($io);
@@ -139,9 +129,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithInstantFeedbackGenericEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithInstantFeedbackGenericEnabledDataProvider')]
     public function testGetAndWithInstantFeedbackGenericEnabled(bool $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withInstantFeedbackGenericEnabled($io);
@@ -158,9 +146,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithInstantFeedbackSpecificEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithInstantFeedbackSpecificEnabledDataProvider')]
     public function testGetAndWithInstantFeedbackSpecificEnabled(bool $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withInstantFeedbackSpecificEnabled($io);
@@ -177,9 +163,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithInstantFeedbackSolutionEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithInstantFeedbackSolutionEnabledDataProvider')]
     public function testGetAndWithInstantFeedbackSolutionEnabled(bool $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withInstantFeedbackSolutionEnabled($io);
@@ -196,9 +180,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithForceInstantFeedbackOnNextQuestionDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithForceInstantFeedbackOnNextQuestionDataProvider')]
     public function testGetAndWithForceInstantFeedbackOnNextQuestion(bool $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withForceInstantFeedbackOnNextQuestion($io);
@@ -215,9 +197,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithLockAnswerOnInstantFeedbackEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithLockAnswerOnInstantFeedbackEnabledDataProvider')]
     public function testGetAndWithLockAnswerOnInstantFeedbackEnabled(bool $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withLockAnswerOnInstantFeedbackEnabled($io);
@@ -234,9 +214,7 @@ class SettingsQuestionBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithLockAnswerOnNextQuestionEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithLockAnswerOnNextQuestionEnabledDataProvider')]
     public function testGetAndWithLockAnswerOnNextQuestionEnabled(bool $io): void
     {
         $Settings_question_behaviour = $this->getTestInstance()->withLockAnswerOnNextQuestionEnabled($io);

--- a/components/ILIAS/Test/tests/Settings/MainSettings/SettingsTestBehaviourTest.php
+++ b/components/ILIAS/Test/tests/Settings/MainSettings/SettingsTestBehaviourTest.php
@@ -22,9 +22,7 @@ use ILIAS\Test\Settings\MainSettings\SettingsTestBehaviour;
 
 class SettingsTestBehaviourTest extends ilTestBaseTestCase
 {
-    /**
-     * @dataProvider getAndWithNumberOfTriesDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithNumberOfTriesDataProvider')]
     public function testGetAndWithNumberOfTries(int $io): void
     {
         $Settings_test_behaviour = (new SettingsTestBehaviour(0))->withNumberOfTries($io);
@@ -42,9 +40,7 @@ class SettingsTestBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithBlockAfterPassedEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithBlockAfterPassedEnabledDataProvider')]
     public function testGetAndWithBlockAfterPassedEnabled(): void
     {
         $Settings_test_behaviour = (new SettingsTestBehaviour(0))->withBlockAfterPassedEnabled(true);
@@ -61,9 +57,7 @@ class SettingsTestBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithPassWaitingDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithPassWaitingDataProvider')]
     public function testGetAndWithPassWaiting(?string $io): void
     {
         $Settings_test_behaviour = (new SettingsTestBehaviour(0))->withPassWaiting($io);
@@ -80,9 +74,7 @@ class SettingsTestBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithProcessingTimeEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithProcessingTimeEnabledDataProvider')]
     public function testGetAndWithProcessingTimeEnabled(bool $io): void
     {
         $Settings_test_behaviour = (new SettingsTestBehaviour(0))->withProcessingTimeEnabled($io);
@@ -99,9 +91,7 @@ class SettingsTestBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithProcessingTimeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithProcessingTimeDataProvider')]
     public function testGetAndWithProcessingTime(?string $io): void
     {
         $Settings_test_behaviour = (new SettingsTestBehaviour(0))->withProcessingTime($io);
@@ -119,9 +109,7 @@ class SettingsTestBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithResetProcessingTimeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithResetProcessingTimeDataProvider')]
     public function testGetAndWithResetProcessingTime(bool $io): void
     {
         $Settings_test_behaviour = (new SettingsTestBehaviour(0))->withResetProcessingTime($io);
@@ -138,9 +126,7 @@ class SettingsTestBehaviourTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithKioskModeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithKioskModeDataProvider')]
     public function testGetAndWithKioskMode(int $io): void
     {
         $Settings_test_behaviour = (new SettingsTestBehaviour(0))->withKioskMode($io);
@@ -159,9 +145,7 @@ class SettingsTestBehaviourTest extends ilTestBaseTestCase
     }
 
     // ExamIdInTestPassEnabled
-    /**
-     * @dataProvider getAndWithExamIdInTestPassEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithExamIdInTestPassEnabledDataProvider')]
     public function testGetAndWithExamIdInTestPassEnabled(bool $io): void
     {
         $Settings_test_behaviour = (new SettingsTestBehaviour(0))->withExamIdInTestAttemptEnabled($io);

--- a/components/ILIAS/Test/tests/Settings/ScoreReporting/SettingsGamificationTest.php
+++ b/components/ILIAS/Test/tests/Settings/ScoreReporting/SettingsGamificationTest.php
@@ -29,9 +29,7 @@ class SettingsGamificationTest extends ilTestBaseTestCase
         $this->assertInstanceOf(SettingsGamification::class, $gamificationTest);
     }
 
-    /**
-     * @dataProvider getAndWithHighscoreEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithHighscoreEnabledDataProvider')]
     public function testGetAndWithHighscoreEnabled(bool $IO): void
     {
         $gamificationTest = new SettingsGamification(0);
@@ -47,9 +45,7 @@ class SettingsGamificationTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithHighscoreOwnTableDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithHighscoreOwnTableDataProvider')]
     public function testGetAndWithHighscoreOwnTable(bool $IO): void
     {
         $gamificationTest = new SettingsGamification(0);
@@ -65,9 +61,7 @@ class SettingsGamificationTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithHighscoreTopTableDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithHighscoreTopTableDataProvider')]
     public function testGetAndWithHighscoreTopTable(bool $IO): void
     {
         $gamificationTest = new SettingsGamification(0);
@@ -83,9 +77,7 @@ class SettingsGamificationTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithHighscoreTopNumDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithHighscoreTopNumDataProvider')]
     public function testGetAndWithHighscoreTopNum(int $IO): void
     {
         $gamificationTest = new SettingsGamification(0);
@@ -102,9 +94,7 @@ class SettingsGamificationTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithHighscoreAnonDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithHighscoreAnonDataProvider')]
     public function testGetAndWithHighscoreAnon(bool $IO): void
     {
         $gamificationTest = new SettingsGamification(0);
@@ -120,9 +110,7 @@ class SettingsGamificationTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithHighscoreAchievedTSDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithHighscoreAchievedTSDataProvider')]
     public function testGetAndWithHighscoreAchievedTS(bool $IO): void
     {
         $gamificationTest = new SettingsGamification(0);
@@ -138,9 +126,7 @@ class SettingsGamificationTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithHighscoreScoreDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithHighscoreScoreDataProvider')]
     public function testGetAndWithHighscoreScore(bool $IO): void
     {
         $gamificationTest = new SettingsGamification(0);
@@ -156,9 +142,7 @@ class SettingsGamificationTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithHighscorePercentageDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithHighscorePercentageDataProvider')]
     public function testGetAndWithHighscorePercentage(bool $IO): void
     {
         $gamificationTest = new SettingsGamification(0);
@@ -174,9 +158,7 @@ class SettingsGamificationTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithHighscoreWTimeDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithHighscoreWTimeDataProvider')]
     public function testGetAndWithHighscoreWTime(bool $IO): void
     {
         $gamificationTest = new SettingsGamification(0);

--- a/components/ILIAS/Test/tests/Settings/ScoreReporting/SettingsResultDetailsTest.php
+++ b/components/ILIAS/Test/tests/Settings/ScoreReporting/SettingsResultDetailsTest.php
@@ -29,9 +29,7 @@ class SettingsResultDetailsTest extends ilTestBaseTestCase
         $this->assertInstanceOf(SettingsResultDetails::class, $settingsResultDetails);
     }
 
-    /**
-     * @dataProvider getAndWithResultsPresentationDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithResultsPresentationDataProvider')]
     public function testGetAndWithResultsPresentation(int $IO): void
     {
         $settingsResultDetails = new SettingsResultDetails(0);
@@ -48,9 +46,7 @@ class SettingsResultDetailsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndShowExamIdInTestResultsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndShowExamIdInTestResultsDataProvider')]
     public function testGetAndShowExamIdInTestResults(bool $IO): void
     {
         $settingsResultDetails = new SettingsResultDetails(0);
@@ -66,9 +62,7 @@ class SettingsResultDetailsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShowPassDetailsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShowPassDetailsDataProvider')]
     public function testGetAndWithShowPassDetails(bool $IO): void
     {
         $settingsResultDetails = new SettingsResultDetails(0);
@@ -84,9 +78,7 @@ class SettingsResultDetailsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShowSolutionPrintviewDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShowSolutionPrintviewDataProvider')]
     public function testGetAndWithShowSolutionPrintview(bool $IO): void
     {
         $settingsResultDetails = new SettingsResultDetails(0);
@@ -102,9 +94,7 @@ class SettingsResultDetailsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShowSolutionFeedbackDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShowSolutionFeedbackDataProvider')]
     public function testGetShowSolutionFeedback(bool $IO): void
     {
         $settingsResultDetails = new SettingsResultDetails(0);
@@ -120,9 +110,7 @@ class SettingsResultDetailsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShowSolutionAnswersOnlyDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShowSolutionAnswersOnlyDataProvider')]
     public function testGetAndWithShowSolutionAnswersOnly(bool $IO): void
     {
         $settingsResultDetails = new SettingsResultDetails(0);
@@ -138,9 +126,7 @@ class SettingsResultDetailsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShowSolutionSignatureDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShowSolutionSignatureDataProvider')]
     public function testGetAndWithShowSolutionSignature(bool $IO): void
     {
         $settingsResultDetails = new SettingsResultDetails(0);
@@ -156,9 +142,7 @@ class SettingsResultDetailsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShowSolutionSuggestedDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShowSolutionSuggestedDataProvider')]
     public function testGetAndWithShowSolutionSuggested(bool $IO): void
     {
         $settingsResultDetails = new SettingsResultDetails(0);
@@ -174,9 +158,7 @@ class SettingsResultDetailsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShowSolutionListComparisonDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShowSolutionListComparisonDataProvider')]
     public function testGetAndWithShowSolutionListComparison(bool $IO): void
     {
         $settingsResultDetails = new SettingsResultDetails(0);
@@ -192,9 +174,7 @@ class SettingsResultDetailsTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithExportSettingsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithExportSettingsDataProvider')]
     public function testGetAndWithExportSettings(int $IO): void
     {
         $settingsResultDetails = new SettingsResultDetails(0);

--- a/components/ILIAS/Test/tests/Settings/ScoreReporting/SettingsResultSummaryTest.php
+++ b/components/ILIAS/Test/tests/Settings/ScoreReporting/SettingsResultSummaryTest.php
@@ -31,9 +31,7 @@ class SettingsResultSummaryTest extends ilTestBaseTestCase
         $this->assertInstanceOf(SettingsResultSummary::class, $settingsResultSummary);
     }
 
-    /**
-     * @dataProvider getAndWithScoreReportingDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithScoreReportingDataProvider')]
     public function testGetAndWithScoreReporting(ScoreReportingTypes $IO): void
     {
         $this->assertEquals(
@@ -51,9 +49,7 @@ class SettingsResultSummaryTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithReportingDateDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithReportingDateDataProvider')]
     public function testGetAndWithReportingDate(?\DateTimeImmutable $IO): void
     {
         $settingsResultSummary = new SettingsResultSummary(0);
@@ -69,9 +65,7 @@ class SettingsResultSummaryTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShowGradingStatusEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShowGradingStatusEnabledDataProvider')]
     public function testGetAndWithShowGradingStatusEnabled(bool $IO): void
     {
         $settingsResultSummary = new SettingsResultSummary(0);
@@ -87,9 +81,7 @@ class SettingsResultSummaryTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShowGradingMarkEnabledDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShowGradingMarkEnabledDataProvider')]
     public function testGetAndWithShowGradingMarkEnabled(bool $IO): void
     {
         $settingsResultSummary = new SettingsResultSummary(0);
@@ -105,9 +97,7 @@ class SettingsResultSummaryTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithPassDeletionAllowedDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithPassDeletionAllowedDataProvider')]
     public function testGetAndWithPassDeletionAllowed(bool $IO): void
     {
         $settingsResultSummary = new SettingsResultSummary(0);
@@ -123,9 +113,7 @@ class SettingsResultSummaryTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithShowPassDetailsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithShowPassDetailsDataProvider')]
     public function testGetAndWithShowPassDetails(bool $IO): void
     {
         $settingsResultSummary = new SettingsResultSummary(0);

--- a/components/ILIAS/Test/tests/Settings/ScoreReporting/SettingsScoringTest.php
+++ b/components/ILIAS/Test/tests/Settings/ScoreReporting/SettingsScoringTest.php
@@ -29,9 +29,7 @@ class SettingsScoringTest extends ilTestBaseTestCase
         $this->assertInstanceOf(SettingsScoring::class, $settingsScoring);
     }
 
-    /**
-     * @dataProvider getAndWithCountSystemDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithCountSystemDataProvider')]
     public function testGetAndWithCountSystem(bool $IO): void
     {
         $settingsScoring = new SettingsScoring(0);
@@ -47,9 +45,7 @@ class SettingsScoringTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithScoreCuttingDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithScoreCuttingDataProvider')]
     public function testGetAndWithScoreCutting(bool $IO): void
     {
         $settingsScoring = new SettingsScoring(0);
@@ -65,9 +61,7 @@ class SettingsScoringTest extends ilTestBaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAndWithPassScoringDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndWithPassScoringDataProvider')]
     public function testGetAndWithPassScoring(bool $IO): void
     {
         $settingsScoring = new SettingsScoring(0);

--- a/components/ILIAS/Test/tests/ilObjTestListGUITest.php
+++ b/components/ILIAS/Test/tests/ilObjTestListGUITest.php
@@ -39,9 +39,7 @@ class ilObjTestListGUITest extends ilTestBaseTestCase
         $this->assertInstanceOf(ilObjTestListGUI::class, $this->testObj);
     }
 
-    /**
-     * @dataProvider createDefaultCommandDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('createDefaultCommandDataProvider')]
     public function testCreateDefaultCommand(array $IO): void
     {
         $this->assertEquals($IO, $this->testObj->createDefaultCommand($IO));

--- a/components/ILIAS/Test/tests/ilTestLPTest.php
+++ b/components/ILIAS/Test/tests/ilTestLPTest.php
@@ -24,9 +24,7 @@ class ilTestLPTest extends ilTestBaseTestCase
         $this->assertInstanceOf(ilTestLP::class, $ilTestLPTest);
     }
 
-    /**
-     * @dataProvider getDefaultModesDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getDefaultModesDataProvider')]
     public function testGetDefaultModes(bool $input, array $output): void
     {
         $this->assertEquals($output, ilTestLP::getDefaultModes($input));

--- a/components/ILIAS/Test/tests/ilTestQuestionPoolSelectorExplorerTest.php
+++ b/components/ILIAS/Test/tests/ilTestQuestionPoolSelectorExplorerTest.php
@@ -49,9 +49,7 @@ class ilTestQuestionPoolSelectorExplorerTest extends ilTestBaseTestCase
         $this->assertInstanceOf(ilRepositorySelectorExplorerGUI::class, $this->testObj);
     }
 
-    /**
-     * @dataProvider getAndSetAvailableQuestionPoolsDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getAndSetAvailableQuestionPoolsDataProvider')]
     public function testGetAndSetAvailableQuestionPools(array $IO): void
     {
         $this->assertEquals([], $this->testObj->getAvailableQuestionPools());

--- a/components/ILIAS/Test/tests/ilTestServiceGUITest.php
+++ b/components/ILIAS/Test/tests/ilTestServiceGUITest.php
@@ -70,9 +70,7 @@ class ilTestServiceGUITest extends ilTestBaseTestCase
         $this->assertEquals($mock, $this->testObj->getObjectiveOrientedContainer());
     }
 
-    /**
-     * @dataProvider buildFixedShufflerSeedDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('buildFixedShufflerSeedDataProvider')]
     public function testBuildFixedShufflerSeed(int $question_id, int $pass_id, int $active_id, int $return): void
     {
         $reflection = new ReflectionClass(ilTestShuffler::class);

--- a/components/ILIAS/TestQuestionPool/tests/SuggestedSolutionTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/SuggestedSolutionTest.php
@@ -108,9 +108,7 @@ class SuggestedSolutionTest extends TestCase
     }
 
 
-    /**
-     * @depends testSuggestedSolutionFile
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testSuggestedSolutionFile')]
     public function testSuggestedSolutionMutatorsFile(SuggestedSolutionFile $sugsol): void
     {
         $values = [

--- a/components/ILIAS/TestQuestionPool/tests/assOrderingQuestionTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assOrderingQuestionTest.php
@@ -66,9 +66,7 @@ class assOrderingQuestionTest extends assBaseTestCase
         return $list;
     }
 
-    /**
-     * @depends testOrderingElementListDefaults
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testOrderingElementListDefaults')]
     public function testOrderingElementListMutation(ilAssOrderingElementList $list)
     {
         $original = $list;
@@ -84,9 +82,7 @@ class assOrderingQuestionTest extends assBaseTestCase
         return $element;
     }
 
-    /**
-     * @depends testOrderingElementDefaults
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testOrderingElementDefaults')]
     public function testOrderingElementMutation(ilAssOrderingElement $element)
     {
         $original = $element;

--- a/components/ILIAS/TestQuestionPool/tests/ilAssQuestionSkillAssignmentRegistryTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssQuestionSkillAssignmentRegistryTest.php
@@ -36,12 +36,12 @@ class ilAssQuestionSkillAssignmentRegistryTest extends assBaseTestCase
     }
 
     /**
-     * @dataProvider serializedData
      * @param          $value
      * @param          $chunkSize
      * @param callable $preCallback
      * @param callable $postCallback
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('serializedData')]
     public function testSkillAssignmentsCanBetStoredAndFetchedBySerializationStrategy($value, $chunkSize, callable $preCallback, callable $postCallback): void
     {
         $this->markTestSkipped('Data Provider needs to be revisited.');
@@ -79,9 +79,7 @@ class ilAssQuestionSkillAssignmentRegistryTest extends assBaseTestCase
         $this->assertEquals($value, $postCallback($actual));
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testInvalidChunkSizeWillRaiseException(): void
     {
         $settingsMock = $this->getMockBuilder('ilSetting')->disableOriginalConstructor()->onlyMethods(['set', 'get', 'delete'])->getMock();

--- a/components/ILIAS/Tracking/tests/ilLPStatusIconsTest.php
+++ b/components/ILIAS/Tracking/tests/ilLPStatusIconsTest.php
@@ -117,9 +117,9 @@ class ilLPStatusIconsTest extends TestCase
     }
 
     /**
-     * @depends testTripleton
      * @param array<string, ilLPStatusIcons> $instances
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testTripleton')]
     public function testSomeExamplesForImagePathsByStatus(array $instances): void
     {
         $path1 = $instances['long']->getImagePathInProgress();
@@ -136,9 +136,9 @@ class ilLPStatusIconsTest extends TestCase
     }
 
     /**
-     * @depends testTripleton
      * @param array<string, ilLPStatusIcons> $instances
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testTripleton')]
     public function testImagePathRunningForLongVariant(array $instances): void
     {
         $this->expectException(ilLPException::class);
@@ -146,9 +146,9 @@ class ilLPStatusIconsTest extends TestCase
     }
 
     /**
-     * @depends testTripleton
      * @param array<string, ilLPStatusIcons> $instances
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testTripleton')]
     public function testImagePathAssetForLongVariant(array $instances): void
     {
         $this->expectException(ilLPException::class);
@@ -156,9 +156,9 @@ class ilLPStatusIconsTest extends TestCase
     }
 
     /**
-     * @depends testTripleton
      * @param array<string, ilLPStatusIcons> $instances
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testTripleton')]
     public function testSomeExamplesForRenderedIcons(array $instances): void
     {
         //try rendering some icons
@@ -178,9 +178,9 @@ class ilLPStatusIconsTest extends TestCase
     }
 
     /**
-     * @depends testTripleton
      * @param array<string, ilLPStatusIcons> $instances
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testTripleton')]
     public function testRenderScormIcons(array $instances): void
     {
         $this->expectException(ilLPException::class);

--- a/components/ILIAS/UI/tests/AbstractFactoryTestCase.php
+++ b/components/ILIAS/UI/tests/AbstractFactoryTestCase.php
@@ -144,9 +144,8 @@ abstract class AbstractFactoryTestCase extends TestCase
 
     /**
      * Tests whether the YAML Kitchen Sink info can be parsed.
-     *
-     * @dataProvider getMethodsProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testCheckYamlExtraction(ReflectionMethod $method_reflection, string $name): array
     {
         try {
@@ -166,9 +165,8 @@ abstract class AbstractFactoryTestCase extends TestCase
 
     /**
      * Tests whether the method either returns a factory or a component.
-     *
-     * @dataProvider getMethodsProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testReturnType(ReflectionMethod $method_reflection, string $name): void
     {
         $message = "TODO ($name): fix return type, it must be a factory or a component.";
@@ -184,9 +182,8 @@ abstract class AbstractFactoryTestCase extends TestCase
 
     /**
      * Tests whether the method name matches the return doctring?
-     *
-     * @dataProvider getMethodsProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testFactoryMethodNameCompatibleDocstring(
         ReflectionMethod $method_reflection,
         string $name
@@ -228,9 +225,8 @@ abstract class AbstractFactoryTestCase extends TestCase
 
     /**
      * Tests whether methods returning factories have no parameters.
-     *
-     * @dataProvider getMethodsProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testMethodParams(ReflectionMethod $method_reflection, string $name): void
     {
         $docstring_data = $this->testCheckYamlExtraction($method_reflection, $name);
@@ -242,10 +238,7 @@ abstract class AbstractFactoryTestCase extends TestCase
 
     // Common rules for all factory methods, regardless whether they return other
     // factories or components.
-
-    /**
-     * @dataProvider getMethodsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testKitchensinkInfoDescription(ReflectionMethod $method_reflection, string $name): void
     {
         $docstring_data = $this->testCheckYamlExtraction($method_reflection, $name);
@@ -267,9 +260,7 @@ abstract class AbstractFactoryTestCase extends TestCase
         }
     }
 
-    /**
-     * @dataProvider getMethodsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testKitchensinkInfoRivals(ReflectionMethod $method_reflection, string $name): void
     {
         $docstring_data = $this->testCheckYamlExtraction($method_reflection, $name);
@@ -281,9 +272,7 @@ abstract class AbstractFactoryTestCase extends TestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * @dataProvider getMethodsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testKitchensinkInfoBackground(ReflectionMethod $method_reflection, string $name): void
     {
         $docstring_data = $this->testCheckYamlExtraction($method_reflection, $name);
@@ -295,9 +284,7 @@ abstract class AbstractFactoryTestCase extends TestCase
         }
     }
 
-    /**
-     * @dataProvider getMethodsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testKitchensinkInfoFeatureWiki(ReflectionMethod $method_reflection, string $name): void
     {
         $docstring_data = $this->testCheckYamlExtraction($method_reflection, $name);
@@ -309,9 +296,7 @@ abstract class AbstractFactoryTestCase extends TestCase
         }
     }
 
-    /**
-     * @dataProvider getMethodsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testKitchensinkInfoJavaScript(ReflectionMethod $method_reflection, string $name): void
     {
         $docstring_data = $this->testCheckYamlExtraction($method_reflection, $name);
@@ -323,9 +308,7 @@ abstract class AbstractFactoryTestCase extends TestCase
         }
     }
 
-    /**
-     * @dataProvider getMethodsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testKitchensinkInfoRules(ReflectionMethod $method_reflection, string $name): void
     {
         $docstring_data = $this->testCheckYamlExtraction($method_reflection, $name);
@@ -347,9 +330,7 @@ abstract class AbstractFactoryTestCase extends TestCase
         }
     }
 
-    /**
-     * @dataProvider getMethodsProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMethodsProvider')]
     final public function testKitchensinkInfoContext(ReflectionMethod $method_reflection, string $name): void
     {
         $docstring_data = $this->testCheckYamlExtraction($method_reflection, $name);

--- a/components/ILIAS/UI/tests/Component/Button/ButtonTest.php
+++ b/components/ILIAS/UI/tests/Component/Button/ButtonTest.php
@@ -69,9 +69,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         );
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonLabelOrGlyphOnly(string $factory_method): void
     {
         $this->expectException(TypeError::class);
@@ -79,9 +77,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $f->$factory_method($this, "http://www.ilias.de");
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonStringActionOnly(string $factory_method): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -89,9 +85,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $f->$factory_method("label", $this);
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonLabel(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -100,9 +94,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertEquals("label", $b->getLabel());
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonWithLabel(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -114,9 +106,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertEquals("label2", $b2->getLabel());
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonWithGlyphLabel(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -126,9 +116,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertEquals($glyph, $b->getSymbol());
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonAction(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -137,9 +125,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertEquals("http://www.ilias.de", $b->getAction());
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonActivatedOnDefault(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -148,9 +134,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertTrue($b->isActive());
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonDeactivation(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -181,9 +165,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         }
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testRenderButtonLabel(string $factory_method): void
     {
         $ln = "http://www.ilias.de";
@@ -200,9 +182,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertHTMLEquals($expected, $html);
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testRenderButtonDisabled(string $factory_method): void
     {
         $ln = "http://www.ilias.de";
@@ -248,9 +228,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertEquals($expected, $html);
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testRenderButtonWithOnLoadCode(string $factory_method): void
     {
         $ln = "http://www.ilias.de";
@@ -375,9 +353,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertEquals($expected, $html);
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonWithAriaLabel(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -385,9 +361,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertEquals("ariatext", $b->getAriaLabel());
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonWithEngageable(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -401,9 +375,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         }
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonWithEngaged(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -418,9 +390,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         }
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testRenderButtonWithAriaLabel(string $factory_method): void
     {
         $ln = "http://www.ilias.de";
@@ -437,9 +407,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertHTMLEquals($expected, $html);
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testRenderButtonWithAriaPressed(string $factory_method): void
     {
         $ln = "http://www.ilias.de";
@@ -461,9 +429,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         }
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testWithOnClickRemovesAction(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -476,9 +442,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertEquals([$signal], $button->getAction());
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testAppendOnClickAppendsToAction(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -491,9 +455,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         $this->assertEquals([$signal1, $signal2], $button->getAction());
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testRenderButtonWithSignal(string $factory_method): void
     {
         $ln = "http://www.ilias.de";
@@ -537,9 +499,7 @@ class ButtonTest extends ILIAS_UI_TestBase
         }
     }
 
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testButtonRendersTooltip(string $factory_method): void
     {
         $f = $this->getButtonFactory();
@@ -569,10 +529,7 @@ class ButtonTest extends ILIAS_UI_TestBase
 
     // TODO: We are missing a test for the rendering of a button with an signal
     // here. Does it still render the action js?
-
-    /**
-     * @dataProvider getButtonTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getButtonTypeProvider')]
     public function testFactoryAcceptsSignalAsAction(string $factory_method): void
     {
         $f = $this->getButtonFactory();

--- a/components/ILIAS/UI/tests/Component/Button/ToggleButtonTest.php
+++ b/components/ILIAS/UI/tests/Component/Button/ToggleButtonTest.php
@@ -162,9 +162,7 @@ EOT;
         $this->assertHTMLEquals("<div>" . $expected . "</div>", "<div>" . $r->render($button) . "</div>");
     }
 
-    /**
-     * @depends testRenderSetOnOnDefault
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testRenderSetOnOnDefault')]
     public function testAppendUnavailAction(Toggle $button): void
     {
         $r = $this->getDefaultRenderer();

--- a/components/ILIAS/UI/tests/Component/ComponentHelperTest.php
+++ b/components/ILIAS/UI/tests/Component/ComponentHelperTest.php
@@ -110,9 +110,7 @@ class ComponentHelperTest extends TestCase
         $this->assertEquals("Test Component Test", $c->getCanonicalName());
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testCheckArgOk(): void
     {
         $this->mock->_checkArg("some_arg", true, "some message");
@@ -125,9 +123,7 @@ class ComponentHelperTest extends TestCase
         $this->mock->_checkArg("some_arg", false, "some message");
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testCheckStringArgOk(): void
     {
         $this->mock->_checkStringArg("some_arg", "bar");
@@ -140,9 +136,7 @@ class ComponentHelperTest extends TestCase
         $this->mock->_checkStringArg("some_arg", 1);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testCheckBoolArgOk(): void
     {
         $this->mock->_checkBoolArg("some_arg", true);
@@ -155,9 +149,7 @@ class ComponentHelperTest extends TestCase
         $this->mock->_checkBoolArg("some_arg", 1);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testCheckArgInstanceofOk(): void
     {
         $this->mock->_checkArgInstanceOf("some_arg", $this->mock, ComponentMock::class);
@@ -171,9 +163,7 @@ class ComponentHelperTest extends TestCase
     }
 
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testCheckArgIsElementOk(): void
     {
         $this->mock->_checkArgIsElement("some_arg", "bar", array("foo", "bar"), "foobar");
@@ -201,9 +191,7 @@ class ComponentHelperTest extends TestCase
         $this->assertEquals(array($foo), $res);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testCheckArgListElementsOk(): void
     {
         $l = array(new Class1(), new Class1(), new Class1());
@@ -218,9 +206,7 @@ class ComponentHelperTest extends TestCase
         $this->mock->_checkArgListElements("some_arg", $l, array("Class1"));
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testCheckArgListElementsMultiClassOk(): void
     {
         $l = array(new Class1(), new Class2(), new Class1());
@@ -235,9 +221,7 @@ class ComponentHelperTest extends TestCase
         $this->mock->_checkArgListElements("some_arg", $l, array("Class1", "Class2"));
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testCheckArgListElementsStringOrIntOk(): void
     {
         $l = array(1, "foo");
@@ -252,9 +236,7 @@ class ComponentHelperTest extends TestCase
         $this->mock->_checkArgListElements("some_arg", $l, array("string", "int"));
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testCheckArgListOk(): void
     {
         $l = array("a" => 1, "b" => 2, "c" => 3);

--- a/components/ILIAS/UI/tests/Component/Counter/CounterTest.php
+++ b/components/ILIAS/UI/tests/Component/Counter/CounterTest.php
@@ -45,9 +45,7 @@ class CounterTest extends ILIAS_UI_TestBase
         $this->assertInstanceOf("ILIAS\\UI\\Component\\Counter\\Counter", $f->novelty(0));
     }
 
-    /**
-     * @dataProvider getNumberProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getNumberProvider')]
     public function testStatusCounter(int $number): void
     {
         $f = $this->getCounterFactory();
@@ -59,9 +57,7 @@ class CounterTest extends ILIAS_UI_TestBase
         $this->assertEquals($number, $c->getNumber());
     }
 
-    /**
-     * @dataProvider getNumberProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getNumberProvider')]
     public function testNoveltyCounter(int $number): void
     {
         $f = $this->getCounterFactory();
@@ -79,9 +75,7 @@ class CounterTest extends ILIAS_UI_TestBase
         new Counter("FOO", 1);
     }
 
-    /**
-     * @dataProvider getNoNumberProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getNoNumberProvider')]
     public function testIntNumbersOnly($no_number): void
     {
         $this->expectException(TypeError::class);
@@ -114,9 +108,7 @@ class CounterTest extends ILIAS_UI_TestBase
         "novelty" => "badge badge-notify il-counter-novelty"
     ];
 
-    /**
-     * @dataProvider getCounterTypeAndNumberProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getCounterTypeAndNumberProvider')]
     public function testRenderStatus(string $type, int $number): void
     {
         $f = $this->getCounterFactory();

--- a/components/ILIAS/UI/tests/Component/Entity/EntityTest.php
+++ b/components/ILIAS/UI/tests/Component/Entity/EntityTest.php
@@ -75,9 +75,7 @@ class EntityTest extends ILIAS_UI_TestBase
         ];
     }
 
-    /**
-     * @dataProvider getEntityAllowedIdentiferTypes
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getEntityAllowedIdentiferTypes')]
     public function testEntityIdentifiers($identifier): void
     {
         $entity = $this->getEntityFactory()->standard($identifier, $identifier);

--- a/components/ILIAS/UI/tests/Component/Input/Field/DurationInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/DurationInputTest.php
@@ -202,9 +202,7 @@ class DurationInputTest extends ILIAS_UI_TestBase
         return $duration;
     }
 
-    /**
-     * @depends testRender
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testRender')]
     public function testRenderWithDifferentLabels($duration): void
     {
         $other_start_label = 'other startlabel';

--- a/components/ILIAS/UI/tests/Component/Input/Field/NumericInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/NumericInputTest.php
@@ -114,9 +114,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
         return $field;
     }
 
-    /**
-     * @depends testNullValue
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testNullValue')]
     public function testEmptyValue(\ILIAS\UI\Component\Input\Container\Form\FormInput $field): void
     {
         $post_data = new DefInputData(['name_0' => '']);
@@ -131,9 +129,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $this->assertTrue($value->isError());
     }
 
-    /**
-     * @depends testNullValue
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testNullValue')]
     public function testZeroIsValidValue(\ILIAS\UI\Component\Input\Container\Form\FormInput $field): void
     {
         $post_data = new DefInputData(['name_0' => 0]);
@@ -148,9 +144,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $this->assertEquals(0, $value->value());
     }
 
-    /**
-     * @depends testNullValue
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testNullValue')]
     public function testConstraintForRequirementForFloat(\ILIAS\UI\Component\Input\Container\Form\FormInput $field): void
     {
         $post_data = new DefInputData(['name_0' => 1.1]);

--- a/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SwitchableGroupInputTest.php
@@ -468,9 +468,7 @@ EOT;
         return $sg;
     }
 
-    /**
-     * @depends testRender
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testRender')]
     public function testRenderWithValue(SG $sg): void
     {
         $r = $this->getDefaultRenderer();

--- a/components/ILIAS/UI/tests/Component/Input/Field/TagInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/TagInputTest.php
@@ -44,9 +44,7 @@ class TagInputTest extends ILIAS_UI_TestBase
         $this->name_source = new DefNamesource();
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testImplementsFactoryInterface(): void
     {
         $f = $this->getFieldFactory();

--- a/components/ILIAS/UI/tests/Component/Input/UploadLimitResolverTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/UploadLimitResolverTest.php
@@ -108,9 +108,7 @@ class UploadLimitResolverTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideUploadLimitResolutionDataSet
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideUploadLimitResolutionDataSet')]
     public function testUploadLimitResolution(
         int $php_ini_value,
         ?int $custom_global_value,

--- a/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlPaginationTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/ViewControl/ViewControlPaginationTest.php
@@ -124,9 +124,7 @@ class ViewControlPaginationTest extends ViewControlTestBase
         ];
     }
 
-    /**
-     * @dataProvider providePaginationInput
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('providePaginationInput')]
     public function testViewControlPaginationWithInput(
         int $offset,
         int $page_size,

--- a/components/ILIAS/UI/tests/Component/Legacy/LegacyTest.php
+++ b/components/ILIAS/UI/tests/Component/Legacy/LegacyTest.php
@@ -69,9 +69,7 @@ class LegacyTest extends ILIAS_UI_TestBase
         $this->assertEquals("Legacy Content", $r->render($g));
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testCreateWithCustomSignal(): void
     {
         $f = $this->getUIFactory();

--- a/components/ILIAS/UI/tests/Component/MainControls/MainBarTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/MainBarTest.php
@@ -158,9 +158,7 @@ class MainBarTest extends ILIAS_UI_TestBase
             ->withAdditionalToolEntry('test', $slate);
     }
 
-    /**
-     * @depends testAddEntry
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testAddEntry')]
     public function testActive(C\MainControls\MainBar $mb): void
     {
         $mb = $mb->withActive('testbtn');

--- a/components/ILIAS/UI/tests/Component/MainControls/Slate/DrilldownSlateTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/Slate/DrilldownSlateTest.php
@@ -83,9 +83,7 @@ class DrilldownSlateTest extends ILIAS_UI_TestBase
         return $slate;
     }
 
-    /**
-     * @depends testImplementsFactoryInterface
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testImplementsFactoryInterface')]
     public function testRendering(Drilldown $slate): void
     {
         $r = $this->getDefaultRenderer();

--- a/components/ILIAS/UI/tests/Component/MainControls/Slate/SlateTest.php
+++ b/components/ILIAS/UI/tests/Component/MainControls/Slate/SlateTest.php
@@ -73,18 +73,14 @@ class SlateTest extends ILIAS_UI_TestBase
         return $slate;
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithEngaged(Slate $slate): void
     {
         $slate = $slate->withEngaged(true);
         $this->assertTrue($slate->getEngaged());
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithAriaRole(Slate $slate): void
     {
         try {
@@ -95,9 +91,7 @@ class SlateTest extends ILIAS_UI_TestBase
         }
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithAriaRoleIncorrect(Slate $slate): void
     {
         try {
@@ -108,9 +102,7 @@ class SlateTest extends ILIAS_UI_TestBase
         }
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testSignals(Slate $slate): array
     {
         $signals = [
@@ -124,9 +116,7 @@ class SlateTest extends ILIAS_UI_TestBase
         return $signals;
     }
 
-    /**
-     * @depends testSignals
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testSignals')]
     public function testDifferentSignals(array $signals): void
     {
         $this->assertEquals(

--- a/components/ILIAS/UI/tests/Component/Menu/Drilldown/DrilldownTest.php
+++ b/components/ILIAS/UI/tests/Component/Menu/Drilldown/DrilldownTest.php
@@ -95,9 +95,7 @@ class DrilldownTest extends ILIAS_UI_TestBase
         return $menu;
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetLabel(C\Menu\Drilldown $menu): void
     {
         $this->assertEquals(
@@ -106,9 +104,7 @@ class DrilldownTest extends ILIAS_UI_TestBase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetItems($menu): void
     {
         $this->assertEquals(
@@ -143,9 +139,7 @@ class DrilldownTest extends ILIAS_UI_TestBase
         $f->menu()->drilldown('label', [$this->legacy]);
     }
 
-    /**
-     * @depends testWithEntries
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testWithEntries')]
     public function testRendering(): void
     {
         $r = $this->getDefaultRenderer();
@@ -169,9 +163,7 @@ class DrilldownTest extends ILIAS_UI_TestBase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithPersistenceId($menu): void
     {
         $this->assertNull($menu->getPersistenceId()) ;

--- a/components/ILIAS/UI/tests/Component/MessageBox/MessageBoxTest.php
+++ b/components/ILIAS/UI/tests/Component/MessageBox/MessageBoxTest.php
@@ -77,9 +77,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
         };
     }
 
-    /**
-     * @dataProvider getMessageboxTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMessageboxTypeProvider')]
     public function testImplementsFactoryInterface(string $factory_method): void
     {
         $f = $this->getMessageBoxFactory();
@@ -88,9 +86,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
         $this->assertInstanceOf("ILIAS\\UI\\Component\\MessageBox\\MessageBox", $f->$factory_method("Lorem ipsum dolor sit amet."));
     }
 
-    /**
-     * @dataProvider getMessageboxTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMessageboxTypeProvider')]
     public function testMessageboxTypes(string $factory_method): void
     {
         $f = $this->getMessageBoxFactory();
@@ -100,9 +96,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
         $this->assertEquals($factory_method, $g->getType());
     }
 
-    /**
-     * @dataProvider getMessageboxTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMessageboxTypeProvider')]
     public function testMessageboxMessagetext(string $factory_method): void
     {
         $f = $this->getMessageBoxFactory();
@@ -112,9 +106,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
         $this->assertEquals("Lorem ipsum dolor sit amet.", $g->getMessageText());
     }
 
-    /**
-     * @dataProvider getMessageboxTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMessageboxTypeProvider')]
     public function testWithButtons(string $factory_method): void
     {
         $f = $this->getMessageBoxFactory();
@@ -128,9 +120,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
         $this->assertNotEmpty($g2->getButtons());
     }
 
-    /**
-     * @dataProvider getMessageboxTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMessageboxTypeProvider')]
     public function testWithLinks(string $factory_method): void
     {
         $f = $this->getMessageBoxFactory();
@@ -147,9 +137,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
         $this->assertNotEmpty($g2->getLinks());
     }
 
-    /**
-     * @dataProvider getMessageboxTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMessageboxTypeProvider')]
     public function testWithButtonsAndLinks(string $factory_method): void
     {
         $f = $this->getMessageBoxFactory();
@@ -168,9 +156,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
         $this->assertTrue(count($g2->getButtons()) > 0 && count($g2->getLinks()) > 0);
     }
 
-    /**
-     * @dataProvider getMessageboxTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMessageboxTypeProvider')]
     public function testRenderSimple(string $factory_method): void
     {
         $f = $this->getMessageBoxFactory();
@@ -186,9 +172,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
         $this->assertHTMLEquals($expected, $html);
     }
 
-    /**
-     * @dataProvider getMessageboxTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMessageboxTypeProvider')]
     public function testRenderWithButtons(string $factory_method): void
     {
         $f = $this->getMessageBoxFactory();
@@ -210,9 +194,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
         $this->assertHTMLEquals($expected, $html);
     }
 
-    /**
-     * @dataProvider getMessageboxTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMessageboxTypeProvider')]
     public function testRenderWithLinks(string $factory_method): void
     {
         $f = $this->getMessageBoxFactory();
@@ -237,9 +219,7 @@ class MessageBoxTest extends ILIAS_UI_TestBase
         $this->assertHTMLEquals($expected, $html);
     }
 
-    /**
-     * @dataProvider getMessageboxTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getMessageboxTypeProvider')]
     public function testRenderWithButtonsAndLinks(string $factory_method): void
     {
         $f = $this->getMessageBoxFactory();

--- a/components/ILIAS/UI/tests/Component/Modal/InterruptiveItem/InterruptiveItemTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/InterruptiveItem/InterruptiveItemTest.php
@@ -43,9 +43,7 @@ class InterruptiveItemTest extends ILIAS_UI_TestBase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetId(): void
     {
         $id = '1';

--- a/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
+++ b/components/ILIAS/UI/tests/Component/Modal/LightboxTest.php
@@ -44,9 +44,7 @@ class LightboxTest extends ModalBase
         $this->assertEquals($pages, $lightbox->getPages());
     }
 
-    /**
-     * @dataProvider getPageProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getPageProvider')]
     public function testSimplePageRendering(string $method, array $args, string $expected_html): void
     {
         $lightbox = $this->getModalFactory()->lightbox($this->getModalFactory()->$method(...$args));

--- a/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
+++ b/components/ILIAS/UI/tests/Component/Symbol/Glyph/GlyphTest.php
@@ -171,7 +171,8 @@ class GlyphTest extends ILIAS_UI_TestBase
         G\Glyph::UNCHECKED => "unchecked",
     );
 
-    #[DataProvider('getGlyphTypeProvider')] public function testImplementsFactoryInterface(string $factory_method): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('getGlyphTypeProvider')]
+    public function testImplementsFactoryInterface(string $factory_method): void
     {
         $f = $this->getGlyphFactory();
 
@@ -179,7 +180,8 @@ class GlyphTest extends ILIAS_UI_TestBase
         $this->assertInstanceOf("ILIAS\\UI\\Component\\Symbol\\Glyph\\Glyph", $f->$factory_method());
     }
 
-    #[DataProvider('getGlyphTypeProvider')] public function testGlyphTypes(string $factory_method): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('getGlyphTypeProvider')]
+    public function testGlyphTypes(string $factory_method): void
     {
         $f = $this->getGlyphFactory();
         $g = $f->$factory_method();
@@ -188,7 +190,8 @@ class GlyphTest extends ILIAS_UI_TestBase
         $this->assertEquals($factory_method, $g->getType());
     }
 
-    #[DataProvider('getGlyphTypeProvider')] public function testGlyphNoAction(string $factory_method): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('getGlyphTypeProvider')]
+    public function testGlyphNoAction(string $factory_method): void
     {
         $f = $this->getGlyphFactory();
         $g = $f->$factory_method();
@@ -197,7 +200,8 @@ class GlyphTest extends ILIAS_UI_TestBase
         $this->assertEquals(null, $g->getAction());
     }
 
-    #[DataProvider('getGlyphTypeProvider')] public function testWithUnavailableAction(string $factory_method): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('getGlyphTypeProvider')]
+    public function testWithUnavailableAction(string $factory_method): void
     {
         $f = $this->getGlyphFactory();
         $g = $f->$factory_method();
@@ -218,7 +222,8 @@ class GlyphTest extends ILIAS_UI_TestBase
         $this->assertTrue($g2->isHighlighted());
     }
 
-    #[DataProvider('getGlyphTypeProvider')] public function testNoCounter(string $factory_method): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('getGlyphTypeProvider')]
+    public function testNoCounter(string $factory_method): void
     {
         $f = $this->getGlyphFactory();
         $g = $f->$factory_method();
@@ -226,7 +231,8 @@ class GlyphTest extends ILIAS_UI_TestBase
         $this->assertCount(0, $g->getCounters());
     }
 
-    #[DataProvider('getCounterTypeProvider')] public function testOneCounter(string $counter_type): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('getCounterTypeProvider')]
+    public function testOneCounter(string $counter_type): void
     {
         $gf = $this->getGlyphFactory();
         $cf = $this->getCounterFactory();
@@ -337,9 +343,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         ];
     }
 
-    /**
-     * @dataProvider getGlyphTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getGlyphTypeProvider')]
     public function testRenderSimple(string $type): void
     {
         $f = $this->getGlyphFactory();
@@ -355,9 +359,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         $this->assertEquals($expected, $html);
     }
 
-    /**
-     * @dataProvider getGlyphTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getGlyphTypeProvider')]
     public function testRenderWithUnavailableAction(string $type): void
     {
         $f = $this->getGlyphFactory();
@@ -376,9 +378,7 @@ class GlyphTest extends ILIAS_UI_TestBase
         $this->assertEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($html));
     }
 
-    /**
-     * @dataProvider getCounterTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getCounterTypeProvider')]
     public function testRenderWithCounter(string $type): void
     {
         $fg = $this->getGlyphFactory();
@@ -440,7 +440,8 @@ class GlyphTest extends ILIAS_UI_TestBase
         $r->render($f->status(0), $this->getDefaultRenderer());
     }
 
-    #[DataProvider('getGlyphTypeProvider')] public function testRenderWithOnLoadCode(string $type): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('getGlyphTypeProvider')]
+    public function testRenderWithOnLoadCode(string $type): void
     {
         $f = $this->getGlyphFactory();
         $r = $this->getDefaultRenderer();

--- a/components/ILIAS/UI/tests/Component/Symbol/Icon/IconTest.php
+++ b/components/ILIAS/UI/tests/Component/Symbol/Icon/IconTest.php
@@ -131,9 +131,7 @@ class IconTest extends ILIAS_UI_TestBase
         return $ico;
     }
 
-    /**
-     * @depends testRenderingStandard
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testRenderingStandard')]
     public function testRenderingStandardDisabled(Standard $ico): void
     {
         $ico = $ico->withDisabled(true);
@@ -143,9 +141,7 @@ class IconTest extends ILIAS_UI_TestBase
         $this->assertEquals($expected, $html);
     }
 
-    /**
-     * @depends testRenderingStandard
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testRenderingStandard')]
     public function testRenderingStandardAbbreviation(Standard $ico): void
     {
         $ico = $ico->withAbbreviation('CRS');
@@ -177,9 +173,7 @@ imgtag;
         }
     }
 
-    /**
-     * @depends testRenderingStandard
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testRenderingStandard')]
     public function testRenderingStandardJSBindable($ico): void
     {
         $ico = $ico->withAdditionalOnLoadCode(function ($id) {
@@ -220,9 +214,7 @@ imgtag;
         $this->assertEquals($expected, $html);
     }
 
-    /**
-     * @depends testRenderingStandard
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testRenderingStandard')]
     public function testHTMLInAbbreviation(): void
     {
         $ico = $this->getIconFactory()->standard('name', 'label')->withAbbreviation('<h1>abbreviation</h1>');

--- a/components/ILIAS/UI/tests/Component/Table/Column/ColumnFactoryTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/Column/ColumnFactoryTest.php
@@ -69,9 +69,7 @@ class ColumnFactoryTest extends AbstractFactoryTestCase
         ];
     }
 
-    /**
-     * @dataProvider getColumnTypeProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getColumnTypeProvider')]
     public function testDataTableColsImplementInterfaces(\Closure $col): void
     {
         $factory = $this->buildColumnFactory();

--- a/components/ILIAS/UI/tests/Component/Table/Column/ColumnTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/Column/ColumnTest.php
@@ -185,9 +185,7 @@ class ColumnTest extends ILIAS_UI_TestBase
         ];
     }
 
-    /**
-￼    * @dataProvider provideColumnFormats
-￼    */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideColumnFormats')]
     public function testDataTableColumnAllowedFormats(
         Column\Column $column,
         mixed $value,

--- a/components/ILIAS/UI/tests/Component/Table/DataRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/DataRendererTest.php
@@ -393,9 +393,7 @@ EOT;
         return [$rb, $columns, $actions];
     }
 
-    /**
-     * @depends testDataTableRowBuilder
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testDataTableRowBuilder')]
     public function testDataTableDataRowFromBuilder(array $params): I\Table\DataRow
     {
         list($rb, $columns, $actions) = $params;
@@ -422,9 +420,7 @@ EOT;
         return $row;
     }
 
-    /**
-     * @depends testDataTableDataRowFromBuilder
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testDataTableDataRowFromBuilder')]
     public function testDataTableRenderStandardRow(I\Table\DataRow $row)
     {
         $actual = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($row));

--- a/components/ILIAS/UI/tests/Component/Toast/ToastTest.php
+++ b/components/ILIAS/UI/tests/Component/Toast/ToastTest.php
@@ -52,9 +52,7 @@ class ToastTest extends ILIAS_UI_TestBase
         $this->assertInstanceOf("ILIAS\\UI\\Component\\Toast\\Container", $f->container());
     }
 
-    /**
-     * @dataProvider getToastProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getToastProvider')]
     public function testToast(string $title, string $description, string $action): void
     {
         $toast = $this->getToastFactory()->standard($title, $this->getIconFactory()->standard('', ''))
@@ -72,9 +70,7 @@ class ToastTest extends ILIAS_UI_TestBase
         $this->assertInstanceOf(Icon::class, $toast->getIcon());
     }
 
-    /**
-     * @dataProvider getToastProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getToastProvider')]
     public function testToastContainer(string $title, string $description): void
     {
         $container = $this->getToastFactory()->container()->withAdditionalToast(

--- a/components/ILIAS/UI/tests/Component/Tree/Node/NodeTest.php
+++ b/components/ILIAS/UI/tests/Component/Tree/Node/NodeTest.php
@@ -62,9 +62,7 @@ class NodeTest extends ILIAS_UI_TestBase
         return $node;
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testDefaults(TestingNode $node): void
     {
         $this->assertFalse($node->isExpanded());
@@ -72,9 +70,7 @@ class NodeTest extends ILIAS_UI_TestBase
         $this->assertEquals([], $node->getSubnodes());
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithExpanded(TestingNode $node): void
     {
         $this->assertTrue(
@@ -82,9 +78,7 @@ class NodeTest extends ILIAS_UI_TestBase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithHighlighted(TestingNode $node): void
     {
         $this->assertTrue(
@@ -92,9 +86,7 @@ class NodeTest extends ILIAS_UI_TestBase
         );
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithOnClick(TestingNode $node): Clickable
     {
         $sig_gen = new I\SignalGenerator();
@@ -106,9 +98,7 @@ class NodeTest extends ILIAS_UI_TestBase
         return $node;
     }
 
-    /**
-     * @depends testWithOnClick
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testWithOnClick')]
     public function testWithAppendOnClick(Clickable $node): void
     {
         $sig_gen = new I\SignalGenerator();
@@ -119,9 +109,7 @@ class NodeTest extends ILIAS_UI_TestBase
         $this->assertEquals($sig, $check);
     }
 
-    /**
-     * @depends testWithOnClick
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testWithOnClick')]
     public function testWithURI(Clickable $node): void
     {
         $uri = new URI('http://google.de:8080');

--- a/components/ILIAS/UI/tests/Component/Tree/Node/SimpleNodeTest.php
+++ b/components/ILIAS/UI/tests/Component/Tree/Node/SimpleNodeTest.php
@@ -82,42 +82,32 @@ class SimpleNodeTest extends ILIAS_UI_TestBase
         return $node;
     }
 
-    /**
-     * @depends testConstructionWithIconAndDifferentLabels
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstructionWithIconAndDifferentLabels')]
     public function testGetDifferentLabels(C\Tree\Node\Simple $node): void
     {
         $this->assertNotEquals($this->icon->getLabel(), $node->getLabel());
     }
 
-    /**
-     * @depends testConstructionWithIcon
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstructionWithIcon')]
     public function testGetLabel(C\Tree\Node\Simple $node): void
     {
         $this->assertEquals("label", $node->getLabel());
     }
 
-    /**
-     * @depends testConstructionWithIcon
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstructionWithIcon')]
     public function testGetIcon(C\Tree\Node\Simple $node): C\Tree\Node\Simple
     {
         $this->assertEquals($this->icon, $node->getIcon());
         return $node;
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testDefaultAsyncLoading(C\Tree\Node\Simple $node): void
     {
         $this->assertFalse($node->getAsyncLoading());
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithAsyncURL(C\Tree\Node\Simple $node): C\Tree\Node\Simple
     {
         $url = 'something.de';
@@ -127,9 +117,7 @@ class SimpleNodeTest extends ILIAS_UI_TestBase
         return $node;
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testRendering(C\Tree\Node\Simple $node): void
     {
         $r = $this->getDefaultRenderer();
@@ -149,9 +137,7 @@ EOT;
         );
     }
 
-    /**
-     * @depends testWithAsyncURL
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testWithAsyncURL')]
     public function testRenderingWithAsync(C\Tree\Node\Simple $node): void
     {
         $r = $this->getDefaultRenderer();
@@ -174,9 +160,7 @@ EOT;
         );
     }
 
-    /**
-     * @depends testConstructionWithIcon
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstructionWithIcon')]
     public function testRenderingWithIcon(C\Tree\Node\Simple $node): void
     {
         $r = $this->getDefaultRenderer();
@@ -202,9 +186,8 @@ EOT;
      * This test is successfull if the icon label differs from the node label.
      * As a result the alt attribute will get the icon's label as content.
      * Else the alt attribute will be empty (see testRenderingWithIcon).
-     *
-     * @depends testConstructionWithIconAndDifferentLabels
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstructionWithIconAndDifferentLabels')]
     public function testRenderingWithIconAndAltAttribute(C\Tree\Node\Simple $node): void
     {
         $r = $this->getDefaultRenderer();

--- a/components/ILIAS/UI/tests/Component/Tree/TreeTest.php
+++ b/components/ILIAS/UI/tests/Component/Tree/TreeTest.php
@@ -73,52 +73,40 @@ class TreeTest extends ILIAS_UI_TestBase
         return $tree;
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetLabel(TestingTree $tree): void
     {
         $this->assertEquals("label", $tree->getLabel());
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testGetRecursion(TestingTree $tree): void
     {
         $this->assertInstanceOf("ILIAS\\UI\\Component\\Tree\\TreeRecursion", $tree->getRecursion());
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithEnvironment(TestingTree $tree): void
     {
         $env = ['key1' => 'val1', 'key2' => 2];
         $this->assertEquals($env, $tree->withEnvironment($env)->getEnvironment());
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithData(TestingTree $tree): void
     {
         $data = ['entry1', 'entry2'];
         $this->assertEquals($data, $tree->withData($data)->getData());
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithHighlightOnNodeClick(TestingTree $tree): void
     {
         $this->assertFalse($tree->getHighlightOnNodeClick());
         $this->assertTrue($tree->withHighlightOnNodeClick(true)->getHighlightOnNodeClick());
     }
 
-    /**
-     * @depends testConstruction
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testConstruction')]
     public function testWithIsSubTree(TestingTree $tree): void
     {
         $this->assertFalse($tree->isSubTree());

--- a/components/ILIAS/UI/tests/Examples/ExamplesTest.php
+++ b/components/ILIAS/UI/tests/Examples/ExamplesTest.php
@@ -130,9 +130,7 @@ class ExamplesTest extends ILIAS_UI_TestBase
         }
     }
 
-    /**
-     * @dataProvider getFullFunctionNamesAndPathExample
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getFullFunctionNamesAndPathExample')]
     public function testAllExamplesRenderAString(string $example_function_name, string $example_path): void
     {
         global $DIC;
@@ -146,9 +144,7 @@ class ExamplesTest extends ILIAS_UI_TestBase
         }
     }
 
-    /**
-     * @dataProvider getFullFunctionNamesAndPathExample
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getFullFunctionNamesAndPathExample')]
     public function testAllExamplesHaveExpectedOutcomeInDocs(string $example_function_name, string $example_path)
     {
         $docs = $this->example_parser->parseYamlStringArrayFromFile($example_path);
@@ -178,9 +174,7 @@ class ExamplesTest extends ILIAS_UI_TestBase
         return $function_names;
     }
 
-    /**
-     * @dataProvider getListOfFullscreenExamples
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getListOfFullscreenExamples')]
     public function testFullscreenModeExamples(string $example_function_name, string $example_path): void
     {
         global $DIC;

--- a/components/ILIAS/UI/tests/MainFactoryTest.php
+++ b/components/ILIAS/UI/tests/MainFactoryTest.php
@@ -41,17 +41,13 @@ class MainFactoryTest extends AbstractFactoryTestCase
 
     public static string $factory_title = 'ILIAS\\UI\\Factory';
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testProperNamespace(): void
     {
         // Nothing to test here.
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testProperName(): void
     {
         // Nothing to test here.

--- a/components/ILIAS/UI/tests/Renderer/DefaultRendererTest.php
+++ b/components/ILIAS/UI/tests/Renderer/DefaultRendererTest.php
@@ -209,9 +209,7 @@ class DefaultRendererTest extends ILIAS_UI_TestBase
         $this->assertEquals('foofoo', $html);
     }
 
-    /**
-     * @dataProvider getRenderType
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getRenderType')]
     public function testPassesSelfAsRootIfNoRootExist($render_type)
     {
         $this->component_renderer = $this->createMock(ComponentRenderer::class);
@@ -229,9 +227,7 @@ class DefaultRendererTest extends ILIAS_UI_TestBase
         $renderer->$render_type($component);
     }
 
-    /**
-     * @dataProvider getRenderType
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getRenderType')]
     public function testPassesOtherOnAsRoot($render_type)
     {
         $this->component_renderer = $this->createMock(ComponentRenderer::class);

--- a/components/ILIAS/UICore/tests/Structure/ilCtrlStructureTest.php
+++ b/components/ILIAS/UICore/tests/Structure/ilCtrlStructureTest.php
@@ -182,9 +182,7 @@ class ilCtrlStructureTest extends TestCase
         $structure->setPermanentParameterByClass('Class2', $parameter_name);
     }
 
-    /**
-     * @dataProvider getProtectedParameters
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getProtectedParameters')]
     public function testStructureSavedParametersWithProtectedKey($protected_parameter): void
     {
         $structure = new ilCtrlStructure([], [], []);

--- a/components/ILIAS/UICore/tests/ilCtrlQueryParserTest.php
+++ b/components/ILIAS/UICore/tests/ilCtrlQueryParserTest.php
@@ -88,9 +88,7 @@ class ilCtrlQueryParserTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider queryStringProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('queryStringProvider')]
     public function testQueryParser(string $query_string, array $expected_queries): void
     {
         $this->markTestSkipped('Failed for some unknown reason.');

--- a/components/ILIAS/UICore/tests/ilTemplateTest.php
+++ b/components/ILIAS/UICore/tests/ilTemplateTest.php
@@ -131,9 +131,7 @@ class ilTemplateTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider templatePathDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('templatePathDataProvider')]
     public function testGetTemplatePath(
         string $skin,
         string $style,

--- a/components/ILIAS/Utilities/tests/ilUtilTest.php
+++ b/components/ILIAS/Utilities/tests/ilUtilTest.php
@@ -49,9 +49,7 @@ class ilUtilTest extends TestCase
         unset($GLOBALS['DIC']);
     }
 
-    /**
-     * @dataProvider provideGotoLinkData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGotoLinkData')]
     public function testMakeClickableWithGotoLinksAndInvalidRefId(string $expected, string $input, array $ref_to_obj, array $obj_to_title): void
     {
         $wrap_array = static fn(array $array): array => (

--- a/components/ILIAS/VirusScanner/tests/VirusScannerFactoryTest.php
+++ b/components/ILIAS/VirusScanner/tests/VirusScannerFactoryTest.php
@@ -33,10 +33,8 @@ use ilVirusScannerICapClient;
 
 require_once __DIR__ . '/bootstrap.php';
 
-/**
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
- */
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
 class VirusScannerFactoryTest extends VirusScannerBaseTestCase
 {
     public static ilLogger $logger;

--- a/components/ILIAS/VirusScanner/tests/VirusScannerPreProcessorTestTBD.php
+++ b/components/ILIAS/VirusScanner/tests/VirusScannerPreProcessorTestTBD.php
@@ -27,12 +27,10 @@ use PHPUnit\Framework\TestCase;
 use ilVirusScannerPreProcessor;
 use Mockery;
 
-/**
- * @runTestsInSeparateProcesses
- * @preserveGlobalState    disabled
- * @backupGlobals          disabled
- * @backupStaticAttributes disabled
- */
+#[\PHPUnit\Framework\Attributes\BackupGlobals(false)]
+#[\PHPUnit\Framework\Attributes\BackupStaticProperties(false)]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
 class VirusScannerPreProcessorTest extends TestCase
 {
     use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;

--- a/components/ILIAS/WebDAV/tests/dav/ilDAVContainerTest.php
+++ b/components/ILIAS/WebDAV/tests/dav/ilDAVContainerTest.php
@@ -447,10 +447,8 @@ class ilDAVContainerTest extends TestCase
         }
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
+    #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testCreateDirectoryWithNonDavableNameThrowsForbiddenError(): void
     {
         define('ILIAS_LOG_ENABLED', false);

--- a/components/ILIAS/WebDAV/tests/lock/ilWebDAVLockUriPathResolverTest.php
+++ b/components/ILIAS/WebDAV/tests/lock/ilWebDAVLockUriPathResolverTest.php
@@ -22,10 +22,8 @@ use PHPUnit\Framework\TestCase;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\NotFound;
 
-/**
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
- */
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
 class ilWebDAVLockUriPathResolverTest extends TestCase
 {
     protected ilWebDAVTestHelper $webdav_test_helper;

--- a/components/ILIAS/WebDAV/tests/mount_instructions/ilWebDAVMountInstructionsDocumentProcessorBaseTest.php
+++ b/components/ILIAS/WebDAV/tests/mount_instructions/ilWebDAVMountInstructionsDocumentProcessorBaseTest.php
@@ -35,9 +35,9 @@ class ilWebDAVMountInstructionsDocumentProcessorBaseTest extends TestCase
     }
 
     /**
-     * @test
      * @small
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function parseInstructionsToAssocArray_noOpenNoCloseTags_returnArrayOnlyWithInputString(): void
     {
         // Arrange
@@ -52,9 +52,9 @@ class ilWebDAVMountInstructionsDocumentProcessorBaseTest extends TestCase
     }
 
     /**
-     * @test
      * @small
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function parseInstructionsToAssocArray_onlyOpenNoCloseTag_returnArrayOnlyWithInputString(): void
     {
         // Arrange
@@ -69,9 +69,9 @@ class ilWebDAVMountInstructionsDocumentProcessorBaseTest extends TestCase
     }
 
     /**
-     * @test
      * @small
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function parseInstructionsToAssocArray_noOpenOnlyCloseTag_returnArrayOnlyWithInputString(): void
     {
         // Arrange
@@ -86,9 +86,9 @@ class ilWebDAVMountInstructionsDocumentProcessorBaseTest extends TestCase
     }
 
     /**
-     * @test
      * @small
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function parseInstructionsToAssocArray_openTagAtStartCloseTagAtEnd_returnArrayOnlyWithInputString(): void
     {
         // Arrange
@@ -107,9 +107,9 @@ class ilWebDAVMountInstructionsDocumentProcessorBaseTest extends TestCase
     }
 
     /**
-     * @test
      * @small
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function parseInstructionsToAssocArray_tagsContainSpaces_returnArrayOnlyWithInputString(): void
     {
         // Arrange
@@ -128,9 +128,9 @@ class ilWebDAVMountInstructionsDocumentProcessorBaseTest extends TestCase
     }
 
     /**
-     * @test
      * @small
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function parseInstructionsToAssocArray_tagsContainSpecialChars_returnArrayOnlyWithInputString(): void
     {
         // Arrange
@@ -149,9 +149,9 @@ class ilWebDAVMountInstructionsDocumentProcessorBaseTest extends TestCase
     }
 
     /**
-     * @test
      * @small
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function parseInstructionsToAssocArray_beforeStartTagAndAfterEndTagIsText_returnArrayOnlyWithStringBetweenTags(
     ): void {
         // Arrange
@@ -170,9 +170,9 @@ class ilWebDAVMountInstructionsDocumentProcessorBaseTest extends TestCase
     }
 
     /**
-     * @test
      * @small
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function parseInstructionsToAssocArray_placeholderBeforeStartTag_returnArrayOnlyWithStringBetweenTags(): void
     {
         // Arrange
@@ -191,9 +191,9 @@ class ilWebDAVMountInstructionsDocumentProcessorBaseTest extends TestCase
     }
 
     /**
-     * @test
      * @small
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function parseInstructionsToAssocArray_withTwoOpenAndCloseTags_returnArrayWithBothInstructions(): void
     {
         // Arrange

--- a/components/ILIAS/WebResource/tests/ilWebResourceDatabaseRepositoryTest.php
+++ b/components/ILIAS/WebResource/tests/ilWebResourceDatabaseRepositoryTest.php
@@ -129,9 +129,9 @@ class ilWebResourceDatabaseRepositoryTest extends TestCase
     /**
      * Test creating an item with two intact parameters, and
      * an external link.
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
      */
+    #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testCreateExternalItem(): void
     {
         $mock_db = $this->getMockBuilder(ilDBInterface::class)
@@ -255,9 +255,9 @@ class ilWebResourceDatabaseRepositoryTest extends TestCase
     /**
      * Test creating an item with one intact and one broken parameter,
      * and an internal link.
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
      */
+    #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testCreateInternalItemWithBrokenParameter(): void
     {
         $mock_db = $this->getMockBuilder(ilDBInterface::class)
@@ -360,10 +360,8 @@ class ilWebResourceDatabaseRepositoryTest extends TestCase
         );
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
+    #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testCreateItemBrokenInternalLinkException(): void
     {
         $mock_db = $this->getMockBuilder(ilDBInterface::class)
@@ -414,10 +412,8 @@ class ilWebResourceDatabaseRepositoryTest extends TestCase
         $this->web_link_repo->createItem($item);
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
+    #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testCreateList(): void
     {
         $mock_db = $this->getMockBuilder(ilDBInterface::class)
@@ -467,10 +463,8 @@ class ilWebResourceDatabaseRepositoryTest extends TestCase
         );
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
+    #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testCreateAllItemsInDraftContainer(): void
     {
         $mock_db = $this->getMockBuilder(ilDBInterface::class)


### PR DESCRIPTION
```php
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;
use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
use Rector\Php80\ValueObject\AnnotationToAttribute;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\AnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\RequiresAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\TicketAnnotationToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DependsAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\TestWithAnnotationToAttributeRector;
use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->rules([
        TicketAnnotationToAttributeRector::class,
        TestWithAnnotationToAttributeRector::class,
        DataProviderAnnotationToAttributeRector::class,
        CoversAnnotationWithValueToAttributeRector::class,
        RequiresAnnotationWithValueToAttributeRector::class,
        DependsAnnotationWithValueToAttributeRector::class,
    ]);

    $rectorConfig->ruleWithConfiguration(AnnotationWithValueToAttributeRector::class, [
        new AnnotationWithValueToAttribute('backupGlobals', 'PHPUnit\Framework\Attributes\BackupGlobals', [
            'enabled' => true,
            'disabled' => false,
        ]),
        new AnnotationWithValueToAttribute('backupStaticAttributes', 'PHPUnit\Framework\Attributes\BackupStaticProperties', [
            'enabled' => true,
            'disabled' => false,
        ]),
        new AnnotationWithValueToAttribute('preserveGlobalState', 'PHPUnit\Framework\Attributes\PreserveGlobalState', [
            'enabled' => true,
            'disabled' => false,
        ]),

        new AnnotationWithValueToAttribute('depends', 'PHPUnit\Framework\Attributes\Depends'),
    ]);

    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
        new AnnotationToAttribute('doesNotPerformAssertions', 'PHPUnit\Framework\Attributes\DoesNotPerformAssertions'),
        new AnnotationToAttribute('runInSeparateProcess', 'PHPUnit\Framework\Attributes\RunInSeparateProcess'),
        new AnnotationToAttribute(
            'runTestsInSeparateProcesses',
            'PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses'
        ),
        new AnnotationToAttribute('test', 'PHPUnit\Framework\Attributes\Test'),
    ]);
};
```