### PR TITLE
File: do not pass empty format to LOM (43236)

### DIFF
--- a/components/ILIAS/File/classes/trait.ilObjFileMetadata.php
+++ b/components/ILIAS/File/classes/trait.ilObjFileMetadata.php
@@ -160,11 +160,14 @@ trait ilObjFileMetadata
     {
         global $DIC;
 
-        $DIC->learningObjectMetadata()->manipulate($this->getId(), 0, $this->getType())
-                                      ->prepareCreateOrUpdate($this->getPathToSize(), (string) $this->getFileSize())
-                                      ->prepareCreateOrUpdate($this->getPathToFirstFormat(), $this->getFileType())
-                                      ->prepareCreateOrUpdate($this->getPathToVersion(), (string) $this->getVersion())
-                                      ->execute();
+        $manipulator = $DIC->learningObjectMetadata()
+                           ->manipulate($this->getId(), 0, $this->getType())
+                           ->prepareCreateOrUpdate($this->getPathToSize(), (string) $this->getFileSize())
+                           ->prepareCreateOrUpdate($this->getPathToVersion(), (string) $this->getVersion());
+        if ($this->getFileType() !== '') {
+            $manipulator = $manipulator->prepareCreateOrUpdate($this->getPathToFirstFormat(), $this->getFileType());
+        }
+        $manipulator->execute();
     }
 
     /**


### PR DESCRIPTION
This PR fixes [43236](https://mantis.ilias.de/view.php?id=43236) by not passing empty strings as format to the LOM service. I should probably have a look at making the API a bit less fussy in this regard, but that is not super straightforward.

The root cause of the issue is that `ilObjFile::getFileType` gives back an empty string (at least at the time when the object is updated). If that is not the expected behavior, then this should probably be fixed differently.

Cheers, @schmitz-ilias 