### PR TITLE
Move CSVReader to Survey component to remove dependency on unmaintained CSV component

### DIFF
--- a/components/ILIAS/Survey/CSV/CSVReader.php
+++ b/components/ILIAS/Survey/CSV/CSVReader.php
@@ -16,7 +16,12 @@
  *
  *********************************************************************/
 
-class ilCSVReader
+namespace ILIAS\Survey;
+
+use ilUtil;
+use RuntimeException;
+
+class CSVReader
 {
     /**
      * @var resource

--- a/components/ILIAS/Survey/Participants/class.ilSurveyParticipantsGUI.php
+++ b/components/ILIAS/Survey/Participants/class.ilSurveyParticipantsGUI.php
@@ -16,6 +16,7 @@
  *
  *********************************************************************/
 
+use ILIAS\Survey\CSVReader;
 use ILIAS\Survey\Participants;
 
 /**
@@ -737,7 +738,7 @@ class ilSurveyParticipantsGUI
                 $existing[$item["code"]] = $item["id"];
             }
 
-            $reader = new ilCSVReader();
+            $reader = new CSVReader();
             $reader->open($_FILES['codes']['tmp_name']);
             foreach ($reader->getCsvAsArray() as $row) {
                 // numeric check of used column due to #26176
@@ -1011,7 +1012,7 @@ class ilSurveyParticipantsGUI
         }
 
         if (trim($_FILES['externalmails']['tmp_name'])) {
-            $reader = new ilCSVReader();
+            $reader = new CSVReader();
             $reader->open($_FILES['externalmails']['tmp_name']);
             $data = $reader->getCsvAsArray();
             $fields = array_shift($data);


### PR DESCRIPTION
The CSV component is currently unmaintained. As outlined in the [JourFixe documentation](https://docu.ilias.de/go/wiki/wpage_8688_1357), the Technical Board advised that all usages of the CSV component should be removed in the future.
An analysis showed that `components/ILIAS/CSV/classes/class.ilCSVReader.php` is only used by the `Survey` component, which led to the decision to move this class into `Survey` entirely.

This PR:
- Moves the `ilCSVReader` class to the `Survey` component
- Renames the file (by removing the `class.il` prefix) and updates the namespace to `ILIAS\Survey`
- Adjusts the usages within the  `Survey` component accordingly