### PR TITLE
IRSS: Add micro optimizations for resource database repository

### DIFF
--- a/components/ILIAS/ResourceStorage/classes/ResourceDBRepository.php
+++ b/components/ILIAS/ResourceStorage/classes/ResourceDBRepository.php
@@ -71,18 +71,20 @@ class ResourceDBRepository implements ResourceRepository
      */
     public function get(ResourceIdentification $identification): StorableResource
     {
-        if (isset($this->cache[$identification->serialize()])) {
-            return $this->cache[$identification->serialize()];
+        $rid = $identification->serialize();
+
+        if (isset($this->cache[$rid])) {
+            return $this->cache[$rid];
         }
 
-        $q = "SELECT " . self::IDENTIFICATION . ", storage_id, rtype FROM " . self::TABLE_NAME . " WHERE " . self::IDENTIFICATION . " = %s";
-        $r = $this->db->queryF($q, ['text'], [$identification->serialize()]);
+        $q = "SELECT storage_id, rtype FROM " . self::TABLE_NAME . " WHERE " . self::IDENTIFICATION . " = %s";
+        $r = $this->db->queryF($q, ['text'], [$rid]);
         $d = $this->db->fetchObject($r);
 
         $resource = $this->blank($identification, ResourceType::from($d->rtype));
         $resource->setStorageID($d->storage_id);
 
-        $this->cache[$identification->serialize()] = $resource;
+        $this->cache[$rid] = $resource;
 
         return $resource;
     }
@@ -92,13 +94,17 @@ class ResourceDBRepository implements ResourceRepository
      */
     public function has(ResourceIdentification $identification): bool
     {
-        if (isset($this->cache[$identification->serialize()])) {
+        $rid = $identification->serialize();
+
+        if (isset($this->cache[$rid])) {
             return true;
         }
-        $q = "SELECT " . self::IDENTIFICATION . " FROM " . self::TABLE_NAME . " WHERE " . self::IDENTIFICATION . " = %s";
-        $r = $this->db->queryF($q, ['text'], [$identification->serialize()]);
 
-        return (bool)$r->numRows() > 0;
+        $q = "SELECT EXISTS(SELECT 1 FROM " . self::TABLE_NAME . " WHERE " . self::IDENTIFICATION . " = %s) AS found";
+        $r = $this->db->queryF($q, ['text'], [$rid]);
+        $d = $this->db->fetchAssoc($r);
+
+        return (bool) $d['found'];
     }
 
     /**
@@ -107,30 +113,18 @@ class ResourceDBRepository implements ResourceRepository
     public function store(StorableResource $resource): void
     {
         $rid = $resource->getIdentification()->serialize();
-        if ($this->has($resource->getIdentification())) {
-            // UPDATE
-            $this->db->update(
-                self::TABLE_NAME,
-                [
-                    self::IDENTIFICATION => ['text', $rid],
-                    'storage_id' => ['text', $resource->getStorageID()],
-                    'rtype' => ['text', $resource->getType()->value],
-                ],
-                [
-                    self::IDENTIFICATION => ['text', $rid],
-                ]
-            );
-        } else {
-            // CREATE
-            $this->db->insert(
-                self::TABLE_NAME,
-                [
-                    self::IDENTIFICATION => ['text', $rid],
-                    'storage_id' => ['text', $resource->getStorageID()],
-                    'rtype' => ['text', $resource->getType()->value],
-                ]
-            );
-        }
+
+        $this->db->replace(
+            self::TABLE_NAME,
+            [
+                self::IDENTIFICATION => ['text', $rid]
+            ],
+            [
+                'storage_id' => ['text', $resource->getStorageID()],
+                'rtype' => ['text', $resource->getType()->value],
+            ]
+        );
+
         $this->cache[$rid] = $resource;
     }
 


### PR DESCRIPTION
If approved, this should (at least) be picked to all "upper" ILIAS versions/branches.

What this PR suggests:

- Use `EXISTS` in the SQL query when we only want to check if a resource identification already exists, and we are not interested in the actual number of found rows
- Don't select columns which are already part of the `WHERE` condtions in the SQL string
- Don't serialize multiple times in the same scope, only call `seralize` once and store the result in a local variable `$rid`

---

And, this PR suggests changing the approach used to persist the resource in `\ILIAS\ResourceStorage\Resource\Repository\ResourceDBRepository::store`.

Issues:

1. Round-trips: 1 × `SELECT` + (1 × `UPDATE` or 1 × `INSERT`)
2. Potential race condition (unlikely in the IRSS context): Time goes by between the `SELECT` and (`UPDATE` or `INSERT`)
    - And specifically: Handling this in the application would have a lot of drawbacks (restriction of concurrency, slow, complexity depending on the approach) / Update: It seems to be already handled by the table names provided via `\ILIAS\ResourceStorage\Lock\LockingRepository::getNamesForLocking`

In both cases, for `INSERT` and `UPDATE`, we currently persist values for **all** database fields in `il_resource`.

So to address the problems I mentioned above, I hereby suggest using `\ilDBInterface::replace` (I know, if a row does exist, `REPLACE` deletes it and inserts the new data, in one atomic step, which should not be a problem IMO) instead, which is (IMO) also more readable.

To debate on: Alternatively, we could use an `INSERT INTO ... ON DUPLICATE KEY UPDATE ...`.
