### PR TITLE
[FIX] issue with deleted objects in item blocks

### DIFF
--- a/components/ILIAS/Container/Content/class.ilContainerRenderer.php
+++ b/components/ILIAS/Container/Content/class.ilContainerRenderer.php
@@ -933,6 +933,10 @@ class ilContainerRenderer
                 }
 
                 $item_data = $this->item_presentation->getRawDataByRefId($ref_id);
+                // Item Data may be null
+                if ($item_data === null) {
+                    continue;
+                }
                 $checkbox = \ILIAS\Containter\Content\ItemRenderer::CHECKBOX_NONE;
                 if ($this->container_gui->isActiveAdministrationPanel()) {
                     $checkbox = \ILIAS\Containter\Content\ItemRenderer::CHECKBOX_ADMIN;


### PR DESCRIPTION
We had an error

```
Whoops\Exception\ErrorException thrown with message "Trying to access array offset on value of type null"
Stacktrace:
#14 Whoops\Exception\ErrorException in /var/www/ilias/components/ILIAS/Container/Content/class.ilContainerRenderer.php:962
```

in some rare cases, seems to be related with deleted objects. but anyway, since `$this->item_presentation->getRawDataByRefId($ref_id);`may return null as well, this should be checked before continuing in the loop.

Not sure if a general issue, may be related to inconsistent data but this check would be an improvement anyway.