### PR TITLE
BT 37326: Fixes incorrect usage scenario for language variable when booking for other users

### DIFF
--- a/components/ILIAS/BookingManager/BookingProcess/class.ilBookingProcessWithoutScheduleGUI.php
+++ b/components/ILIAS/BookingManager/BookingProcess/class.ilBookingProcessWithoutScheduleGUI.php
@@ -263,7 +263,7 @@ class ilBookingProcessWithoutScheduleGUI implements \ILIAS\BookingManager\Bookin
             ), true);
             $this->ctrl->redirect($this, "redirectToParticipantsList");
         } else {
-            $conf->setHeaderText($this->lng->txt('book_confirm_booking_no_schedule'));
+            $conf->setHeaderText($this->lng->txt('book_confirm_booking_for_users'));
             $conf->addHiddenItem("object_id", $this->book_obj_id);
             $conf->setConfirm($this->lng->txt("assign"), "saveMultipleBookings");
         }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2591,6 +2591,7 @@ book#:#book_bulk_creation#:#Massenerstellung
 book#:#book_bulk_data#:#Daten zu Angeboten
 book#:#book_cal_entry#:#Buchung:
 book#:#book_confirm_booking#:#Buchung vornehmen
+book#:#book_confirm_booking_for_users#:#Sind Sie sicher, dass Sie dieses Angebot für die folgenden Teilnehmer buchen wollen?
 book#:#book_confirm_booking_no_schedule#:#Sind Sie sicher, dass Sie das folgende Angebot buchen wollen?
 book#:#book_confirm_booking_schedule_number_of_objects#:#Buchungsbestätigung
 book#:#book_confirm_booking_schedule_number_of_objects_info#:#Bitte wählen Sie die Anzahl der zu buchenden Angebote.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2592,6 +2592,7 @@ book#:#book_bulk_creation#:#Bulk Creation
 book#:#book_bulk_data#:#Item Data
 book#:#book_cal_entry#:#Booking:
 book#:#book_confirm_booking#:#Confirm Booking
+book#:#book_confirm_booking_for_users#:#Are you sure you want to book this item for the following user(s)?
 book#:#book_confirm_booking_no_schedule#:#Are you sure you want to book the following item?
 book#:#book_confirm_booking_schedule_number_of_objects#:#Booking Confirmation
 book#:#book_confirm_booking_schedule_number_of_objects_info#:#Please enter the number of items that you would like to book.


### PR DESCRIPTION
This PR attempts to solve the issue described in https://mantis.ilias.de/view.php?id=37326.

Previously, when booking for other users in a booking pool, the confirmation header text used the `book_confirm_booking_no_schedule` language variable, which has been deemed to be incorrect here. The list displays the participants for whom the bookings will be made. The language variable does not align with the desired action.

I have added in a new variable that correctly suits this behavior now.

This may also be cherry-picked to release_9.

Kind regards,
@bidzanaaron 

CC: @thojou 