### PR TITLE
Fix: Correct declarations of LTI symbols

### DIFF
--- a/components/ILIAS/UI/src/Component/Symbol/Icon/Standard.php
+++ b/components/ILIAS/UI/src/Component/Symbol/Icon/Standard.php
@@ -145,7 +145,7 @@ interface Standard extends Icon
     public const LHTS = 'lhts';	//Learning History
     public const COMS = 'coms';	//Comments
     public const LTI = 'lti';	//LTI
-    public const LTIS = 'ltis';	//LTIs
+    public const LTIS = 'ltis';	//LTI administration
     public const CMIS = 'cmis';	//xAPI/cmi5
     public const REP = 'rep';	//Repository
     public const TASK = 'task';   //Task

--- a/components/ILIAS/UI/src/Component/Symbol/Icon/Standard.php
+++ b/components/ILIAS/UI/src/Component/Symbol/Icon/Standard.php
@@ -144,7 +144,8 @@ interface Standard extends Icon
     public const NOTS = 'nots';	//Notes
     public const LHTS = 'lhts';	//Learning History
     public const COMS = 'coms';	//Comments
-    public const LTIS = 'lti';	//LTI
+    public const LTI = 'lti';	//LTI
+    public const LTIS = 'ltis';	//LTIs
     public const CMIS = 'cmis';	//xAPI/cmi5
     public const REP = 'rep';	//Repository
     public const TASK = 'task';   //Task

--- a/components/ILIAS/UI/src/Implementation/Component/Symbol/Icon/Standard.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Symbol/Icon/Standard.php
@@ -139,6 +139,7 @@ class Standard extends Icon implements C\Symbol\Icon\Standard
         self::NOTS,
         self::LHTS,
         self::COMS,
+        self::LTI,
         self::LTIS,
         self::CMIS,
         self::TASK,


### PR DESCRIPTION
The "LTIS" const has been modified to redefine the "ltis" icon and a new "LTI" const has been added to define the "lti" icon.
With this change, the LTI configuration icon in the administrative panel appears correctly.