### PR TITLE
Mail: Allow placeholders within salutation placeholder

### DIFF
--- a/Services/Mail/classes/class.ilAccountMail.php
+++ b/Services/Mail/classes/class.ilAccountMail.php
@@ -269,6 +269,16 @@ class ilAccountMail
             default:
                 $replacements["MAIL_SALUTATION"] = trim($a_amail["sal_g"]);
         }
+
+        $replacements['MAIL_SALUTATION'] = $mustache_factory->getBasicEngine()->render(
+            $replacements['MAIL_SALUTATION'],
+            [
+                'FIRST_NAME' => $a_user->getFirstname(),
+                'LAST_NAME' => $a_user->getLastname(),
+                'LOGIN' => $a_user->getLogin(),
+            ]
+        );
+
         $replacements["LOGIN"] = $a_user->getLogin();
         $replacements["FIRST_NAME"] = $a_user->getFirstname();
         $replacements["LAST_NAME"] = $a_user->getLastname();


### PR DESCRIPTION
This change makes it possible to use `{{FIRST_NAME}}`, `{{LAST_NAME}}` and `{{LOGIN}}` within the `{{MAIL_SALUTATION}}` placeholder.

See: https://mantis.ilias.de/view.php?id=45607