### PR TITLE
Improve description of getXMLTree

### DIFF
--- a/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
+++ b/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
@@ -438,7 +438,8 @@ class ilNusoapUserAdministrationAdapter
             SERVICE_NAMESPACE . '#getXMLTree',
             SERVICE_STYLE,
             SERVICE_USE,
-            'ILIAS getXMLTree(): Returns a xml stream with the subtree objects.'
+            'ILIAS getXMLTree(): Returns a XML stream with the subtree objects under the given ref_id. Use the "types" array to exclude specific object types (e.g., course, group). ' . 
+            'Note: This is the opposite behavior of getTreeChilds(), where "types" is used to include specific types.'
         );
 
         $this->server->register(

--- a/webservice/soap/server.php
+++ b/webservice/soap/server.php
@@ -49,6 +49,8 @@ if (IL_SOAPMODE === IL_SOAPMODE_INTERNAL && strcasecmp($_SERVER["REQUEST_METHOD"
     $soapServer->setObject(new ilSoapFunctions());
     $soapServer->handle();
 } else {
+    require_once("Services/Init/classes/class.ilInitialisation.php");
+    ilInitialisation::initILIAS();
     // This is a request to display the available SOAP methods or WSDL...
     include('webservice/soap/nusoapserver.php');
 }


### PR DESCRIPTION
0031236: Improve description of getXMLTree
https://mantis.ilias.de/view.php?id=31236

The existing SOAP documentation for getXMLTree() doesn't explain how its parameters work, especially the types array. This update clarifies that types is used to exclude certain object types from the result, which is the opposite of how it's used in getTreeChilds(). The improved description should make the method easier to understand and use correctly in integrations.