### PR TITLE
[LTI] Fix: role assignation

### DIFF
--- a/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderObjectSetting.php
+++ b/components/ILIAS/LTIProvider/classes/InternalProvider/class.ilLTIProviderObjectSetting.php
@@ -144,7 +144,7 @@ class ilLTIProviderObjectSetting
             $this->ref_id = (int) $row->ref_id;
             $this->consumer_id = (int) $row->ext_consumer_id;
             $this->setAdminRole((int) $row->admin);
-            $this->setAdminRole((int) $row->tutor);
+            $this->setTutorRole((int) $row->tutor);
             $this->setMemberRole((int) $row->member);
         }
         return true;


### PR DESCRIPTION
An error was detected in the assignation role process. The error prevented the tutor role from being read correctly. With this change ILIAS is able to read the correct role.