### PR TITLE
[FIX] LTI: extra breadcrumbs deleted and test access fixed

### DIFF
--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -266,7 +266,7 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
         }
 
         $platform = ilLTIPlatform::fromConsumerKey($this->provider->platform->getKey(), $this->provider->platform->getDataConnector());
-
+        ilSession::clear("lti_context_ids");
         $this->ref_id = $platform->getRefId();
 
         $lti_context_ids = ilSession::get('lti_context_ids');
@@ -338,7 +338,7 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
             $internal_account = $this->createUser($platform);
         }
 
-        $this->handleLocalRoleAssignments($internal_account, $platform);
+        $this->handleLocalRoleAssignments($internal_account, $platform, $this->ref_id);
 
         $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
         $status->setAuthenticatedUserId($internal_account);
@@ -529,11 +529,9 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
         return $userObj->getId();
     }
 
-    protected function handleLocalRoleAssignments(int $user_id, ilLTIPlatform $consumer): bool
+    protected function handleLocalRoleAssignments(int $user_id, ilLTIPlatform $consumer, int $target_ref_id): bool
     {
         global $DIC;
-
-        $target_ref_id = $this->ref_id;
         $this->getLogger()->info('$target_ref_id: ' . $target_ref_id);
         if (!$target_ref_id) {
             $this->getLogger()->warning('No target id given');
@@ -558,6 +556,11 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
 
         $this->getLogger()->info('Recieved roles: ' . implode(', ', $role_arr));
 
+        $tree = $DIC->repositoryTree();
+        $parent = $tree->getParentId($target_ref_id);
+        if($parent != 1) {
+            $this->handleLocalRoleAssignments($user_id, $consumer, $parent);
+        }
 
         foreach ($role_arr as $role) {
             $role = trim($role);

--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -558,7 +558,7 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
 
         $tree = $DIC->repositoryTree();
         $parent = $tree->getParentId($target_ref_id);
-        if($parent != 1) {
+        if ($parent != 1) {
             $this->handleLocalRoleAssignments($user_id, $consumer, $parent);
         }
 

--- a/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
+++ b/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
@@ -25,12 +25,14 @@ class CustomBreadcrumbPagePartProvider implements PagePartProvider
 {
     private PagePartProvider $original;
     private RefineryFactory $refinery;
+    private ilLogger $logger;
 
     public function __construct(PagePartProvider $original)
     {
         global $DIC;
         $this->refinery = $DIC->refinery();
         $this->original = $original;
+        $this->logger = $DIC->logger()->root();
     }
 
     public function getTitle(): string
@@ -50,14 +52,13 @@ class CustomBreadcrumbPagePartProvider implements PagePartProvider
         if ($breadcrumbs === null) {
             return null;
         }
-        if (!isset($_SESSION["ref_id"])) {
+        if (!isset($_SESSION["lti_context_ids"])) {
             return $breadcrumbs;
         }
 
         $goto_crumbs = [];
         $non_goto_crumbs = [];
-        $ref_id = $_SESSION["ref_id"];
-
+        $ref_id = $_SESSION["lti_context_ids"][0];
         foreach ($breadcrumbs->getItems() as $crumb) {
             $action = (string) $crumb->getAction();
             if (method_exists($crumb, 'getAction') && str_contains($action, 'goto.php')) {

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIViewGUI.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIViewGUI.php
@@ -246,7 +246,7 @@ class ilLTIViewGUI
                 //                $this->dic->ui()->mainTemplate()->setOnScreenMessage('failure', $this->lng->txt('permission_denied'), true);
                 $redirect = $this->link_dir . "goto.php?target=" . $obj_type . "_" . $ref_id . "&lti_context_id=" . $context_id;
                 $this->log->debug("redirect: " . $redirect);
-                ilUtil::redirect($redirect);
+                $DIC->ctrl()->redirectToURL($redirect);
             }
         }
         $lti_context_ids = ilSession::get('lti_context_ids');


### PR DESCRIPTION
Currently, one user is not able to share a test into a course with LTI, with this change we change it.
Also there were some case where we saw some extra breadcrumb, we reviewed the workflow and we fixed it.

This PR solves these problems reported in mantis:
https://mantis.ilias.de/view.php?id=44855
https://mantis.ilias.de/view.php?id=44921