### PR TITLE
Default-HTML-Frame for Mail in System Style (1/3)

### DIFF
--- a/components/ILIAS/UI/resources/ui-examples/css/mail_examples.css
+++ b/components/ILIAS/UI/resources/ui-examples/css/mail_examples.css
@@ -1,0 +1,122 @@
+.table {
+  background-color: #f0f0f0;
+  width: 100%;
+}
+
+.header {
+  background-color: white;
+  border-bottom: 2px solid #f0f0f0;
+}
+
+.footer {
+  background-color: white;
+}
+
+.image-data {
+  width: 90px;
+}
+
+td.spacing {
+  padding: 20px 0;
+}
+
+.logo {
+  width: 45px;
+  height: 45px;
+  outline-style: none;
+  text-decoration: none;
+  border: none;
+  margin: 0;
+}
+
+.installation-text {
+  vertical-align: middle;
+}
+.installation-text span {
+  border-collapse: collapse;
+  color: #161616;
+  font-family: "Open Sans", Arial, Helvetica, sans-serif;
+  font-size: 16px;
+  line-height: 22px;
+}
+
+.content .spacing {
+  padding: 80px 0;
+}
+
+.content td td {
+  background-color: white;
+}
+
+.text-color {
+  color: #4c6586;
+}
+
+.footer .font-definition {
+  color: #161616;
+}
+
+.font-definition {
+  font-family: "Open Sans", Arial, Helvetica, sans-serif;
+  font-size: 16px;
+  line-height: 22px;
+  padding: 30px;
+}
+
+body {
+  height: 100% !important;
+  margin: 0;
+  padding: 0;
+  width: 100% !important;
+  mso-margin-top-alt: 0px;
+  mso-margin-bottom-alt: 0px;
+  mso-padding-alt: 0px 0px 0px 0px;
+  overflow-y: scroll;
+  -webkit-text-size-adjust: none;
+  -ms-text-size-adjust: none;
+}
+
+.center {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.w-750 {
+  width: 750px;
+}
+
+.link-color {
+  color: #4c6586;
+}
+
+table {
+  mso-table-lspace: 0pt;
+  mso-table-rspace: 0pt;
+}
+
+table, table th, table td {
+  border-collapse: collapse;
+}
+
+a, img, a img {
+  border: 0;
+  outline: none;
+  text-decoration: none;
+}
+
+img {
+  -ms-interpolation-mode: bicubic;
+}
+
+body, table, td, th, p, a, li {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
+@media only screen and (max-width: 760px) {
+  .w-750 {
+    width: 100%;
+  }
+}
+
+/*# sourceMappingURL=mail.css.map */

--- a/components/ILIAS/UI/src/Component/Layout/Page/Factory.php
+++ b/components/ILIAS/UI/src/Component/Layout/Page/Factory.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\Component\Layout\Page;
 
+use ILIAS\UI\Component\Legacy\Content;
+use ILIAS\Data\Link;
 use ILIAS\UI\Component\MainControls\Mainbar;
 use ILIAS\UI\Component\MainControls\MetaBar;
 use ILIAS\UI\Component\Breadcrumbs\Breadcrumbs;
@@ -109,4 +111,43 @@ interface Factory
         string $short_title = '',
         string $view_title = ''
     ): Standard;
+
+    /**
+     * ---
+     * description:
+     *   purpose: The Mail Page is used to render HTML content for mails.
+     *   composition: >
+     *    The Mail Page consists of HTML content, a header and a footer.
+     *    The header contains the logo and the installation-text.
+     *    The footer contains the installation-text and a link to ILIAS.
+     *    The stylesheet path refers to the CSS file that is used to style the page and will be included in the HTML.
+     *
+     * rules:
+     *   usage:
+     *     1: The Mail Page MUST be rendered with content.
+     *     2: >
+     *        The Mail Page MUST be rendered with a logo.
+     *        The logo must be either
+     *        a cid URL (see https://datatracker.ietf.org/doc/html/rfc2392)
+     *        or a data URL (see https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data).
+     *     3: The Mail Page MUST be rendered with a footer.
+     *     4: The Mail Page MUST be rendered with a stylesheet path.
+     *     5: The Header of the Mail Page MUST contain the logo and the installation-text.
+     *     6: The Footer of the Mail Page MUST contain the installation-text and a link to ILIAS.
+     *     7: The Mail Page's stylesheet path MUST include all necessary styles to render the page correctly.
+     * ----
+     * @param string $stylesheet_path
+     * @param string $logo_url
+     * @param string $installation_title
+     * @param \ILIAS\UI\Component\Legacy\Content $html_content
+     * @param Link $footer_url
+     * @return \ILIAS\UI\Component\Layout\Page\Mail
+     */
+    public function mail(
+        string $stylesheet_path,
+        string $logo_url,
+        string $installation_title,
+        Content $html_content,
+        Link $footer_url,
+    ): Mail;
 }

--- a/components/ILIAS/UI/src/Component/Layout/Page/Mail.php
+++ b/components/ILIAS/UI/src/Component/Layout/Page/Mail.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Component\Layout\Page;
+
+/**
+ * This describes the Mail.
+ */
+interface Mail extends Page
+{
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Layout/Page/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Layout/Page/Factory.php
@@ -23,8 +23,10 @@ namespace ILIAS\UI\Implementation\Component\Layout\Page;
 use ILIAS\UI\Component\Breadcrumbs\Breadcrumbs;
 use ILIAS\UI\Component\Image\Image;
 use ILIAS\UI\Component\Layout\Page;
+use ILIAS\Data\Link;
 use ILIAS\UI\Component\MainControls;
 use ILIAS\UI\Component\Toast\Container;
+use ILIAS\UI\Component\Legacy\Content;
 
 class Factory implements Page\Factory
 {
@@ -55,6 +57,22 @@ class Factory implements Page\Factory
             $title,
             $short_title,
             $view_title
+        );
+    }
+
+    public function mail(
+        string $stylesheet_path,
+        string $logo_url,
+        string $installation_title,
+        Content $html_content,
+        Link $footer_url,
+    ): Mail {
+        return new Mail(
+            $stylesheet_path,
+            $logo_url,
+            $installation_title,
+            $html_content,
+            $footer_url,
         );
     }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Layout/Page/Mail.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Layout/Page/Mail.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Layout\Page;
+
+use ILIAS\UI\Component\Layout\Page;
+use ILIAS\UI\Component\Legacy\Content;
+use ILIAS\Data\Link;
+use ILIAS\UI\Implementation\Component\ComponentHelper;
+use ILIAS\UI\Implementation\Component\JavaScriptBindable;
+use InvalidArgumentException;
+
+class Mail implements Page\Mail
+{
+    use ComponentHelper;
+    use JavaScriptBindable;
+
+    public function __construct(
+        protected string $stylesheet_path,
+        protected string $logo_url,
+        protected string $installation_title,
+        protected Content $html_content,
+        protected Link $footer_url,
+    ) {
+        if (!is_readable($this->getStyleSheetPath())) {
+            throw new InvalidArgumentException("Could not read stylesheet at {$this->getStyleSheetPath()}.");
+        }
+
+        if (!str_starts_with($this->getLogoURL(), 'cid:') && !str_starts_with($this->getLogoURL(), 'data:')) {
+            throw new InvalidArgumentException('The logo URL must be a cid or data URL.');
+        }
+    }
+
+    public function getContent(): array
+    {
+        return [
+            $this->html_content,
+        ];
+    }
+
+    public function getLogoURL(): string
+    {
+        return $this->logo_url;
+    }
+
+    public function getInstallationTitle(): string
+    {
+        return $this->installation_title;
+    }
+
+    public function getStyleSheetPath(): string
+    {
+        return $this->stylesheet_path;
+    }
+
+    public function getFooterURL(): Link
+    {
+        return $this->footer_url;
+    }
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Layout/Page/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Layout/Page/Renderer.php
@@ -27,7 +27,6 @@ use ilGlobalPageTemplate;
 use ILIAS\UI\Implementation\Render\Template;
 use ILIAS\UI\Implementation\Render\ResourceRegistry;
 use iljQueryUtil;
-use LogicException;
 
 class Renderer extends AbstractComponentRenderer
 {
@@ -40,6 +39,8 @@ class Renderer extends AbstractComponentRenderer
     {
         if ($component instanceof Component\Layout\Page\Standard) {
             return $this->renderStandardPage($component, $default_renderer);
+        } elseif ($component instanceof Mail) {
+            return $this->renderMailPage($component, $default_renderer);
         }
 
         $this->cannotHandleComponent($component);
@@ -111,6 +112,22 @@ class Renderer extends AbstractComponentRenderer
         $tpl->setVariable('META_DATA', $this->getDataFactory()->htmlMetadata()->collection(
             $component->getMetaData()
         )->toHtml());
+
+        return $tpl->get();
+    }
+
+    protected function renderMailPage(
+        Mail $component,
+        RendererInterface $default_renderer
+    ): string {
+
+        $tpl = $this->getTemplate('tpl.mailpage.html', true, true);
+
+        $tpl->setVariable('LOGO_SRC', $component->getLogoURL());
+        $tpl->setVariable('INSTALLATION_TITLE', $component->getInstallationTitle());
+        $tpl->setVariable('CONTENT', $default_renderer->render($component->getContent()));
+        $tpl->setVariable('FOOTER_URL', $default_renderer->render($this->getUIFactory()->link()->standard($component->getFooterURL()->getLabel(), $component->getFooterURL()->getURL()->getBaseURI())));
+        $tpl->setVariable('CSS_CONTENT', file_get_contents($component->getStyleSheetPath()) ?: '');
 
         return $tpl->get();
     }

--- a/components/ILIAS/UI/src/examples/Layout/Page/Mail/base.php
+++ b/components/ILIAS/UI/src/examples/Layout/Page/Mail/base.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Layout\Page\Mail;
+
+use ILIAS\Data\Factory;
+use ILIAS\Data\URI;
+use ILIAS\DI\Container;
+use ilInitialisation;
+
+/**
+ * ---
+ * description: >
+ *   Example for rendering a Mail Page.
+ *
+ * expected output: >
+ *   ILIAS shows a mail page with a header which contains a logo and an installation-text.
+ *   The content of the page is a headline and a paragraph.
+ *   The footer contains an installation-text and a link to the ILIAS website.
+ * ---
+ */
+function base(): string
+{
+    global $DIC;
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+
+    $icon = $factory->symbol()->icon()->standard('root', '')->withSize('large');
+    $target = new URI(
+        $DIC->http()->request()->getUri()->__toString() . '&new_ui=1'
+    );
+
+    return $renderer->render(
+        $factory->link()->bulky($icon, 'See UI in fullscreen-mode', $target),
+    );
+}
+
+global $DIC;
+$request_wrapper = $DIC->http()->wrapper()->query();
+$refinery = $DIC->refinery();
+
+if ($request_wrapper->has('new_ui')
+    && $request_wrapper->retrieve('new_ui', $refinery->kindlyTo()->int()) === 1
+) {
+    ilInitialisation::initILIAS();
+    echo(renderFullDemoPage($DIC));
+    exit();
+}
+
+function renderFullDemoPage(Container $dic): string
+{
+    $factory = $dic->ui()->factory();
+    $renderer = $dic->ui()->renderer();
+    $dataFactory = new Factory();
+
+    $page = $factory->layout()->page()->mail(
+        'assets/ui-examples/css/mail_examples.css',
+        'data:image/svg+xml;base64,' . base64_encode(file_get_contents('assets/images/logo/HeaderIcon.svg')),
+        'ILIAS e-Learning',
+        $factory->legacy()->content('<h1>Mail Page Content</h1><p>Dear John Doe, ...<p/>'),
+        $dataFactory->link('https://www.ilias.de', $dataFactory->uri('https://www.ilias.de')),
+    );
+
+    return $renderer->render($page);
+}

--- a/components/ILIAS/UI/src/templates/default/Layout/tpl.mailpage.html
+++ b/components/ILIAS/UI/src/templates/default/Layout/tpl.mailpage.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+	<meta name="viewport" content="width=device-width"/>
+    <style>
+        {CSS_CONTENT}
+    </style>
+</head>
+
+<body>
+
+<!--full mail-template-->
+<table class="table">
+
+	<!--header-row-->
+	<tr class="header">
+		<td class="spacing">
+			<table class="w-750 center">
+				<tr class="rowheight"></tr>
+				<tr>
+					<td class="image-data">
+						<img class="logo" src="{LOGO_SRC}" alt="Logo">
+					</td>
+					<td class="installation-text">
+						<span>
+							<strong>{INSTALLATION_TITLE}</strong>
+						</span>
+					</td>
+				</tr>
+				<tr class="rowheight"></tr>
+			</table>
+		</td>
+	</tr>
+
+	<!--content-row-->
+	<tr class="content">
+		<td class="spacing">
+			<table class="w-750 center">
+				<tr class="headerheight"></tr>
+				<tr>
+					<td class="font-definition">
+						{CONTENT}
+					</td>
+				</tr>
+				<tr class="headerheight"></tr>
+			</table>
+		</td>
+	</tr>
+
+	<!--footer-row-->
+	<tr class="footer">
+		<td class="spacing">
+			<table class="w-750 center">
+				<tr>
+					<td class="font-definition">
+						<span>{INSTALLATION_TITLE}</span>
+						<br>
+						{FOOTER_URL}
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+
+</body>
+
+</html>

--- a/components/ILIAS/UI/tests/Component/Layout/Page/MailPageTest.php
+++ b/components/ILIAS/UI/tests/Component/Layout/Page/MailPageTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace Component\Layout\Page;
+
+require_once('vendor/composer/vendor/autoload.php');
+require_once(__DIR__ . '/../../../Base.php');
+
+use ILIAS\Data\URI;
+use ILIAS\UI\Implementation\Component\Legacy\Content;
+use ILIAS\Data\Link as DataLink;
+use ILIAS\UI\Implementation\Component\Link;
+use ILIAS_UI_TestBase;
+use ILIAS\UI\Implementation\Component\Layout\Page;
+use NoUIFactory;
+
+class MailPageTest extends ILIAS_UI_TestBase
+{
+    protected Page\Mail $mailpage;
+    protected Page\Factory $factory;
+    protected string $logo;
+    protected string $installation_title;
+    protected string $stylesheet_path;
+    protected URI $uri;
+    protected Content $html_content;
+    protected DataLink $footer_url;
+
+    public function setUp(): void
+    {
+        $this->html_content = $this->createMock(Content::class);
+        $this->html_content->method('getContent')->willReturn('ILIAS HTML Content');
+
+        $this->logo = 'cid:ILIAS Logo';
+        $this->installation_title = 'ILIAS Installation Title';
+        $this->stylesheet_path = __FILE__;
+        $this->uri = $this->createMock(URI::class);
+        $this->uri->method('getBaseURI')->willReturn('ILIAS Link URI');
+        $this->footer_url = $this->createMock(DataLink::class);
+        $this->footer_url->method('getLabel')->willReturn('ILIAS Link Label');
+        $this->footer_url->method('getURL')->willReturn($this->uri);
+
+        $this->factory = new Page\Factory();
+        $this->mailpage = $this->factory->mail(
+            $this->stylesheet_path,
+            $this->logo,
+            $this->installation_title,
+            $this->html_content,
+            $this->footer_url,
+        );
+    }
+
+    public function testConstruction(): void
+    {
+        static::assertInstanceOf(
+            Page\Mail::class,
+            $this->mailpage,
+        );
+    }
+
+    public static function provideGetData(): array
+    {
+        return [
+            ['html_content', 'getContent', 'assertContains'],
+            ['logo', 'getLogoURL', 'assertEquals'],
+            ['installation_title', 'getInstallationTitle', 'assertEquals'],
+            ['stylesheet_path', 'getStyleSheetPath', 'assertEquals'],
+            ['footer_url', 'getFooterURL', 'assertEquals'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetData
+     */
+    public function testGet(mixed $expected, string $method_to_call, string $assert_method): void
+    {
+        static::$assert_method(
+            $this->$expected,
+            $this->mailpage->$method_to_call(),
+        );
+    }
+
+    public function testRenderMailPage(): void
+    {
+        $renderer = $this->getDefaultRenderer(null, [$this->html_content]);
+        $mailpage = $this->factory->mail(
+            $this->stylesheet_path,
+            $this->logo,
+            $this->installation_title,
+            $this->html_content,
+            $this->footer_url,
+        );
+
+        $html = $this->brutallyTrimHTML($renderer->render($mailpage));
+        $expected = $this->brutallyTrimHTML('
+<body>
+<table class="table">
+	<tr class="header">
+		<td class="spacing">
+			<table class="w-750 center">
+				<tr class="rowheight"></tr>
+				<tr>
+					<td class="image-data">
+						<img class="logo" src="' . $this->logo . '" alt="Logo">
+					</td>
+					<td class="installation-text">
+						<span>
+							<strong>' . $this->installation_title . '</strong>
+						</span>
+					</td>
+				</tr>
+				<tr class="rowheight"></tr>
+			</table>
+		</td>
+	</tr>
+	<tr class="content">
+		<td class="spacing">
+			<table class="w-750 center">
+				<tr class="headerheight"></tr>
+				<tr>
+					<td class="font-definition">
+						' . $renderer->render($this->html_content) . '
+					</td>
+				</tr>
+				<tr class="headerheight"></tr>
+			</table>
+		</td>
+	</tr>
+	<tr class="footer">
+		<td class="spacing">
+			<table class="w-750 center">
+				<tr>
+					<td class="font-definition">
+						<span>' . $this->installation_title . '</span>
+						<br>
+						<a href="ILIAS Link URI">ILIAS Link Label</a>
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+</body>');
+
+        static::assertStringContainsString($expected, $html);
+    }
+
+    public function getUIFactory(): NoUIFactory
+    {
+        return new class () extends NoUIFactory {
+            public function link(): Link\Factory
+            {
+                return new Link\Factory();
+            }
+        };
+    }
+}


### PR DESCRIPTION
### **What has been changed?**

ILIAS system mails previously used a basic HTML template that included the default ILIAS logo and the installation title "Open Source eLearning".
Customizing this mail layout required manually overwriting the corresponding template file in the System-Style, which was technically functional but not aligned with system-wide design principles.

We developed a solution that:

- Uses a **modernized look & feel** for system emails
- **Integrates logo and color values** from active System-Style
- Eliminates the need to overwrite the mail template separately
- Introduces a **new UI layout component** ("Mail Page") to the kitchen sink for reusability and consistency

---

### **Why was it implemented this way?**

The main goal was to **centralize styling logic** and make mail templates easier to manage when applying individual System-Stylings. By providing a new SCSS file which can be customized via System-Styles , we aimed to:

- Ensure visual consistency across interfaces
- Reduce the need for manual adjustmenting Templates of the System-Style

This decision was based on discussions we had with @Amstutz, where he gave us the initial impulse to bring the mail layout into the UI framework.

A technical challenge we encountered was embedding the logo.
To ensure that the logo would be delivered as an attachment and correctly referenced in all email clients, we had to directly embed the image from a given file path.
This method gives full control over how the image is embedded and allows the mail to include it as an actual attachment, increasing compatibility and flexibility for users.

---

### **How was it tested?**

Manual testing was conducted across a wide range of mail clients to ensure rendering consistency.
This was particularly important because many email clients use outdated rendering engines, leading to inconsistent support for modern HTML and CSS standards.
Not all clients could be tested due to device constraints. 
Results:

| Mail Client | Tested on | Known Issues |
|-------------|-----------|--------------|
| Apple Mail iOS | :white_check_mark: 04.10.2024 |  |
| Apple Mail macOS | :white_check_mark: 04.10.2024 |  |
| Gmail Desktop | \- |  |
| Gmail iOS | :white_check_mark: 22.10.2024 |  |
| Gmail Android | :white_check_mark: 15.10.2024 |  |
| Gmail Mobile Webmail | \- |  |
| Outlook Windows | \- |  |
| Outlook Windows Mail | \- |  |
| Outlook macOS | :white_check_mark: 04.10.2024 |  |
| Outlook.com | :white_check_mark: 15.10.2024 |  |
| Outlook iOS | :white_check_mark: 04.10.2024 |  |
| Outlook Android | :white_check_mark: 15.10.2024 |  |
| Yahoo! Desktop | \- |  |
| Yahoo! iOS | \- |  |
| Yahoo! Android | \- |  |
| AOL Desktop Webmail | \- |  |
| AOL iOS | \- |  |
| AOL Android | \- |  |
| Samsung E-Mail Android | \- |  |
| Thunderbird Windows | :white_check_mark: 04.10.2024 |  |
| Thunderbird macOS | \- |  |
| ProtonMail Desktop Webmail | :white_check_mark: 04.10.2024 |  |
| ProtonMail iOS | :white_check_mark: 22.10.2024 |  |
| ProtonMail Android | :warning: 04.10.2024 | Mail scrolls horizontally |
| WEB.DE Desktop Webmail | :white_check_mark: 15.10.2024 |  |
| WEB.DE iOS | :white_check_mark: 16.10.2024 |  |
| WEB.DE Android | \- |  |

---

### **Notes for reviewers**

We're still looking for a clean and user-friendly way to notify developers and designers of System-Styles that **two SCSS files  need to be compiled now** instead of just one.

Currently, this introduces a second compilation layer, which is not ideal.
An alternative approach, extracting the mail section from the compiled CSS, was discussed in the same meeting with @Amstutz, but was ultimately dismissed by mutual agreement, as it was considered less sustainable in the long term. 

We're considering developing a small script to assist with this step. Feedback on this point is welcome :)

---

### **Related Tickets / References**

Feature Request:

https://docu.ilias.de/go/wiki/wpage_7280_1357
Due to the work on the UI component and the PR, the FeatureRequest will be reworked accordingly before it is presented again to the JourFixe for 11/Trunk.

Internal Reviews:
- https://github.com/marvin-matuschek/ilias/pull/1
- https://github.com/marvin-matuschek/ilias/pull/2

Related PR's:
- https://github.com/ILIAS-eLearning/ILIAS/pull/9565
- https://github.com/ILIAS-eLearning/ILIAS/pull/9566
