### PR TITLE
UI: Do Not Double Encode Values

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -256,7 +256,7 @@ class Renderer extends AbstractComponentRenderer
             // with declare(strict_types=1) in place,
             // htmlspecialchars will not silently convert to string anymore;
             // therefore, the typecast must be explicit
-            return htmlspecialchars((string) $v, ENT_QUOTES);
+            return htmlspecialchars((string) $v, ENT_QUOTES, 'utf-8', false);
         };
     }
 
@@ -266,7 +266,7 @@ class Renderer extends AbstractComponentRenderer
             // with declare(strict_types=1) in place,
             // htmlentities will not silently convert to string anymore;
             // therefore, the typecast must be explicit
-            return htmlentities((string) $v);
+            return htmlentities((string) $v, ENT_QUOTES, 'utf-8', false);
         };
     }
 


### PR DESCRIPTION
Dear UI-Coordinators

This PR is one way to solve the problem with mustache-placeholders in text-fields (See: https://mantis.ilias.de/view.php?id=45141). Let me know, if you would prefer another solution.

Thanks and best,
@kergomard 