### PR TITLE
ErrorHandling: Hide sensitive information

### DIFF
--- a/Services/Exceptions/classes/class.ilDelegatingHandler.php
+++ b/Services/Exceptions/classes/class.ilDelegatingHandler.php
@@ -34,12 +34,15 @@ use Whoops\Handler\HandlerInterface;
  */
 final class ilDelegatingHandler extends Handler
 {
-    private ilErrorHandling $error_handling;
     private ?HandlerInterface $current_handler = null;
 
-    public function __construct(ilErrorHandling $error_handling)
-    {
-        $this->error_handling = $error_handling;
+    /**
+     * @param list<string> $sensitive_data
+     */
+    public function __construct(
+        private readonly ilErrorHandling $error_handling,
+        private readonly array $sensitive_data = []
+    ) {
     }
 
     private function hideSensitiveData(array $key_value_pairs): array
@@ -49,7 +52,7 @@ final class ilDelegatingHandler extends Handler
                 $value = $this->hideSensitiveData($value);
             }
 
-            if ($key === 'password' && is_string($value)) {
+            if (is_string($value) && in_array($key, $this->sensitive_data, true)) {
                 $value = 'REMOVED FOR SECURITY';
             }
 

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -100,7 +100,7 @@ class ilErrorHandling
         }
         $ilRuntime = $this->getIlRuntime();
         $this->whoops = $this->getWhoops();
-        $this->whoops->pushHandler(new ilDelegatingHandler($this));
+        $this->whoops->pushHandler(new ilDelegatingHandler($this, self::SENSTIVE_PARAMETER_NAMES));
         if ($ilRuntime->shouldLogErrors()) {
             $this->whoops->pushHandler($this->loggingHandler());
         }


### PR DESCRIPTION
This PR fixes an issue where certain values are not removed from the `ArrayAccess` super global variables when used as drop-in replacement for the regular PHP super global variables.

This is a successor of #6050 