### PR TITLE
HTMLLearningModule: fix export/import of files (44138, 44462)

### DIFF
--- a/components/ILIAS/HTMLLearningModule/Service/class.InternalRepoService.php
+++ b/components/ILIAS/HTMLLearningModule/Service/class.InternalRepoService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\HTMLLearningModule;
 

--- a/components/ILIAS/HTMLLearningModule/Service/class.InternalRepoService.php
+++ b/components/ILIAS/HTMLLearningModule/Service/class.InternalRepoService.php
@@ -20,11 +20,15 @@ declare(strict_types=1);
 
 namespace ILIAS\HTMLLearningModule;
 
+use ILIAS\Repository\RepoServiceBase;
+
 /**
  * @author Alexander Killing <killing@leifos.de>
  */
 class InternalRepoService
 {
+    use RepoServiceBase;
+
     protected InternalDataService $data;
     protected \ilDBInterface $db;
 

--- a/components/ILIAS/HTMLLearningModule/classes/class.ilHTLMExportOptionHTML.php
+++ b/components/ILIAS/HTMLLearningModule/classes/class.ilHTLMExportOptionHTML.php
@@ -21,17 +21,24 @@ declare(strict_types=1);
 use ILIAS\Data\ObjectId;
 use ILIAS\Export\ExportHandler\Consumer\ExportOption\BasicLegacyHandler as ilLegacyExportOption;
 use ILIAS\Export\ExportHandler\I\Consumer\Context\HandlerInterface as ilExportHandlerConsumerContextInterface;
+use ILIAS\ResourceStorage\Services as IRSS;
 use ILIAS\DI\Container;
+use ILIAS\Filesystem\Filesystem;
+use ILIAS\Filesystem\Util\LegacyPathHelper;
 
 class ilHTLMExportOptionHTML extends ilLegacyExportOption
 {
     protected ilCtrl $ctrl;
     protected ilLanguage $lng;
+    protected IRSS $irss;
+    protected Filesystem $storage;
 
     public function init(Container $DIC): void
     {
         $this->ctrl = $DIC->ctrl();
         $this->lng = $DIC->language();
+        $this->irss = $DIC->resourceStorage();
+        $this->storage = $DIC->filesystem()->storage();
         parent::init($DIC);
     }
 
@@ -72,24 +79,15 @@ class ilHTLMExportOptionHTML extends ilLegacyExportOption
             $object->getType()
         );
 
-        $subdir = $object->getType() . "_" . $object->getId();
-
-        $target_dir = $export_dir . "/" . $subdir;
-
-        ilFileUtils::delDir($target_dir);
-        ilFileUtils::makeDir($target_dir);
-
-        $source_dir = $object->getDataDirectory();
-
-        ilFileUtils::rCopy($source_dir, $target_dir);
-
-        // zip it all
+        // write files as zip to legacy storage
         $date = time();
-        $zip_file = $export_dir . "/" . $date . "__" . IL_INST_ID . "__" .
-            $object->getType() . "_" . $object->getId() . ".zip";
-        ilFileUtils::zip($target_dir, $zip_file);
+        $zip_file = LegacyPathHelper::createRelativePath(
+            $export_dir . "/" . $date . "__" . IL_INST_ID . "__" .
+            $object->getType() . "_" . $object->getId() . ".zip"
+        );
 
-        ilFileUtils::delDir($target_dir);
+        $stream = $this->irss->consume()->stream($object->getResource()->getIdentification())->getStream();
+        $this->storage->writeStream($zip_file, $stream);
 
         $this->ctrl->redirect($context->exportGUIObject(), $context->exportGUIObject()::CMD_LIST_EXPORT_FILES);
     }

--- a/components/ILIAS/HTMLLearningModule/classes/class.ilHTMLLearningModuleDataSet.php
+++ b/components/ILIAS/HTMLLearningModule/classes/class.ilHTMLLearningModuleDataSet.php
@@ -16,6 +16,9 @@
  *
  *********************************************************************/
 
+use ILIAS\Dataset\IRSSContainerExportConfig;
+use ILIAS\Repository\IRSS\IRSSWrapper;
+
 /**
  * HTML learning module data set class
  * @author Alexander Killing <killing@leifos.de>
@@ -23,6 +26,15 @@
 class ilHTMLLearningModuleDataSet extends ilDataSet
 {
     protected ilObjFileBasedLM $current_obj;
+    protected IRSSWrapper $irss_wrapper;
+
+    public function __construct()
+    {
+        global $DIC;
+
+        parent::__construct();
+        $this->irss_wrapper = $DIC->htmlLearningModule()->internal()->repo()->irss();
+    }
 
     public function getSupportedVersions(): array
     {
@@ -44,7 +56,7 @@ class ilHTMLLearningModuleDataSet extends ilDataSet
                         "Title" => "text",
                         "Description" => "text",
                         "StartFile" => "text",
-                        "Dir" => "directory");
+                        "Dir" => "rscontainer");
             }
         }
         return [];
@@ -58,7 +70,7 @@ class ilHTMLLearningModuleDataSet extends ilDataSet
             switch ($a_version) {
                 case "4.1.0":
                     $this->getDirectDataFromQuery("SELECT id, title, description, " .
-                        " startfile start_file " .
+                        " startfile start_file" .
                         " FROM file_based_lm JOIN object_data ON (file_based_lm.id = object_data.obj_id) " .
                         "WHERE " .
                         $ilDB->in("id", $a_ids, false, "integer"));
@@ -70,10 +82,30 @@ class ilHTMLLearningModuleDataSet extends ilDataSet
     public function getXmlRecord(string $a_entity, string $a_version, array $a_set): array
     {
         $lm = new ilObjFileBasedLM($a_set["Id"], false);
-        $dir = $lm->getDataDirectory();
-        $a_set["Dir"] = $dir;
+        $a_set["Dir"] = $lm->getResource()->getIdentification();
 
         return $a_set;
+    }
+
+    public function getContainerExportConfig(
+        array $record,
+        string $entity,
+        string $schema_version,
+        string $field,
+        string $value
+    ): ?IRSSContainerExportConfig {
+        if ($entity === "htlm" && $field === "Dir") {
+            $lm = new ilObjFileBasedLM($record["Id"], false);
+            $container = $lm->getResource();
+            if ($container) {
+                return
+                    $this->getIRSSContainerExportConfig(
+                        $container,
+                        ""
+                    );
+            }
+        }
+        return null;
     }
 
     public function importRecord(string $a_entity, array $a_types, array $a_rec, ilImportMapping $a_mapping, string $a_schema_version): void
@@ -94,15 +126,22 @@ class ilHTMLLearningModuleDataSet extends ilDataSet
                 $newObj->setTitle($a_rec["Title"]);
                 $newObj->setDescription($a_rec["Description"]);
                 $newObj->setStartFile($a_rec["StartFile"], true);
-                $newObj->update(true);
-                $this->current_obj = $newObj;
 
                 $dir = str_replace("..", "", $a_rec["Dir"]);
                 if ($dir !== "" && $this->getImportDirectory() !== "") {
                     $source_dir = $this->getImportDirectory() . "/" . $dir;
-                    $target_dir = $newObj->getDataDirectory();
-                    ilFileUtils::rCopy($source_dir, $target_dir);
+                    $rid = $this->irss_wrapper->createContainerFromLocalDir(
+                        $source_dir,
+                        new ilHTLMStakeholder(),
+                        "",
+                        true,
+                        $newObj->getTitle()
+                    );
+                    $newObj->setRID($rid);
                 }
+
+                $newObj->update(true);
+                $this->current_obj = $newObj;
 
                 $a_mapping->addMapping("components/ILIAS/HTMLLearningModule", "htlm", $a_rec["Id"], $newObj->getId());
                 $a_mapping->addMapping(

--- a/components/ILIAS/Repository/Service/IRSS/IRSSWrapper.php
+++ b/components/ILIAS/Repository/Service/IRSS/IRSSWrapper.php
@@ -299,7 +299,7 @@ class IRSSWrapper
         return "";
     }
 
-    public function getResource(string $rid) : ?StorableResource
+    public function getResource(string $rid): ?StorableResource
     {
         $id = $this->getResourceIdForIdString($rid);
         if ($id) {
@@ -420,8 +420,7 @@ class IRSSWrapper
     public function getContainerEntryInfo(
         string $container_id,
         string $path
-    ) : array
-    {
+    ): array {
         $reader = new ZipReader(
             $this->irss->consume()->stream($this->getResourceIdForIdString($container_id))->getStream()
         );
@@ -431,8 +430,7 @@ class IRSSWrapper
     public function deliverContainerEntry(
         string $container_id,
         string $path
-    ) : void
-    {
+    ): void {
         $reader = new ZipReader(
             $this->irss->consume()->stream($this->getResourceIdForIdString($container_id))->getStream()
         );
@@ -610,7 +608,10 @@ class IRSSWrapper
         $rid = $this->createContainer($stakeholder, $title);
         if ($recursive) {
             $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($local_dir_path, \RecursiveDirectoryIterator::SKIP_DOTS),
+                new \RecursiveDirectoryIterator(
+                    $local_dir_path,
+                    \RecursiveDirectoryIterator::SKIP_DOTS | \RecursiveDirectoryIterator::CURRENT_AS_SELF
+                ),
                 \RecursiveIteratorIterator::SELF_FIRST
             );
         } else {


### PR DESCRIPTION
Hi @mbecker-databay, this PR fixes some issues with export/import of HTML Learning Modules, see [44138](https://mantis.ilias.de/view.php?id=44138) and [44462](https://mantis.ilias.de/view.php?id=44462). The files of HTML LMs were migrated to the IRSS, but some export/import stuff hadn't been adapted accordingly so far.

A few caveats: I tried to keep this as slim as possible, so I reused a method from the IRSS wrapper of the Repository component. HTMLLearningModule already uses some Repository stuff for dependency management anyways. Also, the `ilHTLMExportOptionHTML` uses some legacy file stuff, since as far as I can tell the HTML export files are not yet migrated to the IRSS.

@alex40724, I've also assigned you here because of a small fix in your IRSS wrapper. Without the flag I added, `RecursiveDirectoryIterator` iterates over `SplFileInfo`, which doesn't have `isDot`. The flag makes it so that it behaves more like `DirectoryIterator`. As far as I can see, this only matters for this new usage (all the old ones set recursive to false).