### PR TITLE
10/UI/Table Data & Ordering accessibility validation 44005 44065

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -217,10 +217,23 @@ class Renderer extends AbstractComponentRenderer
             $component->getAdditionalParameters()
         );
 
+        // these column counts and index numbers are meant for aria attributes in the html tpl
+        $compensate_col_index = 1; // aria-colindex expects counting to start with 1, not 0
+        if ($component->hasMultiActions()) { // adds column with checkbox before first data column which is numbered 1.
+            $compensate_col_index += 1;
+        }
+        $compensate_col_count = 0; // count starts with 1, only needs to be compensated for special columns
+        if ($component->hasMultiActions()) {
+            $compensate_col_count += 1;
+        }
+        if ($component->hasSingleActions()) { // adds column with action dropdown at the very end
+            $compensate_col_count += 1;
+        }
+
         $id = $this->bindJavaScript($component);
         $tpl->setVariable('ID', $id);
         $tpl->setVariable('TITLE', $component->getTitle());
-        $tpl->setVariable('COL_COUNT', (string) $component->getColumnCount());
+        $tpl->setVariable('COL_COUNT', (string) $component->getColumnCount() + $compensate_col_count);
         $tpl->setVariable('VIEW_CONTROLS', $default_renderer->render($view_controls));
 
         $sortation_signal = null;
@@ -228,7 +241,7 @@ class Renderer extends AbstractComponentRenderer
         if (!$rows->valid()) {
             $this->renderFullWidthDataCell($component, $tpl, $this->txt('ui_table_no_records'));
         } else {
-            $this->renderActionsHeader($default_renderer, $component, $tpl);
+            $this->renderActionsHeader($default_renderer, $component, $tpl, $compensate_col_count);
             $this->appendTableRows($tpl, $rows, $default_renderer);
 
             if ($component->hasMultiActions()) {
@@ -239,8 +252,8 @@ class Renderer extends AbstractComponentRenderer
                     $component->getMultiActionSignal(),
                     $modal->getShowSignal()
                 );
-                $total_number_of_cols = count($component->getVisibleColumns()) + 2; // + selection column and action dropdown column
-                $tpl->setVariable('COLUMN_COUNT', (string) $total_number_of_cols);
+                $multi_action_col_span = count($component->getVisibleColumns()) + $compensate_col_count;
+                $tpl->setVariable('MULTI_ACTION_SPAN', (string) $multi_action_col_span);
                 $tpl->setVariable('MULTI_ACTION_TRIGGERER', $default_renderer->render($multi_actions_dropdown));
                 $tpl->setVariable('MULTI_ACTION_ALL_MODAL', $default_renderer->render($modal));
             }
@@ -255,7 +268,7 @@ class Renderer extends AbstractComponentRenderer
             }
         }
 
-        $this->renderTableHeader($default_renderer, $component, $tpl, $sortation_signal);
+        $this->renderTableHeader($default_renderer, $component, $tpl, $sortation_signal, $compensate_col_index);
         return $tpl->get();
     }
 
@@ -263,7 +276,8 @@ class Renderer extends AbstractComponentRenderer
         RendererInterface $default_renderer,
         Component\Table\Data $component,
         Template $tpl,
-        ?Component\Signal $sortation_signal
+        ?Component\Signal $sortation_signal,
+        int $compensate_col_index,
     ): void {
         $order = $component->getOrder();
         $glyph_factory = $this->getUIFactory()->symbol()->glyph();
@@ -276,18 +290,19 @@ class Renderer extends AbstractComponentRenderer
             $col_title = $col->getTitle();
             if ($col_id === $sort_col) {
                 if ($sort_direction === Order::ASC) {
-                    $sortation = $this->txt('order_option_generic_ascending');
+                    $sortation = "ascending"; // aria-sort should not be translated and always be in English
                     $sortation_glyph = $glyph_factory->sortAscending("#");
                     $param_sort_direction = Order::DESC;
                 }
                 if ($sort_direction === Order::DESC) {
-                    $sortation = $this->txt('order_option_generic_descending');
+                    $sortation = "descending"; // aria-sort should not be translated and always be in English
                     $sortation_glyph = $glyph_factory->sortDescending("#");
                 }
             }
 
             $tpl->setCurrentBlock('header_cell');
-            $tpl->setVariable('COL_INDEX', (string) $col->getIndex());
+
+            $tpl->setVariable('COL_INDEX', (string) $col->getIndex() + $compensate_col_index);
 
             if ($col->isSortable() && !is_null($sortation_signal)) {
                 $sort_signal = clone $sortation_signal;
@@ -312,10 +327,11 @@ class Renderer extends AbstractComponentRenderer
     protected function renderActionsHeader(
         RendererInterface $default_renderer,
         Component\Table\Table $component,
-        Template $tpl
+        Template $tpl,
+        int $compensate_col_count,
     ): void {
         if ($component->hasSingleActions()) {
-            $tpl->setVariable('COL_INDEX_ACTION', (string) count($component->getColumns()));
+            $tpl->setVariable('COL_INDEX_ACTION', (string) $component->getColumnCount() + $compensate_col_count);
             $tpl->setVariable('COL_TITLE_ACTION', $this->txt('actions'));
         }
 
@@ -329,6 +345,12 @@ class Renderer extends AbstractComponentRenderer
             $select_none = $glyph_factory->close()->withOnClick($signal);
             $tpl->setVariable('SELECTION_CONTROL_SELECT', $default_renderer->render($select_all));
             $tpl->setVariable('SELECTION_CONTROL_DESELECT', $default_renderer->render($select_none));
+        }
+
+        if ($component instanceof Component\Table\Ordering) {
+            if (!$component->isOrderingDisabled() && !$component->hasMultiActions()) {
+                $tpl->touchBlock('header_rowselection_cell');
+            }
         }
     }
 
@@ -528,9 +550,6 @@ class Renderer extends AbstractComponentRenderer
         $cell_tpl = $this->getTemplate("tpl.orderingcell.html", true, true);
         $this->fillCells($component, $cell_tpl, $default_renderer);
 
-        $drag_handle = $this->getUIFactory()->symbol()->glyph()->dragHandle();
-        $drag_handle = $default_renderer->render($drag_handle);
-        $cell_tpl->setVariable('DRAG_HANDLE', $drag_handle);
 
         if ($component->isOrderingDisabled()) {
             return $cell_tpl->get();
@@ -570,7 +589,6 @@ class Renderer extends AbstractComponentRenderer
             }
             $cell_tpl->setCurrentBlock('cell');
             $cell_tpl->setVariable('COL_TYPE', strtolower($column->getType()));
-            $cell_tpl->setVariable('COL_INDEX', $column->getIndex());
             $cell_content = $row->getCellContent($col_id);
             if ($cell_content instanceof Component\Component) {
                 $cell_content = $default_renderer->render($cell_content);
@@ -589,6 +607,14 @@ class Renderer extends AbstractComponentRenderer
                 $row->getActions()
             );
             $cell_tpl->setVariable('ACTION_CONTENT', $default_renderer->render($row_actions_dropdown));
+        }
+
+        if ($row instanceof Component\Table\OrderingRow) {
+            if (!$row->isOrderingDisabled()) {
+                $drag_handle = $this->getUIFactory()->symbol()->glyph()->dragHandle();
+                $drag_handle = $default_renderer->render($drag_handle);
+                $cell_tpl->setVariable('DRAG_HANDLE', $drag_handle);
+            }
         }
     }
 
@@ -630,35 +656,50 @@ class Renderer extends AbstractComponentRenderer
             );
         }
 
+        // these column counts and index numbers are meant for aria attributes in the html tpl
+        $compensate_col_index = 1; // aria-colindex expects counting to start with 1, not 0
+        // for column with checkbox and/or drag handle before first data column which is numbered 1.
+        if ($component->hasMultiActions() || !$component->isOrderingDisabled()) {
+            $compensate_col_index += 1; // checkbox & drag handle
+        }
+        if (!$component->isOrderingDisabled()) {
+            $compensate_col_index += 1; // Position input
+        }
+
+        $compensate_col_count = 0; // count starts with 1, only needs to be compensated for special columns
+        if ($component->hasMultiActions() || !$component->isOrderingDisabled()) {
+            $compensate_col_count += 1; // checkbox & drag handle
+        }
+        if (!$component->isOrderingDisabled()) {
+            $compensate_col_count += 1; // Position input
+        }
+        if ($component->hasSingleActions()) { // adds column with action dropdown at the very end
+            $compensate_col_count += 1;
+        }
+
         $tableid = $this->bindJavaScript($component) ?? $this->createId();
-        $total_number_of_cols = count($component->getVisibleColumns());
 
         if (!$component->isOrderingDisabled()) {
-            $total_number_of_cols = $total_number_of_cols + 1;
             $submit = $this->getUIFactory()->button()->standard($this->txt('sorting_save'), "")
                 ->withOnLoadCode(static fn($id) => "document.getElementById('$id').addEventListener('click',
                     function() {document.querySelector('#$tableid form.c-table-ordering__form').submit();return false;});");
 
             $tpl->setVariable('FORM_BUTTONS', $default_renderer->render($submit));
             $tpl->setVariable('POS_INPUT_TITLE', $this->txt('table_posinput_col_title'));
-        }
 
-        if (!$component->hasMultiActions()) {
-            $tpl->touchBlock('header_rowselection_ordering_no_multi_actions');
         }
 
         $tpl->setVariable('ID', $tableid);
         $tpl->setVariable('TARGET_URL', $component->getTargetURL() ? $component->getTargetURL()->__toString() : '#');
         $tpl->setVariable('TITLE', $component->getTitle());
-        $tpl->setVariable('COL_COUNT', (string) $component->getColumnCount());
+        $tpl->setVariable('COL_COUNT', (string) $component->getColumnCount() + $compensate_col_count);
         $tpl->setVariable('VIEW_CONTROLS', $default_renderer->render($view_controls));
-
 
         $columns = $component->getVisibleColumns();
         foreach ($columns as $col_id => $col) {
             $col_title = $col->getTitle();
             $tpl->setCurrentBlock('header_cell');
-            $tpl->setVariable('COL_INDEX', (string) $col->getIndex());
+            $tpl->setVariable('COL_INDEX', (string) $col->getIndex() + $compensate_col_index);
             $tpl->setVariable('COL_TITLE', $col_title);
             $tpl->setVariable('COL_TYPE', strtolower($col->getType()));
             $tpl->parseCurrentBlock();
@@ -672,11 +713,10 @@ class Renderer extends AbstractComponentRenderer
                 ->withOrderingDisabled($component->isOrderingDisabled());
         }
 
-        $this->renderActionsHeader($default_renderer, $component, $tpl);
+        $this->renderActionsHeader($default_renderer, $component, $tpl, $compensate_col_count);
         $this->appendTableRows($tpl, $r, $default_renderer);
 
         if ($component->hasMultiActions()) {
-            $total_number_of_cols = $total_number_of_cols + 2;
             $multi_actions = $component->getMultiActions();
             $modal = $this->buildMultiActionsAllObjectsModal($multi_actions, $tableid);
             $multi_actions_dropdown = $this->buildMultiActionsDropdown(
@@ -684,11 +724,15 @@ class Renderer extends AbstractComponentRenderer
                 $component->getMultiActionSignal(),
                 $modal->getShowSignal()
             );
+
             $tpl->setVariable('MULTI_ACTION_TRIGGERER', $default_renderer->render($multi_actions_dropdown));
             $tpl->setVariable('MULTI_ACTION_ALL_MODAL', $default_renderer->render($modal));
         }
+        if ($component->hasMultiActions() || !$component->isOrderingDisabled()) {
+            $multi_action_col_span = count($component->getVisibleColumns()) + $compensate_col_count;
+            $tpl->setVariable('MULTI_ACTION_SPAN', (string) $multi_action_col_span);
+        }
 
-        $tpl->setVariable('COLUMN_COUNT', (string) $total_number_of_cols);
         return $tpl->get();
     }
 

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.datacell.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.datacell.html
@@ -1,17 +1,17 @@
 <!-- BEGIN rowselection_cell -->
-<td class="c-table-data__cell c-table-data__rowselection" role="gridcell" tabindex="-1">
+<td class="c-table-data__cell c-table-data__rowselection" tabindex="-1">
 	<input type="checkbox" value="{ROW_ID}" class="c-table-data__row-selector">
 </td>
 <!-- END rowselection_cell -->
 
 <!-- BEGIN cell -->
-<td class="c-table-data__cell c-table-data__cell--{COL_TYPE} <!-- BEGIN highlighted --> c-table-data__cell--highlighted<!-- END highlighted -->" role="gridcell" aria-colindex="{COL_INDEX}" <!-- BEGIN with_col_span -->colspan="{COL_SPAN}"<!-- END with_col_span --> tabindex="-1">
+<td class="c-table-data__cell c-table-data__cell--{COL_TYPE} <!-- BEGIN highlighted --> c-table-data__cell--highlighted<!-- END highlighted -->" <!-- BEGIN with_col_span -->colspan="{COL_SPAN}"<!-- END with_col_span --> tabindex="-1">
 	<span class="c-table-data__cell__col-title">{CELL_COL_TITLE}: </span>{CELL_CONTENT}
 </td>
 <!-- END cell -->
 
 <!-- BEGIN rowaction_cell -->
-<td class="c-table-data__cell c-table-data__rowaction" role="gridcell" tabindex="-1">
+<td class="c-table-data__cell c-table-data__rowaction" tabindex="-1">
 	{ACTION_CONTENT}
 </td>
 <!-- END rowaction_cell -->

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.datatable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.datatable.html
@@ -7,19 +7,19 @@
 	<div class="viewcontrols">{VIEW_CONTROLS}</div>
 
 	<div class="c-table-data__table-wrapper">
-		<table class="c-table-data__table" role="grid" aria-labelledby="{ID}_label" aria-colcount="{COL_COUNT}">
+		<table class="c-table-data__table" aria-labelledby="{ID}_label" aria-colcount="{COL_COUNT}" role="grid">
 			<thead>
-				<tr class="c-table-data__header c-table-data__row" role="rowgroup">
-					
+				<tr class="c-table-data__header c-table-data__row">
+
 					<!-- BEGIN header_rowselection_cell -->
-					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowselection" role="columnheader" tabindex="-1">
+					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowselection" tabindex="-1" aria-colindex="1">
 						<div class="c-table-data__selection_all">{SELECTION_CONTROL_SELECT}</div>
 						<div class="c-table-data__selection_none">{SELECTION_CONTROL_DESELECT}</div>
 					</th>
 					<!-- END header_rowselection_cell -->
 
 					<!-- BEGIN header_cell -->
-					<th class="c-table-data__header c-table-data__cell c-table-data__cell--{COL_TYPE}" role="columnheader" tabindex="-1" aria-colindex="{COL_INDEX}"<!-- BEGIN header_cell_sortation --> aria-sort="{COL_SORTATION}"<!-- END header_cell_sortation -->>
+					<th class="c-table-data__header c-table-data__cell c-table-data__cell--{COL_TYPE}" tabindex="-1" aria-colindex="{COL_INDEX}"<!-- BEGIN header_cell_sortation --> aria-sort="{COL_SORTATION}"<!-- END header_cell_sortation -->>
 						<div class="c-table-data__header__resize-wrapper">
 							<!-- BEGIN header_cell_sortglyph -->
 							{COL_SORTATION_GLYPH}
@@ -30,20 +30,20 @@
 					<!-- END header_cell -->
 
 					<!-- BEGIN header_action_cell -->
-					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowaction" role="columnheader" aria-colindex="{COL_INDEX_ACTION}">{COL_TITLE_ACTION}</th>
+					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowaction" aria-colindex="{COL_INDEX_ACTION}">{COL_TITLE_ACTION}</th>
 					<!-- END header_action_cell -->
 				</tr>
 			</thead>
 
-			<tbody class="c-table-data__body" role="rowgroup">
+			<tbody class="c-table-data__body" >
 				<!-- BEGIN row -->
-				<tr class="c-table-data__row {ALTERNATION}" role="row">
+				<tr class="c-table-data__row {ALTERNATION}">
 					{CELLS}
 				</tr>
 				<!-- END row -->
 				<!-- BEGIN multi_action -->
 				<tr>
-					<td class="c-table-data__cell c-table-data__cell--multiaction" colspan="{COLUMN_COUNT}">
+					<td class="c-table-data__cell c-table-data__cell--multiaction" colspan="{MULTI_ACTION_SPAN}">
 						<div class="c-table-data__multiaction-triggerer">{MULTI_ACTION_TRIGGERER}</div>
 						{MULTI_ACTION_ALL_MODAL}
 					</td>

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.orderingcell.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.orderingcell.html
@@ -1,24 +1,24 @@
 <!-- BEGIN rowselection_cell -->
-<td class="c-table-data__cell c-table-data__rowselection" role="gridcell" tabindex="-1">
+<td class="c-table-data__cell c-table-data__rowselection" tabindex="-1">
 	{DRAG_HANDLE}
-	<input type="checkbox" value="{ROW_ID}" class="c-table-data__row-selector">
+	<!-- BEGIN rowselection_checkbox --><input type="checkbox" value="{ROW_ID}" class="c-table-data__row-selector"><!-- END rowselection_checkbox -->
 </td>
 <!-- END rowselection_cell -->
 
 <!-- BEGIN orderinput_cell -->
-<td class="c-table-data__cell c-table-data__positioninput" role="gridcell" tabindex="-1">
+<td class="c-table-data__cell c-table-data__positioninput" tabindex="-1">
 	{ORDER_INPUT}
 </td>
 <!-- END orderinput_cell -->
 
 <!-- BEGIN cell -->
-<td class="c-table-data__cell c-table-data__cell--{COL_TYPE} <!-- BEGIN highlighted --> c-table-data__cell--highlighted<!-- END highlighted -->" role="gridcell" aria-colindex="{COL_INDEX}" tabindex="-1">
-	{CELL_CONTENT}
+<td class="c-table-data__cell c-table-data__cell--{COL_TYPE} <!-- BEGIN highlighted --> c-table-data__cell--highlighted<!-- END highlighted -->" tabindex="-1">
+	<span class="c-table-data__cell__col-title">{CELL_COL_TITLE}: </span>{CELL_CONTENT}
 </td>
 <!-- END cell -->
 
 <!-- BEGIN rowaction_cell -->
-<td class="c-table-data__cell c-table-data__rowaction" role="gridcell" tabindex="-1">
+<td class="c-table-data__cell c-table-data__rowaction" tabindex="-1">
 		{ACTION_CONTENT}
 </td>
 <!-- END rowaction_cell -->

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
@@ -8,31 +8,31 @@
 	<div class="viewcontrols">{VIEW_CONTROLS}</div>
 
 	<form method="post" class="c-table-data__table-wrapper c-table-ordering__form" action="{TARGET_URL}">
-		<table class="c-table-data__table" role="grid" aria-labelledby="{ID}_label" aria-colcount="{COL_COUNT}">
+		<table class="c-table-data__table" aria-labelledby="{ID}_label" aria-colcount="{COL_COUNT}" role="grid">
 
 			<thead>
-				<tr class="c-table-data__header c-table-data__row" role="rowgroup">
+				<tr class="c-table-data__header c-table-data__row">
 
 					<!-- BEGIN header_rowselection_cell -->
-					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowselection" role="columnheader" tabindex="-1">
+					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowselection" tabindex="-1" aria-colindex="1">
+						{DRAG_HINT}
+						<!-- BEGIN has_selectall -->
 						<div class="c-table-data__selection_all">{SELECTION_CONTROL_SELECT}</div>
 						<div class="c-table-data__selection_none">{SELECTION_CONTROL_DESELECT}</div>
+						<!-- END has_selectall -->
 					</th>
 					<!-- END header_rowselection_cell -->
 
-                    <!-- BEGIN header_rowselection_ordering_no_multi_actions -->
-					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowselection" role="columnheader" tabindex="-1">
-					</th>
-					<!-- END header_rowselection_ordering_no_multi_actions -->
-
 					<!-- BEGIN header_pos_input -->
-					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowselection" role="columnheader" tabindex="-1">
-						{POS_INPUT_TITLE}
+					<th class="c-table-data__header c-table-data__cell c-table-data__cell--number" tabindex="-1" aria-colindex="2">
+						<div class="c-table-data__header__resize-wrapper">
+							{POS_INPUT_TITLE}
+						</div>
 					</th>
 					<!-- END header_pos_input -->
 
 					<!-- BEGIN header_cell -->
-					<th class="c-table-data__header c-table-data__cell c-table-data__cell--{COL_TYPE}" role="columnheader" tabindex="-1" aria-colindex="{COL_INDEX}">
+					<th class="c-table-data__header c-table-data__cell c-table-data__cell--{COL_TYPE}" tabindex="-1" aria-colindex="{COL_INDEX}">
 						<div class="c-table-data__header__resize-wrapper">
 							{COL_TITLE}
 						</div>
@@ -40,32 +40,32 @@
 					<!-- END header_cell -->
 
 					<!-- BEGIN header_action_cell -->
-					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowaction" role="columnheader" aria-colindex="{COL_INDEX_ACTION}">{COL_TITLE_ACTION}</th>
+					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowaction" aria-colindex="{COL_INDEX_ACTION}">{COL_TITLE_ACTION}</th>
 					<!-- END header_action_cell -->
 				</tr>
 			</thead>
 
-			<tbody class="c-table-data__body" role="rowgroup">
+			<tbody class="c-table-data__body">
 				<!-- BEGIN row -->
-				<tr class="c-table-data__row {ALTERNATION}" role="row">
+				<tr class="c-table-data__row {ALTERNATION}">
 					{CELLS}
 				</tr>
 				<!-- END row -->
 
+				<!-- BEGIN multi_action -->
 				<tr>
-					<td class="c-table-data__cell c-table-data__cell--multiaction" colspan="{COLUMN_COUNT}">
+					<td class="c-table-data__cell c-table-data__cell--multiaction" colspan="{MULTI_ACTION_SPAN}">
 						<div class="l-bar__space-keeper">
-							<!-- BEGIN multi_action -->
 							<div class="l-bar__element">
 								<div class="c-table-data__multiaction-triggerer">{MULTI_ACTION_TRIGGERER}</div>
 							</div>
-							<!-- END multi_action -->
 							<div class="l-bar__element">
 							{FORM_BUTTONS}
 							</div>
 						</div>
 					</td>
 				</tr>
+				<!-- END multi_action -->
 
 			</tbody>
 

--- a/components/ILIAS/UI/tests/Component/Table/DataRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/DataRendererTest.php
@@ -60,14 +60,14 @@ class DTRenderer extends I\Table\Renderer
         $tpl,
         ?I\Signal $sortation_signal
     ) {
-        return $this->renderTableHeader($default_renderer, $component, $tpl, $sortation_signal);
+        $this->renderTableHeader($default_renderer, $component, $tpl, $sortation_signal, 1);
     }
     public function p_renderActionsHeader(
         TestDefaultRenderer $default_renderer,
         I\Table\Data $component,
         $tpl
     ) {
-        return $this->renderActionsHeader($default_renderer, $component, $tpl);
+        $this->renderActionsHeader($default_renderer, $component, $tpl, 1);
     }
 }
 
@@ -202,41 +202,42 @@ class DataRendererTest extends TableRendererTestBase
 <div class="c-table-data" id="{ID}">
     <div class="viewcontrols">{VIEW_CONTROLS}</div>
     <div class="c-table-data__table-wrapper">
-        <table class="c-table-data__table" role="grid" aria-labelledby="{ID}_label" aria-colcount="{COL_COUNT}">
+        <table class="c-table-data__table" aria-labelledby="{ID}_label" aria-colcount="{COL_COUNT}" role="grid">
             <thead>
-                <tr class="c-table-data__header c-table-data__row" role="rowgroup">
-                    <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" role="columnheader" tabindex="-1" aria-colindex="0" aria-sort="order_option_generic_ascending">
-                        <div class="c-table-data__header__resize-wrapper">
-                            <a tabindex="0" class="glyph" href="#" aria-label="sort_ascending" id="id_2"><span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span></a>
-                            <button class="btn btn-link" id="id_1">Field 1</button>
-                        </div>
-                    </th>
-                    <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" role="columnheader" tabindex="-1" aria-colindex="1">
-                        <div class="c-table-data__header__resize-wrapper">Field 2</div>
-                    </th>
-                    <th class="c-table-data__header c-table-data__cell c-table-data__cell--number" role="columnheader" tabindex="-1" aria-colindex="2">
-                        <div class="c-table-data__header__resize-wrapper">
-                            <button class="btn btn-link" id="id_3">Field 3</button>
-                        </div>
-                    </th>
-                </tr>
+            <tr class="c-table-data__header c-table-data__row">
+                <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" tabindex="-1" aria-colindex="1" aria-sort="ascending">
+                    <div class="c-table-data__header__resize-wrapper">
+                        <a tabindex="0" class="glyph" href="#" aria-label="sort_ascending" id="id_2"><span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span></a>
+                        <button class="btn btn-link" id="id_1">Field 1</button>
+                    </div>
+                </th>
+                <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" tabindex="-1" aria-colindex="2">
+                    <div class="c-table-data__header__resize-wrapper">Field 2</div>
+                </th>
+                <th class="c-table-data__header c-table-data__cell c-table-data__cell--number" tabindex="-1" aria-colindex="3">
+                    <div class="c-table-data__header__resize-wrapper">
+                        <button class="btn btn-link" id="id_3">Field 3</button>
+                    </div>
+                </th>
+            </tr>
             </thead>
-            <tbody class="c-table-data__body" role="rowgroup"></tbody>
+            <tbody class="c-table-data__body"></tbody>
         </table>
     </div>
     <div class="c-table-data__async_modal_container"></div>
-
     <dialog class="c-table-data__async_message c-modal" id="{ID}_msgmodal">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form>
+                    <form>
+                        <button formmethod="dialog" class="close" aria-label="close">
+                            <span aria-hidden="true">&times;</span></button>
+                    </form>
                 </div>
                 <div class="c-table-data__async_messageresponse modal-body"></div>
             </div>
         </div>
     </dialog>
-
 </div>
 EOT;
         $expected = $this->brutallyTrimHTML($expected);
@@ -283,34 +284,34 @@ EOT;
 <div class="c-table-data" id="{ID}">
     <div class="viewcontrols">{VIEW_CONTROLS}</div>
     <div class="c-table-data__table-wrapper">
-        <table class="c-table-data__table" role="grid" aria-labelledby="{ID}_label" aria-colcount="{COL_COUNT}">
+        <table class="c-table-data__table" aria-labelledby="{ID}_label" aria-colcount="{COL_COUNT}" role="grid">
             <thead>
-                <tr class="c-table-data__header c-table-data__row" role="rowgroup">
-                    <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" role="columnheader" tabindex="-1" aria-colindex="0">
-                        <div class="c-table-data__header__resize-wrapper">Field 1</div>
-                    </th>
-                    <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" role="columnheader" tabindex="-1" aria-colindex="1">
-                        <div class="c-table-data__header__resize-wrapper">Field 2</div>
-                    </th>
-                </tr>
+            <tr class="c-table-data__header c-table-data__row">
+                <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" tabindex="-1" aria-colindex="1">
+                    <div class="c-table-data__header__resize-wrapper">Field 1</div>
+                </th>
+                <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" tabindex="-1" aria-colindex="2">
+                    <div class="c-table-data__header__resize-wrapper">Field 2</div>
+                </th>
+            </tr>
             </thead>
-            <tbody class="c-table-data__body" role="rowgroup"></tbody>
+            <tbody class="c-table-data__body"></tbody>
         </table>
     </div>
-
     <div class="c-table-data__async_modal_container"></div>
-
     <dialog class="c-table-data__async_message c-modal" id="{ID}_msgmodal">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <form><button formmethod="dialog" class="close" aria-label="close"><span aria-hidden="true">&times;</span></button></form>
+                    <form>
+                        <button formmethod="dialog" class="close" aria-label="close">
+                            <span aria-hidden="true">&times;</span></button>
+                    </form>
                 </div>
                 <div class="c-table-data__async_messageresponse modal-body"></div>
             </div>
         </div>
     </dialog>
-
 </div>
 EOT;
         $expected = $this->brutallyTrimHTML($expected);
@@ -361,7 +362,7 @@ EOT;
         $renderer->p_renderActionsHeader($this->getDefaultRenderer(), $table, $tpl);
         $actual = $this->brutallyTrimHTML($tpl->get());
 
-        $expected = '<th class="c-table-data__header c-table-data__cell c-table-data__header__rowaction" role="columnheader" aria-colindex="1">actions</th>';
+        $expected = '<th class="c-table-data__header c-table-data__cell c-table-data__header__rowaction" aria-colindex="2">actions</th>';
         $this->assertStringContainsString($expected, $actual);
     }
 
@@ -429,27 +430,29 @@ EOT;
     {
         $actual = $this->brutallyTrimHTML($this->getDefaultRenderer()->render($row));
         $expected = <<<EOT
-<td class="c-table-data__cell c-table-data__rowselection" role="gridcell" tabindex="-1">
-    <input type="checkbox" value="row_id-1" class="c-table-data__row-selector">
+<td class="c-table-data__cell c-table-data__rowselection" tabindex="-1">
+    <input type="checkbox" value="row_id-1" class="c-table-data__row-selector"></td>
+<td class="c-table-data__cell c-table-data__cell--text " tabindex="-1"><span class="c-table-data__cell__col-title">Field 1:</span>v1
 </td>
-<td class="c-table-data__cell c-table-data__cell--text " role="gridcell" aria-colindex="1" tabindex="-1">
-    <span class="c-table-data__cell__col-title">Field 1:</span>v1
+<td class="c-table-data__cell c-table-data__cell--text " tabindex="-1"><span class="c-table-data__cell__col-title">Field 2:</span>v2
 </td>
-<td class="c-table-data__cell c-table-data__cell--text " role="gridcell" aria-colindex="2" tabindex="-1">
-    <span class="c-table-data__cell__col-title">Field 2:</span>v2
+<td class="c-table-data__cell c-table-data__cell--number " tabindex="-1"><span class="c-table-data__cell__col-title">Field 3:</span>3
 </td>
-<td class="c-table-data__cell c-table-data__cell--number " role="gridcell" aria-colindex="3" tabindex="-1">
-    <span class="c-table-data__cell__col-title">Field 3:</span>3
-</td>
-<td class="c-table-data__cell c-table-data__rowaction" role="gridcell" tabindex="-1">
+<td class="c-table-data__cell c-table-data__rowaction" tabindex="-1">
     <div class="dropdown" id="id_3">
-        <button class="btn btn-default dropdown-toggle" type="button" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu"><span class="caret"></span></button>
+        <button class="btn btn-default dropdown-toggle" type="button" aria-label="actions" aria-haspopup="true" aria-expanded="false" aria-controls="id_3_menu">
+            <span class="caret"></span></button>
         <ul id="id_3_menu" class="dropdown-menu">
-            <li><button class="btn btn-link" data-action="http://wwww.ilias.de?ref_id=1&namespace_param%5B%5D=row_id-1" id="id_1">label1</button></li>
-            <li><button class="btn btn-link" data-action="http://wwww.ilias.de?ref_id=1&namespace_param%5B%5D=row_id-1" id="id_2">label2</button></li>
+            <li>
+                <button class="btn btn-link" data-action="http://wwww.ilias.de?ref_id=1&namespace_param%5B%5D=row_id-1" id="id_1">label1</button>
+            </li>
+            <li>
+                <button class="btn btn-link" data-action="http://wwww.ilias.de?ref_id=1&namespace_param%5B%5D=row_id-1" id="id_2">label2</button>
+            </li>
         </ul>
     </div>
 </td>
+
 EOT;
         $expected = $this->brutallyTrimHTML($expected);
         $this->assertEquals($expected, $actual);

--- a/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
@@ -71,36 +71,57 @@ class OrderingRendererTest extends TableRendererTestBase
 
         $actual = $renderer->renderOrderingTable($table, $this->getDefaultRenderer());
         $expected = <<<EOT
-<div class="c-table-ordering" id="id_1">
-	<h2 class="ilHeader" id="id_1_label"></h2>
-	<div class="viewcontrols"><form class="il-viewcontrols-form l-bar__space-keeper" method="get" id="id_2"></form></div>
-	<form method="post" class="c-table-data__table-wrapper c-table-ordering__form" action="https://localhost">
-		<table class="c-table-data__table" role="grid" aria-labelledby="id_1_label" aria-colcount="3">
-			<thead>
-				<tr class="c-table-data__header c-table-data__row" role="rowgroup">
-					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowselection" role="columnheader" tabindex="-1"></th>
-					<th class="c-table-data__header c-table-data__cell c-table-data__header__rowselection" role="columnheader" tabindex="-1">table_posinput_col_title</th>
-					<th class="c-table-data__header c-table-data__cell c-table-data__cell--text" role="columnheader" tabindex="-1" aria-colindex="0"><div class="c-table-data__header__resize-wrapper">Field 1</div></th>
-					<th class="c-table-data__header c-table-data__cell c-table-data__cell--text" role="columnheader" tabindex="-1" aria-colindex="1"><div class="c-table-data__header__resize-wrapper">Field 2</div></th>
-					<th class="c-table-data__header c-table-data__cell c-table-data__cell--number" role="columnheader" tabindex="-1" aria-colindex="2"><div class="c-table-data__header__resize-wrapper">Field 3</div></th>
-				</tr>
-			</thead>
-			<tbody class="c-table-data__body" role="rowgroup">
-				<tr>
-					<td class="c-table-data__cell c-table-data__cell--multiaction" colspan="4"><div class="l-bar__space-keeper"><div class="l-bar__element"><button class="btn btn-default" data-action="" id="id_1">sorting_save</button></div></div></td>
-				</tr>
-			</tbody>
-		</table>
-	</form>
-	<div class="c-table-data__async_modal_container"></div>
-	<div class="c-table-data__async_message modal" role="dialog" id="id_1_msgmodal">
-		<div class="modal-dialog" role="document">
-			<div class="modal-content">
-				<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="close"><span aria-hidden="true">&times;</span></button></div>
-				<div class="c-table-data__async_messageresponse modal-body"></div>
-			</div>
-		</div>
-	</div>
+<div class="c-table-ordering" id="id_1"><h2 class="ilHeader" id="id_1_label"></h2>
+    <div class="viewcontrols">
+        <form class="il-viewcontrols-form l-bar__space-keeper" method="get" id="id_2"></form>
+    </div>
+    <form method="post" class="c-table-data__table-wrapper c-table-ordering__form" action="https://localhost">
+        <table class="c-table-data__table" aria-labelledby="id_1_label" aria-colcount="5" role="grid">
+            <thead>
+            <tr class="c-table-data__header c-table-data__row">
+                <th class="c-table-data__header c-table-data__cell c-table-data__header__rowselection" tabindex="-1" aria-colindex="1"></th>
+                <th class="c-table-data__header c-table-data__cell c-table-data__cell--number" tabindex="-1" aria-colindex="2">
+                    <div class="c-table-data__header__resize-wrapper">table_posinput_col_title</div>
+                </th>
+                <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" tabindex="-1" aria-colindex="3">
+                    <div class="c-table-data__header__resize-wrapper">Field 1</div>
+                </th>
+                <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" tabindex="-1" aria-colindex="4">
+                    <div class="c-table-data__header__resize-wrapper">Field 2</div>
+                </th>
+                <th class="c-table-data__header c-table-data__cell c-table-data__cell--number" tabindex="-1" aria-colindex="5">
+                    <div class="c-table-data__header__resize-wrapper">Field 3</div>
+                </th>
+            </tr>
+            </thead>
+            <tbody class="c-table-data__body">
+            <tr>
+                <td class="c-table-data__cell c-table-data__cell--multiaction" colspan="5">
+                    <div class="l-bar__space-keeper">
+                        <div class="l-bar__element">
+                            <div class="c-table-data__multiaction-triggerer"></div>
+                        </div>
+                        <div class="l-bar__element">
+                            <button class="btn btn-default" data-action="" id="id_1">sorting_save</button>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </form>
+    <div class="c-table-data__async_modal_container"></div>
+    <div class="c-table-data__async_message modal" role="dialog" id="id_1_msgmodal">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="close">
+                        <span aria-hidden="true">&times;</span></button>
+                </div>
+                <div class="c-table-data__async_messageresponse modal-body"></div>
+            </div>
+        </div>
+    </div>
 </div>
 EOT;
         $this->assertEquals($this->brutallyTrimHTML($expected), $this->brutallyTrimHTML($actual));


### PR DESCRIPTION
# Issue

DataTable and OrderingTable UI Component did not pass W3C Validator.

![image](https://github.com/user-attachments/assets/9af96d24-4383-4d47-85bf-80ec99705bbe)

# Changes

![image](https://github.com/user-attachments/assets/48561c3b-add1-48b5-8023-e7561982bb43)

I went on a mysterious journey into the depth of W3C and MDN :mage_man: 

There is a bug in the W3C validator: If you use `aria-colindex` on `<td>`, everything explodes with very unhelpful errors for the table header. The actual problem was that you can't have `aria-colindex` on `<td>` if you also have it on `<th>`, but none of the errors said that. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-colindex

Furthermore many, many roles are not necessary and even discouraged on `<table>`, `<tr>` and `<td>` in a `display: table;` context, so I simplified some tags. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/table_role

`aria-colindex` and `aria-colcount` and the colspan for the multi select footer were calculated incorrectly as
1. `aria-colindex`starts counting with 1 and doesn't allow 0.
1. we add many columns that are not in the actual table data (multi-select & drag and drop column, position column, single select action column).

The logic is a bit hacky, as the OrderingTable uses the same column for multi-select and the drag and drop handle.

Input/Viewcontrol Fieldselection had a button in an `<ul>` not wrapped in `<li>`.

# Not quite done

I will do the Unit Tests after code review, when we are sure the html structure will not change.

The Kitchen Sink page of the Ordering Table still fails to pass because something is not right with the UI form input select-field-input setting selected twice. That's another issue though.