### PR TITLE
[FIX] SOAP entry point

### DIFF
--- a/components/ILIAS/Init/classes/class.ilInitialisation.php
+++ b/components/ILIAS/Init/classes/class.ilInitialisation.php
@@ -34,6 +34,7 @@ use ILIAS\Refinery\Transformation;
 use ILIAS\FileDelivery\Init;
 use ILIAS\LegalDocuments\Conductor;
 use ILIAS\ILIASObject\Properties\AdditionalProperties\Icon\Factory as CustomIconFactory;
+use ILIAS\Init\AllModernComponents;
 
 // needed for slow queries, etc.
 if (!isset($GLOBALS['ilGlobalStartTime']) || !$GLOBALS['ilGlobalStartTime']) {
@@ -1140,7 +1141,10 @@ class ilInitialisation
     }
 
     /**
-     * ilias initialisation
+     * @deprecated please use the component bootstrap mechanism and the
+     *             legacy initialisation adapter instead:
+     *
+     * @see ILIAS\Init\AllModernComponents
      */
     public static function initILIAS(): void
     {

--- a/components/ILIAS/soap/resources/soap/server.php
+++ b/components/ILIAS/soap/resources/soap/server.php
@@ -61,6 +61,8 @@ if (strcasecmp($_SERVER['REQUEST_METHOD'], 'post') === 0) {
     $soapServer->handle();
 } else {
     // This is a request to display the available SOAP methods or WSDL...
-    ilInitialisation::initILIAS();
+    require_once './vendor/composer/vendor/autoload.php';
+    require_once './artifacts/bootstrap_default.php';
+    entry_point('ILIAS Legacy Initialisation Adapter');
     require './components/ILIAS/soap/nusoapserver.php';
 }


### PR DESCRIPTION
Hi @jeph864,

Not entirely sure if this should be assigned to you - feel free to reassign.

Nonetheless, I noticed the SOAP entry point wasn't using the new component bootstrap mechanism and the legacy initialisation adapter (`ILIAS\Init\AllModernComponents`), which populates components initialised with the bootstrap mechanism inside the legacy environment. This PR

* Fixes this issue by using the legacy initialisation adapter and bootstrap mechanism inside the `server.php` entry point, and
* Deprecates the `ilInitialisation::initILIAS()` method, so when debugging future entry points, this will become more obvious.

Kind regards,
@thibsy 