### PR TITLE
Export: Remove MathJax call

### DIFF
--- a/components/ILIAS/Export/HTML/class.Util.php
+++ b/components/ILIAS/Export/HTML/class.Util.php
@@ -122,8 +122,6 @@ class Util
      */
     public function exportCOPageFiles(int $style_sheet_id = 0, string $obj_type = ""): void
     {
-        \ilMathJax::getInstance()->init(\ilMathJax::PURPOSE_EXPORT);
-
         // init co page html exporter
         $this->co_page_html_export->setContentStyleId($style_sheet_id);
         if (is_null($this->export_collector)) {


### PR DESCRIPTION
The call of ilMathJax::includeMathJax is obsolete.

Rendering of latex content on page presentation andin html exports will work when PR when the PR https://github.com/ILIAS-eLearning/ILIAS/pull/9873 is merged.