### PR TITLE
Possible type error fixed: ilSCORMOrganizations::setDefaultOrganization()

### DIFF
--- a/Modules/ScormAicc/classes/SCORM/class.ilSCORMOrganizations.php
+++ b/Modules/ScormAicc/classes/SCORM/class.ilSCORMOrganizations.php
@@ -68,7 +68,7 @@ class ilSCORMOrganizations extends ilSCORMObject
             array($this->getId())
         );
         $obj_rec = $ilDB->fetchAssoc($obj_set);
-        $this->setDefaultOrganization($obj_rec["default_organization"]);
+        $this->setDefaultOrganization($obj_rec["default_organization"] ?? '');
     }
 
     public function create(): void


### PR DESCRIPTION
TypeError thrown with message "ilSCORMOrganizations::setDefaultOrganization(): Argument 0000001 ($a_def_org) must be of type string, null given, called in /Modules/ScormAicc/classes/SCORM/class.ilSCORMOrganizations.php on line 71"
https://mantis.ilias.de/view.php?id=45306