### PR TITLE
T&A 45211: Fixes single choice answers throwing an exception when adding comma values for points

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -612,7 +612,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
                 $answertext = $answer;
                 $this->object->addAnswer(
                     $answertext,
-                    $choice['points'][$index],
+                    $this->refinery->kindlyTo()->float()->transform($choice['points'][$index]),
                     $index,
                     null,
                     $choice['answer_id'][$index]


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45211

Using the Refinery, I convert numeric strings that contain a comma or period into valid floating-point values.