### PR TITLE
[LTI] Fix: include date and datetime into certificates

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/Certificate/class.ilLTIConsumerPlaceholderValues.php
+++ b/components/ILIAS/LTIConsumer/classes/Certificate/class.ilLTIConsumerPlaceholderValues.php
@@ -146,8 +146,8 @@ class ilLTIConsumerPlaceholderValues implements ilCertificatePlaceholderValues
         ) {
             /** @var ilObjUser $user */
             $user = $this->objectHelper->getInstanceByObjId($userId);
-            $placeHolders['DATE_COMPLETED'] = $this->dateHelper->formatDate($completionDate, $user);
-            $placeHolders['DATETIME_COMPLETED'] = $this->dateHelper->formatDateTime($completionDate, $user);
+            $placeholders['DATE_COMPLETED'] = $this->dateHelper->formatDate($completionDate, $user);
+            $placeholders['DATETIME_COMPLETED'] = $this->dateHelper->formatDateTime($completionDate, $user);
         }
 
         return $placeholders;


### PR DESCRIPTION
These changes fix a problem that prevented the correct display of some labels in certificates that are transmitted via LTI.

Associated mantis ticket:
https://mantis.ilias.de/view.php?id=44930