### PR TITLE
T&A 44305: Fix Special Character Escaping in Corrections Form

### DIFF
--- a/Modules/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
+++ b/Modules/TestQuestionPool/classes/tables/class.ilAnswerFrequencyStatisticTableGUI.php
@@ -140,8 +140,10 @@ class ilAnswerFrequencyStatisticTableGUI extends ilTable2GUI
 
     public function fillRow(array $a_set): void
     {
+        $a_set['answer'] = ilLegacyFormElementsUtil::prepareFormOutput((string) $a_set['answer']);
+
         $this->tpl->setCurrentBlock('answer');
-        $this->tpl->setVariable('ANSWER', htmlspecialchars((string) $a_set['answer'], ENT_QUOTES));
+        $this->tpl->setVariable('ANSWER', $a_set['answer']);
         $this->tpl->parseCurrentBlock();
 
         $this->tpl->setCurrentBlock('frequency');

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -241,7 +241,7 @@ class Renderer extends AbstractComponentRenderer
             // with declare(strict_types=1) in place,
             // htmlspecialchars will not silently convert to string anymore;
             // therefore, the typecast must be explicit
-            return htmlspecialchars((string) $v, ENT_QUOTES);
+            return htmlspecialchars((string) $v, ENT_QUOTES, 'utf-8', false);
         };
     }
 
@@ -251,7 +251,7 @@ class Renderer extends AbstractComponentRenderer
             // with declare(strict_types=1) in place,
             // htmlentities will not silently convert to string anymore;
             // therefore, the typecast must be explicit
-            return htmlentities((string) $v);
+            return htmlentities((string) $v, ENT_QUOTES, 'utf-8', false);
         };
     }
 


### PR DESCRIPTION
Hi everyone,

This PR refers to the problem described in [44305](https://mantis.ilias.de/view.php?id=44305) that answers containing the special characters “{” and “}” are not displayed correctly in the post-correction. This is due to the fact that the curly brackets are interpreted as placeholders during template rendering. A possible fix would be to replace the curly brackets with special HTML characters before rendering. However, this results in double encoding during rendering, which must be deactivated in the `FieldRenderer`. I have therefore integrated the suggested changes from https://github.com/ILIAS-eLearning/ILIAS/pull/9605 by  @kergomard.

I look forward to your feedback. As usual, these changes were internally reviewed by @thojou.