### PR TITLE
UI: fix #41308

### DIFF
--- a/components/ILIAS/LearningSequence/tests/LSLocatorBuilderTest.php
+++ b/components/ILIAS/LearningSequence/tests/LSLocatorBuilderTest.php
@@ -103,9 +103,9 @@ class LSLocatorBuilderTest extends ILIAS_UI_TestBase
         $this->assertInstanceOf(Breadcrumbs::class, $out);
 
         $expected = $this->stripHTML(
-            '<nav aria-label="breadcrumbs_aria_label" class="breadcrumb_wrapper"> ' .
-            '	<div class="breadcrumb"> ' .
-            '		<span class="crumb"> ' .
+            '<nav aria-label="breadcrumbs_aria_label" class="breadcrumb-wrapper"> ' .
+            '	<div class="breadcrumb" dir="rtl"> ' .
+            '		<span class="breadcrumb-crumb" dir="ltr"> ' .
             '			<a href="https://ilias.de/somepath?lsocmd=cmd&lsov=1">item 1</a>' .
             '		</span> ' .
             '	</div>' .

--- a/components/ILIAS/UI/src/Implementation/Component/Breadcrumbs/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Breadcrumbs/Renderer.php
@@ -38,15 +38,15 @@ class Renderer extends AbstractComponentRenderer
         $tpl = $this->getTemplate("tpl.breadcrumbs.html", true, true);
 
         $tpl->setVariable("ARIA_LABEL", $this->txt('breadcrumbs_aria_label'));
-        foreach ($component->getItems() as $key => $crumb) {
+        $add_separator = false;
+        foreach (array_reverse($component->getItems()) as $key => $crumb) {
+            if ($add_separator) {
+                $tpl->touchBlock("separator");
+            }
             $tpl->setCurrentBlock("crumbs");
             $tpl->setVariable("CRUMB", $default_renderer->render($crumb));
-            if (!preg_match('/[a-zA-Z0-9\ ]$/', $crumb->getLabel())
-                && ($key === array_key_last($component->getItems()))) {
-                $tpl->setCurrentBlock("lrmmark");
-                $tpl->setVariable("LRMMARK", htmlspecialchars_decode("&lrm;", ENT_HTML5));
-            }
             $tpl->parseCurrentBlock();
+            $add_separator = true;
         }
         return $tpl->get();
     }

--- a/components/ILIAS/UI/src/templates/default/Breadcrumbs/tpl.breadcrumbs.html
+++ b/components/ILIAS/UI/src/templates/default/Breadcrumbs/tpl.breadcrumbs.html
@@ -1,11 +1,9 @@
-<nav aria-label="{ARIA_LABEL}" class="breadcrumb_wrapper">
-	<div class="breadcrumb">
+<nav aria-label="{ARIA_LABEL}" class="breadcrumb-wrapper">
+	<div class="breadcrumb" dir="rtl">
 		<!-- BEGIN crumbs -->
-		<span class="crumb">
+        <!-- BEGIN separator --><span class="breadcrumb-separator" dir="rtl">&#9247;</span><!-- END separator -->
+		<span class="breadcrumb-crumb" dir="ltr">
 			{CRUMB}
-			<!-- BEGIN lrmmark -->
-			{LRMMARK}
-			<!-- END lrmmark -->
 		</span>
 		<!-- END crumbs -->
 	</div>

--- a/components/ILIAS/UI/tests/Component/Breadcrumbs/BreadcrumbsTest.php
+++ b/components/ILIAS/UI/tests/Component/Breadcrumbs/BreadcrumbsTest.php
@@ -84,13 +84,14 @@ class BreadcrumbsTest extends ILIAS_UI_TestBase
         $c = $f->Breadcrumbs($crumbs);
 
         $html = $this->normalizeHTML($r->render($c));
-        $expected = '<nav aria-label="breadcrumbs_aria_label" class="breadcrumb_wrapper">'
-            . '	<div class="breadcrumb">'
-            . '		<span class="crumb">'
-            . '			<a href="#">label</a>'
-            . '		</span>'
-            . '		<span class="crumb">'
+        $expected = '<nav aria-label="breadcrumbs_aria_label" class="breadcrumb-wrapper">'
+            . '	<div class="breadcrumb" dir="rtl">'
+            . '		<span class="breadcrumb-crumb" dir="ltr">'
             . '			<a href="#">label2</a>'
+            . '		</span>'
+            . '     <span class="breadcrumb-separator" dir="rtl">&#9247;</span>'
+            . '		<span class="breadcrumb-crumb" dir="ltr">'
+            . '			<a href="#">label</a>'
             . '		</span>'
             . '	</div>'
             . '</nav>';
@@ -113,14 +114,14 @@ class BreadcrumbsTest extends ILIAS_UI_TestBase
         $c = $f->Breadcrumbs($crumbs);
 
         $html = $this->brutallyTrimHTML($r->render($c));
-        $expected = '<nav aria-label="breadcrumbs_aria_label" class="breadcrumb_wrapper">'
-            . '	<div class="breadcrumb">'
-            . '		    <span class="crumb">'
-            . '			    <a href="#">label without special characters</a>'
-            . '		    </span>'
-            . '		    <span class="crumb">'
+        $expected = '<nav aria-label="breadcrumbs_aria_label" class="breadcrumb-wrapper">'
+            . '	<div class="breadcrumb" dir="rtl">'
+            . '		    <span class="breadcrumb-crumb" dir="ltr">'
             . '			    <a href="#">label with special characters + –...+}*@ç%#&/($</a>'
-            . '&lrm;'
+            . '		    </span>'
+            . '         <span class="breadcrumb-separator" dir="rtl">&#9247;</span>'
+            . '		    <span class="breadcrumb-crumb" dir="ltr">'
+            . '			    <a href="#">label without special characters</a>'
             . '		    </span>'
             . '	</div>'
             . '</nav>';

--- a/components/ILIAS/UI/tests/Component/Layout/Page/StandardPageTest.php
+++ b/components/ILIAS/UI/tests/Component/Layout/Page/StandardPageTest.php
@@ -469,8 +469,8 @@ class StandardPageTest extends ILIAS_UI_TestBase
         <div class="nav il-maincontrols">MainBar Stub</div>
         <main class="il-layout-page-content">
                 <div class="breadcrumbs">
-                    <nav aria-label="breadcrumbs_aria_label" class="breadcrumb_wrapper">
-                        <div class="breadcrumb"><span class="crumb"><a href="#">label1</a></span><span class="crumb"><a href="#">label2</a></span><span class="crumb"><a href="#">label3</a></span></div>
+                    <nav aria-label="breadcrumbs_aria_label" class="breadcrumb-wrapper">
+                        <div class="breadcrumb" dir="rtl"><span class="breadcrumb-crumb" dir="ltr"><a href="#">label3</a></span><span class="breadcrumb-separator" dir="rtl">&#9247;</span><span class="breadcrumb-crumb" dir="ltr"><a href="#">label2</a></span><span class="breadcrumb-separator" dir="rtl">&#9247;</span><span class="breadcrumb-crumb" dir="ltr"><a href="#">label1</a></span></div>
                     </nav>
                 </div>some content
         </main>

--- a/templates/default/070-components/UI-framework/Breadcrumbs/_ui-component_breadcrumbs.scss
+++ b/templates/default/070-components/UI-framework/Breadcrumbs/_ui-component_breadcrumbs.scss
@@ -3,7 +3,7 @@
 @use "../../../050-layout/standardpage/"as *;
 @use "../../../030-tools/tool_focus-outline" as *;
 
-.breadcrumb_wrapper {
+.breadcrumb-wrapper {
 	width: 100%;
 	display: inline-grid;
 	background: $il-standard-page-breadcrumbs-bg-color;
@@ -12,7 +12,6 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		direction: rtl;
 		text-align: left;
 		margin: 0;
 		font-weight: $il-standard-page-breadcrumbs-font-weight;
@@ -20,7 +19,7 @@
 		padding: ($il-padding-small-vertical * 2);
 		padding-left: $il-standard-page-content-padding;
 
-		span.crumb a {
+		div.breadcrumb-crumb a {
 			color: $il-standard-page-breadcrumbs-color;
 			&:hover {
 				color: $il-standard-page-breadcrumbs-active-color;
@@ -29,10 +28,15 @@
 			@include il-focus-outline-only();
 		}
 
-		&>span+span:before {
+		.breadcrumb-separator {
+            visibility: hidden;
+        }
+
+		.breadcrumb-separator:after {
+            visibility: visible;
 			content: $il-standard-page-breadcrumbs-seperator;
 			color: $il-standard-page-breadcrumbs-divider-color;
-			padding: 8px 10px;
+			padding: 2px 8px;
 			font-weight: $il-font-weight-base;
 			font-family: "il-icons";
 		}

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2568,16 +2568,15 @@ code {
   display: inline-block;
 }
 
-.breadcrumb_wrapper {
+.breadcrumb-wrapper {
   width: 100%;
   display: inline-grid;
   background: white;
 }
-.breadcrumb_wrapper .breadcrumb {
+.breadcrumb-wrapper .breadcrumb {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  direction: rtl;
   text-align: left;
   margin: 0;
   font-weight: 600;
@@ -2585,38 +2584,42 @@ code {
   padding: 6px;
   padding-left: 20px;
 }
-.breadcrumb_wrapper .breadcrumb span.crumb a {
+.breadcrumb-wrapper .breadcrumb div.breadcrumb-crumb a {
   color: #4c6586;
 }
-.breadcrumb_wrapper .breadcrumb span.crumb a:hover {
+.breadcrumb-wrapper .breadcrumb div.breadcrumb-crumb a:hover {
   color: #3a4c65;
 }
-.breadcrumb_wrapper .breadcrumb span.crumb a:focus {
+.breadcrumb-wrapper .breadcrumb div.breadcrumb-crumb a:focus {
   border: inherit;
   box-shadow: inherit;
   outline: none;
   outline-offset: 0px;
 }
-.breadcrumb_wrapper .breadcrumb span.crumb a:focus::after {
+.breadcrumb-wrapper .breadcrumb div.breadcrumb-crumb a:focus::after {
   content: none;
 }
-.breadcrumb_wrapper .breadcrumb span.crumb a:focus-visible {
+.breadcrumb-wrapper .breadcrumb div.breadcrumb-crumb a:focus-visible {
   border: inherit;
   box-shadow: inherit;
   outline: none;
   outline-offset: 0px;
 }
-.breadcrumb_wrapper .breadcrumb span.crumb a:focus-visible::after {
+.breadcrumb-wrapper .breadcrumb div.breadcrumb-crumb a:focus-visible::after {
   content: none;
 }
-.breadcrumb_wrapper .breadcrumb span.crumb a:focus-visible {
+.breadcrumb-wrapper .breadcrumb div.breadcrumb-crumb a:focus-visible {
   outline: 3px solid #0078D7;
   box-shadow: inset 0px 0px 0px 2px #FFFFFF, 0px 0px 0px 5px #FFFFFF;
 }
-.breadcrumb_wrapper .breadcrumb > span + span:before {
+.breadcrumb-wrapper .breadcrumb .breadcrumb-separator {
+  visibility: hidden;
+}
+.breadcrumb-wrapper .breadcrumb .breadcrumb-separator:after {
+  visibility: visible;
   content: " \e606";
   color: #737373;
-  padding: 8px 10px;
+  padding: 2px 8px;
   font-weight: 400;
   font-family: "il-icons";
 }


### PR DESCRIPTION
Dear colleagues,

this fixes [#41308](https://mantis.ilias.de/view.php?id=41308) (I hope...).

The goal is to have a breadcrumb where an ellipsis (that three dots...) is shown on the left side once space for the complete path is too long. General idea is to use RTL text direction with according CSS to achieve that goal. This mostly works fine, but sometimes it breaks when certain symbols are involved.

This shall improve the situation by changing the implemenation a bit:

* The complete breadcrumb is marked as RTL _in the DOM_ to create that "ellipsis on the left" effect.
* The individual parts of the breadcrumb are marked LTR _in the DOM_ to make the browser understand that it shall not do funny stuff with these parts.
* The parts are separated via the rather ancient but somehow obscure "unit separator" symbol: https://www.compart.com/en/unicode/U+241F. For one, this symbol makes the browser render the parts of the breadcrumb in the expected direction. This would have been achieved by many other chars, e.g. a simple "f", but not by whitespace chars. On the other hand, given the meaning of the symbol, its seems to be semantically sound to use it. There are in fact units that are separated by this symbol...
* The symbol then is hidden via CSS (it looks funny and wrong...) and the previous mechanism to use `:after` and `content` in the CSS is used to reinsert the > as a separator.

As a side effect, the DOM now contains the breadcrumbs from more specific to less specific (giving e.g. the "Repository" last), which from my POV is good for e.g. screen readers as the most relevant information ("Where am I exactly?") comes before the information that is not very informativ ("I'm in the Repository indeed...").

Intersting stuff, hope you enjoy this just like I did.

Kind regards!