### PR TITLE
[LTI] Fix: Adjustments to hide breadcrumbs when consuming LTI

### DIFF
--- a/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
+++ b/components/ILIAS/LTIProvider/classes/Screen/CustomBreadcrumbPagePartProvider.php
@@ -47,11 +47,16 @@ class CustomBreadcrumbPagePartProvider implements PagePartProvider
 
     private function getRefId(): string|null
     {
-        if(isset($_GET["ref_id"])) {
-            return (string) $_GET["ref_id"];
+        global $DIC;
+
+        if($DIC ->http()->wrapper()->query()->has("ref_id")) {
+            return $DIC ->http()->wrapper()->query()->retrieve("ref_id", $DIC->refinery()->to()->string());
         }
-        if(isset($_SESSION["lti_context_ids"]) && is_array($_SESSION["lti_context_ids"]) && count($_SESSION["lti_context_ids"]) > 0) {
-            return (string) $_SESSION["lti_context_ids"][0];
+        if(ilSession::has("ref_id")) {
+            return (string) ilSession::get("ref_id");
+        }
+        if(ilSession::has("lti_context_ids") && is_array(ilSession::get("lti_context_ids")) && count(ilSession::get("lti_context_ids")) > 0) {
+            return (string) ilSession::get("lti_context_ids")[0];
         }
         return null;
     }


### PR DESCRIPTION
Previously, there are some extra elements that appears in breadcrumbs, this change want to limitate which element appears.

Associated mantis link:
https://mantis.ilias.de/view.php?id=44921