### PR TITLE
[LTI] Fix: user login fixed

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumer.php
@@ -668,6 +668,7 @@ class ilObjLTIConsumer extends ilObject2
     ): array {
         global $DIC;
         /* @var \ILIAS\DI\Container $DIC */
+        $DIC->user()->setExternalAccount($cmixUser->getUsrIdent());
 
         $roles = $DIC->access()->checkAccess('write', '', $this->getRefId()) ? "Instructor" : "Learner";
         //todo if object is in course or group, roles would have to be taken from there s. Mantis 35435 - if necessary Jour Fixe topic

--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -876,6 +876,9 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
                 if ($DIC->ctrl()->getCmd() === 'save') {
                     $this->checkContentSelection();
                 } else {
+                    if (isset($this->object) && !$this->isContentTabAvailable()) {
+                        $DIC->ctrl()->redirectToURL($this->ctrl->getLinkTargetByClass(ilInfoScreenGUI::class));
+                    }
                     $command = $DIC->ctrl()->getCmd(self::DEFAULT_CMD);
                     $this->{$command}();
                 }
@@ -905,6 +908,15 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         }
     }
 
+    public function isContentTabAvailable(): bool
+    {
+        if (!$this->object->getOfflineStatus() &&
+            $this->object->getProvider()->getAvailability() != ilLTIConsumeProvider::AVAILABILITY_NONE) {
+            return true;
+        }
+        return false;
+    }
+
     protected function setTabs(): void
     {
         global $DIC;
@@ -912,9 +924,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         /* @var \ILIAS\DI\Container $DIC */
         $DIC->language()->loadLanguageModule('lti');
 
-        if (!$this->object->getOfflineStatus() &&
-            $this->object->getProvider()->getAvailability() != ilLTIConsumeProvider::AVAILABILITY_NONE
-        ) {
+        if (isset($this->object) && $this->isContentTabAvailable()) {
             $DIC->tabs()->addTab(
                 self::TAB_ID_CONTENT,
                 $DIC->language()->txt(self::TAB_ID_CONTENT),


### PR DESCRIPTION
Related with the test: https://testrail.ilias.de//index.php?/tests/view/79639

When the user selects the privacy option "External User ID combined with a unique ILIAS platform ID formatted as an email address," no user ID was sent. This change allows that ID to be sent.

Additionally, a bug related to permissions while an LTI consumer object is offline was detected and fixed.