### PR TITLE
(ILIAS 9) Forum Bugfix: moveThreadsObject Table in ilObjForumGUI isn't shown

### DIFF
--- a/Modules/Forum/classes/class.ilObjForumGUI.php
+++ b/Modules/Forum/classes/class.ilObjForumGUI.php
@@ -4015,7 +4015,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
             $tblThr->setRowTemplate('tpl.forums_threads_move_thr_row.html', 'Modules/Forum');
             $tblThr->setDefaultOrderField('is_sticky');
 
-            #$tblThr->setData($result);
+            $tblThr->setData($result);
             $moveThreadTemplate->setVariable('THREAD_TITLE', sprintf($this->lng->txt('move_chosen_topics'), $thread->getSubject()));
             $moveThreadTemplate->setVariable('THREADS_TABLE', $tblThr->getHTML());
             $moveThreadTemplate->setVariable('FRM_SELECTION_TREE', $exp->getHTML());

--- a/Modules/Forum/templates/default/tpl.forums_threads_move.html
+++ b/Modules/Forum/templates/default/tpl.forums_threads_move.html
@@ -1,5 +1,6 @@
 <form method="post" action="{FORMACTION}" role="form" class="preventDoubleSubmission">
 <h2 class="ilHeader ilTableHeaderTitle">{THREAD_TITLE}</h2>
+{THREADS_TABLE}
 <p>&nbsp;</p>
 {FRM_SELECTION_TREE}
 <p>&nbsp;</p>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45143