### PR TITLE
10/UI/Dropdown/btn entry disabled state 45480

### DIFF
--- a/components/ILIAS/UI/src/examples/Dropdown/Standard/with_buttons_and_links.php
+++ b/components/ILIAS/UI/src/examples/Dropdown/Standard/with_buttons_and_links.php
@@ -13,7 +13,8 @@ namespace ILIAS\UI\examples\Dropdown\Standard;
  *   ILIAS shows a base dropdown button. Clicking the button will open a
  *   dropdown menu with the entries "ILIAS" rendered as a link and "GitHub" rendered as a shy button. Clicking the
  *   shy button will open the appropriate website in the same browser window while clicking the link will open the
- *   appropriate website in a new browser tab.
+ *   appropriate website in a new browser tab. One entry reads "An unavailable action" with a dull design to
+ *   indicate inactivity. Clicking it does nothing.
  * ---
  */
 function with_buttons_and_links()
@@ -24,6 +25,7 @@ function with_buttons_and_links()
 
     $items = array(
         $f->button()->shy("Github", "https://www.github.com"),
+        $f->button()->shy("An unavailable action", "#")->withUnavailableAction(),
         $f->link()->standard("ILIAS", "https://www.ilias.de")->withOpenInNewViewport(true)
     );
     return $renderer->render($f->dropdown()->standard($items)->withLabel("Actions"));

--- a/templates/default/070-components/UI-framework/Button/_ui-component_button.scss
+++ b/templates/default/070-components/UI-framework/Button/_ui-component_button.scss
@@ -133,7 +133,7 @@ input.btn {
 
 // Link buttons
 // -------------------------
-
+// design doesn't use the btn mixin because it is easier to style without it
 // Make a button look and behave like a link
 .btn-link {
   padding: 0;
@@ -167,6 +167,7 @@ input.btn {
     background-color: s.$il-disabled-btn-bg;
     color: s.$il-disabled-btn-color;
     border: 1px solid s.$il-disabled-btn-border;
+    cursor: s-form.$cursor-disabled;
     &:hover {
       text-decoration: none;
     }

--- a/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
+++ b/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
@@ -1,6 +1,7 @@
 @use "sass:math";
 @use "../../../010-settings/" as s;
 @use "../../../010-settings/legacy-settings/legacy-settings_menu" as t-menu;
+@use "../../../010-settings/legacy-settings/legacy-settings_form" as s-form;
 @use "../../../030-tools/legacy-bootstrap-mixins/nav-divider" as t-ndiv;
 @use "../../../030-tools/_tool_browser-prefixes" as t-ven;
 @use "../../../050-layout/basics" as l;
@@ -50,7 +51,7 @@ $cursor-disabled: not-allowed !default;
 	border-right: s.$il-caret-width-base solid transparent;
 	border-left: s.$il-caret-width-base solid transparent;
   }
-  
+
   // The dropdown wrapper (div)
   .dropup,
   .dropdown {
@@ -58,7 +59,7 @@ $cursor-disabled: not-allowed !default;
 	display: inline-block; // so dropdown can be in one line with a button
 	min-width: max-content;
   }
-  
+
   // The dropdown menu (ul)
   .dropdown-menu {
 	  width: 320px;
@@ -80,7 +81,7 @@ $cursor-disabled: not-allowed !default;
 	border: 1px solid $dropdown-border;
 	border-radius: s.$il-border-radius-base;
 	@include t-ven.box-shadow(0 6px 12px rgba(0, 0, 0, .175));
-  
+
 	// Aligns the dropdown menu to right
 	//
 	// Deprecated as of 3.1.0 in favor of `.dropdown-menu-[dir]`
@@ -88,7 +89,7 @@ $cursor-disabled: not-allowed !default;
 	  right: 0;
 	  left: auto;
 	}
- 
+
 	&.dropdown-menu__right {
 	  right: auto;
 	  left: 0;
@@ -114,7 +115,7 @@ $cursor-disabled: not-allowed !default;
 		list-style-type: none;
 	}
   }
-  
+
   // Active state
   .dropdown-menu > .active > a {
 	&,
@@ -126,18 +127,18 @@ $cursor-disabled: not-allowed !default;
 	  outline: 0;
 	}
   }
-  
+
   // Disabled state
   //
   // Gray out text and ensure the hover/focus state remains gray
-  
+
   .dropdown-menu > .disabled > a {
 	&,
 	&:hover,
 	&:focus {
 	  color: $dropdown-link-disabled-color;
 	}
-  
+
 	// Nuke hover/focus effects
 	&:hover,
 	&:focus {
@@ -148,20 +149,20 @@ $cursor-disabled: not-allowed !default;
 	  // @include reset-filter;
 	}
   }
-  
+
   // Open state for the dropdown
   .open {
 	// Show the menu
 	> .dropdown-menu {
 	  display: block;
 	}
-  
+
 	// Remove the outline when :focus is triggered
 	> a {
 	  outline: 0;
 	}
   }
-  
+
   // Menu positioning
   //
   // Add extra class to `.dropdown-menu` to flip the alignment of the dropdown
@@ -180,7 +181,7 @@ $cursor-disabled: not-allowed !default;
 	right: auto;
 	left: 0;
   }
-  
+
   // Backdrop to catch body clicks on mobile, etc.
   .dropdown-backdrop {
 	position: fixed;
@@ -190,18 +191,18 @@ $cursor-disabled: not-allowed !default;
 	left: 0;
 	z-index: ($zindex-dropdown - 10);
   }
-  
+
   // Right aligned dropdowns
   .pull-right > .dropdown-menu {
 	right: 0;
 	left: auto;
   }
-  
+
   // Allow for dropdowns to go bottom up (aka, dropup-menu)
   //
   // Just add .dropup after the standard .dropdown class and you're set, bro.
   // TODO: abstract this so that the navbar fixed styles are not placed here?
-  
+
   .dropup,
   .navbar-fixed-bottom .dropdown {
 	// Reverse the caret
@@ -218,7 +219,7 @@ $cursor-disabled: not-allowed !default;
 	  margin-bottom: 2px;
 	}
   }
-  
+
 
 .dropdown-header {
 	padding: 3px 10px;
@@ -244,25 +245,32 @@ $cursor-disabled: not-allowed !default;
 			padding-left: math.div(l.$grid-gutter-width, 2);
 		}
 	}
-	// Links within the dropdown menu
-	li > a,
-	li > .btn-link {
-		display: block;
+	// Menu items within the dropdown menu
+	// TO DO: this would be better as a reusable menu pattern tool
+	li a,
+	li .btn-link {
+		display: flex;
+		align-items: center;
 		width: 100%;
-		clear: both;
 		border: none;
-		padding: l.$il-padding-small-vertical l.$il-padding-xlarge-horizontal;
 		font-weight: s.$il-font-weight-base;
 		font-size: t-menu.$il-font-size-dropdown;
 		line-height: s.$il-line-height-base;
 		background-color: t-menu.$dropdown-link-bg;
 		color: $dropdown-link-color;
-		white-space: nowrap; // prevent links from randomly breaking onto new lines
+		min-height: s-form.$il-input-min-height;
+		width: 100%;
+		padding: l.$il-padding-small-vertical l.$il-padding-xlarge-horizontal;
+		justify-content: start;
+		white-space: nowrap;
 		&:hover,
 		&:focus {
-			text-decoration: none;
 			color: $dropdown-link-hover-color;
 			background-color: $dropdown-link-hover-bg;
+			text-decoration: none;
+		}
+		&[disabled] {
+			background-color: s.$il-disabled-btn-bg;
 		}
 	}
 	img {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -518,26 +518,33 @@
 .dropdown-menu .row > ul[class*=col-] {
   padding-left: 15px;
 }
-.dropdown-menu li > a,
-.dropdown-menu li > .btn-link {
-  display: block;
+.dropdown-menu li a,
+.dropdown-menu li .btn-link {
+  display: flex;
+  align-items: center;
   width: 100%;
-  clear: both;
   border: none;
-  padding: 3px 15px;
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.428571429;
   background-color: transparent;
   color: #161616;
+  min-height: 28px;
+  width: 100%;
+  padding: 3px 15px;
+  justify-content: start;
   white-space: nowrap;
 }
-.dropdown-menu li > a:hover, .dropdown-menu li > a:focus,
-.dropdown-menu li > .btn-link:hover,
-.dropdown-menu li > .btn-link:focus {
-  text-decoration: none;
+.dropdown-menu li a:hover, .dropdown-menu li a:focus,
+.dropdown-menu li .btn-link:hover,
+.dropdown-menu li .btn-link:focus {
   color: black;
   background-color: #e2e8ef;
+  text-decoration: none;
+}
+.dropdown-menu li a[disabled],
+.dropdown-menu li .btn-link[disabled] {
+  background-color: #b0b0b0;
 }
 .dropdown-menu img {
   border: 0;
@@ -3363,6 +3370,7 @@ input.btn, input.il-link.link-bulky,
   background-color: #b0b0b0;
   color: black;
   border: 1px solid #b0b0b0;
+  cursor: not-allowed;
 }
 .btn-link[disabled]:hover, fieldset[disabled] .btn-link:hover {
   text-decoration: none;
@@ -7512,6 +7520,7 @@ input.btn, .c-drilldown input.c-drilldown__menulevel--trigger, input.il-link.lin
   background-color: #b0b0b0;
   color: black;
   border: 1px solid #b0b0b0;
+  cursor: not-allowed;
 }
 
 .btn-link[disabled]:hover, fieldset[disabled] .btn-link:hover {
@@ -20599,7 +20608,6 @@ div.framed {
 	background-repeat: repeat-x;
 }
 */
-
 span.latex {
   color: green;
   font-weight: bold;


### PR DESCRIPTION
## Inactive Buttons in Dropdown

`medium impact` `UI framework` `mental model`

[→ Mantis Issue](https://mantis.ilias.de/view.php?id=45480)

### Issue

Buttons with unavailable actions inside a UI component dropdown look exactly like buttons with available actions. This violates user expectations because they expect the action to be available.

### Changes

<img width="800" height="850" alt="inactive-buttons-in-dropdowns_comparison" src="https://github.com/user-attachments/assets/420d417f-146f-4f35-b66b-73f1c445649b" />

UI Component Dropdown

* Fix: Using the disabled background color for the entire menu item
* Fix: As all other unavailable buttons, cursor symbol is now set to "not-allowed"
* Maintenance: Ensure buttons and links in dropdowns have the same height

### Impact

* for system styles: check in Kitchen Sink if your skin visibly marks unavailable actions in Dropdowns

### Outlook

* We should consider adding a menu tool/pattern to derive drodpown, drilldown, tree,... buttons from.
