### PR TITLE
Soap: Move internal soap URL into own Port. Ensure correct query params

### DIFF
--- a/components/ILIAS/WebServices/SOAP/classes/class.ilSoapClient.php
+++ b/components/ILIAS/WebServices/SOAP/classes/class.ilSoapClient.php
@@ -95,7 +95,11 @@ class ilSoapClient
         $internal_path = $this->settings->get('soap_internal_wsdl_path');
         if (trim($this->getServer()) === '') {
             if ($internal_path) {
-                $this->uri = $internal_path;
+                $uri = (new \ILIAS\Data\URI($internal_path));
+                parse_str($uri->getQuery() ?? '', $query);
+                $this->uri = (string) (isset($query['wsdl']) ?
+                                       $uri :
+                                       $uri->withQuery(http_build_query(array_merge($query, ['wsdl' => '']))));
             } elseif (trim($this->settings->get('soap_wsdl_path', '')) !== '') {
                 $this->uri = $this->settings->get('soap_wsdl_path', '');
             } else {

--- a/components/ILIAS/soap/lib/nusoap.php
+++ b/components/ILIAS/soap/lib/nusoap.php
@@ -4552,15 +4552,11 @@ class nusoap_server extends nusoap_base
 
     public function addInternalPort(string $serviceName, string $url): void
     {
-        $port = $this->wsdl->ports[$serviceName . 'Port'] ?? [
+        $this->wsdl->ports['Internal' . $serviceName . 'Port'] = [
             'binding' => $serviceName . 'Binding',
-            'location' => [],
+            'location' => (string) (new \ILIAS\Data\URI($url))->withQuery(),
             'bindingType' => 'http://schemas.xmlsoap.org/wsdl/soap/'
         ];
-
-        $port['location'] = is_array($port['location']) ? array_merge($port['location'], [$url]) : [$port['location'], $url];
-
-        $this->wsdl->ports[$serviceName . 'Port'] = $port;
     }
 }
 

--- a/components/ILIAS/soap/resources/soap/server.php
+++ b/components/ILIAS/soap/resources/soap/server.php
@@ -26,6 +26,8 @@ const ILIAS_MODULE = 'components/ILIAS/soap';
 chdir('../..');
 
 require_once 'vendor/composer/vendor/autoload.php';
+require_once __DIR__ . '/../../artifacts/bootstrap_default.php';
+entry_point('ILIAS Legacy Initialisation Adapter');
 
 // Initialize the error_reporting level, until it will be overwritte when ILIAS gets initialized
 error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);


### PR DESCRIPTION
Sister PR to: #10063
This PR also fixes the `soap/server.php` script to use the `entry_point` function for initialisation.