### PR TITLE
T&A Use htmlspecialchars for answer output in correction statistics gui

### DIFF
--- a/Modules/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
@@ -141,7 +141,7 @@ class ilAnswerFrequencyStatisticTableGUI extends ilTable2GUI
     public function fillRow(array $a_set): void
     {
         $this->tpl->setCurrentBlock('answer');
-        $this->tpl->setVariable('ANSWER', ilHtmlPurifierFactory::getInstanceByType('qpl_usersolution')->purify($a_set['answer']));
+        $this->tpl->setVariable('ANSWER', htmlspecialchars((string) $a_set['answer'], ENT_QUOTES));
         $this->tpl->parseCurrentBlock();
 
         $this->tpl->setCurrentBlock('frequency');


### PR DESCRIPTION
This PR is related to Mantis-Ticket https://mantis.ilias.de/view.php?id=44305

This PR replaces the use of `ilHtmlPurifierFactory` with the native `htmlspecialchars` function. The change ensures that HTML tags are preserved in the output rather than being stripped, aligning with the intended display behavior.

If merged, this must be cherry-picked into release_10 and trunk

Best,
@thojou 