### PR TITLE
BT9 37203: Fixes issue when creating a schedule and leaving the deadline empty when x hours before time slot begins is selected

### DIFF
--- a/Modules/BookingManager/Schedule/class.ilBookingScheduleGUI.php
+++ b/Modules/BookingManager/Schedule/class.ilBookingScheduleGUI.php
@@ -184,6 +184,7 @@ class ilBookingScheduleGUI
         $deadline->setMinValue(1);
         $deadline->setSize(3);
         $deadline->setMaxLength(3);
+        $deadline->setRequired(true);
         $deadline_time->addSubItem($deadline);
 
         $deadline_start = new ilRadioOption($lng->txt("book_deadline_slot_start"), "slot_start");


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=37203

Aims to fix the issue when creating a schedule and leaving the deadline empty when x hours before time slot begins is selected.

Already reviewed by @thojou.