### PR TITLE
Admin: Show Access Denied Instead of Throwing

### DIFF
--- a/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
+++ b/components/ILIAS/Administration/classes/class.ilAdministrationGUI.php
@@ -76,7 +76,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
     protected int $requested_obj_id = 0;
     protected AdminGUIRequest $request;
     protected ilObjectGUI $gui_obj;
-    private readonly ilErrorHandling $error;
+    private readonly ilLogger $logger;
 
     public function __construct()
     {
@@ -85,6 +85,7 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
 
         $this->help = $DIC["ilHelp"];
         $this->db = $DIC->database();
+        $this->logger = $DIC->logger()->root();
         $lng = $DIC->language();
         $tpl = $DIC->ui()->mainTemplate();
         $tree = $DIC->repositoryTree();
@@ -99,7 +100,6 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
         $this->rbacsystem = $rbacsystem;
         $this->objDefinition = $objDefinition;
         $this->ctrl = $ilCtrl;
-        $this->error = $DIC['ilErr'];
 
         $context = $DIC->globalScreen()->tool()->context();
         $context->claim()->administration();
@@ -139,12 +139,15 @@ class ilAdministrationGUI implements ilCtrlBaseClassInterface
         $rbacsystem = $this->rbacsystem;
         $objDefinition = $this->objDefinition;
         $ilHelp = $this->help;
-        $ilDB = $this->db;
 
         // permission checks
         if (!$rbacsystem->checkAccess("visible", SYSTEM_FOLDER_ID) &&
                 !$rbacsystem->checkAccess("read", SYSTEM_FOLDER_ID)) {
-            $this->error->raiseError($this->lng->txt('permission_denied'), $this->error->MESSAGE);
+            $this->logger->log($this->lng->txt('permission_denied'));
+            $this->tpl->setOnScreenMessage('failure', $this->lng->txt('permission_denied'), true);
+            $this->ctrl->redirectToURL(
+                ilUserUtil::getStartingPointAsUrl()
+            );
         }
 
         // check creation mode


### PR DESCRIPTION
Hi @fneumann 

This PR tackles the issue described in the mantis report [here](https://mantis.ilias.de/view.php?id=44700).

The problem was actually not a big one (even though the experience is slightly hampered, if you get hit by an exception every time you try to reload a page in the administration after the system has logged you out) until we added direct links to the documentation.

This gives users more information and uses the starting-point to redirect to somewhere accessible.

Best,
@kergomard 