### PR TITLE
Init: Don't use absolute path to client.ini if `CLIENT_WEB_DIR` is de…

### DIFF
--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -514,11 +514,10 @@ class ilInitialisation
         if (defined('CLIENT_WEB_DIR')) {
             $ini_file = CLIENT_WEB_DIR . $ini_file;
         } else {
-            $ini_file = ILIAS_WEB_DIR . "/" . CLIENT_ID . "/client.ini.php";
+            $ini_file = __DIR__ . '/../../../../public/' . ILIAS_WEB_DIR . '/' . CLIENT_ID . '/client.ini.php';
         }
 
-        // get settings from ini file
-        $ilClientIniFile = new ilIniFile(__DIR__ . "/../../../../public/" . $ini_file);
+        $ilClientIniFile = new ilIniFile($ini_file);
         $ilClientIniFile->read();
 
         // invalid client id / client ini


### PR DESCRIPTION
…fined

See: https://mantis.ilias.de/view.php?id=42368

If approved, this must be picked to `trunk`.