### PR TITLE
OnScreenChat: Don't remove conversation on abort modal

### DIFF
--- a/components/ILIAS/OnScreenChat/resources/onscreenchat.js
+++ b/components/ILIAS/OnScreenChat/resources/onscreenchat.js
@@ -126,9 +126,12 @@
 				let currentThen = null;
 				const modal = loadModal('confirmRemove');
 				modal.then(({node, closeModal}) => node.querySelector('form').addEventListener('submit', e => {
+					const isSubmit = document.activeElement.matches('input[type="submit"]');
 					e.preventDefault();
 					closeModal();
-					currentThen();
+					if (isSubmit) {
+						currentThen();
+					}
 				}));
 
 				return then => {


### PR DESCRIPTION
This PR fixes the "Remove Chat" Modal. With this PR the conversation is not closed if the modal is cancelled.

For trunk this is fixed with PR: #9949.