### PR TITLE
CSS: Transfer "Authority to (De-)Assign Authorities" to yvseiler

### DIFF
--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -471,7 +471,7 @@ of ILIAS. The file contains the following fields:
       , [catenglaender](https://docu.ilias.de/go/usr/79291)
     * Authority to Curate Test Cases: [amstutz](https://docu.ilias.de/go/usr/26468)
       , [yvseiler](https://docu.ilias.de/go/usr/17694)
-    * Authority to (De-)Assign Authorities: [amstutz](https://docu.ilias.de/go/usr/26468)
+    * Authority to (De-)Assign Authorities: [yvseiler](https://docu.ilias.de/go/usr/17694)
 	* Tester: [fschmid](https://docu.ilias.de/go/usr/21087)
     * Assignee for Security Reports: [amstutz](https://docu.ilias.de/go/usr/26468)
     * Assignee for Security Issues: [amstutz](https://docu.ilias.de/go/usr/26468)


### PR DESCRIPTION
With this PR, I would kindly ask to take over the CSS Authority "Authority to (De-)Assign Authorities" from @amstutz.

As described in the guidelines, I contacted @amstutz and discussed the proposal with him. As @amstutz will no longer be taking on this role at the end of the year, we need a new person to take over the ‘Authority to (De-)Assign Authorities’ for CSS. I am therefore making myself available to take over this role.

Thank you for considering my request.

Kindly,
@yvseiler 