### PR TITLE
Exercise: Make migrations more robust if no step is left

### DIFF
--- a/Modules/Exercise/classes/Setup/class.ilExerciseInstructionFilesMigration.php
+++ b/Modules/Exercise/classes/Setup/class.ilExerciseInstructionFilesMigration.php
@@ -57,11 +57,14 @@ class ilExerciseInstructionFilesMigration implements Migration
 
     public function step(Environment $environment): void
     {
-        $db = $this->helper->getDatabase();
         $r = $this->helper->getDatabase()->query(
             "SELECT id, exc_id, owner FROM exc_assignment JOIN object_data ON exc_id = obj_id WHERE if_rcid IS NULL OR if_rcid = '' LIMIT 1;"
         );
         $d = $this->helper->getDatabase()->fetchObject($r);
+        if (!($d instanceof stdClass)) {
+            return;
+        }
+
         $exec_id = (int)$d->exc_id;
         $assignment_id = (int)$d->id;
         $resource_owner_id = (int)$d->owner;

--- a/Modules/Exercise/classes/Setup/class.ilExerciseSampleSolutionMigration.php
+++ b/Modules/Exercise/classes/Setup/class.ilExerciseSampleSolutionMigration.php
@@ -53,11 +53,14 @@ class ilExerciseSampleSolutionMigration implements Migration
 
     public function step(Environment $environment): void
     {
-        $db = $this->helper->getDatabase();
         $r = $this->helper->getDatabase()->query(
             "SELECT id, exc_id, owner FROM exc_assignment JOIN object_data ON exc_id = obj_id WHERE solution_rid IS NULL LIMIT 1;"
         );
         $d = $this->helper->getDatabase()->fetchObject($r);
+        if (!($d instanceof stdClass)) {
+            return;
+        }
+
         $exec_id = (int)$d->exc_id;
         $assignment_id = (int)$d->id;
         $resource_owner_id = (int)$d->owner;

--- a/Modules/Exercise/classes/Setup/class.ilExerciseTutorFeedbackFileMigration.php
+++ b/Modules/Exercise/classes/Setup/class.ilExerciseTutorFeedbackFileMigration.php
@@ -54,11 +54,14 @@ class ilExerciseTutorFeedbackFileMigration implements Migration
 
     public function step(Environment $environment): void
     {
-        $db = $this->helper->getDatabase();
         $r = $this->helper->getDatabase()->query(
             "SELECT ass.id, ass.exc_id, ob.owner, st.usr_id FROM exc_assignment ass JOIN object_data ob ON ass.exc_id = ob.obj_id JOIN exc_mem_ass_status st ON st.ass_id = ass.id WHERE st.feedback_rcid IS NULL OR st.feedback_rcid = '' LIMIT 1;"
         );
         $d = $this->helper->getDatabase()->fetchObject($r);
+        if (!($d instanceof stdClass)) {
+            return;
+        }
+
         $exec_id = (int)$d->exc_id;
         $assignment_id = (int)$d->id;
         $resource_owner_id = (int)$d->owner;

--- a/Modules/Exercise/classes/Setup/class.ilExerciseTutorTeamFeedbackFileMigration.php
+++ b/Modules/Exercise/classes/Setup/class.ilExerciseTutorTeamFeedbackFileMigration.php
@@ -54,11 +54,14 @@ class ilExerciseTutorTeamFeedbackFileMigration implements Migration
 
     public function step(Environment $environment): void
     {
-        $db = $this->helper->getDatabase();
         $r = $this->helper->getDatabase()->query(
             "SELECT ass.id, ass.exc_id, ob.owner, te.id team_id FROM exc_assignment ass JOIN object_data ob ON ass.exc_id = ob.obj_id JOIN il_exc_team te ON te.ass_id = ass.id JOIN exc_team_data td ON te.id = td.id WHERE td.feedback_rcid IS NULL OR td.feedback_rcid = '' LIMIT 1;"
         );
         $d = $this->helper->getDatabase()->fetchObject($r);
+        if (!($d instanceof stdClass)) {
+            return;
+        }
+
         $exec_id = (int)$d->exc_id;
         $assignment_id = (int)$d->id;
         $resource_owner_id = (int)$d->owner;


### PR DESCRIPTION
This PRs make the `step` method for exercise-related setup migrations more robust. We received errors by community members (which will hopefully create a corresponding issue) where the migrations try to access properties of `NULL`. The database query simply does not return any object/stdClass in these cases. The amount of steps is zero when executing the migrations again.