### PR TITLE
T&A 45212: Fixes missing question type lable in question creation view and incoorrect breadcrumb when saving question

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -1234,7 +1234,7 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                     ilAssQuestionPreviewGUI::CMD_SHOW
                 )
             );
-            $question_gui->editQuestion(false, false);
+            $this->ctrl->redirect($question_gui, 'editQuestion');
         }
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -1062,7 +1062,7 @@ abstract class assQuestionGUI
             }
         }
 
-        return $this->questionrepository->getForQuestionId($this->object->getId())->getTypeName($this->lng);
+        return $this->lng->txt($this->object->getQuestionType());
     }
 
     protected function getTypeOptions(): array


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45212

These changes aim to fix the issue mentioned in the Mantis ticket.