### PR TITLE
Give correct list of file formats for errors in ImageOutputOptions

### DIFF
--- a/src/Filesystem/Util/Convert/ImageOutputOptions.php
+++ b/src/Filesystem/Util/Convert/ImageOutputOptions.php
@@ -106,7 +106,7 @@ class ImageOutputOptions
         }
 
         if (!in_array($format, $this->allowed_formats, true)) {
-            throw new \InvalidArgumentException('Format must be either jpg or png, ' . $format . ' given.');
+            throw new \InvalidArgumentException('Format must be one of ' . implode(', ',$this->allowed_formats) . ', but ' . $format . ' was given.');
         }
         return $format;
     }


### PR DESCRIPTION
Should be self-explanatory.

Currently throws error-message:
> InvalidArgumentException thrown with message "Format must be either jpg or png, gif given."

Which is missing webp.

This fix uses the actually array that is checked against to list supported file formats like:
> InvalidArgumentException thrown with message "Format must one of jpg, png, webp, keep, but gif was given."