### PR TITLE
Certificate: Bugfix Remove integer type hint for DateHelper::formatDate

### DIFF
--- a/components/ILIAS/Certificate/classes/Helper/ilCertificateDateHelper.php
+++ b/components/ILIAS/Certificate/classes/Helper/ilCertificateDateHelper.php
@@ -30,6 +30,12 @@ class ilCertificateDateHelper
             $dateFormat = IL_CAL_DATETIME;
         }
 
+        if ($dateFormat === IL_CAL_UNIX) {
+            $date = (int) $date;
+        } else {
+            $date = (string) $date;
+        }
+
         $oldDatePresentationValue = ilDatePresentation::useRelativeDates();
         ilDatePresentation::setUseRelativeDates(false);
         $date = ilDatePresentation::formatDate(
@@ -53,6 +59,12 @@ class ilCertificateDateHelper
         if (null === $dateFormat) {
             require_once __DIR__ . '/../../../Calendar/classes/class.ilDateTime.php'; // Required because of global constant IL_CAL_DATE
             $dateFormat = IL_CAL_DATETIME;
+        }
+
+        if ($dateFormat === IL_CAL_UNIX) {
+            $dateTime = (int) $dateTime;
+        } else {
+            $dateTime = (string) $dateTime;
         }
 
         $oldDatePresentationValue = ilDatePresentation::useRelativeDates();

--- a/components/ILIAS/Certificate/classes/Placeholder/Values/class.ilDefaultPlaceholderValues.php
+++ b/components/ILIAS/Certificate/classes/Placeholder/Values/class.ilDefaultPlaceholderValues.php
@@ -29,7 +29,7 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
     private readonly array $placeholder;
     private readonly ilCertificateObjectHelper $objectHelper;
     private readonly ilCertificateDateHelper $dateHelper;
-    private readonly int $dateFormat;
+    private readonly int $unix_ts_format_id;
     private readonly int $birthdayDateFormat;
     private readonly ilLanguage $language;
     private readonly ilCertificateUtilHelper $utilHelper;
@@ -41,7 +41,7 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
     public function __construct(
         ?ilCertificateObjectHelper $objectHelper = null,
         ?ilCertificateDateHelper $dateHelper = null,
-        ?int $dateFormat = null,
+        ?int $unix_ts_format_id = null,
         ?ilLanguage $language = null,
         ?ilCertificateUtilHelper $utilHelper = null,
         ?ilUserDefinedFieldsPlaceholderValues $userDefinedFieldsPlaceholderValues = null,
@@ -53,7 +53,7 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
 
         require_once __DIR__ . '/../../../../Calendar/classes/class.ilDateTime.php'; // Required because of global contant IL_CAL_DATE
 
-        $this->dateFormat = $dateFormat ?? IL_CAL_UNIX;
+        $this->unix_ts_format_id = $unix_ts_format_id ?? IL_CAL_UNIX;
         $this->birthdayDateFormat = $birthdayDateFormat ?? IL_CAL_DATE;
 
         if (null === $language) {
@@ -139,12 +139,12 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
         $placeholder['DATE'] = $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDate(
             time(),
             $user,
-            $this->dateFormat
+            $this->unix_ts_format_id
         ))));
         $placeholder['DATETIME'] = $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDateTime(
             time(),
             $user,
-            $this->dateFormat
+            $this->unix_ts_format_id
         ))));
 
         return array_merge(
@@ -175,7 +175,7 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
             "USER_BIRTHDAY" => $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDate(
                 time(),
                 null,
-                $this->dateFormat
+                $this->unix_ts_format_id
             )))),
             "USER_INSTITUTION" => $this->utilHelper->prepareFormOutput($this->language->txt("certificate_var_user_institution")),
             "USER_DEPARTMENT" => $this->utilHelper->prepareFormOutput($this->language->txt("certificate_var_user_department")),
@@ -187,22 +187,22 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
             'DATE' => $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDate(
                 time(),
                 null,
-                $this->dateFormat
+                $this->unix_ts_format_id
             )))),
             'DATETIME' => $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDateTime(
                 time(),
                 null,
-                $this->dateFormat
+                $this->unix_ts_format_id
             )))),
             'DATE_COMPLETED' => $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDate(
                 time(),
                 null,
-                $this->dateFormat
+                $this->unix_ts_format_id
             )))),
             'DATETIME_COMPLETED' => $this->utilHelper->prepareFormOutput((trim($this->dateHelper->formatDateTime(
                 time(),
                 null,
-                $this->dateFormat
+                $this->unix_ts_format_id
             ))))
         ];
 

--- a/components/ILIAS/Certificate/tests/ilDefaultPlaceholderValuesTest.php
+++ b/components/ILIAS/Certificate/tests/ilDefaultPlaceholderValuesTest.php
@@ -152,12 +152,12 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
         $placeHolderObject = new ilDefaultPlaceholderValues(
             $objectHelper,
             $dateHelper,
-            1,
+            3,
             $language,
             $utilHelper,
             $userDefinePlaceholderMock,
             $uuid_factory_mock,
-            1
+            2
         );
         $placeHolderObject->setUserLanguage($language);
 
@@ -236,12 +236,12 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
         $placeHolderObject = new ilDefaultPlaceholderValues(
             $objectHelper,
             $dateHelper,
-            1,
+            3,
             $language,
             $utilHelper,
             $userDefinePlaceholderMock,
             $uuid_factory_mock,
-            1
+            2
         );
 
         $result = $placeHolderObject->getPlaceholderValuesForPreview(


### PR DESCRIPTION
ilDate accepts both integer and string inputs but internally calls preg_match on the provided date. Since preg_match only permits strings, passing an integer can cause a TypeError (since PHP 8.1).

* Updated all usages of formatDate within the Certificate component to ensure a string is always passed.
* Other components using certificateDateHelper already pass strings and require no changes.