### PR TITLE
T&A 44339: Fixes error when trying to apply old nr of tries in personal test settings

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -6297,7 +6297,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
             )
             ->withTestBehaviourSettings(
                 $main_settings->getTestBehaviourSettings()
-                ->withNumberOfTries($testsettings['NrOfTries'])
+                ->withNumberOfTries((int) $testsettings['NrOfTries'])
                 ->withBlockAfterPassedEnabled((bool) $testsettings['BlockAfterPassed'])
                 ->withPassWaiting($testsettings['pass_waiting'])
                 ->withKioskMode($testsettings['Kiosk'])


### PR DESCRIPTION
This PR aims to fix the issue mentioned in:
https://mantis.ilias.de/view.php?id=44339

A possible fix is to always typecast the value to an int. This allows older personal system settings to also be applied correctly.