### PR TITLE
BookingManager 42784: Disable group switch parent options only

### DIFF
--- a/components/ILIAS/BookingManager/Service/Form/FormAdapterGUI.php
+++ b/components/ILIAS/BookingManager/Service/Form/FormAdapterGUI.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\BookingManager\Service\Form;
+
+use ILIAS\Repository\Form\FormAdapterGUI as RepositoryFormAdapterGUI;
+use ILIAS\UI\Implementation\Component\Input\Field\SwitchableGroup;
+
+class FormAdapterGUI extends RepositoryFormAdapterGUI
+{
+    public function disabledGroup($disabled = true): self
+    {
+        if ($disabled && ($field = $this->getLastField()) && $field instanceof SwitchableGroup) {
+            $field = $field->withDisabledGroupSwitch(true);
+            $this->disable[$this->last_key] = true;
+            $this->replaceLastField($field);
+        }
+        return $this;
+    }
+}

--- a/components/ILIAS/BookingManager/Settings/class.SettingsGUI.php
+++ b/components/ILIAS/BookingManager/Settings/class.SettingsGUI.php
@@ -22,9 +22,9 @@ namespace ILIAS\BookingManager\Settings;
 
 use ILIAS\BookingManager\InternalDomainService;
 use ILIAS\BookingManager\InternalGUIService;
-use ILIAS\Repository\Form\FormAdapterGUI;
 use ILIAS\BookingManager\InternalDataService;
 use ilDidacticTemplateGUI;
+use ILIAS\BookingManager\Service\Form\FormAdapterGUI;
 
 /**
  * @ilCtrl_Calls ILIAS\BookingManager\Settings\SettingsGUI: ilDidacticTemplateGUI
@@ -76,12 +76,12 @@ class SettingsGUI
     {
         $lng = $this->domain->lng();
         $settings = $this->domain->bookingSettings()->getByObjId($this->obj_id);
-        $form = $this->gui->form(self::class, "save")
-                          ->section("general", $lng->txt("book_edit"))
-                          ->addStdTitleAndDescription(
-                              $this->obj_id,
-                              "book"
-                          );
+        $form = (new FormAdapterGUI(self::class, 'save'))
+            ->section("general", $lng->txt("book_edit"))
+            ->addStdTitleAndDescription(
+                $this->obj_id,
+                "book"
+            );
         $form = $form->addDidacticTemplates(
             "book",
             $this->ref_id,
@@ -180,7 +180,7 @@ class SettingsGUI
         $form->end();
 
         if ($mode_disabled) {
-            $form = $form->disabled(true);
+            $form = $form->disabledGroup(true);
         }
 
         $form = $form


### PR DESCRIPTION
This PR addresses Mantis tickets https://mantis.ilias.de/view.php?id=42784 and https://mantis.ilias.de/view.php?id=44203.

With these changes, only the parent options of the stype group switch are disabled once the first booking items have been added to the object.

To fix the issue without introducing changes to other modules, we implemented the behavior by extending `ilFormAdapterGUI` from the `Repository` module with a custom version within our own module.