### PR TITLE
Filesystem: Fix path to row template

### DIFF
--- a/components/ILIAS/Filesystem/classes/class.ilFileSystemTableGUI.php
+++ b/components/ILIAS/Filesystem/classes/class.ilFileSystemTableGUI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -103,7 +104,7 @@ class ilFileSystemTableGUI extends ilTable2GUI
         $this->setFormAction($this->ctrl->getFormAction($a_parent_obj));
         $this->setRowTemplate(
             "tpl.directory_row.html",
-            "components/ILIAS/FileSystem"
+            "components/ILIAS/Filesystem"
         );
         $this->setEnableTitle(true);
     }


### PR DESCRIPTION
The path to the legacay row template file of the `ilFileSystemGUI` is not correct and leads to issues like this:

```
DEAR TESTER! AN ERROR OCCURRED... PLEASE INCLUDE THE FOLLOWING OUTPUT AS ADDITIONAL INFORMATION IN YOUR BUG REPORT.

ilTemplateException thrown with message "Cannot find this block"tbl_content'"

Stacktrace:
#11 ilTemplateException in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/UICore/lib/html-it/IT.php:566
#10 HTML_Template_IT:setCurrentBlock in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/UICore/classes/class.ilTemplate.php:194
#9 ilTemplate:setCurrentBlock in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/Table/classes/class.ilTable2GUI.php:1356
#8 ilTable2GUI:getHTML in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/Filesystem/classes/class.ilFileSystemGUI.php:511
#7 ilFileSystemGUI:listFiles in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/Filesystem/classes/class.ilFileSystemGUI.php:232
#6 ilFileSystemGUI:executeCommand in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/UICore/classes/class.ilCtrl.php:119
#5 ilCtrl:forwardCommand in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php:123
#4 ilObjSAHSLearningModuleGUI:executeCommand in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/UICore/classes/class.ilCtrl.php:119
#3 ilCtrl:forwardCommand in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/ScormAicc/Editing/classes/class.ilSAHSEditGUI.php:119
#2 ilSAHSEditGUI:executeCommand in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/UICore/classes/class.ilCtrl.php:119
#1 ilCtrl:forwardCommand in /srv/www/test10.ilias.de/html/ilias/components/ILIAS/UICore/classes/class.ilCtrl.php:92
#0 ilCtrl:callBaseClass in /srv/www/test10.ilias.de/html/ilias/public/ilias.php:32
```

If approved, this has to be picked to `trunk`.

Mantis Issue: https://mantis.ilias.de/view.php?id=45025