### PR TITLE
URI Parameter Encoding

### DIFF
--- a/components/ILIAS/Data/src/URI.php
+++ b/components/ILIAS/Data/src/URI.php
@@ -61,8 +61,7 @@ class URI
     private const UNRESERVED = self::ALPHA_DIGIT . '|[\\-\\._~]';
     private const UNRESERVED_NO_DOT = self::ALPHA_DIGIT . '|[\\-_~]';
 
-    private const PCHAR = self::UNRESERVED . '|' . self::SUBDELIMS . '|' . self::PCTENCODED . '|:|@';
-    private const BASEURI_PCHAR = self::UNRESERVED . '|' . self::BASEURI_SUBDELIMS . '|' . self::PCTENCODED . '|:|@';
+    private const PCHAR = self::UNRESERVED . '|' . self::SUBDELIMS . '|' . self::PCTENCODED;
 
     private const SCHEMA = '#^' . self::ALPHA . '(' . self::ALPHA_DIGIT . '|' . self::PIMP . ')*$#';
     private const DOMAIN_LABEL = self::ALPHA_DIGIT . '((' . self::UNRESERVED_NO_DOT . '|' . self::PCTENCODED . '|' . self::BASEURI_SUBDELIMS . ')*' . self::ALPHA_DIGIT . ')*';

--- a/components/ILIAS/Data/tests/URITest.php
+++ b/components/ILIAS/Data/tests/URITest.php
@@ -38,12 +38,12 @@ class URITest extends TestCase
     private const URI_NO_QUERY_1 = 'git://one-letter-top-level.a:8080/someaccount/somerepo/somerepo.git/#fragment';
     private const URI_NO_QUERY_2 = 'git://github.com:8080/someaccount/somerepo/somerepo.git#fragment';
 
-    private const URI_AUTHORITY_AND_QUERY_1 = 'git://github.com?query_p$,;:A!\'*+()ar_1=val_1&quer?y_par_2=val_2';
-    private const URI_AUTHORITY_AND_QUERY_2 = 'git://github.com/?qu/ery_p$,;:A!\'*+()ar_1=val_1&quer?y_par_2=val_2';
+    private const URI_AUTHORITY_AND_QUERY_1 = 'git://github.com?query_p$,;A!\'*+()ar_1=val_1&quer?y_par_2=val_2';
+    private const URI_AUTHORITY_AND_QUERY_2 = 'git://github.com/?qu/ery_p$,;A!\'*+()ar_1=val_1&quer?y_par_2=val_2';
 
-    private const URI_AUTHORITY_AND_FRAGMENT = 'git://github.com:8080/#fragment$,;:A!\'*+()ar_1=val_1&';
+    private const URI_AUTHORITY_AND_FRAGMENT = 'git://github.com:8080/#fragment$,;A!\'*+()ar_1=val_1&';
 
-    private const URI_AUTHORITY_PATH_FRAGMENT = 'git://git$,;hub.com:8080/someacc$,;ount/somerepo/somerepo.git#frag:A!\'*+()arment';
+    private const URI_AUTHORITY_PATH_FRAGMENT = 'git://git$,;hub.com:8080/someacc$,;ount/somerepo/somerepo.git#fragA!\'*+()arment';
 
     private const URI_PATH = 'git://git$,;hub.com:8080/someacc$,;ount/somerepo/somerepo.git/';
 
@@ -58,8 +58,9 @@ class URITest extends TestCase
     private const URI_WRONG_AUTHORITY_1 = 'git://git$,;hu<b.com:8080/someacc$,;ount/somerepo/somerepo.git/';
     private const URI_WRONG_AUTHORITY_2 = 'git://git$,;hu=b.com/someacc$,;ount/somerepo/somerepo.git/';
 
-
     private const URI_INVALID = 'https://host.de/ilias.php/"><script>alert(1)</script>?baseClass=ilObjChatroomGUI&cmd=getOSDNotifications&cmdMode=asynch&max_age=15192913';
+
+    private const URI_INVALID_CHARACTERS_IN_QUERY = 'git://github.com?query_p=:&query_p2=ilias@ilias.de';
 
     private const URI_FAKEPCENC = 'g+it://github.com:8080/someaccoun%t/somerepo/somerepo.git/?query_par_1=val_1&query_par_2=val_2#fragment';
 
@@ -250,7 +251,7 @@ class URITest extends TestCase
         $this->assertEquals('github.com', $uri->getHost());
         $this->assertNull($uri->getPort());
         $this->assertNull($uri->getPath());
-        $this->assertEquals('query_p$,;:A!\'*+()ar_1=val_1&quer?y_par_2=val_2', $uri->getQuery());
+        $this->assertEquals('query_p$,;A!\'*+()ar_1=val_1&quer?y_par_2=val_2', $uri->getQuery());
         $this->assertNull($uri->getFragment());
 
         $uri = new ILIAS\Data\URI(self::URI_AUTHORITY_AND_QUERY_2);
@@ -259,7 +260,7 @@ class URITest extends TestCase
         $this->assertEquals('github.com', $uri->getHost());
         $this->assertNull($uri->getPort());
         $this->assertNull($uri->getPath());
-        $this->assertEquals('qu/ery_p$,;:A!\'*+()ar_1=val_1&quer?y_par_2=val_2', $uri->getQuery());
+        $this->assertEquals('qu/ery_p$,;A!\'*+()ar_1=val_1&quer?y_par_2=val_2', $uri->getQuery());
         $this->assertNull($uri->getFragment());
     }
 
@@ -273,7 +274,7 @@ class URITest extends TestCase
         $this->assertEquals('8080', $uri->getPort());
         $this->assertNull($uri->getPath());
         $this->assertNull($uri->getQuery());
-        $this->assertEquals('fragment$,;:A!\'*+()ar_1=val_1&', $uri->getFragment());
+        $this->assertEquals('fragment$,;A!\'*+()ar_1=val_1&', $uri->getFragment());
     }
 
     #[\PHPUnit\Framework\Attributes\Depends('test_init')]
@@ -286,7 +287,7 @@ class URITest extends TestCase
         $this->assertEquals('8080', $uri->getPort());
         $this->assertEquals('someacc$,;ount/somerepo/somerepo.git', $uri->getPath());
         $this->assertNull($uri->getQuery());
-        $this->assertEquals('frag:A!\'*+()arment', $uri->getFragment());
+        $this->assertEquals('fragA!\'*+()arment', $uri->getFragment());
     }
 
     #[\PHPUnit\Framework\Attributes\Depends('test_init')]
@@ -357,6 +358,13 @@ class URITest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         new ILIAS\Data\URI(self::URI_INVALID);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Depends('test_init')]
+    public function test_invalid_characters_in_query(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ILIAS\Data\URI(self::URI_INVALID_CHARACTERS_IN_QUERY);
     }
 
     #[\PHPUnit\Framework\Attributes\Depends('test_init')]

--- a/components/ILIAS/LegalDocuments/tests/Provide/ProvideDocumentTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Provide/ProvideDocumentTest.php
@@ -72,7 +72,7 @@ class ProvideDocumentTest extends TestCase
     {
         $dummy_gui = new stdClass();
 
-        $uri = 'http://myIlias/ilias.php?baseClass=iladministrationgui&cmdNode=2g:qo:gq&cmdClass=ilLegalDocumentsAdministrationGUI&cmd=documents&ref_id=50';
+        $uri = 'http://myIlias/ilias.php?baseClass=iladministrationgui&cmdNode=2g.qo.gq&cmdClass=ilLegalDocumentsAdministrationGUI&cmd=documents&ref_id=50';
 
         $container = $this->mockTree(Container::class, [
             'ui' => [
@@ -97,7 +97,7 @@ class ProvideDocumentTest extends TestCase
 
         $dummy_gui = new stdClass();
 
-        $uri = 'http://myIlias/ilias.php?baseClass=iladministrationgui&cmdNode=2g:qo:gq&cmdClass=ilLegalDocumentsAdministrationGUI&cmd=documents&ref_id=50';
+        $uri = 'http://myIlias/ilias.php?baseClass=iladministrationgui&cmdNode=2g.qo.gq&cmdClass=ilLegalDocumentsAdministrationGUI&cmd=documents&ref_id=50';
 
         $container = $this->mockTree(Container::class, [
             'ui' => [

--- a/components/ILIAS/LegalDocuments/tests/Table/DocumentTableTest.php
+++ b/components/ILIAS/LegalDocuments/tests/Table/DocumentTableTest.php
@@ -52,7 +52,7 @@ class DocumentTableTest extends TestCase
     public function testConstruct(): void
     {
         $uri = $this->mock(UriInterface::class);
-        $uri->method('__toString')->willReturn('http://myIlias/ilias.php?baseClass=iladministrationgui&cmdNode=2g:qo:gq&cmdClass=ilLegalDocumentsAdministrationGUI&cmd=documents&ref_id=50');
+        $uri->method('__toString')->willReturn('http://myIlias/ilias.php?baseClass=iladministrationgui&cmdNode=2g.qo.gq&cmdClass=ilLegalDocumentsAdministrationGUI&cmd=documents&ref_id=50');
 
         $request = $this->mock(ServerRequestInterface::class);
         $request->method("getUri")->willReturn($uri);
@@ -75,7 +75,7 @@ class DocumentTableTest extends TestCase
     public function testCriterionName(): void
     {
         $uri = $this->mock(UriInterface::class);
-        $uri->method('__toString')->willReturn('http://myIlias/ilias.php?baseClass=iladministrationgui&cmdNode=2g:qo:gq&cmdClass=ilLegalDocumentsAdministrationGUI&cmd=documents&ref_id=50');
+        $uri->method('__toString')->willReturn('http://myIlias/ilias.php?baseClass=iladministrationgui&cmdNode=2g.qo.gq&cmdClass=ilLegalDocumentsAdministrationGUI&cmd=documents&ref_id=50');
 
         $request = $this->mock(ServerRequestInterface::class);
         $request->method("getUri")->willReturn($uri);

--- a/components/ILIAS/UI/tests/Component/Link/BulkyLinkTest.php
+++ b/components/ILIAS/UI/tests/Component/Link/BulkyLinkTest.php
@@ -101,7 +101,7 @@ class BulkyLinkTest extends ILIAS_UI_TestBase
         $with_query = $plain . "?query1=1";
         $with_multi_query = $with_query . "&query2=2";
         $with_fragment = $plain . "#fragment";
-        $with_multi_query_and_fragment_uri = $with_multi_query . $with_fragment;
+        $with_multi_query_and_fragment_uri = $with_multi_query . "#fragment";
 
         $plain_uri = new Data\URI($plain);
         $with_query_uri = new Data\URI($with_query);


### PR DESCRIPTION
Hi @thibsy and @klees 

This is a PR to start a discussion about fixing:
- https://mantis.ilias.de/view.php?id=45678 and
- https://mantis.ilias.de/view.php?id=45677

In a first discussion with @thibsy we came to the conclusion that it was wrong, that URI treated the uri-string passed through the constructor differently then when adding a parameter through `URI::withParameter<s>()`. I believe now, that I was wrong: These two cases should be treated differently as they are different.

From where I stand the problem is, that we do accept ':' and '@' in query parameters probably for legacy reasons.

I thus suggest to remove the exception for ':' in trunk. As I personally also think the exception for '@', but am not sure we want to tackle this right now, I remove this in a separate commit.

There are four commits here:
1. The first commit implements the original solution also encoding the query part of the uri-string in the constructor (c5ffd65).
2. The second commit roles the changes back and remove ':' from the allowed characters (cdc771e).
3. The third commit adapts `ilCtrl` to work with encoded ":" (0a860ef).
4. Also removes the '@' from the allowed characters (c2067a1).

Thank you very much and best,
@kergomard 

PS: I will fix the failing test and add corresponding additional tests, as soon as we know what way we want to take.