### PR TITLE
Forum: Migrate MathJax calls to UI

### DIFF
--- a/components/ILIAS/Forum/classes/GUI/class.ilForumThreadFormGUI.php
+++ b/components/ILIAS/Forum/classes/GUI/class.ilForumThreadFormGUI.php
@@ -91,6 +91,7 @@ class ilForumThreadFormGUI extends ilPropertyFormGUI
             'formatselect'
         ]);
         $message->setPurifier(ilHtmlPurifierFactory::getInstanceByType('frm_post'));
+        $message->setInfo($this->lng->txt('latex_edit_info'));
         $this->addItem($message);
     }
 

--- a/components/ILIAS/Forum/classes/class.ilForum.php
+++ b/components/ILIAS/Forum/classes/class.ilForum.php
@@ -54,6 +54,8 @@ class ilForum
     public ilDBInterface $db;
     public ilObjUser $user;
     public ilSetting $settings;
+    private ILIAS\UI\Factory $ui_factory;
+    private ILIAS\UI\Renderer $ui_renderer;
 
     public function __construct()
     {
@@ -65,6 +67,8 @@ class ilForum
         $this->user = $DIC->user();
         $this->settings = $DIC->settings();
         $this->event = $DIC->event();
+        $this->ui_factory = $DIC->ui()->factory();
+        $this->ui_renderer = $DIC->ui()->renderer();
     }
 
     public function setForumId(int $a_obj_id): void
@@ -1484,8 +1488,9 @@ class ilForum
 
         if ($type !== 'export') {
             if ($edit === 0) {
-                $text = ilMathJax::getInstance()->insertLatexImages($text, "\<span class\=\"latex\">", "\<\/span>");
-                $text = ilMathJax::getInstance()->insertLatexImages($text, "\[tex\]", "\[\/tex\]");
+                // todo: uncomment when PR 9870 is merged
+                // $text = ilRTE::replaceLatexSpan($text);
+                $text = $this->ui_renderer->render($this->ui_factory->legacy()->latexContent($text));
             }
 
             // workaround for preventing template engine

--- a/components/ILIAS/Forum/classes/class.ilForum.php
+++ b/components/ILIAS/Forum/classes/class.ilForum.php
@@ -1488,8 +1488,7 @@ class ilForum
 
         if ($type !== 'export') {
             if ($edit === 0) {
-                // todo: uncomment when PR 9870 is merged
-                // $text = ilRTE::replaceLatexSpan($text);
+                $text = ilRTE::replaceLatexSpan($text);
                 $text = $this->ui_renderer->render($this->ui_factory->legacy()->latexContent($text));
             }
 

--- a/components/ILIAS/Forum/classes/class.ilForumExportGUI.php
+++ b/components/ILIAS/Forum/classes/class.ilForumExportGUI.php
@@ -84,19 +84,25 @@ class ilForumExportGUI
         return $ref_id;
     }
 
-    private function prepare(): void
-    {
-        ilMathJax::getInstance()
-            ->init(ilMathJax::PURPOSE_EXPORT)
-            ->setZoomFactor(10);
-    }
-
     private function ensureThreadBelongsToForum(int $objId, ilForumTopic $thread): void
     {
         $forumId = ilObjForum::lookupForumIdByObjId($objId);
         if ($thread->getForumId() !== $forumId) {
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
+    }
+
+    /**
+     * Register the resources needed for latex rendering
+     * We can't query these resources from the UI framework in a clean way.
+     * So we have to repeat them here.
+     *
+     * @see \ILIAS\UI\Implementation\Component\Legacy\Renderer::registerResources
+     */
+    private function addLatexResources(ilGlobalTemplateInterface $tpl)
+    {
+        $tpl->addJavaScript('assets/js/mathjax_config.js');
+        $tpl->addJavaScript('node_modules/mathjax/es5/tex-chtml-full.js');
     }
 
     public function executeCommand(): void
@@ -258,8 +264,6 @@ class ilForumExportGUI
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
-        $this->prepare();
-
         ilDatePresentation::setUseRelativeDates(false);
 
         $tpl = new ilGlobalTemplate('tpl.forums_export_print.html', true, true, 'components/ILIAS/Forum');
@@ -267,7 +271,7 @@ class ilForumExportGUI
         $tpl->setVariable('LOCATION_STYLESHEET', $location_stylesheet);
 
         iljQueryUtil::initjQuery($tpl);
-        ilMathJax::getInstance()->includeMathJax($tpl);
+        $this->addLatexResources($tpl);
 
         $this->frm->setMDB2WhereCondition('top_pk = %s ', ['integer'], [$this->http->wrapper()->query()->retrieve(
             'thr_top_fk',
@@ -311,8 +315,6 @@ class ilForumExportGUI
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
-        $this->prepare();
-
         ilDatePresentation::setUseRelativeDates(false);
 
         $tpl = new ilGlobalTemplate('tpl.forums_export_print.html', true, true, 'components/ILIAS/Forum');
@@ -320,7 +322,7 @@ class ilForumExportGUI
         $tpl->setVariable('LOCATION_STYLESHEET', $location_stylesheet);
 
         iljQueryUtil::initjQuery($tpl);
-        ilMathJax::getInstance()->includeMathJax($tpl);
+        $this->addLatexResources($tpl);
 
         $this->frm->setMDB2WhereCondition('top_pk = %s ', ['integer'], [$this->http->wrapper()->query()->retrieve(
             'top_pk',
@@ -353,8 +355,6 @@ class ilForumExportGUI
             $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
         }
 
-        $this->prepare();
-
         ilDatePresentation::setUseRelativeDates(false);
 
         $tpl = new ilGlobalTemplate('tpl.forums_export_html.html', true, true, 'components/ILIAS/Forum');
@@ -363,7 +363,6 @@ class ilForumExportGUI
         $tpl->setVariable('BASE', (str_ends_with(ILIAS_HTTP_PATH, '/') ? ILIAS_HTTP_PATH : ILIAS_HTTP_PATH . '/'));
 
         iljQueryUtil::initjQuery($tpl);
-        ilMathJax::getInstance()->includeMathJax($tpl);
 
         /** @var ilForumTopic[] $threads */
         $threads = [];
@@ -436,6 +435,9 @@ class ilForumExportGUI
             $tpl->setCurrentBlock('thread_block');
             $tpl->parseCurrentBlock();
         }
+
+        $this->addLatexResources($tpl);
+        $tpl->fillJavaScriptFiles();
 
         ilUtil::deliverData(
             $tpl->get(),

--- a/components/ILIAS/Forum/classes/class.ilForumExportGUI.php
+++ b/components/ILIAS/Forum/classes/class.ilForumExportGUI.php
@@ -99,7 +99,7 @@ class ilForumExportGUI
      *
      * @see \ILIAS\UI\Implementation\Component\Legacy\Renderer::registerResources
      */
-    private function addLatexResources(ilGlobalTemplateInterface $tpl)
+    private function addLatexResources(ilGlobalTemplateInterface $tpl): void
     {
         $tpl->addJavaScript('assets/js/mathjax_config.js');
         $tpl->addJavaScript('node_modules/mathjax/es5/tex-chtml-full.js');

--- a/components/ILIAS/Forum/classes/class.ilObjForumGUI.php
+++ b/components/ILIAS/Forum/classes/class.ilObjForumGUI.php
@@ -2430,6 +2430,7 @@ class ilObjForumGUI extends ilObjectGUI implements ilDesktopItemHandling, ilForu
         }
 
         $oPostGUI->setPurifier(ilHtmlPurifierFactory::getInstanceByType('frm_post'));
+        $oPostGUI->setInfo($this->lng->txt('latex_edit_info'));
 
         $this->replyEditForm->addItem($oPostGUI);
 


### PR DESCRIPTION
This PR implements the FR [Streamline LaTeX usage](https://docu.ilias.de/go/wiki/wpage_5614_1357) in the Forum component.

* Content with latex code is wrapped in the `Legacy\LatexContent` ui component for display.
* Latex resources are added to the HTML of print views and export.
* A byline with editing info is added to the input field of messages (the language variable will be defined in a separate PR).

