### PR TITLE
[LTI] Chore: Removed deprecated ilCtrl methods

### DIFF
--- a/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
+++ b/components/ILIAS/LTIConsumer/classes/class.ilObjLTIConsumerGUI.php
@@ -1047,10 +1047,7 @@ class ilObjLTIConsumerGUI extends ilObject2GUI
         /* @var \ILIAS\DI\Container $DIC */
 
         $DIC->tabs()->activateTab(self::TAB_ID_INFO);
-
-        // @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-        // $DIC->ctrl()->setCmd("showSummary");
-        // $DIC->ctrl()->setCmdClass("ilinfoscreengui");
+        
         $this->infoScreenForward();
     }
 

--- a/components/ILIAS/LTIProvider/resources/lti.php
+++ b/components/ILIAS/LTIProvider/resources/lti.php
@@ -29,7 +29,6 @@ ilInitialisation::initILIAS();
 
 // authentication is done here ->
 global $DIC;
-// @todo: removed deprecated ilCtrl methods, this needs inspection by a maintainer.
-// $DIC->ctrl()->setCmd('doLTIAuthentication');
+
 $DIC->ctrl()->setTargetScript('ilias.php');
 $DIC->ctrl()->callBaseClass('ilStartUpGUI');


### PR DESCRIPTION
Removed deprecated ilCtrl calls that were commented out in the code and were not needed.