### PR TITLE
Fix typo in LTI token response

### DIFF
--- a/components/ILIAS/LTIConsumer/resources/ltitoken.php
+++ b/components/ILIAS/LTIConsumer/resources/ltitoken.php
@@ -138,7 +138,7 @@ function sendAccessToken(string $scopes, ilLTIConsumeProvider $provider): void
         $accessToken = JWT::encode($token, $privateKey['key'], 'RS256', $privateKey['kid']);
         $responseData = array(
             'access_token' => $accessToken,
-            'token_type' => 'baerer',
+            'token_type' => 'bearer',
             'expires_in' => 3600,
             'scope' => $scopes
         );


### PR DESCRIPTION
This prevented a sending of learning results by some external tools

Apply of #9670 from ILIAS 9.