### PR TITLE
Redirect to platform URL if `ilCtrlException` bubbles to `ilias.php` …

### DIFF
--- a/ilias.php
+++ b/ilias.php
@@ -1,17 +1,21 @@
 <?php
-/******************************************************************************
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
  *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
  *
  * If this is not the case or you just want to try ILIAS, you'll find
  * us at:
  * https://www.ilias.de
  * https://github.com/ILIAS-eLearning
  *
- *****************************************************************************/
+ *********************************************************************/
+
 /** @noRector */
 require_once("libs/composer/vendor/autoload.php");
 ilInitialisation::initILIAS();
@@ -21,6 +25,11 @@ ilInitialisation::initILIAS();
  */
 global $DIC;
 
-$DIC->ctrl()->callBaseClass();
+try {
+    $DIC->ctrl()->callBaseClass();
+} catch (ilCtrlException) {
+    $DIC->ctrl()->redirectToURL(ilUtil::_getHttpPath());
+}
+
 $DIC['ilBench']->save();
 $DIC['http']?->close();


### PR DESCRIPTION
…script

Mantis Issue: https://mantis.ilias.de/view.php?id=44170 / https://mantis.ilias.de/view.php?id=45707

If approved, this should be picked to all maintained branches.