### PR TITLE
Chatroom: Replace moment js with native code

### DIFF
--- a/components/ILIAS/Chatroom/README.md
+++ b/components/ILIAS/Chatroom/README.md
@@ -33,6 +33,10 @@ interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
   - [Proxy Configuration](#proxy-configuration)
       - [Proxy configuration via nginx](#proxy-configuration-via-nginx)
       - [Proxy configuration via apache2](#proxy-configuration-via-apache2)
+    - [Dependency Management](#dependency-management)
+      - [Development](#development)
+      - [Production](#production)
+  - [Known Issues](#known-issues)
 
 <!-- /TOC -->
 
@@ -486,3 +490,28 @@ In the ILIAS configuration the proxy configurations are adjusted in the ***Chat 
 Example:
 
     https://onscreenchat.domain.de
+
+### Dependency Management
+
+The node module dependencies should be managed by [npm](https://www.npmjs.com/).
+
+#### Development
+
+Dependencies can be installed by the following command:
+
+```bash
+npm clean-install --ignore-scripts
+```
+
+#### Production
+
+Dependencies can be installed by the following command:
+
+```bash
+npm clean-install --omit=dev --ignore-scripts
+```
+
+# Known Issues
+
+As noted in comment: https://github.com/ILIAS-eLearning/ILIAS/pull/9808#issuecomment-3143866215
+the replacement of the dependency `moment` (removed in PR [#8570](https://github.com/ILIAS-eLearning/ILIAS/pull/8570)) with the builtin [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) Object resulted in some grammar issues in some languages (e.g. `vor 1 Jahr` instead of `vor einem Jahr`) which cannot be fixed easily.

--- a/components/ILIAS/Chatroom/classes/gui/class.ilChatroomViewGUI.php
+++ b/components/ILIAS/Chatroom/classes/gui/class.ilChatroomViewGUI.php
@@ -251,7 +251,7 @@ class ilChatroomViewGUI extends ilChatroomGUIHandler
 
     private function legacy(string $html): Component
     {
-        return $this->uifactory->legacy()->content($html);
+        return $this->uiFactory->legacy()->content($html);
     }
 
     /**

--- a/components/ILIAS/OnScreenChat/resources/moment.js
+++ b/components/ILIAS/OnScreenChat/resources/moment.js
@@ -1,20 +1,59 @@
-(function ($, moment, scope) {
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ */
+
+(function ($, scope) {
 	scope = scope || {};
+	let locale = null;
 
 	scope.ChatDateTimeFormatter = {};
 
-	scope.ChatDateTimeFormatter.setLocale = function (locale) {
-		moment.locale(locale);
+	scope.ChatDateTimeFormatter.setLocale = function (theLocale) {
+		locale = theLocale;
 	};
 
 	scope.ChatDateTimeFormatter.fromNowToTime = function (time) {
-		let currentTime = new Date().getTime();
+		const now = new Date()
+		const currentTime = now.getTime();
 
 		if (isNaN(time) || time > currentTime) {
 			time = currentTime;
 		}
 
-		return moment(time).fromNow();
+		const date = new Date(time);
+		const seconds = diffSeconds(now, date);
+		const years = now.getFullYear() - date.getFullYear()
+		const months = (now.getFullYear() * 12 + now.getMonth()) - (date.getFullYear() * 12 + date.getMonth());
+		const days = Math.floor(seconds / 86400);
+
+		return new Intl.RelativeTimeFormat(locale).format(...firstMatch([
+			[years === 1 && months > 10 || years > 1, years, 'year'],
+			[months === 1 && days > 27 || months > 1, months, 'month'],
+			[604800, 'week'],
+			[86400, 'day'],
+			[3600, 'hour'],
+			[60, 'minute'],
+			[true, seconds, 'second'],
+		]));
+
+		function firstMatch(array)
+		{
+			const match = array.find(a => typeof a[0] === 'boolean' ? a[0] : seconds / a[0] >= 1);
+			return typeof match[0] === 'boolean' ?
+				[-match[1], match[2]] :
+				[-Math.floor(seconds / match[0]), match[1]];
+		}
 	};
 
 	scope.ChatDateTimeFormatter.format = function (time, format) {
@@ -24,27 +63,35 @@
 			time = currentTime;
 		}
 
-		return moment(time).format(format);
+		if (format !== 'LT') {
+			throw Error('Only format LT allowed');
+		}
+
+		return new Intl.DateTimeFormat(locale, {timeStyle: 'medium'}).format(new Date(time));
 	};
 
 	scope.ChatDateTimeFormatter.formatDate = function (time) {
-		let currentTime = new Date().getTime();
+		const now = new Date();
+		const currentTime = now.getTime();
 
 		if (isNaN(time) || time > currentTime) {
 			time = currentTime;
 		}
 
-		let fromNow = moment(time).format('LL');
+		const date = new Date(time);
+		const seconds = diffSeconds(now, date);
 
-		return moment(time).calendar(null, {
-			sameDay: '[' + il.Language.txt('today') + ']',
-			lastDay: '[' + il.Language.txt('yesterday') + ']',
-			lastWeek: function (now) {
-				return "[" + fromNow + "]";
-			},
-			sameElse: function (now) {
-				return "[" + fromNow + "]";
-			}
-		});
+		if (now.getFullYear() === date.getFullYear() && now.getMonth() === date.getMonth() && now.getDate() <= date.getDate() + 1) {
+			return now.getDate() === date.getDate() ?
+				il.Language.txt('today') :
+				il.Language.txt('yesterday');
+		}
+
+		return new Intl.DateTimeFormat(locale, {dateStyle: 'long'}).format(new Date(time));
 	};
-})(jQuery, moment, window.il);
+
+	function diffSeconds(a, b)
+	{
+		return Math.round((a.getTime() - b.getTime()) / 1000);
+	}
+})(jQuery, window.il);

--- a/components/ILIAS/OnScreenChat/resources/onscreenchat.js
+++ b/components/ILIAS/OnScreenChat/resources/onscreenchat.js
@@ -220,7 +220,7 @@
 				});
 				$('[data-message-time]').each(() => {
 					let $this = $(this);
-					$this.attr("title", dateTimeFormatter.format($this.data("message-time", "LT")));
+					$this.attr('title', dateTimeFormatter.format($this.data('message-time'), 'LT'));
 				});
 			}, 60000);
 


### PR DESCRIPTION
This PR replaces the dependency `moment` with native JS code, as the dependency was dropped for ILIAS 11.