### PR TITLE
T&A10 43482: Fixes test export with user results and adds user file upload question file uploads to export and import

### DIFF
--- a/components/ILIAS/Test/classes/class.ilTestImporter.php
+++ b/components/ILIAS/Test/classes/class.ilTestImporter.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\ResourceStorage\Services as ResourceStorage;
 use ILIAS\TestQuestionPool\Import\TestQuestionsImportTrait;
 use ILIAS\Test\TestDIC;
 use ILIAS\Test\Logging\TestLogger;
@@ -39,12 +40,14 @@ class ilTestImporter extends ilXmlImporter
 
     private readonly TestLogger $logger;
     private readonly ilDBInterface $db;
+    private readonly ResourceStorage $irss;
 
     public function __construct()
     {
         global $DIC;
         $this->logger = TestDIC::dic()['logging.logger'];
         $this->db = $DIC['ilDB'];
+        $this->irss = $DIC['resource_storage'];
 
         parent::__construct();
     }
@@ -119,7 +122,7 @@ class ilTestImporter extends ilXmlImporter
         }
 
         if ($results_file_path !== null && file_exists($results_file_path)) {
-            $results = new ilTestResultsImportParser($results_file_path, $new_obj, $this->db, $this->logger);
+            $results = new ilTestResultsImportParser($results_file_path, $new_obj, $this->db, $this->logger, $this->irss);
             $results->setQuestionIdMapping($a_mapping->getMappingsOfEntity('components/ILIAS/Test', 'quest'));
             $results->setSrcPoolDefIdMapping($a_mapping->getMappingsOfEntity('components/ILIAS/Test', 'rnd_src_pool_def'));
             $results->startParsing();

--- a/components/ILIAS/Test/classes/class.ilTestResultsImportParser.php
+++ b/components/ILIAS/Test/classes/class.ilTestResultsImportParser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Filesystem\Stream\Stream;
+use ILIAS\ResourceStorage\Services as ResourceStorage;
 use ILIAS\Test\Logging\TestLogger;
 
 class ilTestResultsImportParser extends ilSaxParser
@@ -30,6 +33,8 @@ class ilTestResultsImportParser extends ilSaxParser
 
     protected $src_pool_def_id_mapping;
 
+    private string $import_directory;
+
     /**
     * Constructor
     */
@@ -37,14 +42,15 @@ class ilTestResultsImportParser extends ilSaxParser
         ?string $a_xml_file,
         private ilObjTest $test_obj,
         private ilDBInterface $db,
-        private TestLogger $log
+        private TestLogger $log,
+        private ResourceStorage $irss
     ) {
         parent::__construct($a_xml_file, true);
         $this->table = '';
         $this->active_id_mapping = [];
         $this->question_id_mapping = [];
-        $this->user_criteria_checked = false;
         $this->src_pool_def_id_mapping = [];
+        $this->import_directory = dirname($a_xml_file);
     }
 
     /**
@@ -228,7 +234,7 @@ class ilTestResultsImportParser extends ilSaxParser
                             "solution_id" => ["integer", $next_id],
                             "active_fi" => ["integer", $this->active_id_mapping[$a_attribs['active_fi']]],
                             "question_fi" => ["integer", $this->question_id_mapping[$a_attribs['question_fi']]],
-                            "value1" => ["clob", (strlen($a_attribs['value1'])) ? $a_attribs['value1'] : null],
+                            "value1" => ["clob", $this->importParticipantsUploadedFiles($a_attribs)],
                             "value2" => ["clob", (strlen($a_attribs['value2'])) ? $a_attribs['value2'] : null],
                             "pass" => ["integer", $a_attribs['pass']],
                             "tstamp" => ["integer", $a_attribs['tstamp']]
@@ -314,5 +320,41 @@ class ilTestResultsImportParser extends ilSaxParser
         }
 
         return null;
+    }
+
+    /**
+     * @param array{value1: string, value2: string} $a_attribs
+     * @return string
+     */
+    private function importParticipantsUploadedFiles(array $a_attribs): ?string
+    {
+        ['value1' => $value1, 'value2' => $value2] = $a_attribs;
+
+        if ($value2 !== 'rid') {
+            return $value1 ?: null;
+        }
+
+        $resource_directory = "$this->import_directory/objects/resources/$value1";
+        $file_name = $this->getFirstFileName($resource_directory);
+        if (!is_string($file_name)) {
+            return $value1 ?: null;
+        }
+
+        $file_path = "$resource_directory/$file_name";
+        $new_rid = $this->irss->manage()->stream(
+            new Stream(fopen($file_path, 'rwb')),
+            new assFileUploadStakeholder(),
+            basename($file_path),
+        );
+        return $new_rid->serialize();
+    }
+
+    private function getFirstFileName(string $resource_directory): mixed
+    {
+        $entries = array_filter(
+            scandir($resource_directory),
+            static fn(string $entry): bool => is_file("$resource_directory/$entry") && !in_array($entry, ['.', '..']),
+        );
+        return array_shift($entries);
     }
 }

--- a/components/ILIAS/Test/classes/class.ilTestResultsToXML.php
+++ b/components/ILIAS/Test/classes/class.ilTestResultsToXML.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\ResourceStorage\Services as ResourceStorage;
+
 class ilTestResultsToXML extends ilXmlWriter
 {
     private $active_ids;
@@ -27,6 +29,8 @@ class ilTestResultsToXML extends ilXmlWriter
     public function __construct(
         private int $test_id,
         private ilDBInterface $db,
+        private ResourceStorage $irss,
+        private string $objects_export_directory,
         private bool $anonymized = false
     ) {
         parent::__construct();
@@ -200,18 +204,50 @@ class ilTestResultsToXML extends ilXmlWriter
         $result = $this->db->query($query);
         $this->xmlStartTag('tst_test_result', null);
         while ($row = $this->db->fetchAssoc($result)) {
+            $active_fi = $row['active_fi'];
+            $pass = $row['pass'] ?? '';
             $attrs = [
                 'test_result_id' => $row['test_result_id'],
-                'active_fi' => $row['active_fi'],
+                'active_fi' => $active_fi,
                 'question_fi' => $row['question_fi'],
                 'points' => $row['points'] ?? '',
-                'pass' => $row['pass'] ?? '',
+                'pass' => $pass,
                 'manual' => $row['manual'] ?? '',
                 'tstamp' => $row['tstamp'] ?? ''
             ];
+
+            if (($question = assQuestion::instantiateQuestion($row['question_fi'])) instanceof assFileUpload) {
+                $this->exportParticipantUploadedFiles($question->getUploadedFiles($active_fi, $pass));
+            }
+
             $this->xmlElement('row', $attrs);
         }
         $this->xmlEndTag('tst_test_result');
+    }
+
+    /**
+     * @param array{value1: string, value2: string} $uploaded_files
+     */
+    protected function exportParticipantUploadedFiles(array $uploaded_files): void
+    {
+        foreach ($uploaded_files as $uploaded_file) {
+            if ($uploaded_file['value2'] !== 'rid') {
+                continue;
+            }
+
+            $rid_string = $uploaded_file['value1'];
+            $rid = $this->irss->manage()->find($rid_string);
+            if ($rid === null) {
+                continue;
+            }
+
+            $target_dir = "$this->objects_export_directory/resources/$rid_string";
+            ilFileUtils::makeDirParents($target_dir);
+            file_put_contents(
+                "$target_dir/{$this->irss->manage()->getCurrentRevision($rid)->getTitle()}",
+                $this->irss->consume()->stream($rid)->getStream(),
+            );
+        }
     }
 
     protected function exportTestTimes(): void

--- a/components/ILIAS/Test/src/ExportImport/Export.php
+++ b/components/ILIAS/Test/src/ExportImport/Export.php
@@ -24,6 +24,7 @@ use ILIAS\Test\Logging\TestLogger;
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
 use ILIAS\Language\Language;
 use ILIAS\FileDelivery\Services as FileDeliveryServices;
+use ILIAS\ResourceStorage\Services as ResourceStorage;
 
 /**
  * Export class for tests
@@ -61,7 +62,8 @@ abstract class Export implements Exporter
         protected readonly \ilComponentRepository $component_repository,
         protected readonly GeneralQuestionPropertiesRepository $questionrepository,
         protected readonly FileDeliveryServices $file_delivery,
-        protected readonly \ilObjTest $test_obj
+        protected readonly \ilObjTest $test_obj,
+        protected readonly ResourceStorage $irss
     ) {
         $this->inst_id = (string) IL_INST_ID;
         $this->export_dir = $test_obj->getExportDirectory();
@@ -163,7 +165,13 @@ abstract class Export implements Exporter
         $this->bench->stop('TestExport', 'write_dumpToFile');
 
         if ($this->isResultExportingEnabled()) {
-            $resultwriter = new \ilTestResultsToXML($this->test_obj->getTestId(), $this->db, $this->test_obj->getAnonymity());
+            $resultwriter = new \ilTestResultsToXML(
+                $this->test_obj->getTestId(),
+                $this->db,
+                $this->irss,
+                $this->export_dir . "/" . $this->subdir . "/objects",
+                $this->test_obj->getAnonymity()
+            );
             $resultwriter->setIncludeRandomTestQuestionsEnabled($this->test_obj->isRandomTest());
             $this->bench->start('TestExport', 'write_results');
             $resultwriter->xmlDumpFile($this->export_dir . '/' . $this->subdir . '/' . $this->resultsfile, false);

--- a/components/ILIAS/Test/src/ExportImport/Factory.php
+++ b/components/ILIAS/Test/src/ExportImport/Factory.php
@@ -23,6 +23,7 @@ namespace ILIAS\Test\ExportImport;
 use ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository;
 use ILIAS\Test\Logging\TestLogger;
 use ILIAS\FileDelivery\Services as FileDeliveryServices;
+use ILIAS\ResourceStorage\Services as ResourceStorage;
 
 class Factory
 {
@@ -37,7 +38,8 @@ class Factory
         private readonly \ilComponentFactory $component_factory,
         private readonly FileDeliveryServices $file_delivery,
         private readonly \ilObjUser $current_user,
-        private readonly GeneralQuestionPropertiesRepository $questionrepository
+        private readonly GeneralQuestionPropertiesRepository $questionrepository,
+        private readonly ResourceStorage $irss
     ) {
     }
 
@@ -97,7 +99,8 @@ class Factory
                     $this->component_repository,
                     $this->questionrepository,
                     $this->file_delivery,
-                    $test_obj
+                    $test_obj,
+                    $this->irss
                 );
 
                 if ($export_type === Types::XML_WITH_RESULTS) {

--- a/components/ILIAS/Test/src/TestDIC.php
+++ b/components/ILIAS/Test/src/TestDIC.php
@@ -182,7 +182,8 @@ class TestDIC extends PimpleContainer
                 $DIC['component.factory'],
                 $DIC['file_delivery'],
                 $DIC['ilUser'],
-                $c['question.general_properties.repository']
+                $c['question.general_properties.repository'],
+                $DIC['resource_storage'],
             );
 
         $dic['exportimport.repository'] = static fn($c): ExportImportRepository =>

--- a/components/ILIAS/Test/tests/ExportImport/ExportFactoryTest.php
+++ b/components/ILIAS/Test/tests/ExportImport/ExportFactoryTest.php
@@ -45,7 +45,8 @@ class ExportFactoryTest extends \ilTestBaseTestCase
             $this->createMock(\ilComponentFactory::class),
             $this->createMock(\ILIAS\FileDelivery\Services::class),
             $this->createMock(\ilObjUser::class),
-            $this->createMock(GeneralQuestionPropertiesRepository::class)
+            $this->createMock(GeneralQuestionPropertiesRepository::class),
+            $this->createMock(\ILIAS\ResourceStorage\Services::class)
         );
     }
 

--- a/components/ILIAS/Test/tests/ExportImport/ExportFixedQuestionSetTest.php
+++ b/components/ILIAS/Test/tests/ExportImport/ExportFixedQuestionSetTest.php
@@ -31,10 +31,12 @@ class ExportFixedQuestionSetTest extends \ilTestBaseTestCase
 
     protected function setUp(): void
     {
+        global $DIC;
         parent::setUp();
 
         $this->addGlobal_ilErr();
         $this->addGlobal_ilias();
+        $this->addGlobal_resourceStorage();
 
         $this->testObj = new ExportFixedQuestionSet(
             $this->createMock(\ILIAS\Language\Language::class),
@@ -45,7 +47,8 @@ class ExportFixedQuestionSetTest extends \ilTestBaseTestCase
             $this->createMock(\ilComponentRepository::class),
             $this->createMock(\ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository::class),
             $this->createMock(\ILIAS\FileDelivery\Services::class),
-            $this->createMock(\ilObjTest::class)
+            $this->createMock(\ilObjTest::class),
+            $DIC['resource_storage']
         );
     }
 

--- a/components/ILIAS/Test/tests/ExportImport/ExportRandomQuestionSetTest.php
+++ b/components/ILIAS/Test/tests/ExportImport/ExportRandomQuestionSetTest.php
@@ -35,6 +35,7 @@ class ExportRandomQuestionSetTest extends \ilTestBaseTestCase
         parent::setUp();
 
         $this->addGlobal_ilErr();
+        $this->addGlobal_resourceStorage();
 
         $this->testObj = new ExportRandomQuestionSet(
             $this->createMock(\ILIAS\Language\Language::class),
@@ -45,7 +46,8 @@ class ExportRandomQuestionSetTest extends \ilTestBaseTestCase
             $DIC['component.repository'],
             $this->createMock(\ILIAS\TestQuestionPool\Questions\GeneralQuestionPropertiesRepository::class),
             $this->createMock(\ILIAS\FileDelivery\Services::class),
-            $this->getTestObjMock()
+            $this->getTestObjMock(),
+            $DIC['resource_storage']
         );
     }
 

--- a/components/ILIAS/Test/tests/ilTestBaseTestCase.php
+++ b/components/ILIAS/Test/tests/ilTestBaseTestCase.php
@@ -68,6 +68,7 @@ class ilTestBaseTestCase extends TestCase
         $this->addGlobal_ilCtrl();
         $this->addGlobal_ilBench();
         $this->addGlobal_ilSetting();
+        $this->addGlobal_resourceStorage();
 
         $this->defineGlobalConstants();
 

--- a/components/ILIAS/Test/tests/ilTestResultsToXMLTest.php
+++ b/components/ILIAS/Test/tests/ilTestResultsToXMLTest.php
@@ -28,11 +28,14 @@ class ilTestResultsToXMLTest extends ilTestBaseTestCase
 
     protected function setUp(): void
     {
+        global $DIC;
         parent::setUp();
 
         $this->testObj = new ilTestResultsToXML(
             0,
-            $this->createMock(ilDBInterface::class),
+            $DIC['ilDB'],
+            $DIC['resource_storage'],
+            '',
             false
         );
     }


### PR DESCRIPTION
[Mantis: 43482](https://mantis.ilias.de/view.php?id=43482)

When exporint a test with participant data, the file uploads from file upload questions do not get exported. This causes the files to be missing on import and preventing a manual correction if the question.

I believe this should fix this issue, by including the participants file uploads in the export and importing them on import into the systems storage.