### PR TITLE
T&A 45301: Fixes rounding of points to the nearest integer value in manual question scoring table

### DIFF
--- a/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTable.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTable.php
@@ -68,8 +68,16 @@ class ScoringByQuestionTable
             [
                 self::COLUMN_NAME => $f->column()->text($this->lng->txt('name'))->withIsSortable(true),
                 self::COLUMN_ATTEMPT => $f->column()->number($this->lng->txt('tst_attempt')),
-                self::COLUMN_POINTS_REACHED => $f->column()->number($this->lng->txt('tst_reached_points'))->withIsSortable(true),
-                self::COLUMN_POINTS_AVAILABLE => $f->column()->number($this->lng->txt('tst_maximum_points'))->withIsSortable(true),
+                self::COLUMN_POINTS_REACHED => $f
+                    ->column()
+                    ->number($this->lng->txt('tst_reached_points'))
+                    ->withDecimals(2)
+                    ->withIsSortable(true),
+                self::COLUMN_POINTS_AVAILABLE => $f
+                    ->column()
+                    ->number($this->lng->txt('tst_maximum_points'))
+                    ->withDecimals(2)
+                    ->withIsSortable(true),
                 self::COLUMN_FEEDBACK => $f->column()->text($this->lng->txt('tst_feedback')),
                 self::COLUMN_FINALIZED => $f->column()->boolean(
                     $this->lng->txt('finalized_evaluation'),

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
@@ -294,9 +294,7 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
     ): RoundTripModal {
         $question_gui = $this->object->createQuestionGUI('', $question_id);
 
-        $content = [
-            $this->buildSolutionPanel($question_gui, $question_id, $attempt)
-        ];
+        $content = [$this->buildSolutionPanel($question_gui, $active_id, $attempt)];
 
         if ($this->object->getAutosave()
             && $autosave_content = $this->buildAutosavedSolutionPanel($question_gui, $active_id, $attempt)


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45301

These changes aim to fix the issue mentioned in the Mantis ticket.