### PR TITLE
#45442 Possible fix for duplicated navigation buttons in learning module export

### DIFF
--- a/Modules/LearningModule/Presentation/class.ilLMNavigationRendererGUI.php
+++ b/Modules/LearningModule/Presentation/class.ilLMNavigationRendererGUI.php
@@ -89,6 +89,8 @@ class ilLMNavigationRendererGUI
 
     protected function render(bool $top = true): string
     {
+        $this->toolbar->setStickyItems([]);
+        
         $page_id = $this->current_page;
 
         $tpl = new ilTemplate("tpl.lm_navigation.html", true, true, "Modules/LearningModule/Presentation");

--- a/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
+++ b/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
@@ -466,6 +466,16 @@ class ilToolbarGUI
         $this->items = $items;
     }
 
+    public function getStickyItems(): array
+    {
+        return $this->sticky_items;
+    }
+
+    public function setStickyItems(array $items): void
+    {
+        $this->sticky_items = $items;
+    }
+
     /**
      * If the toolbar consists of only one button, make it sticky
      * Note: Atm this is only possible for buttons. If we are dealing with objects implementing the ilToolbarItem


### PR DESCRIPTION
This pull request proposes a possible fix for Mantis ticket #45442.

### Fix summary:
- Clears sticky toolbar items before rendering navigation (`ilLMNavigationRendererGUI`)
- Adds public getter and setter for sticky items in `ilToolbarGUI`

