### PR TITLE
0045334: addObject ignores offline flag for forums

### DIFF
--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  +-----------------------------------------------------------------------------+
  | ILIAS open source                                                           |
@@ -632,6 +633,10 @@ class ilSoapObjectAdministration extends ilSoapAdministration
             $newObj->setTitle($object_data['title']);
             $newObj->setDescription($object_data['description']);
             $newObj->create(); // true for upload
+            if ($object_data['type'] === 'frm' && isset($object_data['offline'])) {
+                $newObj->setOfflineStatus((bool) $object_data['offline']);
+                $newObj->update();
+            }
             $newObj->createReference();
             $newObj->putInTree($a_target_id);
             $newObj->setPermissions($a_target_id);

--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -627,12 +627,13 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                 $newObj->setImportId($object_data['import_id']);
             }
 
-            if ($objDefinition->supportsOfflineHandling($newObj->getType())) {
-                $newObj->setOfflineStatus((bool) $object_data['offline']);
-            }
             $newObj->setTitle($object_data['title']);
             $newObj->setDescription($object_data['description']);
             $newObj->create(); // true for upload
+            if ($objDefinition->supportsOfflineHandling($newObj->getType()) && isset($object_data['offline'])) {
+                $newObj->setOfflineStatus((bool) $object_data['offline']);
+                $newObj->update();
+            }
             if ($object_data['type'] === 'frm' && isset($object_data['offline'])) {
                 $newObj->setOfflineStatus((bool) $object_data['offline']);
                 $newObj->update();

--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -634,10 +634,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                 $newObj->setOfflineStatus((bool) $object_data['offline']);
                 $newObj->update();
             }
-            if ($object_data['type'] === 'frm' && isset($object_data['offline'])) {
-                $newObj->setOfflineStatus((bool) $object_data['offline']);
-                $newObj->update();
-            }
+    
             $newObj->createReference();
             $newObj->putInTree($a_target_id);
             $newObj->setPermissions($a_target_id);

--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -634,7 +634,7 @@ class ilSoapObjectAdministration extends ilSoapAdministration
                 $newObj->setOfflineStatus((bool) $object_data['offline']);
                 $newObj->update();
             }
-    
+
             $newObj->createReference();
             $newObj->putInTree($a_target_id);
             $newObj->setPermissions($a_target_id);

--- a/webservice/soap/classes/class.ilSoapObjectAdministration.php
+++ b/webservice/soap/classes/class.ilSoapObjectAdministration.php
@@ -1,26 +1,22 @@
 <?php
 
-/*
- +-----------------------------------------------------------------------------+
- | ILIAS open source                                                           |
- +-----------------------------------------------------------------------------+
- | Copyright (c) 1998-2001 ILIAS open source, University of Cologne            |
- |                                                                             |
- | This program is free software; you can redistribute it and/or               |
- | modify it under the terms of the GNU General Public License                 |
- | as published by the Free Software Foundation; either version 2              |
- | of the License, or (at your option) any later version.                      |
- |                                                                             |
- | This program is distributed in the hope that it will be useful,             |
- | but WITHOUT ANY WARRANTY; without even the implied warranty of              |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               |
- | GNU General Public License for more details.                                |
- |                                                                             |
- | You should have received a copy of the GNU General Public License           |
- | along with this program; if not, write to the Free Software                 |
- | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. |
- +-----------------------------------------------------------------------------+
-*/
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Soap object administration methods


### PR DESCRIPTION
0045334: addObject ignores offline flag for forums
Fixed an issue where addObject() SOAP call ignored the offline attribute when creating frm (forum) objects. The XML input was parsed correctly, but the offline status was never applied. This fix explicitly sets the offline status for forums based on the provided XML flag (offline="0" for online, offline="1" for offline).
