### PR TITLE
UI/URLBuilder: Use correct type declaration for `acquireParameter`

### DIFF
--- a/src/UI/URLBuilder.php
+++ b/src/UI/URLBuilder.php
@@ -111,7 +111,7 @@ class URLBuilder
      * changed URLBuilder as well as the token for any
      * subsequent changes to the acquired parameter.
      *
-     * @return array<URLBuilder,URLBuilderToken>
+     * @return array{0: URLBuilder, 1: URLBuilderToken}
      * @throws \ilException
      * @throws \InvalidArgumentException
      */


### PR DESCRIPTION
The current return type declaration in the PHPDoc comment results in false positives in SCA (e.g. in PHPStorm).

![Bildschirmfoto vom 2025-04-16 13-43-42](https://github.com/user-attachments/assets/344bc87f-7a16-4b9a-9cb9-0b193117346e)

With the change this PR suggests, calls to `withParameter` are **not** reported as "method not found" anymore.