### PR TITLE
[LTI] Fix: group's elements access

### DIFF
--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilAuthProviderLTI.php
@@ -538,9 +538,20 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
             return false;
         }
 
+        $tree = $DIC->repositoryTree();
+        $parent = $tree->getParentId($target_ref_id);
+
         $obj_settings = new ilLTIProviderObjectSetting($target_ref_id, $consumer->getExtConsumerId());
 
         $roles = $this->messageParameters['roles'] ?? '';
+
+        if ($parent != 1) {
+            $this->handleLocalRoleAssignments($user_id, $consumer, $parent);
+        }
+
+        if($target_ref_id == 104) {
+            $this->getLogger()->info('we are working wih: ' . $target_ref_id);
+        }
 
         if (!is_string($roles) || empty($roles)) {
             $this->getLogger()->warning('No role information given or invalid role format.');
@@ -556,18 +567,11 @@ class ilAuthProviderLTI extends \ilAuthProvider implements \ilAuthProviderInterf
 
         $this->getLogger()->info('Recieved roles: ' . implode(', ', $role_arr));
 
-        $tree = $DIC->repositoryTree();
-        $parent = $tree->getParentId($target_ref_id);
-        if ($parent != 1) {
-            $this->handleLocalRoleAssignments($user_id, $consumer, $parent);
-        }
-
         foreach ($role_arr as $role) {
             $role = trim($role);
             $local_role_id = $this->mapLTIRoleToLocalRole($role, $obj_settings);
-
-            if ($local_role_id) {
-                $this->getLogger()->info('Assigning local role ID: ' . $local_role_id . ' for LTI role: ' . $role);
+            if (isset($local_role_id)) {
+                $this->getLogger()->info('Assigning local role ID: ' . $local_role_id . ' for LTI role: ' . $role . ' to user ID: ' . $user_id);
                 $DIC->rbac()->admin()->assignUser($local_role_id, $user_id);
             } else {
                 $this->getLogger()->info('No local role mapping found for LTI role: ' . $role);


### PR DESCRIPTION
These changes fix the infinite redirection problem reported at https://mantis.ilias.de/view.php?id=44855 when consuming any object within a group by LTI.