### PR TITLE
CSS: Change Focus on btn-file to Make Perceivable

### DIFF
--- a/templates/default/030-tools/_tool_focus-outline.scss
+++ b/templates/default/030-tools/_tool_focus-outline.scss
@@ -59,6 +59,7 @@ $il-focus-outline-outer-width: 2px;
 	$il-focus-outline-outer: $il-focus-outline-outer-width solid $il-focus-protection-color;
 	&:focus-within{
 		outline: $il-focus-outline-inner;
+		box-shadow: inset 0px 0px 0px $il-focus-outline-outer-width $il-focus-protection-color, 0px 0px 0px ($il-focus-outline-outer-width + $il-focus-outline-inner-width) $il-focus-protection-color;
 		@if $clearAfter {
 			&::after {
 				content: none;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -17509,6 +17509,7 @@ div.ilHFormFooter .ilFormCmds {
 }
 .btn-file:focus-within {
   outline: 3px solid #0078D7;
+  box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
 }
 
 .btn-file input[type=file] {


### PR DESCRIPTION
Hi @Amstutz 

This is about the outline on legacy file inputs. I just adapted the mixin to show a double border as this is the only place this mixin is actually used. I didn't change its name as the behavior now is equivalent to `@il-focus-outline-only()`.

See: https://mantis.ilias.de/view.php?id=44118

If accepted this should be picked to trunk too as I don't think we will get rid of this damn inputs with ILIAS 11.

Thanks and best,
@kergomard 