### PR TITLE
[LTI] Fix: save not attended status

### DIFF
--- a/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
@@ -144,7 +144,7 @@ class ilLTIAppEventListener implements \ilAppEventListener
         $this->logger->info('Trying outcome service with status ' . $a_status . ' and percentage ' . $a_percentage);
         $user = UserResult::fromResourceLink($resource_link, $ext_account);
 
-        if(!$a_percentage && $a_status != ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM) {
+        if (!$a_percentage && $a_status != ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM) {
             $score = 0;
         } else {
             if ($a_status == ilLPStatus::LP_STATUS_COMPLETED_NUM || $a_status == ilLPStatus::LP_STATUS_FAILED_NUM) {

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
@@ -144,17 +144,16 @@ class ilLTIAppEventListener implements \ilAppEventListener
         $this->logger->info('Trying outcome service with status ' . $a_status . ' and percentage ' . $a_percentage);
         $user = UserResult::fromResourceLink($resource_link, $ext_account);
 
-        if ($a_status == ilLPStatus::LP_STATUS_COMPLETED_NUM) {
+        if ($a_status == ilLPStatus::LP_STATUS_COMPLETED_NUM || $a_status == ilLPStatus::LP_STATUS_FAILED_NUM) {
             $score = $a_percentage / 100;
         } elseif (
-            $a_status == ilLPStatus::LP_STATUS_FAILED_NUM ||
             $a_status == ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM
         ) {
             $score = 0;
         } elseif (!$a_percentage) {
             $score = 0;
         } else {
-            $score = $a_percentage / 100;
+            $score = 0;
         }
 
         $this->logger->info('Sending score: ' . (string) $score);

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
@@ -144,16 +144,18 @@ class ilLTIAppEventListener implements \ilAppEventListener
         $this->logger->info('Trying outcome service with status ' . $a_status . ' and percentage ' . $a_percentage);
         $user = UserResult::fromResourceLink($resource_link, $ext_account);
 
-        if ($a_status == ilLPStatus::LP_STATUS_COMPLETED_NUM || $a_status == ilLPStatus::LP_STATUS_FAILED_NUM) {
-            $score = $a_percentage / 100;
-        } elseif (
-            $a_status == ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM
-        ) {
-            $score = 0;
-        } elseif (!$a_percentage) {
+        if(!$a_percentage && $a_status != ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM) {
             $score = 0;
         } else {
-            $score = 0;
+            if ($a_status == ilLPStatus::LP_STATUS_COMPLETED_NUM || $a_status == ilLPStatus::LP_STATUS_FAILED_NUM) {
+                $score = $a_percentage / 100;
+            } elseif (
+                $a_status == ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM
+            ) {
+                $score = null;
+            } else {
+                $score = 0;
+            }
         }
 
         $this->logger->info('Sending score: ' . (string) $score);

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -48,7 +48,9 @@ class ilLPStatusLtiOutcome extends ilLPStatus
             $object = $this->ensureObject($a_obj_id, $a_obj);
             $ltiMasteryScore = $object->getMasteryScore();
 
-            if ($ltiResult->getResult() >= $ltiMasteryScore) {
+            if ($ltiResult->getResult() == null) {
+                return self::LP_STATUS_NOT_ATTEMPTED_NUM;
+            } elseif ($ltiResult->getResult() >= $ltiMasteryScore) {
                 return self::LP_STATUS_COMPLETED_NUM;
             } else {
                 return self::LP_STATUS_FAILED_NUM;

--- a/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
+++ b/components/ILIAS/Tracking/classes/status/class.ilLPStatusLtiOutcome.php
@@ -50,9 +50,9 @@ class ilLPStatusLtiOutcome extends ilLPStatus
 
             if ($ltiResult->getResult() >= $ltiMasteryScore) {
                 return self::LP_STATUS_COMPLETED_NUM;
+            } else {
+                return self::LP_STATUS_FAILED_NUM;
             }
-
-            return self::LP_STATUS_IN_PROGRESS_NUM;
         }
 
         return self::LP_STATUS_NOT_ATTEMPTED_NUM;


### PR DESCRIPTION
These changes address an issue that prevented learning progress status from being saved correctly even when the test is not attended.

Associated mantis ticket:
https://mantis.ilias.de/view.php?id=44985