### PR TITLE
BT 37436: Fixes issues where messagebox is not displayed, when adding already added participants to booking pool

### DIFF
--- a/components/ILIAS/BookingManager/Participants/class.ilBookingParticipantGUI.php
+++ b/components/ILIAS/BookingManager/Participants/class.ilBookingParticipantGUI.php
@@ -151,7 +151,7 @@ class ilBookingParticipantGUI
                 if ($participant_obj->getIsNew()) {
                     $this->tpl->setOnScreenMessage('success', $this->lng->txt("book_participant_assigned"), true);
                 } else {
-                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt("book_participant_already_assigned"));
+                    $this->tpl->setOnScreenMessage('failure', $this->lng->txt("book_participant_already_assigned"), true);
                 }
             } else {
                 $this->tpl->setOnScreenMessage('failure', "dummy error message, change me");


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=37436

Aims to fix the issue where messagebox is not displayed, when adding already added participants to booking pool.

Already reviewed by @thojou.

Release 9: #9864 