### PR TITLE
UICore: Fix str_starts_with Does Not Accept Null

### DIFF
--- a/components/ILIAS/UICore/classes/class.ilTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilTemplate.php
@@ -335,7 +335,7 @@ class ilTemplate extends HTML_Template_ITX
     /**
      * @throws ilSystemStyleException
      */
-    protected function getTemplatePath(string $a_tplname, string $a_in_module = null): string
+    protected function getTemplatePath(string $a_tplname, string $a_in_module = ''): string
     {
         $ilias_root = realpath(__DIR__ . '/../../../../') . '/';
 

--- a/components/ILIAS/UICore/classes/class.ilTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilTemplate.php
@@ -225,7 +225,7 @@ class ilTemplate extends HTML_Template_ITX
     {
         global $DIC;
 
-        $tplfile = $this->getTemplatePath($tplname, $in_module);
+        $tplfile = $this->getTemplatePath($tplname, $in_module ?? '');
         if (file_exists($tplfile) === false) {
             echo "<br/>Template '" . $tplfile . "' doesn't exist! aborting...";
             return false;


### PR DESCRIPTION
Hi @thibsy 

There is an error in `ilTemplate` where `$a_in_module` might get set to `null` which then is not accepted by `str_starts_with`. This would be a possible solution, I think.

See: https://mantis.ilias.de/view.php?id=44919

...the failing tests come from the superfluous `Modules`-folder introduced in a previous commit.

Thanks and best,
@kergomard 