### PR TITLE
Default-HTML-Frame for Mail in System Style (3/3)

### DIFF
--- a/components/ILIAS/Mail/Mail.php
+++ b/components/ILIAS/Mail/Mail.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS;
 
+use ILIAS\Component\Resource\ComponentCSS;
+
 class Mail implements Component\Component
 {
     public function init(
@@ -38,6 +40,8 @@ class Mail implements Component\Component
             );
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\ComponentJS($this, "ilMailComposeFunctions.js");
+        $contribute[Component\Resource\PublicAsset::class] = fn() =>
+            new ComponentCSS($this, '/../../../../templates/default/mail.css');
         $contribute[User\Settings\UserSettings::class] = fn() =>
             new Mail\UserSettings\Settings();
         $contribute[User\Profile\ChangeListeners\UserFieldAttributesChangeListener::class] = fn() =>

--- a/components/ILIAS/Mail/classes/class.ilMimeMail.php
+++ b/components/ILIAS/Mail/classes/class.ilMimeMail.php
@@ -18,11 +18,17 @@
 
 declare(strict_types=1);
 
+use ILIAS\Data\Factory;
 use ILIAS\Refinery\Factory as Refinery;
 
 class ilMimeMail
 {
     final public const string MAIL_SUBJECT_PREFIX = '[ILIAS]';
+    private const string SKIN_LOGO_PATH = '/public/Customizing/skin/%s/images/logo';
+    private const string SKIN_CSS_PATH = '/public/Customizing/skin/%s/mail.css';
+    private const string MAIL_CSS_PATH = 'assets/css/mail.css';
+    private const string MAIL_LOGO_PATH = '/public/assets/images/logo/HeaderIcon.svg';
+    private const string ROOT_DIR_IDENTIFICATION_FILE = '/ilias_version.php';
 
     protected static ?ilMailMimeTransport $default_transport = null;
 
@@ -39,7 +45,7 @@ class ilMimeMail
     protected array $acc = [];
     /** @var string[] */
     protected array $abcc = [];
-    /** @var array<string, array{path: string, cid: string, name: string}> */
+    /** @var array<string, array{path: string, cid: string, name: string, as_logo: bool}> */
     protected array $images = [];
     /** @var string[] */
     protected array $aattach = [];
@@ -244,8 +250,22 @@ class ilMimeMail
             $skin = $DIC['ilClientIniFile']->readVariable('layout', 'skin');
             $style = $DIC['ilClientIniFile']->readVariable('layout', 'style');
 
-            $this->buildBodyMultiParts($skin, $style);
-            $this->buildHtmlInlineImages($skin, $style);
+            $data_factory = new Factory();
+            $factory = $DIC->ui()->factory();
+            $renderer = $DIC->ui()->renderer();
+
+            $this->prepareHTMLBody();
+
+            $page = $factory->layout()->page()->mail(
+                $this->getStyleSheetPath($skin, $style),
+                "cid:{$this->getLogoCid($skin, $style)}",
+                ilObjSystemFolder::_getHeaderTitle(),
+                $factory->legacy()->content($this->body),
+                $data_factory->link(ilUtil::_getHttpPath(), $data_factory->uri(ilUtil::_getHttpPath())),
+            );
+
+            $this->final_body = $renderer->render($page);
+            $this->final_body_alt = $this->removeHtmlTags($this->body);
         } else {
             $this->final_body = $this->removeHtmlTags($this->body);
         }
@@ -258,7 +278,22 @@ class ilMimeMail
         return html_entity_decode(strip_tags($maybe_html), ENT_QUOTES);
     }
 
-    protected function buildBodyMultiParts(string $skin, string $style): void
+    private function getPathToRootDirectory(): string
+    {
+        $current_dir = realpath(__DIR__);
+
+        while ($current_dir !== '.') {
+            if (file_exists($current_dir . self::ROOT_DIR_IDENTIFICATION_FILE)) {
+                break;
+            }
+
+            $current_dir = dirname($current_dir);
+        }
+
+        return $current_dir;
+    }
+
+    private function prepareHTMLBody(): void
     {
         if ($this->body === '') {
             $this->body = ' ';
@@ -275,13 +310,7 @@ class ilMimeMail
             $this->body = nl2br($transformed_body);
         }
 
-        $body_with_clickable_urls = $this->refinery->string()->makeClickable()->transform($this->body);
-
-        $this->final_body = str_replace(
-            '{PLACEHOLDER}',
-            $body_with_clickable_urls,
-            $this->getHtmlEnvelope($skin, $style)
-        );
+        $this->body = $this->refinery->string()->makeClickable()->transform($this->body);
     }
 
     private function containsHtmlBlockElementsOrLineBreaks(string $email_body): bool
@@ -299,54 +328,73 @@ class ilMimeMail
         return strip_tags($email_body, '<b><u><i><a>') !== $email_body;
     }
 
-    private function getPathToRootDirectory(): string
+    private function getStyleSheetPath(string $skin, string $style): string
     {
-        return realpath(dirname(__DIR__, 4) . '/');
-    }
-
-    protected function getHtmlEnvelope(string $skin, string $style): string
-    {
-        $bracket_path = $this->getPathToRootDirectory() . '/components/ILIAS/Mail/templates/default/tpl.html_mail_template.html';
         if ($skin !== 'default') {
             $locations = [
                 $skin,
-                $skin . '/' . $style
+                "$skin/$style"
             ];
 
             foreach ($locations as $location) {
-                $custom_path = $this->getPathToRootDirectory(
-                ) . '/public/Customizing/skin/' . $location . '/components/ILIAS/Mail/tpl.html_mail_template.html';
+                $custom_path = $this->getPathToRootDirectory() . sprintf(self::SKIN_CSS_PATH, $location);
                 if (is_file($custom_path)) {
-                    $bracket_path = $custom_path;
-                    break;
+                    return $custom_path;
                 }
             }
         }
 
-        return file_get_contents($bracket_path);
+        return self::MAIL_CSS_PATH;
     }
 
-    protected function buildHtmlInlineImages(string $skin, string $style): void
+    private function getLogoCid(string $skin, string $style): string
     {
-        $this->gatherImagesFromDirectory(
-            $this->getPathToRootDirectory() . '/components/ILIAS/Mail/templates/default/img'
-        );
-
         if ($skin !== 'default') {
             $locations = [
                 $skin,
-                $skin . '/' . $style
+                "$skin/$style"
             ];
 
             foreach ($locations as $location) {
-                $custom_directory = $this->getPathToRootDirectory(
-                ) . '/public/Customizing/skin/' . $location . '/components/ILIAS/Mail/img';
+                $custom_directory = $this->getPathToRootDirectory() . sprintf(self::SKIN_LOGO_PATH, $location);
                 if (is_dir($custom_directory) && is_readable($custom_directory)) {
-                    $this->gatherImagesFromDirectory($custom_directory, true);
-                    break;
+                    $this->gatherImagesFromDirectory($custom_directory);
                 }
             }
+        } else {
+            $path = $this->getPathToRootDirectory() . self::MAIL_LOGO_PATH;
+            if (is_file($path) && is_readable($path)) {
+                return $this->addImage(new SplFileInfo($path), true);
+            }
         }
+
+        foreach ($this->images as $image) {
+            if ($image['as_logo']) {
+                return $image['cid'];
+            }
+        }
+
+        $logo_cid = count($this->images) > 1 ? current($this->images)['cid'] : null;
+
+        foreach ($this->images as $cid => $image) {
+            $file_name = basename($image['path'], '.' . pathinfo($image['path'], PATHINFO_EXTENSION));
+            if (in_array(strtolower($file_name), ['logo', 'headericon'], true)) {
+                $logo_cid = $cid;
+                break;
+            }
+        }
+
+        if (is_string($logo_cid)) {
+            $this->images[$logo_cid]['as_logo'] = true;
+            return $logo_cid;
+        }
+
+        $path = $this->getPathToRootDirectory() . self::MAIL_LOGO_PATH;
+        if (is_file($path) && is_readable($path)) {
+            return $this->addImage(new SplFileInfo($path), true);
+        }
+
+        return '';
     }
 
     protected function gatherImagesFromDirectory(string $directory, bool $clear_previous = false): void
@@ -359,15 +407,22 @@ class ilMimeMail
             new DirectoryIterator($directory),
             '/\.(jpg|jpeg|gif|svg|png)$/i'
         ) as $file) {
-            /** @var SplFileInfo $file */
-            $cid = 'img/' . $file->getFilename();
-
-            $this->images[$cid] = [
-                'path' => $file->getPathname(),
-                'cid' => $cid,
-                'name' => $file->getFilename()
-            ];
+            $this->addImage($file);
         }
+    }
+
+    private function addImage(SplFileInfo $file, bool $as_logo = false): string
+    {
+        $cid = 'img/' . $file->getFilename();
+
+        $this->images[$cid] = [
+            'path' => $file->getPathname(),
+            'cid' => $cid,
+            'name' => $file->getFilename(),
+            'as_logo' => $as_logo
+        ];
+
+        return $cid;
     }
 
     public function Send(?ilMailMimeTransport $transport = null): bool

--- a/components/ILIAS/Mail/classes/class.ilObjMailGUI.php
+++ b/components/ILIAS/Mail/classes/class.ilObjMailGUI.php
@@ -616,7 +616,7 @@ class ilObjMailGUI extends ilObjectGUI
                 '',
             'mail_smtp_encryption' => $this->settings->get('mail_smtp_encryption', ''),
             'mail_subject_prefix' => $subject_prefix,
-            'mail_send_html' => (bool) $this->settings->get('mail_send_html', '0'),
+            'mail_send_html' => (bool) $this->settings->get('mail_send_html', '1'),
             'mail_system_usr_from_addr' => $this->settings->get('mail_system_usr_from_addr', ''),
             'mail_system_usr_from_name' => $this->settings->get('mail_system_usr_from_name', ''),
             'mail_system_usr_env_from_addr' => $this->settings->get('mail_system_usr_env_from_addr', ''),

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -5644,7 +5644,7 @@ common#:#shib_update#:#Dieses Feld bei jeder Anmeldung aktualisieren
 common#:#shib_user_default_role#:#Generelle Rolle für Shibboleth-Benutzer
 common#:#shib_zipcode#:#Attribut für Postleitzahl
 common#:#short_inst_name#:#Kurztitel
-common#:#short_inst_name_info#:#Dieser Text erscheint zusammen mit dem Seitentitel als Titel des Browser-Tabs. Wird hier nichts eingetragen, erscheint 'ILIAS'.
+common#:#short_inst_name_info#:#Dieser Text erscheint zusammen mit dem Seitentitel als Titel des Browser-Tabs. Wird hier nichts eingetragen, erscheint 'ILIAS'. Wenn der HTML-Frame aktiviert ist, wird diese Signatur im Fußbereich der HTML-E-Mail-Vorlage angezeigt.
 common#:#show#:#Anzeigen
 common#:#show_all_details#:#Alle Details anzeigen
 common#:#show_content#:#Inhalt anzeigen
@@ -11724,7 +11724,7 @@ mail#:#mail_select_grp#:#Bitte mindestens eine Gruppe auswählen.
 mail#:#mail_select_one_entry#:#Sie müssen mindestens einen Eintrag auswählen
 mail#:#mail_select_one_file#:#Sie müssen mindestens eine Datei auswählen
 mail#:#mail_send_html#:#HTML-Rahmen
-mail#:#mail_send_html_info#:#Falls aktiviert, wird der Nachrichtentext von externen E-Mails in einen HTML-Rahmen gesetzt. Dieser kann über ein Skin-Template unter './Customizing/global/skin/[SKIN]/[STYLE]/Services/Mail/tpl.html_mail_template.html' (als Kopie von './Services/Mail/templates/default/tpl.html_mail_template.html') angepasst werden.
+mail#:#mail_send_html_info#:#Wenn diese Option aktiviert ist, wird der Nachrichtentext von externen E-Mails in einen HTML-Frame eingebettet. Im aktiviertem Zustand werden die Werte des Standard-System Style verwendet, z. B. das Logo, die Kopfzeile sowie die Farben für Kopf-, Hintergrund- und Fußzeile.
 mail#:#mail_sent_datetime#:#Datum
 mail#:#mail_serial_letter_placeholders#:#Platzhalter für Serienbrief
 mail#:#mail_settings_external_frm_head#:#Externe E-Mails

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11699,7 +11699,7 @@ mail#:#mail_select_grp#:#Please select at least one group.
 mail#:#mail_select_one_entry#:#You must select at least one entry.
 mail#:#mail_select_one_file#:#You must select at least one file.
 mail#:#mail_send_html#:#HTML Frame
-mail#:#mail_send_html_info#:#If enabled, the body of external e-mails will be embedded in a HTML frame. If activated values of deafult System Style e.g. its logo, header title and colors of header, background and footer will be used.
+mail#:#mail_send_html_info#:#If enabled, the body of external e-mails will be embedded in an HTML frame. If activated values of default System Style e.g. its logo, header title and colors of header, background and footer will be used.
 mail#:#mail_sent_datetime#:#Date
 mail#:#mail_serial_letter_placeholders#:#Mail Merge Placeholders
 mail#:#mail_settings_external_frm_head#:#External E-Mails

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5646,7 +5646,7 @@ common#:#shib_update#:#Update this field on login
 common#:#shib_user_default_role#:#Default Role Assigned to Shibboleth Users
 common#:#shib_zipcode#:#Attribute for zipcode
 common#:#short_inst_name#:#Short Title
-common#:#short_inst_name_info#:#This title will appear in the browser header title bar. If no value is entered, ‘ILIAS’ is used.
+common#:#short_inst_name_info#:#This title will appear in the browser header title bar. If no value is entered, ‘ILIAS’ is used. If HTML frame is activated this signature is shown in the footer area of the HTML mail template.
 common#:#show#:#Show
 common#:#show_all_details#:#Show all details
 common#:#show_content#:#Show Content
@@ -11699,7 +11699,7 @@ mail#:#mail_select_grp#:#Please select at least one group.
 mail#:#mail_select_one_entry#:#You must select at least one entry.
 mail#:#mail_select_one_file#:#You must select at least one file.
 mail#:#mail_send_html#:#HTML Frame
-mail#:#mail_send_html_info#:#Embed the body of external e-mails in an HTML frame. The corresponding template can be customised by creating a copy of './Services/Mail/templates/default/tpl.html_mail_template.html' at './Customizing/global/skin/[SKIN]/[STYLE]/Services/Mail/tpl.html_mail_template.html'.
+mail#:#mail_send_html_info#:#If enabled, the body of external e-mails will be embedded in a HTML frame. If activated values of deafult System Style e.g. its logo, header title and colors of header, background and footer will be used.
 mail#:#mail_sent_datetime#:#Date
 mail#:#mail_serial_letter_placeholders#:#Mail Merge Placeholders
 mail#:#mail_settings_external_frm_head#:#External E-Mails


### PR DESCRIPTION
This PR proposes using the "Layout > Page > Mail" UI component (see #9564) for sending external emails in ILIAS.  
The rendered HTML is enhanced with specific styles from the dedicated "mail.css" (see #9565).

Depends on:

- #9564 (read this for full context)
- #9565
