### PR TITLE
UI: Remove novalidate from Forms

### DIFF
--- a/src/UI/templates/default/Input/tpl.no_submit.html
+++ b/src/UI/templates/default/Input/tpl.no_submit.html
@@ -1,4 +1,4 @@
-<form id="{ID}" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" <!-- BEGIN action --> action="{URL}"<!-- END action --> method="post" novalidate="novalidate">
+<form id="{ID}" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" <!-- BEGIN action --> action="{URL}"<!-- END action --> method="post" >
 	<!-- BEGIN error -->
 	<div class="help-block alert alert-danger" role="alert">
 		{ERROR}

--- a/src/UI/templates/default/Input/tpl.standard.html
+++ b/src/UI/templates/default/Input/tpl.standard.html
@@ -1,4 +1,4 @@
-<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post" novalidate="novalidate">
+<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" {NAME}<!-- BEGIN action --> action="{URL}"<!-- END action --> method="post" >
 	<div class="il-standard-form-header clearfix">
 		<div class="il-standard-form-cmd">{BUTTONS_TOP}</div>
 		<!-- BEGIN required_text_top -->

--- a/src/UI/templates/default/Input/tpl.standard_filter.html
+++ b/src/UI/templates/default/Input/tpl.standard_filter.html
@@ -1,5 +1,5 @@
 <div class="il-filter <!-- BEGIN disabled -->disabled<!-- END disabled --><!-- BEGIN enabled -->enabled<!-- END enabled -->" id="{ID_FILTER}">
-    <form class="il-standard-form form-horizontal" enctype="multipart/form-data" method="get" novalidate="novalidate"<!-- BEGIN action --> data-cmd-{ACTION_NAME}="{ACTION}"<!-- END action -->>
+    <form class="il-standard-form form-horizontal" enctype="multipart/form-data" method="get" <!-- BEGIN action --> data-cmd-{ACTION_NAME}="{ACTION}"<!-- END action -->>
         <div class="il-filter-bar">
             <div class="il-filter-bar-opener" data-toggle="collapse" data-target=".il-filter-inputs-active,.il-filter-input-section"> {OPENER} </div>
             <div class="il-filter-bar-toggle"> {TOGGLE} </div>

--- a/tests/UI/Component/Dropzone/File/StandardTest.php
+++ b/tests/UI/Component/Dropzone/File/StandardTest.php
@@ -45,7 +45,7 @@ class StandardTest extends FileTestBase
 			<div class="modal-content">
 				<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="close"><span aria-hidden="true">&times;</span></button><h1 class="modal-title">' . $expected_title . '</h1></div>
 				<div class="modal-body">
-					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">' . $this->input->getCanonicalName() . '</form>
+					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" >' . $this->input->getCanonicalName() . '</form>
 				</div>
 				<div class="modal-footer"><button class="btn btn-default" id="id_3">save</button><button class="btn btn-default" data-dismiss="modal">cancel</button></div>
 			</div>
@@ -114,7 +114,7 @@ class StandardTest extends FileTestBase
 			<div class="modal-content">
 				<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="close"><span aria-hidden="true">&times;</span></button><h1 class="modal-title">' . $expected_title . '</h1></div>
 				<div class="modal-body">
-					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">' . $this->input->getCanonicalName() . '</form>
+					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" >' . $this->input->getCanonicalName() . '</form>
 				</div>
 				<div class="modal-footer"><button class="btn btn-default" id="id_3">save</button><button class="btn btn-default" data-dismiss="modal">cancel</button></div>
 			</div>

--- a/tests/UI/Component/Dropzone/File/WrapperTest.php
+++ b/tests/UI/Component/Dropzone/File/WrapperTest.php
@@ -42,7 +42,7 @@ class WrapperTest extends FileTestBase
 			<div class="modal-content">
 				<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="close"><span aria-hidden="true">&times;</span></button><h1 class="modal-title">' . $expected_title . ' </h1></div>
 				<div class="modal-body">
-					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" novalidate="novalidate">File Field Input</form>
+					<form id="id_2" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="' . $expected_url . '" method="post" >File Field Input</form>
 				</div>
 				<div class="modal-footer"><button class="btn btn-default" id="id_3">save</button><button class="btn btn-default" data-dismiss="modal">cancel</button></div>
 			</div>

--- a/tests/UI/Component/Input/Container/Filter/StandardFilterTest.php
+++ b/tests/UI/Component/Input/Container/Filter/StandardFilterTest.php
@@ -169,7 +169,7 @@ class StandardFilterTest extends ILIAS_UI_TestBase
 
         $expected = <<<EOT
 <div class="il-filter enabled" id="id_1">
-    <form class="il-standard-form form-horizontal" enctype="multipart/form-data" method="get" novalidate="novalidate" data-cmd-expand="#" data-cmd-collapse="#" data-cmd-apply="#" data-cmd-toggleOn="#" data-cmd-toggleOff="#">
+    <form class="il-standard-form form-horizontal" enctype="multipart/form-data" method="get"  data-cmd-expand="#" data-cmd-collapse="#" data-cmd-apply="#" data-cmd-toggleOn="#" data-cmd-toggleOff="#">
         <div class="il-filter-bar">
 		<div class="il-filter-bar-opener" data-toggle="collapse" data-target=".il-filter-inputs-active,.il-filter-input-section">
 			<button class="btn btn-bulky" data-action="" id="id_2">
@@ -305,7 +305,7 @@ EOT;
 
         $expected = <<<EOT
 <div class="il-filter disabled" id="id_1">
-    <form class="il-standard-form form-horizontal" enctype="multipart/form-data" method="get" novalidate="novalidate" data-cmd-expand="#" data-cmd-collapse="#" data-cmd-apply="#" data-cmd-toggleOn="#" data-cmd-toggleOff="#">
+    <form class="il-standard-form form-horizontal" enctype="multipart/form-data" method="get"  data-cmd-expand="#" data-cmd-collapse="#" data-cmd-apply="#" data-cmd-toggleOn="#" data-cmd-toggleOff="#">
         <div class="il-filter-bar">
 		<div class="il-filter-bar-opener" data-toggle="collapse" data-target=".il-filter-inputs-active,.il-filter-input-section">
 			<button class="btn btn-bulky" data-action="" id="id_2">
@@ -441,7 +441,7 @@ EOT;
 
         $expected = <<<EOT
 <div class="il-filter enabled" id="id_1">
-    <form class="il-standard-form form-horizontal" enctype="multipart/form-data" method="get" novalidate="novalidate" data-cmd-expand="#" data-cmd-collapse="#" data-cmd-apply="#" data-cmd-toggleOn="#" data-cmd-toggleOff="#">
+    <form class="il-standard-form form-horizontal" enctype="multipart/form-data" method="get"  data-cmd-expand="#" data-cmd-collapse="#" data-cmd-apply="#" data-cmd-toggleOn="#" data-cmd-toggleOff="#">
         <div class="il-filter-bar">
 		<div class="il-filter-bar-opener" data-toggle="collapse" data-target=".il-filter-inputs-active,.il-filter-input-section">
 			<button class="btn btn-bulky" data-action="" id="id_2">
@@ -577,7 +577,7 @@ EOT;
 
         $expected = <<<EOT
 <div class="il-filter disabled" id="id_1">
-    <form class="il-standard-form form-horizontal" enctype="multipart/form-data" method="get" novalidate="novalidate" data-cmd-expand="#" data-cmd-collapse="#" data-cmd-apply="#" data-cmd-toggleOn="#" data-cmd-toggleOff="#">
+    <form class="il-standard-form form-horizontal" enctype="multipart/form-data" method="get"  data-cmd-expand="#" data-cmd-collapse="#" data-cmd-apply="#" data-cmd-toggleOn="#" data-cmd-toggleOff="#">
         <div class="il-filter-bar">
 		<div class="il-filter-bar-opener" data-toggle="collapse" data-target=".il-filter-inputs-active,.il-filter-input-section">
 			<button class="btn btn-bulky" data-action="" id="id_2">

--- a/tests/UI/Component/Input/Container/Form/NoSubmitFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/NoSubmitFormTest.php
@@ -88,7 +88,7 @@ class NoSubmitFormTest extends \ILIAS_UI_TestBase
         );
 
         $expected_html =
-            "<form id=\"id_1\" role=\"form\" class=\"il-standard-form form-horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\" novalidate=\"novalidate\">" .
+            "<form id=\"id_1\" role=\"form\" class=\"il-standard-form form-horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\" >" .
             $dummy_input->getCanonicalName() .
             "</form>";
 
@@ -116,7 +116,7 @@ class NoSubmitFormTest extends \ILIAS_UI_TestBase
         );
 
         $expected_html =
-            "<form id=\"id_1\" role=\"form\" class=\"il-standard-form form-horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\" novalidate=\"novalidate\">" .
+            "<form id=\"id_1\" role=\"form\" class=\"il-standard-form form-horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\" >" .
             $dummy_input->getCanonicalName() .
             "<div class=\"il-standard-form-footer clearfix\"><span class=\"asterisk\">*</span><span class=\"small\"> $required_lang_var</span></div>" .
             "</form>";
@@ -160,7 +160,7 @@ class NoSubmitFormTest extends \ILIAS_UI_TestBase
         $data = $form->getData();
 
         $expected_html =
-            "<form id=\"id_1\" role=\"form\" class=\"il-standard-form form-horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\" novalidate=\"novalidate\">" .
+            "<form id=\"id_1\" role=\"form\" class=\"il-standard-form form-horizontal\" enctype=\"multipart/form-data\" action=\"$post_url\" method=\"post\" >" .
             "<div class=\"help-block alert alert-danger\" role=\"alert\">$error_lang_var</div>" .
             $dummy_input->getCanonicalName() .
             "</form>";

--- a/tests/UI/Component/Input/Container/Form/StandardFormTest.php
+++ b/tests/UI/Component/Input/Container/Form/StandardFormTest.php
@@ -122,7 +122,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($form));
 
         $expected = $this->brutallyTrimHTML('
-<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="MY_URL" method="post" novalidate="novalidate">
+<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="MY_URL" method="post" >
    <div class="il-standard-form-header clearfix">
       <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
    </div>
@@ -173,7 +173,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($form));
 
         $expected = $this->brutallyTrimHTML('
-<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="MY_URL" method="post" novalidate="novalidate">
+<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="MY_URL" method="post" >
    <div class="il-standard-form-header clearfix">
       <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">create</button></div>
    </div>
@@ -206,7 +206,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($form));
 
         $expected = $this->brutallyTrimHTML('
-<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" method="post" novalidate="novalidate">
+<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" method="post" >
    <div class="il-standard-form-header clearfix">
       <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
    </div>
@@ -268,7 +268,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
 
         $html = $this->brutallyTrimHTML($r->render($form));
         $expected = $this->brutallyTrimHTML('
-            <form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" method="post" novalidate="novalidate">
+            <form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" method="post" >
                 <div class="il-standard-form-header clearfix">
                     <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
                 </div>
@@ -328,7 +328,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
 
         $html = $this->brutallyTrimHTML($r->render($form));
         $expected = $this->brutallyTrimHTML('
-            <form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" method="post" novalidate="novalidate">
+            <form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" method="post" >
                 <div class="il-standard-form-header clearfix">
                     <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
                 </div>
@@ -362,7 +362,7 @@ class StandardFormTest extends ILIAS_UI_TestBase
         $html = $this->brutallyTrimHTML($r->render($form));
 
         $expected = $this->brutallyTrimHTML('
-<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="MY_URL" method="post" novalidate="novalidate">
+<form role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="MY_URL" method="post" >
     <div class="il-standard-form-header clearfix">
         <div class="il-standard-form-cmd"><button class="btn btn-default" data-action="">save</button></div>
         <div class="il-standard-form-required">

--- a/tests/UI/Component/Launcher/LauncherInlineTest.php
+++ b/tests/UI/Component/Launcher/LauncherInlineTest.php
@@ -229,7 +229,7 @@ class LauncherInlineTest extends ILIAS_UI_TestBase
                         <h1 class="modal-title">different label</h1>
                     </div>
                     <div class="modal-body">$msg_html
-                        <form id="id_3" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="http://localhost/ilias.php" method="post" novalidate="novalidate">
+                        <form id="id_3" role="form" class="il-standard-form form-horizontal" enctype="multipart/form-data" action="http://localhost/ilias.php" method="post" >
                             <div class="form-group row">
                                 <label for="id_2" class="control-label col-sm-4 col-md-3 col-lg-2">Understood</label>
                                 <div class="col-sm-8 col-md-9 col-lg-10">


### PR DESCRIPTION
Dear UI-Coordinators

As we run into similar issues with form validation in ILIAS 9 as we did in ILIAS 10 and above (see e.g. https://mantis.ilias.de/view.php?id=45286 ), this PR Proposes to backport
https://github.com/ILIAS-eLearning/ILIAS/pull/8395 to ILIAS 9.

Thanks and best,
@kergomard