### PR TITLE
TA: anon manual scoring

### DIFF
--- a/components/ILIAS/AccessControl/classes/class.ilAccess.php
+++ b/components/ILIAS/AccessControl/classes/class.ilAccess.php
@@ -540,13 +540,22 @@ class ilAccess implements ilAccessHandler
             }
         }
 
-        // in any case, if user has write permission return true
-        if ($this->checkAccessOfUser($a_user_id, "write", "", $a_ref_id)) {
-            $this->ac_cache[$cache_perm][$a_ref_id][$a_user_id] = true;
-            return true;
+        // in any case, if user has write permission return true.
+        // you may specify further exceptions in ilObj[TYPE]Access::getBypassActivationCheckForPermissions;
+        $class = $this->objDefinition->getClassName($a_type);
+        $full_class = "ilObj" . $class . "Access";
+
+        $bypass = method_exists($full_class, 'getBypassActivationCheckForPermissions') ?
+            $full_class::getBypassActivationCheckForPermissions() : ['write'];
+
+        foreach ($bypass as $permission) {
+            if ($this->checkAccessOfUser($a_user_id, $permission, "", $a_ref_id)) {
+                $this->ac_cache[$cache_perm][$a_ref_id][$a_user_id] = true;
+                return true;
+            }
         }
 
-        // no write access => check centralized offline status
+        // no write access/bypass => check centralized offline status
         if (
             $this->objDefinition->supportsOfflineHandling($a_type) &&
             ilObject::lookupOfflineStatus($a_obj_id)

--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -2413,6 +2413,21 @@ class ilObjTest extends ilObject
         );
     }
 
+    /**
+     * return int[]
+     */
+    public function getAnonOnlyParticipantIds(): array
+    {
+        $list = new ilTestParticipantList($this, $this->user, $this->lng, $this->db);
+        $list->initializeFromDbRows($this->getTestParticipants());
+        if ($this->getAnonymity()) {
+            return $list->getAllUserIds();
+        }
+        return $list->getAccessFilteredList(
+            $this->participant_access_filter->getAnonOnlyParticipantsUserFilter($this->getRefId())
+        )->getAllUserIds();
+    }
+
     public function getUnfilteredEvaluationData(): ilTestEvaluationData
     {
         return (new ilTestEvaluationFactory($this->db, $this))

--- a/components/ILIAS/Test/classes/class.ilObjTestAccess.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestAccess.php
@@ -179,7 +179,8 @@ class ilObjTestAccess extends ilObjectAccess implements ilConditionHandling
         return [
             ["permission" => "write", "cmd" => "questionsTabGateway", "lang_var" => "tst_edit_questions"],
             ["permission" => "write", "cmd" => "ILIAS\Test\Settings\MainSettings\SettingsMainGUI::showForm", "lang_var" => "settings"],
-            ["permission" => "read", "cmd" => "ILIAS\Test\Presentation\TestScreenGUI::testScreen", "lang_var" => "tst_run", "default" => true]
+            ["permission" => "read", "cmd" => "ILIAS\Test\Presentation\TestScreenGUI::testScreen", "lang_var" => "tst_run", "default" => true],
+            ["permission" => "score_anon", "cmd" => "ILIAS\Test\Scoring\Manual\TestScoringByQuestionGUI::showManScoringByQuestionParticipantsTable", "lang_var" => "manscoring", "default" => true],
         ];
     }
 
@@ -187,6 +188,17 @@ class ilObjTestAccess extends ilObjectAccess implements ilConditionHandling
     // object specific access related methods
     //
 
+    public static function getBypassActivationCheckForPermissions(): array
+    {
+        return [
+            'write',
+            'score_anon'
+        ];
+    }
+
+    /**
+    * checks wether all necessary parts of the test are given
+    */
     private static function lookupCreationComplete(int $a_obj_id): bool
     {
         global $DIC;

--- a/components/ILIAS/Test/classes/class.ilObjTestAccess.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestAccess.php
@@ -97,7 +97,14 @@ class ilObjTestAccess extends ilObjectAccess implements ilConditionHandling
             $user_id = $this->user->getId();
         }
 
-        $is_admin = $this->rbac_system->checkAccessOfUser($user_id, 'write', $ref_id);
+        $is_admin = $this->rbac_system->checkAccessOfUser($user_id, 'write', $ref_id)
+            || $this->rbac_system->checkAccessOfUser($user_id, 'score_anon', $ref_id);
+
+        $is_online = !ilObject::lookupOfflineStatus($obj_id);
+
+        if (!$is_admin && !$is_online) {
+            return false;
+        }
 
         switch ($permission) {
             case "visible":

--- a/components/ILIAS/Test/classes/class.ilObjTestAccess.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestAccess.php
@@ -196,9 +196,6 @@ class ilObjTestAccess extends ilObjectAccess implements ilConditionHandling
         ];
     }
 
-    /**
-    * checks wether all necessary parts of the test are given
-    */
     private static function lookupCreationComplete(int $a_obj_id): bool
     {
         global $DIC;

--- a/components/ILIAS/Test/classes/class.ilObjTestGUI.php
+++ b/components/ILIAS/Test/classes/class.ilObjTestGUI.php
@@ -545,7 +545,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                 break;
 
             case strtolower(TestScoringByQuestionGUI::class):
-                if ((!$this->access->checkAccess("read", "", $this->testrequest->getRefId()))) {
+                if (!$this->access->checkAccess("read", "", $this->testrequest->getRefId())
+                    && !$this->access->checkAccess("score_anon", "", $this->testrequest->getRefId())
+                ) {
                     $this->redirectAfterMissingRead();
                 }
                 $this->prepareOutput();
@@ -556,7 +558,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
                 break;
 
             case strtolower(TestScoringByParticipantGUI::class):
-                if ((!$this->access->checkAccess("read", "", $this->testrequest->getRefId()))) {
+                if (!$this->access->checkAccess("read", "", $this->testrequest->getRefId())
+                    && !$this->access->checkAccess("score_anon", "", $this->testrequest->getRefId())
+                ) {
                     $this->redirectAfterMissingRead();
                 }
                 $this->prepareOutput();

--- a/components/ILIAS/Test/classes/class.ilTestAccess.php
+++ b/components/ILIAS/Test/classes/class.ilTestAccess.php
@@ -84,19 +84,18 @@ class ilTestAccess
      */
     public function checkScoreParticipantsAccess(): bool
     {
-        if ($this->getAccess()->checkAccess('write', '', $this->getRefId())) {
-            return true;
-        }
-
         if (!$this->getAccess()->checkAccess('read', '', $this->getRefId())) {
             return false;
         }
+        return
+            $this->getAccess()->checkAccess('write', '', $this->getRefId())
+            || $this->getAccess()->checkPositionAccess(ilOrgUnitOperation::OP_SCORE_PARTICIPANTS, $this->getRefId())
+        ;
+    }
 
-        if ($this->getAccess()->checkPositionAccess(ilOrgUnitOperation::OP_SCORE_PARTICIPANTS, $this->getRefId())) {
-            return true;
-        }
-
-        return false;
+    public function checkScoreParticipantsAccessAnon(): bool
+    {
+        return $this->getAccess()->checkAccess('score_anon', '', $this->getRefId());
     }
 
     /**

--- a/components/ILIAS/Test/classes/class.ilTestParticipantAccessFilter.php
+++ b/components/ILIAS/Test/classes/class.ilTestParticipantAccessFilter.php
@@ -49,13 +49,13 @@ class ilTestParticipantAccessFilterFactory
                 $this->access->checkAccess('write', '', $ref_id, 'tst')
                 || $this->access->checkAccess('score_anon', '', $ref_id, 'tst')
             ) {
-                return $this->access->filterUserIdsByPositionOfCurrentUser(
-                    ilOrgUnitOperation::OP_SCORE_PARTICIPANTS,
-                    $ref_id,
-                    $user_ids
-                );
+                return $user_ids;
             }
-            return [];
+            return $this->access->filterUserIdsByPositionOfCurrentUser(
+                ilOrgUnitOperation::OP_SCORE_PARTICIPANTS,
+                $ref_id,
+                $user_ids
+            );
         };
     }
 

--- a/components/ILIAS/Test/classes/class.ilTestParticipantAccessFilter.php
+++ b/components/ILIAS/Test/classes/class.ilTestParticipantAccessFilter.php
@@ -45,20 +45,17 @@ class ilTestParticipantAccessFilterFactory
     public function getScoreParticipantsUserFilter(int $ref_id): Closure
     {
         return function (array $user_ids) use ($ref_id): array {
-            return array_merge(
-                $this->access->filterUserIdsByRbacOrPositionOfCurrentUser(
-                    'write',
+            if (
+                $this->access->checkAccess('write', '', $ref_id, 'tst')
+                || $this->access->checkAccess('score_anon', '', $ref_id, 'tst')
+            ) {
+                return $this->access->filterUserIdsByPositionOfCurrentUser(
                     ilOrgUnitOperation::OP_SCORE_PARTICIPANTS,
                     $ref_id,
                     $user_ids
-                ),
-                $this->access->filterUserIdsByRbacOrPositionOfCurrentUser(
-                    'score_anon',
-                    ilOrgUnitOperation::OP_SCORE_PARTICIPANTS,
-                    $ref_id,
-                    $user_ids
-                ),
-            );
+                );
+            }
+            return [];
         };
     }
 

--- a/components/ILIAS/Test/classes/class.ilTestParticipantAccessFilter.php
+++ b/components/ILIAS/Test/classes/class.ilTestParticipantAccessFilter.php
@@ -58,6 +58,22 @@ class ilTestParticipantAccessFilterFactory
             );
         };
     }
+    public function getAnonOnlyParticipantsUserFilter(int $ref_id): Closure
+    {
+        return function (array $user_ids) use ($ref_id): array {
+            //none, if write.
+            if ($this->access->checkAccess('write', '', $ref_id, 'tst')) {
+                return [];
+            }
+            //orgu permission is not anon
+            $by_orgu = $this->access->filterUserIdsByPositionOfCurrentUser(
+                ilOrgUnitOperation::OP_SCORE_PARTICIPANTS,
+                $ref_id,
+                $user_ids
+            );
+            return array_diff($user_ids, $by_orgu);
+        };
+    }
 
     public function getAccessResultsUserFilter(int $ref_id): Closure
     {

--- a/components/ILIAS/Test/classes/class.ilTestParticipantAccessFilter.php
+++ b/components/ILIAS/Test/classes/class.ilTestParticipantAccessFilter.php
@@ -45,11 +45,19 @@ class ilTestParticipantAccessFilterFactory
     public function getScoreParticipantsUserFilter(int $ref_id): Closure
     {
         return function (array $user_ids) use ($ref_id): array {
-            return $this->access->filterUserIdsByRbacOrPositionOfCurrentUser(
-                'write',
-                ilOrgUnitOperation::OP_SCORE_PARTICIPANTS,
-                $ref_id,
-                $user_ids
+            return array_merge(
+                $this->access->filterUserIdsByRbacOrPositionOfCurrentUser(
+                    'write',
+                    ilOrgUnitOperation::OP_SCORE_PARTICIPANTS,
+                    $ref_id,
+                    $user_ids
+                ),
+                $this->access->filterUserIdsByRbacOrPositionOfCurrentUser(
+                    'score_anon',
+                    ilOrgUnitOperation::OP_SCORE_PARTICIPANTS,
+                    $ref_id,
+                    $user_ids
+                ),
             );
         };
     }

--- a/components/ILIAS/Test/module.xml
+++ b/components/ILIAS/Test/module.xml
@@ -10,7 +10,7 @@
 	<objects>
 		<object id="tst" class_name="Test" dir="classes" default_pos="180" default_pres_pos="170"
 				checkbox="1" inherit="1" allow_link="1" allow_copy="1" translate="0" rbac="1"
-				orgunit_permissions="1" export="1" lti_provider="1" offline_handling="1"
+				orgunit_permissions="1" export="1" lti_provider="1" offline_handling="0"
 		>
 			<parent id="cat">cat</parent>
 			<parent id="crs">crs</parent>

--- a/components/ILIAS/Test/module.xml
+++ b/components/ILIAS/Test/module.xml
@@ -10,7 +10,7 @@
 	<objects>
 		<object id="tst" class_name="Test" dir="classes" default_pos="180" default_pres_pos="170"
 				checkbox="1" inherit="1" allow_link="1" allow_copy="1" translate="0" rbac="1"
-				orgunit_permissions="1" export="1" lti_provider="1" offline_handling="0"
+				orgunit_permissions="1" export="1" lti_provider="1" offline_handling="1"
 		>
 			<parent id="cat">cat</parent>
 			<parent id="crs">crs</parent>

--- a/components/ILIAS/Test/src/Presentation/TabsManager.php
+++ b/components/ILIAS/Test/src/Presentation/TabsManager.php
@@ -204,7 +204,8 @@ class TabsManager
 
     protected function checkScoreParticipantsTabAccess(): bool
     {
-        return $this->test_access->checkScoreParticipantsAccess();
+        return $this->test_access->checkScoreParticipantsAccess()
+            || $this->test_access->checkScoreParticipantsAccessAnon();
     }
 
     public function perform(): void

--- a/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTable.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTable.php
@@ -33,6 +33,7 @@ class ScoringByQuestionTable
     public const ACTION_SCORING = 'getAnswerDetail';
 
     public const COLUMN_NAME = 'name';
+    public const COLUMN_EXAMID = 'examid';
     public const COLUMN_ATTEMPT = 'attempt';
     public const COLUMN_POINTS_REACHED = 'points_reached';
     public const COLUMN_POINTS_AVAILABLE = 'points_available';
@@ -59,15 +60,17 @@ class ScoringByQuestionTable
         \ilUIService $ui_service,
         string $target_url,
         ScoringByQuestionTableBinder $data_retrieval,
+        bool $anonymity
     ): array {
         $filter = $this->getFilter($ui_service, $target_url, $data_retrieval->getMaxAttempts());
 
         $f = $this->ui_factory->table();
+        $columns = $anonymity ? [] : [self::COLUMN_NAME => $f->column()->text($this->lng->txt('name'))->withIsSortable(true)];
         $table = $f->data(
             $data_retrieval->withFilterData($ui_service->filter()->getData($filter) ?? []),
             $title,
-            [
-                self::COLUMN_NAME => $f->column()->text($this->lng->txt('name'))->withIsSortable(true),
+            array_merge($columns, [
+                self::COLUMN_EXAMID => $f->column()->text($this->lng->txt('exam_id_label'))->withIsSortable(true),
                 self::COLUMN_ATTEMPT => $f->column()->number($this->lng->txt('tst_attempt')),
                 self::COLUMN_POINTS_REACHED => $f
                     ->column()
@@ -95,7 +98,7 @@ class ScoringByQuestionTable
                 )->withIsSortable(true),
                 self::COLUMN_FINALIZED_BY => $f->column()->text($this->lng->txt('finalized_by'))->withIsSortable(true),
                 self::COLUMN_FINALIZED_ON => $f->column()->date($this->lng->txt('finalized_on'), $date_format)->withIsSortable(true)
-            ],
+            ])
         )->withActions(
             [
                 self::ACTION_SCORING => $f->action()->single(

--- a/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTableBinder.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTableBinder.php
@@ -61,6 +61,9 @@ class ScoringByQuestionTableBinder implements DataRetrieval
         $this->sortData($order);
         $data = array_slice($this->participant_data, $range->getStart(), $range->getLength());
         foreach ($data as $row) {
+            if (in_array($row['usr_id'], $this->test_obj->getAnonOnlyParticipantIds())) {
+                $row[ScoringByQuestionTable::COLUMN_NAME] = '';
+            }
             yield $row_builder->buildDataRow(
                 array_shift($row),
                 $row
@@ -171,7 +174,8 @@ class ScoringByQuestionTableBinder implements DataRetrieval
                     ScoringByQuestionTable::COLUMN_POINTS_AVAILABLE => $current_participant->getQuestionByAttemptAndId($pd->getPass(), $question_id)['points'] ?? 0.0,
                     ScoringByQuestionTable::COLUMN_FEEDBACK => $feedback_data['feedback'] ?? '',
                     ScoringByQuestionTable::COLUMN_FINALIZED => isset($feedback_data['finalized_evaluation']) && $feedback_data['finalized_evaluation'] === 1,
-                    ScoringByQuestionTable::COLUMN_FINALIZED_BY => $this->buildFinalizedByName($feedback_data)
+                    ScoringByQuestionTable::COLUMN_FINALIZED_BY => $this->buildFinalizedByName($feedback_data),
+                    'usr_id' => $current_participant->getUserId()
                 ];
 
                 if (isset($feedback_data['finalized_tstamp'])

--- a/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTableBinder.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/ScoringByQuestionTableBinder.php
@@ -164,7 +164,8 @@ class ScoringByQuestionTableBinder implements DataRetrieval
 
                 $row = [
                     "{$active_id}_{$pd->getPass()}",
-                    ScoringByQuestionTable::COLUMN_NAME => $this->buildParticipantName($current_participant),
+                    ScoringByQuestionTable::COLUMN_EXAMID => \ilObjTest::buildExamId($active_id, $pd->getPass(), $this->test_obj->getId()),
+                    ScoringByQuestionTable::COLUMN_NAME => $current_participant->getName(),
                     ScoringByQuestionTable::COLUMN_ATTEMPT => $pd->getPass() + 1,
                     ScoringByQuestionTable::COLUMN_POINTS_REACHED => $question_result['reached'] ?? 0.0,
                     ScoringByQuestionTable::COLUMN_POINTS_AVAILABLE => $current_participant->getQuestionByAttemptAndId($pd->getPass(), $question_id)['points'] ?? 0.0,
@@ -229,14 +230,6 @@ class ScoringByQuestionTableBinder implements DataRetrieval
             },
             []
         );
-    }
-
-    private function buildParticipantName(\ilTestEvaluationUserData $participant_data): string
-    {
-        if ($this->test_obj->getAnonymity()) {
-            return $this->lng->txt('anonymous');
-        }
-        return $participant_data->getName();
     }
 
     private function buildFinalizedByName(array $feedback_data): string

--- a/components/ILIAS/Test/src/Scoring/Manual/TestScoringByParticipantTableGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/TestScoringByParticipantTableGUI.php
@@ -63,9 +63,11 @@ class TestScoringByParticipantTableGUI extends \ilTable2GUI
 
     private function initColumns(): void
     {
-        if ($this->parent_obj->getObject()->getAnonymity()) {
-            $this->addColumn($this->lng->txt("name"), 'lastname', '100%');
-        } else {
+        $this->addColumn($this->lng->txt("exam_id_label"), 'examid', '');
+
+        if (!$this->parent_obj->getObject()->getAnonymity()
+            && $this->parent_obj->getTestAccess()->checkScoreParticipantsAccess()
+        ) {
             $this->addColumn($this->lng->txt("lastname"), 'lastname', '');
             $this->addColumn($this->lng->txt("firstname"), 'firstname', '');
             $this->addColumn($this->lng->txt("login"), 'login', '');
@@ -108,14 +110,22 @@ class TestScoringByParticipantTableGUI extends \ilTable2GUI
     {
         $this->ctrl->setParameter($this->parent_obj, 'active_id', $a_set['active_id']);
 
-        if (!$this->parent_obj->getObject()->getAnonymity()) {
+        $participant_examid = $this->getParentObject()->getUserExamId(
+            $a_set['active_id'],
+            'x'
+        );
+        $this->tpl->setVariable("PARTICIPANT_EXAMID", $participant_examid);
+
+        if (!$this->parent_obj->getObject()->getAnonymity()
+            && $this->parent_obj->getTestAccess()->checkScoreParticipantsAccess()
+        ) {
             $this->tpl->setCurrentBlock('personal');
+            $this->tpl->setVariable("PARTICIPANT_LASTNAME", $a_set['lastname']);
             $this->tpl->setVariable("PARTICIPANT_FIRSTNAME", $a_set['firstname']);
             $this->tpl->setVariable("PARTICIPANT_LOGIN", $a_set['login']);
             $this->tpl->parseCurrentBlock();
         }
 
-        $this->tpl->setVariable("PARTICIPANT_LASTNAME", $a_set['lastname']);
 
         $this->tpl->setVariable("HREF_SCORE_PARTICIPANT", $this->ctrl->getLinkTarget($this->parent_obj, self::PARENT_EDIT_SCORING_CMD));
         $this->tpl->setVariable("TXT_SCORE_PARTICIPANT", $this->lng->txt('tst_edit_scoring'));

--- a/components/ILIAS/Test/src/Scoring/Manual/TestScoringByParticipantTableGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/TestScoringByParticipantTableGUI.php
@@ -37,10 +37,11 @@ class TestScoringByParticipantTableGUI extends \ilTable2GUI
     public const PARENT_EDIT_SCORING_CMD = 'showManScoringParticipantScreen';
 
     protected bool $has_name_columns = false;
-    protected ?array $anon_only_user_ids = null;
 
-    public function __construct(TestScoringByParticipantGUI $parent_obj)
-    {
+    public function __construct(
+        TestScoringByParticipantGUI $parent_obj,
+        protected array $anon_only_user_ids
+    ) {
         $this->setPrefix('manScorePartTable');
         $this->setId('manScorePartTable');
 
@@ -110,15 +111,6 @@ class TestScoringByParticipantTableGUI extends \ilTable2GUI
         }
     }
 
-    protected function getAnonOnlyUserIds(): array
-    {
-        if ($this->anon_only_user_ids === null) {
-            $this->anon_only_user_ids =
-                $this->parent_obj->getObject()->getAnonOnlyParticipantIds();
-        }
-        return $this->anon_only_user_ids;
-    }
-
     public function fillRow(array $a_set): void
     {
         $this->ctrl->setParameter($this->parent_obj, 'active_id', $a_set['active_id']);
@@ -129,7 +121,7 @@ class TestScoringByParticipantTableGUI extends \ilTable2GUI
         );
         $this->tpl->setVariable("PARTICIPANT_EXAMID", $participant_examid);
 
-        if (in_array($a_set['usr_id'], $this->getAnonOnlyUserIds())) {
+        if (in_array($a_set['usr_id'], $this->anon_only_user_ids)) {
             $a_set['lastname'] = '';
             $a_set['firstname'] = '';
             $a_set['login'] = '';

--- a/components/ILIAS/Test/src/Scoring/Manual/TestScoringByParticipantTableGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/TestScoringByParticipantTableGUI.php
@@ -36,6 +36,9 @@ class TestScoringByParticipantTableGUI extends \ilTable2GUI
 
     public const PARENT_EDIT_SCORING_CMD = 'showManScoringParticipantScreen';
 
+    protected bool $has_name_columns = false;
+    protected ?array $anon_only_user_ids = null;
+
     public function __construct(TestScoringByParticipantGUI $parent_obj)
     {
         $this->setPrefix('manScorePartTable');
@@ -68,6 +71,7 @@ class TestScoringByParticipantTableGUI extends \ilTable2GUI
         if (!$this->parent_obj->getObject()->getAnonymity()
             && $this->parent_obj->getTestAccess()->checkScoreParticipantsAccess()
         ) {
+            $this->has_name_columns = true;
             $this->addColumn($this->lng->txt("lastname"), 'lastname', '');
             $this->addColumn($this->lng->txt("firstname"), 'firstname', '');
             $this->addColumn($this->lng->txt("login"), 'login', '');
@@ -106,6 +110,15 @@ class TestScoringByParticipantTableGUI extends \ilTable2GUI
         }
     }
 
+    protected function getAnonOnlyUserIds(): array
+    {
+        if ($this->anon_only_user_ids === null) {
+            $this->anon_only_user_ids =
+                $this->parent_obj->getObject()->getAnonOnlyParticipantIds();
+        }
+        return $this->anon_only_user_ids;
+    }
+
     public function fillRow(array $a_set): void
     {
         $this->ctrl->setParameter($this->parent_obj, 'active_id', $a_set['active_id']);
@@ -116,9 +129,12 @@ class TestScoringByParticipantTableGUI extends \ilTable2GUI
         );
         $this->tpl->setVariable("PARTICIPANT_EXAMID", $participant_examid);
 
-        if (!$this->parent_obj->getObject()->getAnonymity()
-            && $this->parent_obj->getTestAccess()->checkScoreParticipantsAccess()
-        ) {
+        if (in_array($a_set['usr_id'], $this->getAnonOnlyUserIds())) {
+            $a_set['lastname'] = '';
+            $a_set['firstname'] = '';
+            $a_set['login'] = '';
+        }
+        if ($this->has_name_columns) {
             $this->tpl->setCurrentBlock('personal');
             $this->tpl->setVariable("PARTICIPANT_LASTNAME", $a_set['lastname']);
             $this->tpl->setVariable("PARTICIPANT_FIRSTNAME", $a_set['firstname']);

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
@@ -116,7 +116,9 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
     */
     public function executeCommand(): void
     {
-        if (!$this->getTestAccess()->checkScoreParticipantsAccess()) {
+        if (!$this->getTestAccess()->checkScoreParticipantsAccess()
+            && !$this->getTestAccess()->checkScoreParticipantsAccessAnon()
+        ) {
             \ilObjTestGUI::accessViolationRedirect();
         }
 
@@ -183,7 +185,12 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
 
         $user_id = $this->object->_getUserIdFromActiveId($active_id);
         $user_fullname = $this->object->userLookupFullName($user_id, false, true);
-        $table_title = sprintf($this->lng->txt('tst_pass_overview_for_participant'), $user_fullname);
+        $participant_name = $this->getUserNamePresentation(
+            $active_id,
+            $pass,
+            $user_fullname
+        );
+        $table_title = sprintf($this->lng->txt('tst_pass_overview_for_participant'), $participant_name);
         $table->setTitle($table_title);
 
         $passOverviewData = $this->service->getPassOverviewData($active_id);
@@ -331,8 +338,10 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
         $scorer->setPreserveManualScores(true);
         $scorer->recalculateSolution($active_id, $attempt);
 
-        if ($this->object->getAnonymity() == 0) {
-            $user_name = \ilObjUser::_lookupName(\ilObjTestAccess::_getParticipantId($active_id));
+        if (!$this->object->getAnonymity()
+            && $this->getTestAccess()->checkScoreParticipantsAccess()
+        ) {
+            $user_name = ilObjUser::_lookupName(ilObjTestAccess::_getParticipantId($active_id));
             $name_real_or_anon = $user_name['firstname'] . ' ' . $user_name['lastname'];
         } else {
             $name_real_or_anon = $this->lng->txt('anonymous');
@@ -479,7 +488,6 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
     private function getManScoringQuestionGuiList(int $active_id, int $pass): array
     {
         $test_result_data = $this->object->getTestResult($active_id, $pass);
-
         $man_scoring_question_gui_list = [];
 
         foreach ($test_result_data as $question_data) {
@@ -494,7 +502,6 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
             $man_scoring_question_gui_list[ $question_data['qid'] ] = $this->object
                 ->createQuestionGUI('', $question_data['qid']);
         }
-
         return $man_scoring_question_gui_list;
     }
 
@@ -518,5 +525,26 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
         }
 
         return $table;
+    }
+
+    public function getUserNamePresentation(
+        int $active_id,
+        int|string $pass,
+        ?string $name = null
+    ): string {
+
+        if ($name !== null
+            && !$this->object->getAnonymity()
+            && $this->getTestAccess()->checkScoreParticipantsAccess()
+        ) {
+            return $name;
+        }
+
+        return $this->getUserExamId($active_id, (string) $pass);
+    }
+
+    public function getUserExamId(int $active_id, string $pass): string
+    {
+        return \ilObjTest::buildExamId($active_id, $pass, $this->object->getId());
     }
 }

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
@@ -532,7 +532,6 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
         int|string $pass,
         ?string $name = null
     ): string {
-
         if ($name !== null
             && !$this->object->getAnonymity()
             && $this->getTestAccess()->checkScoreParticipantsAccess()

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
@@ -532,10 +532,9 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
         int|string $pass,
         ?string $name = null
     ): string {
-        if ($name !== null
-            && !$this->object->getAnonymity()
-            && $this->getTestAccess()->checkScoreParticipantsAccess()
-        ) {
+        $anon_only_usr_ids = $this->object->getAnonOnlyParticipantIds();
+        $user_id = $this->object->_getUserIdFromActiveId($active_id);
+        if ($name !== null && !in_array($user_id, $anon_only_usr_ids)) {
             return $name;
         }
 

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByParticipantGUI.php
@@ -507,7 +507,10 @@ class TestScoringByParticipantGUI extends \ilTestServiceGUI
 
     private function buildManScoringParticipantsTable(bool $with_data = false): TestScoringByParticipantTableGUI
     {
-        $table = new TestScoringByParticipantTableGUI($this);
+        $table = new TestScoringByParticipantTableGUI(
+            $this,
+            $this->object->getAnonOnlyParticipantIds()
+        );
 
         if ($with_data) {
             $participant_list = new \ilTestParticipantList($this->object, $this->user, $this->lng, $this->db);

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
@@ -85,10 +85,10 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
 
         $this->initJavascript();
 
-        if (! ($this->test_access->checkScoreParticipantsAccess()
-            || $this->test_access->checkScoreParticipantsAccessAnon())
-            || !$this->object->getGlobalSettings()->isManualScoringEnabled()
-        ) {
+        $globally_enabled = $this->object->getGlobalSettings()->isManualScoringEnabled();
+        $access_granted = $this->test_access->checkScoreParticipantsAccess()
+            || $this->test_access->checkScoreParticipantsAccessAnon();
+        if (!($globally_enabled && $access_granted)) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('cannot_edit_test'), true);
             $this->ctrl->redirectByClass([\ilRepositoryGUI::class, \ilObjTestGUI::class, \ilInfoScreenGUI::class]);
         }

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
@@ -144,7 +144,7 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
                     $this->object,
                     $question_id
                 ),
-                $this->object->getAnonymity() || !$this->test_access->checkScoreParticipantsAccess()
+                $this->object->getAnonymity() || !$this->test_access->checkScoreParticipantsAccess(),
             )
         ];
 
@@ -382,8 +382,9 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
 
     private function getModalTitle(int $active_id, int $attempt): string
     {
+        $usr_id = $this->object->_getUserIdFromActiveId($active_id);
         if ($this->object->getAnonymity() === true
-            || $this->test_access->checkScoreParticipantsAccess() === false
+            || in_array($usr_id, $this->object->getAnonOnlyParticipantIds())
         ) {
             return $this->lng->txt('answers_of')
                 . ' '

--- a/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
+++ b/components/ILIAS/Test/src/Scoring/Manual/class.TestScoringByQuestionGUI.php
@@ -85,8 +85,10 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
 
         $this->initJavascript();
 
-        if (!$this->test_access->checkScoreParticipantsAccess()
-            || !$this->object->getGlobalSettings()->isManualScoringEnabled()) {
+        if (! ($this->test_access->checkScoreParticipantsAccess()
+            || $this->test_access->checkScoreParticipantsAccessAnon())
+            || !$this->object->getGlobalSettings()->isManualScoringEnabled()
+        ) {
             $this->tpl->setOnScreenMessage('info', $this->lng->txt('cannot_edit_test'), true);
             $this->ctrl->redirectByClass([\ilRepositoryGUI::class, \ilObjTestGUI::class, \ilInfoScreenGUI::class]);
         }
@@ -141,7 +143,8 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
                     $this->participant_access_filter,
                     $this->object,
                     $question_id
-                )
+                ),
+                $this->object->getAnonymity() || !$this->test_access->checkScoreParticipantsAccess()
             )
         ];
 
@@ -332,7 +335,7 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
         ))->getHTMLAsync());
 
         return $this->ui_factory->modal()->roundtrip(
-            $this->getModalTitle($active_id),
+            $this->getModalTitle($active_id, $attempt),
             $content
         );
     }
@@ -377,10 +380,14 @@ class TestScoringByQuestionGUI extends TestScoringByParticipantGUI
         );
     }
 
-    private function getModalTitle(int $active_id): string
+    private function getModalTitle(int $active_id, int $attempt): string
     {
-        if ($this->object->getAnonymity() === true) {
-            return $this->lng->txt('answers_of') . ' ' . $this->lng->txt('anonymous');
+        if ($this->object->getAnonymity() === true
+            || $this->test_access->checkScoreParticipantsAccess() === false
+        ) {
+            return $this->lng->txt('answers_of')
+                . ' '
+                . \ilObjTest::buildExamId($active_id, $attempt, $this->object->getId());
         }
         return $this->lng->txt('answers_of') . ' ' . $this->object->getCompleteEvaluationData()
             ->getParticipant($active_id)

--- a/components/ILIAS/Test/src/Setup/TestSetupAgent.php
+++ b/components/ILIAS/Test/src/Setup/TestSetupAgent.php
@@ -55,6 +55,13 @@ class TestSetupAgent extends NullAgent
             new \ilDatabaseUpdateStepsExecutedObjective(
                 new ilTestNoHintsDBUpdateSteps()
             ),
+            new \ilAccessCustomRBACOperationAddedObjective(
+                'score_anon',
+                'Score Pseudonymously',
+                'object',
+                5000,
+                ['tst']
+            ),
         );
     }
 

--- a/components/ILIAS/Test/templates/default/tpl.il_as_tst_man_scoring_participant_tblrow.html
+++ b/components/ILIAS/Test/templates/default/tpl.il_as_tst_man_scoring_participant_tblrow.html
@@ -1,6 +1,7 @@
 <tr class="{CSS_ROW}">
-	<td class="std">{PARTICIPANT_LASTNAME}</td>
+	<td class="std">{PARTICIPANT_EXAMID}</td>
 	<!-- BEGIN personal -->
+	<td class="std">{PARTICIPANT_LASTNAME}</td>
 	<td class="std">{PARTICIPANT_FIRSTNAME}</td>
 	<td class="std">{PARTICIPANT_LOGIN}</td>
 	<!-- END personal -->

--- a/components/ILIAS/Test/tests/tables/TestScoringByParticipantTableGUITest.php
+++ b/components/ILIAS/Test/tests/tables/TestScoringByParticipantTableGUITest.php
@@ -69,7 +69,7 @@ class TestScoringByParticipantTableGUITest extends ilTestBaseTestCase
         $this->parentObj_mock->expects($this->any())->method('getObject')->willReturn($this->getTestObjMock());
         $this->parentObj_mock->expects($this->any())->method('getTestAccess')->willReturn($access_mock);
 
-        $this->tableGui = new TestScoringByParticipantTableGUI($this->parentObj_mock, "");
+        $this->tableGui = new TestScoringByParticipantTableGUI($this->parentObj_mock, []);
     }
 
     public function test_instantiateObject_shouldReturnInstance(): void

--- a/components/ILIAS/Test/tests/tables/TestScoringByParticipantTableGUITest.php
+++ b/components/ILIAS/Test/tests/tables/TestScoringByParticipantTableGUITest.php
@@ -48,6 +48,11 @@ class TestScoringByParticipantTableGUITest extends ilTestBaseTestCase
                       return "testFormAction";
                   });
 
+        $access_mock = $this->createMock(ilTestAccess::class);
+        $access_mock->expects($this->exactly(1))
+                  ->method("checkScoreParticipantsAccess")
+                  ->willReturn(true);
+
         $this->setGlobalVariable("lng", $lng_mock);
         $this->setGlobalVariable("ilCtrl", $ctrl_mock);
         $this->setGlobalVariable("tpl", $this->createMock(ilGlobalPageTemplate::class));
@@ -57,8 +62,13 @@ class TestScoringByParticipantTableGUITest extends ilTestBaseTestCase
         $this->setGlobalVariable("component.factory", $component_factory);
         $this->setGlobalVariable("ilDB", $this->createMock(ilDBInterface::class));
 
-        $this->parentObj_mock = $this->getMockBuilder(TestScoringByParticipantGUI::class)->disableOriginalConstructor()->onlyMethods(['getObject'])->getMock();
+        $this->parentObj_mock = $this->getMockBuilder(TestScoringByParticipantGUI::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getObject', 'getTestAccess'])
+            ->getMock();
         $this->parentObj_mock->expects($this->any())->method('getObject')->willReturn($this->getTestObjMock());
+        $this->parentObj_mock->expects($this->any())->method('getTestAccess')->willReturn($access_mock);
+
         $this->tableGui = new TestScoringByParticipantTableGUI($this->parentObj_mock, "");
     }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1219,6 +1219,7 @@ assessment#:#save_on_navigation_confirmation#:#Ihre geänderten Antworten werden
 assessment#:#save_on_navigation_forced_feedback_hint#:#Vorher erhalten Sie Feedback zu Ihrer Antwort.
 assessment#:#save_on_navigation_locked_confirmation#:#Ihre geänderten Antworten werden beim Navigieren automatisch gespeichert und festgeschrieben.
 assessment#:#saved_adjustment#:#Veränderung gespeichert.
+assessment#:#score_anon#:#Anonym bewerten
 assessment#:#score_partsol_enabled#:#Halbpunktebewertung aktivieren
 assessment#:#score_partsol_enabled_info#:#Es hat sich als sinnvoll erwiesen, drei korrekte Antworten bereits mit der Hälfte der maximal erreichbaren Punktezahl zu honorieren. Bei weniger als drei korrekten Antworten werden keine Punkte vergeben.
 assessment#:#scored_pass#:#Bewerteter Durchlauf

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1220,6 +1220,7 @@ assessment#:#save_on_navigation_confirmation#:#Your changed answers will be auto
 assessment#:#save_on_navigation_forced_feedback_hint#:#Before you get feedback on your given answer.###fau: testNav
 assessment#:#save_on_navigation_locked_confirmation#:#Your changed answers will be automatically saved and locked when you navigate.###fau: testNav
 assessment#:#saved_adjustment#:#Changes saved.
+assessment#:#score_anon#:#Score anonymously
 assessment#:#score_partsol_enabled#:#Activate Half-Point Scoring
 assessment#:#score_partsol_enabled_info#:#Usually the participant has to answer the question fully correct to get the configured points. With this option the participant gets the half of the configured points with at least three correct decisions.
 assessment#:#scored_pass#:#Scored Test Attempt


### PR DESCRIPTION
https://docu.ilias.de/go/wiki/wpage_8202_1357

This adds a permission to access scoring, anonymized.
The users' examIds will be used as names.