### PR TITLE
Container: fix rendering issue (#45551)

### DIFF
--- a/components/ILIAS/Container/Content/class.ilContainerRenderer.php
+++ b/components/ILIAS/Container/Content/class.ilContainerRenderer.php
@@ -594,7 +594,7 @@ class ilContainerRenderer
                 if (isset($this->block_items[$a_block_id])) {
                     foreach ($this->block_items[$a_block_id] as $item_id) {
                         if ($view_mode === ilContainerContentGUI::VIEW_MODE_LIST) {
-                            $this->addStandardRow($a_block_tpl, $this->items[$item_id]["html"], (int) $item_id);
+                            $this->addStandardRow($a_block_tpl, $this->items[$item_id]["html"], $item_id);
                         } else {
                             $cards[] = $this->items[$item_id]["html"];
                         }
@@ -770,11 +770,11 @@ class ilContainerRenderer
     protected function addStandardRow(
         ilTemplate $a_tpl,
         string $a_html,
-        int $a_ref_id = 0
+        string $a_item_id = null
     ): void {
-        if ($a_ref_id > 0) {
+        if ($a_item_id) {
             $a_tpl->setCurrentBlock("row");
-            $a_tpl->setVariable("ROW_ID", 'id="item_row_' . $a_ref_id . '"');
+            $a_tpl->setVariable("ROW_ID", 'id="item_row_' . $a_item_id . '"');
             $a_tpl->parseCurrentBlock();
         } else {
             $a_tpl->touchBlock("row");


### PR DESCRIPTION
Hi @alex40724,

this fixes [#45551](https://mantis.ilias.de/view.php?id=45551).

This issue causes ~70 instances of invalid HTML on [this one page alone](https://test10.ilias.de/go/cat/31) and I guess it could very well be the single cause that led to @WSchS|s assessment that the accessibility of the system dramatically decreased with ILIAS 10. Hence, I hope this fix is already it =)

Kind regards!