### PR TITLE
10/Plugins: 44502, template not found for plugins

### DIFF
--- a/components/ILIAS/UICore/classes/class.ilTemplate.php
+++ b/components/ILIAS/UICore/classes/class.ilTemplate.php
@@ -80,7 +80,7 @@ class ilTemplate extends HTML_Template_ITX
 
         $fname = $this->getTemplatePath($file, $in_module);
         if (!file_exists($fname)) {
-            throw new ilTemplateException("Template '$fname' was not found.");
+            throw new ilTemplateException("Template '$fname' was not found.\nfile: " . $file . "\nmodule: " . $in_module);
         }
 
         $this->tplName = basename($fname);
@@ -347,13 +347,21 @@ class ilTemplate extends HTML_Template_ITX
             $a_in_module = rtrim($a_in_module, '/');
         }
 
+        $tpl_sub_path = '/templates/default/';
         if (str_starts_with($a_tplname, 'components/ILIAS/UI/')) {
             $a_in_module = 'components/ILIAS/UI/src';
             $a_tplname = str_replace('components/ILIAS/UI/src/templates/default/', '', $a_tplname);
         }
 
+        if (str_starts_with($a_tplname, $ilias_root)) {
+            $a_tplname = str_replace($ilias_root, '', $a_tplname);
+        }
+        if (strpos($a_tplname, 'public/Customizing/global/plugins')) {
+            $tpl_sub_path = '';
+        }
+
         $base_path = $ilias_root;
-        $default = $base_path . $a_in_module . '/templates/default/' . $a_tplname;
+        $default = $base_path . $a_in_module . $tpl_sub_path . $a_tplname;
 
         $skin = $this->getCurrentSkin();
         if ($skin === 'default') {

--- a/components/ILIAS/UICore/tests/ilTemplateTest.php
+++ b/components/ILIAS/UICore/tests/ilTemplateTest.php
@@ -91,6 +91,12 @@ class ilTemplateTest extends TestCase
                 'component' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/EditorAsMode',
                 'expected' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/EditorAsMode/templates/default/tpl.test.html',
             ],
+            'plugin template_file_no_component' => [
+                'skin' => 'default', 'style' => 'delos', 'file_exists' => true,
+                'tpl_filename' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/global/plugins/Services/User/UDFDefinition/CascadingSelect/templates/tpl.prop_cascading_select.html',
+                'component' => '',
+                'expected' => $il_root . '/components/ILIAS/Component/classes/../../../../public/Customizing/global/plugins/Services/User/UDFDefinition/CascadingSelect/templates/tpl.prop_cascading_select.html',
+            ],
             'custom skin' => [
                 'skin' => 'mySkin', 'style' => 'myStyle', 'file_exists' => true,
                 'tpl_filename' => 'tpl.external_settings.html',


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44502

ilTemplate needs to support a full path to the template (from ilPlugin) and must not amend further parts to the path.