### PR TITLE
UI: Add new column type `Breadcrumb` for the UI Table

### DIFF
--- a/components/ILIAS/UI/src/Component/Table/Column/Breadcrumb.php
+++ b/components/ILIAS/UI/src/Component/Table/Column/Breadcrumb.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Component\Table\Column;
+
+interface Breadcrumb extends Column
+{
+}

--- a/components/ILIAS/UI/src/Component/Table/Column/Factory.php
+++ b/components/ILIAS/UI/src/Component/Table/Column/Factory.php
@@ -142,4 +142,16 @@ interface Factory
      * @return \ILIAS\UI\Component\Table\Column\LinkListing
      */
     public function linkListing(string $title): LinkListing;
+
+    /**
+     * ---
+     * description:
+     *   purpose: >
+     *      The Breadcrumb Column is used to show a breadcrumb path.
+     *   composition: >
+     *      The column field requires a Breadcrumbs Component.
+     * ---
+     * @return \ILIAS\UI\Component\Table\Column\Breadcrumb
+     */
+    public function breadcrumb(string $title): Breadcrumb;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Breadcrumb.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Breadcrumb.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\Implementation\Component\Table\Column;
+
+use ILIAS\UI\Component\Table\Column\Breadcrumb as BreadcrumbInterface;
+use ILIAS\UI\Component\Component;
+use ILIAS\UI\Component\Breadcrumbs\Breadcrumbs;
+
+class Breadcrumb extends Column implements BreadcrumbInterface
+{
+    public function format($value): Breadcrumbs
+    {
+        return $value;
+    }
+}

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Column/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Column/Factory.php
@@ -85,4 +85,9 @@ class Factory implements I\Factory
     {
         return new LinkListing($this->lng, $title);
     }
+
+    public function breadcrumb(string $title): I\Breadcrumb
+    {
+        return new Breadcrumb($this->lng, $title);
+    }
 }

--- a/components/ILIAS/UI/src/examples/Table/Column/Breadcrumb/base.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/Breadcrumb/base.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Table\Column\Breadcrumb;
+
+use ILIAS\Data\Range;
+use ILIAS\Data\Order;
+use ILIAS\UI\Component\Table\DataRowBuilder;
+use ILIAS\UI\Component\Table\DataRetrieval;
+
+/**
+ * ---
+ * description: >
+ *   A table with a breadcrumb column.
+ *
+ * expected output: >
+ *   ILIAS shows a table with one column and one row.
+ *   The row consists of 2 clickable links separated by simple arrows (>).
+ * ---
+ */
+function base()
+{
+    global $DIC;
+
+    $data_retrieval = new class () implements DataRetrieval {
+        public function getRows(
+            DataRowBuilder $row_builder,
+            array $visible_column_ids,
+            Range $range,
+            Order $order,
+            ?array $filter_data,
+            ?array $additional_parameters
+        ): \Generator {
+            global $DIC;
+            yield $row_builder->buildDataRow('dummy', [
+                'object' => $DIC->ui()->factory()->breadcrumbs([
+                    $DIC->ui()->factory()->link()->standard('Repository', '/'),
+                    $DIC->ui()->factory()->link()->standard('Course', '/login.php'),
+                ]),
+            ]);
+        }
+
+        public function getTotalRowCount(
+            ?array $filter_data,
+            ?array $additional_parameters
+        ): ?int {
+            return 1;
+        }
+    };
+
+    $columns = [
+        'object' => $DIC->ui()->factory()->table()->column()->breadcrumb('Object'),
+    ];
+
+    $table = $DIC->ui()->factory()->table()->data($data_retrieval, 'Test Breadcrumb Column', $columns)
+        ->withRequest($DIC->http()->request());
+
+    return $DIC->ui()->renderer()->render($table);
+}

--- a/components/ILIAS/UI/src/examples/Table/Column/Breadcrumb/disabled.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/Breadcrumb/disabled.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Table\Column\Breadcrumb;
+
+use ILIAS\Data\Range;
+use ILIAS\Data\Order;
+use ILIAS\UI\Component\Table\DataRowBuilder;
+use ILIAS\UI\Component\Table\DataRetrieval;
+
+/**
+ * ---
+ * description: >
+ *   A table where the second breadcrumb item is disabled.
+ *
+ * expected output: >
+ *   ILIAS shows a table with one column and one row.
+ *   The row consists of one clickable and one non-clickable link separated by simple arrows (>).
+ * ---
+ */
+function disabled()
+{
+    global $DIC;
+
+    $data_retrieval = new class () implements DataRetrieval {
+        public function getRows(
+            DataRowBuilder $row_builder,
+            array $visible_column_ids,
+            Range $range,
+            Order $order,
+            ?array $filter_data,
+            ?array $additional_parameters
+        ): \Generator {
+            global $DIC;
+            yield $row_builder->buildDataRow('dummy', [
+                'object' => $DIC->ui()->factory()->breadcrumbs([
+                    $DIC->ui()->factory()->link()->standard('Repository', '/'),
+                    $DIC->ui()->factory()->link()->standard('Course', '/login.php')->withDisabled(true),
+                ]),
+            ]);
+        }
+
+        public function getTotalRowCount(
+            ?array $filter_data,
+            ?array $additional_parameters
+        ): ?int {
+            return 1;
+        }
+    };
+
+    $columns = [
+        'object' => $DIC->ui()->factory()->table()->column()->breadcrumb('Object'),
+    ];
+
+    $table = $DIC->ui()->factory()->table()->data($data_retrieval, 'Test disabled Breadcrumb Column', $columns)
+        ->withRequest($DIC->http()->request());
+
+    return $DIC->ui()->renderer()->render($table);
+}

--- a/components/ILIAS/UI/src/examples/Table/Column/Breadcrumb/long_path.php
+++ b/components/ILIAS/UI/src/examples/Table/Column/Breadcrumb/long_path.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Table\Column\Breadcrumb;
+
+use ILIAS\Data\Range;
+use ILIAS\Data\Order;
+use ILIAS\UI\Component\Table\DataRowBuilder;
+use ILIAS\UI\Component\Table\DataRetrieval;
+
+/**
+ * ---
+ * description: >
+ *   A table with a very long breadcrumb path.
+ * expected output: >
+ *   ILIAS shows a table with two columns and two row.
+ *   The first column of each row consists of 8 ckickable links separated by simple arrows (>).
+ *   The second column of each row displays the text "Max Mustermann".
+ *   The links break into multiple lines if there is no space left to display all links.
+ * ---
+ */
+function long_path()
+{
+    global $DIC;
+
+    $data_retrieval = new class () implements DataRetrieval {
+        public function getRows(
+            DataRowBuilder $row_builder,
+            array $visible_column_ids,
+            Range $range,
+            Order $order,
+            ?array $filter_data,
+            ?array $additional_parameters
+        ): \Generator {
+            global $DIC;
+            $link = fn($x) => $DIC->ui()->factory()->link()->standard($x, '/');
+            $path = [
+                'Repository', 'Faculty', 'Department', 'Institute', 'Professorship',
+                'Learning Management Systems', 'Best Practice', 'ILIAS',
+            ];
+            $row = $row_builder->buildDataRow('dummy', [
+                'object' => $DIC->ui()->factory()->breadcrumbs(array_map($link, $path)),
+                'owner' => 'Max Mustermann',
+            ]);
+            yield $row;
+            yield $row;
+        }
+
+        public function getTotalRowCount(
+            ?array $filter_data,
+            ?array $additional_parameters
+        ): ?int {
+            return 1;
+        }
+    };
+
+    $columns = [
+        'object' => $DIC->ui()->factory()->table()->column()->breadcrumb('Object'),
+        'owner' => $DIC->ui()->factory()->table()->column()->text('Owner'),
+    ];
+
+    $table = $DIC->ui()->factory()->table()->data($data_retrieval, 'Test long Breadcrumb Column', $columns)
+        ->withRequest($DIC->http()->request());
+
+    return $DIC->ui()->renderer()->render($table);
+}

--- a/components/ILIAS/UI/tests/Component/Table/Column/ColumnFactoryTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/Column/ColumnFactoryTest.php
@@ -35,7 +35,8 @@ class ColumnFactoryTest extends AbstractFactoryTestCase
         "statusIcon" => ["context" => false, "rules" => false],
         "timeSpan" => ["context" => false, "rules" => false],
         "link" => ["context" => false, "rules" => false],
-        "linkListing" => ["context" => false, "rules" => false]
+        "linkListing" => ["context" => false, "rules" => false],
+        "breadcrumb" => ["context" => false, "rules" => false],
     ];
 
     public static string $factory_title = 'ILIAS\\UI\\Component\\Table\\Column\\Factory';

--- a/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
+++ b/templates/default/070-components/UI-framework/Table/_ui-component_table.scss
@@ -368,6 +368,15 @@ td.c-table-data__cell--highlighted {
     }
 }
 
+// Breadcrumb
+.c-table-data__cell--breadcrumb .breadcrumb_wrapper {
+    background-color: transparent;
+    .breadcrumb {
+        white-space: wrap;
+        padding: 0;
+    }
+}
+
 //
 // Data Table on Small Screens
 //

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -11101,6 +11101,14 @@ td.c-table-data__cell--highlighted {
   }
 }
 
+.c-table-data__cell--breadcrumb .breadcrumb_wrapper {
+  background-color: transparent;
+}
+.c-table-data__cell--breadcrumb .breadcrumb_wrapper .breadcrumb {
+  white-space: wrap;
+  padding: 0;
+}
+
 .c-table-data__cell__col-title {
   display: none;
 }


### PR DESCRIPTION
This PR proposes a new column `Path` for the data table.
This addition to the UI framework became necessary as part of the Removing of Legacy-UIComponents-Service and Table project.
@oliversamoila had asked me to provide a PR so that the new UI data table could be used in various places where paths are displayed as information.

For example, a column for mapping paths is required in the following contexts:
* Contacts/Mail : Communication > Contacts > My Courses > : Mapping of paths of courses in the system
* Statistics : Administration > Learning success > Statistics and learning progress > Statistics : Paths of objects
* Roles : Administration > Roles > e.g. local roles : Paths of contexts of roles
