### PR TITLE
Initializes html in the reinitUser function.

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1212,7 +1212,9 @@ class ilInitialisation
         if (ilContext::initClient() && ilContext::hasUser()) {
             self::initSession();
             self::initUser();
-
+            if (ilContext::hasHTML()) {
+                self::initHTML();
+            }
             if (ilContext::supportsPersistentSessions()) {
                 self::resumeUserSession();
             }


### PR DESCRIPTION
When calling from a soap context, ilSoapContext has a 

    public static function hasHTML(): bool
    {
        return true;
    }


but with that being true, HTML was never being initialized, so you couldn't access template globals from a soap call.