### PR TITLE
T&A 44756: Aims to fix wrong message being displayed when trying to force finish test attempts of all users when a time limit is defined

### DIFF
--- a/components/ILIAS/Test/src/Participants/ParticipantTableFinishTestAction.php
+++ b/components/ILIAS/Test/src/Participants/ParticipantTableFinishTestAction.php
@@ -90,11 +90,7 @@ class ParticipantTableFinishTestAction implements TableAction
                 array_map(
                     fn(Participant $participant) => $this->ui_factory->modal()->interruptiveItem()->standard(
                         (string) $participant->getUserId(),
-                        sprintf(
-                            '%s, %s',
-                            $participant->getLastname(),
-                            $participant->getFirstname()
-                        )
+                        (new \ilObjUser($participant->getUserId()))->getPublicName()
                     ),
                     $selected_participants
                 )
@@ -117,6 +113,20 @@ class ParticipantTableFinishTestAction implements TableAction
                 true
             );
             return null;
+        }
+
+        if ($this->test_obj->getEnableProcessingTime()) {
+            foreach ($selected_participants as $participant) {
+                if ($participant->hasUnfinishedAttempts()) {
+                    $this->tpl->setOnScreenMessage(
+                        \ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                        $this->lng->txt('finish_pass_for_all_users_in_processing_time'),
+                        true
+                    );
+
+                    return null;
+                }
+            }
         }
 
         if (!$this->test_obj->getResetProcessingTime() && count($selected_participants) > 1) {
@@ -186,15 +196,12 @@ class ParticipantTableFinishTestAction implements TableAction
             return $this->lng->txt('finish_test_all');
         }
 
-        if (count($selected_participants) === 1) {
-            return sprintf(
-                $this->lng->txt('finish_test_single'),
-                sprintf(
-                    '%s, %s',
-                    $selected_participants[0]->getLastname(),
-                    $selected_participants[0]->getFirstname()
-                )
-            );
+        $selected_participants = array_values($selected_participants);
+
+        if (count($selected_participants) === 1 && isset($selected_participants[0])) {
+            /** @var Participant $selected_participant */
+            $selected_participant = $selected_participants[0];
+            return sprintf($this->lng->txt('finish_test_single'), (new \ilObjUser($selected_participant->getUserId()))->getPublicName());
         }
 
         return $this->lng->txt('finish_test_multiple');

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -746,7 +746,7 @@ assessment#:#finish_pass_for_all_users_in_processing_time#:#Sie können die Durc
 assessment#:#finish_pass_for_user_confirmation#:#Wollen Sie den Test Durchlauf für den Teilnehmer „%s“ wirklich beenden?
 assessment#:#finish_pass_for_user_in_processing_time#:#WARNUNG: die Bearbeitungszeit für diesen Benutzer ist noch nicht vorbei! Sie sollten den Testlauf nur bei zwingendem Grund (z.B. Ausschluss vom Test) beenden.
 assessment#:#finish_test#:#Test beenden
-assessment#:#finish_test_all#:#Sind Sie sicher, dass die den Testdurchlauf für alle Teilnehmer beenden möchten?
+assessment#:#finish_test_all#:#Sind Sie sicher, dass Sie den Testdurchlauf für alle Teilnehmer beenden möchten?
 assessment#:#finish_test_more_than_one_selected#:#Wenn der Test nur einen Durchgang zulässt, darf nur ein einziger Teilnehmer ausgewählt werden, um den Durchgang zu beenden.
 assessment#:#finish_test_multiple#:#Sind Sie sicher, dass Sie den Testdurchlauf für folgende Teilnehmer beenden möchten?
 assessment#:#finish_test_no_valid_participants_selected#:#Für die gewählten Teilnehmer gibt es keine aktiven Testdurchläufe und können daher nicht beendet werden.


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44756

The public name of the user is now used when displaying participants. Also a message is displayed, when trying to finish all test attempts when processing time is enabled and at least one user has some left.