### PR TITLE
Init/ErrorHandling: Make `$code` optional when calling `raiseError`

### DIFF
--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -130,7 +130,7 @@ class ilErrorHandling
 
     public function raiseError(
         string $message,
-        ?int $code
+        ?int $code = null
     ): void {
         $backtrace = debug_backtrace();
         if (isset($backtrace[0], $backtrace[0]['object'])) {


### PR DESCRIPTION
See: https://mantis.ilias.de/view.php?id=45710

If approved, this must be picked to all maintained branches.