### PR TITLE
Mantis #45368: Remove usage of domxml_open_mem method

### DIFF
--- a/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
@@ -1,25 +1,20 @@
 <?php
-/*
- +-----------------------------------------------------------------------------+
- | ILIAS open source                                                           |
- +-----------------------------------------------------------------------------+
- | Copyright (c) 1998-2009 ILIAS open source, University of Cologne            |
- |                                                                             |
- | This program is free software; you can redistribute it and/or               |
- | modify it under the terms of the GNU General Public License                 |
- | as published by the Free Software Foundation; either version 2              |
- | of the License, or (at your option) any later version.                      |
- |                                                                             |
- | This program is distributed in the hope that it will be useful,             |
- | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
- | GNU General Public License for more details.                                |
- |                                                                             |
- | You should have received a copy of the GNU General Public License           |
- | along with this program; if not, write to the Free Software                 |
- | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
- +-----------------------------------------------------------------------------+
-*/
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
 /**
  * Soap user administration methods
@@ -159,20 +154,19 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $ilUser = $DIC['ilUser'];
         $ilLog = $DIC['ilLog'];
 
-        // this takes time but is nescessary
-        $error = false;
-
         // validate to prevent wrong XMLs
-        @domxml_open_mem($usr_xml, DOMXML_LOAD_PARSING, $error);
-        if ($error) {
+        $usr_xml = ltrim($usr_xml); // Remove leading whitespace (including BOM if needed)
+
+        $doc = new DOMDocument();
+        libxml_use_internal_errors(true); // Capture parsing errors
+
+        if (!$doc->loadXML($usr_xml)) {
+            $errors = libxml_get_errors();
             $msg = array();
-            if (is_array($error)) {
-                foreach ($error as $err) {
-                    $msg [] = "(" . $err["line"] . "," . $err["col"] . "): " . $err["errormessage"];
-                }
-            } else {
-                $msg[] = $error;
+            foreach ($errors as $err) {
+                $msg[] = "(" . $err->line . "," . $err->column . "): " . trim($err->message);
             }
+            libxml_clear_errors();
             $msg = implode("\n", $msg);
             return $this->raiseError($msg, "Client");
         }

--- a/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
+++ b/components/ILIAS/soap/classes/class.ilSoapUserAdministration.php
@@ -160,9 +160,12 @@ class ilSoapUserAdministration extends ilSoapAdministration
         $doc = new DOMDocument();
         libxml_use_internal_errors(true); // Capture parsing errors
 
-        if (!$doc->loadXML($usr_xml)) {
-            $errors = libxml_get_errors();
-            $msg = array();
+        $is_loadable = $doc->loadXML($usr_xml);
+        $errors = libxml_get_errors();
+        libxml_clear_errors();
+
+        if (!$is_loadable) {
+            $msg = [];
             foreach ($errors as $err) {
                 $msg[] = "(" . $err->line . "," . $err->column . "): " . trim($err->message);
             }


### PR DESCRIPTION
Fixes: https://mantis.ilias.de/view.php?id=45368

~~Since no other soap functions does any validation of xml prior to passing to parser. I don't think this is needed anymore~~
XML validation added thanks to **satyam.mangroliya@minervis.com** in Mantis issue

If accepted should be picked into **trunk** too.