### PR TITLE
DataCollection: Enable group to read uploaded images

### DIFF
--- a/Modules/DataCollection/classes/Fields/Mob/class.ilDclMobRecordFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Mob/class.ilDclMobRecordFieldModel.php
@@ -72,6 +72,7 @@ class ilDclMobRecordFieldModel extends ilDclFileRecordFieldModel
             }
 
             ilFileUtils::rename($move_file, $target_file_path);
+            chmod($target_file_path, 0640);
             ilFileUtils::renameExecutables($mob_dir);
 
             $format = ilObjMediaObject::getMimeType($target_file_path);


### PR DESCRIPTION
Uploaded temp files have always access right `0600` instead of the default ones. And as the file is moved as is, the resulting file also has right `0600`. To ensure the group can also read the file, this PR sets the rights to `0640`.

This problem does not occur if `move_uploaded_file` is used but the wrapper `ilFileUtils::moveUploadedFile` cannot be used directly (needs more changes) and may introduce other problems (File is renamed again etc.).

As this should be changed in the future to use the `ILIAS\FileUpload` and the `ILIAS\FileSystem` anyways, I used the least intrusive solution.