### PR TITLE
Tabs: remove empty link tag from subtabs (43216)

### DIFF
--- a/components/ILIAS/UIComponent/Tabs/templates/default/tpl.sub_tabs.html
+++ b/components/ILIAS/UIComponent/Tabs/templates/default/tpl.sub_tabs.html
@@ -1,6 +1,6 @@
 <h2 class="ilAccHeadingHidden"><a id="sub_tabs_after_tabs">{TXT_SUBTABS}</a></h2>
 <ul id="ilSubTab" class="ilSubTab nav hidden-print">
 	<!-- BEGIN subtab -->
-	<li id="{ID}" class="{SUB_TAB_TYPE}"><a {SUB_TAB_TARGET} href="{SUB_TAB_LINK}">{SUB_TAB_TEXT}</a>{SUB_LINK}<!-- BEGIN sel_text --> <span class="ilAccHidden">({TXT_SELECTED})</span><!-- END sel_text --></li>
+	<li id="{ID}" class="{SUB_TAB_TYPE}">{SUB_LINK}<!-- BEGIN sel_text --> <span class="ilAccHidden">({TXT_SELECTED})</span><!-- END sel_text --></li>
 	<!-- END subtab -->
 </ul>


### PR DESCRIPTION
This PR fixes [43216](https://mantis.ilias.de/view.php?id=43216), by removing an unused link tag from the html-template for subtabs. As far as I can tell, this is left over from #7869, where the rendering of links in tabs was switched to KS.

The empty link tag is an accessibility problem, it makes tab-navigating through the subtabs confusing, see also [44180](https://mantis.ilias.de/view.php?id=44180).