### PR TITLE
Survey: Restore Latex Support

### DIFF
--- a/components/ILIAS/Survey/Evaluation/class.ilSurveyResultsCumulatedTableGUI.php
+++ b/components/ILIAS/Survey/Evaluation/class.ilSurveyResultsCumulatedTableGUI.php
@@ -21,6 +21,8 @@
  */
 class ilSurveyResultsCumulatedTableGUI extends ilTable2GUI
 {
+    private \ILIAS\DI\UIServices $ui;
+
     public function __construct(
         object $a_parent_obj,
         string $a_parent_cmd,
@@ -30,6 +32,7 @@ class ilSurveyResultsCumulatedTableGUI extends ilTable2GUI
 
         $lng = $DIC->language();
         $ilCtrl = $DIC->ctrl();
+        $this->ui = $DIC->ui();
 
         $this->setId("svy_cum");
         parent::__construct($a_parent_obj, $a_parent_cmd);
@@ -120,11 +123,12 @@ class ilSurveyResultsCumulatedTableGUI extends ilTable2GUI
 
         foreach ($a_results as $question_res) {
             if (!is_array($question_res)) {
+                /** @var SurveyQuestion $question */
                 $question = $question_res->getQuestion();
 
                 $data[] = array(
                     "title" => $question->getTitle(),
-                    "question" => strip_tags($question->getQuestiontext()),
+                    "question" => strip_tags($question->prepareTextareaOutput($question->getQuestiontext(), true)),
                     "question_type" => SurveyQuestion::_getQuestionTypeName($question->getQuestionType()),
                     "users_answered" => $question_res->getUsersAnswered(),
                     "users_skipped" => $question_res->getUsersSkipped(),
@@ -174,7 +178,9 @@ class ilSurveyResultsCumulatedTableGUI extends ilTable2GUI
         foreach ($this->getSelectedColumns() as $c) {
             if (strcmp($c, 'question') === 0) {
                 $this->tpl->setCurrentBlock('question');
-                $this->tpl->setVariable("QUESTION", $a_set['question']);
+                $this->tpl->setVariable("QUESTION", $this->ui->renderer()->render(
+                    $this->ui->factory()->legacy()->latexContent($a_set['question'])
+                ));
                 $this->tpl->parseCurrentBlock();
             }
             if (strcmp($c, 'question_type') === 0) {

--- a/components/ILIAS/Survey/Execution/class.LaunchGUI.php
+++ b/components/ILIAS/Survey/Execution/class.LaunchGUI.php
@@ -219,7 +219,7 @@ class LaunchGUI
         // introduction
         if ($this->survey->getIntroduction() !== '') {
             $introduction = $this->survey->getIntroduction();
-            $this->launch_information[] = $this->survey->prepareTextareaOutput($introduction);
+            $this->launch_information[] = $this->survey->prepareTextareaOutput($introduction, true);
         }
 
         // access information
@@ -275,7 +275,7 @@ class LaunchGUI
 
             foreach ($this->launch_information as $key => $value) {
                 if (is_numeric($key)) {
-                    $items[] = $f->legacy()->content($value);
+                    $items[] = $f->legacy()->latexContent($value);
                 } else {
                     $key_value[$key] = $value;
                 }

--- a/components/ILIAS/Survey/Execution/class.ilSurveyExecutionGUI.php
+++ b/components/ILIAS/Survey/Execution/class.ilSurveyExecutionGUI.php
@@ -651,7 +651,7 @@ class ilSurveyExecutionGUI
                 $r = $this->gui->ui()->renderer();
                 $p = $f->panel()->standard(
                     "",
-                    $f->legacy()->content($this->object->prepareTextareaOutput($this->object->getOutro()))
+                    $f->legacy()->latexContent($this->object->prepareTextareaOutput($this->object->getOutro(), true))
                 );
 
                 $this->tpl->setContent($r->render($p));

--- a/components/ILIAS/Survey/Mode/class.AbstractUIModifier.php
+++ b/components/ILIAS/Survey/Mode/class.AbstractUIModifier.php
@@ -362,12 +362,12 @@ abstract class AbstractUIModifier implements UIModifier
 
         // question "overview"
         $qst_title = $question->getTitle();
-        $svy_text = nl2br($question->getQuestiontext());
+        $svy_text = nl2br($question->prepareTextareaOutput($question->getQuestiontext(), true));
 
         // Question title anchor
         $anchor_id = "svyrdq" . $question->getId();
         $title = "<span id='$anchor_id'>$qst_title</span>";
-        $panel_qst_card = $ui_factory->panel()->sub($title, $ui_factory->legacy()->content($svy_text))
+        $panel_qst_card = $ui_factory->panel()->sub($title, $ui_factory->legacy()->latexContent($svy_text))
             ->withFurtherInformation($this->getPanelCard($question_res));
 
         $panels[] = $panel_qst_card;

--- a/components/ILIAS/Survey/Settings/class.SettingsFormGUI.php
+++ b/components/ILIAS/Survey/Settings/class.SettingsFormGUI.php
@@ -327,7 +327,7 @@ class SettingsFormGUI
         $intro->setValue($survey->prepareTextareaOutput($survey->getIntroduction()));
         $intro->setRows(10);
         $intro->setCols(80);
-        $intro->setInfo($lng->txt("survey_introduction_info"));
+        $intro->setInfo($lng->txt("survey_introduction_info") . ' ' . $lng->txt('latex_edit_info'));
         if (\ilObjAdvancedEditing::_getRichTextEditor() === "tinymce") {
             $intro->setUseRte(true);
             $intro->setRteTagSet("mini");
@@ -450,6 +450,7 @@ class SettingsFormGUI
             $finalstatement->setUseRte(true);
             $finalstatement->setRteTagSet("mini");
         }
+        $finalstatement->setInfo($lng->txt('latex_edit_info'));
         $form->addItem($finalstatement);
 
         // mail notification

--- a/components/ILIAS/Survey/classes/class.ilObjSurvey.php
+++ b/components/ILIAS/Survey/classes/class.ilObjSurvey.php
@@ -3980,13 +3980,17 @@ class ilObjSurvey extends ilObject
     }
 
     /**
-     * Prepares a string for a text area output in surveys
+     * Prepares a string for a text area output in survey forms
+     * @param bool $prepare_for_latex_output    false if content is used in a form, true if content is used elsewhere
+     * @see \SurveyQuestion::prepareTextareaOutput
      */
     public function prepareTextareaOutput(
-        string $txt_output
+        string $txt_output,
+        bool $prepare_for_latex_output = false
     ): string {
-        return ilLegacyFormElementsUtil::prepareTextareaOutput($txt_output);
+        return ilLegacyFormElementsUtil::prepareTextareaOutput($txt_output, $prepare_for_latex_output);
     }
+
 
     /**
      * Checks if a given string contains HTML or not

--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestionGUI.php
@@ -27,6 +27,7 @@ use ILIAS\SurveyQuestionPool\Editing\EditManager;
  */
 abstract class SurveyQuestionGUI
 {
+    protected \ILIAS\DI\UIServices $ui;
     protected \ILIAS\Survey\InternalGUIService $gui;
     protected EditingGUIRequest $request;
     protected EditManager $edit_manager;
@@ -53,6 +54,7 @@ abstract class SurveyQuestionGUI
         $this->access = $DIC->access();
         $this->tree = $DIC->repositoryTree();
         $this->toolbar = $DIC->toolbar();
+        $this->ui = $DIC->ui();
         $lng = $DIC->language();
         $tpl = $DIC["tpl"];
         $ilCtrl = $DIC->ctrl();
@@ -149,7 +151,12 @@ abstract class SurveyQuestionGUI
         if (preg_match("/^<.[\\>]?>(.*?)<\\/.[\\>]*?>$/", $questiontext, $matches)) {
             $questiontext = $matches[1];
         }
-        $template->setVariable("QUESTIONTEXT", $this->object->prepareTextareaOutput($questiontext, true));
+        $questiontext = $this->object->prepareTextareaOutput($questiontext, true);
+
+
+        $template->setVariable("QUESTIONTEXT", $this->ui->renderer()->render(
+            $this->ui->factory()->legacy()->latexContent($questiontext)
+        ));
         if ($this->object->getObligatory()) {
             $template->setVariable("OBLIGATORY_TEXT", ' *');
         }
@@ -262,6 +269,7 @@ abstract class SurveyQuestionGUI
             $question->setUseRte(true);
             $question->setRteTagSet("mini");
         }
+        $question->setInfo($this->lng->txt("latex_edit_info"));
         $form->addItem($question);
 
         // obligatory


### PR DESCRIPTION
This PR implements the FR [Streamline LaTeX usage](https://docu.ilias.de/go/wiki/wpage_5614_1357) in the Survey component.

The Survey supports latex content in its intro, outro and question texts. This was implictly provided by the use of `ilLegacyFormElementsUtil::prepareTextareaOutput`. The related test cases are  [C13057](https://testrail.ilias.de//index.php?/cases/view/13057) and [C13058](https://testrail.ilias.de//index.php?/cases/view/13058&group_by=cases:section_id&group_order=asc&display_deleted_cases=0&group_id=3227).

With the remove of the old MathJax service function, the rendering is no longer done implictly. This PR restores the latex support in surveys:

* It use the `LegacyLatexContent` ui component to display content of intro, outro and question texts.

* It adds an info to the form element of intro, outro and question text on how latex code can be entered. The language variable is commonly defined in [PR 9872](https://github.com/ILIAS-eLearning/ILIAS/pull/9872).

* It uses a parameter of `ilLegacyFormElementsUtil::prepareTextareaOutput` to decide if the content is used in an editing textarea or for presentation. In a textarea, the span with class "latex" that was created by TinyMCE should be kept. For presentation it should be converted to [tex] and [/tex]. This is done by  `ilLegacyFormElementsUtil::prepareTextareaOutput`.