### PR TITLE
UI: Tooltip inside container rendered invisible

### DIFF
--- a/templates/default/070-components/UI-framework/_ui-component_tooltip.scss
+++ b/templates/default/070-components/UI-framework/_ui-component_tooltip.scss
@@ -12,7 +12,7 @@ $c-tooltip-arrow-background-color: $c-tooltip-border-color;
 $c-tooltip-z-index: 9999;
 
 .c-tooltip__container {
-	position: relative;
+	position: fixed;
 	display: inline-block;
 }
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2504,7 +2504,7 @@ code {
 */
 /* UI Framework */
 .c-tooltip__container {
-  position: relative;
+  position: fixed;
   display: inline-block;
 }
 


### PR DESCRIPTION
Related to https://mantis.ilias.de/view.php?id=45492

Tooltip inside container rendered invisible because position: relative creates a new context container for the tooltip which hides it behind other elements. Z-Index: 9999 does not work in this context

I'm no expert in CSS, so maybe there are better ways to solve my problem. Please feel free to suggest improvements.

Best @fhelfer 