### PR TITLE
T&A Feature: Remove Limited Availability Period from Test-Setting

### DIFF
--- a/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
+++ b/Modules/Test/classes/MainSettings/class.ilObjTestSettingsMainGUI.php
@@ -19,6 +19,9 @@
 declare(strict_types=1);
 
 use ILIAS\DI\UIServices;
+use ILIAS\Object\ilObjectDIC;
+use ILIAS\Object\Properties\ObjectReferenceProperties\ObjectAvailabilityPeriodProperty;
+use ILIAS\Object\Properties\ObjectReferenceProperties\ObjectReferencePropertiesRepository;
 use ILIAS\Test\MainSettingsRepository;
 use ILIAS\UI\Component\Modal\Interruptive as InterruptiveModal;
 use ILIAS\UI\Component\Input\Field\Section;
@@ -26,7 +29,6 @@ use ILIAS\UI\Component\Input\Field\Checkbox;
 use ILIAS\UI\Component\Input\Field\OptionalGroup;
 use ILIAS\UI\Component\Input\Container\Form\Standard as StandardForm;
 use ILIAS\Refinery\Factory as Refinery;
-use ILIAS\Refinery\Transformation as TransformationInterface;
 use ILIAS\Data\Factory as DataFactory;
 use Psr\Http\Message\ServerRequestInterface;
 use ILIAS\Refinery\Constraint;
@@ -73,6 +75,8 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
     protected ServerRequestInterface $request;
     protected ilObjectDataCache $object_data_cache;
     protected ilSetting $settings;
+    protected ilObjUser $user;
+    protected ObjectReferencePropertiesRepository $object_reference_properties_repo;
 
     private ilTestQuestionSetConfigFactory $testQuestionSetConfigFactory;
 
@@ -98,6 +102,8 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
         $this->request = $DIC->http()->request();
         $this->object_data_cache = $DIC['ilObjDataCache'];
         $this->settings = $DIC['ilSetting'];
+        $this->user = $DIC->user();
+        $this->object_reference_properties_repo = ilObjectDIC::dic()['object_reference_repository'];
 
         $this->main_settings = $this->test_gui->getTestObject()->getMainSettings();
         $this->main_settings_repository = $this->test_gui->getTestObject()->getMainSettingsRepository();
@@ -163,11 +169,9 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
         );
     }
 
-    private function showForm(StandardForm $form = null, InterruptiveModal $modal = null): void
+    private function showForm(?StandardForm $form = null, ?InterruptiveModal $modal = null): void
     {
-        if ($form === null) {
-            $form = $this->buildForm();
-        }
+        $form ??= $this->buildForm();
 
         if ($this->main_settings->getIntroductionSettings()->getIntroductionText() !== '') {
             $this->toolbar->addComponent(
@@ -187,10 +191,7 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
             );
         }
 
-        $rendered_modal = '';
-        if ($modal !== null) {
-            $rendered_modal = $this->ui->renderer()->render($modal);
-        }
+        $rendered_modal = $modal instanceof InterruptiveModal ? $this->ui->renderer()->render($modal) : '';
 
         $this->tpl->setContent($this->ui->renderer()->render($form) . $rendered_modal);
     }
@@ -216,7 +217,7 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
     {
         $form = $this->buildForm()->withRequest($this->request);
         $data = $form->getData();
-        if ($data === null) {
+        if (!is_array($data) || $data === []) {
             $this->showForm($form);
             return;
         }
@@ -225,8 +226,10 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
         $current_question_config = $this->testQuestionSetConfigFactory->getQuestionSetConfig();
         $new_question_set_type = $data[self::GENERAL_SETTINGS_SECTION_LABEL]['question_set_type'];
 
-        if ($new_question_set_type !== $current_question_set_type
-            && $current_question_config->doesQuestionSetRelatedDataExist()) {
+        if (
+            $new_question_set_type !== $current_question_set_type
+            && $current_question_config->doesQuestionSetRelatedDataExist()
+        ) {
             $modal = $this->populateConfirmationModal($current_question_set_type, $new_question_set_type);
             $this->showForm($form, $modal);
             return;
@@ -327,7 +330,7 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
         return $modal->withOnLoad($modal->getShowSignal());
     }
 
-    private function performSaveForm(array $data)
+    private function performSaveForm(array $data): void
     {
         $old_online_status = $this->test_object->getObjectProperties()->getPropertyIsOnline()->getIsOnline();
         $this->test_object->getObjectProperties()->storePropertyTitleAndDescription(
@@ -425,13 +428,11 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
 
     private function getAvailabilitySettingsSection(): Section
     {
-        $input_factory = $this->ui->factory()->input();
-
-        $inputs['is_online'] = $this->getIsOnlineSettingInput();
-        $inputs['timebased_availability'] = $this->getTimebasedAvailabilityInputs();
-
-        return $input_factory->field()->section(
-            $inputs,
+        return $this->ui->factory()->input()->field()->section(
+            [
+                'is_online' => $this->getIsOnlineSettingInput(),
+                'timebased_availability' => $this->getTimeBasedAvailabilityInputs()
+            ],
             $this->lng->txt('rep_activation_availability')
         );
     }
@@ -462,97 +463,51 @@ class ilObjTestSettingsMainGUI extends ilTestSettingsGUI
         return $is_online;
     }
 
-    private function getTimebasedAvailabilityInputs(): OptionalGroup
+    private function getTimeBasedAvailabilityInputs(): OptionalGroup
     {
-        $field_factory = $this->ui->factory()->input()->field();
-
-        $trafo = $this->getTransformationForActivationLimitedOptionalGroup();
-        $value = $this->getValueForActivationLimitedOptionalGroup();
-
-        $data_factory = new DataFactory();
-        $user_format = $this->activeUser->getDateFormat();
-        $format = $data_factory->dateFormat()->withTime24($user_format);
-
-        $inputs['time_span'] = $field_factory->duration($this->lng->txt('rep_time_period'))
-            ->withTimezone($this->activeUser->getTimeZone())
-            ->withFormat($format)
-            ->withUseTime(true)
-            ->withRequired(true);
-        $inputs['activation_visibility'] = $field_factory->checkbox(
-            $this->lng->txt('rep_activation_limited_visibility'),
-            $this->lng->txt('tst_activation_limited_visibility_info')
-        );
-
-        return $field_factory->optionalGroup(
-            $inputs,
-            $this->lng->txt('rep_time_based_availability')
-        )->withAdditionalTransformation($trafo)
-            ->withValue($value);
-    }
-
-    private function getTransformationForActivationLimitedOptionalGroup(): TransformationInterface
-    {
-        return $this->refinery->custom()->transformation(
-            static function (?array $vs): array {
-                if ($vs === null) {
-                    return [
-                        'is_activation_limited' => false,
-                        'activation_starting_time' => null,
-                        'activation_ending_time' => null,
-                        'activation_visibility' => false
-                    ];
-                }
-
-                $start = $vs['time_span']['start']->getTimestamp();
-                $end = $vs['time_span']['end']->getTimestamp();
-
-                return [
-                    'is_activation_limited' => true,
-                    'activation_starting_time' => $start,
-                    'activation_ending_time' => $end,
-                    'activation_visibility' => $vs['activation_visibility']
-                ];
-            }
-        );
-    }
-
-    private function getValueForActivationLimitedOptionalGroup(): ?array
-    {
-        $value = null;
-        if ($this->test_object->isActivationLimited()) {
-            $value = [
-                'time_span' => [
-                    DateTimeImmutable::createFromFormat(
-                        'U',
-                        (string) $this->test_object->getActivationStartingTime()
-                    )->setTimezone(new DateTimeZone($this->activeUser->getTimeZone())),
-                    DateTimeImmutable::createFromFormat(
-                        'U',
-                        (string) $this->test_object->getActivationEndingTime()
-                    )->setTimezone(new DateTimeZone($this->activeUser->getTimeZone())),
-                ],
-                'activation_visibility' => $this->test_object->getActivationVisibility()
-            ];
-        }
-        return $value;
+        /** @var OptionalGroup $form */
+        $form = $this->object_reference_properties_repo
+            ->getFor($this->test_object->getRefId())
+            ->getPropertyAvailabilityPeriod()
+            ->toForm(
+                $this->lng,
+                $this->ui->factory()->input()->field(),
+                $this->refinery,
+                [
+                    'user_time_zone' => $this->user->getTimeZone(),
+                    'user_date_format' => (new DataFactory())->dateFormat()->withTime24($this->user->getDateFormat())
+                ]
+            );
+        return $form;
     }
 
     private function saveAvailabilitySettingsSection(array $section): void
     {
-        $time_based_availability = $section['timebased_availability'];
+        /**
+         * @var ilObjectPropertyIsOnline $il_object_property_is_online
+         * @var ObjectAvailabilityPeriodProperty $object_availability_period_property
+         */
+        [
+            'is_online' => $il_object_property_is_online,
+            'timebased_availability' => $object_availability_period_property
+        ] = $section;
 
-        $participant_data_exists = $this->test_object->participantDataExist();
-        $this->test_object->storeActivationSettings(
-            $participant_data_exists
-                ? $this->test_object->isActivationLimited()
-                : $time_based_availability['is_activation_limited'],
-            $participant_data_exists
-                ? $this->test_object->getActivationStartingTime()
-                : $time_based_availability['activation_starting_time'],
-            $time_based_availability['activation_ending_time'],
-            $time_based_availability['activation_visibility']
-        );
-        $this->test_object->getObjectProperties()->storePropertyIsOnline($section['is_online']);
+        $this->test_object->getObjectProperties()->storePropertyIsOnline($il_object_property_is_online);
+
+        if ($this->test_object->participantDataExist()) {
+            $current_object_availability_period_property = $this->object_reference_properties_repo
+                ->getFor($this->test_object->getRefId())
+                ->getPropertyAvailabilityPeriod();
+
+            $object_availability_period_property->setAvailabilityPeriodEnabled(
+                $current_object_availability_period_property->getAvailabilityPeriodEnabled()
+            );
+            $object_availability_period_property->setAvailabilityPeriodStart(
+                $current_object_availability_period_property->getAvailabilityPeriodStart()
+            );
+        }
+
+        $this->object_reference_properties_repo->storePropertyAvailabilityPeriod($object_availability_period_property);
     }
 
     protected function getPresentationSettingsSection(): Section

--- a/Modules/Test/classes/class.ilObjTest.php
+++ b/Modules/Test/classes/class.ilObjTest.php
@@ -18,6 +18,7 @@
 
 declare(strict_types=1);
 
+use ILIAS\HTTP\Services as HTTP;
 use ILIAS\Test\InternalRequestService;
 use ILIAS\Test\TestManScoringDoneHelper;
 use ILIAS\Test\MainSettingsRepository;
@@ -111,6 +112,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
     private ilComponentRepository $component_repository;
     private ilComponentFactory $component_factory;
     private Filesystem $filesystem_web;
+    private HTTP $http;
 
     protected ?ilTestParticipantList $access_filtered_participant_list = null;
 
@@ -134,6 +136,7 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
         $this->component_repository = $DIC['component.repository'];
         $this->component_factory = $DIC['component.factory'];
         $this->filesystem_web = $DIC->filesystem()->web();
+        $this->http = $DIC->http();
 
         $local_dic = $this->getLocalDIC();
         $this->participant_access_filter = $local_dic['participantAccessFilterFactory'];
@@ -676,8 +679,18 @@ class ilObjTest extends ilObject implements ilMarkSchemaAware
         }
 
         // moved activation to ilObjectActivation
-        if (isset($this->ref_id)) {
-            $activation = ilObjectActivation::getItem($this->ref_id);
+        // TODO: needs some work
+        /** @var int $ref_id */
+        $ref_id = $this->ref_id ?? $this->http->wrapper()->query()->retrieve(
+            'ref_id',
+            $this->refinery->byTrying([
+                $this->refinery->kindlyTo()->int(),
+                $this->refinery->always(0)
+            ])
+        );
+
+        if ($ref_id > 1) {
+            $activation = ilObjectActivation::getItem($ref_id);
             switch ($activation["timing_type"]) {
                 case ilObjectActivation::TIMINGS_ACTIVATION:
                     $this->setActivationLimited(true);

--- a/Services/Object/classes/Properties/ObjectReferenceProperties/ObjectAvailabilityPeriodProperty.php
+++ b/Services/Object/classes/Properties/ObjectReferenceProperties/ObjectAvailabilityPeriodProperty.php
@@ -50,14 +50,29 @@ class ObjectAvailabilityPeriodProperty implements \ilObjectProperty
         return $this->availability_period_enabled === true;
     }
 
+    public function setAvailabilityPeriodEnabled(?bool $availability_period_enabled): void
+    {
+        $this->availability_period_enabled = $availability_period_enabled;
+    }
+
     public function getAvailabilityPeriodStart(): ?\DateTimeImmutable
     {
         return $this->time_limit_start;
     }
 
+    public function setAvailabilityPeriodStart(?\DateTimeImmutable $time_limit_start): void
+    {
+        $this->time_limit_start = $time_limit_start;
+    }
+
     public function getAvailabilityPeriodEnd(): ?\DateTimeImmutable
     {
         return $this->time_limit_end;
+    }
+
+    public function setAvailabilityPeriodEnd(?\DateTimeImmutable $time_limit_end): void
+    {
+        $this->time_limit_end = $time_limit_end;
     }
 
     public function getVisibleWhenDisabled(): bool
@@ -71,15 +86,11 @@ class ObjectAvailabilityPeriodProperty implements \ilObjectProperty
             return true;
         }
 
-        $timing_start_utc = $this->timing_start->setTimezone(new \DateTimeZone('UTC'));
-        $timing_end_utc = $this->timing_end->setTimezone(new \DateTimeZone('UTC'));
+        $timing_start_utc = $this->time_limit_start->setTimezone(new \DateTimeZone('UTC'));
+        $timing_end_utc = $this->time_limit_end->setTimezone(new \DateTimeZone('UTC'));
         $now_utc = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
-        if ($timing_start_utc < $now_utc && $now_utc < $timing_end_utc) {
-            return true;
-        }
-
-        return false;
+        return $timing_start_utc < $now_utc && $now_utc < $timing_end_utc;
     }
 
     public function withObjectReferenceId(int $object_reference_id): self
@@ -93,7 +104,7 @@ class ObjectAvailabilityPeriodProperty implements \ilObjectProperty
         \ilLanguage $language,
         FieldFactory $field_factory,
         Refinery $refinery,
-        array $environment = null
+        ?array $environment = null
     ): FormInput {
         $constraint = $this->getConstraintForActivationLimitedOptionalGroup(
             $refinery,
@@ -130,9 +141,10 @@ class ObjectAvailabilityPeriodProperty implements \ilObjectProperty
     {
         return $refinery->custom()->transformation(
             function (?array $vs): self {
-                if ($vs === null
-                    || $vs['time_limit_start'] === null
-                        && $vs['time_limit_end'] === null) {
+                if (
+                    $vs === null
+                    || ($vs['time_limit_start'] === null && $vs['time_limit_end'] === null)
+                ) {
                     return new self($this->getObjectReferenceId());
                 }
 


### PR DESCRIPTION
https://docu.ilias.de/go/wiki/wpage_8743_1357

This PR removes the **test-specific availability settings** and replaces them with the **global availability settings** used across all objects.

Currently, this is still a WIP:

* Code that depends on the test-specific settings needs to be updated to use the object-level settings.
* The availability form inside the test settings has been replaced with the object settings form. This form may ultimately need to be removed entirely from the test settings.

@kergomard I hope you find this useful.
