### PR TITLE
T&A 45602: Fixes double page elements on error text question player view (ILIAS9)

### DIFF
--- a/Modules/TestQuestionPool/classes/class.assErrorTextGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assErrorTextGUI.php
@@ -387,7 +387,7 @@ class assErrorTextGUI extends assQuestionGUI implements ilGuiQuestionScoringAdju
             '',
             $is_postponed,
             $active_id,
-            $this->generateQuestionOutput($selections, false)
+            $this->generateQuestionOutput($selections, true)
         );
     }
 


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45602

Aims to fix double page elements on error text question player view.

@thojou