### PR TITLE
DataCollection: fix default filter fallback

### DIFF
--- a/Modules/DataCollection/classes/Content/class.ilDclRecordListGUI.php
+++ b/Modules/DataCollection/classes/Content/class.ilDclRecordListGUI.php
@@ -125,9 +125,6 @@ class ilDclRecordListGUI
         // whereas 'listRecords' handels the filters "normally", filling them from the POST-variable
         switch ($cmd) {
             case self::CMD_SHOW:
-                $this->setSubTabs($this->mode);
-                $this->listRecords(true);
-                break;
             case self::CMD_CANCEL_DELETE:
             case self::CMD_LIST_RECORDS:
                 $this->setSubTabs($this->mode);
@@ -150,9 +147,9 @@ class ilDclRecordListGUI
         }
     }
 
-    public function listRecords(bool $use_tableview_filter = false): void
+    public function listRecords(): void
     {
-        $list = $this->getRecordListTableGUI($use_tableview_filter);
+        $list = $this->getRecordListTableGUI();
 
         $this->createSwitchers();
 
@@ -492,18 +489,12 @@ class ilDclRecordListGUI
         $this->ctrl->clearParameters($this);
     }
 
-    protected function getRecordListTableGUI(bool $use_tableview_filter): ilDclRecordListTableGUI
+    protected function getRecordListTableGUI(): ilDclRecordListTableGUI
     {
         $table_obj = $this->table_obj;
 
         $list = new ilDclRecordListTableGUI($this, "listRecords", $table_obj, $this->tableview_id, $this->mode);
         $list->initFilter();
-        if ($use_tableview_filter) {
-            $list->initFilter();
-            $list->resetOffset();
-            $list->resetFilter();
-            $list->initFilterFromTableView();
-        }
 
         $list->setExternalSegmentation(true);
         $list->setExternalSorting(true);

--- a/Modules/DataCollection/classes/Content/class.ilDclRecordListTableGUI.php
+++ b/Modules/DataCollection/classes/Content/class.ilDclRecordListTableGUI.php
@@ -317,54 +317,24 @@ class ilDclRecordListTableGUI extends ilTable2GUI
         return $return;
     }
 
-    /**
-     * init filters with values from tableview
-     */
-    public function initFilterFromTableView(): void
-    {
-        $this->filters = [];
-        $this->filter = [];
-        foreach ($this->tableview->getFilterableFieldSettings() as $field_set) {
-            $field = $field_set->getFieldObject();
-            ilDclCache::getFieldRepresentation($field)->addFilterInputFieldToTable($this);
-
-            //set filter values
-            $filter = end($this->filters);
-            $value = $field_set->getFilterValue();
-            $filter->setValueByArray($value);
-            $filter->writeToSession();
-            $this->applyFilter($field->getId(), empty(array_filter($value)) ? null : $filter->getValue());
-
-            //Disable filters
-            if (!$field_set->isFilterChangeable()) {
-                $filter->setDisabled(true);
-                if ($filter instanceof ilCombinationInputGUI) {
-                    $filter->__call('setDisabled', [true]);
-                }
-            }
-        }
-    }
-
-    /**
-     * normally initialize filters - used by applyFilter and resetFilter
-     */
     public function initFilter(): void
     {
         foreach ($this->tableview->getFilterableFieldSettings() as $field_set) {
             $field = $field_set->getFieldObject();
             $value = ilDclCache::getFieldRepresentation($field)->addFilterInputFieldToTable($this);
+            $filter = $this->getFilterItemByPostVar('filter_' . $field->getId());
 
-            //Disable filters
-            $filter = end($this->filters);
-            if (!$field_set->isFilterChangeable()) {
-                //always set tableview-filtervalue with disabled fields, so resetFilter won't reset it
+            $isset = ilSession::has("form_" . $filter->getParentTable()->getId() . "_" . $filter->getFieldId());
+            if (!$field_set->isFilterChangeable() || !$isset) {
                 $value = $field_set->getFilterValue();
                 $filter->setValueByArray($value);
                 $value = $filter->getValue();
 
-                $filter->setDisabled(true);
-                if ($filter instanceof ilCombinationInputGUI) {
-                    $filter->__call('setDisabled', [true]);
+                if (!$field_set->isFilterChangeable()) {
+                    $filter->setDisabled(true);
+                    if ($filter instanceof ilCombinationInputGUI) {
+                        $filter->__call('setDisabled', [true]);
+                    }
                 }
             }
 

--- a/Modules/DataCollection/classes/class.ilObjDataCollectionGUI.php
+++ b/Modules/DataCollection/classes/class.ilObjDataCollectionGUI.php
@@ -349,7 +349,7 @@ class ilObjDataCollectionGUI extends ilObject2GUI
         $params = explode("_", $a_target);
         //41821: Handles old permanent links. This is deprecated and removed for ILIAS 10
         if (count($params) > 1) {
-            if (!str_contains($DIC->http()->request()->getServerParams()['HTTP_REFERER'], 'login.php')) {
+            if (!str_contains($DIC->http()->request()->getServerParams()['HTTP_REFERER'] ?? '', 'login.php')) {
                 $goto_string = explode('/', $DIC->http()->request()->getRequestTarget());
                 if (str_contains(end($goto_string), 'dcl_')) {
                     $view = new ilDclTableView((int) $params[1]);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44993

General improvement of the dc table filter.
The new behavior falls back to the filter default when no filter is set (no matter its value) within the session.
A session filter is only applied via a set filter user interaction and removed on a reset filter (or deletion of the session).