### PR TITLE
T&A 45403: Fixes ArgumentCountError when saving hotspot/image map question into question pool from test

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assImagemapQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assImagemapQuestion.php
@@ -822,7 +822,7 @@ class assImagemapQuestion extends assQuestion implements ilObjQuestionScoringAdj
 
     public function syncWithOriginal(): void
     {
-        if ($this->questioninfo->getOriginalId()) {
+        if ($this->questioninfo->getOriginalId($this->getId())) {
             parent::syncWithOriginal();
         }
     }


### PR DESCRIPTION
This PR attempts to solve the issue described in https://mantis.ilias.de/view.php?id=45403.

When saving a hotspot/image map question into a question pool from inside a test, an ArgumentCountError will be thrown.
This happens due to the questionId not being passed into `getOriginalId()` when `syncWithOriginal` is being executed.

I have now added the current questionId into the function call, which solves this error.

Kind regards,
@bidzanaaron 