### PR TITLE
T&A 45356: Disables starting and ending period input of test if participant data already exists

### DIFF
--- a/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
+++ b/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
@@ -477,7 +477,8 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
             ->withTimezone($this->activeUser->getTimeZone())
             ->withFormat($format)
             ->withUseTime(true)
-            ->withRequired(true);
+            ->withRequired(true)
+            ->withDisabled($this->test_object->participantDataExist());
         $inputs['activation_visibility'] = $field_factory->checkbox(
             $this->lng->txt('rep_activation_limited_visibility'),
             $this->lng->txt('tst_activation_limited_visibility_info')


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45356

This PR aims to disable the starting and ending period input of a test if participant data already exists.

Already reviewed by @thojou.