### PR TITLE
IRSS: Add micro optimizations for information database repository

### DIFF
--- a/components/ILIAS/ResourceStorage/classes/InformationDBRepository.php
+++ b/components/ILIAS/ResourceStorage/classes/InformationDBRepository.php
@@ -67,50 +67,24 @@ class InformationDBRepository implements InformationRepository
     public function store(Information $information, Revision $revision): void
     {
         $rid = $revision->getIdentification()->serialize();
-        $r = $this->db->queryF(
-            "SELECT " . self::IDENTIFICATION . " FROM " . self::TABLE_NAME . " WHERE " . self::IDENTIFICATION . " = %s AND version_number = %s",
+        $version = $revision->getVersionNumber();
+
+        $this->db->replace(
+            self::TABLE_NAME,
             [
-                'text',
-                'integer'
+                self::IDENTIFICATION => ['text', $rid],
+                'version_number' => ['integer', $version]
             ],
             [
-                $rid,
-                $revision->getVersionNumber()
+                'title' => ['text', $information->getTitle()],
+                'mime_type' => ['text', $information->getMimeType()],
+                'suffix' => ['text', $information->getSuffix()],
+                'size' => ['integer', $information->getSize()],
+                'creation_date' => ['integer', $information->getCreationDate()->getTimestamp()]
             ]
         );
 
-        if ($r->numRows() > 0) {
-            // UPDATE
-            $this->db->update(
-                self::TABLE_NAME,
-                [
-                    'title' => ['text', $information->getTitle()],
-                    'mime_type' => ['text', $information->getMimeType()],
-                    'suffix' => ['text', $information->getSuffix()],
-                    'size' => ['integer', $information->getSize()],
-                    'creation_date' => ['integer', $information->getCreationDate()->getTimestamp()],
-                ],
-                [
-                    self::IDENTIFICATION => ['text', $rid],
-                    'version_number' => ['integer', $revision->getVersionNumber()]
-                ]
-            );
-        } else {
-            // CREATE
-            $this->db->insert(
-                self::TABLE_NAME,
-                [
-                    self::IDENTIFICATION => ['text', $rid],
-                    'version_number' => ['integer', $revision->getVersionNumber()],
-                    'title' => ['text', $information->getTitle()],
-                    'mime_type' => ['text', $information->getMimeType()],
-                    'suffix' => ['text', $information->getSuffix()],
-                    'size' => ['integer', $information->getSize()],
-                    'creation_date' => ['integer', $information->getCreationDate()->getTimestamp()],
-                ]
-            );
-        }
-        $this->cache[$rid][$revision->getVersionNumber()] = $information;
+        $this->cache[$rid][$version] = $information;
     }
 
     /**
@@ -183,11 +157,11 @@ class InformationDBRepository implements InformationRepository
     private function getFileInfoFromArrayData(array $data): FileInformation
     {
         $i = new FileInformation();
-        $i->setTitle((string)$data['title']);
-        $i->setSize((int)$data['size']);
-        $i->setMimeType((string)$data['mime_type']);
-        $i->setSuffix((string)$data['suffix']);
-        $i->setCreationDate((new \DateTimeImmutable())->setTimestamp((int)$data['creation_date'] ?? 0));
+        $i->setTitle((string) $data['title']);
+        $i->setSize((int) $data['size']);
+        $i->setMimeType((string) $data['mime_type']);
+        $i->setSuffix((string) $data['suffix']);
+        $i->setCreationDate((new \DateTimeImmutable())->setTimestamp((int) ($data['creation_date'] ?? 0)));
 
         return $i;
     }


### PR DESCRIPTION
If approved, this should (at least) be picked to all "upper" ILIAS versions/branches.

This PR suggests changing the approach used to persist resource information in `\ILIAS\ResourceStorage\Information\Repository\InformationDBRepository::store`.

Issues:

1. Round-trips: 1 × `SELECT` + (1 × `UPDATE` or 1 × `INSERT`)
2. Potential race condition (unlikely in the IRSS context): Time goes by between the `SELECT` and (`UPDATE` or `INSERT`)
    - And specifically: Handling this in the application would have a lot of drawbacks (restriction of concurrency, slow, complexity depending on the approach) / Update: It seems to be already handled by the table names provided via `\ILIAS\ResourceStorage\Lock\LockingRepository::getNamesForLocking`

In both cases, for `INSERT` and `UPDATE`, we currently persist values for **all** database fields in `il_resource_info`. Furthermore, the primary of table `il_resource_info` is a combined key: `rid` and `version_number`

So to address the problems I mentioned above, I hereby suggest using `\ilDBInterface::replace` (I know, if a row does exist, `REPLACE` deletes it and inserts the new data, in one atomic step, which should not be a problem IMO) instead, which is (IMO) also more readable.

To debate on: Alternatively, we could use an `INSERT INTO ... ON DUPLICATE KEY UPDATE ...`.
