### PR TITLE
IRSS/Flavour/Engine: Don't use `Imagick` method if not "running"

### DIFF
--- a/src/ResourceStorage/Flavour/Engine/ImagickEngine.php
+++ b/src/ResourceStorage/Flavour/Engine/ImagickEngine.php
@@ -26,6 +26,8 @@ namespace ILIAS\ResourceStorage\Flavour\Engine;
 class ImagickEngine implements Engine
 {
     use PHPMemoryLimit;
+
+    /** @var list<string> */
     protected array $whitelist = [
         'jpg',
         'jpeg',
@@ -40,27 +42,28 @@ class ImagickEngine implements Engine
         'pdf',
         'svg',
     ];
+    /** @var list<string> */
     protected array $supported;
 
     public function __construct()
     {
         $this->supported = array_intersect(
             array_map(
-                fn($item): string => strtolower($item),
-                \Imagick::queryFormats()
+                static fn(string $item): string => strtolower($item),
+                $this->isRunning() ? \Imagick::queryFormats() : []
             ),
             $this->whitelist
-        ) ?? [];
+        );
     }
 
     public function supports(string $suffix): bool
     {
-        return in_array(strtolower($suffix), $this->supported, true);
+        return \in_array(strtolower($suffix), $this->supported, true);
     }
 
     public function isRunning(): bool
     {
-        return extension_loaded('imagick') && class_exists(\Imagick::class);
+        return \extension_loaded('imagick') && class_exists(\Imagick::class);
     }
 
 }


### PR DESCRIPTION
If approved, this must be picked to all maintained branches.

Mantis Issue: https://mantis.ilias.de/view.php?id=45360