### PR TITLE
IGR10 45594: Sorts item groups in page editor alphabetically 

### DIFF
--- a/components/ILIAS/COPage/PC/Resources/class.ilPCResourcesGUI.php
+++ b/components/ILIAS/COPage/PC/Resources/class.ilPCResourcesGUI.php
@@ -169,6 +169,7 @@ class ilPCResourcesGUI extends ilPageContentGUI
         if ($this->supportsItemGroups() && count($item_groups) > 0) {
             // item groups
             $options = $item_groups;
+            sort($options);
             $si = new ilSelectInputGUI($this->lng->txt("obj_itgr"), "itgr");
             $si->setOptions($options);
             $selected = ($a_insert)


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45594

Aims to fix the sorting of item groups in the page editor.

@thojou 

Release 9: #10021