### PR TITLE
Mantis #0045481: Fix for error when trying to call documentation of ILIASSoapWebservice

### DIFF
--- a/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
+++ b/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
@@ -1469,6 +1469,12 @@ class ilNusoapUserAdministrationAdapter
             'Process task in background'
         );
 
+        // Note: We need a context that does not handle authentication at this point, because this is
+        // handled by an actual SOAP request which always contains the session ID and client
+        ilContext::init(ilContext::CONTEXT_SOAP_NO_AUTH);
+        ilInitialisation::initILIAS();
+        ilContext::init(ilContext::CONTEXT_SOAP);
+
         // OrgUnits Functions
         /**
          * @var $f Base[]
@@ -1511,12 +1517,6 @@ class ilNusoapUserAdministrationAdapter
      */
     protected function handleSoapPlugins(): void
     {
-        // Note: We need a context that does not handle authentication at this point, because this is
-        // handled by an actual SOAP request which always contains the session ID and client
-        ilContext::init(ilContext::CONTEXT_SOAP_NO_AUTH);
-        ilInitialisation::initILIAS();
-        ilContext::init(ilContext::CONTEXT_SOAP);
-
         global $DIC;
 
         $component_factory = $DIC['component.factory'];

--- a/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
+++ b/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php
@@ -1469,12 +1469,6 @@ class ilNusoapUserAdministrationAdapter
             'Process task in background'
         );
 
-        // Note: We need a context that does not handle authentication at this point, because this is
-        // handled by an actual SOAP request which always contains the session ID and client
-        ilContext::init(ilContext::CONTEXT_SOAP_NO_AUTH);
-        ilInitialisation::initILIAS();
-        ilContext::init(ilContext::CONTEXT_SOAP);
-
         // OrgUnits Functions
         /**
          * @var $f Base[]
@@ -1517,6 +1511,12 @@ class ilNusoapUserAdministrationAdapter
      */
     protected function handleSoapPlugins(): void
     {
+        // Note: We need a context that does not handle authentication at this point, because this is
+        // handled by an actual SOAP request which always contains the session ID and client
+        ilContext::init(ilContext::CONTEXT_SOAP_NO_AUTH);
+        ilInitialisation::initILIAS();
+        ilContext::init(ilContext::CONTEXT_SOAP);
+
         global $DIC;
 
         $component_factory = $DIC['component.factory'];

--- a/webservice/soap/nusoapserver.php
+++ b/webservice/soap/nusoapserver.php
@@ -40,6 +40,9 @@ if (!defined('ILIAS_MODULE') || (defined('ILIAS_MODULE') && ILIAS_MODULE !== "we
     define("IL_SOAPMODE", IL_SOAPMODE_NUSOAP);
 }
 
+include_once "Services/Init/classes/class.ilInitialisation.php";
+ilInitialisation::initILIAS();
+
 include_once './webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php';
 $server = new ilNusoapUserAdministrationAdapter(true);
 $server->start();


### PR DESCRIPTION
### Problem:

Fatal exception when visiting `<BASE_URL>/webservice/soap/server.php`.

- original ticket: https://mantis.ilias.de/view.php?id=45481
- issue demo: https://docu.ilias.de/webservice/soap/server.php

```
Fatal error: Uncaught Pimple\Exception\UnknownIdentifierException: Identifier "ilDB" is not defined. in /srv/www/docu.ilias.de/html/ilias/libs/composer/vendor/pimple/pimple/src/Pimple/Container.php:105
Stack trace:
#0 /srv/www/docu.ilias.de/html/ilias/Modules/OrgUnit/classes/class.ilOrgUnitLocalDIC.php(44): Pimple\Container-&gt;offsetGet('ilDB')
#1 /srv/www/docu.ilias.de/html/ilias/libs/composer/vendor/pimple/pimple/src/Pimple/Container.php(122): ilOrgUnitLocalDIC::{closure}(Object(Pimple\Container))
#2 /srv/www/docu.ilias.de/html/ilias/Modules/OrgUnit/classes/Webservices/SOAP/Base.php(54): Pimple\Container-&gt;offsetGet('repo.Positions')
#3 /srv/www/docu.ilias.de/html/ilias/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php(1477): ILIAS\OrgUnit\Webservices\SOAP\Base-&gt;__construct()
#4 /srv/www/docu.ilias.de/html/ilias/webservice/soap/classes/class.ilNusoapUserAdministrationAdapter.php(62): ilNusoapUserAdministrationAdapter-&gt;registerMethods()
#5 /srv/www/docu.ilias.de/html/ilias/webservice/soap/nusoapserver.php(44): ilNusoapUserAdministrationAdapter-&gt;__construct(true)
#6 /srv/www/docu.ilias.de/html/ilias/webservice/soap/server.php(53):
```


---

### Reason:

Pimple container was introduced in _release_9_ and it requires some dependencies from `$DIC` before ILIAS is initialized and `$DIC` properly populated. 

---

### Solution:

initialize ILIAS core container before nusoap server is initiated. 