### PR TITLE
UI Tag Input: 45126 remove encoding as it is already encoded through …

### DIFF
--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -373,7 +373,7 @@ class Renderer extends AbstractComponentRenderer
         if ($value) {
             $value = array_map(
                 function ($v) {
-                    return ['value' => urlencode($this->convertSpecialCharacters($v)), 'display' => $v];
+                    return ['value' => urlencode($v), 'display' => $v];
                 },
                 $value
             );

--- a/src/UI/Implementation/Component/Input/Field/Tag.php
+++ b/src/UI/Implementation/Component/Input/Field/Tag.php
@@ -75,7 +75,8 @@ class Tag extends FormInput implements C\Input\Field\Tag
             if (count($v) == 1 && $v[0] === '') {
                 return [];
             }
-            return array_map("urldecode", $v);
+            $array = array_map("urldecode", $v);
+            return array_map('strip_tags', $array);
         }));
     }
 


### PR DESCRIPTION
…the Tag Input code. 

Also strip tags to prevent e.g. JavaScript injections.

https://mantis.ilias.de/view.php?id=45126

Before fix:
![TagInput_encoding_special_chars_before](https://github.com/user-attachments/assets/63164c73-d2b5-430f-9e85-f66131b561e5)


Now with fix:
![TagInput_encoding_special_chars_after](https://github.com/user-attachments/assets/7a904676-c899-457c-9eb7-d876aebb4b33)

