### PR TITLE
[FIX] #45701 Page-Editor: make more text styles visible

### DIFF
--- a/components/ILIAS/COPage/templates/default/tpl.tiny_menu.html
+++ b/components/ILIAS/COPage/templates/default/tpl.tiny_menu.html
@@ -22,7 +22,7 @@
 <!-- END par_edit -->
 <div class="ilClearFloat"></div>
 <!-- BEGIN section -->
-<div class="ilTinyMenuSection">
+<div class="ilTinyMenuSection ilTinyParagraphClassSelector">
 	<h3 class="ilTinyInfo">{TXT_SECTION}</h3>
 	<!-- BEGIN button -->{BUTTON}<!-- END button -->
 </div>


### PR DESCRIPTION
Hi @alex40724

This PR fixes https://mantis.ilias.de/view.php?id=45701 by adding a missing `ilTinyParagraphClassSelector` class to the text styles section. This makes these styles from `_component_copage.scss` apply to the second dropdown menu inside the tool as well:

```scss
.ilTinyParagraphClassSelector ul.dropdown-menu,
.ilTinyMenuSection > div.dropdown:nth-child(2) > ul.dropdown-menu,
.ilSectionClassSelector ul.dropdown-menu {
	right: auto;
}
```

Otherwise the applied style would be `right: 0`, which makes them disappear under the main menu. Not sure if there is a better way, but it works and does not seem to have unintended side-effects.

Kind regards,
@thibsy