### PR TITLE
BookingManager: fix files in calendar (43574)

### DIFF
--- a/components/ILIAS/BookingManager/Objects/class.ObjectsDBRepository.php
+++ b/components/ILIAS/BookingManager/Objects/class.ObjectsDBRepository.php
@@ -117,10 +117,10 @@ class ObjectsDBRepository
         }
     }
 
-    public function getObjectInfoPath(int $booking_object_id): void
+    public function getObjectInfoPath(int $booking_object_id): string
     {
         $rid = $this->getObjectInfoRidForBookingObjectId($booking_object_id);
-        $this->wrapper->getResourcePath($rid);
+        return $this->wrapper->getResourcePath($rid);
     }
 
     public function deliverObjectInfo(int $booking_object_id): void
@@ -195,10 +195,10 @@ class ObjectsDBRepository
         $this->wrapper->deliverFile($rid);
     }
 
-    public function getBookingInfoPath(int $booking_object_id): void
+    public function getBookingInfoPath(int $booking_object_id): string
     {
         $rid = $this->getBookingInfoRidForBookingObjectId($booking_object_id);
-        $this->wrapper->getResourcePath($rid);
+        return $this->wrapper->getResourcePath($rid);
     }
 
     public function getBookingInfoFilename(int $booking_object_id): string

--- a/components/ILIAS/BookingManager/Objects/class.ObjectsManager.php
+++ b/components/ILIAS/BookingManager/Objects/class.ObjectsManager.php
@@ -3,14 +3,17 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
+ *
  *********************************************************************/
 
 declare(strict_types=1);

--- a/components/ILIAS/BookingManager/Objects/class.ObjectsManager.php
+++ b/components/ILIAS/BookingManager/Objects/class.ObjectsManager.php
@@ -133,11 +133,21 @@ class ObjectsManager
         );
     }
 
+    public function hasObjectInfo(int $booking_obj_id): bool
+    {
+        return $this->object_repo->hasObjectInfo($booking_obj_id);
+    }
+
     public function deliverObjectInfo(int $booking_obj_id): void
     {
         if ($this->object_repo->hasObjectInfo($booking_obj_id)) {
             $this->object_repo->deliverObjectInfo($booking_obj_id);
         }
+    }
+
+    public function hasBookingInfo(int $booking_obj_id): bool
+    {
+        return $this->object_repo->hasBookingInfo($booking_obj_id);
     }
 
     public function deliverBookingInfo(int $booking_obj_id): void
@@ -181,12 +191,12 @@ class ObjectsManager
         }
     }
 
-    public function getObjectInfoPath(int $booking_object_id): int
+    public function getObjectInfoPath(int $booking_object_id): string
     {
         return $this->object_repo->getObjectInfoPath($booking_object_id);
     }
 
-    public function getBookingInfoPath(int $booking_object_id): int
+    public function getBookingInfoPath(int $booking_object_id): string
     {
         return $this->object_repo->getBookingInfoPath($booking_object_id);
     }

--- a/components/ILIAS/BookingManager/Objects/class.ObjectsManager.php
+++ b/components/ILIAS/BookingManager/Objects/class.ObjectsManager.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -14,6 +12,8 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\BookingManager\Objects;
 

--- a/components/ILIAS/Calendar/classes/AppointmentPresentation/class.ilAppointmentPresentationBookingPoolGUI.php
+++ b/components/ILIAS/Calendar/classes/AppointmentPresentation/class.ilAppointmentPresentationBookingPoolGUI.php
@@ -3,14 +3,17 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
+ *
  *********************************************************************/
 
 declare(strict_types=1);

--- a/components/ILIAS/Calendar/classes/AppointmentPresentation/class.ilAppointmentPresentationBookingPoolGUI.php
+++ b/components/ILIAS/Calendar/classes/AppointmentPresentation/class.ilAppointmentPresentationBookingPoolGUI.php
@@ -11,6 +11,8 @@ class ilAppointmentPresentationBookingPoolGUI extends ilAppointmentPresentationG
 {
     public function collectPropertiesAndActions(): void
     {
+        global $DIC;
+
         $a_app = $this->appointment;
         $cat_info = $this->getCatInfo();
 
@@ -21,6 +23,7 @@ class ilAppointmentPresentationBookingPoolGUI extends ilAppointmentPresentationG
         $res = new ilBookingReservation($res_id);
         $b_obj = new ilBookingObject($res->getObjectId());
         $obj_id = $b_obj->getPoolId();
+        $objects_manager = $DIC->bookingManager()->internal()->domain()->objects($obj_id);
 
         $refs = $this->getReadableRefIds($obj_id);
 
@@ -44,7 +47,7 @@ class ilAppointmentPresentationBookingPoolGUI extends ilAppointmentPresentationG
             $this->addCalendarInfo($cat_info);
 
             // section: booking information
-            if ($b_obj->getDescription() || $b_obj->getFile()) {
+            if ($b_obj->getDescription() || $objects_manager->hasObjectInfo($b_obj->getId())) {
                 $this->addInfoSection($this->lng->txt("book_booking_information"));
             }
 
@@ -54,7 +57,7 @@ class ilAppointmentPresentationBookingPoolGUI extends ilAppointmentPresentationG
             $this->ctrl->setParameterByClass("ilbookingobjectgui", "object_id", $res->getObjectId());
 
             // info file
-            if ($b_obj->getFile()) {
+            if ($objects_manager->hasObjectInfo($b_obj->getId())) {
                 $this->has_files = true;
                 $link = $this->ctrl->getLinkTargetByClass(array("ilRepositoryGUI",
                                                                 "ilObjBookingPoolGUI",
@@ -62,7 +65,7 @@ class ilAppointmentPresentationBookingPoolGUI extends ilAppointmentPresentationG
                 ), "deliverInfo");
 
                 $link = $this->ui->renderer()->render(
-                    $this->ui->factory()->button()->shy($b_obj->getFile(), $link)
+                    $this->ui->factory()->button()->shy($objects_manager->getObjectInfoFilename($b_obj->getId()), $link)
                 );
 
                 $this->addInfoProperty($this->lng->txt("book_additional_info_file"), $link);
@@ -79,17 +82,17 @@ class ilAppointmentPresentationBookingPoolGUI extends ilAppointmentPresentationG
                 $text = str_replace("[PERIOD]", $period, $text);
                 $array_info[] = $text;
             }
-            if ($b_obj->getPostFile()) {
+            if ($objects_manager->hasBookingInfo($b_obj->getId())) {
                 $this->has_files = true;
 
                 $link = $this->ctrl->getLinkTargetByClass(array("ilRepositoryGUI",
                                                                 "ilObjBookingPoolGUI",
                                                                 "ilbookingobjectgui",
-                                                                "ilBookingProcessGUI"
+                                                                "ilBookingProcessWithScheduleGUI"
                 ), "deliverPostFile");
 
                 $array_info[] = $this->ui->renderer()->render(
-                    $this->ui->factory()->button()->shy($b_obj->getPostFile(), $link)
+                    $this->ui->factory()->button()->shy($objects_manager->getBookingInfoFilename($b_obj->getId()), $link)
                 );
             }
             if ($array_info) {

--- a/components/ILIAS/Calendar/classes/AppointmentPresentation/class.ilAppointmentPresentationBookingPoolGUI.php
+++ b/components/ILIAS/Calendar/classes/AppointmentPresentation/class.ilAppointmentPresentationBookingPoolGUI.php
@@ -1,5 +1,18 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *********************************************************************/
+
 declare(strict_types=1);
 
 /**

--- a/components/ILIAS/Calendar/classes/FileHandler/class.ilAppointmentBookingPoolFileHandler.php
+++ b/components/ILIAS/Calendar/classes/FileHandler/class.ilAppointmentBookingPoolFileHandler.php
@@ -3,14 +3,17 @@
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
+ *
  *********************************************************************/
 
 declare(strict_types=1);

--- a/components/ILIAS/Calendar/classes/FileHandler/class.ilAppointmentBookingPoolFileHandler.php
+++ b/components/ILIAS/Calendar/classes/FileHandler/class.ilAppointmentBookingPoolFileHandler.php
@@ -1,8 +1,19 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *********************************************************************/
 
-/* Copyright (c) 1998-2017 ILIAS open source, Extended GPL, see docs/LICENSE */
+declare(strict_types=1);
 
 use ILIAS\Calendar\FileHandler\ilFileProperty;
 

--- a/components/ILIAS/Calendar/classes/FileHandler/class.ilAppointmentBookingPoolFileHandler.php
+++ b/components/ILIAS/Calendar/classes/FileHandler/class.ilAppointmentBookingPoolFileHandler.php
@@ -18,24 +18,27 @@ class ilAppointmentBookingPoolFileHandler extends ilAppointmentBaseFileHandler i
      */
     public function getFiles(): array
     {
+        global $DIC;
+
         // context id is reservation id (see ilObjBookingPoolGUI->processBooking)
         $res_id = $this->appointment['event']->getContextId();
         $res = new ilBookingReservation($res_id);
         $b_obj = new ilBookingObject($res->getObjectId());
+        $objects_manager = $DIC->bookingManager()->internal()->domain()->objects($b_obj->getPoolId());
 
         $files = [];
 
-        if ($b_obj->getFile() !== "") {
+        if ($objects_manager->hasObjectInfo($b_obj->getId())) {
             $file_property = new ilFileProperty();
-            $file_property->setAbsolutePath($b_obj->getFileFullPath());
-            $file_property->setFileName($b_obj->getFile());
+            $file_property->setAbsolutePath($objects_manager->getObjectInfoPath($b_obj->getId()));
+            $file_property->setFileName($objects_manager->getObjectInfoFilename($b_obj->getId()));
             $files[] = $file_property;
         }
 
-        if ($b_obj->getPostFile() !== "") {
+        if ($objects_manager->hasBookingInfo($b_obj->getId())) {
             $file_property = new ilFileProperty();
-            $file_property->setAbsolutePath($b_obj->getPostFileFullPath());
-            $file_property->setFileName($b_obj->getPostFile());
+            $file_property->setAbsolutePath($objects_manager->getBookingInfoPath($b_obj->getId()));
+            $file_property->setFileName($objects_manager->getBookingInfoFilename($b_obj->getId()));
             $files[] = $file_property;
         }
 


### PR DESCRIPTION
This PR fixes [43574](https://mantis.ilias.de/view.php?id=43574), by tying up some loose ends in some booking pool specific classes in Calendar.

I introduced the `BookingManager\Objects\ObjectsManager` as a dependency to those Calendar classes, I'm not sure if that's the intended way. A different option would be to expose the relevant methods of the `ObjectsManager` through the `ilBookingObject`.