### PR TITLE
Improve description of getXMLTree

### DIFF
--- a/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
+++ b/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
@@ -438,7 +438,8 @@ class ilNusoapUserAdministrationAdapter
             SERVICE_NAMESPACE . '#getXMLTree',
             SERVICE_STYLE,
             SERVICE_USE,
-            'ILIAS getXMLTree(): Returns a xml stream with the subtree objects.'
+            'ILIAS getXMLTree(): Returns a XML stream with the subtree objects. The "types" array acts as an exclusion filter (i.e., listed types will be excluded).' .
+            'This is the opposite of getTreeChilds(), where "types" acts as an inclusion filter.'
         );
 
         $this->server->register(


### PR DESCRIPTION
0031236: Improve description of getXMLTree
https://mantis.ilias.de/view.php?id=31236

The existing SOAP documentation for getXMLTree() doesn't explain how its parameters work, especially the types array. This update clarifies that types is used to exclude certain object types from the result, which is the opposite of how it's used in getTreeChilds(). The improved description should make the method easier to understand and use correctly in integrations.