### PR TITLE
Glossary/Table: fix rendering of legacy table (41853)

### DIFF
--- a/Modules/Glossary/Presentation/class.ilGlossaryPresentationGUI.php
+++ b/Modules/Glossary/Presentation/class.ilGlossaryPresentationGUI.php
@@ -809,7 +809,7 @@ class ilGlossaryPresentationGUI implements ilCtrlBaseClassInterface
                     $this->ctrl->getLinkTarget($this, "downloadExportFile")
                 );
 
-                $this->tpl->parseCurrentBlock();
+                $this->tpl->parseCurrentBlock("tbl_content");
             }
         } else {
             $this->tpl->setVariable("TXT_OBJECT_NOT_FOUND", $this->lng->txt("obj_not_found"));

--- a/Services/Table/classes/class.ilTableGUI.php
+++ b/Services/Table/classes/class.ilTableGUI.php
@@ -638,13 +638,13 @@ class ilTableGUI
                     $this->tpl->setVariable("TBL_COLUMN_WIDTH_NO_LINK", " width=\"" . $this->column_width[$key] . "\"");
                 }
                 $this->tpl->setVariable("TBL_HEADER_CELL_NO_LINK", $tbl_header_cell);
-                $this->tpl->parseCurrentBlock();
+                $this->tpl->parseCurrentBlock("tbl_header_no_link");
                 continue;
             }
             if (($key == $this->order_column) && ($this->order_direction != "")) {
                 if (strcmp($this->header_vars[$key], "") != 0) {
                     $this->tpl->setCurrentBlock("tbl_order_image");
-                    $this->tpl->parseCurrentBlock();
+                    $this->tpl->parseCurrentBlock("tbl_order_image");
                 }
             }
 
@@ -669,11 +669,11 @@ class ilTableGUI
             }
 
             $this->setOrderLink($key, $order_dir);
-            $this->tpl->parseCurrentBlock();
+            $this->tpl->parseCurrentBlock("tbl_header_cell");
         }
 
         $this->tpl->setCurrentBlock("tbl_header");
-        $this->tpl->parseCurrentBlock();
+        $this->tpl->parseCurrentBlock("tbl_header");
     }
 
     public function setOrderLink(string $key, string $order_dir): void


### PR DESCRIPTION
This PR fixes [41853](https://mantis.ilias.de/view.php?id=41853), along with a few more rendering issues in the Download table in Glossaries. Rendering of `ilTableGUI` (note the missing `2`), specifically when using the global `tpl.table.html`, got broken at some point by changes to templating. This usage in glossaries is the last such table.

 [This commit](https://github.com/ILIAS-eLearning/ILIAS/commit/3e4535e8656aa10b9c100010499708aefe5f73d9) introduced the issue: the default block was added to the list of ignored blocks in `ilGlobalPageTemplate`, so calling `parseCurrentBlock` without an argument doesn't work anymore.

Note that a few changes were necessary to `ilTableGUI`, to also properly render the table header. If that is a problem, the immediate issue would also be fixed with just the small change in Glossary.

There is no need to pick these changes to 10 or higher. The afflicted table has been removed there.