### PR TITLE
CSS: Remove padding for buttons in header actions list

### DIFF
--- a/templates/default/070-components/legacy/_component_headline.scss
+++ b/templates/default/070-components/legacy/_component_headline.scss
@@ -61,12 +61,6 @@ div.ilHeadAction a:hover {
 	text-decoration: none;
 }
 
-div.ilHeadAction ul.dropdown-menu button {
-	text-decoration: none;
-	border: none;
-	padding-left: 10px;
-}
-
 div.ilHeaderDesc {
 	font-size: $il-font-size-base;
 	padding: 0;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -9660,12 +9660,6 @@ div.ilHeadAction a:hover {
   text-decoration: none;
 }
 
-div.ilHeadAction ul.dropdown-menu button {
-  text-decoration: none;
-  border: none;
-  padding-left: 10px;
-}
-
 div.ilHeaderDesc {
   font-size: 0.875rem;
   padding: 0;


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=45529

This PR fixes an obsolete `padding-left` for buttons in the header actions list.

If approved, please pick this to all relevant branches.