### PR TITLE
UI: Tagify.js No Without min

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -835,7 +835,7 @@ class Renderer extends AbstractComponentRenderer
     public function registerResources(ResourceRegistry $registry): void
     {
         parent::registerResources($registry);
-        $registry->register('assets/js/tagify.min.js');
+        $registry->register('assets/js/tagify.js');
         $registry->register('assets/css/tagify.css');
         $registry->register('assets/js/tagInput.js');
 


### PR DESCRIPTION
Dear UI coordinators

There is a small change in the tagify-library, so that it is now saved without the "min" in its name.

Best,
@kergomard 