### PR TITLE
Database: addForeignKey: Add `use` statement & fix sql syntax error

### DIFF
--- a/Services/Database/classes/PDO/FieldDefinition/ForeignKeyConstraints.php
+++ b/Services/Database/classes/PDO/FieldDefinition/ForeignKeyConstraints.php
@@ -1,19 +1,22 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
+ *
  * ILIAS is licensed with the GPL-3.0,
  * see https://www.gnu.org/licenses/gpl-3.0.en.html
  * You should have received a copy of said license along with the
  * source code, too.
+ *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
+ *
  *********************************************************************/
+
+declare(strict_types=1);
 
 namespace ILIAS\Services\Database\PDO\FieldDefinition;
 
@@ -21,7 +24,7 @@ enum ForeignKeyConstraints: string
 {
     case CASCADE = 'CASCADE';
     case RESTRICT = 'RESTRICT';
-    case SET_NULL = 'SET_NULL';
-    case NO_ACTION = 'NO_ACTION';
-    case SET_DEFAULT = 'SET_DEFAULT';
+    case SET_NULL = 'SET NULL';
+    case NO_ACTION = 'NO ACTION';
+    case SET_DEFAULT = 'SET DEFAULT';
 }

--- a/Services/Database/classes/PDO/Manager/class.ilDBPdoManager.php
+++ b/Services/Database/classes/PDO/Manager/class.ilDBPdoManager.php
@@ -18,6 +18,8 @@
 
 declare(strict_types=1);
 
+use ILIAS\Services\Database\PDO\FieldDefinition\ForeignKeyConstraints;
+
 /**
  * Class ilDBPdoManager
  * @author Fabian Schmid <fs@studer-raimann.ch>


### PR DESCRIPTION
This PR adds a missing `use` statement for `ForeignKeyConstraints` and fixes a SQL syntax error when using `addForeignKey` (instead of e.g. `SET_NULL` it must be `SET NULL`, see https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/optimization-and-indexes/foreign-keys).

The `addForeignKey` method was introduced in PR: #5338