### PR TITLE
Mantis 45667: Include *all* folders in ./components to classmapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
 		},
 		"classmap": [
 			"./public/Customizing/global/plugins",
-			"./components/ILIAS",
+			"./components",
 			"./vendor/ilias",
 			"./components/ILIAS/soap",
 			"./components/ILIAS/setup_/classes"


### PR DESCRIPTION
When introducing a vendor namespace into ILIAS/components, the directories need to be included in the classmap in order to be found by ILIAS.

Current classmapping only looks into ./components/ILIAS, which ignores additions there.

This PR changes the classmap-directive in composer.json to address this.