### PR TITLE
Main Menu Administration order

### DIFF
--- a/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
+++ b/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
@@ -227,8 +227,8 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
             "extending_ilias" =>
                 array('ecss', "ltis", "wbdv", "cmis", "cmps", "extt"),
             "repository_and_objects" =>
-                array("reps", "crss", "grps", "prgs", "bibs", "blga", "cpad", "chta", "facs", "frma", "lrss",
-                      "mcts", "mobs", "svyf", "assf", "wbrs", 'lsos'),
+                array("reps", "crss", "grps", "prgs", "bibs", "blga", "cpad", "chta", "facs", "frma", "lrss", 'lsos',
+                      "mcts", "mobs", "svyf", "assf", "wbrs"),
         );
         $groups = [];
         // now get all items and groups that are accessible

--- a/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
+++ b/components/ILIAS/Administration/GlobalScreen/classes/AdministrationMainBarProvider.php
@@ -212,23 +212,23 @@ class AdministrationMainBarProvider extends AbstractStaticMainMenuProvider
                 array("adm", "lngf", "hlps", "wfe", 'fils', 'logs', 'sysc', "recf", "root"),
             "layout_and_navigation" =>
                 array("mme", "gsfo", "dshs", "stys", "adve"),
-            "repository_and_objects" =>
-                array("reps", "crss", "grps", "prgs", "bibs", "blga", "cpad", "chta", "facs", "frma", "lrss",
-                      "mcts", "mobs", "svyf", "assf", "wbrs", 'lsos'),
+            "legal_regulations" =>
+                array("impr" ,"tos", "accs", 'dpro'),
+            "user_administration" =>
+                array("usrf", "rolf", "otpl", "auth", "ps"),
             "personal_workspace" =>
                 array("tags", "cals", "prfa", "prss", "nots"),
             "achievements" =>
                 array("lhts", "skmg", "trac", "bdga", "cert"),
             "communication" =>
                 array("mail", "cadm", "nwss", "coms", "adn", "awra", "nota"),
-            "user_administration" =>
-                array("usrf", "rolf", "otpl", "auth", "ps"),
             "search_and_find" =>
                 array("seas", "mds", "taxs"),
             "extending_ilias" =>
                 array('ecss', "ltis", "wbdv", "cmis", "cmps", "extt"),
-            "legal_regulations" =>
-                array("impr" ,"tos", "accs", 'dpro')
+            "repository_and_objects" =>
+                array("reps", "crss", "grps", "prgs", "bibs", "blga", "cpad", "chta", "facs", "frma", "lrss",
+                      "mcts", "mobs", "svyf", "assf", "wbrs", 'lsos'),
         );
         $groups = [];
         // now get all items and groups that are accessible


### PR DESCRIPTION
Change the order of the administration main menu to:
1. System Settings and Maintenance
2. Layout and Navigation
3. Legal Regulations
4. Users and Roles
5. Personal Workspace
6. Achievements
7. Communication
8. Organisation
9. Search an Find
10. Extending ILIAS
11. Repository and Objects