### PR TITLE
Wiki: Remove MathJax call

### DIFF
--- a/components/ILIAS/Wiki/Export/WikiHtmlExport.php
+++ b/components/ILIAS/Wiki/Export/WikiHtmlExport.php
@@ -96,8 +96,6 @@ class WikiHtmlExport
         $ilUser = $this->user;
 
         $this->log->debug("buildExportFile...");
-        //init the mathjax rendering for HTML export
-        \ilMathJax::getInstance()->init(\ilMathJax::PURPOSE_EXPORT);
 
         if (in_array($this->getMode(), [self::MODE_USER, self::MODE_USER_COMMENTS])) {
             $this->user_html_exp = new \ilWikiUserHTMLExport($this->wiki, $ilDB, $ilUser, ($this->getMode() === self::MODE_USER_COMMENTS));


### PR DESCRIPTION
This PR implements the FR [Streamline LaTeX usage](https://docu.ilias.de/go/wiki/wpage_5614_1357) in the Wiki component.

The call of ilMathJax::includeMathJax is obsolete.

Rendering of latex content on page presentation andin html exports will work when PR when the PR https://github.com/ILIAS-eLearning/ILIAS/pull/9873 is merged.