### PR TITLE
TA: 45200, skip permission check for cmd='autosave' in ilObjTestGUI

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -453,7 +453,10 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                 break;
 
             case "iltestplayerfixedquestionsetgui":
-                if ((!$this->access->checkAccess("read", "", $this->testrequest->getRefId()))) {
+                if (
+                    $cmd !== 'autosave' &&
+                    (!$this->access->checkAccess("read", "", $this->testrequest->getRefId()))
+                ) {
                     $this->redirectAfterMissingRead();
                 }
                 $this->trackTestObjectReadEvent();
@@ -466,7 +469,10 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                 break;
 
             case "iltestplayerrandomquestionsetgui":
-                if ((!$this->access->checkAccess("read", "", $this->testrequest->getRefId()))) {
+                if (
+                    $cmd !== 'autosave' &&
+                    (!$this->access->checkAccess("read", "", $this->testrequest->getRefId()))
+                ) {
                     $this->redirectAfterMissingRead();
                 }
                 $this->trackTestObjectReadEvent();


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45200

Autosave is called asynch and retrieves its message from ilTestPlayerAbstractGUI, accessed via ilRepositoryGUI, ilObjTestGUI,ilTestPlayerFixedQuestionSetGUI.
Permissioncheck is done in ilTestPlayerAbstractGUI, so for "autosave" command, ilObjTestGUI must not redirect.