### PR TITLE
Soap: Move internal soap URL into own Port. Ensure correct query params

### DIFF
--- a/components/ILIAS/WebServices/SOAP/classes/class.ilSoapClient.php
+++ b/components/ILIAS/WebServices/SOAP/classes/class.ilSoapClient.php
@@ -1,8 +1,22 @@
 <?php
 
-declare(strict_types=1);
-/* Copyright (c) 1998-2009 ILIAS open source, Extended GPL, see docs/LICENSE */
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
 
+declare(strict_types=1);
 
 /**
  * Wrapper class for soap_client

--- a/components/ILIAS/WebServices/SOAP/classes/class.ilSoapClient.php
+++ b/components/ILIAS/WebServices/SOAP/classes/class.ilSoapClient.php
@@ -82,7 +82,11 @@ class ilSoapClient
         $internal_path = $this->settings->get('soap_internal_wsdl_path');
         if (trim($this->getServer()) === '') {
             if ($internal_path) {
-                $this->uri = $internal_path;
+                $uri = (new \ILIAS\Data\URI($internal_path));
+                parse_str($uri->getQuery() ?? '', $query);
+                $this->uri = (string) (isset($query['wsdl']) ?
+                                       $uri :
+                                       $uri->withQuery(http_build_query(array_merge($query, ['wsdl' => '']))));
             } elseif (trim($this->settings->get('soap_wsdl_path', '')) !== '') {
                 $this->uri = $this->settings->get('soap_wsdl_path', '');
             } else {

--- a/components/ILIAS/soap/lib/nusoap.php
+++ b/components/ILIAS/soap/lib/nusoap.php
@@ -4595,15 +4595,11 @@ class nusoap_server extends nusoap_base
 
     public function addInternalPort(string $serviceName, string $url): void
     {
-        $port = $this->wsdl->ports[$serviceName . 'Port'] ?? [
-            'binding'=> $serviceName . 'Binding',
-            'location'=> [],
-            'bindingType'=>'http://schemas.xmlsoap.org/wsdl/soap/'
+        $this->wsdl->ports['Internal' . $serviceName . 'Port'] = [
+            'binding' => $serviceName . 'Binding',
+            'location'=> (string) (new \ILIAS\Data\URI($url))->withQuery(),
+            'bindingType' => 'http://schemas.xmlsoap.org/wsdl/soap/'
         ];
-
-        $port['location'] = is_array($port['location']) ? array_merge($port['location'], [$url]) : [$port['location'], $url];
-
-        $this->wsdl->ports[$serviceName . 'Port'] = $port;
     }
 }
 

--- a/components/ILIAS/soap/lib/nusoap.php
+++ b/components/ILIAS/soap/lib/nusoap.php
@@ -193,26 +193,26 @@ class nusoap_base
     */
     public $typemap = array(
     'http://www.w3.org/2001/XMLSchema' => array(
-        'string'=>'string','boolean'=>'boolean','float'=>'double','double'=>'double','decimal'=>'double',
-        'duration'=>'','dateTime'=>'string','time'=>'string','date'=>'string','gYearMonth'=>'',
-        'gYear'=>'','gMonthDay'=>'','gDay'=>'','gMonth'=>'','hexBinary'=>'string','base64Binary'=>'string',
+        'string' => 'string','boolean' => 'boolean','float' => 'double','double' => 'double','decimal' => 'double',
+        'duration' => '','dateTime' => 'string','time' => 'string','date' => 'string','gYearMonth' => '',
+        'gYear' => '','gMonthDay' => '','gDay' => '','gMonth' => '','hexBinary' => 'string','base64Binary' => 'string',
         // abstract "any" types
-        'anyType'=>'string','anySimpleType'=>'string',
+        'anyType' => 'string','anySimpleType' => 'string',
         // derived datatypes
-        'normalizedString'=>'string','token'=>'string','language'=>'','NMTOKEN'=>'','NMTOKENS'=>'','Name'=>'','NCName'=>'','ID'=>'',
-        'IDREF'=>'','IDREFS'=>'','ENTITY'=>'','ENTITIES'=>'','integer'=>'integer','nonPositiveInteger'=>'integer',
-        'negativeInteger'=>'integer','long'=>'integer','int'=>'integer','short'=>'integer','byte'=>'integer','nonNegativeInteger'=>'integer',
-        'unsignedLong'=>'','unsignedInt'=>'','unsignedShort'=>'','unsignedByte'=>'','positiveInteger'=>''),
+        'normalizedString' => 'string','token' => 'string','language' => '','NMTOKEN' => '','NMTOKENS' => '','Name' => '','NCName' => '','ID' => '',
+        'IDREF' => '','IDREFS' => '','ENTITY' => '','ENTITIES' => '','integer' => 'integer','nonPositiveInteger' => 'integer',
+        'negativeInteger' => 'integer','long' => 'integer','int' => 'integer','short' => 'integer','byte' => 'integer','nonNegativeInteger' => 'integer',
+        'unsignedLong' => '','unsignedInt' => '','unsignedShort' => '','unsignedByte' => '','positiveInteger' => ''),
     'http://www.w3.org/2000/10/XMLSchema' => array(
-        'i4'=>'','int'=>'integer','boolean'=>'boolean','string'=>'string','double'=>'double',
-        'float'=>'double','dateTime'=>'string',
-        'timeInstant'=>'string','base64Binary'=>'string','base64'=>'string','ur-type'=>'array'),
+        'i4' => '','int' => 'integer','boolean' => 'boolean','string' => 'string','double' => 'double',
+        'float' => 'double','dateTime' => 'string',
+        'timeInstant' => 'string','base64Binary' => 'string','base64' => 'string','ur-type' => 'array'),
     'http://www.w3.org/1999/XMLSchema' => array(
-        'i4'=>'','int'=>'integer','boolean'=>'boolean','string'=>'string','double'=>'double',
-        'float'=>'double','dateTime'=>'string',
-        'timeInstant'=>'string','base64Binary'=>'string','base64'=>'string','ur-type'=>'array'),
-    'http://soapinterop.org/xsd' => array('SOAPStruct'=>'struct'),
-    'http://schemas.xmlsoap.org/soap/encoding/' => array('base64'=>'string','array'=>'array','Array'=>'array'),
+        'i4' => '','int' => 'integer','boolean' => 'boolean','string' => 'string','double' => 'double',
+        'float' => 'double','dateTime' => 'string',
+        'timeInstant' => 'string','base64Binary' => 'string','base64' => 'string','ur-type' => 'array'),
+    'http://soapinterop.org/xsd' => array('SOAPStruct' => 'struct'),
+    'http://schemas.xmlsoap.org/soap/encoding/' => array('base64' => 'string','array' => 'array','Array' => 'array'),
     'http://xml.apache.org/xml-soap' => array('Map')
     );
 
@@ -428,7 +428,7 @@ class nusoap_base
     * @return	string	The serialized element, possibly with child elements
     * @access	public
     */
-    public function serialize_val($val, $name=false, $type=false, $name_ns=false, $type_ns=false, $attributes=false, $use='encoded', $soapval=false)
+    public function serialize_val($val, $name = false, $type = false, $name_ns = false, $type_ns = false, $attributes = false, $use = 'encoded', $soapval = false)
     {
         $this->debug("in serialize_val: name=$name, type=$type, name_ns=$name_ns, type_ns=$type_ns, use=$use, soapval=$soapval");
         $this->appendDebug('value=' . $this->varDump($val));
@@ -536,7 +536,7 @@ class nusoap_base
                     $xml .= "<$name$xmlns xsi:type=\"xsd:int\"$atts>$val</$name>";
                 }
                 break;
-            case (is_float($val)|| is_double($val) || $type == 'float'):
+            case (is_float($val) || is_double($val) || $type == 'float'):
                 $this->debug("serialize_val: serialize float");
                 if ($use == 'literal') {
                     $xml .= "<$name$xmlns$atts>$val</$name>";
@@ -586,12 +586,12 @@ class nusoap_base
             case (is_array($val) || $type):
                 // detect if struct or array
                 $valueType = $this->isArraySimpleOrStruct($val);
-                if ($valueType=='arraySimple' || preg_match('/^ArrayOf/', $type)) {
+                if ($valueType == 'arraySimple' || preg_match('/^ArrayOf/', $type)) {
                     $this->debug("serialize_val: serialize array");
                     $i = 0;
-                    if (is_array($val) && count($val)> 0) {
+                    if (is_array($val) && count($val) > 0) {
                         foreach ($val as $v) {
-                            if (is_object($v) && get_class($v) ==  'soapval') {
+                            if (is_object($v) && get_class($v) == 'soapval') {
                                 $tt_ns = $v->type_ns;
                                 $tt = $v->type;
                             } elseif (is_array($v)) {
@@ -695,7 +695,7 @@ class nusoap_base
     * @return string the message
     * @access public
     */
-    public function serializeEnvelope($body, $headers=false, $namespaces=array(), $style='rpc', $use='encoded', $encodingStyle='http://schemas.xmlsoap.org/soap/encoding/')
+    public function serializeEnvelope($body, $headers = false, $namespaces = array(), $style = 'rpc', $use = 'encoded', $encodingStyle = 'http://schemas.xmlsoap.org/soap/encoding/')
     {
         // TODO: add an option to automatically run utf8_encode on $body and $headers
         // if $this->soap_defencoding is UTF-8.  Not doing this automatically allows
@@ -936,7 +936,7 @@ class nusoap_base
 * @param	boolean $utc Whether the time stamp is UTC or local
 * @access   public
 */
-function timestamp_to_iso8601($timestamp, $utc=true)
+function timestamp_to_iso8601($timestamp, $utc = true)
 {
     $datestr = date('Y-m-d\TH:i:sO', $timestamp);
     if ($utc) {
@@ -984,7 +984,7 @@ function iso8601_to_timestamp($datestr)
         if ($regs[8] != 'Z') {
             $op = substr($regs[8], 0, 1);
             $h = substr($regs[8], 1, 2);
-            $m = substr($regs[8], strlen($regs[8])-2, 2);
+            $m = substr($regs[8], strlen($regs[8]) - 2, 2);
             if ($op == '-') {
                 $regs[4] = $regs[4] + $h;
                 $regs[5] = $regs[5] + $m;
@@ -994,7 +994,7 @@ function iso8601_to_timestamp($datestr)
             }
         }
         return gmmktime($regs[4], $regs[5], $regs[6], $regs[2], $regs[3], $regs[1]);
-    //		return strtotime("$regs[1]-$regs[2]-$regs[3] $regs[4]:$regs[5]:$regs[6]Z");
+        //		return strtotime("$regs[1]-$regs[2]-$regs[3] $regs[4]:$regs[5]:$regs[6]Z");
     } else {
         return false;
     }
@@ -1065,7 +1065,7 @@ class nusoap_fault extends nusoap_base
     * @param string $faultstring human readable error message
     * @param mixed $faultdetail detail, typically a string or array of string
     */
-    public function __construct($faultcode, $faultactor='', $faultstring='', $faultdetail='')
+    public function __construct($faultcode, $faultactor = '', $faultstring = '', $faultdetail = '')
     {
         parent::__construct();
         $this->faultcode = $faultcode;
@@ -1161,7 +1161,7 @@ class nusoap_xmlschema extends nusoap_base
     * @param	string $namespaces namespaces defined in enclosing XML
     * @access   public
     */
-    public function __construct($schema='', $xml='', $namespaces=array())
+    public function __construct($schema = '', $xml = '', $namespaces = array())
     {
         parent::__construct();
         $this->debug('nusoap_xmlschema class instantiated, inside constructor');
@@ -1322,7 +1322,7 @@ class nusoap_xmlschema extends nusoap_base
                     } else {
                         $this->defaultNamespace[$pos] = $v;
                         if (! $this->getPrefixFromNamespace($v)) {
-                            $this->namespaces['ns' . (count($this->namespaces)+1)] = $v;
+                            $this->namespaces['ns' . (count($this->namespaces) + 1)] = $v;
                         }
                     }
                     if ($v == 'http://www.w3.org/2001/XMLSchema' || $v == 'http://www.w3.org/1999/XMLSchema' || $v == 'http://www.w3.org/2000/10/XMLSchema') {
@@ -1521,7 +1521,7 @@ class nusoap_xmlschema extends nusoap_base
                     //$this->xdebug('import namespace ' . $attrs['namespace']);
                     $this->imports[$attrs['namespace']][] = array('location' => '', 'loaded' => true);
                     if (! $this->getPrefixFromNamespace($attrs['namespace'])) {
-                        $this->namespaces['ns' . (count($this->namespaces)+1)] = $attrs['namespace'];
+                        $this->namespaces['ns' . (count($this->namespaces) + 1)] = $attrs['namespace'];
                     }
                 }
                 break;
@@ -1929,16 +1929,16 @@ class nusoap_xmlschema extends nusoap_base
 					<td><input type='text' name='parameters[" . $name . "][$childDef[name]]'></td></tr>";
                 }
                 $buffer .= '</table>';
-            // if array
+                // if array
             } elseif ($typeDef['phpType'] == 'array') {
                 $buffer .= '<table>';
-                for ($i=0;$i < 3; $i++) {
+                for ($i = 0;$i < 3; $i++) {
                     $buffer .= "
 					<tr><td align='right'>array item (type: $typeDef[arrayType]):</td>
 					<td><input type='text' name='parameters[" . $name . "][]'></td></tr>";
                 }
                 $buffer .= '</table>';
-            // if scalar
+                // if scalar
             } else {
                 $buffer .= "<input type='text' name='parameters[$name]'>";
             }
@@ -1989,17 +1989,17 @@ class nusoap_xmlschema extends nusoap_base
     * @access public
     * @see getTypeDef
     */
-    public function addComplexType($name, $typeClass='complexType', $phpType='array', $compositor='', $restrictionBase='', $elements=array(), $attrs=array(), $arrayType='')
+    public function addComplexType($name, $typeClass = 'complexType', $phpType = 'array', $compositor = '', $restrictionBase = '', $elements = array(), $attrs = array(), $arrayType = '')
     {
         $this->complexTypes[$name] = array(
-        'name'		=> $name,
-        'typeClass'	=> $typeClass,
-        'phpType'	=> $phpType,
-        'compositor'=> $compositor,
+        'name' => $name,
+        'typeClass' => $typeClass,
+        'phpType' => $phpType,
+        'compositor' => $compositor,
         'restrictionBase' => $restrictionBase,
-        'elements'	=> $elements,
-        'attrs'		=> $attrs,
-        'arrayType'	=> $arrayType
+        'elements' => $elements,
+        'attrs' => $attrs,
+        'arrayType' => $arrayType
         );
 
         $this->xdebug("addComplexType $name:");
@@ -2018,14 +2018,14 @@ class nusoap_xmlschema extends nusoap_base
     * @see nusoap_xmlschema
     * @see getTypeDef
     */
-    public function addSimpleType($name, $restrictionBase='', $typeClass='simpleType', $phpType='scalar', $enumeration=array())
+    public function addSimpleType($name, $restrictionBase = '', $typeClass = 'simpleType', $phpType = 'scalar', $enumeration = array())
     {
         $this->simpleTypes[$name] = array(
-        'name'			=> $name,
-        'typeClass'		=> $typeClass,
-        'phpType'		=> $phpType,
-        'type'			=> $restrictionBase,
-        'enumeration'	=> $enumeration
+        'name' => $name,
+        'typeClass' => $typeClass,
+        'phpType' => $phpType,
+        'type' => $restrictionBase,
+        'enumeration' => $enumeration
         );
 
         $this->xdebug("addSimpleType $name:");
@@ -2130,7 +2130,7 @@ class soapval extends nusoap_base
     * @param	mixed $attributes associative array of attributes to add to element serialization
     * @access   public
     */
-    public function __construct($name='soapval', $type=false, $value=-1, $element_ns=false, $type_ns=false, $attributes=false)
+    public function __construct($name = 'soapval', $type = false, $value = -1, $element_ns = false, $type_ns = false, $attributes = false)
     {
         parent::__construct();
         $this->name = $name;
@@ -2148,7 +2148,7 @@ class soapval extends nusoap_base
     * @return	string XML data
     * @access   public
     */
-    public function serialize($use='encoded')
+    public function serialize($use = 'encoded')
     {
         return $this->serialize_val($this->value, $this->name, $this->type, $this->element_ns, $this->type_ns, $this->attributes, $use, true);
     }
@@ -2353,7 +2353,7 @@ class soap_transport_http extends nusoap_base
     * @return	boolean true if connected, false if not
     * @access   private
     */
-    public function connect($connection_timeout=0, $response_timeout=30)
+    public function connect($connection_timeout = 0, $response_timeout = 30)
     {
         // For PHP 4.3 with OpenSSL, change https scheme to ssl, then treat like
         // "regular" socket.
@@ -2596,7 +2596,7 @@ class soap_transport_http extends nusoap_base
     * @return	string data
     * @access   public
     */
-    public function send($data, $timeout=0, $response_timeout=30, $cookies=null)
+    public function send($data, $timeout = 0, $response_timeout = 30, $cookies = null)
     {
         $this->debug('entered send() with data of length: ' . strlen($data));
 
@@ -2637,7 +2637,7 @@ class soap_transport_http extends nusoap_base
     * @access   public
     * @deprecated
     */
-    public function sendHTTPS($data, $timeout=0, $response_timeout=30, $cookies=null)
+    public function sendHTTPS($data, $timeout = 0, $response_timeout = 30, $cookies = null)
     {
         return $this->send($data, $timeout, $response_timeout, $cookies);
     }
@@ -2677,7 +2677,7 @@ class soap_transport_http extends nusoap_base
                 $A2 = $this->request_method . ':' . $this->digest_uri;
 
                 // H(A2)
-                $HA2 =  md5($A2);
+                $HA2 = md5($A2);
 
                 // KD(secret, data) = H(concat(secret, ":", data))
                 // if qop == auth:
@@ -2738,7 +2738,7 @@ class soap_transport_http extends nusoap_base
     * @param    string $enc encoding style. supported values: gzip, deflate, or both
     * @access   public
     */
-    public function setEncoding($enc='gzip, deflate')
+    public function setEncoding($enc = 'gzip, deflate')
     {
         if (function_exists('gzdeflate')) {
             $this->protocol_version = '1.1';
@@ -2853,7 +2853,7 @@ class soap_transport_http extends nusoap_base
             }
 
             // read chunk-data and CRLF
-            $chunk = substr($buffer, $chunkstart, $chunkend-$chunkstart);
+            $chunk = substr($buffer, $chunkstart, $chunkend - $chunkstart);
             // append chunk-data to entity-body
             $new .= $chunk;
             // length := length + chunk-size
@@ -2865,7 +2865,7 @@ class soap_transport_http extends nusoap_base
             if ($chunkend == false) {
                 break; //Just in case we got a broken connection
             }
-            $temp = substr($buffer, $chunkstart, $chunkend-$chunkstart);
+            $temp = substr($buffer, $chunkstart, $chunkend - $chunkstart);
             $chunk_size = hexdec(trim($temp));
             $chunkstart = $chunkend;
         }
@@ -3062,7 +3062,7 @@ class soap_transport_http extends nusoap_base
 
             // loop until msg has been received
             if (isset($this->incoming_headers['transfer-encoding']) && strtolower($this->incoming_headers['transfer-encoding']) == 'chunked') {
-                $content_length =  2147483647;	// ignore any content-length header
+                $content_length = 2147483647;	// ignore any content-length header
                 $chunked = true;
                 $this->debug("want to read chunked content");
             } elseif (isset($this->incoming_headers['content-length'])) {
@@ -3070,7 +3070,7 @@ class soap_transport_http extends nusoap_base
                 $chunked = false;
                 $this->debug("want to read content of length $content_length");
             } else {
-                $content_length =  2147483647;
+                $content_length = 2147483647;
                 $chunked = false;
                 $this->debug("want to read content to EOF");
             }
@@ -3142,15 +3142,15 @@ class soap_transport_http extends nusoap_base
             }
 
             // decode transfer-encoding
-        //		if(isset($this->incoming_headers['transfer-encoding']) && strtolower($this->incoming_headers['transfer-encoding']) == 'chunked'){
-        //			if(!$data = $this->decodeChunked($data, $lb)){
-        //				$this->setError('Decoding of chunked data failed');
-        //				return false;
-        //			}
-        //print "<pre>\nde-chunked:\n---------------\n$data\n\n---------------\n</pre>";
-        // set decoded payload
-        //			$this->incoming_payload = $header_data.$lb.$lb.$data;
-        //		}
+            //		if(isset($this->incoming_headers['transfer-encoding']) && strtolower($this->incoming_headers['transfer-encoding']) == 'chunked'){
+            //			if(!$data = $this->decodeChunked($data, $lb)){
+            //				$this->setError('Decoding of chunked data failed');
+            //				return false;
+            //			}
+            //print "<pre>\nde-chunked:\n---------------\n$data\n\n---------------\n</pre>";
+            // set decoded payload
+            //			$this->incoming_payload = $header_data.$lb.$lb.$data;
+            //		}
         } elseif ($this->io_method() == 'curl') {
             // send and receive
             $this->debug('send and receive with cURL');
@@ -3442,7 +3442,7 @@ class soap_transport_http extends nusoap_base
         if ($sep_pos) {
             $name = substr($value_str, 0, $sep_pos);
             $value = substr($value_str, $sep_pos + 1);
-            $cookie= array(	'name' => $name,
+            $cookie = array(	'name' => $name,
                             'value' => $value,
                             'domain' => $domain,
                             'path' => $path,
@@ -3462,7 +3462,7 @@ class soap_transport_http extends nusoap_base
      * @return	string for Cookie-HTTP-Header
      * @access	private
      */
-    public function getCookiesForRequest($cookies, $secure=false)
+    public function getCookiesForRequest($cookies, $secure = false)
     {
         $cookie_str = '';
         if ((! is_null($cookies)) && (is_array($cookies))) {
@@ -3677,7 +3677,7 @@ class nusoap_server extends nusoap_base
     * @param mixed $wsdl file path or URL (string), or wsdl instance (object)
     * @access   public
     */
-    public function __construct($wsdl=false)
+    public function __construct($wsdl = false)
     {
         parent::__construct();
         // turn on debugging?
@@ -3757,7 +3757,7 @@ class nusoap_server extends nusoap_base
         if (preg_match('/wsdl/', $qs)) {
             $this->debug("In service, this is a request for WSDL");
             if ($this->externalWSDLURL) {
-                if (strpos($this->externalWSDLURL, "://")!==false) { // assume URL
+                if (strpos($this->externalWSDLURL, "://") !== false) { // assume URL
                     header('Location: ' . $this->externalWSDLURL);
                 } else { // assume file
                     header("Content-Type: text/xml\r\n");
@@ -3813,7 +3813,7 @@ class nusoap_server extends nusoap_base
         if (function_exists('getallheaders')) {
             $this->debug("In parse_http_headers, use getallheaders");
             $headers = getallheaders();
-            foreach ($headers as $k=>$v) {
+            foreach ($headers as $k => $v) {
                 $k = strtolower($k);
                 $this->headers[$k] = $v;
                 $this->request .= "$k: $v\r\n";
@@ -3933,7 +3933,7 @@ class nusoap_server extends nusoap_base
     * @param    string $data XML string
     * @access   private
     */
-    public function parse_request($data='')
+    public function parse_request($data = '')
     {
         $this->debug('entering parse_request()');
         $this->parse_http_headers();
@@ -4025,7 +4025,7 @@ class nusoap_server extends nusoap_base
         }
         // set class handler
         // added to support single operations
-        if ($class == '' && $this->class !='') {
+        if ($class == '' && $this->class != '') {
             $class = $this->class;
             $delim = "..";
             $method = $this->methodname;
@@ -4131,13 +4131,13 @@ class nusoap_server extends nusoap_base
     {
         $this->debug('Entering serialize_return methodname: ' . $this->methodname . ' methodURI: ' . $this->methodURI);
         // if fault
-        if (isset($this->methodreturn) && ((get_class((object)$this->methodreturn) == 'soap_fault') || (get_class((object)$this->methodreturn) == 'nusoap_fault'))) {
+        if (isset($this->methodreturn) && ((get_class((object) $this->methodreturn) == 'soap_fault') || (get_class((object) $this->methodreturn) == 'nusoap_fault'))) {
             $this->debug('got a fault object from method');
             $this->fault = $this->methodreturn;
             return;
         } elseif ($this->methodreturnisliteralxml) {
             $return_val = $this->methodreturn;
-        // returned value(s)
+            // returned value(s)
         } else {
             $this->debug('got a(n) ' . gettype($this->methodreturn) . ' from method');
             $this->debug('serializing return value');
@@ -4348,7 +4348,7 @@ class nusoap_server extends nusoap_base
         if ($err = $parser->getError()) {
             $this->result = 'fault: error in msg parsing: ' . $err;
             $this->fault('SOAP-ENV:Client', "error in msg parsing:\n" . $err);
-        // else successfully parsed request into soapval object
+            // else successfully parsed request into soapval object
         } else {
             // get/set methodname
             $this->methodURI = $parser->root_struct_namespace;
@@ -4432,7 +4432,7 @@ class nusoap_server extends nusoap_base
     * @param	string $encodingStyle optional (usually 'http://schemas.xmlsoap.org/soap/encoding/' for encoded)
     * @access   public
     */
-    public function register($name, $in=array(), $out=array(), $namespace=false, $soapaction=false, $style=false, $use=false, $documentation='', $encodingStyle='')
+    public function register($name, $in = array(), $out = array(), $namespace = false, $soapaction = false, $style = false, $use = false, $documentation = '', $encodingStyle = '')
     {
         global $HTTP_SERVER_VARS;
 
@@ -4502,7 +4502,7 @@ class nusoap_server extends nusoap_base
     * @param	string $faultdetail
     * @access   public
     */
-    public function fault($faultcode, $faultstring, $faultactor='', $faultdetail='')
+    public function fault($faultcode, $faultstring, $faultactor = '', $faultdetail = '')
     {
         if ($faultdetail == '' && $this->debug_flag) {
             $faultdetail = $this->getDebug();
@@ -4522,7 +4522,7 @@ class nusoap_server extends nusoap_base
     * @param string $transport optional SOAP transport
     * @param mixed $schemaTargetNamespace optional 'types' targetNamespace for service schema or false
     */
-    public function configureWSDL($serviceName, $namespace = false, $endpoint = false, $style='rpc', $transport = 'http://schemas.xmlsoap.org/soap/http', $schemaTargetNamespace = false)
+    public function configureWSDL($serviceName, $namespace = false, $endpoint = false, $style = 'rpc', $transport = 'http://schemas.xmlsoap.org/soap/http', $schemaTargetNamespace = false)
     {
         global $HTTP_SERVER_VARS;
 
@@ -4583,21 +4583,21 @@ class nusoap_server extends nusoap_base
         $this->wsdl->schemas[$schemaTargetNamespace][0]->imports['http://schemas.xmlsoap.org/soap/encoding/'][0] = array('location' => '', 'loaded' => true);
         $this->wsdl->schemas[$schemaTargetNamespace][0]->imports['http://schemas.xmlsoap.org/wsdl/'][0] = array('location' => '', 'loaded' => true);
         $this->wsdl->bindings[$serviceName . 'Binding'] = array(
-            'name'=>$serviceName . 'Binding',
-            'style'=>$style,
-            'transport'=>$transport,
-            'portType'=>$serviceName . 'PortType');
+            'name' => $serviceName . 'Binding',
+            'style' => $style,
+            'transport' => $transport,
+            'portType' => $serviceName . 'PortType');
         $this->wsdl->ports[$serviceName . 'Port'] = array(
-            'binding'=>$serviceName . 'Binding',
-            'location'=>$endpoint,
-            'bindingType'=>'http://schemas.xmlsoap.org/wsdl/soap/');
+            'binding' => $serviceName . 'Binding',
+            'location' => $endpoint,
+            'bindingType' => 'http://schemas.xmlsoap.org/wsdl/soap/');
     }
 
     public function addInternalPort(string $serviceName, string $url): void
     {
         $this->wsdl->ports['Internal' . $serviceName . 'Port'] = [
             'binding' => $serviceName . 'Binding',
-            'location'=> (string) (new \ILIAS\Data\URI($url))->withQuery(),
+            'location' => (string) (new \ILIAS\Data\URI($url))->withQuery(),
             'bindingType' => 'http://schemas.xmlsoap.org/wsdl/soap/'
         ];
     }
@@ -4684,7 +4684,7 @@ class wsdl extends nusoap_base
      * @param boolean $use_curl try to use cURL
      * @access public
      */
-    public function __construct($wsdl = '', $proxyhost=false, $proxyport=false, $proxyusername=false, $proxypassword=false, $timeout=0, $response_timeout=30, $curl_options=null, $use_curl=false)
+    public function __construct($wsdl = '', $proxyhost = false, $proxyport = false, $proxyusername = false, $proxypassword = false, $timeout = 0, $response_timeout = 30, $curl_options = null, $use_curl = false)
     {
         parent::__construct();
         $this->debug("ctor wsdl=$wsdl timeout=$timeout response_timeout=$response_timeout");
@@ -5075,7 +5075,7 @@ class wsdl extends nusoap_base
                     } else {
                         $this->import[$attrs['namespace']][] = array('location' => '', 'loaded' => true);
                         if (! $this->getPrefixFromNamespace($attrs['namespace'])) {
-                            $this->namespaces['ns' . (count($this->namespaces)+1)] = $attrs['namespace'];
+                            $this->namespaces['ns' . (count($this->namespaces) + 1)] = $attrs['namespace'];
                         }
                         $this->debug('parsing import ' . $attrs['namespace'] . ' - [no location] (' . count($this->import[$attrs['namespace']]) . ')');
                     }
@@ -5533,7 +5533,7 @@ class wsdl extends nusoap_base
             }
         }
         // types
-        if (count($this->schemas)>=1) {
+        if (count($this->schemas) >= 1) {
             $xml .= "\n<types>\n";
             foreach ($this->schemas as $ns => $list) {
                 foreach ($list as $xs) {
@@ -5920,7 +5920,7 @@ class wsdl extends nusoap_base
      * @return string value serialized as an XML string
      * @access private
      */
-    public function serializeType($name, $type, $value, $use='encoded', $encodingStyle=false, $unqualified=false)
+    public function serializeType($name, $type, $value, $use = 'encoded', $encodingStyle = false, $unqualified = false)
     {
         $this->debug("in serializeType: name=$name, type=$type, use=$use, encodingStyle=$encodingStyle, unqualified=" . ($unqualified ? "unqualified" : "qualified"));
         $this->appendDebug("value=" . $this->varDump($value));
@@ -6253,7 +6253,7 @@ class wsdl extends nusoap_base
                     $this->debug("no value provided for attribute $aName");
                 }
                 if ($xname) {
-                    $xml .=  " $aName=\"" . $this->expandEntities($xvalue[$xname]) . "\"";
+                    $xml .= " $aName=\"" . $this->expandEntities($xvalue[$xname]) . "\"";
                 }
             }
         } else {
@@ -6287,7 +6287,7 @@ class wsdl extends nusoap_base
      * @return string value serialized as an XML string
      * @access private
      */
-    public function serializeComplexTypeElements($typeDef, $value, $ns, $uqType, $use='encoded', $encodingStyle=false)
+    public function serializeComplexTypeElements($typeDef, $value, $ns, $uqType, $use = 'encoded', $encodingStyle = false)
     {
         $xml = '';
         if (isset($typeDef['elements']) && is_array($typeDef['elements'])) {
@@ -6390,7 +6390,7 @@ class wsdl extends nusoap_base
     * @see nusoap_xmlschema
     * @access public
     */
-    public function addComplexType($name, $typeClass='complexType', $phpType='array', $compositor='', $restrictionBase='', $elements=array(), $attrs=array(), $arrayType='')
+    public function addComplexType($name, $typeClass = 'complexType', $phpType = 'array', $compositor = '', $restrictionBase = '', $elements = array(), $attrs = array(), $arrayType = '')
     {
         if (count($elements) > 0) {
             $eElements = array();
@@ -6438,7 +6438,7 @@ class wsdl extends nusoap_base
     * @see nusoap_xmlschema
     * @access public
     */
-    public function addSimpleType($name, $restrictionBase='', $typeClass='simpleType', $phpType='scalar', $enumeration=array())
+    public function addSimpleType($name, $restrictionBase = '', $typeClass = 'simpleType', $phpType = 'scalar', $enumeration = array())
     {
         $restrictionBase = strpos($restrictionBase, ':') ? $this->expandQname($restrictionBase) : $restrictionBase;
 
@@ -6530,7 +6530,7 @@ class wsdl extends nusoap_base
                 $this->messages[$name . 'Request'][$pName] = $pType;
             }
         } else {
-            $this->messages[$name . 'Request']= '0';
+            $this->messages[$name . 'Request'] = '0';
         }
         if ($out) {
             foreach ($out as $pName => $pType) {
@@ -6540,7 +6540,7 @@ class wsdl extends nusoap_base
                 $this->messages[$name . 'Response'][$pName] = $pType;
             }
         } else {
-            $this->messages[$name . 'Response']= '0';
+            $this->messages[$name . 'Response'] = '0';
         }
         return true;
     }
@@ -6605,7 +6605,7 @@ class nusoap_parser extends nusoap_base
     * @param    string $decode_utf8 whether to decode UTF-8 to ISO-8859-1
     * @access   public
     */
-    public function __construct($xml, $encoding='UTF-8', $method='', $decode_utf8=true)
+    public function __construct($xml, $encoding = 'UTF-8', $method = '', $decode_utf8 = true)
     {
         parent::__construct();
         $this->xml = $xml;
@@ -6706,7 +6706,7 @@ class nusoap_parser extends nusoap_base
         // update class level pos
         $pos = $this->position++;
         // and set mine
-        $this->message[$pos] = array('pos' => $pos,'children'=>'','cdata'=>'');
+        $this->message[$pos] = array('pos' => $pos,'children' => '','cdata' => '');
         // depth = how many levels removed from root?
         // set mine as current global depth and increment global depth value
         $this->message[$pos]['depth'] = $this->depth++;
@@ -6737,8 +6737,8 @@ class nusoap_parser extends nusoap_base
         } elseif ($name == 'Body' && $this->status = 'envelope') {
             $this->status = 'body';
             $this->body_position = $pos;
-        // set method
-        } elseif ($this->status == 'body' && $pos == ($this->body_position+1)) {
+            // set method
+        } elseif ($this->status == 'body' && $pos == ($this->body_position + 1)) {
             $this->status = 'method';
             $this->root_struct_name = $name;
             $this->root_struct = $pos;
@@ -6811,7 +6811,7 @@ class nusoap_parser extends nusoap_base
                 // specifies nil value (or not)
             } elseif ($key_localpart == 'nil') {
                 $this->message[$pos]['nil'] = ($value == 'true' || $value == '1');
-            // some other attribute
+                // some other attribute
             } elseif ($key != 'href' && $key != 'xmlns' && $key_localpart != 'encodingStyle' && $key_localpart != 'root') {
                 $this->message[$pos]['xattrs']['!' . $key] = $value;
             }
@@ -6878,8 +6878,8 @@ class nusoap_parser extends nusoap_base
                 // add placeholder to href array
                 $this->multirefs[$id][$pos] = 'placeholder';
                 // add set a reference to it as the result value
-                $this->message[$pos]['result'] =& $this->multirefs[$id][$pos];
-            // build complexType values
+                $this->message[$pos]['result'] = & $this->multirefs[$id][$pos];
+                // build complexType values
             } elseif ($this->message[$pos]['children'] != '') {
                 // if result has already been generated (struct/array)
                 if (!isset($this->message[$pos]['result'])) {
@@ -6902,7 +6902,7 @@ class nusoap_parser extends nusoap_base
                     }
                 }
                 $this->message[$pos]['result'] = $this->message[$pos]['xattrs'];
-            // set value of simpleType (or nil complexType)
+                // set value of simpleType (or nil complexType)
             } else {
                 //$this->debug('adding data for scalar value '.$this->message[$pos]['name'].' of value '.$this->message[$pos]['cdata']);
                 if (isset($this->message[$pos]['nil']) && $this->message[$pos]['nil']) {
@@ -6964,7 +6964,7 @@ class nusoap_parser extends nusoap_base
     public function character_data($parser, $data)
     {
         $pos = $this->depth_array[$this->depth];
-        if ($this->xml_encoding=='UTF-8') {
+        if ($this->xml_encoding == 'UTF-8') {
             // TODO: add an option to disable this for folks who want
             // raw UTF-8 that, e.g., might not map to iso-8859-1
             // TODO: this can also be handled with xml_parser_set_option($this->parser, XML_OPTION_TARGET_ENCODING, "ISO-8859-1");
@@ -7093,8 +7093,8 @@ class nusoap_parser extends nusoap_base
             array_shift($children); // knock off empty
             // md array
             if (isset($this->message[$pos]['arrayCols']) && $this->message[$pos]['arrayCols'] != '') {
-                $r=0; // rowcount
-                $c=0; // colcount
+                $r = 0; // rowcount
+                $c = 0; // colcount
                 foreach ($children as $child_pos) {
                     $this->debug("in buildVal, got an MD array element: $r, $c");
                     $params[$r][] = $this->message[$child_pos]['result'];
@@ -7118,7 +7118,7 @@ class nusoap_parser extends nusoap_base
                     $params[$this->message[$kv[1]]['result']] = &$this->message[$kv[2]]['result'];
                 }
                 // generic compound type
-            //} elseif($this->message[$pos]['type'] == 'SOAPStruct' || $this->message[$pos]['type'] == 'struct') {
+                //} elseif($this->message[$pos]['type'] == 'SOAPStruct' || $this->message[$pos]['type'] == 'struct') {
             } else {
                 // Apache Vector type: treat as an array
                 $this->debug('in buildVal, adding Java Vector or generic compound type ' . $this->message[$pos]['name']);
@@ -7355,7 +7355,7 @@ class nusoap_client extends nusoap_base
     * @return	mixed	response from SOAP call
     * @access   public
     */
-    public function call($operation, $params=array(), $namespace='http://tempuri.org', $soapAction='', $headers=false, $rpcParams=null, $style='rpc', $use='encoded')
+    public function call($operation, $params = array(), $namespace = 'http://tempuri.org', $soapAction = '', $headers = false, $rpcParams = null, $style = 'rpc', $use = 'encoded')
     {
         $this->operation = $operation;
         $this->fault = false;
@@ -7526,7 +7526,7 @@ class nusoap_client extends nusoap_base
                     $this->debug('return shifted value: ');
                     $this->appendDebug($this->varDump($return));
                     return $return;
-                // nothing returned (ie, echoVoid)
+                    // nothing returned (ie, echoVoid)
                 } else {
                     return "";
                 }
@@ -7610,7 +7610,7 @@ class nusoap_client extends nusoap_base
     * @return	mixed native PHP types.
     * @access   private
     */
-    public function send($msg, $soapaction = '', $timeout=0, $response_timeout=30)
+    public function send($msg, $soapaction = '', $timeout = 0, $response_timeout = 30)
     {
         $this->checkCookies();
         // detect transport
@@ -7619,7 +7619,7 @@ class nusoap_client extends nusoap_base
             case preg_match('/^http/', $this->endpoint):
                 $this->debug('transporting via HTTP');
                 if ($this->persistentConnection == true && is_object($this->persistentConnection)) {
-                    $http =& $this->persistentConnection;
+                    $http = & $this->persistentConnection;
                 } else {
                     $http = new soap_transport_http($this->endpoint, $this->curl_options, $this->use_curl);
                     if ($this->persistentConnection) {
@@ -7839,7 +7839,7 @@ class nusoap_client extends nusoap_base
     * @param    string $enc HTTP encoding
     * @access   public
     */
-    public function setHTTPEncoding($enc='gzip, deflate')
+    public function setHTTPEncoding($enc = 'gzip, deflate')
     {
         $this->debug("setHTTPEncoding(\"$enc\")");
         $this->http_encoding = $enc;
@@ -7985,9 +7985,9 @@ class nusoap_client extends nusoap_base
                         $paramArrayStr .= "'$name' => \$$name, ";
                         $paramCommentStr .= "$type \$$name, ";
                     }
-                    $paramStr = substr($paramStr, 0, strlen($paramStr)-2);
-                    $paramArrayStr = substr($paramArrayStr, 0, strlen($paramArrayStr)-2);
-                    $paramCommentStr = substr($paramCommentStr, 0, strlen($paramCommentStr)-2);
+                    $paramStr = substr($paramStr, 0, strlen($paramStr) - 2);
+                    $paramArrayStr = substr($paramArrayStr, 0, strlen($paramArrayStr) - 2);
+                    $paramCommentStr = substr($paramCommentStr, 0, strlen($paramCommentStr) - 2);
                 } else {
                     $paramStr = '';
                     $paramArrayStr = '';


### PR DESCRIPTION
This PR moves the internal WSDL Path into it's own `Port` Element, as 2 addresses within one `Port` Element is not allowed for a valid WSDL XML File.
Additionally this PR ensures that the query parameters for the internal WSDL URL
- are removed when shown in the WSDL document
- contain wsdl as a query parameter when used with the `SoapClient`