### PR TITLE
UI: Add ProblemBuilder to Select-Constraint

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Select.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Select.php
@@ -77,7 +77,9 @@ class Select extends FormInput implements C\Input\Field\Select
         return $this->refinery->logical()->sequential([
             $this->refinery->to()->string(),
             $this->refinery->string()->hasMinLength(1)
-        ]);
+        ])->withProblemBuilder(function ($txt) {
+            return $txt('required');
+        });
     }
 
     /**

--- a/components/ILIAS/UI/tests/Component/Input/Field/CommonFieldRendering.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/CommonFieldRendering.php
@@ -31,13 +31,12 @@ trait CommonFieldRendering
     protected function getFieldFactory(): I\Input\Field\Factory
     {
         $df = new Data\Factory();
-        $language = $this->createMock(ilLanguage::class);
         return new I\Input\Field\Factory(
             $this->createMock(UploadLimitResolver::class),
             new SignalGenerator(),
             $df,
-            new Refinery($df, $language),
-            $language
+            new Refinery($df, $this->getLanguage()),
+            $this->getLanguage()
         );
     }
 

--- a/components/ILIAS/UI/tests/Component/Input/Field/LinkInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/LinkInputTest.php
@@ -58,7 +58,7 @@ class LinkInputTest extends ILIAS_UI_TestBase
 
         $f1 = $this->getFormWrappedHtml(
             'text-field-input',
-            '',
+            'ui_link_label',
             '<input id="id_1" type="text" name="name_0/label_1" class="c-field-text" />',
             null,
             'id_1',
@@ -67,7 +67,7 @@ class LinkInputTest extends ILIAS_UI_TestBase
         );
         $f2 = $this->getFormWrappedHtml(
             'url-field-input',
-            '',
+            'ui_link_url',
             '<input id="id_2" type="url" name="name_0/url_2" class="c-field-url" />',
             null,
             'id_2',


### PR DESCRIPTION
Dear UI-Coordinators

Currently a required Select-input informs users that "The value MUST be of type string." This PR changes this to "Required".

See: https://mantis.ilias.de/view.php?id=45352

Best,
@kergomard 