### PR TITLE
Auth: Configurable Logout Target for SAML Event

### DIFF
--- a/components/ILIAS/Init/classes/class.ilStartUpGUI.php
+++ b/components/ILIAS/Init/classes/class.ilStartUpGUI.php
@@ -1260,15 +1260,6 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
 
         ilSession::setClosingContext(ilSession::SESSION_CLOSE_USER);
         $this->authSession->logout();
-        $this->eventHandler->raise(
-            'components/ILIAS/Authentication',
-            'afterLogout',
-            [
-                'username' => $this->user->getLogin(),
-                'is_explicit_logout' => true,
-                'used_external_auth_mode' => $used_external_auth_mode,
-            ]
-        );
 
         $target = new ConfigurableLogoutTarget(
             $this->ctrl,
@@ -1278,6 +1269,17 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         );
         $target = $legal_documents->logoutTarget($target);
         $url = $target->asURI();
+
+        $this->eventHandler->raise(
+            'components/ILIAS/Authentication',
+            'afterLogout',
+            [
+                'username' => $this->user->getLogin(),
+                'is_explicit_logout' => true,
+                'used_external_auth_mode' => $used_external_auth_mode,
+                'logout_target' => $url
+            ]
+        );
 
         $this->mainTemplate->setOnScreenMessage(
             $this->mainTemplate::MESSAGE_TYPE_INFO,

--- a/components/ILIAS/Saml/classes/class.ilSamlAppEventListener.php
+++ b/components/ILIAS/Saml/classes/class.ilSamlAppEventListener.php
@@ -28,7 +28,8 @@ class ilSamlAppEventListener implements ilAppEventListener
             isset($a_parameter['is_explicit_logout']) && $a_parameter['is_explicit_logout'] === true &&
             isset($a_parameter['used_external_auth_mode']) && $a_parameter['used_external_auth_mode']) {
             if ((int) $a_parameter['used_external_auth_mode'] === ilAuthUtils::AUTH_SAML) {
-                $DIC->ctrl()->redirectToURL('saml.php?action=logout&logout_url=' . urlencode(ILIAS_HTTP_PATH . '/login.php'));
+                $url = $a_parameter['logout_target'] ?? ILIAS_HTTP_PATH . '/login.php';
+                $DIC->ctrl()->redirectToURL('saml.php?action=logout&logout_url=' . urlencode($url));
             }
         }
     }


### PR DESCRIPTION
This adds to https://github.com/ILIAS-eLearning/ILIAS/pull/7754 which introduced Configurable Logout Targets. This PR allows the Logout Target to be passed to the SAML afterLogout Event