### PR TITLE
AccessControl: Don't redirect in loop when adjusting roles

### DIFF
--- a/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
+++ b/Services/AccessControl/classes/class.ilObjRoleFolderGUI.php
@@ -506,10 +506,10 @@ class ilObjRoleFolderGUI extends ilObjectGUI
                         break;
                 }
             }
-
-            $this->tpl->setOnScreenMessage('success', $this->lng->txt('rbac_copy_finished'), true);
-            $this->ctrl->redirect($this, 'view');
         }
+
+        $this->tpl->setOnScreenMessage('success', $this->lng->txt('rbac_copy_finished'), true);
+        $this->ctrl->redirect($this, 'view');
     }
 
     /**


### PR DESCRIPTION
This PR fixes an HTTP redirect after the first iteration when processing the selected roles (plural) to be adjusted.

IMO we'll just have to move the redirect outside of this loop.

Mantis Issue: https://mantis.ilias.de/view.php?id=45705