### PR TITLE
Update e-mail-address in  how-to-write-a-privacy.md

### DIFF
--- a/docs/development/how-to-write-a-privacy.md
+++ b/docs/development/how-to-write-a-privacy.md
@@ -7,7 +7,6 @@ Version 2.3 [updated 2025-02-26]
 This guide provides recommendations for structuring and composing PRIVACY.md files for ILIAS. It is designed to help authorities create PRIVACY.md files for their components. The target group of the PRIVACY.md files is the e-learning team of an educational provider, not other authorities. These teams need to provide relevant information to the officer responsible for ensuring compliance with the EU General Data Protection Regulation (GDPR). Please use clear and accessible language to make the information easy to understand.
 Your feedback and change requests are welcome. Please send them to privacy@lists.ilias.de.
 
-
 ## 2 Where to write » Use Git
 
 - Create **one** file named “PRIVACY.md” **per component**.

--- a/docs/development/how-to-write-a-privacy.md
+++ b/docs/development/how-to-write-a-privacy.md
@@ -5,7 +5,8 @@ Version 2.3 [updated 2025-02-26]
 ## 1 Purpose and target group
 
 This guide provides recommendations for structuring and composing PRIVACY.md files for ILIAS. It is designed to help authorities create PRIVACY.md files for their components. The target group of the PRIVACY.md files is the e-learning team of an educational provider, not other authorities. These teams need to provide relevant information to the officer responsible for ensuring compliance with the EU General Data Protection Regulation (GDPR). Please use clear and accessible language to make the information easy to understand.
-Your feedback and change requests are welcome. Please send them to toedt@leifos.com and elyesa.seidel@hhu.de.
+Your feedback and change requests are welcome. Please send them to privacy@lists.ilias.de.
+
 
 ## 2 Where to write » Use Git
 


### PR DESCRIPTION
I have edited the "How th write a privacy.md". Since verification and correction are among the tasks of the privacy clinic, I believe that the email address of the Privacy Clinic should  be provided. 