### PR TITLE
SCORM: Fix URLs to debugging tool

### DIFF
--- a/components/ILIAS/Scorm2004/classes/class.ilSCORM13PlayerGUI.php
+++ b/components/ILIAS/Scorm2004/classes/class.ilSCORM13PlayerGUI.php
@@ -410,8 +410,8 @@ class ilSCORM13PlayerGUI
         $config['get_gobjective_url'] = 'ilias.php?baseClass=ilSAHSPresentationGUI' . '&cmd=getGobjective&ref_id=' . $this->ref_id;
         $config['ping_url'] = 'ilias.php?baseClass=ilSAHSPresentationGUI' . '&cmd=pingSession&ref_id=' . $this->ref_id;
         $config['scorm_player_unload_url'] = $unload_url;
-        $config['post_log_url'] = 'ilias.php?baseClass=ilSAHSPresentationGUI' . '&cmd=postLogEntry&ref_id=' . $this->ref_id;
-        $config['livelog_url'] = 'ilias.php?baseClass=ilSAHSPresentationGUI' . '&cmd=liveLogContent&ref_id=' . $this->ref_id;
+        $config['post_log_url'] = $DIC->ctrl()->getLinkTarget($this, 'postLogEntry');
+        $config['livelog_url'] = $DIC->ctrl()->getLinkTarget($this, 'liveLogContent');
         $config['package_url'] = $this->getDataDirectory() . "/";
 
         //editor


### PR DESCRIPTION
This PR fixes issues with the endpoints used in the context of the SCORM debugging tool.

The current problem is, that due to the abandoned `ilCtrl::setCmdClass` and `ilCtrl::setCmd` methods, the HTTP POST requests result in an HTTP 302 redirect, which leads to a loss of all data contained in the HTTP POST body.