### PR TITLE
0044414: Failed test: Report Accessibility Issue without registration

### DIFF
--- a/components/ILIAS/GlobalScreen_/classes/UI/Footer/class.ilFooterStandardGroupsProvider.php
+++ b/components/ILIAS/GlobalScreen_/classes/UI/Footer/class.ilFooterStandardGroupsProvider.php
@@ -48,10 +48,6 @@ final class ilFooterStandardGroupsProvider extends AbstractStaticFooterProvider
     {
         return [
             $this->item_factory->group(
-                $this->getIdentificationFor(ilFooterStandardGroups::ACCESSIBILITY),
-                $this->translator->translate('accessibility')
-            )->withPosition(10),
-            $this->item_factory->group(
                 $this->getIdentificationFor(ilFooterStandardGroups::LEGAL_INFORMATION),
                 $this->translator->translate('legal_information')
             )->withPosition(20),
@@ -75,31 +71,6 @@ final class ilFooterStandardGroupsProvider extends AbstractStaticFooterProvider
     public function getEntries(): array
     {
         $entries = [];
-        // Accessibility Items
-        // accessibility control concept
-        if (($accessibility_control_url = \ilAccessibilityControlConceptGUI::getFooterLink()) !== '') {
-            $accessibility_control_title = \ilAccessibilityControlConceptGUI::getFooterText();
-            $entries[] = $this->item_factory
-                ->link(
-                    $this->id_factory->identifier('accessibility_control'),
-                    $accessibility_control_title
-                )
-                ->withAction($this->buildURI($accessibility_control_url))
-                ->withParent($this->getIdentificationFor(ilFooterStandardGroups::ACCESSIBILITY));
-        }
-
-        // report accessibility issue
-        if (($accessibility_report_url = \ilAccessibilitySupportContactsGUI::getFooterLink()) !== '') {
-            $accessibility_report_title = \ilAccessibilitySupportContactsGUI::getFooterText();
-            $entries[] = $this->item_factory
-                ->link(
-                    $this->id_factory->identifier('accessibility_report'),
-                    $accessibility_report_title
-                )
-                ->withAction($this->buildURI($accessibility_report_url))
-                ->withParent($this->getIdentificationFor(ilFooterStandardGroups::ACCESSIBILITY));
-        }
-
         // Imprint
         /*$base_class = ($this->dic->http()->wrapper()->query()->has(\ilCtrlInterface::PARAM_BASE_CLASS)) ?
             $this->dic->http()->wrapper()->query()->retrieve(
@@ -174,11 +145,6 @@ final class ilFooterStandardGroupsProvider extends AbstractStaticFooterProvider
             $this->translator->translate('permanent'),
             new URI($permanant_link)
         );
-    }
-
-    private function txt(string $key): string
-    {
-        return $this->dic->language()->txt($key);
     }
 
 }

--- a/components/ILIAS/SystemFolder/classes/class.ilAccessibilitySupportFooterProvider.php
+++ b/components/ILIAS/SystemFolder/classes/class.ilAccessibilitySupportFooterProvider.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\GlobalScreen\Scope\MetaBar\Provider\AbstractStaticFooterProvider;
+use ILIAS\DI\Container;
+
+/**
+ * Class ilAccessibilitySupportFooterProvider
+ */
+class ilAccessibilitySupportFooterProvider extends AbstractStaticFooterProvider
+{
+    private ilLanguage $lng;
+
+    public function __construct(Container $dic)
+    {
+        parent::__construct($dic);
+        $this->lng = $dic->language();
+        $this->lng->loadLanguageModule('gsfo');
+    }
+
+    public function getGroups(): array
+    {
+        return [
+            $this->item_factory->group(
+                $this->id_factory->identifier(ilFooterStandardGroups::ACCESSIBILITY->value),
+                $this->lng->txt('accessibility')
+            )->withPosition(10),
+        ];
+    }
+
+    public function getEntries(): array
+    {
+        $entries = [];
+        // Accessibility Items
+        // accessibility control concept
+        if (($accessibility_control_url = \ilAccessibilityControlConceptGUI::getFooterLink()) !== '') {
+            $accessibility_control_title = \ilAccessibilityControlConceptGUI::getFooterText();
+            $entries[] = $this->item_factory
+                ->link(
+                    $this->id_factory->identifier('accessibility_control'),
+                    $accessibility_control_title
+                )
+                ->withAction($accessibility_control_url)
+                ->withParent($this->id_factory->identifier(ilFooterStandardGroups::ACCESSIBILITY->value));
+        }
+
+        // report accessibility issue
+        if (($accessibility_report_url = \ilAccessibilitySupportContactsGUI::getFooterLink()) !== '') {
+            $accessibility_report_title = \ilAccessibilitySupportContactsGUI::getFooterText();
+            $entries[] = $this->item_factory
+                ->link(
+                    $this->id_factory->identifier('accessibility_report'),
+                    $accessibility_report_title
+                )
+                ->withAction($accessibility_report_url)
+                ->withParent($this->id_factory->identifier(ilFooterStandardGroups::ACCESSIBILITY->value));
+        }
+
+        return $entries;
+    }
+
+}


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=44414

the GS Footer items now allow strings for actions as well as (since the corresponding UI-components takes also strings), see https://github.com/ILIAS-eLearning/ILIAS/commit/00cb7caca5f84c866fee2a8f01913ed6bd96b7e5.

This PR moves the default items to an own provider, please note that you may reset the footer in the administration to see the change.

The new provider uses the links directly as string how they are generated in ilAccessibilityControlConceptGUI and ilAccessibilitySupportContactsGUI.

if you are still facing issues with the sub-path of your installation, please open a new issue in mantis since this is (no longer) related to the GS. I assume there are issues in `\ILIAS\Init\Environment\HttpPathBuilder` then.