### PR TITLE
11/data/mail address

### DIFF
--- a/components/ILIAS/Data/src/EmailAddress.php
+++ b/components/ILIAS/Data/src/EmailAddress.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data;
+
+/**
+ * An Email Address is a common personal address for people online.
+ * This class ensures the address follows common format requirements.
+ * It also splits the address into some of the parts outlined in RFC 2822 that can then be retrieved separately.
+ * Non-ASCII characters are technically valid in the local (RFC 6531) and the domain (RFC 3490) parts, but...
+ *      - in the local part they are only supported by a small amount of mailservers
+ *      - in the domain part they are converted to ASCII punycode
+ * Because of this limited support, PHP's own FILTER_VALIDATE_EMAIL does not allow Unicode characters. However, we don't
+ * want to be as strict. ILIAS is used internationally where Latin-1 Supplement characters like ö, ä, ü, é, ø become
+ * more common in email addresses. Some Service Providers need to allow Japanese, Chinese and Cyrillic/Ukrainian
+ * scripts. Therefore, we allow Unicode characters covered by the Email Address Internationalization (EAI) framework.
+ * Be aware that not all email servers can process these by default and that additional steps might be necessary to
+ * enable ILIAS to send those emails.
+ * You can use isAscii() to check if an address is following the old standards and is likely supported by all servers.
+ *
+ * @author Ferdinand Engländer <ferdinand.englaender@concepts-and-training.de>
+ */
+class EmailAddress
+{
+    protected string $addressFull;
+    protected string $domainPart;
+    protected string $localPart;
+    protected bool $isAscii;
+    protected bool $isDomainPartAscii;
+    protected bool $isLocalPartAscii;
+
+
+    public function __construct(string $address_Full)
+    {
+        $this->addressFull = $this->digestFullAddress($address_Full);
+        $this->domainPart = $this->digestDomainPart($address_Full);
+        $this->localPart = $this->digestLocalPart($address_Full);
+        if ($this->isDomainPartAscii && $this->isLocalPartAscii) {
+            $this->isAscii = true;
+        } else {
+            $this->isAscii = false;
+        }
+    }
+
+    public function getAddressFull(): string
+    {
+        return $this->addressFull;
+    }
+
+    public function getDomainPart(): string
+    {
+        return $this->domainPart;
+    }
+
+    public function getLocalPart(): string
+    {
+        return $this->localPart;
+    }
+
+    public function getIsAscii(): bool
+    {
+        return $this->isAscii;
+    }
+
+    public function getIsDomainPartAscii(): bool
+    {
+        return $this->isDomainPartAscii;
+    }
+
+    public function getIsLocalPartAscii(): bool
+    {
+        return $this->isLocalPartAscii;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getAddressFull();
+    }
+
+    protected function checkAscii(string $str): bool
+    {
+        return mb_check_encoding($str, 'ASCII');
+    }
+
+    protected function digestFullAddress(string $address): string
+    {
+        $address = trim($address);
+
+        if (substr_count($address, '@') !== 1) {
+            throw new \InvalidArgumentException("Email must contain exactly one '@' character.");
+        }
+
+        [$local, $domain] = explode('@', $address, 2);
+
+        if ($local === '' || $domain === '') {
+            throw new \InvalidArgumentException("Email must have non-empty local and domain parts.");
+        }
+
+        $this->addressFull = $address;
+        return $address;
+    }
+
+    protected function digestDomainPart(string $address): string
+    {
+        [, $domain] = explode('@', $address, 2);
+
+        $this->isDomainPartAscii = $this->checkAscii($domain);
+
+        if ($domain === 'localhost') {
+            return $domain;
+        }
+
+        if (preg_match('/[\p{C}\p{Z}]/u', $domain)) {
+            throw new \InvalidArgumentException("Domain part contains invalid characters (e.g., whitespace or control).");
+        }
+
+        if (str_contains($domain, '..')) {
+            throw new \InvalidArgumentException("Domain part contains consecutive dots.");
+        }
+
+        // not flagging double hyphens as punycode uses those
+
+        if (substr_count($domain, '.') < 1) {
+            throw new \InvalidArgumentException("Domain must contain at least one dot except for 'localhost'.");
+        }
+
+        if (strlen($domain) > 254) {
+            throw new \InvalidArgumentException("Domain part exceeds 254 character limit.");
+        }
+
+        $labels = explode('.', $domain);
+        foreach ($labels as $label) {
+            if (strlen($label) > 63) {
+                throw new \InvalidArgumentException("Domain label exceeds 63 character limit.");
+            }
+
+            if ($label === '') {
+                throw new \InvalidArgumentException("Domain contains an empty label.");
+            }
+
+            if ($label[0] === '-' || $label[strlen($label) - 1] === '-') {
+                throw new \InvalidArgumentException("Domain labels must not start or end with a hyphen.");
+            }
+        }
+
+        return $domain;
+    }
+
+    protected function digestLocalPart(string $address): string
+    {
+        [$local,] = explode('@', $address, 2);
+
+        if (!mb_check_encoding($local, 'UTF-8')) {
+            throw new \InvalidArgumentException("Local part is not valid UTF-8.");
+        }
+
+        if ($local[0] === '.' || str_ends_with($local, '.')) {
+            throw new \InvalidArgumentException("Local part cannot start or end with a dot.");
+        }
+
+        if (str_contains($local, '..')) {
+            throw new \InvalidArgumentException("Local part cannot contain consecutive dots.");
+        }
+
+        // double quotes are allowed only as first and last character
+        if (str_starts_with($local, '"') && str_ends_with($local, '"')) {
+            $local_strip_quotes = substr($local, 1, -1);
+        } else {
+            $local_strip_quotes = $local;
+        }
+
+        if (preg_match('/[\x00-\x1F\x7F]/', $local_strip_quotes)) {
+            throw new \InvalidArgumentException("Local part contains unsupported control characters or invalid escape sequences.");
+        }
+
+        // check if safe Ascii
+        if (preg_match('/^[a-zA-Z0-9!#$%&\'*+\/=?^_`{|}~\.-]+$/', $local_strip_quotes)) {
+            $this->isLocalPartAscii = true;
+        } else {
+            $this->isLocalPartAscii = false;
+        }
+        // check if save Unicode
+        if (!self::isAllowedIntlUnicode($local_strip_quotes)) {
+            throw new \InvalidArgumentException("Local part is not a valid Unicode string.");
+        }
+
+        return $local;
+    }
+
+    protected static function isAllowedIntlUnicode(string $string): bool
+    {
+        // Check allowed Unicode characters this includes e.g.
+        //      * a-z, A-Z, 0-9
+        //      * Latin accented: é, ñ, ö, č
+        //      * Greek: Α, β, Ω
+        //      * Cyrillic: Б, и, я
+        //      * Arabic letters: ا, ب, خ
+        //      * Hebrew: א, ב, ג
+        //      * East Asian ideographs (CJK): 日, 本, 語, 汉, 字
+        //      * Devanagari (Hindi, Marathi): अ, आ, क
+        //      * Hangul (Korean): 한, 글
+        //      * and more
+        // \p{L} includes all characters Unicode defines as letters
+        // \p{N} includes all characters Unicode defines as numbers
+        // this excludes emojis and control characters which are not allowed in the local part
+        if (!preg_match('/^[\p{L}\p{N}!#$%&\'*+\/=?^_`{|}~\.-]+$/u', $string)) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}

--- a/components/ILIAS/Data/src/Factory.php
+++ b/components/ILIAS/Data/src/Factory.php
@@ -237,6 +237,10 @@ class Factory
         }
         return $this->text_factory;
     }
+    public function emailAddress(string $address): EmailAddress
+    {
+        return new EmailAddress($address);
+    }
 
     public function description(): Description\Factory
     {

--- a/components/ILIAS/Data/tests/EmailAddressTest.php
+++ b/components/ILIAS/Data/tests/EmailAddressTest.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Data\EmailAddress;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the Link Datatype
+ */
+class EmailAddressTest extends TestCase
+{
+    #[DataProvider('validEmailProvider')]
+    public function testEmailObjectConstruction(
+        string $input,
+        string $expected_local,
+        string $expected_domain
+    ): void {
+        $email = new EmailAddress($input);
+
+        $this->assertInstanceOf(EmailAddress::class, $email);
+        $this->assertEquals($input, $email->getAddressFull(), 'Full address mismatch');
+        $this->assertEquals($expected_local, $email->getLocalPart(), 'Local part mismatch');
+        $this->assertEquals($expected_domain, $email->getDomainPart(), 'Domain part mismatch');
+    }
+
+    #[DataProvider('invalidEmailProvider')]
+    public function testEmailThrows(
+        string $input,
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        new EmailAddress($input);
+    }
+
+    #[DataProvider('invalidEmailDomainProvider')]
+    public function testEmailDomainThrows(
+        string $input,
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        new EmailAddress($input);
+    }
+
+    #[DataProvider('invalidEmailLocalProvider')]
+    public function testEmailLocalThrows(
+        string $input,
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        new EmailAddress($input);
+    }
+
+    #[DataProvider('validAsciiEmailProvider')]
+    public function testAsciiEmailFlags(
+        string $input,
+    ): void {
+        $address = new EmailAddress($input);
+        $this->assertTrue($address->getIsAscii());
+        $this->assertTrue($address->getIsLocalPartAscii());
+        $this->assertTrue($address->getIsDomainPartAscii());
+    }
+
+    #[DataProvider('validUnicodeEmailProvider')]
+    public function testAsciiEmailFlagsWhenUnicode(
+        string $input,
+    ): void {
+        $address = new EmailAddress($input);
+        $this->assertFalse($address->getIsAscii());
+        $this->assertFalse($address->getIsLocalPartAscii());
+        $this->assertFalse($address->getIsDomainPartAscii());
+    }
+    public static function validEmailProvider(): array
+    {
+        return [
+            "email_ascii" => [
+                "john.doe@example.com",
+                "john.doe",
+                "example.com"
+            ],
+            "email_unicode" => [
+                "jöhn.doe@exämple.com",
+                "jöhn.doe",
+                "exämple.com"
+            ],
+            "email_unicode2" => [
+                "Ωéяגخ本आ한@Ωéяגخ本आ한.com",
+                "Ωéяגخ本आ한",
+                "Ωéяגخ本आ한.com"
+            ],
+            "email_unicode3" => [
+                "hi@📖💡🤓.ws",
+                "hi",
+                "📖💡🤓.ws"
+            ],
+            "email_short_no_dot" => [
+                "hi@example.com",
+                "hi",
+                "example.com"
+            ],
+            "email_domain_hyphen" => [
+                "someone@domain-with-hyphens.com",
+                "someone",
+                "domain-with-hyphens.com"
+            ],
+            "email_domain_subdomain" => [
+                "someone@subdomain.domain.org",
+                "someone",
+                "subdomain.domain.org"
+            ],
+            "email_domain_many_subdomains" => [
+                "someone@en.m.wikipedia.org",
+                "someone",
+                "en.m.wikipedia.org"
+            ],
+            "email_localhost" => [
+                "someone@localhost",
+                "someone",
+                "localhost"
+            ],
+            "email_ip_127" => [
+                "someone@[127.0.0.1]",
+                "someone",
+                "[127.0.0.1]"
+            ],
+            "email_quoted_string" => [
+                '"quoted.string"@example.com',
+                '"quoted.string"',
+                "example.com"
+            ]
+        ];
+    }
+    public static function invalidEmailProvider(): array
+    {
+        return [
+            "email_nothing" => [
+                "",
+            ],
+            "email_just_whitespace" => [
+                " ",
+            ],
+            "email_no_domain" => [
+                "john.doe@",
+            ],
+            "email_no_local" => [
+                "@example.com",
+            ],
+            "email_two_ats" => [
+                "john.doe@@example.com",
+            ],
+        ];
+    }
+    public static function invalidEmailDomainProvider(): array
+    {
+        $domainLabelsTooLong = str_repeat('a', 64);
+        $domainLabelValidLength = str_repeat('a', 63);
+        $domainTooLong = $domainLabelValidLength . "." . $domainLabelValidLength . "." . $domainLabelValidLength . "." . $domainLabelValidLength;
+        return [
+            "email_domain_no_dot" => [
+                "hi@example",
+            ],
+            "email_domain_labels_too_long" => [
+                "local@" . $domainLabelsTooLong . "." . $domainLabelsTooLong,
+            ],
+            "email_domain_too_long" => [
+                "local@" . $domainTooLong,
+            ],
+            "email_domain_hyphen_start" => [
+                "local@-baddomain.com"
+            ],
+            "email_domain_hyphen_end" => [
+                "local@baddomain-.com"
+            ],
+            "email_consecutive_dots" => [
+                "someone@bad..domain.com"
+            ],
+            "email_domain_label_empty" => [
+                "someone@.baddomain.de"
+            ],
+            "email_domain_whitespace" => [
+                "someone@bad domain.com"
+            ]
+        ];
+    }
+    public static function invalidEmailLocalProvider(): array
+    {
+        return [
+            "email_local_broken_bytes" => [
+                // invalid 2-byte sequence
+                "\xC3\x28@example.com",
+            ],
+            "email_local_dot_start" => [
+                ".invalid@example.com",
+            ],
+            "email_local_dot_end" => [
+                "invalid.@example.com",
+            ],
+            "email_local_two_dots" => [
+                "in..valid@example.com",
+            ],
+            "email_whitespace" => [
+                "in valid@example.com"
+            ],
+            "email_local_emoji" => [
+                "📖💡🤓@example.com",
+            ],
+            "email_local_invalid_control_character" => [
+                "hello\x07world@example.com",
+            ],
+        ];
+    }
+    public static function validAsciiEmailProvider(): array
+    {
+        return [
+            "email_ascii" => [
+                "john.doe@example.com",
+            ],
+            "email_ascii_symbols" => [
+                "&-.+~@example&my-sons.com"
+            ]
+        ];
+    }
+
+    public static function validUnicodeEmailProvider(): array
+    {
+        return [
+            "email_unicode" => [
+                "käthe@exämple.com",
+            ],
+            "email_unicode2" => [
+                "frédericö.Ωéяגخ本आ한@äéö📖💡🤓.ws"
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
This is an EmailAddress Data Type for more consistent and accurate validation.

Since ILIAS is used internationally, we are allowing many more characters than most Email Validators do. Umlauts ä, ö, ü and accented vowels become more and more common since updated standards technically allow them. Sadly, most existing checkers only let a subset of ASCII characters through. For this strict validation you can use isAscii() to verify that the email address is safe by old standards.

If isAscii() returns false, but the object did not throw an error on construction, it's a valid Unicode email address. However, most email servers (and php itself) cannot handle those optimally by default. One day when this Data Object is actually used for Email Addresses, PHP itself and the web server still need to be configured to handle Unicode strings correctly.