### PR TITLE
#44703 / Paths in rCopy do not inherit directory permissions

### DIFF
--- a/Services/FileServices/classes/class.ilFileUtils.php
+++ b/Services/FileServices/classes/class.ilFileUtils.php
@@ -151,6 +151,7 @@ class ilFileUtils
                     $item->getPath(),
                     strlen($sourceDir)
                 );
+                self::makeDirParents(dirname(ILIAS_WEB_DIR . '/' . CLIENT_NAME .'/' . $itemPath));
                 $stream = $sourceFS->readStream($item->getPath());
                 $targetFS->writeStream($itemPath, $stream);
             } catch (\ILIAS\Filesystem\Exception\FileAlreadyExistsException $e) {


### PR DESCRIPTION
Following a report from a client about copied resources being inaccessible, here's a fix for https://mantis.ilias.de/view.php?id=44703
The makeDirParents method inherits the first existing parents permissions, so that works here.