### PR TITLE
T&A 45249: add position of question to results (ILIAS 10)

### DIFF
--- a/components/ILIAS/Test/src/Results/Data/Factory.php
+++ b/components/ILIAS/Test/src/Results/Data/Factory.php
@@ -306,7 +306,8 @@ class Factory
                 $answered,
                 $requested_hints,
                 $recapitulation,
-                $autosave_output
+                $autosave_output,
+                $idx
             );
         }
 

--- a/components/ILIAS/Test/src/Results/Data/QuestionResult.php
+++ b/components/ILIAS/Test/src/Results/Data/QuestionResult.php
@@ -39,7 +39,8 @@ class QuestionResult
         private readonly bool $answered,
         private readonly int $requested_hints,
         private readonly ?string $content_for_recapitulation,
-        private readonly ?string $autosaved_answer
+        private readonly ?string $autosaved_answer,
+        private readonly int $position,
     ) {
     }
 
@@ -112,6 +113,10 @@ class QuestionResult
     public function getAutosavedAnswer(): ?string
     {
         return $this->autosaved_answer;
+    }
+    public function getPosition(): int
+    {
+        return $this->position;
     }
 
 }

--- a/components/ILIAS/Test/src/Results/Presentation/AttemptResultsTable.php
+++ b/components/ILIAS/Test/src/Results/Presentation/AttemptResultsTable.php
@@ -23,6 +23,7 @@ namespace ILIAS\Test\Results\Presentation;
 use ILIAS\Test\Results\Data\AttemptResult;
 use ILIAS\Test\Results\Data\QuestionResult;
 use ILIAS\UI\Component\Table\Presentation as PresentationTable;
+use ILIAS\UI\Component\Table\PresentationRow;
 use ILIAS\UI\URLBuilder;
 use ILIAS\UI\Factory as UIFactory;
 use ILIAS\UI\Renderer as UIRenderer;
@@ -180,19 +181,16 @@ class AttemptResultsTable
 
     private function getMapping(): \Closure
     {
-        return function ($row, $question, $ui_factory, $environment) {
+        return function (PresentationRow $row, QuestionResult $question, UIFactory $ui_factory, array $environment) {
             $env = $environment[self::ENV];
             $lng = $environment[self::LNG];
 
-            $title = sprintf(
-                '%s [ID: %s]',
-                $this->refinery->encode()->htmlSpecialCharsAsEntities()->transform(
-                    $question->getTitle()
-                ),
-                (string) $question->getId()
+            $title = $this->refinery->encode()->htmlSpecialCharsAsEntities()->transform(
+                $question->getTitle()
             );
 
             $important_fields = [
+                $lng->txt('position') => (string) ($question->getPosition() + 1),
                 $lng->txt('question_id') => (string) $question->getId(),
                 $lng->txt('question_type') => $lng->txt($question->getType()),
                 $lng->txt('points') => sprintf(

--- a/components/ILIAS/Test/tests/Results/Data/QuestionResultTest.php
+++ b/components/ILIAS/Test/tests/Results/Data/QuestionResultTest.php
@@ -41,6 +41,7 @@ class QuestionResultTest extends TestCase
             $requested_hints = 2,
             $recapitulation = 'some recap',
             $autosave = 'some autosave content',
+            $position = 765
         );
 
         $this->assertEquals($id, $qr->getId());
@@ -56,5 +57,6 @@ class QuestionResultTest extends TestCase
         $this->assertEquals($recapitulation, $qr->getContentForRecapitulation());
         $this->assertEquals($requested_hints, $qr->getNumberOfRequestedHints());
         $this->assertEquals($autosave, $qr->getAutosavedAnswer());
+        $this->assertEquals($position, $qr->getPosition());
     }
 }


### PR DESCRIPTION
This commit is related to Mantis-Ticket https://mantis.ilias.de/view.php?id=45249.

It ports the changes originally implemented by @nhaagen in #9712, commit https://github.com/ILIAS-eLearning/ILIAS/pull/9712/commits/c7074ca4f9fb416845e8a071a8b7c2eefd9133f6 to ILIAS 10 and later versions.