### PR TITLE
Tracking: remove unused table (44940)

### DIFF
--- a/Services/Tracking/classes/Setup/class.ilTrackingSetupAgent.php
+++ b/Services/Tracking/classes/Setup/class.ilTrackingSetupAgent.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Setup;
+use ILIAS\Setup\Config;
+
+class ilTrackingSetupAgent extends Setup\Agent\NullAgent
+{
+    public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
+    {
+        return new ilDatabaseUpdateStepsExecutedObjective(new ilTrackingUpdateSteps9());
+    }
+
+    public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
+    {
+        return new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilTrackingUpdateSteps9());
+    }
+}

--- a/Services/Tracking/classes/Setup/class.ilTrackingUpdateSteps9.php
+++ b/Services/Tracking/classes/Setup/class.ilTrackingUpdateSteps9.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+class ilTrackingUpdateSteps9 implements ilDatabaseUpdateSteps
+{
+    protected \ilDBInterface $db;
+
+    public function prepare(\ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Remove the unused table 'catch_write_events'
+     */
+    public function step_1(): void
+    {
+        if ($this->db->tableExists('catch_write_events')) {
+            $this->db->dropTable('catch_write_events');
+        }
+    }
+}

--- a/Services/Tracking/classes/class.ilChangeEvent.php
+++ b/Services/Tracking/classes/class.ilChangeEvent.php
@@ -518,39 +518,16 @@ class ilChangeEvent
      * @param $usr_id    int The user.
      * @param $timestamp string|null timestamp.
      * @return void
+     *
+     * This method was only used to write to catch_write_events,
+     * but the methods reading out that table are not used anywhere.
+     * @deprecated, will be removed with ILIAS 11
      */
     public static function _catchupWriteEvents(
         int $obj_id,
         int $usr_id,
         ?string $timestamp = null
     ): void {
-        global $DIC;
-
-        $ilDB = $DIC['ilDB'];
-
-        $query = "SELECT obj_id FROM catch_write_events " .
-            "WHERE obj_id = " . $ilDB->quote($obj_id, 'integer') . " " .
-            "AND usr_id  = " . $ilDB->quote($usr_id, 'integer');
-        $res = $ilDB->query($query);
-        if ($res->numRows()) {
-            $ts = ($timestamp == null)
-                ? ilUtil::now()
-                : $timestamp;
-        } else {
-            $ts = ilUtil::now();
-        }
-
-        // alex, use replace due to bug #10406
-        $ilDB->replace(
-            "catch_write_events",
-            array(
-                "obj_id" => array("integer", $obj_id),
-                "usr_id" => array("integer", $usr_id)
-            ),
-            array(
-                "ts" => array("timestamp", $ts)
-            )
-        );
     }
 
     /**
@@ -559,52 +536,16 @@ class ilChangeEvent
      * @param $obj_id int The object
      * @param $usr_id int The user who is interested into these events.
      * @return array with rows from table write_event
+     *
+     * This method is unused, so the table it read from was
+     * removed for performance reasons.
+     * @deprecated, will be removed with ILIAS 11
      */
     public static function _lookupUncaughtWriteEvents(
         int $obj_id,
         int $usr_id
     ): array {
-        global $DIC;
-
-        $ilDB = $DIC['ilDB'];
-        $q = "SELECT ts " .
-            "FROM catch_write_events " .
-            "WHERE obj_id=" . $ilDB->quote($obj_id, 'integer') . " " .
-            "AND usr_id=" . $ilDB->quote($usr_id, 'integer');
-        $r = $ilDB->query($q);
-        $catchup = null;
-        while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_ASSOC)) {
-            $catchup = $row['ts'];
-        }
-
-        if ($catchup == null) {
-            $query = sprintf(
-                'SELECT * FROM write_event ' .
-                'WHERE obj_id = %s ' .
-                'AND usr_id <> %s ' .
-                'ORDER BY ts DESC',
-                $ilDB->quote($obj_id, 'integer'),
-                $ilDB->quote($usr_id, 'integer')
-            );
-            $res = $ilDB->query($query);
-        } else {
-            $query = sprintf(
-                'SELECT * FROM write_event ' .
-                'WHERE obj_id = %s ' .
-                'AND usr_id <> %s ' .
-                'AND ts >= %s ' .
-                'ORDER BY ts DESC',
-                $ilDB->quote($obj_id, 'integer'),
-                $ilDB->quote($usr_id, 'integer'),
-                $ilDB->quote($catchup, 'timestamp')
-            );
-            $res = $ilDB->query($query);
-        }
-        $events = array();
-        while ($row = $ilDB->fetchAssoc($res)) {
-            $events[] = $row;
-        }
-        return $events;
+        return [];
     }
 
     /**
@@ -615,56 +556,14 @@ class ilChangeEvent
      * @return int 0 = object is unchanged,
      *                1 = object is new,
      *                2 = object has changed
+     *
+     * This method is unused, so the table it read from was
+     * removed for performance reasons.
+     * @deprecated, will be removed with ILIAS 11
      */
     public static function _lookupChangeState(int $obj_id, int $usr_id): int
     {
-        global $DIC;
-
-        $ilDB = $DIC['ilDB'];
-
-        $q = "SELECT ts " .
-            "FROM catch_write_events " .
-            "WHERE obj_id=" . $ilDB->quote($obj_id, 'integer') . " " .
-            "AND usr_id=" . $ilDB->quote($usr_id, 'integer');
-        $r = $ilDB->query($q);
-        $catchup = null;
-        while ($row = $r->fetchRow(ilDBConstants::FETCHMODE_ASSOC)) {
-            $catchup = $row['ts'];
-        }
-
-        if ($catchup == null) {
-            $ilDB->setLimit(1);
-            $query = sprintf(
-                'SELECT * FROM write_event ' .
-                'WHERE obj_id = %s ' .
-                'AND usr_id <> %s ',
-                $ilDB->quote($obj_id, 'integer'),
-                $ilDB->quote($usr_id, 'integer')
-            );
-            $res = $ilDB->query($query);
-        } else {
-            $ilDB->setLimit(1);
-            $query = sprintf(
-                'SELECT * FROM write_event ' .
-                'WHERE obj_id = %s ' .
-                'AND usr_id <> %s ' .
-                'AND ts > %s ',
-                $ilDB->quote($obj_id, 'integer'),
-                $ilDB->quote($usr_id, 'integer'),
-                $ilDB->quote($catchup, 'timestamp')
-            );
-            $res = $ilDB->query($query);
-        }
-
-        $numRows = $res->numRows();
-        if ($numRows > 0) {
-            $row = $ilDB->fetchAssoc($res);
-            // if we have write events, and user never catched one, report as new (1)
-            // if we have write events, and user catched an old write event, report as changed (2)
-            return ($catchup == null) ? 1 : 2;
-        } else {
-            return 0; // user catched all write events, report as unchanged (0)
-        }
+        return 0;
     }
 
     /**

--- a/Services/Tracking/classes/class.ilChangeEvent.php
+++ b/Services/Tracking/classes/class.ilChangeEvent.php
@@ -1,7 +1,22 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=0);
-/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 /**
  * Class ilChangeEvent tracks change events on repository objects.


### PR DESCRIPTION
This PR removes the unused table `catch_write_events` (see [44940](https://mantis.ilias.de/view.php?id=44940)), but leaves related methods in `ilChangeEvent` as stubs. In a separate PR for trunk (#9470), those stubs (and all usages of the write-only method `_catchupWriteEvents`) will be removed.

Note that I'll also provide a sister PR to this for 10 and trunk, which also puts the new `ilTrackingSetupAgent` into `Tracking.php`: #9468 