### PR TITLE
[LTI] Fix: LP percentage of groups and courses

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResult.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResult.php
@@ -109,7 +109,7 @@ class ilLTIConsumerResult
         $this->id = (int) $data['id'];
         $this->obj_id = (int) $data['obj_id'];
         $this->usr_id = (int) $data['usr_id'];
-        $this->result = (float) $data['result'];
+        $this->result = $data['result'] == null ? null : (float) $data['result'];
     }
 
     /**

--- a/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilLTIConsumerResultService.php
@@ -115,9 +115,8 @@ class ilLTIConsumerResultService
             $this->operation = str_replace('Request', '', $request->getName());
 
             $request = $body->replaceResultRequest;
-            $logger->info("LTI Consumer Result Service: operation loaded ($this->operation)");
-
             $token = ilCmiXapiAuthToken::getInstanceByToken((string) $request->resultRecord->sourcedGUID->sourcedId);
+            $logger->info("LTI Consumer Result Service: operation loaded ($this->operation), user " . $token->getUsrId() . " and objId " . $token->getObjId());
 
             $logger->info("LTI Consumer Result Service: token loaded");
             $this->result = ilLTIConsumerResult::getByKeys($token->getObjId(), $token->getUsrId(), false);
@@ -195,13 +194,13 @@ class ilLTIConsumerResultService
         global $DIC;
         $logger = $DIC->logger()->root();
 
-        $logger->info('LTI Consumer Result Service: Replace result');
         $result = (string) $request->resultRecord->result->resultScore->textString;
+        $logger->info('LTI Consumer Result Service: Replace result. Result: ' . $result);
         if (!is_numeric($result)) {
             $code = "failure";
             $severity = "status";
             $description = "The result is not a number.";
-        } elseif ($result < 0 or $result > 1) {
+        } elseif ($result > 1) {
             $code = "failure";
             $severity = "status";
             $description = "The result is out of range from 0 to 1.";

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
@@ -135,10 +135,10 @@ class ilLTIAppEventListener implements \ilAppEventListener
         global $DIC;
         $logger = $DIC->logger()->root();
         $logger->debug('definePercentageByObjectId');
-        $indentifier = ilObjectFactory::getInstanceByRefId((int)$obj_id)->getType();
+        $indentifier = ilObjectFactory::getInstanceByRefId((int) $obj_id)->getType();
         $logger->info('Object type: ' . $indentifier . " for object id: " . $obj_id);
         if (in_array($indentifier, ['crs', 'grp'])) {
-            if($status == ilLPStatus::LP_STATUS_COMPLETED_NUM || $status == ilLPStatus::LP_STATUS_FAILED_NUM) {
+            if ($status == ilLPStatus::LP_STATUS_COMPLETED_NUM || $status == ilLPStatus::LP_STATUS_FAILED_NUM) {
                 $percentage = 100;
             }
         }

--- a/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
+++ b/components/ILIAS/LTIProvider/classes/class.ilLTIAppEventListener.php
@@ -108,8 +108,8 @@ class ilLTIAppEventListener implements \ilAppEventListener
             }
             $usr_id = ilObjUser::_lookupId($login);
             foreach ($user_resources as $resource_info) {
-                $this->logger->info('Found resource: ' . $resource_info);
                 list($resource_id, $resource_ref_id) = explode('__', $resource_info);
+                $this->logger->info('Found resource: ' . $resource_info . " for user: " . $usr_id . " resource_id: " . $resource_id . " resource_ref_id: " . $resource_ref_id);
 
                 // lookup lp status
                 $status = ilLPStatus::_lookupStatus(
@@ -120,9 +120,29 @@ class ilLTIAppEventListener implements \ilAppEventListener
                     ilObject::_lookupObjId((int) $resource_ref_id),
                     $usr_id
                 );
+                $percentage = $this->definePercentageByObjectId($status, $resource_ref_id, $percentage);
                 $this->tryOutcomeService((int) $resource_id, $ext_account, $status, $percentage);
             }
         }
+    }
+
+    /**
+     * @throws ilObjectNotFoundException
+     * @throws ilDatabaseException
+     */
+    protected function definePercentageByObjectId(int|null $status, string $obj_id, int|null $percentage): int
+    {
+        global $DIC;
+        $logger = $DIC->logger()->root();
+        $logger->debug('definePercentageByObjectId');
+        $indentifier = ilObjectFactory::getInstanceByRefId((int)$obj_id)->getType();
+        $logger->info('Object type: ' . $indentifier . " for object id: " . $obj_id);
+        if (in_array($indentifier, ['crs', 'grp'])) {
+            if($status == ilLPStatus::LP_STATUS_COMPLETED_NUM || $status == ilLPStatus::LP_STATUS_FAILED_NUM) {
+                $percentage = 100;
+            }
+        }
+        return $percentage;
     }
 
     protected function isLTIAuthMode(string $auth_mode): bool


### PR DESCRIPTION
In order to comply with test case https://testrail.ilias.de//index.php?/tests/view/79627&group_by=tests:status_id&group_order=desc&group_id=5, we have changed how the learning progress status is assigned based on the score saved in the database.