### PR TITLE
Introducing Activities

### DIFF
--- a/cli/entry_point.php
+++ b/cli/entry_point.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+$info = <<<INFO
+Hello there.
+
+This calls an arbitrary entrypoint of ILIAS for testing purpose. For more informations
+about entrypoints, have a look into `components/ILIAS/Component/src/EntryPoint.php`.
+
+INFO;
+
+if (count($argv) !== 3) {
+    echo $info;
+    die("php cli/entry_point.php \$bootstrap \$name\n");
+}
+
+$bootstrap = $argv[1];
+$entry_point = $argv[2];
+
+require_once(__DIR__ . "/../artifacts/bootstrap_$bootstrap.php");
+
+exit(entry_point($entry_point));

--- a/components/ILIAS/Component/Component.php
+++ b/components/ILIAS/Component/Component.php
@@ -32,7 +32,18 @@ class Component implements Component\Component
         array | \ArrayAccess &$pull,
         array | \ArrayAccess &$internal,
     ): void {
+        $define[] = Component\Activities\Repository::class;
+
+        $implement[Component\Activities\Repository::class] = static fn() =>
+            new Component\Activities\StaticRepository(
+                $seek[Component\Activities\Activity::class]
+            );
+
         $contribute[Component\EntryPoint::class] = static fn() => new Component\EntryPoint\HelloWorld("Component/HelloWorld");
+        $contribute[Component\EntryPoint::class] = static fn() =>
+            new Component\Activities\ListActivitiesEntryPoint(
+                $use[Component\Activities\Repository::class]
+            );
 
         $contribute[\ILIAS\Setup\Agent::class] = static fn() =>
             new \ilComponentsSetupAgent(

--- a/components/ILIAS/Component/src/Activities/Activity.php
+++ b/components/ILIAS/Component/src/Activities/Activity.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Component\Activities;
+
+use ILIAS\Component\Dependencies\Name;
+use ILIAS\UI\Component\Input\Control\Form\FormInput;
+use ILIAS\Data\Result;
+use ILIAS\Data\Text;
+
+/**
+ * An Activity is an action on the domain layer action of a component.
+ *
+ * This defines the interface to any activity. When implementing Activities,
+ * you should use one of these base classes:
+ *
+ *
+ *
+ */
+interface Activity
+{
+    /**
+     * Shall return classname of the Activity, wrapped in Name.
+     */
+    public function getName(): Name;
+
+    public function getType(): ActivityType;
+
+    public function getDescription(): Text\SimpleDocumentMarkdown;
+
+    public function getInputDescription(): FormInput; // might better be ILIAS/UI/Input/Input, but we would need to promote many properties there before.
+
+    /**
+     * This shall check if the given user is allowed to perform the activity based
+     * on business rules of this component. This shall, for example, check if the
+     * given user may add this other user to a course based on RBAC and position
+     * permissions, but this shall not check overall business rules such as: root
+     * may do everything. This shall not cause any observable side effects.
+     *
+     * @param mixed $parameters whatever the `FormInput` from `getInputDescription` produces.
+     */
+    public function isAllowedToPerform(int $usr_id, mixed $parameters): bool;
+
+    /**
+     * This shall perform the activity. This shall not check if a user is allowed to perform the activity.
+     *
+     * @throws any SPL Exception (https://www.php.net/manual/en/spl.exceptions.php)
+     * @param mixed $parameters whatever the `FormInput` from `getInputDescription` produces.
+     */
+    public function perform(mixed $parameters): mixed;
+
+    /**
+     * Grinds the $raw_parameters through the input description, checks if the users
+     * is allowed to perform the action as requested and, if so, then attempts to
+     * performs it. Wraps the result and possible errors in the `Result` type.
+     */
+    public function maybePerformAs(int $usr_id, array $raw_parameters): Result;
+}

--- a/components/ILIAS/Component/src/Activities/Activity.php
+++ b/components/ILIAS/Component/src/Activities/Activity.php
@@ -24,6 +24,7 @@ use ILIAS\Component\Dependencies\Name;
 use ILIAS\UI\Component\Input\Control\Form\FormInput;
 use ILIAS\Data\Result;
 use ILIAS\Data\Text;
+use ILIAS\Data\Description;
 
 /**
  * An Activity is an action on the domain layer action of a component.
@@ -47,6 +48,8 @@ interface Activity
 
     public function getInputDescription(): FormInput; // might better be ILIAS/UI/Input/Input, but we would need to promote many properties there before.
 
+    public function getOutputDescription(Description\Factory $f): Description\Description;
+
     /**
      * This shall check if the given user is allowed to perform the activity based
      * on business rules of this component. This shall, for example, check if the
@@ -59,7 +62,9 @@ interface Activity
     public function isAllowedToPerform(int $usr_id, mixed $parameters): bool;
 
     /**
-     * This shall perform the activity. This shall not check if a user is allowed to perform the activity.
+     * This shall perform the activity. This shall not check if a user is allowed to
+     * perform the activity. The returned data should match the Description given by
+     * `getOutputDescription`.
      *
      * @throws any SPL Exception (https://www.php.net/manual/en/spl.exceptions.php)
      * @param mixed $parameters whatever the `FormInput` from `getInputDescription` produces.

--- a/components/ILIAS/Component/src/Activities/ActivityImpl.php
+++ b/components/ILIAS/Component/src/Activities/ActivityImpl.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Component\Activities;
+
+/**
+ * Basic Implementation for Activities. Use Command or Query for more speficism
+ * instead.
+ */
+abstract class ActivityImpl implements Activity
+{
+    public function getName(): \ILIAS\Component\Dependencies\Name
+    {
+        return new \ILIAS\Component\Dependencies\Name(static::class);
+    }
+}

--- a/components/ILIAS/Component/src/Activities/ActivityType.php
+++ b/components/ILIAS/Component/src/Activities/ActivityType.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Component\Activities;
+
+enum ActivityType: string
+{
+    case Command = "command";
+    case Query = "query";
+}

--- a/components/ILIAS/Component/src/Activities/ListActivitiesEntryPoint.php
+++ b/components/ILIAS/Component/src/Activities/ListActivitiesEntryPoint.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Component\Activities;
+
+use ILIAS\Component\EntryPoint;
+use ILIAS\Component\Component;
+
+/**
+ * A simple entrypoint that just says hello, for testing and documentation
+ * purpose.
+ */
+class ListActivitiesEntryPoint extends EntryPoint\Base
+{
+    public function __construct(
+        protected Repository $repository
+    ) {
+        parent::__construct(self::class);
+    }
+
+    public function enter(): int
+    {
+        echo join("\n", array_keys(iterator_to_array($this->repository->getActivitiesByName("/.*/"))));
+        echo "\n";
+        return 0;
+    }
+}

--- a/components/ILIAS/Component/src/Activities/Query.php
+++ b/components/ILIAS/Component/src/Activities/Query.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Component\Activities;
+
+/**
+ * Basic class for Queries.
+ */
+abstract class Query extends ActivityImpl
+{
+    public function getType(): \ILIAS\Component\Activities\ActivityType
+    {
+        return ActivityType::Query;
+    }
+}

--- a/components/ILIAS/Component/src/Activities/README.md
+++ b/components/ILIAS/Component/src/Activities/README.md
@@ -1,0 +1,190 @@
+# Activities
+
+## Abstract
+
+The aim of the facilities in this folder is to allow to build a discernible layer
+where developers can find "Activities" with objects and services in the system.
+
+**An Activity is a way in which a user would want to use our system or the a
+subsystem thereof.** Hence, Activities target the domain layer of our system
+and the various subsystems and make the things that user do there referenceable.
+Examples for activities would be things like: "Create a Course", "Add Members to
+a Group", "Make a Test available.".
+
+These examples, superficially, might look as if they could be mapped onto according
+calls on existing objects, such as `ilObjCourse::create`, `ilParticipants::addMember`
+or `ilObjTest::setOnline`. But in reality this is not the case. When users say they
+want to create a course, they do no only mean to programmatically "Create a ilObjCourse"
+PHP-object. The object needs to be put in the Repository somewhere. Permissions need
+to be checked. Same for "Add Members to a Group". This is what the "Domain" of our
+software is, in difference to the programming that we use to implement that domain.
+
+By explicitly introducing Activities via a common framework, the system and its
+components gain a lot of benefits:
+
+* Activities offer a way to present a domain level API to other developers, webservices
+  and end users in a machine-readable way.
+* Activities offer a documentation in the ILIAS GUI for end users to take advantage
+  of the available services e.g. in webservice integrations or workflow definitions.
+* Activities to maintain such APIs in the components where they arise but still
+  present them to the complete system in a consumer agnostic way.
+
+## Design
+
+From the perspective of a component, every [**Activity**](./Activity.php) is provided
+as the general way to use the component, together with according information and
+facilities to make actual use of the activity. Activities have a name that is the
+class name of the activity. They have a description in markdown format that shall
+give additional information about the Activity that can not be derived from its name.
+Activities describe their input as a FormInput from the UI framework, which is a
+common and widely useful way to talk about user inputs to the system. The central
+functions of any `Activity` are one function to check the permission for a given
+user to perform a certain activity and the method to actually perform it.
+
+Activities are contributed to the system via the [according mechanisms of the
+component framework](docs/development/components-and-directories.md#contribute-to-service-or-functionality).
+Activities can use then use the mechanisms from the component framework to use
+facilities from other components. An Activity can and should also use activities
+from other components, if it requires cooperation from other domains. Depending
+on the case at hand, the implementor should then decide if a permission check for
+the Activity at hand should or should not delegate to checks to sub permissions.
+Any dependency of an Activity should be introduced via dependency injection.
+
+Activities come in two flavors:
+
+* A `Command` changes the state of the system, but does not return data from the
+  system. It can and should of course return information e.g. regarding the success
+  of the state change. And it can and should of course use data from the system
+  to perform the command.
+* A `Query` returns data from the system, but does not induce state changes. A state
+  change is understood as a change in the business data of the system, even queries
+  could e.g. cause entries in logs.
+
+This differentiation is important to allow the system to make various decisions,
+such as:
+
+* If the Activity is performed via an HTTP endpoint: Would it be GET or POST?
+* Can I reorder this sequence of Activities without changing meaning?
+* Can I cache the results of that Activity? Do I expect the same results upon
+  performing the same Activity twice?
+
+That means that implementors of Activities should carefully decide which type an
+Activity actually has to prevent side effects.
+
+The flavors are represented as a property on activities to allow the framework to
+combine activities. Some `Query` that returns a list of users and some `Command`
+that acts on one user could be combined to a `Command` that act on multiple users.
+Facilities to allow for combinations won't be implemented in the first iterations
+on the framework, though.
+
+## Usage
+
+### As User of a Specific Activity
+
+For many use cases you will want to perform a specific activity. A table of members,
+for example, will need a specific `Query` to get the data for this exact table. If
+we want to do something with a row in that table, we also should know which exact
+`Command` it is that should be performed.
+
+For this cases, you most likely should [pull](docs/development/components-and-directories.md#pull-code)
+the required Activity as a dependency into the location where you need it, e.g.
+a GUI class. You will need this exact `Activity` after all, not any similar `Activity`
+or a some stand in.
+
+If the `Activity` at hand is an activity of your component, or some very closely
+related component, you might already have the correct `$parameters` at hand anyway
+and you could use `isAllowedToPerform` and `perform` in appropriate locations. An
+activity "Remove Member" for example, belongs to the component that shows the table
+of members.
+
+If the components are only losely related, you might be better of using `maybePerformAs`
+with the parameters provided as primitives in an array. This method will internally
+mangle the parameters accordingly via the `InputDescription`. This should be more
+robust with regards to changes in the other component, such as changes in internal
+data representation or inputs that are accepted. "Send Mail to Member" for example,
+could be considered an activity from a losely related component for our member table.
+
+### As User of Generic Activities
+
+For some use cases, you won't be interested in any specific `Activity` but instead
+you will want to have access to all activities provided by the system. Just similar
+to the Kitchen Sink, we may want to build an automated documentation about all
+available activities some day.
+
+For this case, you most likely will want to use the [`Repository`](components/ILIAS/Component/src/Activities/Repository.php)
+of activities. The Repository will allow you to select some or all Activities from
+the system.
+
+To deal with a single but generic `Activity` from the `Repository`, keep in mind
+that the input to the `Activity` as described by `getInputDescription` is a quite
+generic tool, although being defined in terms of the UI framework:
+
+* the `FormInput` can be used verbatim to collect input from users via the GUI
+* `FormInput` supports input in JSON format, so it should be simple to use it when
+  serialization comes into play
+* `FormInputs` provide information about the single fields that can be used as
+  a description of the expected inputs
+* `FormInput` can be used to get appropriatly represented data to be used as
+  `$parameters` for `isAllowedToPerform` and `perform` without needing to know
+  the actual content or representation of said data
+
+By using the `Repository` and the information and methods from a single `Activity`,
+you should be able to get a firm grip on each and every `Activity` in the system
+without the requirement to actually know any `Activity` individually.
+
+### As Implementor
+
+Please take the documentation in `Activity` seriously. The methods in every `Activity`
+have a specific relation to each other that need to be maintained to allow the
+coherent usage of activities, be it specific activities or generic activities as
+described above. This e.g. means:
+
+* If an input is accepted by `getInputDescription` it shall not make `isAllowedToPerform` or `perform` crash.
+* `maybePerformAs` shall use `getInputDescription`, `isAllowedToPerform` and `perform`
+ in a very specific pattern.
+* If `getType` is `Query`, perform shouldn't cause side effects.
+
+To simplify the implementation, the documentation for the class lists some base
+classes that could be used for the implementation.
+
+If you have implemented activities for your component you should integrate them
+with the system according to the [existing integration mechanisms](docs/development/components-and-directories.md):
+
+* You should [provide them with as specific name](docs/development/components-and-directories.md#pull-code), so other components can pull them.
+* You should [contribute them to the system](docs/development/components-and-directories.md#contribute-to-service-or-functionality) so generic facilities such as the `Repository` can discover them as well.
+
+## Introduction to the System
+
+Currently (in late 2024), the Activities only exist as an idea in this readme and
+some code to support the usage of them. But this is very thin, as there are no
+actual Activities on the one hand but also no users of the Activities on the other
+hand. We do not aim to implement all possible Activities at once, neither we expect
+that all possible Activities will be implemented ever.
+
+The next phase, after this general idea and the supporting code is approved by the
+community, we aim to:
+
+* implement a webservice interface over the activities
+* pick one specific component (currently we think Study Programme) and implement
+  some useful Activities for the Study Programme
+
+This should showcase how the Activities are useful, but also should provide actual
+value and lay the groundwork to quickly provide more value by adding additional
+activities.
+
+We also will be looking to replace the current SOAP implementation with an Activity
+based implementation and provide the according actions as Activities.
+
+In this process we will also introduce the Activities that we implement into the
+according GUIs to demonstrate how Activities also will provide value from a code
+maintenance perspective.
+
+Once this phase is finished, we will leave it to the community to create further
+momentum. If we can demonstrate the value of the Activities and the connected implementations,
+it will be as easy as never before to expose functionality via webservice. We expect
+to create a win/win situation, where funding will be available for new Activities and
+developers will be eager to move code from GUIs to Activities as well.
+
+We also expect interesting new uses of Activities to arise that could be implemented
+as proof-of-concept components without the ILIAS community as a component provided
+by a vendor, or be included in existing ILIAS infrastructure.

--- a/components/ILIAS/Component/src/Activities/Repository.php
+++ b/components/ILIAS/Component/src/Activities/Repository.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Component\Activities;
+
+interface Repository
+{
+    /**
+     * Get all activities where the name matches the provided regexp.
+     *
+     * @param string $name_matcher as preg_match can understand
+     * @return Iterator<string, Activity> where keys are the name
+     */
+    public function getActivitiesByName(string $name_matcher, ?ActivityType $type = null, ?Range $range = null): \Iterator;
+}

--- a/components/ILIAS/Component/src/Activities/StaticRepository.php
+++ b/components/ILIAS/Component/src/Activities/StaticRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Component\Activities;
+
+class StaticRepository implements Repository
+{
+    protected array $activities = [];
+
+    /**
+     * @param array<Activity> $ativities
+     */
+    public function __construct(
+        array $activities
+    ) {
+        foreach ($activities as $activity) {
+            if (!($activity instanceof Activity)) {
+                throw new \InvalidArgumentException(
+                    "Expected `Activity`, got: " . get_class($activity)
+                );
+            }
+            $this->activities[(string) $activity->getName()] = $activity;
+        }
+    }
+
+    public function getActivitiesByName(string $name_matcher, ?ActivityType $type = null, ?Range $range = null): \Iterator
+    {
+        foreach ($this->activities as $name => $activity) {
+            if (preg_match($name_matcher, $name)) {
+                yield $name => $activity;
+            }
+        }
+    }
+}

--- a/components/ILIAS/Component/tests/Activities/StaticRepositoryTest.php
+++ b/components/ILIAS/Component/tests/Activities/StaticRepositoryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Component\Tests\Activities;
+
+use PHPUnit\Framework\TestCase;
+use ILIAS\Component\Activities\StaticRepository;
+use ILIAS\Component\Activities\Activity;
+use ILIAS\Component\Dependencies\Name;
+
+class StaticRepositoryTest extends TestCase
+{
+    public function testEmptyRepository(): void
+    {
+        $repository = new StaticRepository([]);
+
+        $this->assertEquals([], iterator_to_array($repository->getActivitiesByName("%.*%")));
+    }
+
+    public function testKeyIsName(): void
+    {
+        $name = "\\ILIAS\\Component\\Tests\\SomeActivity";
+
+        $activity = $this->createMock(Activity::class);
+        $activity
+            ->method("getName")
+            ->willReturn(new Name($name));
+
+        $repository = new StaticRepository([$activity]);
+
+        $activities = iterator_to_array($repository->getActivitiesByName("%.*%"));
+
+        $this->assertEquals($activity, $activities[$name]);
+    }
+
+    public function testGetActivitiesByNameNoMatch(): void
+    {
+        $name = "\\ILIAS\\Component\\Tests\\SomeActivity";
+
+        $activity = $this->createMock(Activity::class);
+        $activity
+            ->method("getName")
+            ->willReturn(new Name($name));
+
+        $repository = new StaticRepository([$activity]);
+
+        $activities = iterator_to_array($repository->getActivitiesByName("%Foo%"));
+
+        $this->assertEquals([], $activities);
+    }
+
+    public function testGetActivitiesByNameMatch(): void
+    {
+        $name = "\\ILIAS\\Component\\Tests\\SomeActivity";
+
+        $activity = $this->createMock(Activity::class);
+        $activity
+            ->method("getName")
+            ->willReturn(new Name($name));
+
+        $repository = new StaticRepository([$activity]);
+
+        $activities = iterator_to_array($repository->getActivitiesByName("%.*Some.*%"));
+
+        $this->assertEquals($activity, $activities[$name]);
+    }
+}

--- a/components/ILIAS/Data/README.md
+++ b/components/ILIAS/Data/README.md
@@ -27,6 +27,7 @@ interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 * [HTML Metadata](#htmlmetadata)
 * [OpenGraph Metadata](#opengraphmetadata)
 * [LanguageTag](#languagetag)
+* [Description](#description)
 
 Other examples for data types that could (and maybe should) be added here:
 
@@ -671,3 +672,44 @@ If the given string is no valid tag an exception is thrown.
 The language tag can have several different forms, which are represented with the classes: `Standard`, `Irregular`, `Regular` and `Privateuse`.
 
 The specific meaning of the different language tags can be found in the [RFC](https://www.ietf.org/rfc/bcp/bcp47.txt).
+
+## Description
+
+`Description`s describe generic data structures like lists, objects, maps or primitive
+values, that are likely to be found in every modern programming language. On the one
+hand, a `Description` describes the data contained in these structures, on the other
+hand the structure is enhanced with a human readable description. Finally, the descriptions
+can turn a data structure that fits the `Description` into a canonical form, i.e. a
+form only using standard PHP data structures and known structural elements.
+
+The general idea of the descriptions is that they are supposed to offer a hook into
+output of the system, to allow ILIAS components to transform this outputs into a
+suitable form. `Description`s thus supply a tightly controlled vocabulary to talk
+about data structures that should allow it to transform the data into many formats
+(such as JSON) and move it to other systems via appropriate interfaces. The current
+use case that called for this vocabulary were the Webservice component and the Activities
+it uses to integrate with ILIAS components. Other use cases that require some form of
+serialisation, e.g. a command bus, are imaginable and could be build onto this abstraction.
+
+
+```php
+<?php
+
+$f = new \ILIAS\Data\Factory;
+$df = $f->description();
+$md = fn($t) => $f->text()->markdown()->simpleDocument($t);
+
+$describes_an_object = $df->object(
+    $md("Some object with fields..."),
+    [
+        "name" => $df->string(
+            $md("The name of the thingy...")
+        ),
+        "integers" => $df->list(
+            $md("Just some integers"),
+            $df->int($md("Represents nothing"))
+        )
+    ]
+);
+
+?>

--- a/components/ILIAS/Data/src/Description/DList.php
+++ b/components/ILIAS/Data/src/Description/DList.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Description;
+
+use ILIAS\Data\Text;
+
+class DList extends Description
+{
+    use ErrorHandling;
+
+    public function __construct(
+        Text\SimpleDocumentMarkdown $description,
+        protected Description $value_type
+    ) {
+        parent::__construct($description);
+    }
+
+    public function getPrimitiveRepresentation(mixed $data): mixed
+    {
+        if (!is_array($data)) {
+            return fn() => yield "Expected an array.";
+        }
+
+        $repr = [];
+        $errors = [];
+
+        foreach ($data as $v) {
+            $value = $this->value_type->getPrimitiveRepresentation($v);
+
+            if ($value instanceof \Closure) {
+                $errors[] = $value;
+            } else {
+                $repr[] = $value;
+            }
+        }
+
+        if ($errors) {
+            return $this->mergeErrors($errors);
+        }
+
+        return $repr;
+    }
+
+    public function getValueType(): Description
+    {
+        return $this->value_type;
+    }
+}

--- a/components/ILIAS/Data/src/Description/DMap.php
+++ b/components/ILIAS/Data/src/Description/DMap.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Description;
+
+use ILIAS\Data\Text;
+
+class DMap extends Description
+{
+    use ErrorHandling;
+
+    public function __construct(
+        Text\SimpleDocumentMarkdown $description,
+        protected DValue $key_type,
+        protected Description $value_type
+    ) {
+        parent::__construct($description);
+    }
+
+    public function getPrimitiveRepresentation(mixed $data): mixed
+    {
+        if (!is_array($data)) {
+            return fn() => yield "Expected an array.";
+        }
+
+        $repr = [];
+        $errors = [];
+
+        foreach ($data as $k => $v) {
+            $key = $this->key_type->getPrimitiveRepresentation($k);
+            $value = $this->value_type->getPrimitiveRepresentation($v);
+
+            $key_is_error = $key instanceof \Closure;
+            $value_is_error = $value instanceof \Closure;
+
+            if ($key_is_error) {
+                $errors[] = $key;
+            }
+            if ($value_is_error) {
+                $errors[] = $value;
+            }
+
+            if (!$key_is_error && !$value_is_error) {
+                $repr[$key] = $value;
+            }
+        }
+
+        if ($errors) {
+            return $this->mergeErrors($errors);
+        }
+
+        return $repr;
+    }
+
+    public function getKeyType(): DValue
+    {
+        return $this->key_type;
+    }
+
+    public function getValueType(): Description
+    {
+        return $this->value_type;
+    }
+}

--- a/components/ILIAS/Data/src/Description/DObject.php
+++ b/components/ILIAS/Data/src/Description/DObject.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Description;
+
+use ILIAS\Data\Text;
+
+class DObject extends Description
+{
+    use ErrorHandling;
+
+    protected array $fields;
+
+    public function __construct(
+        Text\SimpleDocumentMarkdown $description,
+        Field ...$fields
+    ) {
+        parent::__construct($description);
+        $this->fields = $fields;
+    }
+
+    public function getFields(): \Generator
+    {
+        foreach ($this->fields as $field) {
+            yield $field;
+        }
+    }
+
+    public function getPrimitiveRepresentation(mixed $data): mixed
+    {
+        if (!is_object($data)) {
+            return fn() => yield "Expected an object.";
+        }
+
+        $repr = new \StdClass();
+        $errors = [];
+
+        foreach ($this->fields as $field) {
+            $name = $field->getName();
+            $found = false;
+            $value = null;
+            foreach ($this->possibleMethodNames($name) as $method) {
+                if (method_exists($data, $method)) {
+                    $found = true;
+                    $value = $data->$method();
+                    break;
+                }
+            }
+            if (!$found) {
+                foreach ($this->possiblePropertyNames($name) as $property) {
+                    if (property_exists($data, $property)) {
+                        $found = true;
+                        $value = $data->$property;
+                        break;
+                    }
+                }
+            }
+            if (!$found) {
+                $errors[] = fn() => yield "Object does not have property \"$name\".";
+                continue;
+            }
+
+            $value = $field->getType()->getPrimitiveRepresentation($value);
+            if ($value instanceof \Closure) {
+                $errors[] = $value;
+            } else {
+                $repr->$name = $value;
+            }
+
+        }
+
+        if ($errors) {
+            die("foo");
+            return $this->mergeErrors($errors);
+        }
+
+        return $repr;
+    }
+
+    protected function possibleMethodNames(string $name): \Generator
+    {
+        $camel_cased = $this->camelCased($name);
+        $snake_cased = $this->snakeCased($name);
+
+        yield "get" . ucfirst($name);
+        yield "get_" . $name;
+        yield "get" . $camel_cased;
+        yield "get_" . $snake_cased;
+        yield "is" . ucfirst($name);
+        yield "is_" . $name;
+        yield "is" . $camel_cased;
+        yield "is_" . $snake_cased;
+    }
+
+    protected function possiblePropertyNames(string $name): \Generator
+    {
+        yield $name;
+        yield ucfirst($name);
+        yield $this->camelCased($name);
+        yield $this->snakeCased($name);
+    }
+
+
+    protected function camelCased(string $name): string
+    {
+        return preg_replace_callback("/_(\w)/", fn($v) => strtoupper($v[1]), $name);
+    }
+
+    protected function snakeCased(string $name): string
+    {
+        return preg_replace_callback("/[A-Z]/", fn($v) => "_" . strtolower($v[0]), $name);
+    }
+}

--- a/components/ILIAS/Data/src/Description/DValue.php
+++ b/components/ILIAS/Data/src/Description/DValue.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Description;
+
+use ILIAS\Data\Text;
+
+class DValue extends Description
+{
+    public function __construct(
+        Text\SimpleDocumentMarkdown $description,
+        protected ValueType $type,
+    ) {
+        parent::__construct($description);
+    }
+
+    public function getType(): ValueType
+    {
+        return $this->type;
+    }
+
+    public function getPrimitiveRepresentation(mixed $data): mixed
+    {
+        switch ($this->type) {
+            case ValueType::INT:
+                if (!is_int($data)) {
+                    return fn() => yield "Expected an integer.";
+                }
+                return $data;
+
+            case ValueType::FLOAT:
+                if (!is_float($data)) {
+                    return fn() => yield "Expected a float.";
+                }
+                return $data;
+
+            case ValueType::STRING:
+                if (!is_string($data)) {
+                    return fn() => yield "Expected a string.";
+                }
+                return $data;
+
+            case ValueType::DATETIME:
+                if (!$data instanceof \DateTimeImmutable) {
+                    return fn() => yield "Expected a \\DateTimeImmutable.";
+                }
+                return $data;
+
+            case ValueType::BOOL:
+                if (!is_bool($data)) {
+                    return fn() => yield "Expected a bool.";
+                }
+                return $data;
+
+            case ValueType::NULL:
+                if (!is_null($data)) {
+                    return fn() => yield "Expected null.";
+                }
+                return $data;
+
+            default:
+                throw new \LogicException("Unmatch type.");
+        }
+    }
+}

--- a/components/ILIAS/Data/src/Description/Description.php
+++ b/components/ILIAS/Data/src/Description/Description.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Description;
+
+use ILIAS\Data\Text;
+
+/**
+ * This describes some datastructure in terms of standard data structures such as
+ * primitives, lists, maps and objects and helpful (hopefully...) human readable
+ * texts.
+ * The class is not to be derived but instead acts as a common base class for all
+ * classes Description\D* in the subfolder. The set of Description\D* classes is fixed.
+ */
+abstract class Description
+{
+    public function __construct(
+        protected ?Text\SimpleDocumentMarkdown $description,
+    ) {
+    }
+
+    public function getDescription(): ?Text\SimpleDocumentMarkdown
+    {
+        return $this->description;
+    }
+
+    /**
+     * Each of the types that can be described has a canonical representation created
+     * from primitive PHP types. This attempts to transform the provided data into
+     * such a representation.
+     *
+     * If this returns a \Closure, the data cannot be transformed into such a
+     * representation and the \Closure will produce a generator that provides a
+     * list of defects where $data does not match the description. If this does
+     * return something else it will be plain old php data according to the description.
+     */
+    abstract public function getPrimitiveRepresentation(mixed $data): mixed;
+
+    public function matches(mixed $data): bool
+    {
+        if ($this->getPrimitiveRepresentation($data) instanceof \Generator) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/components/ILIAS/Data/src/Description/ErrorHandling.php
+++ b/components/ILIAS/Data/src/Description/ErrorHandling.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Description;
+
+trait ErrorHandling
+{
+    protected function mergeErrors(array &$errors): \Closure
+    {
+        return function () use (&$errors) {
+            foreach ($errors as $errs) {
+                foreach ($errs() as $e) {
+                    yield $e;
+                }
+            }
+        };
+    }
+}

--- a/components/ILIAS/Data/src/Description/Factory.php
+++ b/components/ILIAS/Data/src/Description/Factory.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Description;
+
+use ILIAS\Data\Text\SimpleDocumentMarkdown;
+
+class Factory
+{
+    public function int(SimpleDocumentMarkdown $description): Description
+    {
+        return new DValue($description, ValueType::INT);
+    }
+
+    public function float(SimpleDocumentMarkdown $description): Description
+    {
+        return new DValue($description, ValueType::FLOAT);
+    }
+
+    public function string(SimpleDocumentMarkdown $description): Description
+    {
+        return new DValue($description, ValueType::STRING);
+    }
+
+    public function datetime(SimpleDocumentMarkdown $description): Description
+    {
+        return new DValue($description, ValueType::DATETIME);
+    }
+
+    public function bool(SimpleDocumentMarkdown $description): Description
+    {
+        return new DValue($description, ValueType::BOOL);
+    }
+
+    public function null(SimpleDocumentMarkdown $description): Description
+    {
+        return new DValue($description, ValueType::NULL);
+    }
+
+    public function list(SimpleDocumentMarkdown $description, Description $value_type): Description
+    {
+        return new DList($description, $value_type);
+    }
+
+    public function map(SimpleDocumentMarkdown $description, DValue $key_type, Description $value_type): Description
+    {
+        return new DMap($description, $key_type, $value_type);
+    }
+
+    /**
+     * @param array<string, Description> $fields
+     */
+    public function object(SimpleDocumentMarkdown $description, array $fields)
+    {
+        return new DObject($description, ...array_map(
+            fn($k, $v) => new Field($k, $v),
+            array_keys($fields),
+            array_values($fields)
+        ));
+    }
+}

--- a/components/ILIAS/Data/src/Description/Field.php
+++ b/components/ILIAS/Data/src/Description/Field.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Description;
+
+class Field
+{
+    /**
+     * @param string $name needs to match [a-zA-Z](\w|_)+
+     */
+    public function __construct(
+        protected string $name,
+        protected Description $type,
+    ) {
+        if (preg_match("/^[a-zA-Z](\w|_)+$/", $this->name) !== 1) {
+            throw new \InvalidArgumentException("Expected name to match [a-zA-Z](\w|_)+, got \"$name\"");
+        }
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getType(): Description
+    {
+        return $this->type;
+    }
+}

--- a/components/ILIAS/Data/src/Description/ValueType.php
+++ b/components/ILIAS/Data/src/Description/ValueType.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Data\Description;
+
+enum ValueType: string
+{
+    case INT = "int";
+    case FLOAT = "float";
+    case STRING = "string";
+    case DATETIME = "datetime";
+    case BOOL = "bool";
+    case NULL = "null";
+}

--- a/components/ILIAS/Data/src/Factory.php
+++ b/components/ILIAS/Data/src/Factory.php
@@ -40,7 +40,7 @@ class Factory
     private ?Meta\Html\Factory $html_metadata_factory = null;
     private ?Meta\Html\OpenGraph\Factory $open_graph_metadata_factory = null;
     private ?Text\Factory $text_factory = null;
-
+    private ?Description\Factory $description_factory = null;
 
     /**
      * Get an ok result.
@@ -236,5 +236,13 @@ class Factory
             );
         }
         return $this->text_factory;
+    }
+
+    public function description(): Description\Factory
+    {
+        if ($this->description_factory === null) {
+            $this->description_factory = new Description\Factory();
+        }
+        return $this->description_factory;
     }
 }

--- a/components/ILIAS/Data/tests/Description/DListTest.php
+++ b/components/ILIAS/Data/tests/Description/DListTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @author  Richard Klees <richard.klees@concepts-and-training.de>
+ */
+
+namespace ILIAS\Data\Description;
+
+use ILIAS\Data\Description\Description;
+use ILIAS\Data\Description\DValue;
+use ILIAS\Data\Description\DList;
+use PHPUnit\Framework\TestCase;
+
+class DListTest extends TestCase
+{
+    protected DList $l;
+    protected Description $v;
+
+    public function setUp(): void
+    {
+        $this->v = $this->createMock(Description::class);
+        $this->l = new DList(
+            $this->createMock(\ILIAS\Data\Text\SimpleDocumentMarkdown::class),
+            $this->v
+        );
+    }
+
+    /**
+     * @dataProvider obviousNoMatchProvider
+     */
+    public function testObviouslyNotMatching($data): void
+    {
+        $res = $this->l->getPrimitiveRepresentation($data);
+
+        $this->assertInstanceOf(\Closure::class, $res);
+        $errors = iterator_to_array($res());
+        $this->assertCount(1, $errors);
+        $this->assertTrue(is_string($errors[0]));
+    }
+
+    public static function obviousNoMatchProvider(): array
+    {
+        return [
+            [1], ["1"], [null], [true], [new \StdClass()], [new \DateTimeImmutable()]
+        ];
+    }
+
+    public function testEmptyMatches(): void
+    {
+        $res = $this->l->getPrimitiveRepresentation([]);
+
+        $this->assertEquals([], $res);
+    }
+
+    public function testForwardsToSubDescription(): void
+    {
+        $data = ["a","b"];
+
+        $values = ["c", "d"];
+        $this->v->expects($this->exactly(2))
+            ->method("getPrimitiveRepresentation")
+            ->willReturnCallback(function ($v) use (&$values) {
+                array_push($values, $v);
+                return array_shift($values);
+            });
+
+        $expected = ["c", "d"];
+
+        $res = $this->l->getPrimitiveRepresentation($data);
+
+        $this->assertEquals($expected, $res);
+        $this->assertEquals(["a", "b"], $values);
+    }
+
+    public function testFailsOnValueFailure(): void
+    {
+        $data = ["a"];
+
+        $this->v
+            ->method("getPrimitiveRepresentation")
+            ->willReturn(fn() => yield "FAILURE");
+
+        $res = $this->l->getPrimitiveRepresentation($data);
+
+        $this->assertInstanceOf(\Closure::class, $res);
+        $errors = iterator_to_array($res());
+        $this->assertCount(1, $errors);
+        $this->assertTrue(is_string($errors[0]));
+        $this->assertTrue(str_contains($errors[0], "FAILURE"));
+    }
+
+    public function testRenumbersEntrys(): void
+    {
+        $data = [2 => "a", 27 => "b"];
+
+        $this->v
+            ->method("getPrimitiveRepresentation")
+            ->will($this->returnCallback(fn($v) => $v));
+
+        $res = $this->l->getPrimitiveRepresentation($data);
+
+        $expected = ["a", "b"];
+
+        $this->assertEquals($expected, $res);
+        $this->assertNotEquals($data, $res);
+    }
+}

--- a/components/ILIAS/Data/tests/Description/DMapTest.php
+++ b/components/ILIAS/Data/tests/Description/DMapTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @author  Richard Klees <richard.klees@concepts-and-training.de>
+ */
+
+namespace ILIAS\Data;
+
+use ILIAS\Data\Description\Description;
+use ILIAS\Data\Description\DValue;
+use ILIAS\Data\Description\DMap;
+use PHPUnit\Framework\TestCase;
+
+class DMapTest extends TestCase
+{
+    protected DMap $m;
+    protected DValue $k;
+    protected Description $v;
+
+    public function setUp(): void
+    {
+        $this->k = $this->createMock(DValue::class);
+        $this->v = $this->createMock(Description::class);
+        $this->m = new DMap(
+            $this->createMock(\ILIAS\Data\Text\SimpleDocumentMarkdown::class),
+            $this->k,
+            $this->v
+        );
+    }
+
+    /**
+     * @dataProvider obviousNoMatchProvider
+     */
+    public function testObviouslyNotMatching($data): void
+    {
+        $res = $this->m->getPrimitiveRepresentation($data);
+
+        $this->assertInstanceOf(\Closure::class, $res);
+        $errors = iterator_to_array($res());
+        $this->assertCount(1, $errors);
+        $this->assertTrue(is_string($errors[0]));
+    }
+
+    public static function obviousNoMatchProvider(): array
+    {
+        return [
+            [1], ["1"], [null], [true], [new \StdClass()], [new \DateTimeImmutable()]
+        ];
+    }
+
+    public function testEmptyMatches(): void
+    {
+        $res = $this->m->getPrimitiveRepresentation([]);
+
+        $this->assertEquals([], $res);
+    }
+
+    public function testForwardsToSubDescriptions(): void
+    {
+        $data = [
+            "a" => 1,
+            "b" => 2
+        ];
+
+        $keys = ["c", "d"];
+        $this->k->expects($this->exactly(2))
+            ->method("getPrimitiveRepresentation")
+            ->willReturnCallback(function ($v) use (&$keys) {
+                array_push($keys, $v);
+                return array_shift($keys);
+            });
+
+        $values = [3, 4];
+        $this->v->expects($this->exactly(2))
+            ->method("getPrimitiveRepresentation")
+            ->willReturnCallback(function ($v) use (&$values) {
+                array_push($values, $v);
+                return array_shift($values);
+            });
+
+        $expected = [
+            "c" => 3,
+            "d" => 4
+        ];
+
+        $res = $this->m->getPrimitiveRepresentation($data);
+
+        $this->assertEquals($expected, $res);
+        $this->assertEquals(["a", "b"], $keys);
+        $this->assertEquals([1, 2], $values);
+    }
+
+    public function testFailsOnKeyFailure(): void
+    {
+        $data = ["a" => 1];
+
+        $this->v
+            ->method("getPrimitiveRepresentation")
+            ->willReturn(1);
+
+        $this->k
+            ->method("getPrimitiveRepresentation")
+            ->willReturn(fn() => yield "FAILURE");
+
+        $res = $this->m->getPrimitiveRepresentation($data);
+
+        $this->assertInstanceOf(\Closure::class, $res);
+        $errors = iterator_to_array($res());
+        $this->assertCount(1, $errors);
+        $this->assertTrue(is_string($errors[0]));
+        $this->assertTrue(str_contains($errors[0], "FAILURE"));
+    }
+
+    public function testFailsOnValueFailure(): void
+    {
+        $data = ["a" => 1];
+
+        $this->v
+            ->method("getPrimitiveRepresentation")
+            ->willReturn(fn() => yield "FAILURE");
+
+        $this->k
+            ->method("getPrimitiveRepresentation")
+            ->willReturn("a");
+
+        $res = $this->m->getPrimitiveRepresentation($data);
+
+        $this->assertInstanceOf(\Closure::class, $res);
+        $errors = iterator_to_array($res());
+        $this->assertCount(1, $errors);
+        $this->assertTrue(is_string($errors[0]));
+        $this->assertTrue(str_contains($errors[0], "FAILURE"));
+    }
+}

--- a/components/ILIAS/Data/tests/Description/DObjectTest.php
+++ b/components/ILIAS/Data/tests/Description/DObjectTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @author  Richard Klees <richard.klees@concepts-and-training.de>
+ */
+
+namespace ILIAS\Data\Description;
+
+use ILIAS\Data\Description\Description;
+use ILIAS\Data\Description\DValue;
+use ILIAS\Data\Description\ValueType;
+use ILIAS\Data\Description\DObject;
+use ILIAS\Data\Description\Field;
+use PHPUnit\Framework\TestCase;
+
+class DObjectTest extends TestCase
+{
+    /**
+     * @dataProvider simpleObjectsProvider
+     */
+    public function testSimpleObject(string $field, $object, $expected): void
+    {
+        $md = $this->createMock(\ILIAS\Data\Text\SimpleDocumentMarkdown::class);
+        $desc = new DObject(
+            $md,
+            new Field(
+                $field,
+                new DValue(
+                    $this->createMock(\ILIAS\Data\Text\SimpleDocumentMarkdown::class),
+                    ValueType::INT
+                )
+            )
+        );
+
+        $res = $desc->getPrimitiveRepresentation($object);
+
+        if (!is_null($expected)) {
+            $this->assertEquals($expected, $res);
+        } else {
+            $this->assertInstanceOf(\Closure::class, $res);
+            $errors = iterator_to_array($res());
+            $this->assertCount(1, $errors);
+            $this->assertTrue(is_string($errors[0]));
+        }
+    }
+
+    public static function simpleObjectsProvider(): array
+    {
+        $v1 = "value";
+        $o1_a = new class () {
+            public function getValue(): int
+            {
+                return 42;
+            }
+        };
+        $o1_b = new class () {
+            public $value = 42;
+        };
+        $e1 = new \StdClass();
+        $e1->value = 42;
+
+        $v2 = "some_value";
+        $o2_a = new class () {
+            public function getSomeValue(): int
+            {
+                return 23;
+            }
+        };
+        $o2_b = new class () {
+            public $some_value = 23;
+        };
+        $o2_c = new class () {
+            public $someValue = 23;
+        };
+        $e2 = new \StdClass();
+        $e2->some_value = 23;
+
+
+        return [
+            [$v1, $o1_a, $e1],
+            [$v1, $o1_b, $e1],
+            [$v2, $o2_a, $e2],
+            [$v2, $o2_b, $e2],
+            [$v2, $o2_c, $e2],
+        ];
+    }
+
+    /**
+     * @dataProvider fieldNamesProvider
+     */
+    public function testAllowedFieldNames(string $name, bool $is_allowed): void
+    {
+        if (!$is_allowed) {
+            $this->expectException(\InvalidArgumentException::class);
+        }
+
+        $field = new Field($name, $this->createMock(Description::class));
+        $this->assertEquals($name, $field->getName());
+    }
+
+    public static function fieldNamesProvider(): array
+    {
+        return [
+            ["someName", true],
+            ["some_name", true],
+            ["some", true],
+            ["some1", true],
+            ["1some", false],
+            ["some one", false]
+        ];
+    }
+
+    /**
+     * @dataProvider obviousNoMatchProvider
+     */
+    public function testObviouslyNotMatching($data): void
+    {
+        $desc = new DObject(
+            $this->createMock(\ILIAS\Data\Text\SimpleDocumentMarkdown::class)
+        );
+        $res = $desc->getPrimitiveRepresentation($data);
+
+        $this->assertInstanceOf(\Closure::class, $res);
+        $errors = iterator_to_array($res());
+        $this->assertCount(1, $errors);
+        $this->assertTrue(is_string($errors[0]));
+    }
+
+    public static function obviousNoMatchProvider(): array
+    {
+        return [
+            [1], ["1"], [null], [true], [[]]
+        ];
+    }
+}

--- a/components/ILIAS/Data/tests/Description/DValueTest.php
+++ b/components/ILIAS/Data/tests/Description/DValueTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @author  Richard Klees <richard.klees@concepts-and-training.de>
+ */
+
+namespace ILIAS\Data\Description;
+
+use ILIAS\Data\Description\DValue;
+use ILIAS\Data\Description\ValueType;
+use PHPUnit\Framework\TestCase;
+
+class DDValueTest extends TestCase
+{
+    /**
+     * @dataProvider casesProvider
+     */
+    public function testIntRepresentation(ValueType $type, $value, $is_match): void
+    {
+        $desc = new DValue(
+            $this->createMock(\ILIAS\Data\Text\SimpleDocumentMarkdown::class),
+            $type
+        );
+
+        $res = $desc->getPrimitiveRepresentation($value);
+
+        if ($is_match) {
+            $this->assertEquals($value, $res);
+        } else {
+            $this->assertInstanceOf(\Closure::class, $res);
+            $errors = iterator_to_array($res());
+            $this->assertCount(1, $errors);
+            $this->assertTrue(is_string($errors[0]));
+        }
+    }
+
+    public static function casesProvider(): array
+    {
+        return [
+            [ValueType::INT, 42, true],
+            [ValueType::INT, "foo", false],
+            [ValueType::FLOAT, 2.3, true],
+            [ValueType::FLOAT, "foo", false],
+            [ValueType::STRING, "foo", true],
+            [ValueType::STRING, 2, false],
+            [ValueType::DATETIME, new \DateTimeImmutable(), true],
+            [ValueType::DATETIME, "foo", false],
+            [ValueType::BOOL, true, true],
+            [ValueType::BOOL, false, true],
+            [ValueType::BOOL, "true", false],
+            [ValueType::BOOL, 1, false],
+            [ValueType::BOOL, null, false],
+            [ValueType::NULL, null, true],
+            [ValueType::NULL, false, false],
+        ];
+    }
+}

--- a/components/ILIAS/Data/tests/Description/FactoryTest.php
+++ b/components/ILIAS/Data/tests/Description/FactoryTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+/**
+ * @author  Richard Klees <richard.klees@concepts-and-training.de>
+ */
+
+namespace ILIAS\Data\Description;
+
+use ILIAS\Data\Description\Factory;
+use ILIAS\Data\Description\Description;
+use ILIAS\Data\Description\DValue;
+use ILIAS\Data\Description\ValueType;
+use ILIAS\Data\Description\DList;
+use ILIAS\Data\Description\DMap;
+use ILIAS\Data\Description\DObject;
+use PHPUnit\Framework\TestCase;
+
+class FactoryTest extends TestCase
+{
+    protected Factory $f;
+    protected \ILIAS\Data\Text\SimpleDocumentMarkdown $md;
+
+    public function setUp(): void
+    {
+        $this->f = new Factory();
+        $this->md = $this->createMock(\ILIAS\Data\Text\SimpleDocumentMarkdown::class);
+    }
+
+    public function testInt(): void
+    {
+        $value = $this->f->int($this->md);
+
+        $this->assertInstanceOf(Description::class, $value);
+        $this->assertInstanceOf(DValue::class, $value);
+        $this->assertEquals(ValueType::INT, $value->getType());
+    }
+
+    public function testFloat(): void
+    {
+        $value = $this->f->float($this->md);
+
+        $this->assertInstanceOf(Description::class, $value);
+        $this->assertInstanceOf(DValue::class, $value);
+        $this->assertEquals(ValueType::FLOAT, $value->getType());
+    }
+
+    public function testString(): void
+    {
+        $value = $this->f->string($this->md);
+
+        $this->assertInstanceOf(Description::class, $value);
+        $this->assertInstanceOf(DValue::class, $value);
+        $this->assertEquals(ValueType::STRING, $value->getType());
+    }
+
+    public function testDateTime(): void
+    {
+        $value = $this->f->datetime($this->md);
+
+        $this->assertInstanceOf(Description::class, $value);
+        $this->assertInstanceOf(DValue::class, $value);
+        $this->assertEquals(ValueType::DATETIME, $value->getType());
+    }
+
+    public function testBool(): void
+    {
+        $value = $this->f->bool($this->md);
+
+        $this->assertInstanceOf(Description::class, $value);
+        $this->assertInstanceOf(DValue::class, $value);
+        $this->assertEquals(ValueType::BOOL, $value->getType());
+    }
+
+    public function testNull(): void
+    {
+        $value = $this->f->null($this->md);
+
+        $this->assertInstanceOf(Description::class, $value);
+        $this->assertInstanceOf(DValue::class, $value);
+        $this->assertEquals(ValueType::NULL, $value->getType());
+    }
+
+    public function testList(): void
+    {
+        $value = $this->f->string($this->md);
+        $list = $this->f->list($this->md, $value);
+
+        $this->assertInstanceOf(Description::class, $list);
+        $this->assertInstanceOf(DList::class, $list);
+        $this->assertEquals($value, $list->getValueType());
+    }
+
+    public function testMap(): void
+    {
+        $key = $this->f->string($this->md);
+        $value = $this->f->string($this->md);
+        $map = $this->f->map($this->md, $key, $value);
+
+        $this->assertInstanceOf(Description::class, $map);
+        $this->assertInstanceOf(DMap::class, $map);
+        $this->assertEquals($key, $map->getKeyType());
+        $this->assertEquals($value, $map->getValueType());
+    }
+
+    public function testObject(): void
+    {
+        $f1_type = $this->f->int($this->md);
+        $f1_name = "field1";
+        $f2_type = $this->f->float($this->md);
+        $f2_name = "field2";
+        $object = $this->f->object($this->md, [$f1_name => $f1_type, $f2_name => $f2_type]);
+
+        $this->assertInstanceOf(Description::class, $object);
+        $this->assertInstanceOf(DObject::class, $object);
+        [$f1, $f2] = iterator_to_array($object->getFields());
+        $this->assertEquals($f1_name, $f1->getName());
+        $this->assertEquals($f1_type, $f1->getType());
+        $this->assertEquals($f2_name, $f2->getName());
+        $this->assertEquals($f2_type, $f2->getType());
+    }
+}

--- a/components/ILIAS/Setup/Setup.php
+++ b/components/ILIAS/Setup/Setup.php
@@ -54,6 +54,9 @@ class Setup implements Component\Component
         $implement[\ILIAS\Setup\AgentFinder::class] = static fn(): \ILIAS\Setup\ImplementationOfAgentFinder =>
                 $internal["agent_finder"];
 
+        $contribute[\ILIAS\Component\Activities\Activity::class] = static fn() =>
+            new \ILIAS\Setup\Activities\GetStatus();
+
         $internal["command.install"] = static fn() =>
             new \ILIAS\Setup\CLI\InstallCommand(
                 $internal["agent_finder"],

--- a/components/ILIAS/Setup/src/Activities/GetStatus.php
+++ b/components/ILIAS/Setup/src/Activities/GetStatus.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Setup\Activities;
+
+use ILIAS\Component\Dependencies\Name;
+use ILIAS\UI\Component\Input\Control\Form\FormInput;
+use ILIAS\Data\Result;
+
+class GetStatus extends \ILIAS\Component\Activities\Query
+{
+    public function getDescription(): string
+    {
+    }
+
+    public function getInputDescription(): \ILIAS\UI\Component\Input\Control\Form\FormInput
+    {
+    }
+
+    public function isAllowedToPerform(int $usr_id, mixed $parameters): bool
+    {
+    }
+
+    public function perform(mixed $parameters): mixed
+    {
+    }
+
+    public function maybePerformAs(int $usr_id, array $raw_parameters): Result
+    {
+    }
+}

--- a/components/ILIAS/Setup/src/Activities/GetStatus.php
+++ b/components/ILIAS/Setup/src/Activities/GetStatus.php
@@ -23,14 +23,22 @@ namespace ILIAS\Setup\Activities;
 use ILIAS\Component\Dependencies\Name;
 use ILIAS\UI\Component\Input\Control\Form\FormInput;
 use ILIAS\Data\Result;
+use ILIAS\Data\Text;
 
+/**
+ * This is a stub...
+ */
 class GetStatus extends \ILIAS\Component\Activities\Query
 {
-    public function getDescription(): string
+    public function getDescription(): Text\SimpleDocumentMarkdown
     {
     }
 
     public function getInputDescription(): \ILIAS\UI\Component\Input\Control\Form\FormInput
+    {
+    }
+
+    public function getOutputDescription(\ILIAS\Data\Description\Factory $f): \ILIAS\Data\Description\Description
     {
     }
 


### PR DESCRIPTION
Dear colleagues,

I talked and wrote about Activities quite often now =)

This will finally add the code to the core that will make the idea actually happen. Quick rundown of the stuff contained in here:

* implementation of [`Activities` as described in the project](https://docu.ilias.de/go/wiki/wpage_8112_1357)
* implementation of a repository to get hold of these activities
* a stub for an activity and some minimal infrastructure to actually instantiate that activity. Call `php cli/entry_point.php default ILIAS\\Component\\Activities\\ListActivitiesEntryPoint` to get a list of all activities known to the system.
* a mildly elaborate framework to describe generic data (as required for the activities in the context of webservice, at least)

The gist of all this is described in the [paper](https://github.com/ILIAS-eLearning/ILIAS/pull/9534/files#diff-484aba0fe4333c64be984bc134939b3383038882ed627edf117d0c732f26cbce) included here. The implementation has been developed in tight coordination with @jeph864, who is looking to build web services on this.

I will shortly present this on the JF 2025-05-12 and then leave it open for feedback and questions for about two weeks.

Kind regards!
