### PR TITLE
10/UI/Button/month Firefox fallback 43178

### DIFF
--- a/components/ILIAS/UI/resources/js/Button/button.js
+++ b/components/ILIAS/UI/resources/js/Button/button.js
@@ -19,13 +19,97 @@ il.UI.button = il.UI.button || {};
 (function ($, il) {
   il.UI.button = (function ($) {
     /* month button */
+    const isMonthSupported = () => {
+      const input = document.createElement('input');
+      input.setAttribute('type', 'month');
+
+      // Valid browsers will reject this value in a month input, Firefox does currently accept it.
+      const notADateValue = 'not-a-month';
+      input.value = notADateValue;
+      const rejectsInvalid = input.value !== notADateValue;
+
+      // Safari does reject the input but also has a bad month picker on desktop
+      const userAgent = navigator.userAgent.toLowerCase();
+      const isIphone = userAgent.includes('iphone');
+      const isIpad = userAgent.includes('ipad');
+      const isSafari = userAgent.includes('safari') && !userAgent.includes('chrome'); // chrome's user agent also includes the word 'safari'
+
+      const isLikelyBadWebKit = isSafari && !isIphone && !isIpad;
+
+      return rejectsInvalid && !isLikelyBadWebKit;
+    };
+
     const initMonth = function (id) {
+      const container = document.querySelector(`#${id}`);
       const btn = document.querySelector(`#${id} > input`);
-      btn.addEventListener('change', (e) => {
-        const value = e.srcElement.value.split('-').reverse().join('-');
-        const id = e.srcElement.closest('.il-btn-month').getAttribute('id');
+      const triggerEvent = (id, value) => {
         $(`#${id}`).trigger('il.ui.button.month.changed', [id, value]);
+      };
+      btn.addEventListener('change', (e) => {
+        const value = e.target.value.split('-').reverse().join('-');
+        const id = e.target.closest('.il-btn-month').getAttribute('id');
+        triggerEvent(id, value);
       });
+
+      //
+      // Fallback for browsers that do not support a month picker e.g. Firefox, Safari on desktop
+      // Be aware that this disregards the initially rendered input element, but fires the same event.
+      //
+      if (!isMonthSupported()) {
+        btn.style.display = 'none';
+        const valueOnLoad = btn.value.split('-');
+
+        // month selector dropdown
+        const monthDropdown = document.createElement('select');
+        function populateMonthDropdown(selectElement, locale = navigator.language) {
+          // DateTimeFormat generates month names in the client's language
+          const formatter = new Intl.DateTimeFormat(locale, { month: 'long' });
+
+          for (let i = 0; i < 12; i++) {
+            const monthValue = String(i + 1).padStart(2, '0');
+            const date = new Date(2020, i, 1);
+            const monthLabel = formatter.format(date);
+
+            const option = document.createElement('option');
+            option.value = monthValue;
+            option.textContent = monthLabel;
+
+            selectElement.appendChild(option);
+          }
+        }
+        populateMonthDropdown(monthDropdown);
+        monthDropdown.value = valueOnLoad[1];
+        container.appendChild(monthDropdown);
+
+        // year input
+        const yearNumber = document.createElement('input');
+        // relying on inputmode rather than type=number because html5 validation only works on type=text
+        yearNumber.setAttribute('type', 'text');
+        yearNumber.setAttribute('inputmode', 'numeric');
+        yearNumber.setAttribute('minlength', '2');
+        yearNumber.setAttribute('maxlength', '4');
+        yearNumber.setAttribute(
+          'pattern',
+          '([0-9]{2})|([0-9]{4})',
+        );
+        yearNumber.style.width = '6ch';
+        yearNumber.value = valueOnLoad[0];
+        container.appendChild(yearNumber);
+
+        // handle input
+        const passOnValues = () => {
+          if (yearNumber.value.length === 2) { // converting two digit years like 19 to 2019
+            yearNumber.value = `20${yearNumber.value}`;
+          }
+          if (yearNumber.checkValidity()) { // prevents the event to trigger on 1 or 3 digit inputs
+            const monthYear = `${monthDropdown.value}-${yearNumber.value}`;
+            triggerEvent(id, monthYear);
+          }
+        };
+
+        yearNumber.addEventListener('change', passOnValues);
+        monthDropdown.addEventListener('change', passOnValues);
+      }
     };
 
     /* toggle button */

--- a/components/ILIAS/UI/src/Component/Button/Factory.php
+++ b/components/ILIAS/UI/src/Component/Button/Factory.php
@@ -208,12 +208,16 @@ interface Factory
      *   purpose: >
      *       The Month Button enables to select a specific month to fire some action (probably a change of view).
      *   composition: >
-     *       The Month Button is composed of a Button showing the default month directly (probably the
-     *       month currently rendered by some view). A dropdown contains an interface enabling the selection of a month from
-     *       the future or the past.
+     *       On browsers supporting the html5 type='month' button (Chrome, Edge): The Month Button is composed of a
+     *       Button showing the default month directly (probably the month currently rendered by some view). A dropdown
+     *       contains an interface enabling the selection of a month and year from the future or the past.
+     *       On other browsers (Firefox, Safari on desktop): A select field shows the default month, a text input
+     *       presents the year. The select's dropdown can be used to change the selected month. In the text input, a two
+     *       or four digit year can be entered.
      *   effect: >
-     *      Selecting a month from the dropdown directly fires the according action (e.g. switching the view to the
+     *      Selecting a month and/or year from directly fires the according action (e.g. switching the view to the
      *      selected month). Technically this is currently a Javascript event being fired.
+     *      In the fallback version: Entering two digits for the year adds '20' to the beginning. '24' becomes '2024'.
      *
      * context:
      *      - Marginal Grid Calendar
@@ -222,6 +226,12 @@ interface Factory
      *   interaction:
      *       1: >
      *          Selecting a month from the dropdown MUST directly fire the according action.
+     *       2: >
+     *          You MUST use the fired event to handle the selection of the month. You MUST NOT watch the month input's
+     *          value with your own listeners, because the fallback version disregards this originally rendered input.
+     *       3: >
+     *          Another component MUST NOT modify the month input's element value through a simple javascript
+     *          re-assignment. Instead, destroy it and fetch a new button from the server in its place.
      *
      * ---
      * @param string $default Initial value, use format "mm-yyyy".

--- a/components/ILIAS/UI/src/examples/Button/Month/base.php
+++ b/components/ILIAS/UI/src/examples/Button/Month/base.php
@@ -11,9 +11,15 @@ namespace ILIAS\UI\examples\Button\Month;
  *   opened.
  *
  * expected output: >
- *   ILIAS shows a button including a month and year. Clicking the button will open a selection of other months and years
- *   which can be selected. Another click onto a month opens a dialog which confirms the click. In this dialog the selected
- *   month (e.g. 03-2020) is included.
+ *   ILIAS shows a month and year.
+ *   On browsers that support type='month' inputs like Chrome or Safari on iPhone and iPad: Clicking the button will
+ *   open a picker for other months and years which can be selected. Another click onto a month opens a dialog which
+ *   confirms the click. In this dialog the selected month (e.g. 03-2020) is mentioned.
+ *   On other browsers like Firefox and Safari on desktop: There might be a flicker while the browser loads the fallback
+ *   solution. Then, the month can be changed through a select input dropdown and the year can be changed through a
+ *   text input. On a valid input, a dialog will appear and mention the selected month (e.g. 03-2020). On an invalid
+ *   year input (e.g. one or three digits), the year text field will be highlighted as invalid. A two-digit year input
+ *   e.g.'24' will be converted to a four-digit year e.g. '2024'.
  * ---
  */
 function base()

--- a/templates/default/060-elements/_elements_input.scss
+++ b/templates/default/060-elements/_elements_input.scss
@@ -25,6 +25,8 @@ input[type="text"],
 input[type="submit"],
 input[type="datetime-local"],
 input[type="url"],
+input[type="number"],
+input[type="password"],
 select {
 	min-height: $il-input-min-height;
 }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2129,6 +2129,8 @@ input[type=text],
 input[type=submit],
 input[type=datetime-local],
 input[type=url],
+input[type=number],
+input[type=password],
 select {
   min-height: 28px;
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43178

# Issue

The month button in Firefox and Safari on desktop has no fancy month/year picker dropdown and shows a very confusing `yyyy-mm` string.

![image](https://github.com/user-attachments/assets/cba07536-7009-492a-a5f5-f393bb4de1ca)

# Change

The javascript setting up the EventListener, now also renders a fallback version on init for the browsers that do not have a user-friendly month picker:

![month-picker](https://github.com/user-attachments/assets/c5877cc4-ca61-4c34-bc05-639742221a9a)

- A flicker from the ugly, unwanted initial render to the fallback version is something we have to live with for now. 
- Firefox is recognized because it accepts any strings in the input. A browser with a good month input only accepts `yyyy-mm` strings
- Safari on desktop technically has a month input, but it's also ugly and unusable so we check the user agent for Safari - but excluding iPhones and iPads which have a good month picker.
- The fallback hides the original input and creates a month select dropdown and a year text input (not a number input so we can use html5 pattern validation and the very accessible invalid/valid mechanisms)
- Styling is minimal on purpose as this is only a temporary solution.
- The month select input fetches the names of the months from the user's client using DateTimeFormat, so they are localized to the user's OS, but might not be identical to the language selected in ILIAS
- The year input uses html5 validation. Only numbers, two-digits or four-digits are valid. Two-digit numbers e.g. 24 are converted to four-digit years e.g. 2024.
- Change fires the same event the original input would fire.
- Note that rather than having another component modify the input using javascript value re-assignment, it's better to destroy the whole thing and fetch a new month button from the server - which is what the calendar views and sidebar block calendar do. Otherwise original input and fallback could go out of sync. I gave up syncing them because the original input with `display: none;` on it cannot listen to events and does not take value assignments. There are workarounds, but I didn't want to make it more complex than it has to be. Let me know if you want me to make this more fool-proof.