### PR TITLE
UI: Numeric Input with stepsize

### DIFF
--- a/components/ILIAS/Test/tests/Scoring/Settings/ScoreSettingsTest.php
+++ b/components/ILIAS/Test/tests/Scoring/Settings/ScoreSettingsTest.php
@@ -462,7 +462,7 @@ class ScoreSettingsTest extends ilTestBaseTestCase
         $fields .= $this->getFormWrappedHtml(
             'numeric-field-input',
             'tst_highscore_top_num<span class="asterisk" aria-label="required_field">*</span>',
-            '<input id="id_3" type="number" value="10" class="c-field-number" />',
+            '<input id="id_3" type="number" step="1" value="10" class="c-field-number" />',
             'tst_highscore_top_num_description',
             'id_3',
             null,

--- a/components/ILIAS/UI/src/Component/Input/Field/Numeric.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Numeric.php
@@ -27,4 +27,12 @@ use ILIAS\UI\Component\Input\Container\Filter\FilterInput;
  */
 interface Numeric extends FilterInput
 {
+    /**
+     * This will not only set the steps for the input's arrow controls,
+     * but will also alter the field's transformation.
+     * The value will be the same type as the parameter given here, so
+     * even a $stepsize = 1.0 will result in an float value.
+     * Please be aware of that when attaching further transformations!
+     */
+    public function withStepSize(int|float $stepsize = 1): self;
 }

--- a/components/ILIAS/UI/src/Component/Input/Field/Numeric.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Numeric.php
@@ -30,9 +30,14 @@ interface Numeric extends FilterInput
     /**
      * This will not only set the steps for the input's arrow controls,
      * but will also alter the field's transformation.
-     * The value will be the same type as the parameter given here, so
-     * even a $stepsize = 1.0 will result in an float value.
-     * Please be aware of that when attaching further transformations!
+     * The value will be the same type as the parameter given here,
+     * so even a $stepsize = 1.0 will result in an float value.
+     * This also means that all existing transformations need to be wiped,
+     * since the type of the initially contained value changes!
+     *
+     * ATTENTION: Using withStepSize (and altering the type) will erase
+     * all existing transformations on the field.
+     * Please re-consider carefully if you really want to use floats at all ;)
      */
     public function withStepSize(int|float $stepsize = 1): self;
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Numeric.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Numeric.php
@@ -32,6 +32,8 @@ use ILIAS\Refinery\ConstraintViolationException;
  */
 class Numeric extends FormInput implements C\Input\Field\Numeric
 {
+    protected int|float $stepsize = 1;
+
     public function __construct(
         DataFactory $data_factory,
         \ILIAS\Refinery\Factory $refinery,
@@ -39,17 +41,7 @@ class Numeric extends FormInput implements C\Input\Field\Numeric
         ?string $byline
     ) {
         parent::__construct($data_factory, $refinery, $label, $byline);
-
-        /**
-         * @var $trafo_numericOrNull Transformation
-         */
-        $trafo_numericOrNull = $this->refinery->byTrying([
-            $this->refinery->kindlyTo()->null(),
-            $this->refinery->kindlyTo()->int()
-        ])
-        ->withProblemBuilder(fn($txt) => $txt("numeric_only"));
-
-        $this->setAdditionalTransformation($trafo_numericOrNull);
+        $this->setAdditionalTransformation($this->getStandardTrafoInt());
     }
 
     /**
@@ -90,4 +82,48 @@ class Numeric extends FormInput implements C\Input\Field\Numeric
     {
         return false;
     }
+
+    public function withStepSize(int|float $stepsize = 1): self
+    {
+        $clone = clone $this;
+        $clone->stepsize = $stepsize;
+
+        if (is_int($stepsize)) {
+            $clone->operations[0] = $this->getStandardTrafoInt();
+        }
+
+        if (is_float($stepsize)) {
+            $clone->operations[0] = $this->getStandardTrafoFloat();
+        }
+        if ($clone->content !== null) {
+            if (!$clone->content->isError()) {
+                $clone->content = $trafo->applyTo($clone->content);
+            }
+            if ($clone->content->isError()) {
+                $clone->setError($clone->content->error());
+            }
+        }
+        return $clone;
+    }
+
+    private function getStandardTrafoInt(): Transformation
+    {
+        return $this->refinery->byTrying([
+            $this->refinery->kindlyTo()->null(),
+            $this->refinery->kindlyTo()->int()
+        ]);
+    }
+    private function getStandardTrafoFloat(): Transformation
+    {
+        return $this->refinery->byTrying([
+            $this->refinery->kindlyTo()->null(),
+            $this->refinery->kindlyTo()->float()
+        ]);
+    }
+
+    public function getStepSize(): int|float
+    {
+        return $this->stepsize;
+    }
+
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Numeric.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Numeric.php
@@ -95,14 +95,6 @@ class Numeric extends FormInput implements C\Input\Field\Numeric
         if (is_float($stepsize) && is_int($this->stepsize)) {
             $clone->operations = [$this->getStandardTrafoFloat()];
         }
-        if ($clone->content !== null) {
-            if (!$clone->content->isError()) {
-                $clone->content = $clone->operations[0]->applyTo($clone->content);
-            }
-            if ($clone->content->isError()) {
-                $clone->setError($clone->content->error());
-            }
-        }
         return $clone;
     }
 

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Numeric.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Numeric.php
@@ -88,16 +88,16 @@ class Numeric extends FormInput implements C\Input\Field\Numeric
         $clone = clone $this;
         $clone->stepsize = $stepsize;
 
-        if (is_int($stepsize)) {
-            $clone->operations[0] = $this->getStandardTrafoInt();
+        if (is_int($stepsize) && is_float($this->stepsize)) {
+            $clone->operations = [$this->getStandardTrafoInt()];
         }
 
-        if (is_float($stepsize)) {
-            $clone->operations[0] = $this->getStandardTrafoFloat();
+        if (is_float($stepsize) && is_int($this->stepsize)) {
+            $clone->operations = [$this->getStandardTrafoFloat()];
         }
         if ($clone->content !== null) {
             if (!$clone->content->isError()) {
-                $clone->content = $trafo->applyTo($clone->content);
+                $clone->content = $clone->operations[0]->applyTo($clone->content);
             }
             if ($clone->content->isError()) {
                 $clone->setError($clone->content->error());

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Renderer.php
@@ -302,6 +302,8 @@ class Renderer extends AbstractComponentRenderer
         $this->applyName($component, $tpl);
         $this->applyValue($component, $tpl, $this->escapeSpecialChars());
 
+        $tpl->setVariable("STEPSIZE", $component->getStepSize());
+
         $label_id = $this->createId();
         $tpl->setVariable('ID', $label_id);
         return $this->wrapInFormContext($component, $component->getLabel(), $tpl->get(), $label_id);

--- a/components/ILIAS/UI/src/examples/Input/Field/Numeric/numeric_inputs.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Numeric/numeric_inputs.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Input\Field\Numeric;
 
+use ILIAS\UI\URLBuilder;
+
 /**
  * ---
  * description: >
@@ -48,6 +50,14 @@ function numeric_inputs()
     $ui = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
     $request = $DIC->http()->request();
+    $refinery = $DIC->refinery();
+    $df = new \ILIAS\Data\Factory();
+    $query = $DIC->http()->wrapper()->query();
+    $here_uri = $df->uri($request->getUri()->__toString());
+    $url_builder = new URLBuilder($here_uri);
+    $example_namespace = ['input', 'numeric'];
+    list($url_builder, $example_name) = $url_builder->acquireParameters($example_namespace, "example_name");
+    $url_builder = $url_builder->withParameter($example_name, "numeric");
 
     //Step 1: Declare the numeric input
     $number_input = $ui->input()->field()
@@ -57,21 +67,16 @@ function numeric_inputs()
     $number_input2 = $number_input->withRequired(true)->withValue('');
 
     //Step 2, define form and form actions
-    $DIC->ctrl()->setParameterByClass(
-        'ilsystemstyledocumentationgui',
-        'example_name',
-        'numeric'
-    );
-    $form_action = $DIC->ctrl()->getFormActionByClass('ilsystemstyledocumentationgui');
+    $form_action = $url_builder->buildURI()->__toString();
     $form = $ui->input()->container()->form()->standard($form_action, [
         'n1' => $number_input,
         'n2' => $number_input2
     ]);
 
     //Step 3, implement some form data processing.
-    if ($request->getMethod() == "POST"
-       && array_key_exists('example_name', $request->getQueryParams())
-       && $request->getQueryParams()['example_name'] == 'numeric') {
+    if ($query->has($example_name->getName())
+        && $query->retrieve($example_name->getName(), $refinery->custom()->transformation(fn($v) => $v === 'numeric'))
+    ) {
         $form = $form->withRequest($request);
         $result = $form->getData();
     } else {

--- a/components/ILIAS/UI/src/examples/Input/Field/Numeric/numeric_with_decimals.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Numeric/numeric_with_decimals.php
@@ -23,55 +23,74 @@ namespace ILIAS\UI\examples\Input\Field\Numeric;
 /**
  * ---
  * description: >
- *   Base example showing how to plug a numeric input into a form.
+ *   Example showing how to use a numeric input with decimals.
  *
  * expected output: >
- *   ILIAS shows two input fields titled "Some Number". One input field already displays a number. The other input field
- *   is required (*). You can enter numbers into the fields or choose a number by using the the arrows at the end of the fields.
+ *   ILIAS shows four numric input fields.
+ *   You can enter numbers into the fields or choose a number by using the the arrows at the end of the fields.
+ *   Operation the arrows will in-/decrease the value by the given step size.
  *   Clicking "Save" reloads the page.
  *   Afterwards ILIAS will show the inserted number in the following format:
  *
  *   Array
  *   (
- *       [n1] => 56
- *       [n2] => 77
+ *       [0] => 3 (integer)
+ *       [1] => 0.4 (double)
+ *       [2] => 0.1 (double)
+ *       [3] => 10.7 (double)
  *   )
  *
  *   If you insert one or more non-numeric numbers into the field the input field will get highlighted in red. Saving
  *   those inputs results in displaying an error message right above the required field.
  * ---
  */
-function numeric_inputs()
+function numeric_with_decimals()
 {
-    //Step 0: Declare dependencies
     global $DIC;
     $ui = $DIC->ui()->factory();
     $renderer = $DIC->ui()->renderer();
     $request = $DIC->http()->request();
+    $refinery = $DIC->refinery();
 
-    //Step 1: Declare the numeric input
     $number_input = $ui->input()->field()
-        ->numeric("Some Number", "Put in a number.")
-        ->withValue(133);
+        ->numeric("int", "step size is 3")
+        ->withStepSize(3)
+        ->withValue(3);
 
-    $number_input2 = $number_input->withRequired(true)->withValue('');
+    $number_input2 = $ui->input()->field()
+        ->numeric("float", "step size is .2")
+        ->withStepSize(.2)
+        ->withValue(.4);
 
-    //Step 2, define form and form actions
+    $number_input3 = $ui->input()->field()
+        ->numeric("float", "step size is .0005")
+        ->withStepSize(.0005)
+        ->withValue(.1);
+
+    $number_input4 = $ui->input()->field()
+        ->numeric("float", "step size is 111.01, initial value is 10.7")
+        ->withStepSize(111.01)
+        ->withValue(10.7);
+
     $DIC->ctrl()->setParameterByClass(
         'ilsystemstyledocumentationgui',
         'example_name',
-        'numeric'
+        'decimals'
     );
     $form_action = $DIC->ctrl()->getFormActionByClass('ilsystemstyledocumentationgui');
-    $form = $ui->input()->container()->form()->standard($form_action, [
-        'n1' => $number_input,
-        'n2' => $number_input2
-    ]);
+    $form = $ui->input()->container()->form()->standard(
+        $form_action,
+        [$number_input, $number_input2, $number_input3, $number_input4]
+    )
+    ->withAdditionalTransformation(
+        $refinery->custom()->transformation(
+            fn($v) => array_map(fn($val) => $val . ' (' . gettype($val) . ')', $v)
+        )
+    );
 
-    //Step 3, implement some form data processing.
     if ($request->getMethod() == "POST"
-       && array_key_exists('example_name', $request->getQueryParams())
-       && $request->getQueryParams()['example_name'] == 'numeric') {
+        && array_key_exists('example_name', $request->getQueryParams())
+        && $request->getQueryParams()['example_name'] == 'decimals') {
         $form = $form->withRequest($request);
         $result = $form->getData();
     } else {

--- a/components/ILIAS/UI/src/examples/Input/Field/Numeric/numeric_with_decimals.php
+++ b/components/ILIAS/UI/src/examples/Input/Field/Numeric/numeric_with_decimals.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace ILIAS\UI\examples\Input\Field\Numeric;
 
+use ILIAS\UI\URLBuilder;
+
 /**
  * ---
  * description: >
@@ -41,7 +43,7 @@ namespace ILIAS\UI\examples\Input\Field\Numeric;
  *   )
  *
  *   If you insert one or more non-numeric numbers into the field the input field will get highlighted in red. Saving
- *   those inputs results in displaying an error message right above the required field.
+ *   those inputs results in displaying an error message right next to the required field.
  * ---
  */
 function numeric_with_decimals()
@@ -51,6 +53,14 @@ function numeric_with_decimals()
     $renderer = $DIC->ui()->renderer();
     $request = $DIC->http()->request();
     $refinery = $DIC->refinery();
+    $df = new \ILIAS\Data\Factory();
+    $query = $DIC->http()->wrapper()->query();
+    $here_uri = $df->uri($request->getUri()->__toString());
+    $url_builder = new URLBuilder($here_uri);
+    $example_namespace = ['input', 'numeric'];
+    list($url_builder, $example_name) = $url_builder->acquireParameters($example_namespace, "example_name");
+    $url_builder = $url_builder->withParameter($example_name, "decimals");
+
 
     $number_input = $ui->input()->field()
         ->numeric("int", "step size is 3")
@@ -72,12 +82,7 @@ function numeric_with_decimals()
         ->withStepSize(111.01)
         ->withValue(10.7);
 
-    $DIC->ctrl()->setParameterByClass(
-        'ilsystemstyledocumentationgui',
-        'example_name',
-        'decimals'
-    );
-    $form_action = $DIC->ctrl()->getFormActionByClass('ilsystemstyledocumentationgui');
+    $form_action = $url_builder->buildURI()->__toString();
     $form = $ui->input()->container()->form()->standard(
         $form_action,
         [$number_input, $number_input2, $number_input3, $number_input4]
@@ -88,9 +93,9 @@ function numeric_with_decimals()
         )
     );
 
-    if ($request->getMethod() == "POST"
-        && array_key_exists('example_name', $request->getQueryParams())
-        && $request->getQueryParams()['example_name'] == 'decimals') {
+    if ($query->has($example_name->getName())
+        && $query->retrieve($example_name->getName(), $refinery->custom()->transformation(fn($v) => $v === 'decimals'))
+    ) {
         $form = $form->withRequest($request);
         $result = $form->getData();
     } else {

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.numeric.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.numeric.html
@@ -1,1 +1,1 @@
-<input id="{ID}" type="number"<!-- BEGIN value --> value="{VALUE}"<!-- END value --><!-- BEGIN name --> name="{NAME}"<!-- END name --><!-- BEGIN disabled --> {DISABLED}<!-- END disabled --> class="c-field-number" />
+<input id="{ID}" type="number" step="{STEPSIZE}"<!-- BEGIN value --> value="{VALUE}"<!-- END value --><!-- BEGIN name --> name="{NAME}"<!-- END name --><!-- BEGIN disabled --> {DISABLED}<!-- END disabled --> class="c-field-number" />

--- a/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Container/Filter/FilterInputTest.php
@@ -154,7 +154,7 @@ class FilterInputTest extends ILIAS_UI_TestBase
         <div class="col-md-6 col-lg-4 il-popover-container">
             <div class="input-group">
                 <label for="id_1" class="input-group-addon leftaddon">label</label>
-                <input id="id_1" type="number" class="c-field-number" />
+                <input id="id_1" type="number" step="1" class="c-field-number" />
                 <span class="input-group-addon rightaddon">
                     <a class="glyph" href="" aria-label="remove" id="id_2">
                         <span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>

--- a/components/ILIAS/UI/tests/Component/Input/Field/NumericInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/NumericInputTest.php
@@ -28,6 +28,7 @@ use ILIAS\UI\Implementation\Component\SignalGenerator;
 use ILIAS\UI\Component\Input\Field;
 use ILIAS\Data;
 use ILIAS\Refinery\Factory as Refinery;
+use ILIAS\Data\Factory as DataFactory;
 
 class NumericInputTest extends ILIAS_UI_TestBase
 {
@@ -197,5 +198,33 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $this->assertIsFloat($value->value());
     }
 
+    public function testDecimalsTransformationsStack(): void
+    {
+        $data_factory = new DataFactory();
+        $language = $this->createMock(ILIAS\Language\Language::class);
+        $refinery = new Refinery($data_factory, $language);
 
+        $f = $this->getFieldFactory();
+        $field = $f->numeric('')->withNameFrom($this->name_source)
+            ->withStepSize(.2)
+            ->withAdditionalTransformation(
+                $refinery->custom()->transformation(fn(float $v): float => $v + 1)
+            );
+
+        $post_data = new DefInputData(['name_0' => 1]);
+
+        $value = $field
+            ->withInput($post_data)
+            ->getContent();
+        $this->assertTrue($value->isOk());
+        $this->assertIsFloat($value->value());
+        $this->assertEquals(2, $value->value());
+
+        $value = $field
+            ->withStepSize(0)
+            ->withInput($post_data)
+            ->getContent();
+        $this->assertIsInt($value->value());
+        $this->assertEquals(1, $value->value());
+    }
 }

--- a/components/ILIAS/UI/tests/Component/Input/Field/NumericInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/NumericInputTest.php
@@ -61,7 +61,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $expected = $this->getFormWrappedHtml(
             'numeric-field-input',
             $label,
-            '<input id="id_1" type="number" name="name_0" class="c-field-number" />',
+            '<input id="id_1" type="number" step="1" name="name_0" class="c-field-number" />',
             $byline,
             'id_1'
         );
@@ -91,7 +91,7 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $expected = $this->getFormWrappedHtml(
             'numeric-field-input',
             $label,
-            '<input id="id_1" type="number" value="10" name="name_0" class="c-field-number" />',
+            '<input id="id_1" type="number" step="1" value="10" name="name_0" class="c-field-number" />',
             null,
             'id_1'
         );
@@ -159,4 +159,43 @@ class NumericInputTest extends ILIAS_UI_TestBase
         $this->assertTrue($value->isOK());
         $this->assertEquals(1, $value->value());
     }
+
+    #[\PHPUnit\Framework\Attributes\Depends('testNullValue')]
+    public function testFloatValue(\ILIAS\UI\Component\Input\Container\Form\FormInput $field): void
+    {
+        $post_data = new DefInputData(['name_0' => 1.1]);
+        $value = $field
+            ->withStepSize(.1)
+            ->withInput($post_data)
+            ->getContent();
+        $this->assertTrue($value->isOk());
+        $this->assertEquals(1.1, $value->value());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Depends('testNullValue')]
+    public function testFloatValueOffsetStep(\ILIAS\UI\Component\Input\Container\Form\FormInput $field): void
+    {
+        $post_data = new DefInputData(['name_0' => 1.2]);
+        $value = $field
+            ->withStepSize(.5)
+            ->withInput($post_data)
+            ->getContent();
+        $this->assertTrue($value->isOk());
+        $this->assertEquals(1.2, $value->value());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Depends('testNullValue')]
+    public function testFloatValueForInt(\ILIAS\UI\Component\Input\Container\Form\FormInput $field): void
+    {
+        $post_data = new DefInputData(['name_0' => 2]);
+        $value = $field
+            ->withStepSize(.5)
+            ->withInput($post_data)
+            ->getContent();
+        $this->assertTrue($value->isOk());
+        $this->assertEquals(2, $value->value());
+        $this->assertIsFloat($value->value());
+    }
+
+
 }


### PR DESCRIPTION
Currently, the UI Framework lacks an input for floats.
HTML5 specifies the step-attribute for numeric inputs: https://html.spec.whatwg.org/multipage/input.html#attr-input-step

We propose "withStepSize" for \ILIAS\UI\Component\Input\Field\Numeric as [described below](https://github.com/ILIAS-eLearning/ILIAS/blob/910cf82bcc877c3a98ff0678873ba8d91727c2e8/components/ILIAS/UI/src/Component/Input/Field/Numeric.php#L31-L37).
This limits the steps to numerics without the "any" option and lets us predict the expected value as int or float.

Consequently, when the step size is given as a floating point number, the field's value will be a float, too, even if it's a whole number. When the stepsize is omited or given as int, decimals will not be allowed or possible.

This will not have any impact on existing code, but will enhance the possibilities of numeric input.
A close-by usecase is the scoring of test questions, where points are given as floats.