### PR TITLE
T&A: Restore Latex Support in Test Questions

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assClozeTestGUI.php
@@ -327,7 +327,8 @@ JS;
         $cloze_text = new ilTextAreaInputGUI($this->lng->txt("cloze_text"), 'cloze_text');
         $cloze_text->setRequired(true);
         $cloze_text->setValue($this->applyIndizesToGapText($this->object->getClozeText()));
-        $cloze_text->setInfo($this->lng->txt("close_text_hint"));
+        $cloze_text->setInfo($this->lng->txt("close_text_hint") . ' '
+            . $this->lng->txt('latex_edit_info'));
         $cloze_text->setRows(10);
         $cloze_text->setCols(80);
         if (!$this->object->getSelfAssessmentEditingMode()) {
@@ -800,8 +801,8 @@ JS;
                     break;
             }
         }
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
-        $template->setVariable("CLOZETEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($output, true));
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
+        $template->setVariable("CLOZETEXT", $this->renderLatex(ilLegacyFormElementsUtil::prepareTextareaOutput($output, true)));
         $questionoutput = $template->get();
         if (!$show_question_only) {
             // get page object output
@@ -988,13 +989,11 @@ JS;
         }
 
         if ($show_question_text) {
-            $template->setVariable(
-                "QUESTIONTEXT",
-                $this->object->getQuestionForHTMLOutput()
-            );
+            $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         }
 
-        $template->setVariable("CLOZETEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($output, true));
+        $template->setVariable("CLOZETEXT", $this->renderLatex(ilLegacyFormElementsUtil::prepareTextareaOutput($output, true)));
+
         // generate the question output
         $solutiontemplate = new ilTemplate("tpl.il_as_tst_solution_output.html", true, true, "components/ILIAS/TestQuestionPool");
         $questionoutput = $template->get();
@@ -1016,7 +1015,9 @@ JS;
             );
 
             $solutiontemplate->setVariable("ILC_FB_CSS_CLASS", $cssClass);
-            $solutiontemplate->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true));
+            $solutiontemplate->setVariable("FEEDBACK", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true)
+            ));
         }
 
         $solutiontemplate->setVariable("SOLUTION_OUTPUT", $questionoutput);
@@ -1066,10 +1067,10 @@ JS;
 
         $output = '';
         if ($correct_feedback . $incorrect_feedback !== '') {
-            $output = $this->genericFeedbackOutputBuilder($correct_feedback, $incorrect_feedback, $active_id, $pass);
+            $output = $this->genericFeedbackOutputBuilder($active_id, $pass);
         }
         //$test = new ilObjTest($this->object->active_id);
-        return ilLegacyFormElementsUtil::prepareTextareaOutput($output, true);
+        return $this->renderLatex(ilLegacyFormElementsUtil::prepareTextareaOutput($output, true));
     }
 
     public function getTestOutput(
@@ -1165,8 +1166,8 @@ JS;
             }
         }
 
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
-        $template->setVariable("CLOZETEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($output, true));
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
+        $template->setVariable("CLOZETEXT", $this->renderLatex(ilLegacyFormElementsUtil::prepareTextareaOutput($output, true)));
         $questionoutput = $template->get();
         $pageoutput = $this->outQuestionPage("", $is_question_postponed, $active_id, $questionoutput);
         return $pageoutput;
@@ -1196,7 +1197,7 @@ JS;
         }
         $feedback .= '</tbody></table>';
 
-        return ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true);
+        return $this->renderLatex(ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true));
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.assErrorTextGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assErrorTextGUI.php
@@ -292,7 +292,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         }
 
         if ($show_question_text === true) {
-            $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+            $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         }
 
         $correctness_icons = [
@@ -373,7 +373,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         if ($this->object->getTextSize() >= 10) {
             $template->setVariable("STYLE", " style=\"font-size: " . $this->object->getTextSize() . "%;\"");
         }
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $errortext = $this->object->assembleErrorTextOutput($selections);
         if ($this->getTargetGuiClass() !== null) {
             $this->ctrl->setParameterByClass($this->getTargetGuiClass(), 'errorvalue', '');
@@ -432,7 +432,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
         }
         $feedback .= '</tbody></table>';
 
-        return ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true);
+        return $this->renderLatex(ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true));
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.assFileUploadGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFileUploadGUI.php
@@ -228,7 +228,7 @@ class assFileUploadGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
             $template->setVariable("RESULT_OUTPUT", sprintf($resulttext, $reached_points));
         }
         if ($show_question_text == true) {
-            $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+            $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         }
         $questionoutput = $template->get();
         $solutiontemplate = new ilTemplate("tpl.il_as_tst_solution_output.html", true, true, "components/ILIAS/TestQuestionPool");
@@ -285,7 +285,7 @@ class assFileUploadGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
             $template->setVariable("TXT_ALLOWED_EXTENSIONS", ilLegacyFormElementsUtil::prepareTextareaOutput($this->lng->txt("allowedextensions") . ": " . $this->object->getAllowedExtensions()));
             $template->parseCurrentBlock();
         }
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $template->setVariable("CMD_UPLOAD", $this->getQuestionActionCmd());
         $template->setVariable("TEXT_UPLOAD", ilLegacyFormElementsUtil::prepareTextareaOutput($this->lng->txt('upload')));
         $template->setVariable("TXT_UPLOAD_FILE", ilLegacyFormElementsUtil::prepareTextareaOutput($this->lng->txt('file_add')));
@@ -337,7 +337,7 @@ class assFileUploadGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
             $template->setVariable("TXT_ALLOWED_EXTENSIONS", ilLegacyFormElementsUtil::prepareTextareaOutput($this->lng->txt("allowedextensions") . ": " . $this->object->getAllowedExtensions()));
             $template->parseCurrentBlock();
         }
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $template->setVariable("CMD_UPLOAD", self::HANDLE_FILE_UPLOAD);
         $template->setVariable("TEXT_UPLOAD", ilLegacyFormElementsUtil::prepareTextareaOutput($this->lng->txt('upload')));
         $template->setVariable("TXT_UPLOAD_FILE", ilLegacyFormElementsUtil::prepareTextareaOutput($this->lng->txt('file_add')));

--- a/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assFormulaQuestionGUI.php
@@ -877,7 +877,9 @@ class assFormulaQuestionGUI extends assQuestionGUI
             'not_correct' => $this->generateCorrectnessIconsForCorrectness(self::CORRECTNESS_NOT_OK)
         ];
         $questiontext = $this->object->substituteVariables($user_solutions, $graphical_output, true, $result_output, $correctness_icons);
-        $template->setVariable("QUESTIONTEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true));
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex(
+            ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true)
+        ));
         $questionoutput = $template->get();
         $solutiontemplate = new ilTemplate("tpl.il_as_tst_solution_output.html", true, true, "components/ILIAS/TestQuestionPool");
         $feedback = ($show_feedback) ? $this->getGenericFeedbackOutput((int) $active_id, $pass) : "";
@@ -887,7 +889,9 @@ class assFormulaQuestionGUI extends assQuestionGUI
                 ilAssQuestionFeedback::CSS_CLASS_FEEDBACK_CORRECT : ilAssQuestionFeedback::CSS_CLASS_FEEDBACK_WRONG
             );
             $solutiontemplate->setVariable("ILC_FB_CSS_CLASS", $cssClass);
-            $solutiontemplate->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true));
+            $solutiontemplate->setVariable("FEEDBACK", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true)
+            ));
         }
         $solutiontemplate->setVariable("SOLUTION_OUTPUT", $questionoutput);
 
@@ -940,7 +944,9 @@ class assFormulaQuestionGUI extends assQuestionGUI
         } else {
             $questiontext = $this->object->substituteVariables([]);
         }
-        $template->setVariable("QUESTIONTEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true));
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex(
+            ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true)
+        ));
         $questionoutput = $template->get();
         if (!$show_question_only) {
             // get page object output
@@ -1005,7 +1011,9 @@ class assFormulaQuestionGUI extends assQuestionGUI
 
         $questiontext = $this->object->substituteVariables($user_solution);
 
-        $template->setVariable("QUESTIONTEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true));
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex(
+            ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true)
+        ));
 
         $questionoutput = $template->get();
         $pageoutput = $this->outQuestionPage("", $is_question_postponed, $active_id, $questionoutput);

--- a/components/ILIAS/TestQuestionPool/classes/class.assImagemapQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assImagemapQuestionGUI.php
@@ -507,7 +507,9 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $template = new ilTemplate("tpl.il_as_qpl_imagemap_question_output_solution.html", true, true, "components/ILIAS/TestQuestionPool");
         $solutiontemplate = new ilTemplate("tpl.il_as_tst_solution_output.html", true, true, "components/ILIAS/TestQuestionPool");
         if ($show_question_text == true) {
-            $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+            $template->setVariable("QUESTIONTEXT", $this->renderLatex(
+                $this->object->getQuestionForHTMLOutput()
+            ));
         }
 
         try {
@@ -621,7 +623,7 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
             $template->setVariable("TITLE", ilLegacyFormElementsUtil::prepareFormOutput($answer->getAnswertext()));
             $template->parseCurrentBlock();
         }
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         try {
             $template->setVariable("IMG_SRC", ilWACSignedPath::signFile($imagepath));
         } catch (ilWACException $e) {
@@ -694,7 +696,9 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
                 }
             }
         }
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex(
+            $this->object->getQuestionForHTMLOutput()
+        ));
         try {
             $template->setVariable("IMG_SRC", ilWACSignedPath::signFile($imagepath));
         } catch (ilWACException $e) {
@@ -780,7 +784,7 @@ class assImagemapQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
         $output .= '</tbody></table>';
 
-        return ilLegacyFormElementsUtil::prepareTextareaOutput($output, true);
+        return $this->renderLatex(ilLegacyFormElementsUtil::prepareTextareaOutput($output, true));
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.assKprimChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assKprimChoiceGUI.php
@@ -288,7 +288,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
     public function populateAnswerSpecificFormPart(ilPropertyFormGUI $form): ilPropertyFormGUI
     {
         $answers = new ilKprimChoiceWizardInputGUI($this->lng->txt('answers'), 'kprimanswers');
-        $answers->setInfo($this->lng->txt('kprim_answers_info'));
+        $answers->setInfo($this->lng->txt('kprim_answers_info') . ' ' . $this->lng->txt('latex_edit_info'));
         $answers->setSize(64);
         $answers->setRequired(true);
         $answers->setAllowMove(true);
@@ -419,7 +419,9 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
 
             $template->setCurrentBlock("answer_row");
             $template->setVariable("ANSWER_ID", $answer_id);
-            $template->setVariable("ANSWER_TEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true));
+            $template->setVariable("ANSWER_TEXT", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true)
+            ));
             $template->setVariable('VALUE_TRUE', 1);
             $template->setVariable('VALUE_FALSE', 0);
 
@@ -431,7 +433,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
             $template->parseCurrentBlock();
         }
 
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $template->setVariable("INSTRUCTIONTEXT", $this->object->getInstructionTextTranslation(
             $this->lng,
             $this->object->getOptionLabel()
@@ -503,7 +505,9 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
 
             $template->setCurrentBlock("answer_row");
             $template->setVariable("ANSWER_ID", $answer_id);
-            $template->setVariable("ANSWER_TEXT", ilLegacyFormElementsUtil::prepareTextareaOutput((string) $answer->getAnswertext(), true));
+            $template->setVariable("ANSWER_TEXT", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput((string) $answer->getAnswertext(), true)
+            ));
             $template->setVariable('VALUE_TRUE', 1);
             $template->setVariable('VALUE_FALSE', 0);
 
@@ -518,7 +522,9 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         if ($show_inline_feedback && $this->hasInlineFeedback()) {
             $questiontext .= $this->buildFocusAnchorHtml();
         }
-        $template->setVariable("QUESTIONTEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true));
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex(
+            ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true)
+        ));
 
         $template->setVariable("INSTRUCTIONTEXT", $this->object->getInstructionTextTranslation(
             $this->lng,
@@ -657,7 +663,9 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
             }
 
             $template->setCurrentBlock("answer_row");
-            $template->setVariable("ANSWER_TEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true));
+            $template->setVariable("ANSWER_TEXT", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true)
+            ));
 
             if ($this->renderPurposeSupportsFormHtml() || $this->isRenderPurposePrintPdf()) {
                 if (isset($user_solution[$answer->getPosition()])) {
@@ -766,7 +774,9 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
                 $fb = $this->object->feedbackOBJ->getSpecificAnswerFeedbackTestPresentation($this->object->getId(), 0, $answer_id);
                 if (strlen($fb)) {
                     $template->setCurrentBlock("feedback");
-                    $template->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true));
+                    $template->setVariable("FEEDBACK", $this->renderLatex(
+                        ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true)
+                    ));
                     $template->parseCurrentBlock();
                 }
             }
@@ -776,7 +786,9 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
             $fb = $this->object->feedbackOBJ->getSpecificAnswerFeedbackTestPresentation($this->object->getId(), 0, $answer_id);
             if (strlen($fb)) {
                 $template->setCurrentBlock("feedback");
-                $template->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true));
+                $template->setVariable("FEEDBACK", $this->renderLatex(
+                    ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true)
+                ));
                 $template->parseCurrentBlock();
             }
         }
@@ -788,7 +800,9 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
                 $fb = $this->object->feedbackOBJ->getSpecificAnswerFeedbackTestPresentation($this->object->getId(), 0, $answer_id);
                 if (strlen($fb)) {
                     $template->setCurrentBlock("feedback");
-                    $template->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true));
+                    $template->setVariable("FEEDBACK", $this->renderLatex(
+                        ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true)
+                    ));
                     $template->parseCurrentBlock();
                 }
             }

--- a/components/ILIAS/TestQuestionPool/classes/class.assLongMenuGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assLongMenuGUI.php
@@ -386,7 +386,7 @@ class assLongMenuGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjus
 
         $template = new ilTemplate("tpl.il_as_qpl_longmenu_question_output_solution.html", true, true, "components/ILIAS/TestQuestionPool");
         if ($show_question_text) {
-            $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+            $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         }
         $template->setVariable('LONGMENU_TEXT_SOLUTION', $this->getLongMenuTextWithInputFieldsInsteadOfGaps($user_solution, true, $graphical_output));
 
@@ -470,7 +470,7 @@ class assLongMenuGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjus
             . json_encode($this->object->getAvailableAnswerOptions())
             . ')');
 
-        $template->setVariable('QUESTIONTEXT', $this->object->getQuestionForHTMLOutput());
+        $template->setVariable('QUESTIONTEXT', $this->renderLatex($this->renderLatex($this->object->getQuestionForHTMLOutput())));
         $template->setVariable('LONGMENU_TEXT', $this->getLongMenuTextWithInputFieldsInsteadOfGaps($user_solution));
         return $template;
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
@@ -352,6 +352,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         if ($this->isDefImgUploadCommand()) {
             $definitions->checkInput();
         }
+        $definitions->setInfo($this->lng->txt('latex_edit_info'));
         $form->addItem($definitions);
 
         $terms = new ilMatchingWizardInputGUI($this->lng->txt("terms"), "terms");
@@ -374,6 +375,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         if ($this->isTermImgUploadCommand()) {
             $terms->checkInput();
         }
+        $terms->setInfo($this->lng->txt('latex_edit_info'));
         $form->addItem($terms);
 
         $pairs = new ilMatchingPairWizardInputGUI($this->lng->txt('matching_pairs'), 'pairs');
@@ -696,7 +698,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
             )
         );
 
-        $template->setVariable('QUESTIONTEXT', $this->object->getQuestionForHTMLOutput());
+        $template->setVariable('QUESTIONTEXT', $this->renderLatex($this->object->getQuestionForHTMLOutput()));
 
         $questionoutput = $template->get();
 
@@ -726,13 +728,17 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
             $template->setVariable('THUMBNAIL_HREF', $thumbweb);
             $template->setVariable('THUMB_ALT', $this->lng->txt('image'));
             $template->setVariable('THUMB_TITLE', $this->lng->txt('image'));
-            $template->setVariable('TEXT_DEFINITION', (strlen($definition->getText())) ? ilLegacyFormElementsUtil::prepareTextareaOutput($definition->getText(), true, true) : '');
+            $template->setVariable('TEXT_DEFINITION', (strlen($definition->getText())) ? $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($definition->getText(), true, true)
+            ) : '');
             $template->setVariable('TEXT_PREVIEW', $this->lng->txt('preview'));
             $template->setVariable('IMG_PREVIEW', ilUtil::getImagePath('media/enlarge.svg'));
             $template->parseCurrentBlock();
         } else {
             $template->setCurrentBlock('definition_text');
-            $template->setVariable('DEFINITION', ilLegacyFormElementsUtil::prepareTextareaOutput($definition->getText(), true, true));
+            $template->setVariable('DEFINITION', $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($definition->getText(), true, true)
+            ));
             $template->parseCurrentBlock();
         }
 
@@ -801,7 +807,9 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
 
         if ($term->getPicture() === '') {
             $template->setCurrentBlock('term_text');
-            $template->setVariable('TERM_TEXT', ilLegacyFormElementsUtil::prepareTextareaOutput($term->getText(), true, true));
+            $template->setVariable('TERM_TEXT', $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($term->getText(), true, true)
+            ));
             $template->parseCurrentBlock();
             return $template->get();
         }
@@ -819,7 +827,9 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $template->setVariable('THUMB_TITLE', $this->lng->txt('image'));
         $template->setVariable('TEXT_PREVIEW', $this->lng->txt('preview'));
         $template->setVariable('TEXT_TERM', $term->getText() !== ''
-            ? ilLegacyFormElementsUtil::prepareTextareaOutput($term->getText(), true, true)
+            ? $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($term->getText(), true, true)
+            )
             : '');
         $template->setVariable('IMG_PREVIEW', ilUtil::getImagePath('media/enlarge.svg'));
         $template->parseCurrentBlock();
@@ -925,7 +935,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
             )
         );
 
-        $template->setVariable('QUESTIONTEXT', $this->object->getQuestionForHTMLOutput());
+        $template->setVariable('QUESTIONTEXT', $this->renderLatex($this->object->getQuestionForHTMLOutput()));
 
         return $this->outQuestionPage('', $is_question_postponed, $active_id, $template->get());
     }
@@ -975,7 +985,7 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         }
 
         $feedback .= '</tbody></table>';
-        return ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true);
+        return $this->renderLatex(ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true));
     }
 
     /**

--- a/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -320,7 +320,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
                             );
                             if (strlen($fb)) {
                                 $template->setCurrentBlock("feedback");
-                                $template->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true));
+                                $template->setVariable("FEEDBACK", $this->renderLatex(
+                                    ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true)
+                                ));
                                 $template->parseCurrentBlock();
                             }
                         }
@@ -335,7 +337,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
                     );
                     if (strlen($fb)) {
                         $template->setCurrentBlock("feedback");
-                        $template->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true));
+                        $template->setVariable("FEEDBACK", $this->renderLatex(
+                            ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true)
+                        ));
                         $template->parseCurrentBlock();
                     }
                 }
@@ -352,7 +356,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
                         );
                         if (strlen($fb)) {
                             $template->setCurrentBlock("feedback");
-                            $template->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true));
+                            $template->setVariable("FEEDBACK", $this->renderLatex(
+                                ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true)
+                            ));
                             $template->parseCurrentBlock();
                         }
                     }
@@ -362,7 +368,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
 
 
             $template->setCurrentBlock("answer_row");
-            $template->setVariable("ANSWER_TEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true));
+            $template->setVariable("ANSWER_TEXT", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true)
+            ));
             $checked = false;
             if ($result_output) {
                 $pointschecked = $this->object->answers[$answer_id]->getPointsChecked();
@@ -402,7 +410,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
             $questiontext .= $this->buildFocusAnchorHtml();
         }
         if ($show_question_text == true) {
-            $template->setVariable("QUESTIONTEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true));
+            $template->setVariable("QUESTIONTEXT", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true)
+            ));
         }
         $questionoutput = $template->get();
         $feedback = ($show_feedback && !$this->isTestPresentationContext()) ? $this->getGenericFeedbackOutput((int) $active_id, $pass) : "";
@@ -414,7 +424,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
             );
 
             $solutiontemplate->setVariable("ILC_FB_CSS_CLASS", $cssClass);
-            $solutiontemplate->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true));
+            $solutiontemplate->setVariable("FEEDBACK", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true)
+            ));
         }
         $solutiontemplate->setVariable("SOLUTION_OUTPUT", $questionoutput);
 
@@ -478,7 +490,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
             $template->setCurrentBlock("answer_row");
             $template->setVariable("QID", $this->object->getId());
             $template->setVariable("ANSWER_ID", $answer_id);
-            $template->setVariable("ANSWER_TEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true));
+            $template->setVariable("ANSWER_TEXT", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true)
+            ));
             foreach ($user_solution as $mc_solution) {
                 if ((string) $mc_solution === (string) $answer_id) {
                     $template->setVariable("CHECKED_ANSWER", " checked=\"checked\"");
@@ -502,7 +516,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         if ($show_inline_feedback && $this->hasInlineFeedback()) {
             $questiontext .= $this->buildFocusAnchorHtml();
         }
-        $template->setVariable("QUESTIONTEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true));
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex(
+            ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true)
+        ));
         $questionoutput = $template->get();
         if (!$show_question_only) {
             // get page object output
@@ -587,7 +603,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
             $template->setCurrentBlock("answer_row");
             $template->setVariable("QID", $this->object->getId());
             $template->setVariable("ANSWER_ID", $answer_id);
-            $template->setVariable("ANSWER_TEXT", ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true));
+            $template->setVariable("ANSWER_TEXT", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true)
+            ));
             foreach ($user_solution as $mc_solution) {
                 if ((string) $mc_solution === (string) $answer_id) {
                     $template->setVariable("CHECKED_ANSWER", " checked=\"checked\"");
@@ -596,7 +614,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
             $template->parseCurrentBlock();
         }
 
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $template->setVariable("QUESTION_ID", $this->object->getId());
         if ($this->object->getSelectionLimit()) {
             $template->setVariable('SELECTION_LIMIT_HINT', sprintf(
@@ -846,6 +864,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
             },
             $this->object->getAnswers()
         ));
+        $choices->setInfo($this->lng->txt('latex_edit_info'));
         $form->addItem($choices);
         return $form;
     }
@@ -908,7 +927,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
                     $fb = $this->object->feedbackOBJ->getSpecificAnswerFeedbackTestPresentation($this->object->getId(), 0, $answer_id);
                     if (strlen($fb)) {
                         $template->setCurrentBlock("feedback");
-                        $template->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true));
+                        $template->setVariable("FEEDBACK", $this->renderLatex(
+                            ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true)
+                        ));
                         $template->parseCurrentBlock();
                     }
                 }
@@ -919,7 +940,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
             $fb = $this->object->feedbackOBJ->getSpecificAnswerFeedbackTestPresentation($this->object->getId(), 0, $answer_id);
             if (strlen($fb)) {
                 $template->setCurrentBlock("feedback");
-                $template->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true));
+                $template->setVariable("FEEDBACK", $this->renderLatex(
+                    ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true)
+                ));
                 $template->parseCurrentBlock();
             }
         }
@@ -931,7 +954,9 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
                 $fb = $this->object->feedbackOBJ->getSpecificAnswerFeedbackTestPresentation($this->object->getId(), 0, $answer_id);
                 if (strlen($fb)) {
                     $template->setCurrentBlock("feedback");
-                    $template->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true));
+                    $template->setVariable("FEEDBACK", $this->renderLatex(
+                        ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true)
+                    ));
                     $template->parseCurrentBlock();
                 }
             }

--- a/components/ILIAS/TestQuestionPool/classes/class.assNumeric.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assNumeric.php
@@ -146,7 +146,7 @@ class assNumeric extends assQuestion implements ilObjQuestionScoringAdjustable, 
             $points = $this->getPoints();
         }
 
-        return $this->ensureNonNegativePoints($reachedPoints);
+        return $this->ensureNonNegativePoints($points);
     }
 
     public function calculateReachedPoints(

--- a/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assNumericGUI.php
@@ -231,7 +231,7 @@ class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjust
         }
         $template->setVariable("NUMERIC_SIZE", $this->object->getMaxChars());
         if ($show_question_text == true) {
-            $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+            $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         }
         $questionoutput = $template->get();
         //$feedback = ($show_feedback) ? $this->getAnswerFeedbackOutput($active_id, $pass) : ""; // Moving new method
@@ -266,7 +266,7 @@ class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjust
             $template->setVariable("NUMERIC_VALUE", " value=\"" . $this->getPreviewSession()->getParticipantsSolution() . "\"");
         }
         $template->setVariable("NUMERIC_SIZE", $this->object->getMaxChars());
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $questionoutput = $template->get();
         if (!$show_question_only) {
             // get page object output
@@ -301,7 +301,7 @@ class assNumericGUI extends assQuestionGUI implements ilGuiQuestionScoringAdjust
             }
         }
         $template->setVariable("NUMERIC_SIZE", $this->object->getMaxChars());
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $questionoutput = $template->get();
         $pageoutput = $this->outQuestionPage("", $is_question_postponed, $active_id, $questionoutput);
         return $pageoutput;

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingHorizontalGUI.php
@@ -201,7 +201,7 @@ class assOrderingHorizontalGUI extends assQuestionGUI implements ilGuiQuestionSc
             $template->setVariable("RESULT_OUTPUT", sprintf($resulttext, $reached_points));
         }
         if ($show_question_text == true) {
-            $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+            $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         }
         //		$template->setVariable("SOLUTION_TEXT", ilUtil::prepareFormOutput($solutionvalue));
         if ($this->object->getTextSize() >= 10) {
@@ -266,7 +266,9 @@ class assOrderingHorizontalGUI extends assQuestionGUI implements ilGuiQuestionSc
         if ($this->object->getTextSize() >= 10) {
             $template->setVariable('STYLE', ' style="font-size: ' . $this->object->getTextSize() . '%;"');
         }
-        $template->setVariable('QUESTIONTEXT', $this->object->getQuestionForHTMLOutput());
+        $template->setVariable('QUESTIONTEXT', $this->renderLatex(
+            $this->object->getQuestionForHTMLOutput()
+        ));
         if ($show_question_only) {
             return $template->get();
         }
@@ -306,7 +308,7 @@ class assOrderingHorizontalGUI extends assQuestionGUI implements ilGuiQuestionSc
             $template->setVariable('STYLE', ' style="font-size: ' . $this->object->getTextSize() . '%;"');
         }
         $template->setVariable('VALUE_ORDERRESULT', ' value="' . join('{::}', $elements) . '"');
-        $template->setVariable('QUESTIONTEXT', $this->object->getQuestionForHTMLOutput());
+        $template->setVariable('QUESTIONTEXT', $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         return $this->outQuestionPage("", $is_question_postponed, $active_id, $template->get());
     }
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestion.php
@@ -927,6 +927,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         );
 
         $this->initOrderingElementFormFieldLabels($orderingElementInput);
+        $orderingElementInput->setInfo($orderingElementInput->getInfo() . ' ' . $this->lng->txt('latex_edit_info'));
 
         return $orderingElementInput;
     }

--- a/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assOrderingQuestionGUI.php
@@ -489,9 +489,9 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $solution_html = $answers_gui->getHTML();
 
         $template = new ilTemplate('tpl.il_as_qpl_nested_ordering_output_solution.html', true, true, 'components/ILIAS/TestQuestionPool');
-        $template->setVariable('SOLUTION_OUTPUT', $solution_html);
+        $template->setVariable('SOLUTION_OUTPUT', $this->renderLatex($solution_html));
         if ($show_question_text == true) {
-            $template->setVariable('QUESTIONTEXT', $this->object->getQuestionForHTMLOutput());
+            $template->setVariable('QUESTIONTEXT', $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         }
         $questionoutput = $template->get();
 
@@ -549,9 +549,9 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $template = new ilTemplate('tpl.il_as_qpl_ordering_output.html', true, true, 'components/ILIAS/TestQuestionPool');
 
         $template->setCurrentBlock('nested_ordering_output');
-        $template->setVariable('NESTED_ORDERING', $answers->getHTML());
+        $template->setVariable('NESTED_ORDERING', $this->renderLatex($answers->getHTML()));
         $template->parseCurrentBlock();
-        $template->setVariable('QUESTIONTEXT', $this->object->getQuestionForHTMLOutput());
+        $template->setVariable('QUESTIONTEXT', $this->renderLatex($this->object->getQuestionForHTMLOutput()));
 
         if ($show_question_only) {
             return $template->get();
@@ -585,10 +585,10 @@ class assOrderingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $ordering_gui->setElementList($solutionOrderingElementList);
 
         $template->setCurrentBlock('nested_ordering_output');
-        $template->setVariable('NESTED_ORDERING', $ordering_gui->getHTML());
+        $template->setVariable('NESTED_ORDERING', $this->renderLatex($ordering_gui->getHTML()));
         $template->parseCurrentBlock();
 
-        $template->setVariable('QUESTIONTEXT', $this->object->getQuestionForHTMLOutput());
+        $template->setVariable('QUESTIONTEXT', $this->renderLatex($this->object->getQuestionForHTMLOutput()));
 
         $pageoutput = $this->outQuestionPage('', $is_question_postponed, $active_id, $template->get());
 

--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -904,6 +904,7 @@ abstract class assQuestionGUI
             $question->setRteTags(ilAssSelfAssessmentQuestionFormatter::getSelfAssessmentTags());
             $question->setUseTagsForRteOnly(false);
         }
+        $question->setInfo($this->lng->txt('latex_edit_info'));
         $form->addItem($question);
 
         $question_type = new ilHiddenInputGUI('question_type');
@@ -1010,7 +1011,7 @@ abstract class assQuestionGUI
         if ($this->object->isAdditionalContentEditingModePageObject()) {
             return $output;
         }
-        return ilLegacyFormElementsUtil::prepareTextareaOutput($output, true);
+        return $this->renderLatex(ilLegacyFormElementsUtil::prepareTextareaOutput($output, true));
     }
 
     protected function genericFeedbackOutputBuilder(
@@ -1036,17 +1037,19 @@ abstract class assQuestionGUI
 
     public function getGenericFeedbackOutputForCorrectSolution(): string
     {
-        return ilLegacyFormElementsUtil::prepareTextareaOutput(
+        return $this->renderLatex(ilLegacyFormElementsUtil::prepareTextareaOutput(
             $this->object->feedbackOBJ->getGenericFeedbackTestPresentation($this->object->getId(), true),
             true
-        );
+        ));
     }
 
     public function getGenericFeedbackOutputForIncorrectSolution(): string
     {
-        return ilLegacyFormElementsUtil::prepareTextareaOutput(
-            $this->object->feedbackOBJ->getGenericFeedbackTestPresentation($this->object->getId(), false),
-            true
+        return  $this->renderLatex(
+            ilLegacyFormElementsUtil::prepareTextareaOutput(
+                $this->object->feedbackOBJ->getGenericFeedbackTestPresentation($this->object->getId(), false),
+                true
+            )
         );
     }
 
@@ -1880,14 +1883,9 @@ abstract class assQuestionGUI
             }
         }
 
-        // since server side mathjax rendering does include svg-xml structures that indeed have linebreaks,
-        // do latex conversion AFTER replacing linebreaks with <br>. <svg> tag MUST NOT contain any <br> tags.
         if ($prepare_for_latex_output) {
-            $result = ilMathJax::getInstance()->insertLatexImages($result, "\<span class\=\"latex\">", "\<\/span>");
-            $result = ilMathJax::getInstance()->insertLatexImages($result, "\[tex\]", "\[\/tex\]");
-        }
+            $result = ilRTE::replaceLatexSpan($result);
 
-        if ($prepare_for_latex_output) {
             // replace special characters to prevent problems with the ILIAS template system
             // eg. if someone uses {1} as an answer, nothing will be shown without the replacement
             $result = str_replace("{", "&#123;", $result);
@@ -1896,6 +1894,14 @@ abstract class assQuestionGUI
         }
 
         return $result;
+    }
+
+    /**
+     * Wrap content with latex in a LatexContent UI component and render it to be processed by MathJax in the browser
+     */
+    protected function renderLatex($content)
+    {
+        return $this->ui->renderer()->render($this->ui->factory()->legacy()->latexContent($content));
     }
 
     protected ?SuggestedSolutionsDatabaseRepository $suggestedsolution_repo = null;

--- a/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -290,7 +290,9 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
                 $this->populateInlineFeedback($template, $answer_id, $user_solution);
             }
             $template->setCurrentBlock('answer_row');
-            $template->setVariable('ANSWER_TEXT', ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true));
+            $template->setVariable('ANSWER_TEXT', $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true)
+            ));
 
             if ($this->renderPurposeSupportsFormHtml() || $this->isRenderPurposePrintPdf()) {
                 if ((string) $user_solution === (string) $answer_id) {
@@ -322,7 +324,9 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
             $questiontext .= $this->buildFocusAnchorHtml();
         }
         if ($show_question_text === true) {
-            $template->setVariable('QUESTIONTEXT', ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true));
+            $template->setVariable('QUESTIONTEXT', $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true)
+            ));
         }
         $questionoutput = $template->get();
         $feedback = ($show_feedback && !$this->isTestPresentationContext()) ? $this->getGenericFeedbackOutput((int) $active_id, $pass) : '';
@@ -414,7 +418,9 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
             $template->setCurrentBlock('answer_row');
             $template->setVariable('QID', $this->object->getId() . 'ID');
             $template->setVariable('ANSWER_ID', $answer_id);
-            $template->setVariable('ANSWER_TEXT', ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true));
+            $template->setVariable('ANSWER_TEXT', $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true)
+            ));
 
             if (is_object($this->getPreviewSession())) {
                 $user_solution = $this->getPreviewSession()->getParticipantsSolution();
@@ -429,7 +435,9 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         if ($show_inline_feedback && $this->hasInlineFeedback()) {
             $questiontext .= $this->buildFocusAnchorHtml();
         }
-        $template->setVariable('QUESTIONTEXT', ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true));
+        $template->setVariable('QUESTIONTEXT', $this->renderLatex(
+            ilLegacyFormElementsUtil::prepareTextareaOutput($questiontext, true)
+        ));
         $questionoutput = $template->get();
         if (!$show_question_only) {
             // get page object output
@@ -495,13 +503,17 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
             }
             $template->setCurrentBlock('answer_row');
             $template->setVariable('ANSWER_ID', $answer_id);
-            $template->setVariable('ANSWER_TEXT', ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true));
+            $template->setVariable('ANSWER_TEXT', $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($answer->getAnswertext(), true)
+            ));
             if ($user_solution === (string) $answer_id) {
                 $template->setVariable('CHECKED_ANSWER', ' checked="checked"');
             }
             $template->parseCurrentBlock();
         }
-        $template->setVariable('QUESTIONTEXT', $this->object->getQuestionForHTMLOutput());
+        $template->setVariable('QUESTIONTEXT', $this->renderLatex(
+            $this->object->getQuestionForHTMLOutput()
+        ));
         $questionoutput = $template->get();
         $pageoutput = $this->outQuestionPage('', $is_question_postponed, $active_id, $questionoutput, $show_specific_inline_feedback);
         return $pageoutput;
@@ -701,6 +713,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
             },
             $this->object->getAnswers()
         ));
+        $choices->setInfo($choices->getInfo() . ' ' . $this->lng->txt('latex_edit_info'));
         $form->addItem($choices);
         return $form;
     }
@@ -793,7 +806,9 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
             $fb = $this->object->feedbackOBJ->getSpecificAnswerFeedbackTestPresentation($this->object->getId(), 0, $answer_id);
             if (strlen($fb)) {
                 $template->setCurrentBlock('feedback');
-                $template->setVariable('FEEDBACK', ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true));
+                $template->setVariable('FEEDBACK', $this->renderLatex(
+                    ilLegacyFormElementsUtil::prepareTextareaOutput($fb, true)
+                ));
                 $template->parseCurrentBlock();
             }
         }

--- a/components/ILIAS/TestQuestionPool/classes/class.assTextQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextQuestionGUI.php
@@ -227,7 +227,9 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
             }
         }
         if ($show_question_text == true) {
-            $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+            $template->setVariable("QUESTIONTEXT", $this->renderLatex(
+                $this->object->getQuestionForHTMLOutput()
+            ));
         }
         $questionoutput = $template->get();
 
@@ -245,7 +247,9 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
             );
 
             $solutiontemplate->setVariable("ILC_FB_CSS_CLASS", $cssClass);
-            $solutiontemplate->setVariable("FEEDBACK", ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true));
+            $solutiontemplate->setVariable("FEEDBACK", $this->renderLatex(
+                ilLegacyFormElementsUtil::prepareTextareaOutput($feedback, true)
+            ));
         }
 
         $solutiontemplate->setVariable("SOLUTION_OUTPUT", $questionoutput);
@@ -383,7 +387,7 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
             $keywordString .= $answer->getAnswertext();
 
             $tpl->setCurrentBlock('keyword');
-            $tpl->setVariable('KEYWORD', $keywordString);
+            $tpl->setVariable('KEYWORD', $this->renderLatex($keywordString));
             $tpl->parseCurrentBlock();
         }
 
@@ -451,7 +455,7 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
             );
         }
 
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $template->setVariable("QID", $this->object->getId());
 
         $questionoutput = $template->get();
@@ -511,7 +515,7 @@ class assTextQuestionGUI extends assQuestionGUI implements ilGuiQuestionScoringA
 
         $template->setVariable("QID", $this->object->getId());
         $template->setVariable("ESSAY", $user_solution);
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $questionoutput = $template->get();
 
         $questionoutput .= $this->getJsCode();

--- a/components/ILIAS/TestQuestionPool/classes/class.assTextSubsetGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextSubsetGUI.php
@@ -288,7 +288,7 @@ class assTextSubsetGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
             $template->setVariable("TEXTFIELD_SIZE", $width);
             $template->parseCurrentBlock();
         }
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $questionoutput = $template->get();
         if (!$show_question_only) {
             // get page object output
@@ -324,7 +324,7 @@ class assTextSubsetGUI extends assQuestionGUI implements ilGuiQuestionScoringAdj
             $template->setVariable("TEXTFIELD_SIZE", $width);
             $template->parseCurrentBlock();
         }
-        $template->setVariable("QUESTIONTEXT", $this->object->getQuestionForHTMLOutput());
+        $template->setVariable("QUESTIONTEXT", $this->renderLatex($this->object->getQuestionForHTMLOutput()));
         $questionoutput = $template->get();
         $pageoutput = $this->outQuestionPage("", $is_question_postponed, $active_id, $questionoutput);
         return $pageoutput;

--- a/components/ILIAS/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
+++ b/components/ILIAS/TestQuestionPool/classes/feedback/class.ilAssQuestionFeedback.php
@@ -259,6 +259,7 @@ abstract class ilAssQuestionFeedback
                 $property->setRteTags(ilAssSelfAssessmentQuestionFormatter::getSelfAssessmentTags());
                 $property->setUseTagsForRteOnly(false);
             }
+            $property->setInfo($this->lng->txt('latex_edit_info'));
 
             $property->setRTESupport($this->questionOBJ->getId(), "qpl", "assessment");
         }

--- a/components/ILIAS/TestQuestionPool/classes/questions/class.ilAssSelfAssessmentQuestionFormatter.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/class.ilAssSelfAssessmentQuestionFormatter.php
@@ -30,10 +30,9 @@ class ilAssSelfAssessmentQuestionFormatter implements ilAssSelfAssessmentMigrato
     {
         $string = $this->handleLineBreaks($string);
         $string = ilRTE::_replaceMediaObjectImageSrc($string, 1);
+        $string = ilRTE::replaceLatexSpan($string);
         $string = str_replace("</li><br />", "</li>", $string);
         $string = str_replace("</li><br>", "</li>", $string);
-        $string = ilMathJax::getInstance()->insertLatexImages($string, "\[tex\]", "\[\/tex\]");
-        $string = ilMathJax::getInstance()->insertLatexImages($string, "\<span class\=\"latex\">", "\<\/span>");
         $string = str_replace('{', '&#123;', $string);
         $string = str_replace('}', '&#125;', $string);
 
@@ -48,36 +47,6 @@ class ilAssSelfAssessmentQuestionFormatter implements ilAssSelfAssessmentMigrato
     {
         if (!ilUtil::isHTML($string)) {
             $string = nl2br($string);
-        }
-
-        return $string;
-    }
-
-    /**
-     * @param string $string
-     * @return string
-     */
-    protected function convertLatexSpanToTex($string): string
-    {
-        // we try to save all latex tags
-        $try = true;
-        $ls = '<span class="latex">';
-        $le = '</span>';
-        while ($try) {
-            // search position of start tag
-            $pos1 = strpos($string, $ls);
-            if (is_int($pos1)) {
-                $pos2 = strpos($string, $le, $pos1);
-                if (is_int($pos2)) {
-                    // both found: replace end tag
-                    $string = substr($string, 0, $pos2) . "[/tex]" . substr($string, $pos2 + 7);
-                    $string = substr($string, 0, $pos1) . "[tex]" . substr($string, $pos1 + 20);
-                } else {
-                    $try = false;
-                }
-            } else {
-                $try = false;
-            }
         }
 
         return $string;
@@ -108,7 +77,7 @@ class ilAssSelfAssessmentQuestionFormatter implements ilAssSelfAssessmentMigrato
      */
     public function migrateToLmContent($string): string
     {
-        $string = $this->convertLatexSpanToTex($string);
+        $string = ilRTE::replaceLatexSpan($string);
         $string = $this->stripHtmlExceptSelfAssessmentTags($string);
         return $string;
     }


### PR DESCRIPTION
This PR implements the FR [Streamline LaTeX usage](https://docu.ilias.de/go/wiki/wpage_5614_1357) in the Test Questions.

This was formerly provided by the use of `ilLegacyFormElementsUtil::prepareTextareaOutput`.

With the remove of the old MathJax service function, the rendering is no longer done implictly. This PR restores the latex support in test questions.

* It use the `Legacy\LatexContent` UI component to display content of question texts, feedbacks and specific answer texts.
* It adds an info to the supported inputs in the question editing forms. The language variable is commonly defined in https://github.com/ILIAS-eLearning/ILIAS/pull/9872.
* Content that has been formerly edited in a textarea, uses the span with class "latex" that was created by TinyMCE. For presentation it should be converted to [tex] and [/tex]. This will be done by ilLegacyFormElementsUtil::prepareTextareaOutput when https://github.com/ILIAS-eLearning/ILIAS/pull/9870 is merged.

Supported texts in test questions are (like in ILIAS 10):

* All question types: question text
* All question types: general and specific feedbach
* Cloze question: cloze text
* Kprim question: answer options
* Matching question: terms and definitions
* Ordering question: ordering elements
* Single choice: answer options
* Multiple choice: answer options
* Text question: answers for automated scoring