### PR TITLE
T&A 45311: Fixes issue with malformed points in manual participant scoring

### DIFF
--- a/Modules/Test/classes/class.ilTestScoringGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringGUI.php
@@ -418,14 +418,15 @@ class ilTestScoringGUI extends ilTestServiceGUI
 
 
 
-            $text = new ilTextInputGUI($this->lng->txt('tst_change_points_for_question'), "question__{$questionId}__points");
+            $number_input_gui = new ilNumberInputGUI($this->lng->txt('tst_change_points_for_question'), "question__{$questionId}__points");
+            $number_input_gui->allowDecimals(true);
             if ($initValues) {
-                $text->setValue((string) assQuestion::_getReachedPoints($active_id, $questionId, $pass));
+                $number_input_gui->setValue((string) assQuestion::_getReachedPoints($active_id, $questionId, $pass));
             }
             if ($disabled) {
-                $text->setDisabled($disabled);
+                $number_input_gui->setDisabled($disabled);
             }
-            $form->addItem($text);
+            $form->addItem($number_input_gui);
 
             $nonedit = new ilNonEditableValueGUI($this->lng->txt('tst_manscoring_input_max_points_for_question'), "question__{$questionId}__maxpoints");
             if ($initValues) {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45311

These changes aim to fix the issue mentioned in the Mantis ticket.