### PR TITLE
BT 32520: Changes language variable in repository action menu from common#:#edit_content to book#:#book_booking_objects

### DIFF
--- a/Modules/BookingManager/classes/class.ilObjBookingPoolAccess.php
+++ b/Modules/BookingManager/classes/class.ilObjBookingPoolAccess.php
@@ -36,7 +36,7 @@ class ilObjBookingPoolAccess extends ilObjectAccess
     {
         $commands = array();
         $commands[] = array("permission" => "read", "cmd" => "render", "lang_var" => "show", "default" => true);
-        $commands[] = array("permission" => "write", "cmd" => "render", "lang_var" => "edit_content");
+        $commands[] = array("permission" => "write", "cmd" => "render", "lang_var" => "book_booking_objects");
         $commands[] = array("permission" => "write", "cmd" => "edit", "lang_var" => "settings");
 
         return $commands;

--- a/Modules/BookingManager/classes/class.ilObjBookingPoolListGUI.php
+++ b/Modules/BookingManager/classes/class.ilObjBookingPoolListGUI.php
@@ -50,6 +50,7 @@ class ilObjBookingPoolListGUI extends ilObjectListGUI
 
         // general commands array
         $this->commands = ilObjBookingPoolAccess::_getCommands();
+        $this->lng->loadLanguageModule('book');
     }
 
     public function getCommandLink(string $cmd): string


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=32520

Aims to change language variables in repository action menu from common#:#edit_content to book#:#book_booking_objects for booking pools.

Already reviewed by @thojou.