### PR TITLE
Read and process ecs events in own cron run

### DIFF
--- a/components/ILIAS/WebServices/ECS/classes/class.ilECSEventQueueReader.php
+++ b/components/ILIAS/WebServices/ECS/classes/class.ilECSEventQueueReader.php
@@ -275,11 +275,13 @@ class ilECSEventQueueReader
     {
         try {
             $connector = new ilECSConnector($this->getServer());
-            while (true) {
+            $read_more_events = true;
+            while ($read_more_events) {
                 $res = $connector->readEventFifo(false);
 
                 if (!count($res->getResult())) {
-                    return;
+                    $read_more_events = false;
+                    continue;
                 }
 
                 foreach ($res->getResult() as $result) {
@@ -298,6 +300,7 @@ class ilECSEventQueueReader
         } catch (ilECSConnectorException $e) {
             $this->logger->error(__METHOD__ . ': Cannot read event fifo. Aborting');
         }
+        $this->read();
     }
 
     /**


### PR DESCRIPTION
For historic reasons, the reading of the ecs events from the ecs server and the processing of those has been split. This patch removes this split, which is not needed any more after the transition to a cron based approach.