### PR TITLE
Add missing initialisation for shib_logout.php as with shib_login.php

### DIFF
--- a/shib_logout.php
+++ b/shib_logout.php
@@ -14,7 +14,10 @@
  *****************************************************************************/
 /** @noRector */
 require_once("libs/composer/vendor/autoload.php");
+ilContext::init(ilContext::CONTEXT_SHIBBOLETH);
+ilInitialisation::initILIAS();
 global $DIC;
+
 $q = $DIC->http()->wrapper()->query();
 if (
     $q->has('return')


### PR DESCRIPTION
See https://mantis.ilias.de/view.php?id=45624

Seems like this broke with 9d54dbd408ad2d3e8d445807bb7f972929898cf3