### PR TITLE
T&A 45192: Avoid Blocking Unfinished Attempts

### DIFF
--- a/Modules/Test/classes/TestScreen/class.ilTestScreenGUI.php
+++ b/Modules/Test/classes/TestScreen/class.ilTestScreenGUI.php
@@ -473,7 +473,8 @@ class ilTestScreenGUI
     private function blockUserAfterHavingPassed(): bool
     {
         if ($this->main_settings->getTestBehaviourSettings()->getBlockAfterPassedEnabled()) {
-            return $this->test_passes_selector->hasTestPassedOnce($this->test_session->getActiveId());
+            return $this->test_passes_selector->hasTestPassedOnce($this->test_session->getActiveId())
+                && $this->test_passes_selector->getLastFinishedPass() >= 0;
         }
 
         return false;

--- a/Modules/Test/classes/TestScreen/class.ilTestScreenGUI.php
+++ b/Modules/Test/classes/TestScreen/class.ilTestScreenGUI.php
@@ -473,8 +473,8 @@ class ilTestScreenGUI
     private function blockUserAfterHavingPassed(): bool
     {
         if ($this->main_settings->getTestBehaviourSettings()->getBlockAfterPassedEnabled()) {
-            return $this->test_passes_selector->hasTestPassedOnce($this->test_session->getActiveId())
-                && $this->test_passes_selector->getLastFinishedPass() >= 0;
+            return $this->test_passes_selector->getLastFinishedPass() >= 0
+                && $this->test_passes_selector->hasTestPassedOnce($this->test_session->getActiveId());
         }
 
         return false;


### PR DESCRIPTION
Hi everyone,

This PR addresses the issue described in Ticket [45192](https://mantis.ilias.de/view.php?id=45192), where a test that is limited in attempts refuses further processing after being paused if the participant would have passed the test based on points alone.

This behavior occurs because the `test_result_cache` table is written to every time a question is answered in a test attempt. This means that after the participant has answered enough questions, the *marked* flag is set in the table, even though the test has not yet been completed.

As always, I look forward to feedback on the changes. @thojou  has already approved this PR in an internal review.

Best,
@lukas-heinrich 