### PR TITLE
T&A Prevent reset of submitted passes inside tst_active if extra time is added

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -7619,12 +7619,6 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             }
 
             $this->db->manipulateF(
-                "UPDATE tst_active SET tries = %s, submitted = %s, submittimestamp = %s WHERE active_id = %s",
-                ['integer','integer','timestamp','integer'],
-                [0, 0, null, $active_fi]
-            );
-
-            $this->db->manipulateF(
                 "INSERT INTO tst_addtime (active_fi, additionaltime, tstamp) VALUES (%s, %s, %s)",
                 ['integer','integer','integer'],
                 [$active_fi, $minutes, time()]


### PR DESCRIPTION
This PR is related to Mantis-Ticket https://mantis.ilias.de/view.php?id=45186.

It fixes an issue where already submitted tests are incorrectly shown as "not finished" after extra time is granted. The underlying problem was caused by a database query that reset submission data, which should no longer be necessary in ILIAS 9. The query has been removed to ensure correct status display and prevent user confusion.

This PR must only be merged into release_9, as the behaviour has been reworked from ILIAS >= 10.

Best,
@thojou 