### PR TITLE
Mantis #45385: Truncate notifications in Survey CronJob to fit DB limit Fix

### DIFF
--- a/Modules/Survey/classes/class.ilSurveyCronNotification.php
+++ b/Modules/Survey/classes/class.ilSurveyCronNotification.php
@@ -26,9 +26,10 @@ use ILIAS\Cron\Schedule\CronJobScheduleType;
  */
 class ilSurveyCronNotification extends ilCronJob
 {
+    protected const MAX_MESSAGE_LENGTH = 397;
+
     protected ilLanguage $lng;
     protected ilTree $tree;
-    public const MAX_MESSAGE_LENGTH = 397;
 
     public function __construct()
     {

--- a/Modules/Survey/classes/class.ilSurveyCronNotification.php
+++ b/Modules/Survey/classes/class.ilSurveyCronNotification.php
@@ -28,6 +28,7 @@ class ilSurveyCronNotification extends ilCronJob
 {
     protected ilLanguage $lng;
     protected ilTree $tree;
+    public const MAX_MESSAGE_LENGTH = 397;
 
     public function __construct()
     {
@@ -104,8 +105,18 @@ class ilSurveyCronNotification extends ilCronJob
         $result->setStatus($status);
 
         if (count($message)) {
-            $result->setMessage("Ref-Ids: " . implode(", ", $message) . ' / ' . "#" . count($message));
+            $full_msg = "Ref-Ids: " . implode(", ", $message) . ' / ' . "#" . count($message);
+
+            if (mb_strlen($full_msg) > self::MAX_MESSAGE_LENGTH) {
+                $short_msg = mb_substr($full_msg, 0, self::MAX_MESSAGE_LENGTH) . '...';
+                $log->info("Notification message was truncated to fit DB limit. Full message: \"$full_msg\"");
+            } else {
+                $short_msg = $full_msg;
+            }
+
+            $result->setMessage($short_msg);
         }
+
         $log->debug("end");
         return $result;
     }


### PR DESCRIPTION
This MR fixes a problem causing a runtime exception due to notification length exceeding the allowed 400 characters in the database.
In ILIAS 8.x, values are no longer silently truncated at the database level. As a result, long notification messages (like those persisted by `ilSurveyCronNotification`) must be truncated before.

Changes:
- The notification message passed to `ilCronJobResult::setMessage()` is now truncated if it exceeds a certain amount of characters and `"..."` is appended to indicate the truncation.
- If the notification message got truncated, the original message is written to the ILIAS `log` for preservation purposes.