### PR TITLE
UI/Radio: 45401, value must be null or option (instead of empty string)

### DIFF
--- a/Modules/Test/classes/ScoreReporting/ilObjTestSettingsGamification.php
+++ b/Modules/Test/classes/ScoreReporting/ilObjTestSettingsGamification.php
@@ -57,7 +57,7 @@ class ilObjTestSettingsGamification extends TestSettings
                     ->withOption((string) self::HIGHSCORE_SHOW_OWN_TABLE, $lng->txt('tst_highscore_own_table'), $lng->txt('tst_highscore_own_table_description'))
                     ->withOption((string) self::HIGHSCORE_SHOW_TOP_TABLE, $lng->txt('tst_highscore_top_table'), $lng->txt('tst_highscore_top_table_description'))
                     ->withOption((string) self::HIGHSCORE_SHOW_ALL_TABLES, $lng->txt('tst_highscore_all_tables'), $lng->txt('tst_highscore_all_tables_description'))
-                    ->withValue($this->getHighScoreMode() > 0 ? (string) $this->getHighScoreMode() : '')
+                    ->withValue($this->getHighScoreMode() > 0 ? (string) $this->getHighScoreMode() : null)
                     ->withRequired(true)
                     ,
                 'highscore_top_num' => $f->numeric($lng->txt('tst_highscore_top_num'), $lng->txt('tst_highscore_top_num_description'))

--- a/tests/UI/Component/Input/Field/RadioInputTest.php
+++ b/tests/UI/Component/Input/Field/RadioInputTest.php
@@ -170,4 +170,28 @@ class RadioInputTest extends ILIAS_UI_TestBase
             . "</div>";
         $this->assertHTMLEquals($expected, $r->render($radio));
     }
+
+    public function testRadioValueOK(): void
+    {
+        $radio = $this->buildRadio()->withValue('value0');
+        $this->assertEquals('value0', $radio->getValue());
+    }
+
+    public function testRadioValueNotOK(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $radio = $this->buildRadio()->withValue('something not in options');
+    }
+
+    public function testRadioValueNotOKType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $radio = $this->buildRadio()->withValue('');
+    }
+
+    public function testRadioValueOKForNull(): void
+    {
+        $radio = $this->buildRadio()->withValue(null);
+        $this->assertNull($radio->getValue());
+    }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45401

caused by https://github.com/ILIAS-eLearning/ILIAS/pull/9652