### PR TITLE
[Mantis 44906] ilCalendarCategories should only cache instances that it…

### DIFF
--- a/Services/Calendar/classes/class.ilCalendarCategories.php
+++ b/Services/Calendar/classes/class.ilCalendarCategories.php
@@ -326,14 +326,18 @@ class ilCalendarCategories
         }
 
         if ($a_use_cache) {
-            // Store in cache
-            ilCalendarCache::getInstance()->storeEntry(
-                $this->user_id . ':' . $a_mode . ':categories:' . $a_source_ref_id,
-                $this->sleep(),
-                $this->user_id,
-                $a_mode,
-                'categories'
-            );
+            if ($this->getMode() != self::MODE_REPOSITORY &&
+            $this->getMode() != self::MODE_CONSULTATION &&
+            $this->getMode() != self::MODE_PORTFOLIO_CONSULTATION) {
+                // Store in cache
+                ilCalendarCache::getInstance()->storeEntry(
+                    $this->user_id . ':' . $a_mode . ':categories:' . $a_source_ref_id,
+                    $this->sleep(),
+                    $this->user_id,
+                    $a_mode,
+                    'categories'
+                );
+            }
         }
     }
 


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=44906

**TL;DR:** `ilCalendarCategories::initialize` replaces cache on each invocation (for `$mode self::MODE_REPOSITORY`, `self::MODE_CONSULTATION` and `self::MODE_PORTFOLIO_CONSULTATION`) because the cache is written without checking whether it can be loaded, since `$mode` is part of the cache lookup `entry_id`.

See mantis issue for details.