### PR TITLE
Mail: Add render for Placeholder in MAIL_SALUTATION

### DIFF
--- a/Services/Mail/classes/Mustache/class.ilMailTemplateContextAdapter.php
+++ b/Services/Mail/classes/Mustache/class.ilMailTemplateContextAdapter.php
@@ -37,6 +37,7 @@ class ilMailTemplateContextAdapter
     public function __construct(
         array $contexts,
         array $context_parameters,
+        private Mustache_Engine $mustache_engine,
         ilObjUser $recipient = null
     ) {
         $this->contexts = $contexts;
@@ -72,6 +73,12 @@ class ilMailTemplateContextAdapter
     {
         foreach ($this->contexts as $context) {
             $ret = $context->resolvePlaceholder($name, $this->context_parameter, $this->recipient);
+            if ($name === 'MAIL_SALUTATION') {
+                $ret = $this->mustache_engine->render(
+                    $ret,
+                    $this
+                );
+            }
             if ($ret !== '') {
                 return $ret;
             }

--- a/Services/Mail/classes/Mustache/class.ilMailTemplateContextAdapter.php
+++ b/Services/Mail/classes/Mustache/class.ilMailTemplateContextAdapter.php
@@ -37,7 +37,7 @@ class ilMailTemplateContextAdapter
     public function __construct(
         array $contexts,
         array $context_parameters,
-        private Mustache_Engine $mustache_engine,
+        private readonly Mustache_Engine $mustache_engine,
         ilObjUser $recipient = null
     ) {
         $this->contexts = $contexts;
@@ -73,11 +73,8 @@ class ilMailTemplateContextAdapter
     {
         foreach ($this->contexts as $context) {
             $ret = $context->resolvePlaceholder($name, $this->context_parameter, $this->recipient);
-            if ($name === 'MAIL_SALUTATION') {
-                $ret = $this->mustache_engine->render(
-                    $ret,
-                    $this
-                );
+            if (in_array($name, $context->getNestedPlaceholders(), true)) {
+                $ret = $this->mustache_engine->render($ret, $this);
             }
             if ($ret !== '') {
                 return $ret;

--- a/Services/Mail/classes/class.ilMailTemplateContext.php
+++ b/Services/Mail/classes/class.ilMailTemplateContext.php
@@ -58,7 +58,7 @@ abstract class ilMailTemplateContext
     abstract public function getDescription(): string;
 
     /**
-     * @return array{mail_salutation: array{placeholder: string, label: string, supportsNestedPlaceholders: true}, first_name: array{placeholder: string, label: string}, last_name: array{placeholder: string, label: string}, login: array{placeholder: string, label: string}, title: array{placeholder: string, label: string, supportsCondition: true}, firstname_lastname_superior: array{placeholder: string, label: string}, ilias_url: array{placeholder: string, label: string}, installation_name: array{placeholder: string, label: string}}
+     * @return array{mail_salutation: array{placeholder: string, label: string, supportsNestedPlaceholders?: true}, first_name: array{placeholder: string, label: string}, last_name: array{placeholder: string, label: string}, login: array{placeholder: string, label: string}, title: array{placeholder: string, label: string, supportsCondition: true}, firstname_lastname_superior: array{placeholder: string, label: string}, ilias_url: array{placeholder: string, label: string}, installation_name: array{placeholder: string, label: string}}
      */
     private function getGenericPlaceholders(): array
     {

--- a/Services/Mail/classes/class.ilMailTemplateContext.php
+++ b/Services/Mail/classes/class.ilMailTemplateContext.php
@@ -58,7 +58,7 @@ abstract class ilMailTemplateContext
     abstract public function getDescription(): string;
 
     /**
-     * @return array{mail_salutation: array{placeholder: string, label: string}, first_name: array{placeholder: string, label: string}, last_name: array{placeholder: string, label: string}, login: array{placeholder: string, label: string}, title: array{placeholder: string, label: string, supportsCondition: true}, firstname_lastname_superior: array{placeholder: string, label: string}, ilias_url: array{placeholder: string, label: string}, installation_name: array{placeholder: string, label: string}}
+     * @return array{mail_salutation: array{placeholder: string, label: string, supportsNestedPlaceholders: true}, first_name: array{placeholder: string, label: string}, last_name: array{placeholder: string, label: string}, login: array{placeholder: string, label: string}, title: array{placeholder: string, label: string, supportsCondition: true}, firstname_lastname_superior: array{placeholder: string, label: string}, ilias_url: array{placeholder: string, label: string}, installation_name: array{placeholder: string, label: string}}
      */
     private function getGenericPlaceholders(): array
     {
@@ -66,6 +66,7 @@ abstract class ilMailTemplateContext
             'mail_salutation' => [
                 'placeholder' => 'MAIL_SALUTATION',
                 'label' => $this->getLanguage()->txt('mail_nacc_salutation'),
+                'supportsNestedPlaceholders' => true,
             ],
             'first_name' => [
                 'placeholder' => 'FIRST_NAME',
@@ -97,6 +98,21 @@ abstract class ilMailTemplateContext
                 'label' => $this->getLanguage()->txt('mail_nacc_installation_name'),
             ],
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getNestedPlaceholders(): array
+    {
+        $nested_placeholders = [];
+        foreach ($this->getPlaceholders() as $key => $ph) {
+            if (isset($ph['supportsNestedPlaceholders']) && $ph['supportsNestedPlaceholders']) {
+                $nested_placeholders[] = $ph['placeholder'];
+            }
+        }
+
+        return $nested_placeholders;
     }
 
     final public function getPlaceholders(): array

--- a/Services/Mail/classes/class.ilMailTemplatePlaceholderResolver.php
+++ b/Services/Mail/classes/class.ilMailTemplatePlaceholderResolver.php
@@ -45,6 +45,7 @@ class ilMailTemplatePlaceholderResolver
             new ilMailTemplateContextAdapter(
                 [$context],
                 $contextParameters,
+                $this->mustache_engine,
                 $user
             )
         );


### PR DESCRIPTION
Similar to https://github.com/ILIAS-eLearning/ILIAS/pull/9965 (https://mantis.ilias.de/view.php?id=45607) this adds a second render step for MAIL_SALUTATION to allow Placeholders inside Language Variables like mail_salutation_*