### PR TITLE
10/UI/ViewControls/Pagination next previous button instead glyph link 41562

### DIFF
--- a/components/ILIAS/UI/src/Component/Button/Factory.php
+++ b/components/ILIAS/UI/src/Component/Button/Factory.php
@@ -64,9 +64,9 @@ interface Factory
      *          sticky (stay visible on small screens).
      *   accessibility:
      *       1: >
-     *          Standard buttons MAY define aria-label attribute. Use it in cases
-     *          where a text label is not visible on the screen or when the label
-     *          does not provide enough information about the action.
+     *          Standard buttons MAY define an aria-label attribute. Use it in cases where a text label is not visible
+     *          on the screen, when the button doesn't include a glyph that comes with a fitting aria-label or when the
+     *          label does not provide enough information about the action.
      *       2: >
      *          Some Buttons can be stateful; when engaged, the state MUST be
      *          reflected in the "aria-pressed"-, respectively the "aria-checked"-attribute.
@@ -125,6 +125,10 @@ interface Factory
      *           The loading animation rules of the Standard Button MUST be respected.
      *   accessibility:
      *       1: >
+     *           Primary buttons MAY define an aria-label attribute. Use it in cases where a text label is not visible
+     *           on the screen, when the button doesn't include a glyph that comes with a fitting aria-label or when the
+     *           label does not provide enough information about the action.
+     *       2: >
      *          Some Buttons can be stateful; when engaged, the state MUST be
      *          reflected in the "aria-pressed"-, respectively the "aria-checked"-attribute.
      *          If the Button is not stateful (which is the default), the

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
@@ -333,9 +333,12 @@ class Renderer extends AbstractComponentRenderer
 
         $f = $this->getUIFactory();
 
+        $back_btn = $f->button()->standard("", "");
+        $forward_btn = $f->button()->standard("", "");
+
         if ($component->getTriggeredSignals()) {
-            $back = $f->symbol()->glyph()->back('')->withOnClick($component->getInternalSignal());
-            $forward = $f->symbol()->glyph()->next('')->withOnClick($component->getInternalSignal());
+            $back_btn = $back_btn->withOnClick($component->getInternalSignal());
+            $forward_btn = $forward_btn->withOnClick($component->getInternalSignal());
         } else {
             $url = $component->getTargetURL() ?? '';
             if (strpos($url, '?') === false) {
@@ -352,19 +355,25 @@ class Renderer extends AbstractComponentRenderer
                 $url_next = $base . http_build_query($params);
             }
 
-            $back = $f->symbol()->glyph()->back($url_prev);
-            $forward = $f->symbol()->glyph()->next($url_next);
+            $back_btn = $f->button()->standard("", $url_prev);
+            $forward_btn = $f->button()->standard("", $url_next);
         }
 
         if ($component->getCurrentPage() === 0) {
-            $back = $back->withUnavailableAction();
+            $back_btn = $back_btn->withUnavailableAction();
         }
         if ($component->getCurrentPage() >= $component->getNumberOfPages() - 1) {
-            $forward = $forward->withUnavailableAction();
+            $forward_btn = $forward_btn->withUnavailableAction();
         }
 
-        $tpl->setVariable('PREVIOUS', $default_renderer->render($back));
-        $tpl->setVariable('NEXT', $default_renderer->render($forward));
+        $back_glyph = $f->symbol()->glyph()->back();
+        $forward_glyph = $f->symbol()->glyph()->next();
+
+        $back_btn = $back_btn->withSymbol($back_glyph);
+        $forward_btn = $forward_btn->withSymbol($forward_glyph);
+
+        $tpl->setVariable('PREVIOUS', $default_renderer->render($back_btn));
+        $tpl->setVariable('NEXT', $default_renderer->render($forward_btn));
     }
 
     /**

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.viewcontrol_pagination.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.viewcontrol_pagination.html
@@ -1,6 +1,4 @@
 <div class="il-viewcontrol il-viewcontrol-pagination l-bar__element"<!-- BEGIN id --> id="{ID}" <!-- END id -->>
-
-
     <!-- BEGIN section_part -->
     <div class="dropdown il-viewcontrol-pagination__sectioncontrol">
             <!-- BEGIN selection -->
@@ -17,10 +15,8 @@
                 {INPUT}
                 {BUTTON}
             <!-- END input -->
-
     </div>
     <!-- END section_part -->
-
     <div class="dropdown il-viewcontrol-pagination__num-of-items">
         <button class="btn btn-ctrl dropdown-toggle" type="button" data-toggle="dropdown"<!-- BEGIN aria_label_limit --> aria-label="{ARIA_LABEL_LIMIT}"<!-- END aria_label_limit --> aria-haspopup="true" aria-expanded="false" aria-controls="{ID_MENU_LIMIT}"><span class="caret"></span></button>
         <ul id="{ID_MENU_LIMIT}" class="dropdown-menu">
@@ -29,7 +25,6 @@
             <!-- END option_limit -->
         </ul>
     </div>
-
     <div class="il-viewcontrol-value hidden" role="none">
         {VALUES}
     </div>

--- a/components/ILIAS/UI/src/templates/default/ViewControl/tpl.pagination.html
+++ b/components/ILIAS/UI/src/templates/default/ViewControl/tpl.pagination.html
@@ -1,7 +1,7 @@
 <div class="il-viewcontrol-pagination l-bar__element"<!-- BEGIN id --> id="{ID}"<!-- END id -->>
-<span class="btn btn-ctrl browse previous">{PREVIOUS}</span>
-<!-- BEGIN first --> <span class="first">{FIRST}</span> <!-- END first -->
-<!-- BEGIN entry --> {BUTTON} <!-- END entry -->
-<!-- BEGIN last --> <span class="last">{LAST}</span> <!-- END last -->
-<span class="btn btn-ctrl browse next">{NEXT}</span>
+{PREVIOUS}
+<!-- BEGIN first --><span class="first">{FIRST}</span><!-- END first -->
+<!-- BEGIN entry -->{BUTTON}<!-- END entry -->
+<!-- BEGIN last --><span class="last">{LAST}</span><!-- END last -->
+{NEXT}
 </div>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryLegacyTest.php
@@ -272,13 +272,17 @@ EOT;
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-viewcontrols l-bar__space-keeper">
             <div class="il-viewcontrol-pagination l-bar__element">
-                <span class="btn btn-ctrl browse previous"><a tabindex="0" class="glyph" href="http://ilias.de?page=0" aria-label="back"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></a></span>
+                <button class="btn btn-default" data-action="http://ilias.de?page=0" id="id_6">
+                    <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+                </button>
                 <button class="btn btn-link" data-action="http://ilias.de?page=0" id="id_1">1</button>
                 <button class="btn btn-link engaged" aria-pressed="true" data-action="http://ilias.de?page=1" id="id_2">2</button>
                 <button class="btn btn-link" data-action="http://ilias.de?page=2" id="id_3">3</button>
                 <button class="btn btn-link" data-action="http://ilias.de?page=3" id="id_4">4</button>
                 <button class="btn btn-link" data-action="http://ilias.de?page=4" id="id_5">5</button>
-                <span class="btn btn-ctrl browse next"><a tabindex="0" class="glyph" href="http://ilias.de?page=2" aria-label="next"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></a></span>
+                <button class="btn btn-default" data-action="http://ilias.de?page=2" id="id_7">
+                    <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
+                </button>
             </div>
         </div>
         <div class="panel-controls"></div>

--- a/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelSecondaryListingTest.php
@@ -231,27 +231,22 @@ EOT;
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-viewcontrols l-bar__space-keeper">
             <div class="il-viewcontrol-pagination l-bar__element">
-                <span class="btn btn-ctrl browse previous">
-                    <a tabindex="0" class="glyph" href="http://ilias.de?page=0" aria-label="back">
-                        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-                    </a>
-                </span>
+                <button class="btn btn-default" data-action="http://ilias.de?page=0" id="id_6">
+                    <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+                </button>
                 <button class="btn btn-link" data-action="http://ilias.de?page=0" id="id_1">1</button>
                 <button class="btn btn-link engaged" aria-pressed="true" data-action="http://ilias.de?page=1" id="id_2">2</button>
                 <button class="btn btn-link" data-action="http://ilias.de?page=2" id="id_3">3</button>
                 <button class="btn btn-link" data-action="http://ilias.de?page=3" id="id_4">4</button>
                 <button class="btn btn-link" data-action="http://ilias.de?page=4" id="id_5">5</button>
-                <span class="btn btn-ctrl browse next">
-                    <a tabindex="0" class="glyph" href="http://ilias.de?page=2" aria-label="next">
-                        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-                    </a>
-                </span>
+                <button class="btn btn-default" data-action="http://ilias.de?page=2" id="id_7">
+                    <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
+                </button>
             </div>
         </div>
         <div class="panel-controls"></div>
     </div>
-    <div class="panel-body">
-    </div>
+    <div class="panel-body"></div>
 </div>
 EOT;
         $this->assertEquals(

--- a/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
@@ -519,21 +519,17 @@ EOT;
         <div class="panel-title"><h2>Title</h2></div>
         <div class="panel-viewcontrols l-bar__space-keeper">
             <div class="il-viewcontrol-pagination l-bar__element">
-                    <span class="btn btn-ctrl browse previous">
-                        <a tabindex="0" class="glyph" href="http://ilias.de?page=0" aria-label="back">
-                            <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-                        </a>
-                    </span>
-                    <button class="btn btn-link" data-action="http://ilias.de?page=0" id="id_1">1</button>
-                    <button class="btn btn-link engaged" aria-pressed="true" data-action="http://ilias.de?page=1" id="id_2">2</button>
-                    <button class="btn btn-link" data-action="http://ilias.de?page=2" id="id_3">3</button>
-                    <button class="btn btn-link" data-action="http://ilias.de?page=3" id="id_4">4</button>
-                    <button class="btn btn-link" data-action="http://ilias.de?page=4" id="id_5">5</button>
-                    <span class="btn btn-ctrl browse next">
-                    <a tabindex="0" class="glyph" href="http://ilias.de?page=2" aria-label="next">
-                        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-                    </a>
-                </span>
+                <button class="btn btn-default" data-action="http://ilias.de?page=0" id="id_6">
+                    <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+                </button>
+                <button class="btn btn-link" data-action="http://ilias.de?page=0" id="id_1">1</button>
+                <button class="btn btn-link engaged" aria-pressed="true" data-action="http://ilias.de?page=1" id="id_2">2</button>
+                <button class="btn btn-link" data-action="http://ilias.de?page=2" id="id_3">3</button>
+                <button class="btn btn-link" data-action="http://ilias.de?page=3" id="id_4">4</button>
+                <button class="btn btn-link" data-action="http://ilias.de?page=4" id="id_5">5</button>
+                <button class="btn btn-default" data-action="http://ilias.de?page=2" id="id_7">
+                    <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
+                </button>
             </div>
         </div>
         <div class="panel-controls"></div>

--- a/components/ILIAS/UI/tests/Component/ViewControl/PaginationTest.php
+++ b/components/ILIAS/UI/tests/Component/ViewControl/PaginationTest.php
@@ -104,20 +104,14 @@ class PaginationTest extends ILIAS_UI_TestBase
         //browse-left disabled
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
-	<span class="btn btn-ctrl browse previous">
-		<a class="glyph disabled" aria-label="back" aria-disabled="true">
-			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-		</a>
-	</span>
-
-	<button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=0" id="id_1">1</button>
-	<button class="btn btn-link" data-action="?pagination_offset=1" id="id_2">2</button>
-
-	<span class="btn btn-ctrl browse next">
-		<a tabindex="0" class="glyph" href="?pagination_offset=1" aria-label="next">
-			<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-		</a>
-	</span>
+    <button class="btn btn-default" data-action="?pagination_offset=0" disabled="disabled">
+        <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+    </button>
+    <button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=0" id="id_1">1</button>
+    <button class="btn btn-link" data-action="?pagination_offset=1" id="id_2">2</button>
+    <button class="btn btn-default" data-action="?pagination_offset=1" id="id_3">
+        <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
+    </button>
 </div>
 EOT;
 
@@ -136,25 +130,22 @@ EOT;
         //browse-right disabled
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
-	<span class="btn btn-ctrl browse previous">
-		<a tabindex="0" class="glyph" href="?pagination_offset=0" aria-label="back">
-			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-		</a>
-	</span>
-
-	<button class="btn btn-link" data-action="?pagination_offset=0" id="id_1">1</button>
-	<button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=1" id="id_2">2</button>
-
-	<span class="btn btn-ctrl browse next">
-		<a class="glyph disabled" aria-label="next" aria-disabled="true">
-			<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-		</a>
-	</span>
+    <button class="btn btn-default" data-action="?pagination_offset=0" id="id_3">
+        <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+    </button>
+    <button class="btn btn-link" data-action="?pagination_offset=0" id="id_1">1</button>
+    <button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=1" id="id_2">2</button>
+    <button class="btn btn-default" data-action="?pagination_offset=2" disabled="disabled">
+        <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
+    </button>
 </div>
 EOT;
 
         $html = $this->getDefaultRenderer()->render($p);
-        $this->assertHTMLEquals($expected_html, $html);
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected_html),
+            $this->brutallyTrimHTML($html)
+        );
     }
 
     public function testRenderLimited(): void
@@ -169,27 +160,21 @@ EOT;
         //boundary-button right
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
-	<span class="btn btn-ctrl browse previous">
-		<a class="glyph disabled" aria-label="back" aria-disabled="true">
-			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-		</a>
-	</span>
-
-	<button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=0" id="id_1">1</button>
-
-	<span class="last">
-		<button class="btn btn-link" data-action="?pagination_offset=2" id="id_2">3</button>
-	</span>
-
-	<span class="btn btn-ctrl browse next">
-		<a tabindex="0" class="glyph" href="?pagination_offset=1" aria-label="next">
-			<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-		</a>
-	</span>
+    <button class="btn btn-default" data-action="?pagination_offset=0" disabled="disabled">
+        <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+    </button>
+    <button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=0" id="id_1">1</button>
+    <span class="last"><button class="btn btn-link" data-action="?pagination_offset=2" id="id_2">3</button></span>
+    <button class="btn btn-default" data-action="?pagination_offset=1" id="id_3">
+        <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
+    </button>
 </div>
 EOT;
         $html = $this->getDefaultRenderer()->render($p);
-        $this->assertHTMLEquals($expected_html, $html);
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected_html),
+            $this->brutallyTrimHTML($html)
+        );
     }
 
     public function testRenderLimitedWithCurrentPage(): void
@@ -205,31 +190,21 @@ EOT;
         //both boundary-buttons
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
-	<span class="btn btn-ctrl browse previous">
-		<a tabindex="0" class="glyph" href="?pagination_offset=0" aria-label="back">
-			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-		</a>
-	</span>
-
-	<span class="first">
-		<button class="btn btn-link" data-action="?pagination_offset=0" id="id_2">1</button>
-	</span>
-
-	<button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=1" id="id_1">2</button>
-
-	<span class="last">
-		<button class="btn btn-link" data-action="?pagination_offset=2" id="id_3">3</button>
-	</span>
-
-	<span class="btn btn-ctrl browse next">
-		<a tabindex="0" class="glyph" href="?pagination_offset=2" aria-label="next">
-			<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-		</a>
-	</span>
+    <button class="btn btn-default" data-action="?pagination_offset=0" id="id_4">
+        <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+    </button><span class="first"><button class="btn btn-link" data-action="?pagination_offset=0" id="id_2">1</button></span>
+    <button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=1" id="id_1">2</button>
+    <span class="last"><button class="btn btn-link" data-action="?pagination_offset=2" id="id_3">3</button></span>
+    <button class="btn btn-default" data-action="?pagination_offset=2" id="id_5">
+        <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
+    </button>
 </div>
 EOT;
         $html = $this->getDefaultRenderer()->render($p);
-        $this->assertHTMLEquals($expected_html, $html);
+        $this->assertHTMLEquals(
+            $this->brutallyTrimHTML($expected_html),
+            $this->brutallyTrimHTML($html)
+        );
     }
 
     public function testRenderLimitedWithCurrentPage2(): void
@@ -245,29 +220,22 @@ EOT;
         //boundary-button left only
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
-	<span class="btn btn-ctrl browse previous">
-		<a tabindex="0" class="glyph" href="?pagination_offset=1" aria-label="back">
-			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-		</a>
-	</span>
-	<span class="first">
-		<button class="btn btn-link" data-action="?pagination_offset=0" id="id_2">1</button>
-	</span>
-
-	<button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=2" id="id_1">3</button>
-
-	<span class="btn btn-ctrl browse next">
-		<a class="glyph disabled" aria-label="next" aria-disabled="true">
-			<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-		</a>
-	</span>
+    <button class="btn btn-default" data-action="?pagination_offset=1" id="id_3">
+        <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+    </button>
+    <span class="first"><button class="btn btn-link" data-action="?pagination_offset=0" id="id_2">1</button></span>
+    <button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=2" id="id_1">3</button>
+    <button class="btn btn-default" data-action="?pagination_offset=3" disabled="disabled">
+        <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
+    </button>
 </div>
 EOT;
         $html = $this->getDefaultRenderer()->render($p);
-        $this->assertHTMLEquals($expected_html, $html);
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected_html),
+            $this->brutallyTrimHTML($html)
+        );
     }
-
-
 
     public function testRenderDropdown(): void
     {
@@ -278,30 +246,33 @@ EOT;
 
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
-	<span class="btn btn-ctrl browse previous">
-		<a class="glyph disabled" aria-label="back" aria-disabled="true">
-			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-		</a>
-	</span>
-
-	<div class="dropdown" id="id_4">
-		<button class="btn btn-default dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="id_4_menu" >pagination_label_x_of_y<span class="caret"></span></button>
-		<ul id="id_4_menu" class="dropdown-menu">
-			<li><button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=0" id="id_1">1</button></li>
-			<li><button class="btn btn-link" data-action="?pagination_offset=1" id="id_2">2</button></li>
-			<li><button class="btn btn-link" data-action="?pagination_offset=2" id="id_3">3</button></li>
-		</ul>
-	</div>
-
-	<span class="btn btn-ctrl browse next">
-		<a tabindex="0" class="glyph" href="?pagination_offset=1" aria-label="next">
-			<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-		</a>
-	</span>
+    <button class="btn btn-default" data-action="?pagination_offset=0" disabled="disabled">
+        <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
+    </button>
+    <div class="dropdown" id="id_4">
+        <button class="btn btn-default dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="id_4_menu">pagination_label_x_of_y<span class="caret"></span></button>
+        <ul id="id_4_menu" class="dropdown-menu">
+            <li>
+                <button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=0" id="id_1">1</button>
+            </li>
+            <li>
+                <button class="btn btn-link" data-action="?pagination_offset=1" id="id_2">2</button>
+            </li>
+            <li>
+                <button class="btn btn-link" data-action="?pagination_offset=2" id="id_3">3</button>
+            </li>
+        </ul>
+    </div>
+    <button class="btn btn-default" data-action="?pagination_offset=1" id="id_5">
+        <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
+    </button>
 </div>
 EOT;
         $html = $this->getDefaultRenderer()->render($p);
-        $this->assertEquals($this->brutallyTrimHTML($expected_html), $this->brutallyTrimHTML($html));
+        $this->assertEquals(
+            $this->brutallyTrimHTML($expected_html),
+            $this->brutallyTrimHTML($html)
+        );
     }
 
     public function testGetRangeOnNull(): void

--- a/templates/default/070-components/UI-framework/Button/_ui-component_button.scss
+++ b/templates/default/070-components/UI-framework/Button/_ui-component_button.scss
@@ -37,7 +37,7 @@ $input-min-height-large: s-form.$il-input-min-height * 1.8;
 
 .btn {
   @include make-button($set-basics: true, $set-design: false, $set-size: true);
-  .glyph, 
+  .glyph,
   .glyph .glyphicon {
     color: unset;
   }
@@ -60,7 +60,7 @@ input.btn {
 }
 
 .btn-default {
-  @include make-button($set-basics: false, $set-design: true, 
+  @include make-button($set-basics: false, $set-design: true,
     $button-color: s.$il-btn-standard-bg,
 
     $bg-color: s.$il-btn-standard-bg,
@@ -70,7 +70,7 @@ input.btn {
     $disabled_bg-color: s.$il-disabled-btn-bg,
     $disabled_text-color: s.$il-disabled-btn-color,
     $disabled_border-color: s.$il-disabled-btn-border,
-    
+
     $engaged_bg-color: s.$il-engaged-btn-bg,
     $engaged_text-color: s.$il-engaged-btn-color,
     $engaged_border-color: s.$il-btn-standard-border,
@@ -93,7 +93,7 @@ input.btn {
     $disabled_bg-color: s.$il-disabled-btn-bg,
     $disabled_text-color: s.$il-disabled-btn-color,
     $disabled_border-color: s.$il-disabled-btn-border,
-    
+
     $engaged_bg-color: s.$il-engaged-btn-bg,
     $engaged_text-color: s.$il-engaged-btn-color,
     $engaged_border-color: s.$il-btn-primary-border,
@@ -106,7 +106,11 @@ input.btn {
                         $button-text-color: s.$il-btn-ctrl-color,
                         $button-color: s.$il-btn-ctrl-bg,
                         $border-color: s.$il-btn-ctrl-border,
-                        $hover_border-color: s.$il-btn-ctrl-engaged-border);
+                        $hover_border-color: s.$il-btn-ctrl-engaged-border,
+                        $disabled_bg-color: s.$il-disabled-btn-bg,
+                        $disabled_text-color: s.$il-disabled-btn-color,
+                        $disabled_border-color: s.$il-disabled-btn-border,
+  );
   &.engaged,
   .open & {
     border: 1px solid s.$il-btn-ctrl-engaged-border;
@@ -123,7 +127,7 @@ input.btn {
     @extend .btn-ctrl;
     margin-left: l.$il-margin-xs-horizontal;
   }
-} 
+}
 
 // ILIAS doesn't use btn-success, btn-info, btn-warning, btn-danger
 
@@ -198,7 +202,7 @@ input.btn {
     $disabled_bg-color: s.$il-disabled-btn-bg,
     $disabled_text-color: s.$il-disabled-btn-color,
     $disabled_border-color: s.$il-disabled-btn-border,
-    
+
     $active_transform: null,
 
     $engaged_text-color: inherit,

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -3203,11 +3203,11 @@ input.btn, input.il-link.link-bulky,
 .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a fieldset[disabled] {
-  background-color: white;
+  background-color: #b0b0b0;
   border-width: 1px;
   border-style: solid;
-  border-color: white;
-  color: rgba(76, 101, 134, 0.9);
+  border-color: #b0b0b0;
+  color: black;
   cursor: not-allowed;
   transform: none;
 }
@@ -7429,11 +7429,11 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
 .ilTableNav > table > tbody > tr > td > .btn-group > .btn-link fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .dropdown > .btn-default fieldset[disabled],
 .ilTableNav > table > tbody > tr > td > .navbar-form.dropdown > a fieldset[disabled] {
-  background-color: white;
+  background-color: #b0b0b0;
   border-width: 1px;
   border-style: solid;
-  border-color: white;
-  color: rgba(76, 101, 134, 0.9);
+  border-color: #b0b0b0;
+  color: black;
   cursor: not-allowed;
   transform: none;
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=41562
https://mantis.ilias.de/view.php?id=38505

# Issue

In the older UI component ViewControls/Pagination (NOT Input/ViewControls/Pagination) only the next/previous glyphs are clickable and not the entirety of what looks like a button.

# Changes

This is because the deprecated glyphs with actions have been used. Now the classic ViewControls/Pagination Renderer uses a button with a glyph inside instead (like the Input variant) which is clickable all the way across.

![image](https://github.com/user-attachments/assets/003f783b-fb77-428c-b79d-01d6a0b82aad)

Visibility of disabled state matches the global disabled button color settings now, which are a bit too bold for my taste but better for accessibility.

![image](https://github.com/user-attachments/assets/3bffee84-82ec-4401-a76a-dcc5aba0ca09)

# By the way

Not directly related to the ticket, but just a note: I would prefer not showing a next/previous button if there is no such page. Why show a disabled state at all? The pages communicate sufficiently that there are pages.