### PR TITLE
RTE, Utilities: Add function to replace latex span

### DIFF
--- a/components/ILIAS/RTE/classes/class.ilRTE.php
+++ b/components/ILIAS/RTE/classes/class.ilRTE.php
@@ -178,6 +178,8 @@ class ilRTE
     {
         $start = '<span class="latex">';
         $end = '</span>';
+        $start_len = ilStr::strLen($start);
+        $end_len = ilStr::strLen($end);
 
         // current position to start the search for delimiters
         $cpos = 0;
@@ -186,25 +188,22 @@ class ilRTE
         while (is_int($spos = ilStr::strIPos($text, $start, $cpos))) {
 
             // find position of end delimiter
-            if (is_int($epos = ilStr::strIPos($text, $end, $spos + ilStr::strLen($start)))) {
-
-                // extract the tex code inside the delimiters
-                $tex = ilStr::subStr($text, $spos + ilStr::strLen($start), $epos - $spos - ilStr::strLen($start));
-
-                //wrap in new delimiters
-                $replacement = '[tex]' . $tex . '[/tex]';
-
-                // replace delimiters and tex code with prepared code or generated image
-                $text = ilStr::subStr($text, 0, $spos) . $replacement
-                    . ilStr::subStr($text, $epos + ilStr::strLen($end));
-
-                // continue search behind replacement
-                $cpos = $spos + ilStr::strLen($replacement);
-
-            } else {
-                // end delimiter position not found => stop search
+            $epos = ilStr::strIPos($text, $end, $spos + $start_len);
+            if (!is_int($epos)) {
                 break;
             }
+
+            // extract the tex code inside the delimiters
+            $tex = ilStr::subStr($text, $spos + $start_len, $epos - $spos - $start_len);
+
+            // wrap the tex code in new delimiters
+            $replace = '[tex]' . $tex . '[/tex]';
+
+            // replace the span
+            $text = ilStr::subStr($text, 0, $spos) . $replace . ilStr::subStr($text, $epos + $end_len);
+
+            // continue search behind the replacement
+            $cpos = $spos + ilStr::strLen($replace);
 
             if ($cpos >= ilStr::strlen($text)) {
                 // current position at the end => stop search

--- a/components/ILIAS/RTE/classes/class.ilRTE.php
+++ b/components/ILIAS/RTE/classes/class.ilRTE.php
@@ -165,6 +165,57 @@ class ilRTE
     }
 
     /**
+     * Replace the latex delimiters used by the rich text editor
+     * Unfortunately these can't be processed by MathJax:
+     * "Note that the delimiters can’t look like HTML tags (i.e., can’t include the less-than sign),
+     * as these would be turned into tags by the browser before MathJax has the chance to run.
+     * You can only include text, not tags, as your math delimiters."
+     * @see https://docs.mathjax.org/en/latest/options/input/tex.html#option-descriptions
+     *
+     * This function should called by components that display RTE content.
+     */
+    public static function replaceLatexSpan(string $text): string
+    {
+        $start = '<span class="latex">';
+        $end = '</span>';
+
+        // current position to start the search for delimiters
+        $cpos = 0;
+
+        // find position of start delimiter
+        while (is_int($spos = ilStr::strIPos($text, $start, $cpos))) {
+
+            // find position of end delimiter
+            if (is_int($epos = ilStr::strIPos($text, $end, $spos + ilStr::strLen($start)))) {
+
+                // extract the tex code inside the delimiters
+                $tex = ilStr::subStr($text, $spos + ilStr::strLen($start), $epos - $spos - ilStr::strLen($start));
+
+                //wrap in new delimiters
+                $replacement = '[tex]' . $tex . '[/tex]';
+
+                // replace delimiters and tex code with prepared code or generated image
+                $text = ilStr::subStr($text, 0, $spos) . $replacement
+                    . ilStr::subStr($text, $epos + ilStr::strLen($end));
+
+                // continue search behind replacement
+                $cpos = $spos + ilStr::strLen($replacement);
+
+            } else {
+                // end delimiter position not found => stop search
+                break;
+            }
+
+            if ($cpos >= ilStr::strlen($text)) {
+                // current position at the end => stop search
+                break;
+            }
+        }
+
+        return $text;
+    }
+
+    /**
      * Replaces image source from mob image urls with the mob id or replaces mob id with the correct image source
      * @param string $a_text text, including media object tags
      * @param integer $a_direction 0 to replace image src => mob id, 1 to replace mob id => image src

--- a/components/ILIAS/Utilities/classes/class.ilLegacyFormElementsUtil.php
+++ b/components/ILIAS/Utilities/classes/class.ilLegacyFormElementsUtil.php
@@ -135,14 +135,9 @@ class ilLegacyFormElementsUtil
             }
         }
 
-        // since server side mathjax rendering does include svg-xml structures that indeed have linebreaks,
-        // do latex conversion AFTER replacing linebreaks with <br>. <svg> tag MUST NOT contain any <br> tags.
         if ($prepare_for_latex_output) {
-            $result = ilMathJax::getInstance()->insertLatexImages($result, "\<span class\=\"latex\">", "\<\/span>");
-            $result = ilMathJax::getInstance()->insertLatexImages($result, "\[tex\]", "\[\/tex\]");
-        }
+            $result = ilRTE::replaceLatexSpan($result);
 
-        if ($prepare_for_latex_output) {
             // replace special characters to prevent problems with the ILIAS template system
             // eg. if someone uses {1} as an answer, nothing will be shown without the replacement
             $result = str_replace("{", "&#123;", $result);


### PR DESCRIPTION
The span element used by the RTE editor for latex code is not supported by MathJax. So it needs to be replaced by the supported delimiters. This was formerly done by: 

````php
$text = ilMathJax::getInstance()->insertLatexImages($text, '<span class="latex">, '</span>');
````
With the deprecation of the MathJax service and its replacement by  `Legacy\LatexContent` UI component this does not work anymore.  Existing latex in RTE content will no longer be rendered, if it was not entered by hand with the delimiters [tex] and [/tex].

The new function is a replacement for this call. It should be used in conjuction with the new `Legacy\LatexContent` UI component when RTE content is rendered:

````php
$text = ilRTE::replaceLatexSpan($text);
$text = $this->ui_renderer->render($this->ui_factory->legacy()->latexContent($text));
````

In the widely used function `ilLegacyFormElementsUtil::prepareTextareaOutput` the call of ilMathJax is replaced by a call of the new function. This will be done if the parameter `$prepare_for_latex_output` indicates that the content is be used for display with latex rendering instead of filling a textarea. The new call just ensures the correct delimiters for the display. The wrapping in `Legacy\LatexContent` must be done by the calling component.

