### PR TITLE
Fix missing objective execution

### DIFF
--- a/components/ILIAS/Authentication/classes/Setup/class.ilAuthenticationSetupAgent.php
+++ b/components/ILIAS/Authentication/classes/Setup/class.ilAuthenticationSetupAgent.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\Authentication\Setup\AbandonLoadDependantSessionDatabaseUpdateObjective;
 use ILIAS\Setup;
 use ILIAS\Refinery;
 
@@ -66,7 +67,10 @@ class ilAuthenticationSetupAgent implements Setup\Agent
                 new ilDatabaseUpdateStepsExecutedObjective(
                     new AbandonAuthRichTextEditorDatabaseUpdateSteps()
                 ),
-                new ilSessionMaxIdleIsSetObjective($config)
+                new ilSessionMaxIdleIsSetObjective($config),
+                new ilDatabaseUpdateStepsExecutedObjective(
+                    new AbandonLoadDependantSessionDatabaseUpdateObjective()
+                )
             );
         }
 
@@ -79,6 +83,9 @@ class ilAuthenticationSetupAgent implements Setup\Agent
             new ilDatabaseUpdateStepsExecutedObjective(
                 new AbandonAuthRichTextEditorDatabaseUpdateSteps()
             ),
+            new ilDatabaseUpdateStepsExecutedObjective(
+                new AbandonLoadDependantSessionDatabaseUpdateObjective()
+            )
         );
     }
 


### PR DESCRIPTION
This PR adds the missing executon of a database update objective. We noticed, that this was still missing in the ILIAS 10 beta code.