### PR TITLE
T&A 43220: Benachrichtigung - Keine E-Mail mit Excel wird generiert

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -6505,8 +6505,6 @@ class ilObjTest extends ilObject
             $this,
             ExportImportTypes::SCORED_ATTEMPT
         )->withFilterByActiveId($active_id)
-            ->withResultsPage()
-            ->withUserPages()
             ->write();
 
         $delivered_file_name = 'result_' . $active_id . '.xlsx';


### PR DESCRIPTION
Hi everyone,

this PR is related to [43220](https://mantis.ilias.de/view.php?id=43220). As described in the ticket, an error occurs when trying to send a mail notification after a test pass has been finished. To reproduce the described exception, I needed to adjust the test settings like mentioned in the tickets' description. Also, I updated the composer dependencies. 

In my opinion this error was caused by a duplicate method call of `\ILIAS\Test\ExportImport\ResultsExportExcel::withResultsPage` both in `\ILIAS\Test\ExportImport\Factory::getExporter` and `\ilObjTest::sendAdvancedNotification`. I fixed the issue by removing the method calling outside the factory.

As always, these changes have already been internally approved by @thojou. I look forward to further feedback.

Best,
@lukas-heinrich 