### PR TITLE
Allow longer titles in excel worksheets. This will disable excel 2016 compatiblity

### DIFF
--- a/Services/Excel/classes/class.ilExcel.php
+++ b/Services/Excel/classes/class.ilExcel.php
@@ -129,11 +129,8 @@ class ilExcel
 
         $a_name = str_replace($invalid, '', $a_name);
 
-        // #19056 - phpExcel only allows 31 chars
-        // see https://github.com/PHPOffice/PHPExcel/issues/79
-        $a_name = ilStr::shortenTextExtended($a_name, 31);
-
         $sheet = new Worksheet($this->workbook, $a_name);
+        $sheet->setTitle($a_name,false,false);
         $this->workbook->addSheet($sheet);
         $new_index = $this->workbook->getSheetCount() - 1;
 


### PR DESCRIPTION
This changes the behaviour of all excel Exports in Ilias since 5.2 so be careful. Excel 2016 will not open the files anymore. 

The change allows to make longer worksheet names e.g. full question titles as worksheet names. 