### PR TITLE
T&A 45625: Prevents ghost attempts if a test is finished by admin while user is on results overview

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -3098,9 +3098,9 @@ class ilObjTestGUI extends ilObjectGUI implements ilCtrlBaseClassInterface, ilDe
 
                     $this->toolbar->addSeparator();
                     if ($testSession->getActiveId() > 0) {
-                        $this->toolbar->addButton($this->lng->txt('tst_resume_test'), $this->ctrl->getLinkTarget($player_instance, 'resumePlayer'));
+                        $this->toolbar->addButton($this->lng->txt('tst_resume_test'), $this->ctrl->getLinkTarget($player_instance, ilTestPlayerCommands::RESUME_PLAYER));
                     } else {
-                        $this->toolbar->addButton($this->lng->txt('tst_start_test'), $this->ctrl->getLinkTarget($player_instance, 'startTest'));
+                        $this->toolbar->addButton($this->lng->txt('tst_start_test'), $this->ctrl->getLinkTarget($player_instance, ilTestPlayerCommands::START_TEST));
                     }
                 }
             }

--- a/Modules/Test/classes/class.ilTestOutputGUI.php
+++ b/Modules/Test/classes/class.ilTestOutputGUI.php
@@ -207,11 +207,6 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
                     }
                 }
 
-                if ($cmd === 'outQuestionSummary'
-                    || $cmd === 'submitSolution') {
-                    $this->handleCheckTestPassValid();
-                }
-
                 $cmd .= 'Cmd';
                 $ret = $this->$cmd();
                 break;
@@ -479,8 +474,10 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
         $this->ctrl->redirect($this, ilTestPlayerCommands::SHOW_QUESTION);
     }
 
-    protected function submitSolutionAndNextCmd()
+    protected function submitSolutionAndNextCmd(): void
     {
+        $this->handleCheckTestPassValid();
+
         if ($this->object->isForceInstantFeedbackEnabled()) {
             $this->submitSolutionCmd();
             return;
@@ -509,8 +506,10 @@ abstract class ilTestOutputGUI extends ilTestPlayerAbstractGUI
         $this->ctrl->redirect($this, ilTestPlayerCommands::SHOW_QUESTION);
     }
 
-    protected function submitSolutionCmd()
+    protected function submitSolutionCmd(): void
     {
+        $this->handleCheckTestPassValid();
+
         if ($this->saveQuestionSolution(true, false)) {
             $questionId = $this->testSequence->getQuestionForSequence(
                 $this->getCurrentSequenceElement()

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -63,6 +63,8 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         $this->passwordChecker = new ilTestPasswordChecker($this->rbac_system, $this->user, $this->object, $this->lng);
     }
 
+    abstract protected function handleCheckTestPassValid(): void;
+
     protected function checkReadAccess(): bool|string
     {
         if (!$this->rbac_system->checkAccess('read', $this->object->getRefId())) {
@@ -622,8 +624,10 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
     }
     // fau.
 
-    protected function submitIntermediateSolutionCmd()
+    protected function submitIntermediateSolutionCmd(): void
     {
+        $this->handleCheckTestPassValid();
+
         $this->saveQuestionSolution(false, true);
         // fau: testNav - set the 'answer changed' parameter when an intermediate solution is submitted
         $this->setAnswerChangedParameter(true);
@@ -1247,6 +1251,8 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         bool $obligations_info = false,
         bool $obligations_filter = false
     ) {
+        $this->handleCheckTestPassValid();
+
         $this->help->setScreenIdComponent("tst");
         $this->help->setScreenId("assessment");
         $this->help->setSubScreenId("question_summary");

--- a/Modules/Test/classes/tables/class.ilListOfQuestionsTableGUI.php
+++ b/Modules/Test/classes/tables/class.ilListOfQuestionsTableGUI.php
@@ -108,7 +108,7 @@ class ilListOfQuestionsTableGUI extends ilTable2GUI
         // command buttons
         $this->command_buttons[] = $this->ui_factory->button()->standard(
             $this->lng->txt('tst_resume_test'),
-            $this->ctrl->getLinkTarget($this->parent_obj, ilTestPlayerCommands::SHOW_QUESTION)
+            $this->ctrl->getLinkTarget($this->parent_obj, ilTestPlayerCommands::RESUME_PLAYER)
         );
 
         if (!$this->areObligationsNotAnswered() && $this->isFinishTestButtonEnabled()) {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45625

When a user is working on a test and an admin finishes it in the meantime, the following issue occurs:

1. The user selects an answer (e.g., in a single-choice question) and navigates to the Test Attempt Overview.
2. ILIAS notices the question is unsaved, saves it, and then processes the Overview command.
3. Since the original pass is already finished, ILIAS creates a new (ghost) pass and stores the answer there.
4. This ghost attempt remains unfinished, allowing the user to resume it via the launcher.

Possible fix:

By explicitly calling `handleCheckTestPassValid` before performing any "critical" action, the system ensures that no new pass is created once the test has been finished. This prevents the ghost attempt and its unintended resumability.