### PR TITLE
T&A Remove PHPUnit12 deprecations from TestQuestionPool

### DIFF
--- a/components/ILIAS/TestQuestionPool/tests/assClozeGapTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assClozeGapTest.php
@@ -36,7 +36,7 @@ class assClozeGapTest extends assBaseTestCase
         parent::setUp();
 
         $util_mock = $this->createMock('ilUtil', ['stripSlashes'], [], '', false);
-        $util_mock->expects($this->any())->method('stripSlashes')->will($this->returnArgument(0));
+        $util_mock->expects($this->any())->method('stripSlashes')->willReturnArgument(0);
         $this->setGlobalVariable('ilUtils', $util_mock);
     }
 

--- a/components/ILIAS/TestQuestionPool/tests/assClozeGapTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assClozeGapTest.php
@@ -407,7 +407,7 @@ class assClozeGapTest extends assBaseTestCase
         $item4 = new assAnswerCloze('Esther', 4.0, 3);
 
         $lng_mock = $this->createMock('ilLanguage', ['txt'], [], '', false);
-        $lng_mock->expects($this->any())->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->expects($this->any())->method('txt')->willReturn('Test');
         global $DIC;
         unset($DIC['lng']);
         $DIC['lng'] = $lng_mock;
@@ -434,7 +434,7 @@ class assClozeGapTest extends assBaseTestCase
         $item4 = new assAnswerCloze('Esther', 4, 3);
 
         $lng_mock = $this->createMock('ilLanguage', ['txt'], [], '', false);
-        $lng_mock->expects($this->any())->method('txt')->will($this->returnValue('or'));
+        $lng_mock->expects($this->any())->method('txt')->willReturn('or');
         global $DIC;
         unset($DIC['lng']);
         $DIC['lng'] = $lng_mock;
@@ -463,7 +463,7 @@ class assClozeGapTest extends assBaseTestCase
         $item4 = new assAnswerCloze(100, 4.0, 3);
 
         $lng_mock = $this->createMock('ilLanguage', ['txt'], [], '', false);
-        $lng_mock->expects($this->any())->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->expects($this->any())->method('txt')->willReturn('Test');
         global $DIC;
         unset($DIC['lng']);
         $DIC['lng'] = $lng_mock;
@@ -490,7 +490,7 @@ class assClozeGapTest extends assBaseTestCase
         $item4 = new assAnswerCloze(100, 4.0, 3);
 
         $lng_mock = $this->createMock('ilLanguage', ['txt'], [], '', false);
-        $lng_mock->expects($this->any())->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->expects($this->any())->method('txt')->willReturn('Test');
         global $DIC;
         unset($DIC['lng']);
         $DIC['lng'] = $lng_mock;

--- a/components/ILIAS/TestQuestionPool/tests/assClozeTestGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assClozeTestGUITest.php
@@ -47,7 +47,7 @@ class assClozeTestGUITest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $ilias_mock = new stdClass();

--- a/components/ILIAS/TestQuestionPool/tests/assClozeTestTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assClozeTestTest.php
@@ -42,7 +42,7 @@ class assClozeTestTest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assErrorTextGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assErrorTextGUITest.php
@@ -44,7 +44,7 @@ class assErrorTextGUITest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assErrorTextTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assErrorTextTest.php
@@ -39,7 +39,6 @@ class assErrorTextTest extends assBaseTestCase
         $this->setGlobalVariable('ilCtrl', $ilCtrl_mock);
 
         $lng_mock = $this->createMock('ilLanguage', ['txt'], [], '', false);
-        //$lng_mock->expects( $this->once() )->method( 'txt' )->will( $this->returnValue('Test') );
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assFileUploadGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assFileUploadGUITest.php
@@ -44,7 +44,7 @@ class assFileUploadGUITest extends assBaseTestCase
             ->disableOriginalConstructor()
             ->onlyMethods(['txt'])
             ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assFileUploadTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assFileUploadTest.php
@@ -42,7 +42,7 @@ class assFileUploadTest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assFormulaQuestionGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assFormulaQuestionGUITest.php
@@ -44,7 +44,7 @@ class assFormulaQuestionGUITest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assFormulaQuestionTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assFormulaQuestionTest.php
@@ -38,7 +38,7 @@ class assFormulaQuestionTest extends assBaseTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $lng->method('txt')
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $this->setGlobalVariable('lng', $lng);
     }

--- a/components/ILIAS/TestQuestionPool/tests/assImagemapQuestionTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assImagemapQuestionTest.php
@@ -42,7 +42,7 @@ class assImagemapQuestionTest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assLongMenuTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assLongMenuTest.php
@@ -48,7 +48,6 @@ class assLongmenuTest extends assBaseTestCase
         $this->setGlobalVariable('ilCtrl', $ilCtrl_mock);
 
         $lng_mock = $this->createMock('ilLanguage', ['txt'], [], '', false);
-        //$lng_mock->expects( $this->once() )->method( 'txt' )->will( $this->returnValue('Test') );
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assMatchingQuestionGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assMatchingQuestionGUITest.php
@@ -44,7 +44,7 @@ class assMatchingQuestionGUITest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assMatchingQuestionTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assMatchingQuestionTest.php
@@ -42,7 +42,7 @@ class assMatchingQuestionTest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assMultipleChoiceGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assMultipleChoiceGUITest.php
@@ -46,7 +46,7 @@ class assMultipleChoiceGUITest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assNumericTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assNumericTest.php
@@ -42,7 +42,7 @@ class assNumericTest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assOrderingHorizontalGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assOrderingHorizontalGUITest.php
@@ -39,7 +39,7 @@ class assOrderingHorizontalGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilCtrl', $ilCtrl_mock);
 
         $lng_mock = $this->createMock('ilLanguage', ['txt'], [], '', false);
-        $lng_mock->expects($this->any())->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->expects($this->any())->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assOrderingHorizontalTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assOrderingHorizontalTest.php
@@ -42,7 +42,7 @@ class assOrderingHorizontalTest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assOrderingQuestionGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assOrderingQuestionGUITest.php
@@ -44,7 +44,7 @@ class assOrderingQuestionGUITest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assOrderingQuestionTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assOrderingQuestionTest.php
@@ -42,7 +42,7 @@ class assOrderingQuestionTest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assSingleChoiceGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assSingleChoiceGUITest.php
@@ -46,7 +46,7 @@ class assSingleChoiceGUITest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assTextQuestionGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assTextQuestionGUITest.php
@@ -39,7 +39,7 @@ class assTextQuestionGUITest extends assBaseTestCase
         $this->setGlobalVariable('ilCtrl', $ilCtrl_mock);
 
         $lng_mock = $this->createMock('ilLanguage', ['txt'], [], '', false);
-        $lng_mock->expects($this->any())->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->expects($this->any())->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assTextQuestionTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assTextQuestionTest.php
@@ -42,7 +42,7 @@ class assTextQuestionTest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assTextSubsetGUITest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assTextSubsetGUITest.php
@@ -44,7 +44,7 @@ class assTextSubsetGUITest extends assBaseTestCase
                          ->disableOriginalConstructor()
                          ->onlyMethods(['txt'])
                          ->getMock();
-        $lng_mock->method('txt')->will($this->returnValue('Test'));
+        $lng_mock->method('txt')->willReturn('Test');
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/assTextSubsetTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/assTextSubsetTest.php
@@ -39,7 +39,6 @@ class assTextSubsetTest extends assBaseTestCase
         $this->setGlobalVariable('ilCtrl', $ilCtrl_mock);
 
         $lng_mock = $this->createMock('ilLanguage', ['txt'], [], '', false);
-        //$lng_mock->expects($this->once())->method('txt')->will($this->returnValue('Test'));
         $this->setGlobalVariable('lng', $lng_mock);
 
         $this->setGlobalVariable('ilias', $this->getIliasMock());

--- a/components/ILIAS/TestQuestionPool/tests/ilAssQuestionSkillAssignmentRegistryTest.php
+++ b/components/ILIAS/TestQuestionPool/tests/ilAssQuestionSkillAssignmentRegistryTest.php
@@ -48,24 +48,24 @@ class ilAssQuestionSkillAssignmentRegistryTest extends assBaseTestCase
 
         $settingsMock = $this->getMockBuilder('ilSetting')->disableOriginalConstructor()->onlyMethods(['set', 'get', 'delete'])->getMock();
 
-        $settingsMock->expects($this->any())->method('set')->will(
-            $this->returnCallback(function ($key, $value) {
+        $settingsMock->expects($this->any())->method('set')->willReturnCallback(
+            function ($key, $value) {
                 $this->storage[$key] = $value;
-            })
+            }
         );
 
-        $settingsMock->expects($this->any())->method('get')->will(
-            $this->returnCallback(function ($key, $value) {
+        $settingsMock->expects($this->any())->method('get')->willReturnCallback(
+            function ($key, $value) {
                 return $this->storage[$key] ?? $value;
-            })
+            }
         );
 
-        $settingsMock->expects($this->any())->method('delete')->will(
-            $this->returnCallback(function ($key, $value) {
+        $settingsMock->expects($this->any())->method('delete')->willReturnCallback(
+            function ($key) {
                 if (isset($this->storage[$key])) {
                     unset($this->storage[$key]);
                 }
-            })
+            }
         );
 
         $valueToTest = $preCallback($value);


### PR DESCRIPTION
This PR updates deprecated PHPUnit 12 method calls in the question pool to their modern alternatives.

* `will(returnValue)` => `willReturn`
* `will(returnCallback)` => `willReturnCallback`
* `wil(returnArgument)` => `willReturnArgument`

Best,
@thojou 
