### PR TITLE
Fix Mantis #45640: ($iWeight) must be of type float

### DIFF
--- a/components/ILIAS/Scorm2004/classes/adlparser/SeqTreeBuilder.php
+++ b/components/ILIAS/Scorm2004/classes/adlparser/SeqTreeBuilder.php
@@ -676,7 +676,7 @@ class SeqTreeBuilder
         // Look for 'objectiveMeasureWeight'
         $tempVal = $iNode->getAttribute("objectiveMeasureWeight");
         if ($tempVal) {
-            $ioAct->setObjMeasureWeight($tempVal);
+            $ioAct->setObjMeasureWeight((float)$tempVal);
         }
         // Look for 'rollupProgressCompletion'
         $tempVal = $iNode->getAttribute("rollupProgressCompletion");


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=45640

An attribute "objectiveMeasureWeight" in imsmanifest.xml produces a Type-Error on Import/Copy

PR for ILIAS 10 Cherry-Picked from ILIAS 9