### PR TITLE
T&A Bugfix #0044944: Manual Scoring in Random Test doesnt update Reached Points

### DIFF
--- a/Modules/Test/classes/class.ilTestScoringGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringGUI.php
@@ -269,7 +269,8 @@ class ilTestScoringGUI extends ilTestServiceGUI
                     $maxPointsByQuestionId[$questionId],
                     $pass,
                     true,
-                    $this->object->areObligationsEnabled()
+                    $this->object->areObligationsEnabled(),
+                    $this->getTestAccess()->getTestId()
                 );
             }
 

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -1940,7 +1940,8 @@ abstract class assQuestion
         float $maxpoints,
         int $pass,
         bool $manualscoring,
-        bool $obligationsEnabled
+        bool $obligationsEnabled,
+        ?int $test_id = null
     ): bool {
         global $DIC;
         $ilDB = $DIC['ilDB'];
@@ -1990,8 +1991,8 @@ abstract class assQuestion
             }
 
             if (self::isForcePassResultUpdateEnabled() || $old_points != $points || $rowsnum == 0) {
-                $test_id = ilObjTest::_lookupTestObjIdForQuestionId($question_id);
-                if ($test_id === null) {
+                $test_id = $test_id ? (int) ilObjTest::_getObjectIDFromTestID($test_id) : ilObjTest::_lookupTestObjIdForQuestionId($question_id);
+                if ($test_id === null || $test_id == 0) {
                     return false;
                 }
                 $test = new ilObjTest(


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44944