### PR TITLE
T&A10 45332: Adds missing column label in test attempts for participant table

### DIFF
--- a/components/ILIAS/Test/src/Scoring/Manual/TestScoringByParticipantPassesOverviewTableGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/TestScoringByParticipantPassesOverviewTableGUI.php
@@ -56,7 +56,7 @@ class TestScoringByParticipantPassesOverviewTableGUI extends \ilTable2GUI
         $this->addColumn($this->lng->txt("tst_answered_questions"), 'answered_questions', '');
         $this->addColumn($this->lng->txt("tst_reached_points"), 'reached_points', '');
         $this->addColumn($this->lng->txt("tst_percent_solved"), 'percentage', '');
-        $this->addColumn('', '', '1%');
+        $this->addColumn($this->lng->txt("actions"), '', '1%');
     }
 
     private function initOrdering(): void


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45332

These changes aim to fix the issue mentioned in the Mantis ticket.