### PR TITLE
Modules/File Mantis #0045376 Fix "open in external editor" action for Workspace

### DIFF
--- a/Modules/File/classes/Capabilities/Check/EditContent.php
+++ b/Modules/File/classes/Capabilities/Check/EditContent.php
@@ -40,7 +40,7 @@ class EditContent extends BaseCheck implements Check
         \ilObjFileInfo $info,
         Context $context,
     ): Capability {
-        if ($context->getContext() !== Context::CONTEXT_REPO) {
+        if ($context->getContext() !== Context::CONTEXT_REPO && $context->getContext() !== Context::CONTEXT_WORKSPACE) {
             return $capability->withUnlocked(false);
         }
         if (!$this->hasPermission($helpers, $context, ...$capability->getPermissions())) {

--- a/Modules/File/classes/class.ilObjFileGUI.php
+++ b/Modules/File/classes/class.ilObjFileGUI.php
@@ -284,11 +284,20 @@ class ilObjFileGUI extends ilObject2GUI
 
                 $this->tabs_gui->activateTab('content');
 
+                if ($this->id_type === Context::CONTEXT_WORKSPACE) {
+                    $goto_link = ilWorkspaceAccessHandler::getGotoLink(
+                        $this->object->getRefId(),
+                        $this->object->getId()
+                    );
+                } else {
+                    $goto_link = ilLink::_getLink($this->object->getRefId());
+                }
+
                 $embeded_application = new EmbeddedApplication(
                     $this->storage->manage()->find($this->object->getResourceId()),
                     $action,
                     $this->stakeholder,
-                    new URI(ilLink::_getLink($this->object->getRefId())),
+                    new URI($goto_link),
                     $capability->getCapability() === Capabilities::VIEW_EXTERNAL
                 );
 


### PR DESCRIPTION
Hey @chfsx,

Currently, the Open in external Editor Button for Files in the Workspace isn't shown.
I added a check to enable the capability and edited the Link to WOPI in ilObjFile, to fix a bug that occurred as a result.
This is also an issue for ILIAS 10 and up.

Best @fhelfer 