### PR TITLE
[FIX] 0044037: Repository object plugins are not listed in "add new object" modal

### DIFF
--- a/components/ILIAS/Component/classes/class.ilComponentInfo.php
+++ b/components/ILIAS/Component/classes/class.ilComponentInfo.php
@@ -14,8 +14,7 @@
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
 
 declare(strict_types=1);
 
@@ -25,9 +24,10 @@ declare(strict_types=1);
 class ilComponentInfo
 {
     // TODO: to be replaced with an enum for PHP 8.1...
-    public const TYPES = ["components/ILIAS"];
+    public const TYPE_COMPONENT = "components/ILIAS";
     public const TYPE_MODULES = "Modules";
     public const TYPE_SERVICES = "Services";
+    public const TYPES = [self::TYPE_COMPONENT];
 
     protected string $id;
     protected string $type;

--- a/components/ILIAS/Repository/Administration/class.ilObjRepositorySettings.php
+++ b/components/ILIAS/Repository/Administration/class.ilObjRepositorySettings.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilObjRepositorySettings
@@ -155,17 +155,18 @@ class ilObjRepositorySettings extends ilObject
         global $DIC;
 
         $component_repository = $DIC["component.repository"];
+        /** @var ilObjectDefinition $objDefinition */
         $objDefinition = $DIC["objDefinition"];
 
         $res = [];
 
         // parse modules
         foreach ($component_repository->getComponents() as $mod) {
-            if ($mod->getType() !== ilComponentInfo::TYPE_MODULES) {
+            if (!in_array($mod->getType(), ilComponentInfo::TYPES, true)) {
                 continue;
             }
             $has_repo = false;
-            $rep_types = $objDefinition->getRepositoryObjectTypesForComponent(ilComponentInfo::TYPE_MODULES, $mod->getName());
+            $rep_types = $objDefinition->getRepositoryObjectTypesForComponent(ilComponentInfo::TYPE_COMPONENT, $mod->getName());
             if (count($rep_types) > 0) {
                 foreach ($rep_types as $ridx => $rt) {
                     // we only want to display repository modules


### PR DESCRIPTION
This fixes mantis issue https://mantis.ilias.de/view.php?id=44037

I assigned both @klees and @alex40724 since I made changes in two components for this. maybe there is a better solution