### PR TITLE
Fix Mantis #45570 - Favourited cmi5 objects break dashboard

### DIFF
--- a/Modules/CmiXapi/classes/class.ilObjCmiXapiListGUI.php
+++ b/Modules/CmiXapi/classes/class.ilObjCmiXapiListGUI.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 /**
  * Class ilObjCmiXapiListGUI
@@ -76,7 +76,7 @@ class ilObjCmiXapiListGUI extends ilObjectListGUI
             $certLink = $DIC->ui()->factory()->link()->standard(
                 $DIC->language()->txt('download_certificate'),
                 $DIC->ctrl()->getLinkTargetByClass(
-                    [ilObjCmiXapiGUI::class, ilCmiXapiSettingsGUI::class],
+                    [ilRepositoryGUI::class],
                     ilCmiXapiSettingsGUI::CMD_DELIVER_CERTIFICATE
                 )
             );


### PR DESCRIPTION
Fixes Mantis issue https://mantis.ilias.de/view.php?id=45570 that can occur due to invalid baseClass in certificate download links of cmi5/xApi objects.

Please pick to trunk aswell if approved