### PR TITLE
T&A10 44781: Fallback to first page and reset offset and range if out of bounds after filter

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
@@ -256,7 +256,7 @@ class Renderer extends AbstractComponentRenderer
 
         list(Pagination::FNAME_OFFSET => $offset, Pagination::FNAME_LIMIT => $limit) = array_map('intval', $component->getValue());
         $limit = $limit > 0 ? $limit : reset($limit_options);
-        $offset = $offset > $total_count ? 0 : $offset;
+        $offset = $offset >= $total_count ? 0 : $offset;
 
         if (! $total_count) {
             $input = $ui_factory->input()->field()->numeric('offset')->withValue($offset);

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Data.php
@@ -133,7 +133,7 @@ class Data extends AbstractTable implements T\Data
             $order = ($order instanceof Order) ? $order : null;
 
             if ($range instanceof Range) {
-                $range = $range->withStart($range->getStart() <= $total_count ? $range->getStart() : 0);
+                $range = $range->withStart($range->getStart() < $total_count ? $range->getStart() : 0);
                 $range = $range->croppedTo($total_count ?? PHP_INT_MAX);
             }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44781

This PR addresses an issue where deleting the last question on the last page of a paginated question pool results in an "offset is not in any range" exception. The fix ensures that the pagination state is adjusted correctly when the current page becomes empty after a deletion.