### PR TITLE
[FIX] non working unittests in macOS

### DIFF
--- a/components/ILIAS/Refinery/tests/Encode/Transformation/ProvideUTF8CodepointRange.php
+++ b/components/ILIAS/Refinery/tests/Encode/Transformation/ProvideUTF8CodepointRange.php
@@ -45,7 +45,7 @@ trait ProvideUTF8CodepointRange
             $set_names,
             array_map(
                 fn(string $chr, int $codepoint) => (
-                    ctype_alnum($chr) || in_array($chr, $ignore, true) ?
+                    self::ctype_alnum($chr) || in_array($chr, $ignore, true) ?
                         self::asDataProviderArgs($chr, 'assertSame') :
                         self::asDataProviderArgs(self::isAscii($codepoint) ? $chr : self::twoByteChar($codepoint), 'assertNotSame')
                 ),
@@ -53,6 +53,14 @@ trait ProvideUTF8CodepointRange
                 $byte_range
             )
         );
+    }
+
+    /**
+     * @description ctype_alnum() does not behave the same in all environments, therefore we use a regex here.
+     */
+    private static function ctype_alnum(string $chr): bool
+    {
+        return preg_match('/^[a-zA-Z0-9]+$/', $chr) > 0;
     }
 
     private static function isAscii(int $codepoint): bool


### PR DESCRIPTION
To be honest, I have no idea what exactly I had to change. The decisive clue came from @thibsy, who pointed out that PHP's `ctype_alnum` does not behave the same in all environments. See the last two comments here: https://www.php.net/manual/en/function.ctype-alnum.php#118587
I therefore implemented the suggestion from the last comment. The tests now run correctly on both macOS and Linux.