### PR TITLE
[FIX] #44978 UI: accept `Field\File` mime-type wildcards.

### DIFF
--- a/components/ILIAS/UI/resources/js/Input/Field/file.js
+++ b/components/ILIAS/UI/resources/js/Input/Field/file.js
@@ -347,8 +347,8 @@ il.UI.Input = il.UI.Input || {};
 			}
 
 			// abort if the given file is not an allowed file type.
-			if (dropzones[input_id].options.acceptedFiles !== null &&
-				!dropzones[input_id].options.acceptedFiles.includes(file.type)
+			if (dropzones[input_id].options.acceptedFiles &&
+				!Dropzone.isValidFile(file, dropzones[input_id].options.acceptedFiles)
 			) {
 				displayErrorMessage(
 					I18N.invalid_mime.replace('%s', file.type),


### PR DESCRIPTION
Hi folks,

This fixes https://mantis.ilias.de/view.php?id=44978. Issue most likely exists in all supported versions.

Kind regards
@thibsy 