### PR TITLE
Mantis 45179: Fix missing seconddary speedo if initial result is 0

### DIFF
--- a/Services/Container/Content/ObjectiveView/class.ObjectiveRenderer.php
+++ b/Services/Container/Content/ObjectiveView/class.ObjectiveRenderer.php
@@ -837,7 +837,7 @@ class ObjectiveRenderer
 
                     // force list mode to get rid of next step
                     #$initial_sub = self::buildObjectiveProgressBar(true, $a_objective_id, $a_lo_result["initial"], true, true, $a_tt_suffix);
-                    $compare_value = $a_lo_result['initial']['result_perc'];
+                    $compare_value = max($a_lo_result['initial']['result_perc'],1);
                 }
             } else {
                 $next_step = $lng->txt("crs_loc_progress_do_qualifying_again");


### PR DESCRIPTION
since a compare_value of 0 disables the secondary speedo scale, I set the rendered result to 1 if the initial test result was 0 and a qualifying result is present (as a workaround).