### PR TITLE
Setup: Remove MathJax configuration from documentation

### DIFF
--- a/components/ILIAS/setup_/README.md
+++ b/components/ILIAS/setup_/README.md
@@ -383,38 +383,6 @@ are printed bold**, all other fields might be omitted. A minimal example is
   * *enable* (type: boolean) the logging, defaults to `false`
   * *path_to_logfile* (type: string) to be used for logging
   * *errorlog_dir* (type: string) to put error logs in
-* *mathjax* (type: object) contains settings for ILIAS/MathJax
-    
-    The MathJax settings can also be done manually in the ILIAS adminstration.  
-    Settings included here will overwrite those at the next update.
-    MathJax 3 is supported, but MathJax 2 is recommended.
-    ```
-	"mathjax": {
-		"client_enabled": true,
-		"client_polyfill_url": "",
-		"client_script_url": "https://cdn.jsdelivr.net/npm/mathjax@2.7.9/MathJax.js?config=TeX-AMS-MML_HTMLorMML,Safe",
-		"client_limiter": 0,
-		"server_enabled": true,
-		"server_address": "http://your.mathjax.server:8003",
-		"server_timeout": 5,
-		"server_for_browser": true,
-		"server_for_export": true,
-		"server_for_pdf": true
-	},
-    ```
-  * *client_enabled* (type: boolean) client-side rendering in the browser is enabled
-  * *client_polyfill_url* (type: string) url of a polyfill script for MathJax 3 to support older browsers
-  * *client_script_url* (type: string) url of the MathJax script to be included on the browser page
-  * *client_limiter* (type: integer) type of delimiters expected by the included MathJax script
-    * 0: \\( ... \\)
-    * 1: [tex] ... [/tex]
-    * 2: \<span class="math"\> ... \</span\>
-  * *server_enabled* (type: boolean) server-side rendering is enabled
-  * *server_address* (type: string) address of the rendering server
-  * *server_timeout* (type: integer) timeout in seconds to wait for a server response
-  * *server_for_browser* (type: boolean) use the server for rendering in the browser
-  * *server_for_export* (type: boolean) use the server for HTML exports
-  * *server_for_pdf* (type: boolean) use the server for PDF generation
 * *preview* (type: object) contains settings for ILIAS/Preview
     ```
 	"preview" : {

--- a/docs/configuration/install.md
+++ b/docs/configuration/install.md
@@ -71,7 +71,6 @@ current configuration of the [ILIAS test server](https://test11.ilias.de), which
 | Node.js      | 20 (LTS), 21, 22 (LTS), 23 Recommended: 22             | 16.20            |
 | Ghostscript  | 10.x                                                   | 9.55             |
 | Imagemagick  | 6.9.x                                                  | 6.9.11           |
-| MathJax      | MathJax 3, MathJax 2 with safe mode                    | 2.7.9            |
 | Browser      | a contemporary browser supporting ES6, CSS3 and HTML 5 |                  |
 
 Package names may vary depending on the Linux distribution.

--- a/docs/configuration/settings/ini-file.md
+++ b/docs/configuration/settings/ini-file.md
@@ -30,7 +30,6 @@ to the webserver. These files are located here:
 | java                            | ""                                 |             |
 | ffmpeg                          | ""                                 |             |
 | ghostscript                     | "/usr/bin/gs"                      |             |
-| latex                           | ""                                 |             |
 | vscantype                       | "none"                             |             |
 | scancommand                     | ""                                 |             |
 | cleancommand                    | ""                                 |             |


### PR DESCRIPTION
This PR implements the FR [Streamline LaTeX usage](https://docu.ilias.de/go/wiki/wpage_5614_1357) in the documentation of the ILIAS setup and installation.

As there is no configuration for MathJax anymore, all found descriptions are removed.