### PR TITLE
10/UI/Counter fix positioning on mobile metabar 43828

### DIFF
--- a/templates/default/070-components/UI-framework/Counter/_ui-component_counter.scss
+++ b/templates/default/070-components/UI-framework/Counter/_ui-component_counter.scss
@@ -22,11 +22,22 @@ $il-counter-status-position-bottom: -5px;
 $il-counter-novelty-bg: $il-warning-color;
 $il-counter-novelty-position-top: -5px;
 
+
+// the size of the parent button or glyph link should control the absolute positioning
+// for refactoring: this should probably be a container with the button/link inside
+*:has(> .il-counter) {
+  position: relative;
+}
+
+.il-counter {
+  font-size: $il-font-size-base;
+}
+
+// this class is randomly used stand-alone in some legacy html templates
 .badge {
   min-width: 10px;
   font-size: $il-counter-font-size;
   margin-left: $il-counter-margin-left;
-  position: relative;
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
@@ -36,24 +47,19 @@ $il-counter-novelty-position-top: -5px;
   &:empty {
     display: none;
   }
-}
-
-.il-counter {
-  position: relative;
-  font-size: $il-font-size-base;
-}
-
-.il-counter-novelty {
-  padding: $il-counter-padding;
-  position: absolute;
-  top: $il-counter-novelty-position-top;
-  background-color: $il-counter-novelty-bg;
-}
-.il-counter-status {
-  padding: $il-counter-padding;
-  position: absolute;
-  bottom: $il-counter-status-position-bottom;
-  background-color: $il-counter-status-bg;
+  &.il-counter-novelty,
+  &.il-counter-status {
+    padding: $il-counter-padding;
+    position: absolute;
+  }
+  &.il-counter-novelty {
+    top: $il-counter-novelty-position-top;
+    background-color: $il-counter-novelty-bg;
+  }
+  &.il-counter-status {
+    bottom: $il-counter-status-position-bottom;
+    background-color: $il-counter-status-bg;
+  }
 }
 
 .glyph {

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -3968,11 +3968,18 @@ button .minimize, button .close {
   padding-bottom: 12px;
 }
 
+*:has(> .il-counter) {
+  position: relative;
+}
+
+.il-counter {
+  font-size: 0.875rem;
+}
+
 .badge {
   min-width: 10px;
   font-size: 0.625rem;
   margin-left: -4px;
-  position: relative;
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
@@ -3983,22 +3990,15 @@ button .minimize, button .close {
 .badge:empty {
   display: none;
 }
-
-.il-counter {
-  position: relative;
-  font-size: 0.875rem;
-}
-
-.il-counter-novelty {
+.badge.il-counter-novelty, .badge.il-counter-status {
   padding: 2px 4px;
   position: absolute;
+}
+.badge.il-counter-novelty {
   top: -5px;
   background-color: #B54F00;
 }
-
-.il-counter-status {
-  padding: 2px 4px;
-  position: absolute;
+.badge.il-counter-status {
   bottom: -5px;
   background-color: #737373;
 }
@@ -20599,7 +20599,6 @@ div.framed {
 	background-repeat: repeat-x;
 }
 */
-
 span.latex {
   color: green;
   font-weight: bold;


### PR DESCRIPTION
## Misaligned badges on mobile menu glyph

`medium impact` `UI framework` `broken design` `readability`

[→ Mantis Issue](https://mantis.ilias.de/view.php?id=43828)

### Issue

Notification badge counters overlapped on the menu button inside the metabar on mobile views. This looks broken and makes one badge unreadable.

### Changes

<img width="800" height="600" alt="counter-badge-alignment_comparison" src="https://github.com/user-attachments/assets/4e58a0fa-6635-46bc-9abb-be687dfd5dff" />

UI Component Counter

* Implementation Concept: The UI Component structurally carrying the badge now directly works as the anchor for it.

### Impact

* for delos: potentially anything using badges could show slight side effects. Kitchen Sink examples remain unchanged, but only tests the now deprecated glyph links with badges.

### Outlook

* As Glyphs with links/actions are now deprecated, we should implement badges on buttons. The CSS side should already be done with this PR.
* It appears that legacy components use the class `.badge` from this UI component. We should consider separating the two and always style with `.c-component { &__element {} }` to avoid effects leaking out of the UI component.
