### PR TITLE
Improvement: Keep old file extension on legacy files with suffix ".sec" added

### DIFF
--- a/components/ILIAS/FileServices/tests/ilServicesFileServicesTest.php
+++ b/components/ILIAS/FileServices/tests/ilServicesFileServicesTest.php
@@ -61,7 +61,7 @@ class ilServicesFileServicesTest extends TestCase
         $sanitizer = new ilFileServicesFilenameSanitizer($settings);
         $this->assertTrue($sanitizer->isClean('/lib/test.pdf'));
         $this->assertFalse($sanitizer->isClean('/lib/test.xml'));
-        $this->assertEquals('/lib/testxml.sec', $sanitizer->sanitize('/lib/test.xml'));
+        $this->assertEquals('/lib/test.xml.sec', $sanitizer->sanitize('/lib/test.xml'));
     }
 
     public function testBlacklistedUpload(): void
@@ -124,7 +124,7 @@ class ilServicesFileServicesTest extends TestCase
 
         $insane_filename = 'bellerophon.docx';
         $this->assertNotEquals($insane_filename, $sanitizer->sanitize($insane_filename));
-        $this->assertEquals('bellerophondocx.sec', $sanitizer->sanitize($insane_filename));
+        $this->assertEquals('bellerophon.docx.sec', $sanitizer->sanitize($insane_filename));
     }
 
     public function testActualWhitelist(): void
@@ -197,7 +197,7 @@ class ilServicesFileServicesTest extends TestCase
                  ->willReturn(true);
 
         $policy = new ilFileServicesPolicy($settings);
-        $this->assertEquals('testmp3.sec', $policy->prepareFileNameForConsumer('test.mp3'));
+        $this->assertEquals('test.mp3.sec', $policy->prepareFileNameForConsumer('test.mp3'));
         $this->assertEquals('test.png', $policy->prepareFileNameForConsumer('test.png'));
         $this->assertEquals('test.pdf', $policy->prepareFileNameForConsumer('test.pdf'));
         $this->assertEquals('aeaeaeaeaeaeaeaeae.pdf', $policy->prepareFileNameForConsumer('äääääääää.pdf'));

--- a/components/ILIAS/Filesystem/src/Definitions/SuffixDefinitions.php
+++ b/components/ILIAS/Filesystem/src/Definitions/SuffixDefinitions.php
@@ -65,8 +65,8 @@ final class SuffixDefinitions
             return $filename;
         }
         $pi = pathinfo($filename);
-        // if extension is not in white list, remove all "." and add ".sec" extension
-        $basename = str_replace(".", "", $pi["basename"]);
+        // if extension is not in white list add ".sec" extension
+        $basename = $pi["basename"];
         if (trim($basename) === "") {
             throw new \RuntimeException("Invalid upload filename.");
         }

--- a/components/ILIAS/Filesystem/src/Security/Sanitizing/FilenameSanitizerImpl.php
+++ b/components/ILIAS/Filesystem/src/Security/Sanitizing/FilenameSanitizerImpl.php
@@ -69,11 +69,9 @@ class FilenameSanitizerImpl implements FilenameSanitizer
         }
 
         $pathInfo = pathinfo($filename);
-        $basename = $pathInfo['basename'];
         $parentPath = $pathInfo['dirname'] === '.' ? '' : $pathInfo['dirname'];
 
-        $filename = str_replace('.', '', $basename);
-        $filename .= "." . FilenameSanitizer::CLEAN_FILE_SUFFIX;
+        $filename = $pathInfo['basename'] . "." . FilenameSanitizer::CLEAN_FILE_SUFFIX;
 
         // there is no parent
         if ($parentPath === '') {


### PR DESCRIPTION
When administrators go through the different files uploaded through the legacy uploads. 
The extensions of files that were accepted have the suffix ".sec" added but the dot (.) of the original file extension is also removed.

Example:
`test.exe => testexe.sec`

For some file extensions/names this makes it hard to find out what their original file extensions was.
By keeping the dot (.) of the original file extension, the original file name with extension is available for administrators.

Example:
`test.exe => test.exe.sec`

Since those files are not accessible through ILIAS this change does not affect the ILIAS installation, 
no migration or similar shout be needed

* I know that with more and more parts of ILIAS using the IRSS this change for legacy files will loose it's purpose rather soon 
