### PR TITLE
Mantis #35665: Fix object desc shortened to 128 chars on creation

### DIFF
--- a/Services/Container/classes/class.ilContainer.php
+++ b/Services/Container/classes/class.ilContainer.php
@@ -832,7 +832,7 @@ class ilContainer extends ilObject
         // add default translation
         $this->addTranslation(
             $this->getTitle(),
-            $this->getDescription(),
+            $this->getLongDescription(),
             $lng->getDefaultLanguage(),
             '1'
         );


### PR DESCRIPTION
Fixes https://mantis.ilias.de/view.php?id=35665

When an object is created, the short description (128 characters) is stored as the default translation.

This default translation is then also shown to the user in the objects settings. Which makes it seem like the full description is gone.

A user may then however enter up to 4000 characters into the **Description** input which will then be saved and shown without being shortened).

This text is then only shortened when displaying to an optionally configurable length.

If accepted, should be picked into **ILIAS 10** & **trunk**