### PR TITLE
LegalDocuments: Use default lang if user has no language set

### DIFF
--- a/Services/LegalDocuments/classes/Condition/Definitions/UserLanguageDefinition.php
+++ b/Services/LegalDocuments/classes/Condition/Definitions/UserLanguageDefinition.php
@@ -59,7 +59,7 @@ class UserLanguageDefinition implements ConditionDefinition
 
     public function withCriterion(CriterionContent $criterion): Condition
     {
-        return new UserLanguage($criterion, $this, $this->ui->create());
+        return new UserLanguage($criterion, $this, $this->ui);
     }
 
     public function translatedType(): string

--- a/Services/LegalDocuments/classes/Condition/UserLanguage.php
+++ b/Services/LegalDocuments/classes/Condition/UserLanguage.php
@@ -25,7 +25,7 @@ use ILIAS\LegalDocuments\ConditionDefinition;
 use ILIAS\LegalDocuments\Condition\Definition\UserLanguageDefinition;
 use ILIAS\LegalDocuments\Value\CriterionContent;
 use ILIAS\UI\Component\Component;
-use ILIAS\UI\Factory as UIFactory;
+use ILIAS\LegalDocuments\ConsumerToolbox\UI;
 use ilObjUser;
 
 class UserLanguage implements Condition
@@ -33,13 +33,13 @@ class UserLanguage implements Condition
     public function __construct(
         private readonly CriterionContent $criterion,
         private readonly UserLanguageDefinition $definition,
-        private readonly UIFactory $create
+        private readonly UI $ui
     ) {
     }
 
     public function asComponent(): Component
     {
-        return $this->create->legacy(sprintf(
+        return $this->ui->create()->legacy(sprintf(
             '<div><b>%s</b><br/>%s</div>',
             $this->definition->translatedType(),
             $this->definition->translatedLanguage($this->criterion->arguments()['lng'])
@@ -48,7 +48,8 @@ class UserLanguage implements Condition
 
     public function eval(ilObjUser $user): bool
     {
-        return strtoupper($user->getLanguage()) === strtoupper($this->criterion->arguments()['lng']);
+        $user_lang = $user->getLanguage() ?: $this->ui->getDefaultLanguage();
+        return strtoupper($user_lang) === strtoupper($this->criterion->arguments()['lng']);
     }
 
     public function definition(): ConditionDefinition

--- a/Services/LegalDocuments/classes/ConsumerToolbox/UI.php
+++ b/Services/LegalDocuments/classes/ConsumerToolbox/UI.php
@@ -50,6 +50,11 @@ class UI
         $this->language->loadLanguageModule($module);
     }
 
+    public function getDefaultLanguage(): string
+    {
+        return $this->language->getDefaultLanguage();
+    }
+
     public function txt(string $name): string
     {
         $this->loadLanguageModule($this->id);

--- a/Services/LegalDocuments/test/Condition/UserLanguageTest.php
+++ b/Services/LegalDocuments/test/Condition/UserLanguageTest.php
@@ -28,7 +28,7 @@ use ILIAS\LegalDocuments\Value\CriterionContent;
 use PHPUnit\Framework\TestCase;
 use ILIAS\LegalDocuments\Condition\UserLanguage;
 use ILIAS\LegalDocuments\Condition\Definition\UserLanguageDefinition;
-use ILIAS\UI\Factory as UIFactory;
+use ILIAS\LegalDocuments\ConsumerToolbox\UI;
 
 require_once __DIR__ . '/../ContainerMock.php';
 
@@ -41,7 +41,7 @@ class UserLanguageTest extends TestCase
         $this->assertInstanceOf(UserLanguage::class, new UserLanguage(
             $this->mock(CriterionContent::class),
             $this->mock(UserLanguageDefinition::class),
-            $this->mock(UIFactory::class)
+            $this->mock(UI::class)
         ));
     }
 
@@ -52,7 +52,7 @@ class UserLanguageTest extends TestCase
         $instance = new UserLanguage(
             $this->mockTree(CriterionContent::class, ['arguments' => ['lng' => 'foo']]),
             $this->mock(UserLanguageDefinition::class),
-            $this->mockTree(UIFactory::class, ['legacy' => $legacy])
+            $this->mockTree(UI::class, ['create' => ['legacy' => $legacy]])
         );
 
         $this->assertSame($legacy, $instance->asComponent());
@@ -63,7 +63,7 @@ class UserLanguageTest extends TestCase
         $instance = new UserLanguage(
             $this->mockTree(CriterionContent::class, ['arguments' => ['lng' => 'foo']]),
             $this->mock(UserLanguageDefinition::class),
-            $this->mock(UIFactory::class)
+            $this->mock(UI::class)
         );
 
         $this->assertTrue($instance->eval($this->mockTree(ilObjUser::class, ['getLanguage' => 'foo'])));
@@ -75,7 +75,7 @@ class UserLanguageTest extends TestCase
         $instance = new UserLanguage(
             $this->mock(CriterionContent::class),
             $definition,
-            $this->mock(UIFactory::class)
+            $this->mock(UI::class)
         );
 
         $this->assertSame($definition, $instance->definition());
@@ -86,13 +86,13 @@ class UserLanguageTest extends TestCase
         $instance = new UserLanguage(
             $this->mock(CriterionContent::class),
             $this->mock(UserLanguageDefinition::class),
-            $this->mock(UIFactory::class)
+            $this->mock(UI::class)
         );
 
         $second = new UserLanguage(
             $this->mock(CriterionContent::class),
             $this->mock(UserLanguageDefinition::class),
-            $this->mock(UIFactory::class)
+            $this->mock(UI::class)
         );
 
         $this->assertTrue($instance->knownToNeverMatchWith($second));


### PR DESCRIPTION
Make language criterion more robust, according to Mantis note: https://mantis.ilias.de/view.php?id=45244#c116294