### PR TITLE
Rating Bugfix #0045494: User Rating skips fractured rating stars

### DIFF
--- a/components/ILIAS/JavaScript/resources/Basic.js
+++ b/components/ILIAS/JavaScript/resources/Basic.js
@@ -573,7 +573,7 @@ il.UICore = {
 
           // ...put last child into collapsed drop down
           $(children[count - 1]).prependTo('#ilTabDropDown');
-          if(count == 0) {
+          if (count == 0) {
             more_than_two_lines = false;
           } else {
             more_than_two_lines = tabs.innerHeight() >= 50;
@@ -597,7 +597,6 @@ il.UICore = {
     }
   },
 
-
   initLastTabDropdown() {
     const toggle = document.querySelector('#ilLastTab > .dropdown-toggle');
     const toggler = (e) => {
@@ -612,7 +611,7 @@ il.UICore = {
       lastTab.classList.add('open');
       const dropdownRight = dropdown?.getBoundingClientRect().right;
       if (dropdownRight > window.innerWidth) {
-        dropdown.style.left = (window.innerWidth - dropdownRight - 10) + 'px';
+        dropdown.style.left = `${window.innerWidth - dropdownRight - 10}px`;
       }
     };
     toggle.addEventListener('click', toggler);
@@ -670,7 +669,7 @@ il.UICore = {
         il.Util.fixPosition(this);
       });
     });
-  }
+  },
 };
 
 $(document).on('visibilitychange', () => {
@@ -810,9 +809,10 @@ il.Rating = {
     $(`#${prefix}rating_value_${category_id}`).val(value);
 
     // handle icons
-    for (i = 1; i <= 5; i++) {
-      const icon_id = `${prefix}rating_icon_${category_id}_${i}`;
-      let src = $(`#${icon_id}`).attr('src');
+    for (let i = 1; i <= 5; i++) {
+      const $icon = $(`#${prefix}rating_icon_${category_id}_${i}`);
+      const icon_id = $icon.attr('id');
+      let src = $icon.attr('src');
 
       // active
       if (i <= value) {
@@ -820,13 +820,18 @@ il.Rating = {
           src = `${src.substring(0, src.length - 6)}on_user.svg`;
         } else if (src.substring(src.length - 7) == 'off.svg') {
           src = `${src.substring(0, src.length - 7)}on_user.svg`;
+        } else if (/_\d\.svg$/.test(src)) {
+          src = `${src.replace(/(\d)?\.svg$/, '')}on_user.svg`;
         }
-      }
-      // inactive
-      else if (src.substring(src.length - 6) == 'on.svg') {
-        src = `${src.substring(0, src.length - 6)}off.svg`;
-      } else if (src.substring(src.length - 11) == 'on_user.svg') {
-        src = `${src.substring(0, src.length - 11)}off.svg`;
+      } else {
+        const fraction = $icon.data('rating-fraction');
+        if (fraction === 0) {
+          src = `${src.replace(/(on_user|on|off|\d)?\.svg$/, '')}off.svg`;
+        } else if (fraction === 10) {
+          src = `${src.replace(/(on_user|on|off|\d)?\.svg$/, '')}on.svg`;
+        } else if (fraction < 10 && fraction > 0) {
+          src = `${src.replace(/(_on_user|_on|_off|_\d)?\.svg$/, '')}_${fraction}.svg`;
+        }
       }
 
       // resetting img cache so onmouseout will not change icons again

--- a/components/ILIAS/Rating/classes/class.ilRatingGUI.php
+++ b/components/ILIAS/Rating/classes/class.ilRatingGUI.php
@@ -355,17 +355,20 @@ class ilRatingGUI
                             "SRC_ICON",
                             ilUtil::getImagePath("standard/icon_rate_on.svg")
                         );
+                        $star_tpl->setVariable('RATING_FRACTION', 10);
                     } elseif ($overall_rating["avg"] + 1 <= $i) {
                         $star_tpl->setVariable(
                             "SRC_ICON",
                             ilUtil::getImagePath("standard/icon_rate_off.svg")
                         );
+                        $star_tpl->setVariable('RATING_FRACTION', 0);
                     } else {
                         $nr = round(($overall_rating["avg"] + 1 - $i) * 10);
                         $star_tpl->setVariable(
                             "SRC_ICON",
                             ilUtil::getImagePath("standard/icon_rate_$nr.svg")
                         );
+                        $star_tpl->setVariable("RATING_FRACTION", $nr);
                     }
                     $star_tpl->setVariable(
                         "ALT_ICON",

--- a/components/ILIAS/Rating/templates/default/tpl.js_rating_star.html
+++ b/components/ILIAS/Rating/templates/default/tpl.js_rating_star.html
@@ -1,2 +1,2 @@
 <!-- BEGIN rating_mark --><img class="ilRatingMarker" src="{SRC_MARK}" alt="{ALT_MARK}" style="position:absolute;" border="0" /><!-- END rating_mark -->
-<img class="ilRatingIcon" src="{SRC_ICON}" alt="{ALT_ICON}" border="0" id="{JS_ID}rating_icon_{CATEGORY_ID}_{ICON_VALUE}" />
+<img class="ilRatingIcon" src="{SRC_ICON}" alt="{ALT_ICON}" data-rating-fraction="{RATING_FRACTION}" border="0" id="{JS_ID}rating_icon_{CATEGORY_ID}_{ICON_VALUE}" />


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45494

This not only changes the behaviour, so that Fractured Stars are now also filled "blue" for user input but also skip back to its fractured state if the user inputs a rating below the displayed average 