### PR TITLE
Object: also adopt standard styles when adopting content pages from other container (45013)

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObjectCopyGUI.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObjectCopyGUI.php
@@ -976,13 +976,18 @@ class ilObjectCopyGUI
         }
 
         $style_id = ilObjStyleSheet::lookupObjectStyle($source_object->getId());
-        if ($style_id > 0 && !ilObjStyleSheet::_lookupStandard($style_id)) {
+        if ($style_id <= 0) {
+            return;
+        }
+        if (!ilObjStyleSheet::_lookupStandard($style_id)) {
             $style_obj = ilObjectFactory::getInstanceByObjId($style_id);
             $new_id = $style_obj->ilClone();
             ilObjStyleSheet::writeStyleUsage($target_object->getId(), $new_id);
             ilObjStyleSheet::writeOwner($target_object->getId(), $new_id);
             $reuse = $this->container_repo->readReuse($source_object->getRefId());
             $this->container_repo->updateReuse($target_object->getRefId(), $reuse);
+        } else {
+            ilObjStyleSheet::writeStyleUsage($target_object->getId(), $style_id);
         }
     }
 


### PR DESCRIPTION
This PR fixes [45013](https://mantis.ilias.de/view.php?id=45013), by also transferring selected standard styles when adopting content between two containers.

The same logic can be found internally in Style (see e.g. `ILIAS\Style\Content\Object\ObjectManager::cloneTo`).