### PR TITLE
T&A 45201: Fixes undefined key when copying certain tests with multiple choice questions with feedback

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoice.php
@@ -724,7 +724,7 @@ class assMultipleChoice extends assQuestion implements ilObjQuestionScoringAdjus
 
                     // Reorder feedback
                     $feedback_order_db = intval($feedback_option['answer']);
-                    $db_answer_id = $db_answer_id_for_order[$feedback_order_db];
+                    $db_answer_id = $db_answer_id_for_order[$feedback_order_db] ?? null;
                     // This cuts feedback that currently would have no corresponding answer
                     // This case can happen while copying "broken" questions
                     // Or when saving a question with less answers than feedback


### PR DESCRIPTION
This change will probably fix the issue mentioned here:
https://mantis.ilias.de/view.php?id=45201

The cause seems to be dangling data inside the `qpl_fb_specific` table with no associated question answers.

Pretty much the same issue was fixed in this PR but only for Single Choice questions.
https://github.com/ILIAS-eLearning/ILIAS/commit/7f7e75874e602e9bd8756cc2c4ce42688826a4e6

From what is seems this should also be cherry picked to ILIAS 10, since it is also missing there.

This should be a valid fix, because this was the original intention here. In PHP 7 a undefined key would throw a notice but still return null. Since PHP 8 it throws a warning instead.