### PR TITLE
UI: Ordering Table enable no entries cell and disable ordering on no data

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -691,8 +691,9 @@ class Renderer extends AbstractComponentRenderer
         }
 
         $tableid = $this->bindJavaScript($component) ?? $this->createId();
+        $ordering_table_has_rows = $rows->valid();
 
-        if (!$component->isOrderingDisabled() && $rows->valid()) {
+        if ($ordering_table_has_rows && !$component->isOrderingDisabled()) {
             $submit = $this->getUIFactory()->button()->standard($this->txt('sorting_save'), "")
                 ->withOnLoadCode(static fn($id) => "document.getElementById('$id').addEventListener('click',
                     function() {document.querySelector('#$tableid form.c-table-ordering__form').submit();return false;});");
@@ -717,7 +718,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable('COL_TYPE', strtolower($col->getType()));
             $tpl->parseCurrentBlock();
         }
-        if (!$rows->valid()) {
+        if (!$ordering_table_has_rows) {
             $cell_tpl = $this->getTemplate("tpl.orderingcell.html", true, true);
             $this->renderFullWidthCell($component, $cell_tpl, $tpl, $this->txt('ui_table_no_records'));
         } else {
@@ -747,7 +748,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable('MULTI_ACTION_WARNING', $default_renderer->render($this->getUrlTooLongWarning()));
             $tpl->setVariable('MULTI_ACTION_WARNING_BUTTON_CLOSE_LABEL', $this->txt('datatable_close_warning'));
         }
-        if ($component->hasMultiActions() || (!$component->isOrderingDisabled() && $rows->valid())) {
+        if ($component->hasMultiActions() || (!$component->isOrderingDisabled() && $ordering_table_has_rows)) {
             $multi_action_col_span = count($component->getVisibleColumns()) + $compensate_col_count;
             $tpl->setVariable('MULTI_ACTION_SPAN', (string) $multi_action_col_span);
         }

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -732,25 +732,25 @@ class Renderer extends AbstractComponentRenderer
 
             $this->renderActionsHeader($default_renderer, $component, $tpl, $compensate_col_count);
             $this->appendTableRows($tpl, $r, $default_renderer);
-        }
 
-        if ($component->hasMultiActions()) {
-            $multi_actions = $component->getMultiActions();
-            $modal = $this->buildMultiActionsAllObjectsModal($multi_actions, $tableid);
-            $multi_actions_dropdown = $this->buildMultiActionsDropdown(
-                $multi_actions,
-                $component->getMultiActionSignal(),
-                $modal->getShowSignal()
-            );
+            if ($component->hasMultiActions()) {
+                $multi_actions = $component->getMultiActions();
+                $modal = $this->buildMultiActionsAllObjectsModal($multi_actions, $tableid);
+                $multi_actions_dropdown = $this->buildMultiActionsDropdown(
+                    $multi_actions,
+                    $component->getMultiActionSignal(),
+                    $modal->getShowSignal()
+                );
 
-            $tpl->setVariable('MULTI_ACTION_TRIGGERER', $default_renderer->render($multi_actions_dropdown));
-            $tpl->setVariable('MULTI_ACTION_ALL_MODAL', $default_renderer->render($modal));
-            $tpl->setVariable('MULTI_ACTION_WARNING', $default_renderer->render($this->getUrlTooLongWarning()));
-            $tpl->setVariable('MULTI_ACTION_WARNING_BUTTON_CLOSE_LABEL', $this->txt('datatable_close_warning'));
-        }
-        if ($component->hasMultiActions() || (!$component->isOrderingDisabled() && $ordering_table_has_rows)) {
-            $multi_action_col_span = count($component->getVisibleColumns()) + $compensate_col_count;
-            $tpl->setVariable('MULTI_ACTION_SPAN', (string) $multi_action_col_span);
+                $tpl->setVariable('MULTI_ACTION_TRIGGERER', $default_renderer->render($multi_actions_dropdown));
+                $tpl->setVariable('MULTI_ACTION_ALL_MODAL', $default_renderer->render($modal));
+                $tpl->setVariable('MULTI_ACTION_WARNING', $default_renderer->render($this->getUrlTooLongWarning()));
+                $tpl->setVariable('MULTI_ACTION_WARNING_BUTTON_CLOSE_LABEL', $this->txt('datatable_close_warning'));
+            }
+            if ($component->hasMultiActions() || (!$component->isOrderingDisabled())) {
+                $multi_action_col_span = count($component->getVisibleColumns()) + $compensate_col_count;
+                $tpl->setVariable('MULTI_ACTION_SPAN', (string) $multi_action_col_span);
+            }
         }
 
         return $tpl->get();

--- a/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Table/Renderer.php
@@ -240,7 +240,8 @@ class Renderer extends AbstractComponentRenderer
         $sortation_signal = null;
         // if the generator is empty, and thus invalid, we render an empty row.
         if (!$rows->valid()) {
-            $this->renderFullWidthDataCell($component, $tpl, $this->txt('ui_table_no_records'));
+            $cell_tpl = $this->getTemplate("tpl.datacell.html", true, true);
+            $this->renderFullWidthCell($component, $cell_tpl, $tpl, $this->txt('ui_table_no_records'));
         } else {
             $this->renderActionsHeader($default_renderer, $component, $tpl, $compensate_col_count);
             $this->appendTableRows($tpl, $rows, $default_renderer);
@@ -361,9 +362,12 @@ class Renderer extends AbstractComponentRenderer
      * Renders a full-width cell with a single message within, indication there is no
      * data to display. This is achieved using a <td> colspan attribute.
      */
-    protected function renderFullWidthDataCell(Component\Table\Data $component, Template $tpl, string $content): void
-    {
-        $cell_tpl = $this->getTemplate('tpl.datacell.html', true, true);
+    protected function renderFullWidthCell(
+        Component\Table\Table $component,
+        Template $cell_tpl,
+        Template $main_tpl,
+        string $content
+    ): void {
         $cell_tpl->setCurrentBlock('cell');
         $cell_tpl->setVariable('CELL_CONTENT', $content);
         $cell_tpl->setVariable('COL_SPAN', count($component->getVisibleColumns()));
@@ -371,10 +375,10 @@ class Renderer extends AbstractComponentRenderer
         $cell_tpl->setVariable('COL_INDEX', '1');
         $cell_tpl->parseCurrentBlock();
 
-        $tpl->setCurrentBlock('row');
-        $tpl->setVariable('ALTERNATION', 'even');
-        $tpl->setVariable('CELLS', $cell_tpl->get());
-        $tpl->parseCurrentBlock();
+        $main_tpl->setCurrentBlock('row');
+        $main_tpl->setVariable('ALTERNATION', 'even');
+        $main_tpl->setVariable('CELLS', $cell_tpl->get());
+        $main_tpl->parseCurrentBlock();
     }
 
     protected function registerActions(Component\Table\Table $component): Component\Table\Table
@@ -659,7 +663,7 @@ class Renderer extends AbstractComponentRenderer
         );
 
 
-        if (!$component->isOrderingDisabled()) {
+        if (!$component->isOrderingDisabled() && $rows->valid()) {
             $component = $component->withAdditionalOnLoadCode(
                 static fn($id): string => "il.UI.table.ordering.init('{$id}');"
             );
@@ -688,7 +692,7 @@ class Renderer extends AbstractComponentRenderer
 
         $tableid = $this->bindJavaScript($component) ?? $this->createId();
 
-        if (!$component->isOrderingDisabled()) {
+        if (!$component->isOrderingDisabled() && $rows->valid()) {
             $submit = $this->getUIFactory()->button()->standard($this->txt('sorting_save'), "")
                 ->withOnLoadCode(static fn($id) => "document.getElementById('$id').addEventListener('click',
                     function() {document.querySelector('#$tableid form.c-table-ordering__form').submit();return false;});");
@@ -713,17 +717,21 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable('COL_TYPE', strtolower($col->getType()));
             $tpl->parseCurrentBlock();
         }
+        if (!$rows->valid()) {
+            $cell_tpl = $this->getTemplate("tpl.orderingcell.html", true, true);
+            $this->renderFullWidthCell($component, $cell_tpl, $tpl, $this->txt('ui_table_no_records'));
+        } else {
+            $row_iterator = iterator_to_array($rows);
+            $r = [];
+            foreach ($row_iterator as $idx => $row) {
+                $r[] = $row
+                    ->withPosition($idx + 1)
+                    ->withOrderingDisabled($component->isOrderingDisabled());
+            }
 
-        $rows = iterator_to_array($rows);
-        $r = [];
-        foreach ($rows as $idx => $row) {
-            $r[] = $row
-                ->withPosition($idx + 1)
-                ->withOrderingDisabled($component->isOrderingDisabled());
+            $this->renderActionsHeader($default_renderer, $component, $tpl, $compensate_col_count);
+            $this->appendTableRows($tpl, $r, $default_renderer);
         }
-
-        $this->renderActionsHeader($default_renderer, $component, $tpl, $compensate_col_count);
-        $this->appendTableRows($tpl, $r, $default_renderer);
 
         if ($component->hasMultiActions()) {
             $multi_actions = $component->getMultiActions();
@@ -739,7 +747,7 @@ class Renderer extends AbstractComponentRenderer
             $tpl->setVariable('MULTI_ACTION_WARNING', $default_renderer->render($this->getUrlTooLongWarning()));
             $tpl->setVariable('MULTI_ACTION_WARNING_BUTTON_CLOSE_LABEL', $this->txt('datatable_close_warning'));
         }
-        if ($component->hasMultiActions() || !$component->isOrderingDisabled()) {
+        if ($component->hasMultiActions() || (!$component->isOrderingDisabled() && $rows->valid())) {
             $multi_action_col_span = count($component->getVisibleColumns()) + $compensate_col_count;
             $tpl->setVariable('MULTI_ACTION_SPAN', (string) $multi_action_col_span);
         }

--- a/components/ILIAS/UI/src/examples/Table/Ordering/without_data.php
+++ b/components/ILIAS/UI/src/examples/Table/Ordering/without_data.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\UI\examples\Table\Ordering;
+
+use Generator;
+use ILIAS\Data\URI;
+use ILIAS\UI\Component\Table\OrderingRetrieval;
+use ILIAS\UI\Component\Table\OrderingRowBuilder;
+
+/**
+ * ---
+ * description: >
+ *   Example showing a ordering table without any data and hence no entries, which
+ *   will automatically display an according message.
+ *
+ * expected output: >
+ *   ILIAS shows the rendered Component.
+ * ---
+ */
+function without_data(): string
+{
+    global $DIC;
+
+    $factory = $DIC->ui()->factory();
+    $renderer = $DIC->ui()->renderer();
+    $request = $DIC->http()->request();
+
+    $empty_retrieval = new class () implements OrderingRetrieval {
+        public function getRows(
+            OrderingRowBuilder $row_builder,
+            array $visible_column_ids,
+        ): Generator {
+            yield from [];
+        }
+
+        public function getTotalRowCount(?array $filter_data, ?array $additional_parameters): ?int
+        {
+            return 0;
+        }
+    };
+
+    $target = (new URI((string) $request->getUri()))->withParameter('ordering_example', 1);
+    $table = $factory->table()->ordering(
+        $empty_retrieval,
+        $target,
+        'Empty Data Table',
+        [
+            'col1' => $factory->table()->column()->text('Column 1')
+                ->withIsSortable(false),
+            'col2' => $factory->table()->column()->number('Column 2')
+                ->withIsSortable(false),
+        ],
+    );
+
+    return $renderer->render($table->withRequest($request));
+}

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.orderingcell.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.orderingcell.html
@@ -12,7 +12,7 @@
 <!-- END orderinput_cell -->
 
 <!-- BEGIN cell -->
-<td class="c-table-data__cell c-table-data__cell--{COL_TYPE} <!-- BEGIN highlighted --> c-table-data__cell--highlighted<!-- END highlighted -->" tabindex="-1">
+<td class="c-table-data__cell c-table-data__cell--{COL_TYPE} <!-- BEGIN highlighted --> c-table-data__cell--highlighted<!-- END highlighted -->" <!-- BEGIN with_col_span -->colspan="{COL_SPAN}"<!-- END with_col_span --> tabindex="-1">
 	<span class="c-table-data__cell__col-title">{CELL_COL_TITLE}: </span>{CELL_CONTENT}
 </td>
 <!-- END cell -->

--- a/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
@@ -90,7 +90,7 @@ class OrderingRendererTest extends TableRendererTestBase
             </thead>
             <tbody class="c-table-data__body">
                 <tr class="c-table-data__row even">
-                    <td class="c-table-data__cell c-table-data__cell--full-width " tabindex="-1"><span class="c-table-data__cell__col-title">:</span>ui_table_no_records</td>
+                    <td class="c-table-data__cell c-table-data__cell--full-width " colspan="3" tabindex="-1"><span class="c-table-data__cell__col-title">:</span>ui_table_no_records</td>
                 </tr>
             </tbody>
         </table>

--- a/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
@@ -89,7 +89,7 @@ class OrderingRendererTest extends TableRendererTestBase
             </tr>
             </thead>
             <tbody class="c-table-data__body">
-                <tr class="c-table-data__row even">
+                <tr class="c-table-data__row even" draggable="true">
                     <td class="c-table-data__cell c-table-data__cell--full-width " colspan="3" tabindex="-1"><span class="c-table-data__cell__col-title">:</span>ui_table_no_records</td>
                 </tr>
             </tbody>

--- a/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
@@ -44,7 +44,7 @@ class OrderingRendererTest extends TableRendererTestBase
         );
     }
 
-    public function testOrderingTableRenderTableHeaderWithoutActions()
+    public function testOrderingTableRenderTableHeaderWithoutActionsWithoutData()
     {
         $renderer = $this->getRenderer();
         $f = $this->getColumnFactory();
@@ -71,16 +71,12 @@ class OrderingRendererTest extends TableRendererTestBase
         $expected = <<<EOT
 <div class="c-table-ordering" id="id_1"><h2 class="ilHeader" id="id_1_label"></h2>
     <div class="viewcontrols">
-        <form class="il-viewcontrols-form l-bar__space-keeper" method="get" id="id_2"></form>
+        <form class="il-viewcontrols-form l-bar__space-keeper" method="get" id="id_1"></form>
     </div>
     <form method="post" class="c-table-data__table-wrapper c-table-ordering__form" action="https://localhost">
         <table class="c-table-data__table" aria-labelledby="id_1_label" aria-colcount="5" role="grid">
             <thead>
             <tr class="c-table-data__header c-table-data__row">
-                <th class="c-table-data__header c-table-data__cell c-table-data__header__rowselection" tabindex="-1" aria-colindex="1"></th>
-                <th class="c-table-data__header c-table-data__cell c-table-data__cell--number" tabindex="-1" aria-colindex="2">
-                    <div class="c-table-data__header__resize-wrapper">table_posinput_col_title</div>
-                </th>
                 <th class="c-table-data__header c-table-data__cell c-table-data__cell--text" tabindex="-1" aria-colindex="3">
                     <div class="c-table-data__header__resize-wrapper">Field 1</div>
                 </th>
@@ -93,18 +89,9 @@ class OrderingRendererTest extends TableRendererTestBase
             </tr>
             </thead>
             <tbody class="c-table-data__body">
-            <tr>
-                <td class="c-table-data__cell c-table-data__cell--multiaction" colspan="5">
-                    <div class="l-bar__space-keeper">
-                        <div class="l-bar__element">
-                            <div class="c-table-data__multiaction-triggerer"></div>
-                        </div>
-                        <div class="l-bar__element">
-                            <button class="btn btn-default" data-action="" id="id_1">sorting_save</button>
-                        </div>
-                    </div>
-                </td>
-            </tr>
+                <tr class="c-table-data__row even">
+                    <td class="c-table-data__cell c-table-data__cell--full-width " tabindex="-1"><span class="c-table-data__cell__col-title">:</span>ui_table_no_records</td>
+                </tr>
             </tbody>
         </table>
     </form>


### PR DESCRIPTION
DataTable already has a full width cell if there are no entries, but OrderingTable currently only displays the header row. Also deactivates Ordering Multi-Action Button and JavaScript if there are no entries.

Added example and changed test accordingly
<img width="323" height="268" alt="image" src="https://github.com/user-attachments/assets/e49d4a74-f969-4318-9449-0af7c5e5698f" />


Let me know what you think of this proposal

Best @fhelfer