### PR TITLE
44970: Fix Shuffle for Cloze Question in ILIAS Learning Module

### DIFF
--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -662,7 +662,7 @@ ilias.questions.initClozeTest = function(a_id) {
 			input = jQuery.create('select', {'id': a_id+"_"+closecounter, 'class': 'ilc_qinput_ClozeGapSelect'});
 
             let items = questions[a_id].gaps[closecounter].item;
-            if (questions[a_id].shuffle === true) {
+            if (questions[a_id].gaps[closecounter].shuffle === true) {
                 items = shuffleItems(items);
             }
 			for (var i=0;i<items.length;i++) {


### PR DESCRIPTION
This PR is related to Mantis Ticket https://mantis.ilias.de/view.php?id=44970

This update modifies the JavaScript logic to use the shuffle attribute from individual cloze question gaps instead of reading it globally from the entire question. This allows each gap to independently control whether its options are shuffled. Previously, the shuffle state was hardcoded to true for all gaps, limiting flexibility.

Best
@thojou