### PR TITLE
T&A 29648: Adds export and import of units and unit categories of a formula question

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1304,7 +1304,13 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
             return false;
         }
         $qtiParser = new ilQTIParser($qti_file, ilQTIParser::IL_MO_VERIFY_QTI, 0, "");
-        $qtiParser->startParsing();
+        try {
+            $qtiParser->startParsing();
+        } catch (ilSaxParserException) {
+            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('import_file_not_valid'), true);
+            $this->ctrl->redirect($this, 'create');
+            return false;
+        }
         $founditems = $qtiParser->getFoundItems();
 
         $complete = 0;

--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -1303,7 +1303,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
             $this->ctrl->redirect($this, 'create');
             return false;
         }
-        $qtiParser = new ilQTIParser($qti_file, ilQTIParser::IL_MO_VERIFY_QTI, 0, "");
+        $qtiParser = new ilQTIParser($qti_file, ilQTIParser::IL_MO_VERIFY_QTI, 0, "", [], true);
         try {
             $qtiParser->startParsing();
         } catch (ilSaxParserException) {

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestion.php
@@ -118,6 +118,9 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, ilAs
         }
     }
 
+    /**
+     * @return assFormulaQuestionUnit[]
+     */
     public function getResultUnits(assFormulaQuestionResult $result): array
     {
         if (!isset($this->resultunits[$result->getResult()])) {
@@ -368,13 +371,11 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, ilAs
                         if (is_array($userdata)) {
                             foreach ($result_units as $unit) {
                                 if (isset($userdata[$result]["unit"]) && $userdata[$result]["unit"] == $unit->getId()) {
-                                    $units = $unit->getUnit();
+                                    $units = $unit->getSanitizedUnit();
                                 }
                             }
-                        } else {
-                            if ($resObj->getUnit()) {
-                                $units = $resObj->getUnit()->getUnit();
-                            }
+                        } elseif ($resObj->getUnit()) {
+                            $units = $resObj->getUnit()->getSanitizedUnit();
                         }
                     } else {
                         $units = '<select name="result_' . $result . '_unit">';
@@ -388,7 +389,7 @@ class assFormulaQuestion extends assQuestion implements iQuestionCondition, ilAs
                                     $units .= ' selected="selected"';
                                 }
                             }
-                            $units .= '>' . $unit->getUnit() . '</option>';
+                            $units .= '>' . $unit->getSanitizedUnit() . '</option>';
                         }
                         $units .= '</select>';
                     }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnit.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnit.php
@@ -64,6 +64,11 @@ class assFormulaQuestionUnit
         return $this->unit;
     }
 
+    public function getSanitizedUnit(): string
+    {
+        return htmlspecialchars($this->getUnit(), ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8');
+    }
+
     public function setSequence(int $sequence): void
     {
         $this->sequence = $sequence;
@@ -108,6 +113,11 @@ class assFormulaQuestionUnit
         return $this->baseunit_title;
     }
 
+    public function getSanitizedBaseunitTitle(): ?string
+    {
+        return $this->sanitizeString($this->getBaseunitTitle() ?? '');
+    }
+
     public function setCategory(int $category): void
     {
         $this->category = $category;
@@ -122,14 +132,11 @@ class assFormulaQuestionUnit
     {
         global $DIC;
 
-        $lng = $DIC->language();
-
         $unit = $this->getUnit();
-        if (strcmp('-qpl_qst_formulaquestion_' . $unit . '-', $lng->txt('qpl_qst_formulaquestion_' . $unit)) !== 0) {
-            $unit = $lng->txt('qpl_qst_formulaquestion_' . $unit);
-        }
-
-        return $unit;
+        $txt = $DIC->language()->txt("qpl_qst_formulaquestion_{$unit}");
+        return strcmp("-qpl_qst_formulaquestion_{$unit}-", $txt) !== 0
+            ? $this->sanitizeString($txt)
+            : $this->getSanitizedUnit();
     }
 
     public static function lookupUnitFactor(int $a_unit_id): float
@@ -146,5 +153,10 @@ class assFormulaQuestionUnit
         $row = $ilDB->fetchAssoc($res);
 
         return (float) $row['factor'];
+    }
+
+    private function sanitizeString(string $string): string
+    {
+        return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8');
     }
 }

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnit.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnit.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Formula Question Unit
@@ -40,7 +40,7 @@ class assFormulaQuestionUnit
         $this->factor = (float) $data['factor'];
         $this->baseunit = (int) $data['baseunit_fi'];
         $this->baseunit_title = $data['baseunit_title'] ?? null;
-        $this->category = (int) $data['category'];
+        $this->category = (int) $data['category_fi'];
         $this->sequence = (int) $data['sequence'];
     }
 

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnitCategory.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnitCategory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Formula Question Unit Category

--- a/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnitCategory.php
+++ b/Modules/TestQuestionPool/classes/class.assFormulaQuestionUnitCategory.php
@@ -56,6 +56,11 @@ class assFormulaQuestionUnitCategory
         return $this->category;
     }
 
+    public function getSanitizedCategory(): string
+    {
+        return $this->sanitizeString($this->getCategory());
+    }
+
     public function setQuestionFi(int $question_fi): void
     {
         $this->question_fi = $question_fi;
@@ -70,13 +75,15 @@ class assFormulaQuestionUnitCategory
     {
         global $DIC;
 
-        $lng = $DIC->language();
-
         $category = $this->getCategory();
-        if (strcmp('-qpl_qst_formulaquestion_' . $category . '-', $lng->txt('qpl_qst_formulaquestion_' . $category)) !== 0) {
-            $category = $lng->txt('qpl_qst_formulaquestion_' . $category);
-        }
+        $txt = $DIC->language()->txt("qpl_qst_formulaquestion_{$category}");
+        return strcmp("-qpl_qst_formulaquestion_{$category}-", $txt) !== 0
+            ? $this->sanitizeString($txt)
+            : $this->getSanitizedCategory();
+    }
 
-        return $category;
+    private function sanitizeString(string $string): string
+    {
+        return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8');
     }
 }

--- a/Modules/TestQuestionPool/classes/class.ilLocalUnitConfigurationGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilLocalUnitConfigurationGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilLocalUnitConfigurationGUI
@@ -143,7 +143,9 @@ class ilLocalUnitConfigurationGUI extends ilUnitConfigurationGUI
     protected function confirmImportGlobalCategories(array $category_ids): void
     {
         // @todo: Confirmation Currently not implemented, so forward to import
-        $this->importGlobalCategories($category_ids);
+        $category_ids === []
+            ? $this->showGlobalUnitCategories()
+            : $this->importGlobalCategories($category_ids);
     }
 
     protected function importGlobalCategories(array $category_ids): void
@@ -171,9 +173,9 @@ class ilLocalUnitConfigurationGUI extends ilUnitConfigurationGUI
 
         if ($i) {
             $this->tpl->setOnScreenMessage('success', $this->lng->txt('saved_successfully'), true);
+            $this->ctrl->setParameter($this, 'question_fi', $this->request->getQuestionId());
         }
 
-        $this->ctrl->setParameter($this, 'question_fi', 0);
         $this->ctrl->redirect($this, 'showLocalUnitCategories');
     }
 }

--- a/Modules/TestQuestionPool/classes/class.ilUnitConfigurationGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilUnitConfigurationGUI.php
@@ -478,8 +478,8 @@ abstract class ilUnitConfigurationGUI
             /** @var assFormulaQuestionUnit $unit */
             $data[] = [
                 'unit_id' => $unit->getId(),
-                'unit' => $unit->getUnit(),
-                'baseunit' => $unit->getBaseunitTitle(),
+                'unit' => $unit->getSanitizedUnit(),
+                'baseunit' => $unit->getSanitizedBaseunitTitle(),
                 'baseunit_id' => $unit->getBaseUnit(),
                 'factor' => $unit->getFactor(),
                 'sequence' => $unit->getSequence(),

--- a/Modules/TestQuestionPool/classes/class.ilUnitConfigurationGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilUnitConfigurationGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilUnitConfigurationGUI
@@ -81,15 +81,10 @@ abstract class ilUnitConfigurationGUI
     {
         $cmd = $this->ctrl->getCmd($this->getDefaultCommand());
         $this->checkPermissions($cmd);
-        switch ($cmd) {
-            case 'confirmImportGlobalCategories':
-                $category_ids = $this->request->raw('category_ids');
-                $this->$cmd($category_ids);
-                break;
-            default:
-                $this->$cmd();
-                break;
-        }
+        match ($cmd) {
+            'confirmImportGlobalCategories' => $this->$cmd($this->request->getUnitCategoryIds()),
+            default => $this->$cmd(),
+        };
 
         $this->handleSubtabs();
     }

--- a/Modules/TestQuestionPool/classes/export/qti12/class.assFormulaQuestionExport.php
+++ b/Modules/TestQuestionPool/classes/export/qti12/class.assFormulaQuestionExport.php
@@ -79,15 +79,14 @@ class assFormulaQuestionExport extends assQuestionExport
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "unit_categories");
-        $var = [];
         /** @var assFormulaQuestionUnitCategory $unit_category */
         foreach ($unit_categories as $unit_category) {
-            $var[$unit_category->getCategory()] = [
-                "id" => $unit_category->getId(),
-                "question_fi" => $unit_category->getQuestionFi(),
-            ];
+            $a_xml_writer->xmlElement(
+                "fieldentry",
+                ["id" => $unit_category->getId(), "question_fi" => $unit_category->getQuestionFi()],
+                $unit_category->getCategory()
+            );
         }
-        $a_xml_writer->xmlElement("fieldentry", null, serialize($var));
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $categorized_units = array_filter(
@@ -97,19 +96,21 @@ class assFormulaQuestionExport extends assQuestionExport
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "units");
-        $var = [];
         /** @var assFormulaQuestionUnit $categorized_unit */
         foreach ($categorized_units as $categorized_unit) {
-            $var[$categorized_unit->getUnit()] = [
-                "id" => $categorized_unit->getId(),
-                "sequence" => $categorized_unit->getSequence(),
-                "factor" => $categorized_unit->getFactor(),
-                "base_unit" => $categorized_unit->getBaseUnit(),
-                "base_unit_title" => $categorized_unit->getBaseunitTitle(),
-                "category" => $categorized_unit->getCategory(),
-            ];
+            $a_xml_writer->xmlElement(
+                "fieldentry",
+                [
+                    "id" => $categorized_unit->getId(),
+                    "sequence" => $categorized_unit->getSequence(),
+                    "factor" => $categorized_unit->getFactor(),
+                    "base_unit" => $categorized_unit->getBaseUnit(),
+                    "base_unit_title" => $categorized_unit->getBaseunitTitle(),
+                    "category" => $categorized_unit->getCategory()
+                ],
+                $categorized_unit->getUnit()
+            );
         }
-        $a_xml_writer->xmlElement("fieldentry", null, serialize($var));
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         foreach ($this->object->getVariables() as $variable) {

--- a/Modules/TestQuestionPool/classes/export/qti12/class.assFormulaQuestionExport.php
+++ b/Modules/TestQuestionPool/classes/export/qti12/class.assFormulaQuestionExport.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -65,6 +66,32 @@ class assFormulaQuestionExport extends assQuestionExport
         $a_xml_writer->xmlElement("fieldlabel", null, "points");
         $a_xml_writer->xmlElement("fieldentry", null, $this->object->getPoints());
         $a_xml_writer->xmlEndTag("qtimetadatafield");
+
+        /** @var assFormulaQuestion $object */
+        $object = $this->object;
+        $unit_repository = $object->getUnitRepository();
+
+        $question_id = $this->object->getId();
+        $unit_categories = array_filter(
+            $unit_repository->getAllUnitCategories(),
+            static fn(object $object): bool => $object->getQuestionFi() === $question_id,
+        );
+
+        $a_xml_writer->xmlStartTag("qtimetadatafield");
+        $a_xml_writer->xmlElement("fieldlabel", null, "unit_categories");
+        $a_xml_writer->xmlElement("fieldentry", null, base64_encode(serialize($unit_categories)));
+        $a_xml_writer->xmlEndTag("qtimetadatafield");
+
+        $categorized_units = array_filter(
+            $unit_repository->getCategorizedUnits(),
+            static fn(object $object): bool => $object instanceof assFormulaQuestionUnit,
+        );
+
+        $a_xml_writer->xmlStartTag("qtimetadatafield");
+        $a_xml_writer->xmlElement("fieldlabel", null, "units");
+        $a_xml_writer->xmlElement("fieldentry", null, base64_encode(serialize($categorized_units)));
+        $a_xml_writer->xmlEndTag("qtimetadatafield");
+
         foreach ($this->object->getVariables() as $variable) {
             $var = [
                 "precision" => $variable->getPrecision(),

--- a/Modules/TestQuestionPool/classes/export/qti12/class.assFormulaQuestionExport.php
+++ b/Modules/TestQuestionPool/classes/export/qti12/class.assFormulaQuestionExport.php
@@ -79,7 +79,15 @@ class assFormulaQuestionExport extends assQuestionExport
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "unit_categories");
-        $a_xml_writer->xmlElement("fieldentry", null, base64_encode(serialize($unit_categories)));
+        $var = [];
+        /** @var assFormulaQuestionUnitCategory $unit_category */
+        foreach ($unit_categories as $unit_category) {
+            $var[$unit_category->getCategory()] = [
+                "id" => $unit_category->getId(),
+                "question_fi" => $unit_category->getQuestionFi(),
+            ];
+        }
+        $a_xml_writer->xmlElement("fieldentry", null, serialize($var));
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $categorized_units = array_filter(
@@ -89,7 +97,19 @@ class assFormulaQuestionExport extends assQuestionExport
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "units");
-        $a_xml_writer->xmlElement("fieldentry", null, base64_encode(serialize($categorized_units)));
+        $var = [];
+        /** @var assFormulaQuestionUnit $categorized_unit */
+        foreach ($categorized_units as $categorized_unit) {
+            $var[$categorized_unit->getUnit()] = [
+                "id" => $categorized_unit->getId(),
+                "sequence" => $categorized_unit->getSequence(),
+                "factor" => $categorized_unit->getFactor(),
+                "base_unit" => $categorized_unit->getBaseUnit(),
+                "base_unit_title" => $categorized_unit->getBaseunitTitle(),
+                "category" => $categorized_unit->getCategory(),
+            ];
+        }
+        $a_xml_writer->xmlElement("fieldentry", null, serialize($var));
         $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         foreach ($this->object->getVariables() as $variable) {

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
@@ -172,11 +172,11 @@ class assFormulaQuestionImport extends assQuestionImport
                 $old_sequence = $unit->getSequence();
 
                 $unit->setCategory($unit_category->getId());
-                $unit->setBaseUnit($old_base_unit_id);
                 $unit->setFactor($old_unit_factor);
                 $unit->setSequence($old_sequence);
 
                 $unit_repository->createNewUnit($unit);
+                $unit->setBaseUnit($old_base_unit_id);
 
                 $units[] = $unit;
                 $base_unit_map[$old_unit_id] = $unit->getId();

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
@@ -155,9 +155,8 @@ class assFormulaQuestionImport extends assQuestionImport
         foreach ($item->getUnitCategoryObjets() as $unit_category) {
             $old_category_id = $unit_category->getId();
 
-            $unit_repository->saveNewUnitCategory($unit_category);
             $unit_category->setQuestionFi($this->object->getId());
-            $unit_repository->saveCategory($unit_category);
+            $unit_repository->saveNewUnitCategory($unit_category);
 
             $units = [];
             $base_unit_map = [];
@@ -172,22 +171,54 @@ class assFormulaQuestionImport extends assQuestionImport
                 $old_unit_factor = $unit->getFactor();
                 $old_sequence = $unit->getSequence();
 
-                $unit_repository->createNewUnit($unit);
-
                 $unit->setCategory($unit_category->getId());
                 $unit->setBaseUnit($old_base_unit_id);
                 $unit->setFactor($old_unit_factor);
                 $unit->setSequence($old_sequence);
 
-                $unit_repository->saveUnit($unit);
+                $unit_repository->createNewUnit($unit);
 
                 $units[] = $unit;
                 $base_unit_map[$old_unit_id] = $unit->getId();
+
+                $this->mapAssignedVariableUnits($unit, $old_unit_id);
+                $this->mapAssignedResultUnits($unit, $old_unit_id);
             }
 
             foreach ($units as $unit) {
                 $unit->setBaseUnit($base_unit_map[$unit->getBaseUnit()] ?? 0);
                 $unit_repository->saveUnit($unit);
+            }
+        }
+    }
+
+    private function mapAssignedVariableUnits(assFormulaQuestionUnit $unit, int $old_unit_id): void
+    {
+        /** @var assFormulaQuestionVariable $variable */
+        foreach ($this->object->getVariables() as $variable) {
+            $variable_unit = $variable->getUnit();
+            if ($variable_unit instanceof assFormulaQuestionUnit && $variable_unit->getId() === $old_unit_id) {
+                $variable_unit->setId($unit->getId());
+            }
+        }
+    }
+
+    private function mapAssignedResultUnits(assFormulaQuestionUnit $unit, int $old_unit_id): void
+    {
+        /** @var assFormulaQuestionResult $result */
+        foreach ($this->object->getResults() as $result) {
+            $result_unit = $result->getUnit();
+            if ($result_unit instanceof assFormulaQuestionUnit && $result_unit->getId() === $old_unit_id) {
+                $result_unit->setId($unit->getId());
+            }
+        }
+
+        /** @var assFormulaQuestionUnit[] $result */
+        foreach ($this->object->getAllResultUnits() as $result) {
+            foreach ($result as $result_unit) {
+                if ($result_unit instanceof assFormulaQuestionUnit && $result_unit->getId() === $old_unit_id) {
+                    $result_unit->setId($unit->getId());
+                }
             }
         }
     }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
@@ -152,7 +152,7 @@ class assFormulaQuestionImport extends assQuestionImport
     {
         /** @var ilUnitConfigurationRepository $unit_repository */
         $unit_repository = $this->object->getUnitrepository();
-        foreach ($item->getUnitCategories() as $unit_category) {
+        foreach ($item->getUnitCategoryObjets() as $unit_category) {
             $old_category_id = $unit_category->getId();
 
             $unit_repository->saveNewUnitCategory($unit_category);
@@ -162,7 +162,7 @@ class assFormulaQuestionImport extends assQuestionImport
             $units = [];
             $base_unit_map = [];
 
-            foreach ($item->getUnits() as $unit) {
+            foreach ($item->getUnitObjects() as $unit) {
                 if ($unit->getCategory() !== $old_category_id) {
                     continue;
                 }

--- a/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
+++ b/Modules/TestQuestionPool/classes/import/qti12/class.assFormulaQuestionImport.php
@@ -98,6 +98,9 @@ class assFormulaQuestionImport extends assQuestionImport
             $this->fetchAdditionalContentEditingModeInformation($item)
         );
         $this->object->saveToDb();
+
+        $this->importUnitsAndUnitCategories($item);
+
         // handle the import of media objects in XHTML code
         $questiontext = $this->object->getQuestion();
         $feedbacksgeneric = $this->getFeedbackGeneric($item);
@@ -143,5 +146,49 @@ class assFormulaQuestionImport extends assQuestionImport
             $import_mapping[$item->getIdent()] = ["pool" => $this->object->getId(), "test" => 0];
         }
         return $import_mapping;
+    }
+
+    private function importUnitsAndUnitCategories(ilQTIItem $item): void
+    {
+        /** @var ilUnitConfigurationRepository $unit_repository */
+        $unit_repository = $this->object->getUnitrepository();
+        foreach ($item->getUnitCategories() as $unit_category) {
+            $old_category_id = $unit_category->getId();
+
+            $unit_repository->saveNewUnitCategory($unit_category);
+            $unit_category->setQuestionFi($this->object->getId());
+            $unit_repository->saveCategory($unit_category);
+
+            $units = [];
+            $base_unit_map = [];
+
+            foreach ($item->getUnits() as $unit) {
+                if ($unit->getCategory() !== $old_category_id) {
+                    continue;
+                }
+
+                $old_unit_id = $unit->getId();
+                $old_base_unit_id = $unit->getBaseUnit();
+                $old_unit_factor = $unit->getFactor();
+                $old_sequence = $unit->getSequence();
+
+                $unit_repository->createNewUnit($unit);
+
+                $unit->setCategory($unit_category->getId());
+                $unit->setBaseUnit($old_base_unit_id);
+                $unit->setFactor($old_unit_factor);
+                $unit->setSequence($old_sequence);
+
+                $unit_repository->saveUnit($unit);
+
+                $units[] = $unit;
+                $base_unit_map[$old_unit_id] = $unit->getId();
+            }
+
+            foreach ($units as $unit) {
+                $unit->setBaseUnit($base_unit_map[$unit->getBaseUnit()] ?? 0);
+                $unit_repository->saveUnit($unit);
+            }
+        }
     }
 }

--- a/Modules/TestQuestionPool/classes/tables/class.ilUnitCategoryTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilUnitCategoryTableGUI.php
@@ -111,8 +111,6 @@ abstract class ilUnitCategoryTableGUI extends ilTable2GUI
         $dropdown = $this->ui_factory->dropdown()->standard($actions)->withLabel($this->lng->txt('actions'));
         $row['actions'] = $this->ui_renderer->render($dropdown);
 
-        $row['category'] = htmlspecialchars($row['category'], ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8');
-
         parent::fillRow($row);
     }
 }

--- a/Services/QTI/classes/class.ilQTIItem.php
+++ b/Services/QTI/classes/class.ilQTIItem.php
@@ -264,9 +264,9 @@ class ilQTIItem
         return $this->questiontype;
     }
 
-    public function setUnitCategories(array $unit_categories): void
+    public function addUnitCategory(string $label, array $unit_category): void
     {
-        $this->unit_categories = $unit_categories;
+        $this->unit_categories[$label] = $unit_category;
     }
 
     public function getUnitCategories(): array
@@ -283,17 +283,17 @@ class ilQTIItem
         foreach ($this->getUnitCategories() as $key => $unit_category) {
             $formula_question_unit_category = new assFormulaQuestionUnitCategory();
             $formula_question_unit_category->setCategory($key);
-            $formula_question_unit_category->setId($unit_category['id']);
-            $formula_question_unit_category->setQuestionFi($unit_category['question_fi']);
+            $formula_question_unit_category->setId((int) $unit_category['id']);
+            $formula_question_unit_category->setQuestionFi((int) $unit_category['question_fi']);
             $unit_categories[$key] = $formula_question_unit_category;
         }
 
         return $unit_categories;
     }
 
-    public function setUnits(array $units): void
+    public function addUnit(string $label, array $unit): void
     {
-        $this->units = $units;
+        $this->units[$label] = $unit;
     }
 
     public function getUnits(): array
@@ -310,12 +310,12 @@ class ilQTIItem
         foreach ($this->getUnits() as $key => $unit) {
             $formula_question_unit = new assFormulaQuestionUnit();
             $formula_question_unit->setUnit($key);
-            $formula_question_unit->setId($unit['id']);
-            $formula_question_unit->setSequence($unit['sequence']);
-            $formula_question_unit->setFactor($unit['factor']);
-            $formula_question_unit->setBaseUnit($unit['base_unit']);
+            $formula_question_unit->setId((int) $unit['id']);
+            $formula_question_unit->setSequence((int) $unit['sequence']);
+            $formula_question_unit->setFactor((float) $unit['factor']);
+            $formula_question_unit->setBaseUnit((int) $unit['base_unit']);
             $formula_question_unit->setBaseunitTitle($unit['base_unit_title']);
-            $formula_question_unit->setCategory($unit['category']);
+            $formula_question_unit->setCategory((int) $unit['category']);
             $units[$key] = $formula_question_unit;
         }
 

--- a/Services/QTI/classes/class.ilQTIItem.php
+++ b/Services/QTI/classes/class.ilQTIItem.php
@@ -264,30 +264,62 @@ class ilQTIItem
         return $this->questiontype;
     }
 
-    public function setUnitCategories(string $serialized_and_base64_encoded_unit_categories): void
+    public function setUnitCategories(array $unit_categories): void
     {
-        $this->unit_categories = unserialize(base64_decode($serialized_and_base64_encoded_unit_categories));
+        $this->unit_categories = $unit_categories;
     }
 
-    /**
-     * @return assFormulaQuestionUnitCategory[]
-     */
     public function getUnitCategories(): array
     {
         return $this->unit_categories;
     }
 
-    public function setUnits(string $serialized_and_base64_encoded_units): void
+    /**
+     * @return assFormulaQuestionUnitCategory[]
+     */
+    public function getUnitCategoryObjets(): array
     {
-        $this->units = unserialize(base64_decode($serialized_and_base64_encoded_units));
+        $unit_categories = [];
+        foreach ($this->getUnitCategories() as $key => $unit_category) {
+            $formula_question_unit_category = new assFormulaQuestionUnitCategory();
+            $formula_question_unit_category->setCategory($key);
+            $formula_question_unit_category->setId($unit_category['id']);
+            $formula_question_unit_category->setQuestionFi($unit_category['question_fi']);
+            $unit_categories[$key] = $formula_question_unit_category;
+        }
+
+        return $unit_categories;
+    }
+
+    public function setUnits(array $units): void
+    {
+        $this->units = $units;
+    }
+
+    public function getUnits(): array
+    {
+        return $this->units;
     }
 
     /**
      * @return assFormulaQuestionUnit[]
      */
-    public function getUnits(): array
+    public function getUnitObjects(): array
     {
-        return $this->units;
+        $units = [];
+        foreach ($this->getUnits() as $key => $unit) {
+            $formula_question_unit = new assFormulaQuestionUnit();
+            $formula_question_unit->setUnit($key);
+            $formula_question_unit->setId($unit['id']);
+            $formula_question_unit->setSequence($unit['sequence']);
+            $formula_question_unit->setFactor($unit['factor']);
+            $formula_question_unit->setBaseUnit($unit['base_unit']);
+            $formula_question_unit->setBaseunitTitle($unit['base_unit_title']);
+            $formula_question_unit->setCategory($unit['category']);
+            $units[$key] = $formula_question_unit;
+        }
+
+        return $units;
     }
 
     public function setAuthor(string $a_author): void

--- a/Services/QTI/classes/class.ilQTIItem.php
+++ b/Services/QTI/classes/class.ilQTIItem.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -16,8 +14,9 @@ declare(strict_types=1);
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- ********************************************************************
- */
+ *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * QTI item class
@@ -76,6 +75,9 @@ class ilQTIItem
     protected ?string $iliasSourceVersion = null;
     protected ?string $iliasSourceNic = null;
     protected array $response = [];
+
+    private array $unit_categories = [];
+    private array $units = [];
 
     public function setIdent(string $a_ident): void
     {
@@ -260,6 +262,32 @@ class ilQTIItem
         }
 
         return $this->questiontype;
+    }
+
+    public function setUnitCategories(string $serialized_and_base64_encoded_unit_categories): void
+    {
+        $this->unit_categories = unserialize(base64_decode($serialized_and_base64_encoded_unit_categories));
+    }
+
+    /**
+     * @return assFormulaQuestionUnitCategory[]
+     */
+    public function getUnitCategories(): array
+    {
+        return $this->unit_categories;
+    }
+
+    public function setUnits(string $serialized_and_base64_encoded_units): void
+    {
+        $this->units = unserialize(base64_decode($serialized_and_base64_encoded_units));
+    }
+
+    /**
+     * @return assFormulaQuestionUnit[]
+     */
+    public function getUnits(): array
+    {
+        return $this->units;
     }
 
     public function setAuthor(string $a_author): void

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -611,10 +611,10 @@ class ilQTIParser extends ilSaxParser
                         }
                         break;
                     case "unit_categories":
-                        $this->item?->setUnitCategories($this->metadata["entry"]);
+                        $this->item?->setUnitCategories(unserialize($this->metadata["entry"], ['allowed_classes' => false]));
                         break;
                     case "units":
-                        $this->item?->setUnits($this->metadata["entry"]);
+                        $this->item?->setUnits(unserialize($this->metadata["entry"], ['allowed_classes' => false]));
                         break;
                     case "AUTHOR":
                         if ($this->item !== null) {

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -331,7 +331,7 @@ class ilQTIParser extends ilSaxParser
             case "qtimetadatafield":
                 $this->metadata = ["label" => "", "entry" => ""];
                 break;
-            case "fieldentry";
+            case "fieldentry":
                 $this->attributes = $a_attribs;
                 break;
             case "flow":

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -610,6 +610,12 @@ class ilQTIParser extends ilSaxParser
                             $this->item->setQuestiontype($this->metadata["entry"]);
                         }
                         break;
+                    case "unit_categories":
+                        $this->item?->setUnitCategories($this->metadata["entry"]);
+                        break;
+                    case "units":
+                        $this->item?->setUnits($this->metadata["entry"]);
+                        break;
                     case "AUTHOR":
                         if ($this->item !== null) {
                             $this->item->setAuthor($this->metadata["entry"]);

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -195,7 +195,8 @@ class ilQTIParser extends ilSaxParser
         int $a_mode = self::IL_MO_PARSE_QTI,
         int $a_qpl_id = 0,
         $a_import_idents = '',
-        array $mappings = []
+        array $mappings = [],
+        bool $throw_errors = false
     ) {
         global $DIC;
 
@@ -211,7 +212,7 @@ class ilQTIParser extends ilSaxParser
         }
 
         $this->depth = $this->createParserStorage();
-        $this->setThrowException(true);
+        $this->setThrowException($throw_errors);
     }
 
     public function isIgnoreItemsEnabled(): bool

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -211,6 +211,7 @@ class ilQTIParser extends ilSaxParser
         }
 
         $this->depth = $this->createParserStorage();
+        $this->setThrowException(true);
     }
 
     public function isIgnoreItemsEnabled(): bool

--- a/Services/QTI/classes/class.ilQTIParser.php
+++ b/Services/QTI/classes/class.ilQTIParser.php
@@ -188,6 +188,8 @@ class ilQTIParser extends ilSaxParser
     protected \ILIAS\TestQuestionPool\QuestionFilesService $questionfiles;
     protected array $mappings;
 
+    private array $attributes = [];
+
     public function __construct(
         ?string $a_xml_file,
         int $a_mode = self::IL_MO_PARSE_QTI,
@@ -328,6 +330,9 @@ class ilQTIParser extends ilSaxParser
                 break;
             case "qtimetadatafield":
                 $this->metadata = ["label" => "", "entry" => ""];
+                break;
+            case "fieldentry";
+                $this->attributes = $a_attribs;
                 break;
             case "flow":
                 $this->flow++;
@@ -610,12 +615,6 @@ class ilQTIParser extends ilSaxParser
                             $this->item->setQuestiontype($this->metadata["entry"]);
                         }
                         break;
-                    case "unit_categories":
-                        $this->item?->setUnitCategories(unserialize($this->metadata["entry"], ['allowed_classes' => false]));
-                        break;
-                    case "units":
-                        $this->item?->setUnits(unserialize($this->metadata["entry"], ['allowed_classes' => false]));
-                        break;
                     case "AUTHOR":
                         if ($this->item !== null) {
                             $this->item->setAuthor($this->metadata["entry"]);
@@ -631,6 +630,19 @@ class ilQTIParser extends ilSaxParser
                     $this->assessment->addQtiMetadata($this->metadata);
                 }
                 $this->metadata = ["label" => "", "entry" => ""];
+                break;
+            case "fieldentry":
+                $label = $this->metadata["label"];
+                if ($label === "unit_categories") {
+                    $this->item?->addUnitCategory($this->metadata["entry"], $this->attributes);
+                    break;
+                }
+
+                if ($label === "units") {
+                    $this->item?->addUnit($this->metadata["entry"], $this->attributes);
+                    break;
+                }
+
                 break;
             case "flow":
                 $this->flow--;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=29648

It seems that a unit export/import was never implemented. This PR adds that "feature".

Serializing the unit categories and units and later base64 encoding them, is needed to preserve special characters, such as the German Umlaute.

