### PR TITLE
T&A: fixes 45210: remove &nbsp as description

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -600,7 +600,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
             }
 
             $row['title'] = $tags_trafo->transform($row['title'] ?? '&nbsp;');
-            $row['description'] = $tags_trafo->transform($row['description'] !== '' && $row['description'] !== null ? $row['description'] : '&nbsp;');
+            $row['description'] = $tags_trafo->transform($row['description'] ?? '');
             $row['author'] = $tags_trafo->transform($row['author']);
             $row['taxonomies'] = $this->loadTaxonomyAssignmentData($row['obj_fi'], $row['question_id']);
             $row['ttype'] = $this->lng->txt($row['type_tag']);


### PR DESCRIPTION
This will fix https://mantis.ilias.de/view.php?id=45210

Here is the commit where this line was previously added:
https://github.com/ILIAS-eLearning/ILIAS/commit/11d150938166c3b4aac6f2a567a3401263ddc8cb#diff-8348fef9ba500f473b75a6576bf8310d71df03acedaa247cc62441843c8e4b66