### PR TITLE
CoPage: Change MathJax and support HTML export

### DIFF
--- a/components/ILIAS/COPage/Resources/ResourcesCollector.php
+++ b/components/ILIAS/COPage/Resources/ResourcesCollector.php
@@ -46,7 +46,7 @@ class ResourcesCollector
         if (is_null($pg)) {
             $pg = new \ilLMPage();
         }
-        if($pg->getXMLContent() === "") {
+        if ($pg->getXMLContent() === "") {
             $pg->setXMLContent("<PageObject></PageObject>");
         }
         $this->output_mode = $output_mode;
@@ -67,6 +67,8 @@ class ResourcesCollector
             $this->js_files[] = \iljQueryUtil::getLocaljQueryPath();
             $this->js_files[] = \iljQueryUtil::getLocaljQueryUIPath();
             $this->js_files[] = 'assets/js/Basic.js';
+            $this->js_files[] = 'assets/js/mathjax_config.js';
+            $this->js_files[] = 'node_modules/mathjax/es5/tex-chtml-full.js';
         }
 
         $this->js_files[] = "components/ILIAS/COPage/js/ilCOPagePres.js";

--- a/components/ILIAS/COPage/classes/class.ilCOPageHTMLExport.php
+++ b/components/ILIAS/COPage/classes/class.ilCOPageHTMLExport.php
@@ -194,6 +194,11 @@ class ilCOPageHTMLExport
         foreach ($collector->getCssFiles() as $css) {
             $this->exportResourceFile($this->exp_dir, $css);
         }
+
+        // mathjax needs the whole directory to dynamically load resources
+        if (!is_null($this->export_collector)) {
+            $this->export_collector->addDirectory('node_modules/mathjax/es5', 'node_modules/mathjax/es5');
+        }
     }
 
     protected function exportResourceFile(

--- a/components/ILIAS/COPage/classes/class.ilPageObjectGUI.php
+++ b/components/ILIAS/COPage/classes/class.ilPageObjectGUI.php
@@ -1975,9 +1975,7 @@ class ilPageObjectGUI
             "active_tex",
             true
         )) {
-            if ($mathJaxSetting->get("enable") || defined("URL_TO_LATEX")) {
-                $menu["cont_more_functions"][] = ["text" => 'Tex', "action" => "selection.tex", "data" => []];
-            }
+            $menu["cont_more_functions"][] = ["text" => 'Tex', "action" => "selection.tex", "data" => []];
         }
         if (ilPageEditorSettings::lookupSettingByParentType(
             $a_par_type,

--- a/components/ILIAS/COPage/classes/class.ilPageObjectGUI.php
+++ b/components/ILIAS/COPage/classes/class.ilPageObjectGUI.php
@@ -1555,8 +1555,6 @@ class ilPageObjectGUI
             }
             $output = str_replace("&amp;", "&", $output);
 
-            $output = ilMathJax::getInstance()->insertLatexImages($output);
-
             // insert page snippets
             //$output = $this->insertContentIncludes($output);
 
@@ -1603,6 +1601,9 @@ class ilPageObjectGUI
         }
 
         $this->addResourcesToTemplate($main_tpl);
+
+        // enable rendering of latex in the whole output
+        $output = $this->ui->renderer()->render($this->ui->factory()->legacy()->latexContent($output));
 
         //		$output = $this->selfAssessmentRendering($output);
 


### PR DESCRIPTION
This PR implements the FR [Streamline LaTeX usage](https://docu.ilias.de/go/wiki/wpage_5614_1357) in the CoPage component.

- Page content is wrapped in the `Legacy\LatexContent` ui component for display.
- All necessary resources are exported with the HTML export