### PR TITLE
StaticURL: Add optional query parameters to static URLs

### DIFF
--- a/components/ILIAS/StaticURL/src/Builder/StandardURIBuilder.php
+++ b/components/ILIAS/StaticURL/src/Builder/StandardURIBuilder.php
@@ -40,11 +40,12 @@ class StandardURIBuilder implements URIBuilder
     public function build(
         string $namespace,
         ?ReferenceId $reference_id = null,
-        array $additional_parameters = []
+        array $additional_parameters = [],
+        array $query_parameters = []
     ): URI {
         $uri = $this->getBaseURI()
             . ($this->short_url_possible ? self::SHORT : self::LONG)
-            . $this->buildTarget($namespace, $reference_id, $additional_parameters);
+            . $this->buildTarget($namespace, $reference_id, $additional_parameters, $query_parameters);
 
         return new URI($uri);
     }
@@ -52,12 +53,15 @@ class StandardURIBuilder implements URIBuilder
     public function buildTarget(
         string $namespace,
         ?ReferenceId $reference_id = null,
-        array $additional_parameters = []
+        array $additional_parameters = [],
+        array $query_parameters = []
     ): string {
+        $query = (count($query_parameters) > 0) ? '?' . http_build_query($query_parameters) : '';
         return $namespace
             . ($reference_id !== null ? '/' . $reference_id->toInt() : '')
             . '/'
-            . implode('/', $additional_parameters);
+            . implode('/', $additional_parameters)
+            . $query;
     }
 
     public function getBaseURI(): URI

--- a/components/ILIAS/StaticURL/src/Builder/URIBuilder.php
+++ b/components/ILIAS/StaticURL/src/Builder/URIBuilder.php
@@ -31,7 +31,8 @@ interface URIBuilder
     public function build(
         string $namespace,
         ?ReferenceId $reference_id = null,
-        array $additional_parameters = []
+        array $additional_parameters = [],
+        array $query_parameters = []
     ): URI;
 
     public function getBaseURI(): URI;

--- a/components/ILIAS/StaticURL/tests/URIBuilderTest.php
+++ b/components/ILIAS/StaticURL/tests/URIBuilderTest.php
@@ -63,20 +63,21 @@ class URIBuilderTest extends Base
             ['wiki', 42, [], 'https://test9.ilias.de/goto.php/wiki/42'],
             ['file', 42, ['download'], 'https://test9.ilias.de/goto.php/file/42/download'],
             ['dashboard', null, [], 'https://test9.ilias.de/goto.php/dashboard'],
-
+            ['search', null, [], 'https://test9.ilias.de/goto.php/search?term=knowledge', ['term' => 'knowledge']],
         ];
     }
 
     /**
      * @dataProvider getBuilderParts
      */
-    public function testFullBuilder(string $namespace, ?int $ref_id, array $params, string $expected): void
+    public function testFullBuilder(string $namespace, ?int $ref_id, array $params, string $expected, array $query_params = []): void
     {
         $uri_builder = new StandardURIBuilder('https://test9.ilias.de');
         $uri = $uri_builder->build(
             $namespace,
             $ref_id === null ? null : new ReferenceId($ref_id),
-            $params
+            $params,
+            $query_params
         );
         $this->assertEquals($expected, (string) $uri);
     }


### PR DESCRIPTION
In several internal use cases, we need static URLs to be able to include specific query parameters, e.g. for setting filters or search terms. As the current `$additional_parameters` in `StandardURIBuilder` only support "unnamed" parameters and ignores any specified keys, we have added the ability to specifically include parameters which are kept as a query string.

We would therefore like to propose this addition, because it may be useful for other use cases as well.