### PR TITLE
[Mantis 45656]Test: Question type plugin solution

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -6429,7 +6429,7 @@ class ilObjTest extends ilObject
     public function isPluginActive($a_pname): bool
     {
         if (!$this->component_repository->getComponentByTypeAndName(
-            ilComponentInfo::TYPE_MODULES,
+            ilComponentInfo::TYPE_COMPONENT,
             'TestQuestionPool'
         )->getPluginSlotById('qst')->hasPluginName($a_pname)) {
             return false;
@@ -6437,7 +6437,7 @@ class ilObjTest extends ilObject
 
         return $this->component_repository
             ->getComponentByTypeAndName(
-                ilComponentInfo::TYPE_MODULES,
+                ilComponentInfo::TYPE_COMPONENT,
                 'TestQuestionPool'
             )
             ->getPluginSlotById(

--- a/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetStagingPoolQuestionList.php
+++ b/components/ILIAS/Test/classes/class.ilTestRandomQuestionSetStagingPoolQuestionList.php
@@ -215,7 +215,7 @@ class ilTestRandomQuestionSetStagingPoolQuestionList implements Iterator
         }
 
         if (!$this->component_repository->getComponentByTypeAndName(
-            ilComponentInfo::TYPE_MODULES,
+            ilComponentInfo::TYPE_COMPONENT,
             'TestQuestionPool'
         )->getPluginSlotById('qst')->hasPluginName($question_data['plugin_name'])) {
             return false;
@@ -223,7 +223,7 @@ class ilTestRandomQuestionSetStagingPoolQuestionList implements Iterator
 
         return $this->component_repository
             ->getComponentByTypeAndName(
-                ilComponentInfo::TYPE_MODULES,
+                ilComponentInfo::TYPE_COMPONENT,
                 'TestQuestionPool'
             )
             ->getPluginSlotById(

--- a/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilAssQuestionList.php
@@ -685,7 +685,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         if (
             !isset($questionData['plugin_name'])
             || !$this->component_repository->getComponentByTypeAndName(
-                ilComponentInfo::TYPE_MODULES,
+                ilComponentInfo::TYPE_COMPONENT,
                 'TestQuestionPool'
             )->getPluginSlotById('qst')->hasPluginName($questionData['plugin_name'])
         ) {
@@ -693,7 +693,7 @@ class ilAssQuestionList implements ilTaxAssignedItemInfo
         }
 
         return $this->component_repository
-            ->getComponentByTypeAndName(ilComponentInfo::TYPE_MODULES, 'TestQuestionPool')
+            ->getComponentByTypeAndName(ilComponentInfo::TYPE_COMPONENT, 'TestQuestionPool')
             ->getPluginSlotById('qst')
             ->getPluginByName($questionData['plugin_name'])
             ->isActive();

--- a/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPool.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.ilObjQuestionPool.php
@@ -1189,7 +1189,7 @@ class ilObjQuestionPool extends ilObject
     public function isPluginActive($questionType): bool
     {
         if (!$this->component_repository->getComponentByTypeAndName(
-            ilComponentInfo::TYPE_MODULES,
+            ilComponentInfo::TYPE_COMPONENT,
             'TestQuestionPool'
         )->getPluginSlotById('qst')->hasPluginName($questionType)) {
             return false;
@@ -1197,7 +1197,7 @@ class ilObjQuestionPool extends ilObject
 
         return $this->component_repository
             ->getComponentByTypeAndName(
-                ilComponentInfo::TYPE_MODULES,
+                ilComponentInfo::TYPE_COMPONENT,
                 'TestQuestionPool'
             )
             ->getPluginSlotById(

--- a/components/ILIAS/TestQuestionPool/classes/questions/class.ilAssQuestionType.php
+++ b/components/ILIAS/TestQuestionPool/classes/questions/class.ilAssQuestionType.php
@@ -82,7 +82,7 @@ class ilAssQuestionType
 
         // Plugins MAY overwrite this method an report back their activation status
         if (!$this->component_repository->getComponentByTypeAndName(
-            ilComponentInfo::TYPE_MODULES,
+            ilComponentInfo::TYPE_COMPONENT,
             'TestQuestionPool'
         )->getPluginSlotById('qst')->hasPluginName($this->plugin_name)) {
             return false;
@@ -90,7 +90,7 @@ class ilAssQuestionType
 
         return $this->component_repository
             ->getComponentByTypeAndName(
-                ilComponentInfo::TYPE_MODULES,
+                ilComponentInfo::TYPE_COMPONENT,
                 'TestQuestionPool'
             )
             ->getPluginSlotById(

--- a/components/ILIAS/TestQuestionPool/src/Questions/GeneralQuestionPropertiesRepository.php
+++ b/components/ILIAS/TestQuestionPool/src/Questions/GeneralQuestionPropertiesRepository.php
@@ -411,12 +411,12 @@ class GeneralQuestionPropertiesRepository
             return true;
         }
 
-        $plugin_slot = !$this->component_repository->getComponentByTypeAndName(
-            \ilComponentInfo::TYPE_MODULES,
+        $plugin_slot = $this->component_repository->getComponentByTypeAndName(
+            \ilComponentInfo::TYPE_COMPONENT,
             'TestQuestionPool'
         )->getPluginSlotById('qst');
 
-        if ($plugin_slot->hasPluginName($plugin_name)) {
+        if (!$plugin_slot->hasPluginName($plugin_name)) {
             return false;
         }
 


### PR DESCRIPTION
In **ILIAS 10**, the component registration system was centralized. Due to the new component structure, leading **TestQuestionPool**, under the root type `ilComponentInfo::TYPE_COMPONENT` (which resolves to `components/ILIAS`).

However, several key classes within the **TestQuestionPool** component itself were not updated to reflect this architectural shift. They still attempt to find the TestQuestionPool component by searching for it under the legacy type `ilComponentInfo::TYPE_MODULES` (resolving to `Modules`).

This mismatch leads to a definitive failure in `ilArtifactComponentRepository::getComponentByTypeAndName()`, as it cannot find a component named **TestQuestionPool** under the `Modules` type. This triggers an **InvalidArgumentException -> Unknown component Modules/TestQuestionPool** and causes fatal errors in various contexts of Question type plugins:

- **Listing questions in a Question Pool**: `ilAssQuestionList::isActiveQuestionType()` fails. 
- **Rendering the authoring/editing view**: `GeneralQuestionPropertiesRepository::isQuestionTypeAvailable()` fails.  
- **Verifying question types**: `ilAssQuestionType::isQuestionTypeActive()` fails.  
- **General object handling**: `ilObjQuestionPool::isQuestionTypeActive()` fails.  

> As it stands, this inconsistency makes it **impossible** for any new or existing third-party question type plugin to be created or used in ILIAS 10.  
> The system cannot verify that the plugin is active and belongs to the TestQuestionPool, effectively blocking the entire plugin ecosystem for this component.

---

# The proposed solution

This pull request implements a **minimal fix** by correcting the component type constant used in the affected lookups.  

The solution consists of the following targeted changes:

- In `GeneralQuestionPropertiesRepository.php`, `ilAssQuestionList.php`, `ilAssQuestionType.php`, and `ilObjQuestionPool.php`, the calls to `getComponentByTypeAndName()` have been updated to use `ilComponentInfo::TYPE_COMPONENT` instead of `ilComponentInfo::TYPE_MODULES` when looking for the **TestQuestionPool** component.

This simple changes aligns the code with the current component architecture, ensuring that the TestQuestionPool component is always found correctly.

## Justification and Benefits

- **Restores Plugin Functionality**: This is a critical fix that unblocks the entire question type plugin ecosystem, allowing third-party developers to create and maintain question types for ILIAS 10.  
- **Architectural Consistency**: It resolves a clear inconsistency between the component registration system and the code that consumes it.  
- **Low Risk**: The change is highly targeted and only affects the lookup key for a specific component. It does not alter any business logic and has no foreseeable side effects.  
- **Future-Proofing**: By aligning with the modern `components/ILIAS` structure, this change ensures better compatibility for future development and refactoring of the TestQuestionPool component.  

This correction is essential for maintaining a healthy and extensible plugin ecosystem for one of ILIAS's core features.

## Testing

The issue was reproduced while the development of Stack for ILIAS 10  (`assStackQuestion`).  

- **Before the patch**: The plugin would cause a fatal `InvalidArgumentException -> Unknown component Modules/TestQuestionPool` when viewing the question list in a pool.  
- **After applying the patch**: The plugin functions correctly through the entire lifecycle: creation, saving, editing, and listing within the question pool.  

> We discovered a bug in `GeneralQuestionPropertiesRepository::isQuestionTypeAvailable`, where the method negated the getComponentByTypeAndName() call, converting it into a boolean. This caused an error when later trying to access its attributes, which was fixed by removing the negation.
> 
> We also had to add a negation to the condition that checks whether the plugin slot has the plugin name.

---

This change is a necessary and safe improvement for the stability and consistency of the ILIAS core.  
Thank you for your consider
Best Regards, Surlabs Team!