### PR TITLE
DB: Allow Longer Table Identifier

### DIFF
--- a/components/ILIAS/Database/classes/PDO/FieldDefinition/class.ilDBPdoFieldDefinition.php
+++ b/components/ILIAS/Database/classes/PDO/FieldDefinition/class.ilDBPdoFieldDefinition.php
@@ -41,6 +41,9 @@ abstract class ilDBPdoFieldDefinition
     public const T_TEXT = 'text';
     public const T_TIME = 'time';
     public const T_TIMESTAMP = 'timestamp';
+
+    private const MAX_TABLE_IDENTIFIER_LENGTH = 48;
+
     protected static \ilDBPdoFieldDefinition $instance;
     /**
      * @var string[][]
@@ -866,8 +869,9 @@ abstract class ilDBPdoFieldDefinition
             throw new ilDatabaseException("Invalid table name '" . $table_name . "'. Name must not start with 'sys_'.");
         }
 
-        if (strlen($table_name) > 22) {
-            throw new ilDatabaseException("Invalid table name '" . $table_name . "'. Maximum table identifer length is 22 bytes.");
+        if (strlen($table_name) > self::MAX_TABLE_IDENTIFIER_LENGTH) {
+            throw new ilDatabaseException("Invalid table name '" . $table_name
+                . "'. Maximum table identifer length is " . self::MAX_TABLE_IDENTIFIER_LENGTH . " bytes.");
         }
 
         return true;

--- a/components/ILIAS/Database/classes/PDO/FieldDefinition/class.ilDBPdoFieldDefinition.php
+++ b/components/ILIAS/Database/classes/PDO/FieldDefinition/class.ilDBPdoFieldDefinition.php
@@ -42,7 +42,7 @@ abstract class ilDBPdoFieldDefinition
     public const T_TIME = 'time';
     public const T_TIMESTAMP = 'timestamp';
 
-    private const MAX_TABLE_IDENTIFIER_LENGTH = 48;
+    private const MAX_TABLE_IDENTIFIER_LENGTH = 63;
 
     protected static \ilDBPdoFieldDefinition $instance;
     /**


### PR DESCRIPTION
Hi @chfsx 

With this PR I would like to propose to allow longer table identifier. Right now we are limited to 22 character and I don't think there is much reason to do so anymore. As far as I can see the allowed identifier length for tables in MySQL and MariaDB is 64 characters. PostgresSQL that we do not support, would allow 63 by default. I opted to leave us with some wiggle room, just in case and propose a length of 48 with the sole reason that it is a nice round base16 number.

The reason to allow longer identifiers is that it allows us to create clearer table names otherwise we need to abbreviate everything and the names become hard to understand.

Thank you very much and best,
@kergomard 