### PR TITLE
[FIX] #45478 Page Editor: expand/collapse of nested accordions.

### DIFF
--- a/components/ILIAS/COPage/PC/Tabs/js/presentation.js
+++ b/components/ILIAS/COPage/PC/Tabs/js/presentation.js
@@ -57,7 +57,7 @@ const presentation = (function () {
       hideAllTabs(tabsContainer, contentClass, activeHeadClass);
       showTab(toggler, contentNode, activeHeadClass);
     } else {
-      hideAllTabs(tabsContainer, contentClass);
+      hideAllTabs(tabsContainer, contentClass, activeHeadClass);
     }
   }
 
@@ -141,6 +141,10 @@ const presentation = (function () {
         // register click handler (if not all opened is forced)
         if (behaviour !== 'ForceAllOpen') {
           tabContainer.querySelectorAll(`.${toggleClass}`).forEach((toggler) => {
+            // initialise nested toggles only once.
+            if (toggler.dataset.isInitialised) {
+              return;
+            }
             toggler.querySelectorAll('a').forEach((aInToggler) => {
               aInToggler.addEventListener('click', (e) => {
                 e.stopPropagation(); // enable links inside of accordion header
@@ -152,6 +156,7 @@ const presentation = (function () {
             toggler.addEventListener('keypress', () => {
               toggler.querySelector("div[role='button']").click();
             });
+            toggler.dataset.isInitialised = true;
           });
           if (behaviour === 'FirstOpen') {
             const firstToggler = tabContainer.querySelector(`.${toggleClass}`);


### PR DESCRIPTION
Hi @alex40724,

This PR fixes https://mantis.ilias.de/view.php?id=45478, the expand/collapse behaviour of nested accordions (or tabs), added with the ILIAS page editor. There were actually two issues:

- (a) Nested accordions were initialised multiple times, because the inner loop for registering the click handlers is not restricted to some sort of scope. I am not sure if this could be solved using a `:scope >` inside the selector, because I am unaware of the use cases. Therefore I solved this by using a boolean flag on the toggles dataset.
- (b) Collapsed accordions did not change the glyph back to its original state. I noticed there was a missing `activeHeadClass` argument in the hide function, which fixed the issue.

Kind regards,
@thibsy 