### PR TITLE
T&A 45031: Fixes error when trying to apply old personal default setting that does not have questionSetType

### DIFF
--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -6277,7 +6277,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
         $main_settings = $main_settings
             ->withGeneralSettings(
                 $main_settings->getGeneralSettings()
-                ->withQuestionSetType($testsettings['questionSetType'])
+                ->withQuestionSetType($testsettings['questionSetType'] ?? self::QUESTION_SET_TYPE_FIXED)
                 ->withAnonymity((bool) $testsettings['Anonymity'])
             )
             ->withIntroductionSettings(

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -6274,12 +6274,15 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
         );
 
         $main_settings = $this->getMainSettings();
+
+        $general_settings = $main_settings->getGeneralSettings();
+        if (isset($testsettings['questionSetType'])) {
+            $general_settings = $general_settings->withQuestionSetType($testsettings['questionSetType']);
+        }
+        $general_settings = $general_settings->withAnonymity((bool) $testsettings['Anonymity']);
+
         $main_settings = $main_settings
-            ->withGeneralSettings(
-                $main_settings->getGeneralSettings()
-                ->withQuestionSetType($testsettings['questionSetType'] ?? self::QUESTION_SET_TYPE_FIXED)
-                ->withAnonymity((bool) $testsettings['Anonymity'])
-            )
+            ->withGeneralSettings($general_settings)
             ->withIntroductionSettings(
                 $main_settings->getIntroductionSettings()
                 ->withIntroductionEnabled((bool) $testsettings['IntroEnabled'])


### PR DESCRIPTION
This PR attempts to solve the issue described in https://mantis.ilias.de/view.php?id=45031.

Previously, applying old personal default settings that did not have "questionSetType" would result in an error.
I have now added the default value for questionSetType as a fallback.

Kind regards,
@bidzanaaron 