### PR TITLE
T&A 45270: Fixes syncing a matching question back to the original question pool question which removes the associated images of both questions

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
@@ -1595,6 +1595,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
             ilFileUtils::makeDirParents($origImagePath);
             ilFileUtils::rCopy($dupImagePath, $origImagePath);
         }
+        assQuestion::instantiateQuestion($origQuestionId)->copyImages($dupQuestionId, origParentObjId);
     }
 
     protected function createMatchingTerm(string $term = '', string $picture = '', int $identifier = 0): assAnswerMatchingTerm

--- a/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
@@ -1595,7 +1595,6 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
             ilFileUtils::makeDirParents($origImagePath);
             ilFileUtils::rCopy($dupImagePath, $origImagePath);
         }
-        assQuestion::instantiateQuestion($origQuestionId)->copyImages($dupQuestionId, $origParentObjId);
     }
 
     protected function createMatchingTerm(string $term = '', string $picture = '', int $identifier = 0): assAnswerMatchingTerm

--- a/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
@@ -1595,7 +1595,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
             ilFileUtils::makeDirParents($origImagePath);
             ilFileUtils::rCopy($dupImagePath, $origImagePath);
         }
-        assQuestion::instantiateQuestion($origQuestionId)->copyImages($dupQuestionId, origParentObjId);
+        assQuestion::instantiateQuestion($origQuestionId)->copyImages($dupQuestionId, $origParentObjId);
     }
 
     protected function createMatchingTerm(string $term = '', string $picture = '', int $identifier = 0): assAnswerMatchingTerm

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -1741,7 +1741,7 @@ abstract class assQuestion
 
         $this->syncSuggestedSolutions($this->getOriginalId(), $original_obj_id);
         $this->syncXHTMLMediaObjectsOfQuestion();
-        $this->afterSyncWithOriginal($this->getId(), $this->getOriginalId(), $this->getObjId(), $original_obj_id);
+        $this->afterSyncWithOriginal($this->getOriginalId(), $this->getId(), $this->getObjId(), $original_obj_id);
         $this->syncHints();
     }
 

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -1741,7 +1741,7 @@ abstract class assQuestion
 
         $this->syncSuggestedSolutions($this->getOriginalId(), $original_obj_id);
         $this->syncXHTMLMediaObjectsOfQuestion();
-        $this->afterSyncWithOriginal($this->getOriginalId(), $this->getId(), $this->getObjId(), $original_obj_id);
+        $this->afterSyncWithOriginal($this->getOriginalId(), $this->getId(), $original_obj_id, $this->getObjId());
         $this->syncHints();
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45270

These changes aim to fix the issue mentioned in the Mantis ticket.