### PR TITLE
Add support for role-based upload-limit to legacy code

### DIFF
--- a/Modules/Bibliographic/classes/class.ilObjBibliographicGUI.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographicGUI.php
@@ -432,9 +432,9 @@ class ilObjBibliographicGUI extends ilObject2GUI implements ilDesktopItemHandlin
         $bibl_upload_handler = new ilObjBibliographicUploadHandlerGUI($rid);
 
         $max_filesize_bytes = $this->upload_limit->getBestPossibleUploadLimitInBytes($bibl_upload_handler);
-        $max_filesize_mb = round($max_filesize_bytes / 1024 / 1024, 1);
-        $info_file_limitations = $this->lng->txt('file_notice') . " " . number_format($max_filesize_mb, 1) . " MB <br>"
-            . $this->lng->txt('file_allowed_suffixes') . " .bib, .bibtex, .ris";
+        $max_filesize_mb = $this->upload_limit->getBestPossibleUploadLimitInfo($bibl_upload_handler);
+        $info_file_limitations = $this->lng->txt('file_notice') . " " . $max_filesize_mb . " <br>" . $this->lng->txt('file_allowed_suffixes') . " .bib, .bibtex, .ris";
+
         $section_replace_bibliographic_file = $this->ui_factory
             ->input()
             ->field()

--- a/Modules/Bibliographic/classes/class.ilObjBibliographicGUI.php
+++ b/Modules/Bibliographic/classes/class.ilObjBibliographicGUI.php
@@ -431,7 +431,7 @@ class ilObjBibliographicGUI extends ilObject2GUI implements ilDesktopItemHandlin
         $rid = $bibl_obj->getResourceId() ? $bibl_obj->getResourceId()->serialize() : "";
         $bibl_upload_handler = new ilObjBibliographicUploadHandlerGUI($rid);
 
-        $max_filesize_bytes = $this->upload_limit->getPhpUploadLimitInBytes();
+        $max_filesize_bytes = $this->upload_limit->getBestPossibleUploadLimitInBytes($bibl_upload_handler);
         $max_filesize_mb = round($max_filesize_bytes / 1024 / 1024, 1);
         $info_file_limitations = $this->lng->txt('file_notice') . " " . number_format($max_filesize_mb, 1) . " MB <br>"
             . $this->lng->txt('file_allowed_suffixes') . " .bib, .bibtex, .ris";

--- a/Modules/File/classes/Versions/class.ilFileVersionFormGUI.php
+++ b/Modules/File/classes/Versions/class.ilFileVersionFormGUI.php
@@ -17,7 +17,6 @@
  *********************************************************************/
 
 use Psr\Http\Message\RequestInterface;
-use ILIAS\Data\DataSize;
 use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
@@ -90,11 +89,6 @@ class ilFileVersionFormGUI
                 : ilFileVersionsUploadHandlerGUI::MODE_APPEND
         );
 
-        $size = new DataSize(
-            $this->upload_limit->getBestPossibleUploadLimitInBytes($upload_handler),
-            DataSize::MB
-        );
-
         $inputs = [
             self::F_TITLE => $this->ui_factory->input()->field()->text(
                 $this->lng->txt(self::F_TITLE),
@@ -111,7 +105,7 @@ class ilFileVersionFormGUI
                 $this->lng->txt(self::F_FILE),
                 sprintf(
                     $this->lng->txt('upload_files_limit'),
-                    (string) $size
+                    $this->upload_limit->getBestPossibleUploadLimitInfo($upload_handler)
                 ),
             )->withMaxFiles(1)
              ->withRequired(true),

--- a/Modules/File/classes/class.ilObjFileGUI.php
+++ b/Modules/File/classes/class.ilObjFileGUI.php
@@ -28,7 +28,6 @@ use ILIAS\UI\Component\Input\Container\Form\Standard;
 use ILIAS\File\Icon\IconDatabaseRepository;
 use ILIAS\Modules\File\Settings\General;
 use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
-use ILIAS\Data\DataSize;
 use ILIAS\Refinery\String\Group;
 use ILIAS\Data\Factory;
 use ILIAS\Services\WOPI\Discovery\ActionDBRepository;
@@ -441,18 +440,12 @@ class ilObjFileGUI extends ilObject2GUI
             self::UPLOAD_ORIGIN_STANDARD
         );
 
-        // add file input
-        $size = new DataSize(
-            $this->upload_limit->getBestPossibleUploadLimitInBytes($this->upload_handler),
-            DataSize::MB
-        );
-
         $inputs[self::PARAM_FILES] = $this->ui->factory()->input()->field()->file(
             $this->upload_handler,
             $this->lng->txt('upload_files'),
             sprintf(
                 $this->lng->txt('upload_files_limit'),
-                (string) $size
+                $this->upload_limit->getBestPossibleUploadLimitInfo($this->upload_handler)
             ),
             $this->ui->factory()->input()->field()->group([
                 self::PARAM_TITLE => $this->ui->factory()->input()->field()->text(

--- a/Modules/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
+++ b/Modules/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
@@ -357,7 +357,6 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
             if (($source === 'none') || (!$source)) {
                 $ilErr->raiseError($this->lng->txt("msg_no_file"), $ilErr->MESSAGE);
             }
-            // get_cfg_var("upload_max_filesize"); // get the may filesize form t he php.ini
             switch ($_FILES["scormfile"]["error"]) {
                 case UPLOAD_ERR_INI_SIZE:
                 case UPLOAD_ERR_FORM_SIZE:

--- a/Modules/ScormAicc/classes/class.ilObjSCORMLearningModuleGUI.php
+++ b/Modules/ScormAicc/classes/class.ilObjSCORMLearningModuleGUI.php
@@ -39,6 +39,7 @@ class ilObjSCORMLearningModuleGUI extends ilObjSAHSLearningModuleGUI
 
     protected int $refId;
     protected ilCtrl $ctrl;
+    protected UploadFileLimits $upload_limit;
 
     /**
     * Constructor
@@ -50,6 +51,7 @@ class ilObjSCORMLearningModuleGUI extends ilObjSAHSLearningModuleGUI
         $this->lng = $DIC->language();
         $this->ctrl = $DIC->ctrl();
         $this->tpl = $DIC["tpl"];
+        $this->upload_limit = $DIC['upload_file_limits'];
 
         $this->lng->loadLanguageModule("content");
         $this->lng->loadLanguageModule("search");
@@ -429,33 +431,7 @@ class ilObjSCORMLearningModuleGUI extends ilObjSAHSLearningModuleGUI
 
     public function getMaxFileSize(): string
     {
-        // get the value for the maximal uploadable filesize from the php.ini (if available)
-        $umf = get_cfg_var("upload_max_filesize");
-        // get the value for the maximal post data from the php.ini (if available)
-        $pms = get_cfg_var("post_max_size");
-
-        //convert from short-string representation to "real" bytes
-        $multiplier_a = array("K" => 1024, "M" => 1024 * 1024, "G" => 1024 * 1024 * 1024);
-
-        $umf_parts = preg_split("/(\d+)([K|G|M])/", $umf, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        $pms_parts = preg_split("/(\d+)([K|G|M])/", $pms, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-
-        if (count($umf_parts) == 2) {
-            $umf = $umf_parts[0] * $multiplier_a[$umf_parts[1]];
-        }
-        if (count($pms_parts) == 2) {
-            $pms = $pms_parts[0] * $multiplier_a[$pms_parts[1]];
-        }
-
-        // use the smaller one as limit
-        $max_filesize = min($umf, $pms);
-
-        if (!$max_filesize) {
-            $max_filesize = max($umf, $pms);
-        }
-
-        //format for display in mega-bytes
-        return $max_filesize = sprintf("%.1f MB", $max_filesize / 1024 / 1024);
+        return $this->upload_limit->getRoleBasedUploadSizeInfo();
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -610,16 +610,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
     public function getMaxFilesizeAsString(): string
     {
-        $size = $this->getMaxFilesizeInBytes();
-        if ($size < 1024) {
-            return sprintf('%d Bytes', $size);
-        }
-
-        if ($size < 1024 * 1024) {
-            return  sprintf('%.1f KB', $size / 1024);
-        }
-
-        return sprintf('%.1f MB', $size / 1024 / 1024);
+        return $this->upload_limit->getUploadSizeInfo($this->getMaxFilesizeInBytes());
     }
 
     protected function getMaxFilesizeInBytes(): int

--- a/Modules/TestQuestionPool/classes/class.assFileUpload.php
+++ b/Modules/TestQuestionPool/classes/class.assFileUpload.php
@@ -43,6 +43,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
     private \ILIAS\ResourceStorage\Services $irss;
     private \ILIAS\FileDelivery\Services $file_delivery;
     private \ILIAS\FileUpload\FileUpload $file_upload;
+    protected UploadFileLimits $upload_limit;
 
     protected ?int $maxsize = null;
 
@@ -77,6 +78,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
         /** @var ILIAS\DI\Container $DIC */
         global $DIC;
         $this->irss = $DIC->resourceStorage();
+        $this->upload_limit = $DIC['upload_file_limits'];
         $this->file_delivery = $DIC->fileDelivery();
         $this->file_upload = $DIC->upload();
         $this->current_cmd = $DIC['ilCtrl']->getCmd();
@@ -632,41 +634,7 @@ class assFileUpload extends assQuestion implements ilObjQuestionScoringAdjustabl
 
     public function determineMaxFilesize(): int
     {
-        $upload_max_filesize = ini_get('upload_max_filesize');
-        $post_max_size = ini_get('post_max_size');
-
-        //convert from short-string representation to "real" bytes
-        $multiplier_a = [ "K" => 1024, "M" => 1024 * 1024, "G" => 1024 * 1024 * 1024 ];
-        $umf_parts = preg_split(
-            "/(\d+)([K|G|M])/",
-            $upload_max_filesize,
-            -1,
-            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
-        );
-        $pms_parts = preg_split(
-            "/(\d+)([K|G|M])/",
-            $post_max_size,
-            -1,
-            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
-        );
-
-        if (count($umf_parts) === 2) {
-            $upload_max_filesize = $umf_parts[0] * $multiplier_a[$umf_parts[1]];
-        }
-
-        if (count($pms_parts) === 2) {
-            $post_max_size = $pms_parts[0] * $multiplier_a[$pms_parts[1]];
-        }
-
-        // use the smaller one as limit
-        $max_filesize = min($upload_max_filesize, $post_max_size);
-
-        if (!$max_filesize) {
-            $max_filesize = max($upload_max_filesize, $post_max_size);
-            return $max_filesize;
-        }
-
-        return $max_filesize;
+        return $this->upload_limit->getRoleBasedUploadLimitInBytes();
     }
 
     /**

--- a/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -197,7 +197,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                     $tpl->setVariable("IMAGE_BROWSE", $this->lng->txt('select_file'));
                     $tpl->setVariable("IMAGE_ID", $this->getPostVar() . "[image][{$value->getPosition()}]");
                     $tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
-                    $tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
+                    $tpl->setVariable('MAX_SIZE', $this->upload_limit->getRoleBasedUploadLimitInBytes());
                     $tpl->setVariable("IMAGE_SUBMIT", $this->lng->txt("upload"));
                     $tpl->setVariable("IMAGE_ROW_NUMBER", $value->getPosition());
                     $tpl->setVariable("IMAGE_POST_VAR", $this->getPostVar());

--- a/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilKprimChoiceWizardInputGUI.php
@@ -296,7 +296,7 @@ class ilKprimChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
 
                 $tpl->setCurrentBlock("image_heading");
                 $tpl->setVariable("ANSWER_IMAGE", $this->lng->txt('answer_image'));
-                $tpl->setVariable("TXT_MAX_SIZE", ilFileUtils::getFileSizeInfo());
+                $tpl->setVariable("TXT_MAX_SIZE", $this->upload_limit->getRoleBasedUploadSizeInfo());
                 $tpl->parseCurrentBlock();
             }
         }

--- a/Modules/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
@@ -356,7 +356,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
             }
             $tpl->setCurrentBlock("image_heading");
             $tpl->setVariable("ANSWER_IMAGE", $this->image_name);
-            $tpl->setVariable("TXT_MAX_SIZE", ilFileUtils::getFileSizeInfo());
+            $tpl->setVariable("TXT_MAX_SIZE", $this->upload_limit->getRoleBasedUploadSizeInfo());
             $tpl->parseCurrentBlock();
         }
 

--- a/Modules/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMatchingWizardInputGUI.php
@@ -18,7 +18,6 @@
 
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
-use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
  * This class represents a single choice wizard property in a property form.
@@ -42,7 +41,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
 
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
-    protected UploadLimitResolver $upload_limit;
+    protected UploadFileLimits $upload_limit;
 
     public function __construct($a_title = "", $a_postvar = "")
     {
@@ -51,7 +50,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
         global $DIC;
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
-        $this->upload_limit = $DIC['ui.upload_limit_resolver'];
+        $this->upload_limit = $DIC['upload_file_limits'];
 
         $this->setSuffixes(array("jpg", "jpeg", "png", "gif"));
         $this->setSize('40');
@@ -306,7 +305,7 @@ class ilMatchingWizardInputGUI extends ilTextInputGUI
                 $tpl->setVariable("IMAGE_BROWSE", $lng->txt('select_file'));
                 $tpl->setVariable("IMAGE_ID", $this->getPostVar() . "[image][$i]");
                 $tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
-                $tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
+                $tpl->setVariable('MAX_SIZE', $this->upload_limit->getRoleBasedUploadLimitInBytes());
                 $tpl->setVariable("IMAGE_SUBMIT", $lng->txt("upload"));
                 $tpl->setVariable("IMAGE_ROW_NUMBER", $i);
                 $tpl->setVariable("IMAGE_POST_VAR", $this->getPostVar());

--- a/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -244,7 +244,7 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
                     $tpl->setVariable("IMAGE_BROWSE", $lng->txt('select_file'));
                     $tpl->setVariable("IMAGE_ID", $this->getPostVar() . "[image][$i]");
                     $tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
-                    $tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
+                    $tpl->setVariable('MAX_SIZE', $this->upload_limit->getRoleBasedUploadLimitInBytes());
                     $tpl->setVariable("IMAGE_SUBMIT", $lng->txt("upload"));
                     $tpl->setVariable("IMAGE_ROW_NUMBER", $i);
                     $tpl->setVariable("IMAGE_POST_VAR", $this->getPostVar());

--- a/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilMultipleChoiceWizardInputGUI.php
@@ -361,7 +361,7 @@ class ilMultipleChoiceWizardInputGUI extends ilSingleChoiceWizardInputGUI
 
                 $tpl->setCurrentBlock("image_heading");
                 $tpl->setVariable("ANSWER_IMAGE", $lng->txt('answer_image'));
-                $tpl->setVariable("TXT_MAX_SIZE", ilFileUtils::getFileSizeInfo());
+                $tpl->setVariable("TXT_MAX_SIZE", $this->upload_limit->getRoleBasedUploadSizeInfo());
                 $tpl->parseCurrentBlock();
             }
         }

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -19,7 +19,6 @@
 use ILIAS\HTTP\Wrapper\ArrayBasedRequestWrapper as ArrayBasedRequestWrapper;
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
-use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
 * This class represents a single choice wizard property in a property form.
@@ -41,7 +40,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
     protected ArrayBasedRequestWrapper $post_wrapper;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
-    protected UploadLimitResolver $upload_limit;
+    protected UploadFileLimits $upload_limit;
 
     /**
     * Constructor
@@ -61,7 +60,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
         $this->post_wrapper = $DIC->http()->wrapper()->post();
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
-        $this->upload_limit = $DIC['ui.upload_limit_resolver'];
+        $this->upload_limit = $DIC['upload_file_limits'];
     }
 
     public function setValue($a_value): void
@@ -410,7 +409,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                     $tpl->setVariable("IMAGE_BROWSE", $lng->txt('select_file'));
                     $tpl->setVariable("IMAGE_ID", $this->getPostVar() . "[image][$i]");
                     $tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
-                    $tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
+                    $tpl->setVariable('MAX_SIZE', $this->upload_limit->getRoleBasedUploadLimitInBytes());
                     $tpl->setVariable("IMAGE_SUBMIT", $lng->txt("upload"));
                     $tpl->setVariable("IMAGE_ROW_NUMBER", $i);
                     $tpl->setVariable("IMAGE_POST_VAR", $this->getPostVar());

--- a/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilSingleChoiceWizardInputGUI.php
@@ -522,7 +522,7 @@ class ilSingleChoiceWizardInputGUI extends ilTextInputGUI
                 }
                 $tpl->setCurrentBlock("image_heading");
                 $tpl->setVariable("ANSWER_IMAGE", $lng->txt('answer_image'));
-                $tpl->setVariable("TXT_MAX_SIZE", ilFileUtils::getFileSizeInfo());
+                $tpl->setVariable("TXT_MAX_SIZE", $this->upload_limit->getRoleBasedUploadSizeInfo());
                 $tpl->parseCurrentBlock();
             }
         }

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssMultipleChoiceCorrectionsInputGUI.php
@@ -138,7 +138,7 @@ class ilAssMultipleChoiceCorrectionsInputGUI extends ilMultipleChoiceWizardInput
         if ($this->qstObject->isSingleline()) {
             $tpl->setCurrentBlock("image_heading");
             $tpl->setVariable("ANSWER_IMAGE", $lng->txt('answer_image'));
-            $tpl->setVariable("TXT_MAX_SIZE", ilFileUtils::getFileSizeInfo());
+            $tpl->setVariable("TXT_MAX_SIZE", $this->upload_limit->getRoleBasedUploadSizeInfo());
             $tpl->parseCurrentBlock();
         }
 

--- a/Modules/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilAssSingleChoiceCorrectionsInputGUI.php
@@ -125,7 +125,7 @@ class ilAssSingleChoiceCorrectionsInputGUI extends ilSingleChoiceWizardInputGUI
         if ($this->qstObject->isSingleline()) {
             $tpl->setCurrentBlock("image_heading");
             $tpl->setVariable("ANSWER_IMAGE", $lng->txt('answer_image'));
-            $tpl->setVariable("TXT_MAX_SIZE", ilFileUtils::getFileSizeInfo());
+            $tpl->setVariable("TXT_MAX_SIZE", $this->upload_limit->getRoleBasedUploadSizeInfo());
             $tpl->parseCurrentBlock();
         }
 

--- a/Modules/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilImagemapFileInputGUI.php
@@ -372,7 +372,7 @@ class ilImagemapFileInputGUI extends ilImageFileInputGUI
         $template->setVariable("ID", $this->getFieldId());
         $template->setVariable("TXT_BROWSE", $lng->txt("select_file"));
         $template->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
-        $template->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
+        $template->setVariable('MAX_SIZE', $this->upload_limit->getRoleBasedUploadLimitInBytes());
         $template->setVariable("TXT_MAX_SIZE", $lng->txt("file_notice") . " " .
         $this->getMaxFileSizeString());
 

--- a/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesInputGUI.php
@@ -18,7 +18,6 @@
 
 use ILIAS\UI\Renderer;
 use ILIAS\UI\Component\Symbol\Glyph\Factory as GlyphFactory;
-use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
  * @author        Björn Heyser <bheyser@databay.de>
@@ -58,7 +57,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
     protected ilGlobalTemplateInterface $tpl;
     protected GlyphFactory $glyph_factory;
     protected Renderer $renderer;
-    protected UploadLimitResolver $upload_limit;
+    protected UploadFileLimits $upload_limit;
 
     /**
      * Constructor
@@ -75,7 +74,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
         $this->tpl = $DIC->ui()->mainTemplate();
         $this->glyph_factory = $DIC->ui()->factory()->symbol()->glyph();
         $this->renderer = $DIC->ui()->renderer();
-        $this->upload_limit = $DIC['ui.upload_limit_resolver'];
+        $this->upload_limit = $DIC['upload_file_limits'];
 
         $this->setSuffixes(["jpg", "jpeg", "png", "gif"]);
         $this->setSize(25);
@@ -331,7 +330,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
             $tpl->setVariable("IMAGE_BROWSE", $lng->txt('select_file'));
             $tpl->setVariable("IMAGE_ID", $this->getMultiValuePosIndexedSubFieldId($identifier, self::IMAGE_UPLOAD_SUBFIELD_NAME, $i));
             $tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
-            $tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
+            $tpl->setVariable('MAX_SIZE', $this->upload_limit->getRoleBasedUploadLimitInBytes());
             $tpl->setVariable("TXT_IMAGE_SUBMIT", $lng->txt("upload"));
             $tpl->setVariable("IMAGE_CMD_UPLOAD", $this->buildMultiValueSubmitVar($identifier, $i, $this->getImageUploadCommand()));
             $tpl->setVariable("UPLOAD_IMAGE_POST_VAR", $this->getMultiValuePostVarSubFieldPosIndexed($identifier, self::IMAGE_UPLOAD_SUBFIELD_NAME, $i));

--- a/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesInputGUI.php
+++ b/Modules/TestQuestionPool/classes/forms/class.ilMultipleImagesInputGUI.php
@@ -376,7 +376,7 @@ abstract class ilMultipleImagesInputGUI extends ilIdentifiedMultiValuesInputGUI
             $tpl->parseCurrentBlock();
         }
 
-        $tpl->setVariable("TXT_MAX_SIZE", ilFileUtils::getFileSizeInfo());
+        $tpl->setVariable("TXT_MAX_SIZE", $this->upload_limit->getRoleBasedUploadSizeInfo());
         $tpl->setVariable("ELEMENT_ID", $this->getPostVar());
         $tpl->setVariable("TEXT_YES", $lng->txt('yes'));
         $tpl->setVariable("TEXT_NO", $lng->txt('no'));

--- a/Services/FileServices/classes/UploadService/UploadLimits/UploadFileLimits.php
+++ b/Services/FileServices/classes/UploadService/UploadLimits/UploadFileLimits.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Data\DataSize;
+
+/**
+ * This class handles some upload limit based functionality
+ * that is not explicitly UI related. 
+ * (Otherwise UploadLimitResolver might be a better place!)
+ * 
+ * @author Thomas Hufschmidt <hufschmt@hrz.uni-marburg.de>
+ */
+class UploadFileLimits
+{
+    protected int $php_upload_limit_in_bytes;
+
+    /**
+     * @param $language Instance of ilLanguage for some string conversions
+     * @param $role_based_upload_limit_in_bytes Preferred role-based upload limit for current user (or null)
+     */
+    public function __construct(
+        protected ilLanguage $language,
+        protected ?int $role_based_upload_limit_in_bytes,
+    ) {
+        $this->php_upload_limit_in_bytes = self::fetchPhpUploadSizeLimitInBytes();
+    }
+
+    /**
+     * Returns the php upload limit calculated on class construction.
+     * 
+     * @return The maximum supported upload size on bytes
+     */
+    public function getPhpUploadSizeLimitInBytes(): int
+    {
+        return $this->php_upload_limit_in_bytes;
+    }
+
+    /**
+     * Utility method that will return either the role-based upload
+     * limit if it is lower then the supported upload limit, or
+     * the maximum php upload limit otherwise.
+     * 
+     * @return int Maximum/Best role based upload limit given on construction (or max php upload if less)
+     */
+    public function getRoleBasedUploadLimitInBytes(): int
+    {
+        // Return role-based upload limit if within php limit
+        if ($this->role_based_upload_limit_in_bytes !== null && $this->role_based_upload_limit_in_bytes <= $this->getPhpUploadSizeLimitInBytes()) {
+            return $this->role_based_upload_limit_in_bytes;
+        }
+
+        // Fallback to php limit otherwise
+        return $this->getPhpUploadSizeLimitInBytes();
+    }
+
+    /**
+     * Converts the given upload size (in bytes) into mega-bytes.
+     * Outputs a string with MB suffix!
+     * 
+     * @param $size The value (given in bytes!) that should be converted
+     * 
+     * @return The given value converted to mega-bytes
+     */
+    public function getUploadSizeInfo(int $size): string
+    {
+        $size_str = new DataSize($size, DataSize::MB);
+        return $this->language->txt("file_notice") . " " . $size_str;
+    }
+
+    /**
+     * Converts the given upload size (in bytes) into mega-bytes,
+     * if non is given (default) will fallback to current role-based upload limit.
+     * Outputs a string with MB suffix!
+     * 
+     * @param $size (Optional) The value (given in bytes!) that should be converted
+     * 
+     * @return The given value or current role-based upload limit converted to mega-bytes
+     */
+    public function getRoleBasedUploadSizeInfo(?int $size = null): string
+    {
+        $size_str = new DataSize($size ?? $this->getRoleBasedUploadLimitInBytes(), DataSize::MB);
+        return $this->language->txt("file_notice") . " " . $size_str;
+    }
+
+    /**
+     * Fetches current maximum supported upload size (in bytes) from php config.
+     * This should be the only place where the actual value is read with!
+     * 
+     * @return The maximum supported upload size on bytes
+     */
+    public static function fetchPhpUploadSizeLimitInBytes(): int
+    {
+        // Converts unit suffic into multiplicated value
+        $convertPhpIniSizeValueToBytes = function ($phpIniSizeValue) {
+            // No conversion needed
+            if (is_numeric($phpIniSizeValue)) {
+                return $phpIniSizeValue;
+            }
+
+            // Find value and suffix (eg. 100M)
+            $suffix = substr($phpIniSizeValue, -1);
+            $value = substr($phpIniSizeValue, 0, -1);
+
+            // Multiply from biggest suffix to smallest
+            switch (strtoupper($suffix)) {
+                case 'P':
+                    $value *= 1024;
+                    // no break
+                case 'T':
+                    $value *= 1024;
+                    // no break
+                case 'G':
+                    $value *= 1024;
+                    // no break
+                case 'M':
+                    $value *= 1024;
+                    // no break
+                case 'K':
+                    $value *= 1024;
+                    break;
+            }
+            return $value;
+        };
+
+        // Find minimum of two php configurations and return
+        return min(
+            $convertPhpIniSizeValueToBytes(ini_get('post_max_size')),
+            $convertPhpIniSizeValueToBytes(ini_get('upload_max_filesize'))
+        );
+    }
+}

--- a/Services/FileServices/classes/class.ilFileUtils.php
+++ b/Services/FileServices/classes/class.ilFileUtils.php
@@ -639,16 +639,6 @@ class ilFileUtils
         ilFileUtils::makeDir($a_dir);
     }
 
-    public static function getFileSizeInfo(): string
-    {
-        global $DIC;
-        $size = new DataSize(self::getPhpUploadSizeLimitInBytes(), DataSize::MB);
-        $max_filesize = $size->__toString();
-        $lng = $DIC->language();
-
-        return $lng->txt("file_notice") . " $max_filesize.";
-    }
-
     /**
      * @deprecated
      */
@@ -794,49 +784,6 @@ class ilFileUtils
     {
         $path = preg_replace("/[\/\\\]+$/", "", $path);
         return (string) $path;
-    }
-
-    /**
-     * @deprecated should use DataSize instead
-     */
-    public static function getPhpUploadSizeLimitInBytes(): string
-    {
-        $convertPhpIniSizeValueToBytes = function ($phpIniSizeValue) {
-            if (is_numeric($phpIniSizeValue)) {
-                return $phpIniSizeValue;
-            }
-
-            $suffix = substr($phpIniSizeValue, -1);
-            $value = substr($phpIniSizeValue, 0, -1);
-
-            switch (strtoupper($suffix)) {
-                case 'P':
-                    $value *= 1024;
-                    // no break
-                case 'T':
-                    $value *= 1024;
-                    // no break
-                case 'G':
-                    $value *= 1024;
-                    // no break
-                case 'M':
-                    $value *= 1024;
-                    // no break
-                case 'K':
-                    $value *= 1024;
-                    break;
-            }
-
-            return $value;
-        };
-
-
-        $uploadSizeLimitBytes = min(
-            $convertPhpIniSizeValueToBytes(ini_get('post_max_size')),
-            $convertPhpIniSizeValueToBytes(ini_get('upload_max_filesize'))
-        );
-
-        return $uploadSizeLimitBytes;
     }
 
     public static function _sanitizeFilemame(string $a_filename): string

--- a/Services/Form/classes/class.ilFileInputGUI.php
+++ b/Services/Form/classes/class.ilFileInputGUI.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 use ILIAS\FileUpload\Exception\IllegalStateException;
 use ILIAS\FileUpload\FileUpload;
-use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 
 /**
  * This class represents a file property in a property form.
@@ -39,7 +38,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
     protected array $suffixes = [];
     protected string $value = "";
     protected FileUpload $upload_service;
-    protected UploadLimitResolver $upload_limit;
+    protected UploadFileLimits $upload_limit;
 
     public function __construct(
         string $a_title = "",
@@ -50,7 +49,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
         $this->lng = $DIC->language();
         $lng = $DIC->language();
         $this->upload_service = $DIC->upload();
-        $this->upload_limit = $DIC['ui.upload_limit_resolver'];
+        $this->upload_limit = $DIC['upload_file_limits'];
 
         parent::__construct($a_title, $a_postvar);
         $this->setType("file");
@@ -343,7 +342,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
         }
 
         $f_tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
-        $f_tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
+        $f_tpl->setVariable('MAX_SIZE', $this->upload_limit->getRoleBasedUploadLimitInBytes());
         $f_tpl->setVariable("POST_VAR", $this->getPostVar());
         $f_tpl->setVariable("ID", $this->getFieldId());
         $f_tpl->setVariable("SIZE", $this->getSize());
@@ -390,8 +389,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
 
     protected function getMaxFileSizeString(): string
     {
-        //format for display in mega-bytes
-        return sprintf("%.1f MB", $this->upload_limit->getPhpUploadLimitInBytes() / 1024 / 1024);
+        return $this->upload_limit->getRoleBasedUploadSizeInfo();
     }
 
     /**

--- a/Services/Form/classes/class.ilImageFileInputGUI.php
+++ b/Services/Form/classes/class.ilImageFileInputGUI.php
@@ -164,7 +164,7 @@ class ilImageFileInputGUI extends ilFileInputGUI
         }
 
         $i_tpl->setVariable('MAX_SIZE_WARNING', $this->lng->txt('form_msg_file_size_exceeds'));
-        $i_tpl->setVariable('MAX_SIZE', $this->upload_limit->getPhpUploadLimitInBytes());
+        $i_tpl->setVariable('MAX_SIZE', $this->upload_limit->getRoleBasedUploadLimitInBytes());
         $i_tpl->setVariable("POST_VAR", $this->getPostVar());
         $i_tpl->setVariable("ID", $this->getFieldId());
         $i_tpl->setVariable("LABEL_SELECTED_FILES_INPUT", $this->lng->txt('selected_files'));

--- a/Services/Init/classes/Dependencies/InitUIFramework.php
+++ b/Services/Init/classes/Dependencies/InitUIFramework.php
@@ -59,7 +59,10 @@ class InitUIFramework
         };
         $c["ui.upload_limit_resolver"] = function ($c) {
             return new \ILIAS\UI\Implementation\Component\Input\UploadLimitResolver(
-                (int) \ilFileUtils::getPhpUploadSizeLimitInBytes(),
+                ($c->offsetExists('upload_file_limits')) ?
+                    $c['upload_file_limits']->getPhpUploadSizeLimitInBytes() :
+                    \UploadFileLimits::fetchPhpUploadSizeLimitInBytes()
+                ,
                 ($c->offsetExists('upload_policy_resolver')) ?
                     $c['upload_policy_resolver']->getUserUploadSizeLimitInBytes() :
                     null

--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -376,6 +376,19 @@ class ilInitialisation
         };
     }
 
+    protected static function initUploadLimits(\ILIAS\DI\Container $dic): void
+    {
+        $dic['upload_file_limits'] = static function ($dic): UploadFileLimits {
+            return new UploadFileLimits(
+                $dic->language(),
+                ($dic->offsetExists('upload_policy_resolver')) ?
+                    $dic['upload_policy_resolver']->getUserUploadSizeLimitInBytes() :
+                    null
+                ,
+            );
+        };
+    }
+
     /**
      * builds http path
      */
@@ -1250,6 +1263,7 @@ class ilInitialisation
                 self::initHTML();
             }
         }
+        self::initUploadLimits($GLOBALS["DIC"]);
 
         // this MUST happen after everything else is initialized,
         // because this leads to rather unexpected behaviour which

--- a/Services/Mail/classes/class.ilFileDataMail.php
+++ b/Services/Mail/classes/class.ilFileDataMail.php
@@ -30,6 +30,7 @@ use ILIAS\Filesystem\Filesystem;
 class ilFileDataMail extends ilFileData
 {
     public string $mail_path;
+    protected UploadFileLimits $upload_limit;
     protected int $mail_max_upload_file_size;
     protected Filesystem $tmpDirectory;
     protected Filesystem $storageDirectory;
@@ -51,6 +52,7 @@ class ilFileDataMail extends ilFileData
         $this->db = $DIC->database();
         $this->tmpDirectory = $DIC->filesystem()->temp();
         $this->storageDirectory = $DIC->filesystem()->storage();
+        $this->upload_limit = $DIC['upload_file_limits'];
 
         $this->initAttachmentMaxUploadSize();
     }
@@ -449,45 +451,7 @@ class ilFileDataMail extends ilFileData
 
     protected function initAttachmentMaxUploadSize(): void
     {
-        /** @todo mjansen: Unfortunately we cannot reuse the implementation of ilFileInputGUI */
-
-        // Copy of ilFileInputGUI: begin
-        // get the value for the maximal uploadable filesize from the php.ini (if available)
-        $umf = ini_get("upload_max_filesize");
-        // get the value for the maximal post data from the php.ini (if available)
-        $pms = ini_get("post_max_size");
-
-        //convert from short-string representation to "real" bytes
-        $multiplier_a = ["K" => 1024, "M" => 1024 * 1024, "G" => 1024 * 1024 * 1024];
-
-        $umf_parts = preg_split(
-            "/(\d+)([K|G|M])/",
-            (string) $umf,
-            -1,
-            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
-        );
-        $pms_parts = preg_split(
-            "/(\d+)([K|G|M])/",
-            (string) $pms,
-            -1,
-            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
-        );
-
-        if ((is_countable($umf_parts) ? count($umf_parts) : 0) === 2) {
-            $umf = (float) $umf_parts[0] * $multiplier_a[$umf_parts[1]];
-        }
-        if ((is_countable($pms_parts) ? count($pms_parts) : 0) === 2) {
-            $pms = (float) $pms_parts[0] * $multiplier_a[$pms_parts[1]];
-        }
-
-        // use the smaller one as limit
-        $max_filesize = min($umf, $pms);
-
-        if (!$max_filesize) {
-            $max_filesize = max($umf, $pms);
-        }
-
-        $this->mail_max_upload_file_size = (int) $max_filesize;
+        $this->mail_max_upload_file_size = $this->upload_limit->getRoleBasedUploadLimitInBytes();
     }
 
     public function onUserDelete(): void

--- a/Services/RTE/classes/class.ilRTE.php
+++ b/Services/RTE/classes/class.ilRTE.php
@@ -37,6 +37,7 @@ class ilRTE
     protected AgentDetermination $browser;
     protected ilIniFile $client_init;
     protected ?int $initialWidth = null;
+    protected UploadFileLimits $upload_limit;
 
     /**
      * RTE root block element which surrounds the generated html
@@ -66,6 +67,7 @@ class ilRTE
         $this->browser = $DIC->http()->agent();
         $this->client_init = $DIC['ilClientIniFile'];
         $this->user = $DIC['ilUser'];
+        $this->upload_limit = $DIC['upload_file_limits'];
     }
 
     public function addPlugin(string $a_plugin_name): void

--- a/Services/RTE/classes/class.ilTinyMCE.php
+++ b/Services/RTE/classes/class.ilTinyMCE.php
@@ -201,7 +201,7 @@ class ilTinyMCE extends ilRTE
             $tpl->setVariable('SESSION_ID', $_COOKIE[session_name()]);
             $tpl->setVariable('BLOCKFORMATS', $this->_buildAdvancedBlockformatsFromHTMLTags($tags));
             $tpl->setVariable('VALID_ELEMENTS', $this->_getValidElementsFromHTMLTags($tags));
-            $tpl->setVariable('TXT_MAX_SIZE', ilFileUtils::getFileSizeInfo());
+            $tpl->setVariable('TXT_MAX_SIZE', $this->upload_limit->getRoleBasedUploadSizeInfo());
             // allowed extentions for uploaded image files
             $tinyMCE_valid_imgs = ['gif', 'jpg', 'jpeg', 'png'];
             $tpl->setVariable(
@@ -280,7 +280,7 @@ class ilTinyMCE extends ilRTE
         $tpl->setVariable('SESSION_ID', $_COOKIE[session_name()]);
         $tpl->setVariable('BLOCKFORMATS', $this->_buildAdvancedBlockformatsFromHTMLTags($tags));
         $tpl->setVariable('VALID_ELEMENTS', $this->_getValidElementsFromHTMLTags($tags));
-        $tpl->setVariable('TXT_MAX_SIZE', ilFileUtils::getFileSizeInfo());
+        $tpl->setVariable('TXT_MAX_SIZE', $this->upload_limit->getRoleBasedUploadSizeInfo());
 
         $this->disableButtons('charmap');
         $buttons_1 = $this->_buildAdvancedButtonsFromHTMLTags(1, $tags);

--- a/Services/Repository/Service/Form/class.FormAdapterGUI.php
+++ b/Services/Repository/Service/Form/class.FormAdapterGUI.php
@@ -22,6 +22,7 @@ namespace ILIAS\Repository\Form;
 
 use ILIAS\UI\Component\Input\Container\Form;
 use ILIAS\UI\Component\Input\Container\Form\FormInput;
+use ILIAS\UI\Implementation\Component\Input\UploadLimitResolver;
 use ILIAS\Data\Factory;
 
 /**
@@ -66,6 +67,8 @@ class FormAdapterGUI
     protected ?array $current_group = null;
     protected static bool $initialised = false;
 
+    private UploadLimitResolver $upload_limit;
+
     /**
      * @param string|array $class_path
      */
@@ -85,6 +88,7 @@ class FormAdapterGUI
         $this->lng = $DIC->language();
         $this->main_tpl = $DIC->ui()->mainTemplate();
         $this->user = $DIC->user();
+        $this->upload_limit = $DIC['ui.upload_limit_resolver'];
         $this->data = new \ILIAS\Data\Factory();
         $this->submit_caption = $submit_caption;
         self::initJavascript();
@@ -451,7 +455,7 @@ class FormAdapterGUI
             $title,
             $description
         )
-            ->withMaxFileSize((int) \ilFileUtils::getPhpUploadSizeLimitInBytes());
+            ->withMaxFileSize($this->upload_limit->getBestPossibleUploadLimitInBytes($this->upload_handler[$key]));
         if (!is_null($max_files)) {
             $field = $field->withMaxFiles($max_files);
         }

--- a/Services/WebDAV/classes/class.ilWebDAVDIC.php
+++ b/Services/WebDAV/classes/class.ilWebDAVDIC.php
@@ -57,6 +57,7 @@ class ilWebDAVDIC extends Container
             $DIC->resourceStorage(),
             $DIC->http()->request(),
             $DIC->language(),
+            $DIC['upload_file_limits'],
             $DIC['ilias']->getClientId(),
             (bool) $c['dav_settings']->get('webdav_versioning_enabled', 'true')
         );

--- a/Services/WebDAV/classes/dav/class.ilDAVContainer.php
+++ b/Services/WebDAV/classes/dav/class.ilDAVContainer.php
@@ -38,7 +38,8 @@ class ilDAVContainer implements ICollection
         protected ilObjUser $current_user,
         protected RequestInterface $request,
         protected ilWebDAVObjFactory $dav_factory,
-        protected ilWebDAVRepositoryHelper $repository_helper
+        protected ilWebDAVRepositoryHelper $repository_helper,
+        protected UploadFileLimits $upload_limit
     ) {
     }
 
@@ -120,7 +121,7 @@ class ilDAVContainer implements ICollection
             $size = (int) ($this->request->getHeader('X-Expected-Entity-Length')[0] ?? 0);
         }
 
-        if ($size > ilFileUtils::getPhpUploadSizeLimitInBytes()) {
+        if ($size > $this->upload_limit->getRoleBasedUploadLimitInBytes()) {
             throw new Forbidden('File is too big');
         }
 

--- a/Services/WebDAV/classes/dav/class.ilDAVFile.php
+++ b/Services/WebDAV/classes/dav/class.ilDAVFile.php
@@ -49,6 +49,7 @@ class ilDAVFile implements IFile
         Services $resource_storage,
         protected RequestInterface $request,
         protected ilWebDAVObjFactory $dav_factory,
+        protected UploadFileLimits $upload_limit,
         protected bool $versioning_enabled
     ) {
         $this->resource_manager = $resource_storage->manage();
@@ -89,7 +90,7 @@ class ilDAVFile implements IFile
             $size = (int) $this->request->getHeader('X-Expected-Entity-Length')[0];
         }
 
-        if ($size > ilFileUtils::getPhpUploadSizeLimitInBytes()) {
+        if ($size > $this->upload_limit->getRoleBasedUploadLimitInBytes()) {
             // remove already created file?
             throw new Forbidden('File is too big');
         }

--- a/Services/WebDAV/classes/dav/class.ilWebDAVObjFactory.php
+++ b/Services/WebDAV/classes/dav/class.ilWebDAVObjFactory.php
@@ -50,6 +50,7 @@ class ilWebDAVObjFactory
         protected Services $resource_storage,
         protected RequestInterface $request,
         protected ilLanguage $language,
+        protected UploadFileLimits $upload_limit,
         protected string $client_id,
         protected bool $versioning_enabled
     ) {
@@ -92,6 +93,7 @@ class ilWebDAVObjFactory
                 $this->resource_storage,
                 $this->request,
                 $this,
+                $this->upload_limit,
                 $this->versioning_enabled
             );
         }
@@ -101,7 +103,8 @@ class ilWebDAVObjFactory
             $this->current_user,
             $this->request,
             $this,
-            $this->repository_helper
+            $this->repository_helper,
+            $this->upload_limit
         );
     }
 
@@ -132,6 +135,7 @@ class ilWebDAVObjFactory
                 $this->resource_storage,
                 $this->request,
                 $this,
+                $this->upload_limit,
                 $this->versioning_enabled
             );
         }
@@ -141,7 +145,8 @@ class ilWebDAVObjFactory
             $this->current_user,
             $this->request,
             $this,
-            $this->repository_helper
+            $this->repository_helper,
+            $this->upload_limit
         );
     }
 

--- a/Services/WebDAV/test/dav/class.ilDAVContainerTest.php
+++ b/Services/WebDAV/test/dav/class.ilDAVContainerTest.php
@@ -85,8 +85,9 @@ class ilDAVContainerTest extends TestCase
         $request = $this->createStub(RequestInterface::class);
         $dav_factory = $this->createStub(ilWebDAVObjFactory::class);
         $repository_helper = $this->createStub(ilWebDAVRepositoryHelper::class);
+        $upload_lmit = $this->createStub(UploadFileLimits::class);
 
-        $dav_container = new ilDAVContainer($object, $user, $request, $dav_factory, $repository_helper);
+        $dav_container = new ilDAVContainer($object, $user, $request, $dav_factory, $repository_helper, $upload_lmit);
 
         $this->assertEquals('Some random Title', $dav_container->getName());
     }
@@ -557,6 +558,8 @@ class ilDAVContainerTest extends TestCase
                                ) && $tree[$ref_id]['access'] === 'write'
                            );
 
+        $upload_lmit = $this->createStub(UploadFileLimits::class);
+
         if ($for_create) {
             $object_child = new ilObjFolder();
             $object_child->setType('fold');
@@ -571,6 +574,6 @@ class ilDAVContainerTest extends TestCase
             return $dav_container;
         }
 
-        return new ilDAVContainer($object_folder, $user, $request, $mocked_dav_factory, $mocked_repo_helper);
+        return new ilDAVContainer($object_folder, $user, $request, $mocked_dav_factory, $mocked_repo_helper, $upload_lmit);
     }
 }

--- a/src/FileUpload/FileUpload.php
+++ b/src/FileUpload/FileUpload.php
@@ -72,14 +72,6 @@ interface FileUpload
 
 
     /**
-     * Returns the current upload size limit in bytes.
-     *
-     * @since 5.3
-     */
-    public function uploadSizeLimit(): int;
-
-
-    /**
      * Register a new preprocessor instance.
      * The preprocessor instances are invoked for each uploaded file.
      *

--- a/src/FileUpload/FileUploadImpl.php
+++ b/src/FileUpload/FileUploadImpl.php
@@ -239,15 +239,6 @@ final class FileUploadImpl implements FileUpload
     /**
      * @inheritDoc
      */
-    public function uploadSizeLimit(): int
-    {
-        return ilFileUtils::getPhpUploadSizeLimitInBytes();
-    }
-
-
-    /**
-     * @inheritDoc
-     */
     public function register(PreProcessor $preProcessor): void
     {
         if (!$this->processed) {

--- a/src/UI/Implementation/Component/Input/UploadLimitResolver.php
+++ b/src/UI/Implementation/Component/Input/UploadLimitResolver.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Implementation\Component\Input;
 
+use ILIAS\Data\DataSize;
 use ILIAS\UI\Component\Input\Field\UploadHandler;
 
 /**
@@ -65,6 +66,17 @@ class UploadLimitResolver
 
         return $this->php_upload_limit_in_bytes;
     }
+
+    public function getBestPossibleUploadLimitInfo(
+        UploadHandler $upload_handler,
+        int $local_limit_in_bytes = null
+    ): string {
+        return (string) new DataSize(
+            $this->getBestPossibleUploadLimitInBytes($upload_handler, $local_limit_in_bytes),
+            DataSize::MB
+        );
+    }
+
 
     public function getPhpUploadLimitInBytes(): int
     {


### PR DESCRIPTION
## TL;DR
This set of patches extend the awesome _role-based upload limit_ feature implemented within [Customizable Maximum File Upload Size](https://docu.ilias.de/ilias.php?baseClass=ilwikihandlergui&cmdNode=16g:rq&cmdClass=ilobjwikigui&cmd=viewPage&ref_id=1357&wpg_id=6387) for the rest of the ILIAS code base, effectively making all core components (excluding maybe some plugins) support this new role based upload limit. Note though that this does not magically enable chunking support for all those components, but still only works within the limits of the PHPs `upload_max_filesize` and `post_max_size` settings as before.

## History
Here in Marburg we have had our own set of custom patches for a customizable upload limit since rougly ILIAS 5.4. Initially using user-defined-fields instead of having a role-based approach, which worked well but we never felt like our patches were implemented well enough to share with the world. 

With the release of ILIAS 9 and the new *Customizable Maximum File Upload Size* feature we had hoped to be able to fully drop our custom patches as they where quite extensive. Sadly this new feature so far was only implemented for the new KitchenSink UI elements, missing support in places like:
- Bibliography (Re-Upload)
- Question Types (Mostly related to image upload)
  - K-Prim
  - Matching
  - Multiple-Choice
  - Single Choice
  - Image Map
  - File
- SCORM File-Upload
- TinyMCE
- Mail Attachement Upload
- Classes using FileInputGUI, ilFileWizardInputGUI or ImageFileImport
  - Objekt import Wizard
- Plugins:
  - InteractiveVideo

None the less we'd like to thank TH Köln, Fabian Schmid, Thibeau Fuhrer and Lukas Zehnder for funding and implementing much of the required groundwork to get this into the ILIAS core and allowing us to try and update our internal patches into something that might be viable for the rest of the ILIAS community.

## About the patches
The commits should be mostly self-explanatory, although there might be a few places where additional comments are in order:
- There are two commits (285d8793682a248c3142255be507998d9842042a, a2acf45b646da446de4899d58c121a4407e2d7ad) that drop (deprecated) methods that have been fully replaced in the core, but might still be used by plugins. This PR does not require these to be kept but I thought it a good idea to cleanup the codebase while at it.
- A new helper class `UploadFileLimits` has been implemented as a (legacy support) analog to `UploadLimitResolver` for code that has not implemented the new KitcheSink UploadHandler-Interface UI-Element (or maybe never will, like WebDAV). Ideally most places that now use this class can/should eventuelly be ported to the "real" `UploadLimitResolver`, the only exception being maybe places that are not related to UI, like the WebDAV code.
- The new helper class has been added to the DIC (as `upload_file_limits`) much like the current `UploadLimitResolver` is available as `ui.upload_limit_resolver`. 
- Since I wanted this DIC entry to be always available, regardless of the ILIAS user context and since it ideally should be available before `UploadLimitResolver` (_Since it needs it to read the current PHP limits_), I created a new entry for it in `ilInitialisation`. I'm not 100% sure this **really** required, but I wanted to error on the side of caution since there are a lot of places that need to know the currently max/best/role-based upload limit.
  - Happy to get feedback on this.
- I replaced the instances of `UploadLimitResolver` inside most ILIAS test question classes with the new `UploadFileLimits`, since no class was currently using the new KitchenSink UploadHandler-Interface UI-Element anyway. Once the test question classes are updated to use the new Kitchensink UI elements implementing the UploadHandler-Interface this should of course be changed again.
- Otherwise the commits try to:
  - Replace any non-centralized access to ini_get(`upload_max_filesize`) and ini_get(`post_max_size`) towards `UploadFileLimits` or `UploadLimitResolver`, whatever makes more sense, eg. whether a UploadHandler-Interface handler is available or not.
  - Replaces `ilFileUtils::getFileSizeInfo()` and `ilFileUtils::getPhpUploadSizeLimitInBytes()` with role-based upload-limit aware methods on `UploadFileLimits` or `UploadLimitResolver`.
  - Changes any non-centralized calculation/conversion of filesize from bytes to string into (new) helper methods on `UploadFileLimits` or `UploadLimitResolver` using the new DataSize data structure. (_This saves having to import/use DataSize in some places where `UploadFileLimits` or `UploadLimitResolver` are available anyway._)
  - Minor code cleanup and improvements
  - Dropping some now unused class methods
  
I sincerely hope that these changes can find their way into release_9 and ideally release_10 as well.
On first glance not much in relation to these patches has been changed in ILIAS 10 here (yet).

## WIP
- ~~These patches have been tested and are currently live since today (28.04.2025) on our production system, but another review and some user-facing testing might be useful.~~ Patches have been in production use for about 6 months without issues.
- Feedback is more then welcome. :wink:

### ilInitialisation Order
I might still change the `ilInitialisation` order, putting `$DIC['upload_file_limits']` setup back into the user-based context (again).

Looking at the changes that have been made, I can see the following categories:
1. Places that should only be reachable by the GUI and where I've added `$DIC['upload_file_limits']` access in their constructors. (Commits: a6daabcf779ed3de26954b4318718ae9761a6696)
2. Places that previously where already using the pre-existing `$DIC['ui.upload_limit_resolver']` helper. (Commits: b6a3371d42382903c4a4bf505e16c0f2294ccc52, a4d24e82f3b3f331680f0a25af6027856b396c2a, 7f18881076c7fa9a25752c9e8e7431047d0930b1)
3. Places where the pre-existing `$DIC['ui.upload_limit_resolver']` was replaced by `$DIC['upload_file_limits']` until a new KitchenSink UI element will be used here. (Commit: b25118e753970f94d6865066d30a325e09dac9e1)
4. Places that replace the static `ilFileUtils` methods that have been marked as deprecated. (Commits: e9d37e8dd0719c2366f16890d6674640248c0edb, 0cf35afa5abdb60708cc541ee08f607329458e4d)

Of those places only point **4.** might have issues with the ILIAS init order as the static methods were available/initialized once the `ilFileUtils` class was first auto-loaded. Both commits seemingly involve only GUI classes and WebDAV which uses a context with `hasUser()`, `hasHTML()` and `initClient()` active, so using a user-context **should** be fine.

Both point **1.** and **4.** might cause *undefined array key errors* if the `upload_file_limits` instance is not available in certain contexts when their constructor is called, but seeing as these are all GUI-Class constructors (except WebDav) this **should** be fine.