### PR TITLE
Language: Add Latex edit info and cleanup unused variables

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4441,6 +4441,7 @@ common#:#last_reminder#:#Letzte Erinnerung
 common#:#last_update#:#Aktualisiert
 common#:#last_visited#:#Zuletzt besucht
 common#:#lastname#:#Nachname
+common#:#latex_edit_info#:#Sie können LaTeX-Code in den Begrenzern <code>[tex]</code> und <code>[/tex]</code> eingeben.
 common#:#laugh#:#Laugh
 common#:#launch#:#Start
 common#:#ldap#:#LDAP
@@ -5809,7 +5810,6 @@ common#:#uploading#:#Hochladen...
 common#:#uri#:#URI
 common#:#url#:#URL
 common#:#url_not_found#:#Datei wurde nicht gefunden
-common#:#url_to_latex#:#URL zum LaTeX CGI-Skript
 common#:#use_customized_instructions#:#Angepassten Anleitungstext verwenden:
 common#:#use_default_instructions#:#Standard-Anleitungstext verwenden.
 common#:#user#:#Benutzer
@@ -11647,39 +11647,6 @@ maps#:#maps_std_location#:#Standardposition
 maps#:#maps_std_location_desc#:#Klicken Sie auf die Karte, um die eigene Position anzugeben.
 maps#:#maps_tile_server#:#Server für Kacheln
 maps#:#maps_zoom_level#:#Vergrößerungsstufe
-mathjax#:#mathjax_enable_client#:#MathJax im Browser aktivieren
-mathjax#:#mathjax_enable_client_info#:#Aktiviert die Darstellung von TeX im Browser durch Einbindung des MathJax-Skripts. MathJax 3 wird unterstützt, aber MathJax 2 empfohlen.
-mathjax#:#mathjax_enable_server#:#MathJax im Server aktivieren
-mathjax#:#mathjax_enable_server_info#:#Aktiviert die serverseitige Umwandlung von TeX in Grafiken.
-mathjax#:#mathjax_home_link#:# ➜ MathJax-Webseite
-mathjax#:#mathjax_limiter#:#Trennzeichen
-mathjax#:#mathjax_limiter_info#:#Wählen Sie die Trennzeichen, die ILIAS für das MathJax-Skript produzieren soll
-mathjax#:#mathjax_mathjax#:#MathJax
-mathjax#:#mathjax_polyfill_url#:#Url eines Polyfills
-mathjax#:#mathjax_polyfill_url_desc_line1#:#Für MathJax 2 und MathJax 3 mit aktuellen Browsern nicht benötigt.
-mathjax#:#mathjax_polyfill_url_desc_line2#:#Bitte entfernen Sie die Einbindung von polyfill.io! Siehe https://sansec.io/research/polyfill-supply-chain-attack
-mathjax#:#mathjax_script_url#:#URL des MathJax-Skripts
-mathjax#:#mathjax_script_url_desc_line1#:#Für MathJax 2 z.B. %s
-mathjax#:#mathjax_script_url_desc_line2#:#Bitte verwenden Sie den Safe Mode, um XSS-Angriffe durch MathJax-Code mit Javascript zu vermeiden. Für MathJax 2 kann er an die CDN-Url als Parameter angefügt werden (s.o). Für MathJax 3 müssen Sie ein Skript einbinden, dass ihn konfiguriert, bevor MathJax geladen wird. Verwenden Sie z.B. %s
-mathjax#:#mathjax_server_address#:#Server-Adresse
-mathjax#:#mathjax_server_address_info#:#z.B. http://localhost:8003
-mathjax#:#mathjax_server_cache_cleared#:#Der MathJax-Cache wurde geleert.
-mathjax#:#mathjax_server_cache_size#:#Cache-Größe
-mathjax#:#mathjax_server_cache_size_info#:#Festplattenspeicher, der zur Speicherung der Grafiken verbraucht wird.
-mathjax#:#mathjax_server_clear_cache#:# ➜ Jetzt Cache leeren
-mathjax#:#mathjax_server_for_browser#:#Für den Browser verwenden
-mathjax#:#mathjax_server_for_browser_info#:#TeX wird als SVG-Grafik eingebunden. Damit ist die Aktivierung von MathJax im Browser überflüssig.
-mathjax#:#mathjax_server_for_export#:#Für HTML-Exporte verwenden
-mathjax#:#mathjax_server_for_export_info#:#TeX wird in HTML-Exporten von Lernmodulen als SVG-Grafik exportiert.
-mathjax#:#mathjax_server_for_pdf#:#Für die PDF-Erzeugung verwenden
-mathjax#:#mathjax_server_for_pdf_info#:#Der Server wird zur Darstellung von TeX in PDF-Dokumenten verwendet.
-mathjax#:#mathjax_server_installation#:# ➜ Installationsanleitung
-mathjax#:#mathjax_server_timeout#:#Antwortzeit
-mathjax#:#mathjax_server_timeout_info#:#Maximale Wartezeit auf eine Antwort des MathJax-Servers in Sekunden
-mathjax#:#mathjax_settings#:#MathJax-Einstellungen
-mathjax#:#mathjax_test_expression#:#Test-Ausdruck
-mathjax#:#mathjax_test_expression_info_client#:#Dieser Ausdruck wird mit dem Skript im Browser dargestellt
-mathjax#:#mathjax_test_expression_info_server#:#Dieser Ausdruck wird auf dem Server in eine Grafik umgewandelt
 mcst#:#mcst_add_new_item#:#Neuen Mediacast-Beitrag hinzufügen
 mcst#:#mcst_audio_files#:#Audiodateien
 mcst#:#mcst_audioportable_settings_info#:#Kommagetrennte Liste von Dateiendungen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -4448,6 +4448,7 @@ common#:#last_reminder#:#Last reminder
 common#:#last_update#:#Updated
 common#:#last_visited#:#Last Visited
 common#:#lastname#:#Last Name
+common#:#latex_edit_info#:#You can enter LaTeX code in the delimiters <code>[tex]</code> and <code>[/tex]</code>.
 common#:#laugh#:#Laugh
 common#:#launch#:#Launch
 common#:#ldap#:#LDAP
@@ -5817,7 +5818,6 @@ common#:#uploading#:#Uploading...
 common#:#uri#:#URI
 common#:#url#:#URL
 common#:#url_not_found#:#File Not Found
-common#:#url_to_latex#:#URL to LaTeX CGI script
 common#:#use_customized_instructions#:#Use customized instructions:
 common#:#use_default_instructions#:#Use default instructions.
 common#:#user#:#User
@@ -11657,39 +11657,6 @@ maps#:#maps_std_location#:#Default Location
 maps#:#maps_std_location_desc#:#Click map to set location.
 maps#:#maps_tile_server#:#Server for Tiles
 maps#:#maps_zoom_level#:#Zoom Level
-mathjax#:#mathjax_enable_client#:#Enable MathJax in the Browser
-mathjax#:#mathjax_enable_client_info#:#Activates a client-side rendering of TeX in the browser by including the MathJax script. Mathjax 3 is supported, but MathJax 2 is recommended.
-mathjax#:#mathjax_enable_server#:#Enable MathJax on the Server
-mathjax#:#mathjax_enable_server_info#:#Activates a server-side rendering of TeX to graphics.
-mathjax#:#mathjax_home_link#:# ➜︎ MathJax web site
-mathjax#:#mathjax_limiter#:#Inline Delimiters
-mathjax#:#mathjax_limiter_info#:#Select the inline delimiters that ILIAS should produce for the MathJax script
-mathjax#:#mathjax_mathjax#:#MathJax
-mathjax#:#mathjax_polyfill_url#:#Url of a Polyfill
-mathjax#:#mathjax_polyfill_url_desc_line1#:#For MathJax 2 and MathJax 3 with current browsers not needed.
-mathjax#:#mathjax_polyfill_url_desc_line2#:#Please remove any reference to polyfill.io! See https://sansec.io/research/polyfill-supply-chain-attack
-mathjax#:#mathjax_script_url#:#URL of the MathJax Script
-mathjax#:#mathjax_script_url_desc_line1#:#For MathJax 2 e.g. %s
-mathjax#:#mathjax_script_url_desc_line2#:#Please activate the safe mode to avoid XSS attacks by MathJax code with javascript. For MathJax 2 it can be activated by adding the 'Safe' parameter to the CDN url. For MathJax 3 you need to include a script that configures it before MathJax is loaded. Use for example %s
-mathjax#:#mathjax_server_address#:#Server Address
-mathjax#:#mathjax_server_address_info#:#E.g. http://localhost:8003
-mathjax#:#mathjax_server_cache_cleared#:#The MathJax cache was cleared.
-mathjax#:#mathjax_server_cache_size#:#Cache Size
-mathjax#:#mathjax_server_cache_size_info#:#Disk space used for caching rendered graphics.
-mathjax#:#mathjax_server_clear_cache#:# ➜ Clear Cache Now
-mathjax#:#mathjax_server_for_browser#:#Use for Browser
-mathjax#:#mathjax_server_for_browser_info#:#TeX will be shown as SVG graphics. Enabling MathJax in the browser is unneccessary.
-mathjax#:#mathjax_server_for_export#:#Use for HTML Export
-mathjax#:#mathjax_server_for_export_info#:#TeX will be exported as SVG graphic for learning module exports to HTML.
-mathjax#:#mathjax_server_for_pdf#:#Use for PDF Generation
-mathjax#:#mathjax_server_for_pdf_info#:#The server will be used when PDF files are generated.
-mathjax#:#mathjax_server_installation#:# ➜ Installation Manual
-mathjax#:#mathjax_server_timeout#:#Timeout
-mathjax#:#mathjax_server_timeout_info#:#Timeout for calling the MathJax server in seconds
-mathjax#:#mathjax_settings#:#MathJax Settings
-mathjax#:#mathjax_test_expression#:#Test Expression
-mathjax#:#mathjax_test_expression_info_client#:#This expression will be rendered by the script in the browser.
-mathjax#:#mathjax_test_expression_info_server#:#This expression will be rendered on the server.
 mcst#:#mcst_add_new_item#:#Add New Mediacast Item
 mcst#:#mcst_audio_files#:#Audio Files
 mcst#:#mcst_audioportable_settings_info#:#Comma separated list of file suffixes


### PR DESCRIPTION
This PR implements the FR [Streamline LaTeX usage](https://docu.ilias.de/go/wiki/wpage_5614_1357) in the Language component.

* The variable `latex_edit_info` will be used in different components as a byline to text area inputs with latex support.
* All obsolete mathjax related variables are removed.