### PR TITLE
Category and Repository: Remove "- Copy" suffix from cloned objects title

### DIFF
--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -1692,7 +1692,6 @@ class ilObject
             );
 
             return $this->appendNumberOfCopiesToTitle(
-                $this->lng->txt('copy_n_of_suffix'),
                 $this->getTitle(),
                 $existing_titles
             );
@@ -1719,17 +1718,11 @@ class ilObject
 
         $installed_langs = $this->lng->getInstalledLanguages();
         foreach ($obj_translations->getLanguages() as $language) {
-            $lang_code = $language->getLanguageCode();
-            $suffix_lang = $lang_code;
-            if (!in_array($suffix_lang, $installed_langs)) {
-                $suffix_lang = $this->lng->getDefaultLanguage();
-            }
             $obj_translations = $obj_translations->withLanguage(
                 $language->withTitle(
                     $this->appendNumberOfCopiesToTitle(
-                        $this->lng->txtlng('common', 'copy_n_of_suffix', $suffix_lang),
                         $language->getTitle(),
-                        $title_translations_per_lang[$lang_code] ?? []
+                        $title_translations_per_lang[$language->getLanguageCode()] ?? []
                     )
                 )
             );
@@ -1755,17 +1748,16 @@ class ilObject
     }
 
     private function appendNumberOfCopiesToTitle(
-        string $copy_n_suffix,
         string $title,
         array $other_titles_for_lang
     ): string {
-        $title_without_suffix = $this->buildTitleWithoutCopySuffix($copy_n_suffix, $title);
+        $title_without_suffix = $this->buildTitleWithoutCopySuffix($title);
         if ($this->isTitleUnique($title_without_suffix, $other_titles_for_lang)) {
             return $title_without_suffix;
         }
 
         for ($i = 1; true; $i++) {
-            $title_with_suffix = $title_without_suffix . ' ' . sprintf($copy_n_suffix, $i);
+            $title_with_suffix = $title_without_suffix . " ($i)";
             if ($this->isTitleUnique($title_with_suffix, $other_titles_for_lang)) {
                 return $title_with_suffix;
             }
@@ -1782,7 +1774,7 @@ class ilObject
         return true;
     }
 
-    private function buildTitleWithoutCopySuffix(string $copy_n_suffix, string $title): string
+    private function buildTitleWithoutCopySuffix(string $title): string
     {
         /*
          * create a regular expression from the language text copy_n_of_suffix, so that
@@ -1794,7 +1786,7 @@ class ilObject
             '/([\^$.\[\]|()?*+{}])/',
             '\\\\${1}',
             ' '
-            . $copy_n_suffix
+            . '(%1$s)'
         );
         $regexp_for_file_name = '/' . preg_replace('/%1\\\\\$s/', '([0-9]+)', $regexp_for_suffix) . '$/';
 

--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -1692,7 +1692,6 @@ class ilObject
             );
 
             return $this->appendNumberOfCopiesToTitle(
-                $this->lng->txt('copy_of_suffix'),
                 $this->lng->txt('copy_n_of_suffix'),
                 $this->getTitle(),
                 $existing_titles
@@ -1728,7 +1727,6 @@ class ilObject
             $obj_translations = $obj_translations->withLanguage(
                 $language->withTitle(
                     $this->appendNumberOfCopiesToTitle(
-                        $this->lng->txtlng('common', 'copy_of_suffix', $suffix_lang),
                         $this->lng->txtlng('common', 'copy_n_of_suffix', $suffix_lang),
                         $language->getTitle(),
                         $title_translations_per_lang[$lang_code] ?? []
@@ -1757,19 +1755,16 @@ class ilObject
     }
 
     private function appendNumberOfCopiesToTitle(
-        string $copy_suffix,
         string $copy_n_suffix,
         string $title,
         array $other_titles_for_lang
     ): string {
-        $title_without_suffix = $this->buildTitleWithoutCopySuffix($copy_suffix, $copy_n_suffix, $title);
-        $title_with_suffix = "{$title_without_suffix} {$copy_suffix}";
-        if ($other_titles_for_lang === []
-            || $this->isTitleUnique($title_with_suffix, $other_titles_for_lang)) {
-            return $title_with_suffix;
+        $title_without_suffix = $this->buildTitleWithoutCopySuffix($copy_n_suffix, $title);
+        if ($this->isTitleUnique($title_without_suffix, $other_titles_for_lang)) {
+            return $title_without_suffix;
         }
 
-        for ($i = 2;true;$i++) {
+        for ($i = 1; true; $i++) {
             $title_with_suffix = $title_without_suffix . ' ' . sprintf($copy_n_suffix, $i);
             if ($this->isTitleUnique($title_with_suffix, $other_titles_for_lang)) {
                 return $title_with_suffix;
@@ -1787,7 +1782,7 @@ class ilObject
         return true;
     }
 
-    private function buildTitleWithoutCopySuffix(string $copy_suffix, string $copy_n_suffix, string $title): string
+    private function buildTitleWithoutCopySuffix(string $copy_n_suffix, string $title): string
     {
         /*
          * create a regular expression from the language text copy_n_of_suffix, so that
@@ -1805,16 +1800,6 @@ class ilObject
 
         if (preg_match($regexp_for_file_name, $title, $matches)) {
             return substr($title, 0, -strlen($matches[0]));
-        }
-
-        if (str_ends_with($title, " {$copy_suffix}")) {
-            return substr(
-                $title,
-                0,
-                -strlen(
-                    " {$copy_suffix}"
-                )
-            );
         }
 
         return $title;

--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -1757,7 +1757,7 @@ class ilObject
         }
 
         for ($i = 1; true; $i++) {
-            $title_with_suffix = $title_without_suffix . " ($i)";
+            $title_with_suffix = "{$title_without_suffix} ({$i})";
             if ($this->isTitleUnique($title_with_suffix, $other_titles_for_lang)) {
                 return $title_with_suffix;
             }

--- a/components/ILIAS/ILIASObject/classes/class.ilObject.php
+++ b/components/ILIAS/ILIASObject/classes/class.ilObject.php
@@ -1776,21 +1776,7 @@ class ilObject
 
     private function buildTitleWithoutCopySuffix(string $title): string
     {
-        /*
-         * create a regular expression from the language text copy_n_of_suffix, so that
-         * we can match it against $filenameWithoutExtension, and retrieve the number of the copy.
-         * for example, if copy_n_of_suffix is 'Copy (%1s)', this creates the regular
-         * expression '/ Copy \\([0-9]+)\\)$/'.
-         */
-        $regexp_for_suffix = preg_replace(
-            '/([\^$.\[\]|()?*+{}])/',
-            '\\\\${1}',
-            ' '
-            . '(%1$s)'
-        );
-        $regexp_for_file_name = '/' . preg_replace('/%1\\\\\$s/', '([0-9]+)', $regexp_for_suffix) . '$/';
-
-        if (preg_match($regexp_for_file_name, $title, $matches)) {
+        if (preg_match('/ \((\d+)\)$/', $title, $matches)) {
             return substr($title, 0, -strlen($matches[0]));
         }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -3766,7 +3766,7 @@ common#:#copy#:#Kopieren
 common#:#copyChapter#:#Kopieren
 common#:#copyPage#:#Kopieren
 common#:#copy_all#:#Alle kopieren
-common#:#copy_n_of_suffix#:#- Kopie (%1$s)
+common#:#copy_n_of_suffix#:#(%1$s)
 common#:#copy_of#:#Kopie von
 common#:#copy_of_suffix#:#- Kopie
 common#:#copy_perma_link#:#Link in Zwischenablage kopieren

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -3766,7 +3766,7 @@ common#:#copy#:#Copy
 common#:#copyChapter#:#Copy
 common#:#copyPage#:#Copy
 common#:#copy_all#:#Copy all
-common#:#copy_n_of_suffix#:#- Copy (%1$s)
+common#:#copy_n_of_suffix#:#(%1$s)
 common#:#copy_of#:#Copy of
 common#:#copy_of_suffix#:#- Copy
 common#:#copy_perma_link#:#Copy link to clipboard


### PR DESCRIPTION
The title of cloned objects will now only use numbered suffixes (1) (2), (...)

Starting from **(1)** or none if no object with the same name already exists in the target.

https://docu.ilias.de/go/wiki/wpage_8666_1357