### PR TITLE
Fix 44987: Dynamic rendering of MathJax 3 fails (ILIAS 11 version)

### DIFF
--- a/components/ILIAS/Accordion/resources/accordion.js
+++ b/components/ILIAS/Accordion/resources/accordion.js
@@ -1,4 +1,18 @@
-/* */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ ******************************************************************** */
 
 il.Accordion = {
 

--- a/components/ILIAS/Accordion/resources/accordion.js
+++ b/components/ILIAS/Accordion/resources/accordion.js
@@ -476,10 +476,7 @@ il.Accordion = {
 
   rerenderContent(acc_el) {
     // rerender mathjax
-    if (typeof MathJax !== 'undefined' && typeof MathJax.Hub !== 'undefined') {
-      MathJax.Hub.Queue(['Reprocess', MathJax.Hub, acc_el[0]]);
-    }
-    // see http://docs.mathjax.org/en/latest/typeset.html
+    il.Util.renderMathJax([acc_el[0]]);
 
     // rerender google maps
     if (typeof ilMapRerender !== 'undefined') {

--- a/components/ILIAS/COPage/templates/default/tpl.question_export.html
+++ b/components/ILIAS/COPage/templates/default/tpl.question_export.html
@@ -19,9 +19,8 @@
 		jQuery('div#container{VAL_ID}').autoRender(questions[{VAL_ID}]);
 		{HANDLE_IMAGES}
 
-		if (typeof MathJax != "undefined" && typeof MathJax.Hub != "undefined") {
-			MathJax.Hub.Queue(["Typeset",MathJax.Hub, "container{VAL_ID}"]);
-		}
+		const el = document.getElementById("container{VAL_ID}");
+		il.Util.renderMathJax([el]);
 	}
 </script>
 <!-- END singlechoice -->
@@ -54,9 +53,8 @@ function renderILQuestion{VAL_ID}(){
 
 	question.init();
 
-	if (typeof MathJax != "undefined" && typeof MathJax.Hub != "undefined") {
-		MathJax.Hub.Queue(["Typeset", MathJax.Hub, "container{VAL_ID}"]);
-	}
+	const el = document.getElementById("container{VAL_ID}");
+	il.Util.renderMathJax([el]);
 };
 </script>
 <!-- END multiplechoice -->
@@ -107,9 +105,8 @@ function renderILQuestion{VAL_ID}(){
 
 		{HANDLE_IMAGES}
 
-		if (typeof MathJax != "undefined") {
-			MathJax.Hub.Queue(["Typeset", MathJax.Hub, "container{VAL_ID}"]);
-		}
+		const el = document.getElementById("container{VAL_ID}");
+		il.Util.renderMathJax([el]);
 
 	})(questions[{VAL_ID}]);
 };
@@ -134,9 +131,8 @@ function renderILQuestion{VAL_ID}() {
 	ilias.questions.shuffle(questions[{VAL_ID}]);
 	jQuery('div#container{VAL_ID}').autoRender(questions[{VAL_ID}]);
 	{HANDLE_IMAGES}
-	if (typeof MathJax != "undefined") {
-		MathJax.Hub.Queue(["Typeset", MathJax.Hub, "container{VAL_ID}"]);
-	}
+	const el = document.getElementById("container{VAL_ID}");
+	il.Util.renderMathJax([el]);
     il.test.orderingvertical.init(document.querySelector('#container{VAL_ID}'));
 }
 </script>
@@ -287,9 +283,8 @@ function renderILQuestion{VAL_ID}()
 
 		$(document).ready(
             function () {
-                if (typeof MathJax != "undefined" && typeof MathJax.Hub != "undefined") {
-                    MathJax.Hub.Queue(["Typeset", MathJax.Hub, "container{VAL_ID}"]);
-                }
+				const el = document.getElementById("container{VAL_ID}");
+				il.Util.renderMathJax([el]);
                 il.test.matching.init(document.querySelector('#ilMatchingQuestionContainer_{VAL_ID}'), questionData.matching_mode);
             }
 		);

--- a/components/ILIAS/COPage/templates/default/tpl.question_export.html
+++ b/components/ILIAS/COPage/templates/default/tpl.question_export.html
@@ -18,9 +18,6 @@
 		ilias.questions.shuffle(questions[{VAL_ID}]);
 		jQuery('div#container{VAL_ID}').autoRender(questions[{VAL_ID}]);
 		{HANDLE_IMAGES}
-
-		const el = document.getElementById("container{VAL_ID}");
-		il.Util.renderMathJax([el]);
 	}
 </script>
 <!-- END singlechoice -->
@@ -52,9 +49,6 @@ function renderILQuestion{VAL_ID}(){
 	{HANDLE_IMAGES}
 
 	question.init();
-
-	const el = document.getElementById("container{VAL_ID}");
-	il.Util.renderMathJax([el]);
 };
 </script>
 <!-- END multiplechoice -->
@@ -105,9 +99,6 @@ function renderILQuestion{VAL_ID}(){
 
 		{HANDLE_IMAGES}
 
-		const el = document.getElementById("container{VAL_ID}");
-		il.Util.renderMathJax([el]);
-
 	})(questions[{VAL_ID}]);
 };
 </script>
@@ -131,8 +122,6 @@ function renderILQuestion{VAL_ID}() {
 	ilias.questions.shuffle(questions[{VAL_ID}]);
 	jQuery('div#container{VAL_ID}').autoRender(questions[{VAL_ID}]);
 	{HANDLE_IMAGES}
-	const el = document.getElementById("container{VAL_ID}");
-	il.Util.renderMathJax([el]);
     il.test.orderingvertical.init(document.querySelector('#container{VAL_ID}'));
 }
 </script>
@@ -283,8 +272,6 @@ function renderILQuestion{VAL_ID}()
 
 		$(document).ready(
             function () {
-				const el = document.getElementById("container{VAL_ID}");
-				il.Util.renderMathJax([el]);
                 il.test.matching.init(document.querySelector('#ilMatchingQuestionContainer_{VAL_ID}'), questionData.matching_mode);
             }
 		);

--- a/components/ILIAS/COPage/templates/default/tpl.question_export.html
+++ b/components/ILIAS/COPage/templates/default/tpl.question_export.html
@@ -18,6 +18,9 @@
 		ilias.questions.shuffle(questions[{VAL_ID}]);
 		jQuery('div#container{VAL_ID}').autoRender(questions[{VAL_ID}]);
 		{HANDLE_IMAGES}
+
+		const el = document.getElementById("container{VAL_ID}");
+		il.Util.renderMathJax([el]);
 	}
 </script>
 <!-- END singlechoice -->
@@ -49,6 +52,9 @@ function renderILQuestion{VAL_ID}(){
 	{HANDLE_IMAGES}
 
 	question.init();
+
+	const el = document.getElementById("container{VAL_ID}");
+	il.Util.renderMathJax([el]);
 };
 </script>
 <!-- END multiplechoice -->
@@ -99,6 +105,9 @@ function renderILQuestion{VAL_ID}(){
 
 		{HANDLE_IMAGES}
 
+		const el = document.getElementById("container{VAL_ID}");
+		il.Util.renderMathJax([el]);
+
 	})(questions[{VAL_ID}]);
 };
 </script>
@@ -122,7 +131,9 @@ function renderILQuestion{VAL_ID}() {
 	ilias.questions.shuffle(questions[{VAL_ID}]);
 	jQuery('div#container{VAL_ID}').autoRender(questions[{VAL_ID}]);
 	{HANDLE_IMAGES}
-    il.test.orderingvertical.init(document.querySelector('#container{VAL_ID}'));
+	const el = document.getElementById("container{VAL_ID}");
+	il.Util.renderMathJax([el]);
+  	il.test.orderingvertical.init(document.querySelector('#container{VAL_ID}'));
 }
 </script>
 <!-- END orderingquestion -->
@@ -137,6 +148,8 @@ function renderILQuestion{VAL_ID}() {
 function renderILQuestion{VAL_ID}()
 {
 	jQuery('div#container{VAL_ID}').autoRender(questions[{VAL_ID}]);
+	const el = document.getElementById("container{VAL_ID}");
+	il.Util.renderMathJax([el]);
 	ilias.questions.initClozeTest({VAL_ID});
 }
 </script>
@@ -272,7 +285,9 @@ function renderILQuestion{VAL_ID}()
 
 		$(document).ready(
             function () {
-                il.test.matching.init(document.querySelector('#ilMatchingQuestionContainer_{VAL_ID}'), questionData.matching_mode);
+				const el = document.getElementById("container{VAL_ID}");
+				il.Util.renderMathJax([el]);
+				il.test.matching.init(document.querySelector('#ilMatchingQuestionContainer_{VAL_ID}'), questionData.matching_mode);
             }
 		);
 

--- a/components/ILIAS/JavaScript/resources/Basic.js
+++ b/components/ILIAS/JavaScript/resources/Basic.js
@@ -254,15 +254,44 @@ il.Util = {
   },
 
   /**
+   * Render Mathjax
+   * @param {array} elements Array of DOM elements
+   * @see https://docs.mathjax.org/en/latest/web/typeset.html#typesetting-math-in-a-web-page
+   */
+  renderMathJax(elements, reprocess = false) {
+    if (typeof MathJax !== 'undefined') {
+      const interval_id = setInterval((resolve, reject) => {
+        if (typeof MathJax.startup.promise !== 'undefined') {
+          clearInterval(interval_id);
+          MathJax.startup.promise = MathJax.startup.promise
+            .then(() => {
+              if (reprocess) {
+                MathJax.typesetClear(elements);
+              }
+              MathJax.typesetPromise()
+                .catch((err) => console.log(`MathJax typesetting failed: ${err.message}`));
+            });
+        }
+      });
+    }
+  },
+
+  /**
 	 * print current window, thanks to anoack for the mathjax fix (see bug #)
 	 */
   print() {
     if (typeof (window.print) !== 'undefined') {
-      if (typeof MathJax !== 'undefined' && typeof MathJax.Hub !== 'undefined') {
-        MathJax.Hub.Queue(
-          ['Delay', MathJax.Callback, 700],
-          window.print,
-        );
+      if (typeof MathJax !== 'undefined') {
+        // MathJax 3
+        const interval_id = setInterval((resolve, reject) => {
+          if (typeof MathJax.startup.promise !== 'undefined') {
+            clearInterval(interval_id);
+            MathJax.startup.promise = MathJax.startup.promise
+              .then(() => MathJax.typesetPromise()
+                .then(window.print)
+                .catch((err) => console.log(`MathJax typesetting failed: ${err.message}`)));
+          }
+        });
       } else {
         window.print();
       }

--- a/components/ILIAS/TestQuestionPool/resources/js/dist/question_handling.js
+++ b/components/ILIAS/TestQuestionPool/resources/js/dist/question_handling.js
@@ -296,9 +296,7 @@ ilias.questions.assTextQuestion = function(a_id) {
 	const el = document.getElementById("feedback" + a_id);
 	if (el) {
 		el.style.display = '';
-		if (typeof MathJax != "undefined") {
-			MathJax.Hub.Queue(["Typeset",MathJax.Hub, el]);
-		}
+		il.Util.renderMathJax([el]);
 	}
 	answers[a_id].passed = true;
 	ilias.questions.scormHandler(a_id,"neutral",jQuery('#textarea'+a_id).val());
@@ -957,9 +955,7 @@ ilias.questions.showFeedback = function(a_id) {
 	const el = document.getElementById('feedback' + a_id);
 	if (el) {
 		el.style.display = '';
-		if (typeof MathJax != "undefined" && typeof MathJax.Hub != "undefined") {
-			MathJax.Hub.Queue(["Typeset",MathJax.Hub, el]);
-		}
+		il.Util.renderMathJax([el]);
 	}
 
 	// update question overviews


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=44987

This is an updated version of https://github.com/ILIAS-eLearning/ILIAS/pull/9487 for ILIAS 11. It drops the support for MathJax 2.

Please note that the rendering of Latex on content pages nees the additional merge of https://github.com/ILIAS-eLearning/ILIAS/pull/9873.