### PR TITLE
[Mantis:45078] Ensure "form" language module is loaded for ilFileInpu…

### DIFF
--- a/Services/Form/classes/class.ilFileInputGUI.php
+++ b/Services/Form/classes/class.ilFileInputGUI.php
@@ -48,13 +48,14 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
         global $DIC;
 
         $this->lng = $DIC->language();
-        $lng = $DIC->language();
+        $this->lng->loadLanguageModule('form');
+
         $this->upload_service = $DIC->upload();
         $this->upload_limit = $DIC['ui.upload_limit_resolver'];
 
         parent::__construct($a_title, $a_postvar);
         $this->setType("file");
-        $this->setHiddenTitle("(" . $lng->txt("form_file_input") . ")");
+        $this->setHiddenTitle("(" . $this->lng->txt("form_file_input") . ")");
     }
 
     public function setValueByArray(array $a_values): void
@@ -170,8 +171,6 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
             }
         }
 
-        $lng = $this->lng;
-
         // #18756
         if ($this->getDisabled()) {
             return true;
@@ -180,7 +179,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
         // if no information is received, something went wrong
         // this is e.g. the case, if the post_max_size has been exceeded
         if (!isset($_FILES[$this->getPostVar()]) || !is_array($_FILES[$this->getPostVar()])) {
-            $this->setAlert($lng->txt("form_msg_file_size_exceeds"));
+            $this->setAlert($this->lng->txt("form_msg_file_size_exceeds"));
             return false;
         }
 
@@ -203,32 +202,32 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
             switch ($error) {
                 case UPLOAD_ERR_FORM_SIZE:
                 case UPLOAD_ERR_INI_SIZE:
-                    $this->setAlert($lng->txt("form_msg_file_size_exceeds"));
+                    $this->setAlert($this->lng->txt("form_msg_file_size_exceeds"));
                     return false;
 
                 case UPLOAD_ERR_PARTIAL:
-                    $this->setAlert($lng->txt("form_msg_file_partially_uploaded"));
+                    $this->setAlert($this->lng->txt("form_msg_file_partially_uploaded"));
                     return false;
 
                 case UPLOAD_ERR_NO_FILE:
                     if ($this->getRequired()) {
                         if (!strlen($this->getValue())) {
-                            $this->setAlert($lng->txt("form_msg_file_no_upload"));
+                            $this->setAlert($this->lng->txt("form_msg_file_no_upload"));
                             return false;
                         }
                     }
                     break;
 
                 case UPLOAD_ERR_NO_TMP_DIR:
-                    $this->setAlert($lng->txt("form_msg_file_missing_tmp_dir"));
+                    $this->setAlert($this->lng->txt("form_msg_file_missing_tmp_dir"));
                     return false;
 
                 case UPLOAD_ERR_CANT_WRITE:
-                    $this->setAlert($lng->txt("form_msg_file_cannot_write_to_disk"));
+                    $this->setAlert($this->lng->txt("form_msg_file_cannot_write_to_disk"));
                     return false;
 
                 case UPLOAD_ERR_EXTENSION:
-                    $this->setAlert($lng->txt("form_msg_file_upload_stopped_ext"));
+                    $this->setAlert($this->lng->txt("form_msg_file_upload_stopped_ext"));
                     return false;
             }
         }
@@ -236,12 +235,12 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
         // check suffixes
         if ($_FILES[$this->getPostVar()]["tmp_name"] != "") {
             if (is_array($this->forbidden_suffixes) && in_array(strtolower($suffix), $this->forbidden_suffixes)) {
-                $this->setAlert($lng->txt("form_msg_file_type_is_not_allowed") . " (" . $suffix . ")");
+                $this->setAlert($this->lng->txt("form_msg_file_type_is_not_allowed") . " (" . $suffix . ")");
                 return false;
             }
             if (is_array($this->getSuffixes()) && count($this->getSuffixes()) > 0) {
                 if (!in_array(strtolower($suffix), $this->getSuffixes())) {
-                    $this->setAlert($lng->txt("form_msg_file_wrong_file_type"));
+                    $this->setAlert($this->lng->txt("form_msg_file_wrong_file_type"));
                     return false;
                 }
             }
@@ -251,7 +250,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
         if ($_FILES[$this->getPostVar()]["tmp_name"] != "") {
             $vir = ilVirusScanner::virusHandling($temp_name, $filename);
             if ($vir[0] == false) {
-                $this->setAlert($lng->txt("form_msg_file_virus_found") . "<br />" . $vir[1]);
+                $this->setAlert($this->lng->txt("form_msg_file_virus_found") . "<br />" . $vir[1]);
                 return false;
             }
         }
@@ -272,8 +271,6 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
 
     public function render(string $a_mode = ""): string
     {
-        $lng = $this->lng;
-
         $quota_exceeded = $quota_legend = false;
 
         $f_tpl = new ilTemplate("tpl.prop_file.html", true, true, "Services/Form");
@@ -285,7 +282,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
             $f_tpl->setVariable('POST_FILENAME', $this->getFileNamePostVar());
             $f_tpl->setVariable('VAL_FILENAME', $this->getFilename());
             $f_tpl->setVariable('FILENAME_ID', $this->getFieldId());
-            $f_tpl->setVariable('TXT_FILENAME_HINT', $lng->txt('if_no_title_then_filename'));
+            $f_tpl->setVariable('TXT_FILENAME_HINT', $this->lng->txt('if_no_title_then_filename'));
             $f_tpl->parseCurrentBlock();
         } else {
             if (trim($this->getValue()) != "") {
@@ -294,7 +291,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
                     $f_tpl->setVariable("POST_VAR_D", $this->getPostVar());
                     $f_tpl->setVariable(
                         "TXT_DELETE_EXISTING",
-                        $lng->txt("delete_existing_file")
+                        $this->lng->txt("delete_existing_file")
                     );
                     $f_tpl->parseCurrentBlock();
                 }
@@ -310,7 +307,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
                 $this->outputSuffixes($f_tpl);
 
                 $f_tpl->setCurrentBlock("max_size");
-                $f_tpl->setVariable("TXT_MAX_SIZE", $lng->txt("file_notice") . " " .
+                $f_tpl->setVariable("TXT_MAX_SIZE", $this->lng->txt("file_notice") . " " .
                     $this->getMaxFileSizeString());
                 $f_tpl->parseCurrentBlock();
 
@@ -330,7 +327,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
         $pending = $this->getPending();
         if ($pending) {
             $f_tpl->setCurrentBlock("pending");
-            $f_tpl->setVariable("TXT_PENDING", $lng->txt("file_upload_pending") .
+            $f_tpl->setVariable("TXT_PENDING", $this->lng->txt("file_upload_pending") .
                 ": " . htmlentities($pending));
             $f_tpl->parseCurrentBlock();
         }
@@ -351,7 +348,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
 
 
         /* experimental: bootstrap'ed file upload */
-        $f_tpl->setVariable("TXT_BROWSE", $lng->txt("select_file"));
+        $f_tpl->setVariable("TXT_BROWSE", $this->lng->txt("select_file"));
 
 
         return $f_tpl->get();
@@ -371,8 +368,6 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
         ilTemplate $a_tpl,
         string $a_block = "allowed_suffixes"
     ): void {
-        $lng = $this->lng;
-
         if (is_array($this->getSuffixes()) && count($this->getSuffixes()) > 0) {
             $suff_str = $delim = "";
             foreach ($this->getSuffixes() as $suffix) {
@@ -382,7 +377,7 @@ class ilFileInputGUI extends ilSubEnabledFormPropertyGUI implements ilToolbarIte
             $a_tpl->setCurrentBlock($a_block);
             $a_tpl->setVariable(
                 "TXT_ALLOWED_SUFFIXES",
-                $lng->txt("file_allowed_suffixes") . " " . $suff_str
+                $this->lng->txt("file_allowed_suffixes") . " " . $suff_str
             );
             $a_tpl->parseCurrentBlock();
         }


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=45078

Fixes issues with unavailable form_msg_file_size_exceeds string in its render(...) function which caused issues with for example ILIAS HTML Learning module file upload.