### PR TITLE
Glossary: Change MathJax calls

### DIFF
--- a/components/ILIAS/Glossary/Presentation/class.ilPresentationTableGUI.php
+++ b/components/ILIAS/Glossary/Presentation/class.ilPresentationTableGUI.php
@@ -402,14 +402,14 @@ class ilPresentationTableGUI
             $short_str = \ilStr::shortenTextExtended($short_str, $ltexe + 6, true);
         }
 
-        $short_str = \ilMathJax::getInstance()->insertLatexImages($short_str);
-
         $short_str = \ilPCParagraph::xml2output(
             $short_str,
             false,
             true,
             !$page->getPageConfig()->getPreventHTMLUnmasking()
         );
+
+        $short_str = $this->ui_ren->render($this->ui_fac->legacy()->latexContent($short_str));
 
         return $short_str;
     }

--- a/components/ILIAS/Glossary/Table/class.TermListTable.php
+++ b/components/ILIAS/Glossary/Table/class.TermListTable.php
@@ -326,6 +326,7 @@ class TermListTable
             $this->adv_cols_order,
             $this->adv_term_mode,
             $this->ui_fac,
+            $this->ui_ren,
             $this->df,
             $this->lng,
             $this->term_perm
@@ -340,6 +341,7 @@ class TermListTable
                 protected array $adv_cols_order,
                 protected \ILIAS\AdvancedMetaData\Services\SubObjectModes\DataTable\SupplierInterface $adv_term_mode,
                 protected UI\Factory $ui_fac,
+                protected UI\Renderer $ui_ren,
                 protected Data\Factory $df,
                 protected \ilLanguage $lng,
                 protected \ilGlossaryTermPermission $term_perm
@@ -446,8 +448,6 @@ class TermListTable
                             $short_str = \ilStr::shortenTextExtended($short_str, $ltexe + 6, true);
                         }
 
-                        $short_str = \ilMathJax::getInstance()->insertLatexImages($short_str);
-
                         $short_str = \ilPCParagraph::xml2output(
                             $short_str,
                             false,
@@ -457,6 +457,8 @@ class TermListTable
                     } catch (\Exception $e) {
                         $short_str = "Error: Page is missing.";
                     }
+
+                    $short_str = $this->ui_ren->render($this->ui_fac->legacy()->latexContent($short_str));
 
                     $records[$i]["definition"] = $short_str;
 

--- a/components/ILIAS/Glossary/Term/class.ilGlossaryTermGUI.php
+++ b/components/ILIAS/Glossary/Term/class.ilGlossaryTermGUI.php
@@ -316,8 +316,6 @@ class ilGlossaryTermGUI
         $page_gui->setTemplateOutput(false);
         $output = $page_gui->presentation($page_gui->getOutputMode());
 
-        ilMathJax::getInstance()->includeMathJax($tpl);
-
         $tpl->setCurrentBlock("definition");
         $tpl->setVariable("PAGE_CONTENT", $output);
         $tpl->parseCurrentBlock();


### PR DESCRIPTION
This PR implements the FR [Streamline LaTeX usage](https://docu.ilias.de/go/wiki/wpage_5614_1357) in the Glossary component.

* calls of insertLatexImages() are changed zu UI
* calls of includeMathJax() are removed

This PR affect the rendering of latex in the table of terms. The rendering in the presentation of a term and in the HTML export will work when the PR [CoPage: Change MathJax and support HTML export](https://github.com/ILIAS-eLearning/ILIAS/pull/9873) is merged.