### PR TITLE
UI: 43719, adjust language variable for closing...

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Prompt/State/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Prompt/State/Renderer.php
@@ -71,7 +71,7 @@ class Renderer extends AbstractComponentRenderer
         }
 
         $buttons[] = $this->getUIFactory()->button()
-            ->standard($this->txt('close_prompt'), '')
+            ->standard($this->txt('close'), '')
             ->withOnLoadCode(
                 fn($id) => "$('#$id').on('click', (e)=> {
                     let promptId = e.target.closest('dialog').parentNode.id;

--- a/components/ILIAS/UI/src/examples/Prompt/Standard/parameters.php
+++ b/components/ILIAS/UI/src/examples/Prompt/Standard/parameters.php
@@ -68,6 +68,7 @@ function parameters()
                         fn($id) => "$('#$id').on('click', (e)=> {alert('$id');});"
                     )
                 ];
+                \ilSession::set("full_amount", (string) $idx);
                 $prompt_content = $factory->messageBox()->info('some text')
                     ->withLinks($links)
                     ->withButtons($buttons);
@@ -76,7 +77,7 @@ function parameters()
             case 'promptlink':
                 $back_uri = $url_builder
                         ->withParameter($action_token, "showprompt")
-                        ->withParameter($amount_token, (string) $amount)
+                        ->withParameter($amount_token, (string) \ilSession::get("full_amount"))
                         ->buildURI()->__toString();
                 $back = $factory->button()->standard('back', '#')->withOnLoadCode(
                     fn($id) => "$('#$id').on('click', (e)=> {


### PR DESCRIPTION
... a prompt.

Also fix the amount of links shown after using the back button in a prompt.

https://mantis.ilias.de/view.php?id=43719

**Note:** 
The language variable does not need to be named "close_prompt" as there's is already the standard variable "close" for this specific button.