### PR TITLE
FileSystem: Allow output options for `LegacyImages::convertToFormat`

### DIFF
--- a/src/Filesystem/Util/Convert/LegacyImages.php
+++ b/src/Filesystem/Util/Convert/LegacyImages.php
@@ -166,13 +166,15 @@ class LegacyImages
         string $path_to_output,
         string $output_format,
         ?int $width = null,
-        ?int $height = null
+        ?int $height = null,
+        ?ImageOutputOptions $output_options = null
     ): string {
         $converter = $this->image_converters->convertToFormat(
             $this->buildStream($path_to_original),
             $output_format,
             $width,
-            $height
+            $height,
+            $output_options
         );
         return $this->storeStream($converter, $path_to_output);
     }


### PR DESCRIPTION
This PR suggests making "Output Options" injectable when converting and image with `src/Filesystem/Util/Convert/LegacyImages.php`.

See discussion: https://discord.com/channels/819582183290437642/1022408960302653481/1365248247102443565