### PR TITLE
LegacyUI: Fix Missing JS on LastTab

### DIFF
--- a/components/ILIAS/JavaScript/resources/Basic.js
+++ b/components/ILIAS/JavaScript/resources/Basic.js
@@ -597,6 +597,34 @@ il.UICore = {
     }
   },
 
+
+  initLastTabDropdown() {
+    const toggle = document.querySelector('#ilLastTab > .dropdown-toggle');
+    const toggler = (e) => {
+      const lastTab = e.target.parentElement;
+      const dropdown = e.target.nextElementSibling;
+
+      if (lastTab.classList.contains('open')) {
+        lastTab.classList.remove('open');
+        lastTab.style.removeProperty('left');
+        return;
+      }
+      lastTab.classList.add('open');
+      const dropdownRight = dropdown?.getBoundingClientRect().right;
+      if (dropdownRight > window.innerWidth) {
+        dropdown.style.left = (window.innerWidth - dropdownRight - 10) + 'px';
+      }
+    };
+    toggle.addEventListener('click', toggler);
+    toggle.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        toggler(e);
+      }
+    });
+  },
+
   initFixedDropDowns() {
     $('.ilMainMenu.ilTopFixed .dropdown').on('shown.bs.dropdown', function () {
       const el = $(this).children('.dropdown-menu')[0];

--- a/components/ILIAS/UIComponent/Tabs/classes/class.ilTabsGUI.php
+++ b/components/ILIAS/UIComponent/Tabs/classes/class.ilTabsGUI.php
@@ -519,6 +519,7 @@ class ilTabsGUI
                 }
             }
 
+            $this->tpl->addOnLoadCode('il.UICore.initLastTabDropdown()');
             return $tpl->get();
         } else {
             return "";

--- a/components/ILIAS/UIComponent/Tabs/templates/default/tpl.tabs.html
+++ b/components/ILIAS/UIComponent/Tabs/templates/default/tpl.tabs.html
@@ -10,7 +10,7 @@
 	<li id="{ID}" class="{TAB_TYPE}">{LINK}<!-- BEGIN sel_text --> <span class="ilAccHidden">({TXT_SELECTED})</span><!-- END sel_text --></li>
 	<!-- END tab -->
 	<li id="ilLastTab">
-		<a class="btn dropdown-toggle ilNoDisplay" data-toggle="dropdown" aria-label="{LAST_TAB_LABEL}" href="#">
+		<a class="btn dropdown-toggle ilNoDisplay" aria-label="{LAST_TAB_LABEL}" href="#">
 			... <span class="caret"></span>
 		</a>
 		<ul class="dropdown-menu" id="ilTabDropDown">


### PR DESCRIPTION
Hi all

This PR is just for visibility. I'm going to just merge it without requiring a shepherd. I thinks this is small enough and it only concerns legacy-ui as it fixes the last tab, when not all tabs-fit the screen. There surely are more beautiful solutions.

See: https://mantis.ilias.de/view.php?id=44817

Best,
@kergomard 