### PR TITLE
T&A 44826: In einer Frage im Test/Pool wird Latex nicht markiert angezeigt

### DIFF
--- a/templates/default/080-hacks/_index.scss
+++ b/templates/default/080-hacks/_index.scss
@@ -216,11 +216,6 @@ img {
 	border: 0 none;
 }
 
-span.latex {
-	color: green;
-	font-weight: bold;
-}
-
 div.framed {
 	border: 1px solid #9eadba;
 	padding: 0 10px;
@@ -229,6 +224,12 @@ div.framed {
 	background-repeat: repeat-x;
 }
 */
+
+span.latex {
+	color: green;
+	font-weight: bold;
+}
+
 
 // no longer in use?
 div.ilFrame {
@@ -246,7 +247,7 @@ div.ilFrame {
 	}
 }
 
-// used to be in Services/certificates 
+// used to be in Services/certificates
 
 .il-deck {
 	.il-card {

--- a/templates/default/080-hacks/_index.scss
+++ b/templates/default/080-hacks/_index.scss
@@ -230,7 +230,6 @@ span.latex {
 	font-weight: bold;
 }
 
-
 // no longer in use?
 div.ilFrame {
 	margin-top: -40px;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -18413,11 +18413,6 @@ img {
 	border: 0 none;
 }
 
-span.latex {
-	color: green;
-	font-weight: bold;
-}
-
 div.framed {
 	border: 1px solid #9eadba;
 	padding: 0 10px;
@@ -18426,6 +18421,12 @@ div.framed {
 	background-repeat: repeat-x;
 }
 */
+
+span.latex {
+  color: green;
+  font-weight: bold;
+}
+
 div.ilFrame {
   margin-top: -40px;
   margin-left: auto;


### PR DESCRIPTION
Hi everyone,

this PR refers to ticket [44826](https://mantis.ilias.de/view.php?id=44826) and attempts to fix the issue that LATEX in questions in ILIAS 9 is no longer highlighted in green. As @dsstrassner has already suspected in the ticket, this can be attributed to a missing CSS rule. In this PR, I am reintroducing this rule.

I would appreciate it if @catenglaender could also take a look at this suggestion, as this is a change in the stylesheet and not in the T&A module.

Thanks for the feedback!
Best regards,
Lukas