### PR TITLE
T&A 43916: Makes icons next to single choice question answers more intuitive in results for test attempt

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -1950,7 +1950,7 @@ abstract class assQuestionGUI
                 $label = $this->lng->txt("answer_is_wrong");
                 break;
             case self::CORRECTNESS_MOSTLY_OK:
-                $icon_name = 'standard/icon_ok.svg';
+                $icon_name = 'standard/icon_mostly_ok.svg';
                 $label = $this->lng->txt("answer_is_not_correct_but_positive");
                 break;
             case self::CORRECTNESS_OK:

--- a/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -305,21 +305,12 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         foreach ($keys as $answer_id) {
             $answer = $this->object->answers[$answer_id];
             if ($active_id > 0 && !$show_correct_solution && $graphical_output) {
-                $maximum_points = $this->object->getMaximumPoints();
-                $answer_points = $answer->getPoints();
-                $correctness = $answer_points === $maximum_points || $answer_points > 0
-                        ? self::CORRECTNESS_NOT_OK
-                        : self::CORRECTNESS_OK;
-
-                if ($user_solution === (string) $answer_id) {
-                    $correctness = self::CORRECTNESS_NOT_OK;
-
-                    if ($answer_points === $maximum_points) {
-                        $correctness = self::CORRECTNESS_OK;
-                    } elseif ($answer_points > 0) {
-                        $correctness = self::CORRECTNESS_MOSTLY_OK;
-                    }
-                }
+                $correctness = $this->generateCorrectness(
+                    $user_solution,
+                    (string) $answer_id,
+                    $answer->getPoints(),
+                    $this->object->getMaximumPoints()
+                );
                 $template->setCurrentBlock("icon_ok");
                 $template->setVariable("ICON_OK", $this->generateCorrectnessIconsForCorrectness($correctness));
                 $template->parseCurrentBlock();
@@ -399,6 +390,27 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
             $solutionoutput = $this->getILIASPage($solutionoutput);
         }
         return $solutionoutput;
+    }
+
+    private function generateCorrectness(string $user_solution, string $answer_id, int $answer_points, int $maximum_points): int
+    {
+        if ($user_solution === $answer_id) {
+            if ($answer_points === $maximum_points) {
+                return self::CORRECTNESS_OK;
+            }
+
+            if ($answer_points > 0) {
+                return self::CORRECTNESS_MOSTLY_OK;
+            }
+
+            return self::CORRECTNESS_NOT_OK;
+        }
+
+        if ($answer_points === $maximum_points || $answer_points > 0) {
+            return self::CORRECTNESS_NOT_OK;
+        }
+
+        return self::CORRECTNESS_OK;
     }
 
     public function getPreview($show_question_only = false, $showInlineFeedback = false): string

--- a/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -304,21 +304,25 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         $solutiontemplate = new ilTemplate("tpl.il_as_tst_solution_output.html", true, true, "Modules/TestQuestionPool");
         foreach ($keys as $answer_id) {
             $answer = $this->object->answers[$answer_id];
-            if (($active_id > 0) && (!$show_correct_solution)) {
-                if ($graphical_output) {
-                    $correctness_icon = $this->generateCorrectnessIconsForCorrectness(self::CORRECTNESS_NOT_OK);
+            if ($active_id > 0 && !$show_correct_solution && $graphical_output) {
+                $maximum_points = $this->object->getMaximumPoints();
+                $answer_points = $answer->getPoints();
+                $correctness = $answer_points === $maximum_points || $answer_points > 0
+                        ? self::CORRECTNESS_NOT_OK
+                        : self::CORRECTNESS_OK;
 
-                    if ($user_solution === (string) $answer_id) {
-                        if ($answer->getPoints() == $this->object->getMaximumPoints()) {
-                            $correctness_icon = $this->generateCorrectnessIconsForCorrectness(self::CORRECTNESS_OK);
-                        } elseif ($answer->getPoints() > 0) {
-                            $correctness_icon = $this->generateCorrectnessIconsForCorrectness(self::CORRECTNESS_MOSTLY_OK);
-                        }
+                if ($user_solution === (string) $answer_id) {
+                    $correctness = self::CORRECTNESS_NOT_OK;
+
+                    if ($answer_points === $maximum_points) {
+                        $correctness = self::CORRECTNESS_OK;
+                    } elseif ($answer_points > 0) {
+                        $correctness = self::CORRECTNESS_MOSTLY_OK;
                     }
-                    $template->setCurrentBlock("icon_ok");
-                    $template->setVariable("ICON_OK", $correctness_icon);
-                    $template->parseCurrentBlock();
                 }
+                $template->setCurrentBlock("icon_ok");
+                $template->setVariable("ICON_OK", $this->generateCorrectnessIconsForCorrectness($correctness));
+                $template->parseCurrentBlock();
             }
             if ($answer->hasImage()) {
                 $template->setCurrentBlock("answer_image");


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=43916

These changes aim to fix the issue mentioned in the Mantis ticket.

Already reviewed by @thojou.