### PR TITLE
File/Workspace/WOPI: Fix return URL for workspace files

### DIFF
--- a/Modules/File/classes/class.ilObjFileGUI.php
+++ b/Modules/File/classes/class.ilObjFileGUI.php
@@ -286,7 +286,7 @@ class ilObjFileGUI extends ilObject2GUI
 
                 if ($this->id_type === Context::CONTEXT_WORKSPACE) {
                     $goto_link = ilWorkspaceAccessHandler::getGotoLink(
-                        $this->object->getRefId(),
+                        $this->node_id,
                         $this->object->getId()
                     );
                 } else {


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=45630

This PR fixes the permanent link URL built for file objects in the "Personal Workspace" when launching the WOPI editor. The fix will result in URLs like http://[ILIAS]/go/file/17/_wsp being generated, which seem to work fine/could be handled by `ilFileStaticURLHandler`.

if approved, this has to be picked to all relevant branches.