### PR TITLE
T&A 45332: Adds missing column label in test attempts for participant table

### DIFF
--- a/Modules/Test/classes/tables/class.ilTestPassManualScoringOverviewTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilTestPassManualScoringOverviewTableGUI.php
@@ -54,7 +54,7 @@ class ilTestPassManualScoringOverviewTableGUI extends ilTable2GUI
         $this->addColumn($this->lng->txt("tst_answered_questions"), 'answered_questions', '');
         $this->addColumn($this->lng->txt("tst_reached_points"), 'reached_points', '');
         $this->addColumn($this->lng->txt("tst_percent_solved"), 'percentage', '');
-        $this->addColumn('', '', '1%');
+        $this->addColumn($this->lng->txt("actions"), '', '1%');
     }
 
     private function initOrdering(): void


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45332

These changes aim to fix the issue mentioned in the Mantis ticket.

Already reviewed by @thojou.

Same as https://github.com/ILIAS-eLearning/ILIAS/pull/9739