### PR TITLE
10/UI/popover-scroll-and-mobile-fix 43704

### DIFF
--- a/components/ILIAS/UI/resources/js/Popover/popover.js
+++ b/components/ILIAS/UI/resources/js/Popover/popover.js
@@ -1,109 +1,177 @@
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
 var il = il || {};
 il.UI = il.UI || {};
 
-(function($, UI) {
-
-    UI.popover = (function ($) {
-
-        var defaultOptions = {
-            // Title of the popover
-            title: '',
-            // JQuery selector of the element containing the popover content
-            url: '',
-            // How the popover is being triggered: click|hover
-            trigger: 'click',
-            // Where the popover is placed: auto|horizontal|vertical
-            placement: 'auto',
-            // Allow multiple popovers being opened at the same time
-            multi: false
-        };
-
-        /**
-         * Internal cache to store the initialized popovers
+(function ($, UI) {
+  UI.popover = (function ($) {
+    /**
+         * Tracks the current container to which the scroll listener is bound.
+         * @type {JQuery|null}
          */
-        var initializedPopovers = {};
+    let currentScrollableContainer = null;
 
+    /**
+         * Timeout ID used for debouncing the scroll event.
+         * @type {number|null}
+         */
+    let repositionTimeout = null;
 
-        /**
+    /**
+         * Flag indicating whether the scroll listener is currently bound.
+         * @type {boolean}
+         */
+    let scrollPosRecalcisBound = false;
+
+    /**
+         * Determine the appropriate scroll container based on viewport width.
+         * @return {JQuery}
+         */
+    function getScrollableContainer() {
+      if (window.innerWidth < 768) {
+        return $('body');
+      }
+      return $(document.querySelector('.il-layout-page-content'));
+    }
+
+    /**
+         * Scroll event handler to update the position of open popovers.
+         * Debounced to prevent excessive calls.
+         * @return {void}
+         */
+    const updateAfterScroll = function () {
+      clearTimeout(repositionTimeout);
+      repositionTimeout = setTimeout(() => {
+        $('[data-target*="webuiPopover"]').each(function () {
+          const $triggerer = $(this);
+          const pop = $triggerer.data('plugin_webuiPopover');
+          if (pop && pop._opened) {
+            pop.displayContent();
+          }
+        });
+      }, 30);
+    };
+
+    /**
+         * Sets up a scroll listener on the appropriate container based on screen size.
+         * Ensures only one container is bound at a time.
+         * @type {Function}
+         */
+    const scrollPosRecalcHandler = (function () {
+      return function () {
+        const newScrollableContainer = getScrollableContainer();
+
+        // Only rebind if the container has changed
+        if (scrollPosRecalcisBound && currentScrollableContainer) {
+          currentScrollableContainer.off('scroll', updateAfterScroll);
+          scrollPosRecalcisBound = false;
+        }
+
+        currentScrollableContainer = newScrollableContainer;
+
+        if (!scrollPosRecalcisBound) {
+          currentScrollableContainer.on('scroll', updateAfterScroll);
+          scrollPosRecalcisBound = true;
+        }
+      };
+    }());
+
+    const defaultOptions = {
+      title: '',
+      container: getScrollableContainer(),
+      url: '',
+      trigger: 'click',
+      placement: 'auto',
+      multi: true,
+    };
+
+    const initializedPopovers = {};
+
+    /**
          * Show a popover for a triggerer element (the element triggering the show signal) with the given options.
-         *
          * @param signalData Object containing all data from the signal
          * @param options Object with popover options
          */
-        var showFromSignal = function (signalData, options) {
-            var $triggerer = signalData.triggerer;
-            if (!$triggerer.length) {
-                return;
-            }
-            var triggererId = $triggerer.attr('id');
-            if (signalData.event === 'mouseenter') {
-                options.trigger = 'hover';
-            }
-            var initialized = show($triggerer, options);
-            if (initialized === false) {
-                initializedPopovers[signalData.id] = triggererId;
-            }
-        };
+    const showFromSignal = function (signalData, options) {
+      const $triggerer = signalData.triggerer;
+      if (!$triggerer.length) return;
 
+      const triggererId = $triggerer.attr('id');
+      if (signalData.event === 'mouseenter') {
+        options.trigger = 'hover';
+      }
 
-        /**
+      const initialized = show($triggerer, options);
+      if (initialized === false) {
+        initializedPopovers[signalData.id] = triggererId;
+      }
+
+      scrollPosRecalcHandler();
+    };
+
+    /**
          * Replace the content of the popover showed by the given showSignal with the data returned by the URL
          * set in the signal options.
-         *
          * @param showSignal ID of the show signal for the popover
          * @param signalData Object containing all data from the replace signal
          */
-        var replaceContentFromSignal = function (showSignal, signalData) {
-            // Find the ID of the triggerer where this popover belongs to
-            var triggererId = (showSignal in initializedPopovers) ? initializedPopovers[showSignal] : 0;
-            if (!triggererId) return;
+    const replaceContentFromSignal = function (showSignal, signalData) {
+      const triggererId = (showSignal in initializedPopovers) ? initializedPopovers[showSignal] : 0;
+      if (!triggererId) return;
 
-            var url = signalData.options.url;
-            var $triggerer = $('#' + triggererId);
-            var id = $triggerer.attr('data-target');
+      const { url } = signalData.options;
+      const $triggerer = $(`#${triggererId}`);
+      const id = $triggerer.attr('data-target');
 
-            il.UI.core.replaceContent(id, url, "content");
-        };
+      il.UI.core.replaceContent(id, url, 'content');
+    };
 
-        /**
+    /**
          * Show a popover next to the given triggerer element with the provided options
-         *
          * @param $triggerer JQuery object acting as triggerer
          * @param options Object with popover options
          * @returns {boolean} True if the popover has already been initialized, false otherwise
          */
-        var show = function($triggerer, options) {
+    var show = function ($triggerer, options) {
+      if (WebuiPopovers.isCreated(`#${$triggerer.attr('id')}`)) {
+        return true;
+      }
 
-            if (WebuiPopovers.isCreated('#' + $triggerer.attr('id'))) {
-                return true;
-            }
-            // webui is moving the content at the end of the document which makes it impossible to use
-            // popovers in forms without specifying a container here. We search for upper il-popover-container.
-            // If given we use this element as a container for the popover
-            var container;
-            if (container = $('#' + $triggerer.attr('id')).parents(".il-popover-container")[0]) {
-                options = $.extend({}, {container: container}, options);
+      let container;
+      if (container = $(`#${$triggerer.attr('id')}`).parents('.il-popover-container')[0]) {
+        options = $.extend({}, { container }, options);
+      }
 
-            }
-            options = $.extend({}, {onShow: function($el) {
-                    $el.trigger("il.ui.popover.show");}}, options);
+      options = $.extend({}, {
+        onShow($el) {
+          $el.trigger('il.ui.popover.show');
+        },
+      }, options);
 
-            options = $.extend({}, defaultOptions, options);
-            // Extend options with data from the signal
-            $triggerer.webuiPopover(options).webuiPopover('show');
+      options = $.extend({}, defaultOptions, options);
 
+      $triggerer.webuiPopover(options).webuiPopover('show');
 
-            return false;
-        };
+      return false;
+    };
 
-        /**
-         * Public interface
-         */
-        return {
-            showFromSignal: showFromSignal,
-            replaceContentFromSignal: replaceContentFromSignal,
-            show: show
-        };
-
-    })($);
-})($, il.UI);
+    return {
+      showFromSignal,
+      replaceContentFromSignal,
+      show,
+    };
+  }($));
+}($, il.UI));

--- a/templates/default/060-elements/_elements_html-body.scss
+++ b/templates/default/060-elements/_elements_html-body.scss
@@ -8,11 +8,6 @@ html, body {
 	height:100%;
 	overflow: hidden;
 	margin: 0;
-	@media only screen and (max-width: $il-grid-float-breakpoint-max) {
-		overflow: initial;
-		height: auto;
-		min-height: 100vh;
-	}
 }
 
 html {
@@ -28,6 +23,11 @@ body {
 	line-height: $il-line-height-base;
 	color: $il-text-color;
 	background-color: $il-main-bg;
+	@media only screen and (max-width: $il-grid-float-breakpoint-max) {
+		overflow: auto;
+		height: 100%;
+		min-height: 100%;
+	}
 }
 
 /* see bug ILIAS bug #17589 and http://stackoverflow.com/questions/17045132/scrollbar-overlay-in-ie10-how-do-you-stop-that */

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2069,13 +2069,6 @@ html, body {
   overflow: hidden;
   margin: 0;
 }
-@media only screen and (max-width: 991px) {
-  html, body {
-    overflow: initial;
-    height: auto;
-    min-height: 100vh;
-  }
-}
 
 html {
   font-size: 100%;
@@ -2092,6 +2085,13 @@ body {
   line-height: 1.428571429;
   color: #161616;
   background-color: white;
+}
+@media only screen and (max-width: 991px) {
+  body {
+    overflow: initial;
+    height: auto;
+    min-height: 100vh;
+  }
 }
 
 /* see bug ILIAS bug #17589 and http://stackoverflow.com/questions/17045132/scrollbar-overlay-in-ie10-how-do-you-stop-that */


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43704

Note that webuipopover as a dependency will be removed in 11, as I was informed by my colleague @nhaagen . The new and improved UI Popover will probably use a system closer to the Button tooltip which doesn't rely on fixed positioning and simply cannot have the same problems to begin with. Therefor this fix is more of a band-aid than a future proof solution.

# Issue

Popover UI component fails test because
* popover tooltip doesn't follow scroll
* popvers aren't visible on mobile screen sizes

# Changes

Oh boy was this fiddly.
I couldn't pin point exactly why, but something inside the dependency does not handle scrolling in flexbox or css grids elements well and fails to update the popover's position. This is what I ended up doing:
* passing either "body" on mobile screen sizes OR ".il-layout-page-content" on desktop screen sizes as the scroll container
* attaching a scroll event listener to the currently relevant container
* a debounce reduces the number of scroll events fired
* scroll event reaches into webuipopover's internal methods by using $triggerer.data('plugin_webuiPopover') to detect open popovers and refresh their position

I am aware that the following edge cases are not handled:
* changing the window size between mobile and desktop does not refresh the event listeners. Popovers therefor no longer scrolled until closed with a click and reopened.
* opening and closing the slate does not update the popovers position until scrolled.

Furthermore ESLint has much to complain about the rest of the code in this file.

Since I didn't want to add too many event listeners and those glitches disappear when re-opening the the popover, I decided against fixing those. The Popover in 11 will handle these edge cases.

# Attention

To make this work I had to change the mobile scroll container from html to body. Otherwise the popover would be appended to the html element outside of the body which is not allowed by web standards.

Scrolling body elements are not completely unheard of, but it's unusual. It's problematic as this change effects all pages in ILIAS, which is dangerous for a release that has already been tested so thoroughly.

Maybe someone here has a better idea?