### PR TITLE
Certificate Bugfix: Adds missing Certificate Migration for UdpateSteps11

### DIFF
--- a/components/ILIAS/Certificate/classes/Setup/class.ilCertificatSetupAgent.php
+++ b/components/ILIAS/Certificate/classes/Setup/class.ilCertificatSetupAgent.php
@@ -47,6 +47,7 @@ class ilCertificatSetupAgent implements Setup\Agent
             'Database is updated for component/ILIAS/Certificate',
             true,
             new ilDatabaseUpdateStepsExecutedObjective(new ilCertificateDatabaseUpdateSteps()),
+            new ilDatabaseUpdateStepsExecutedObjective(new ilCertificateDatabaseUpdateSteps11()),
             new ilDatabaseUpdateStepsExecutedObjective(new MigrateCourseCertificateProviderDBUpdateSteps()),
             new ilDatabaseUpdateStepsExecutedObjective(new MigrateExerciseCertificateProviderDBUpdateSteps()),
         );
@@ -63,6 +64,7 @@ class ilCertificatSetupAgent implements Setup\Agent
             'Database is updated for component/ILIAS/Certificate',
             true,
             new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilCertificateDatabaseUpdateSteps()),
+            new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new ilCertificateDatabaseUpdateSteps11()),
             new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new MigrateCourseCertificateProviderDBUpdateSteps()),
             new ilDatabaseUpdateStepsMetricsCollectedObjective($storage, new MigrateExerciseCertificateProviderDBUpdateSteps()),
         );


### PR DESCRIPTION
The Setup Directive ilCertificateDatabaseUpdateSteps11 hasn't been called in ILIAS 11 which results in errors for Certificates