### PR TITLE
Mantis id: 45655 Fix: initialize  in ilDBUpdate to avoid crash

### DIFF
--- a/Services/Component/classes/class.ilPluginDBUpdate.php
+++ b/Services/Component/classes/class.ilPluginDBUpdate.php
@@ -37,6 +37,8 @@ class ilPluginDBUpdate extends ilDBUpdate
     private ?int $current_version;
     private ?int $file_version = null;
 
+    protected string $error = '';
+
     /**
      * constructor
      * @noinspection MagicMethodsValidityInspection


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45655
This PR fixes a bug where the `ilDBUpdate::$error` property was accessed before being initialized.