### PR TITLE
UI: Fix implicit nullable issues in "Field Factory"

### DIFF
--- a/components/ILIAS/UI/src/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Component/Input/Field/Factory.php
@@ -703,7 +703,7 @@ interface Factory
         ImagePurpose $image_purpose,
         string $label,
         ?string $byline = null,
-        FormInput $metadata_input = null,
+        ?FormInput $metadata_input = null,
     ): Image;
 
     /**

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Factory.php
@@ -140,7 +140,7 @@ class Factory implements I\Factory
         ImagePurpose $image_purpose,
         string $label,
         ?string $byline = null,
-        FormInput $metadata_input = null
+        ?FormInput $metadata_input = null
     ): Image {
         return new Image(
             $this->lng,


### PR DESCRIPTION
This PR fixes a PHP 8.4 issue in the "Field Factory" of the "UI" component, which uses implicit nullable parameters.