### PR TITLE
FileInfo: make sprintf robust against invalid translation placeholder…

### DIFF
--- a/Modules/File/classes/trait.ilObjFileInfoProvider.php
+++ b/Modules/File/classes/trait.ilObjFileInfoProvider.php
@@ -103,11 +103,13 @@ trait ilObjFileInfoProvider
         $amount_of_downloads = null;
 
         if ($this->getGeneralSettings()->isShowAmountOfDownloads()) {
-            $amount_of_downloads = sprintf(
-                $this->getLanguage()->txt("amount_of_downloads_since"),
-                $this->getFileObj()->getAmountOfDownloads(),
-                $this->getFileObj()->getCreateDate(),
-            );
+            
+	$amount_of_downloads = $this->safeSprintf(
+    	$this->getLanguage()->txt("amount_of_downloads_since"),
+    	$this->getFileObj()->getAmountOfDownloads(),
+    	$this->getFileObj()->getCreateDate(),
+	);
+
         }
 
         return [
@@ -169,4 +171,22 @@ trait ilObjFileInfoProvider
     abstract protected function getNodeID(): int;
 
     abstract protected function getUser(): ilObjUser;
+
+    /**
+     * Robust sprintf: tolerates broken translation placeholders.
+     */
+    private function safeSprintf(string $format, mixed ...$args): string
+    {
+        try {
+            return sprintf($format, ...$args);
+        } catch (\ValueError $e) {
+            $fixed = preg_replace('/%(?!([0-9]+\$)?[bcdeEfFgGosuxX%])/', '%%', $format);
+            try {
+                return sprintf($fixed, ...$args);
+            } catch (\ValueError $e2) {
+                return $format;
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
# FileInfo: make `sprintf` robust against invalid translation placeholders

## Summary
In Japanese (and potentially other locales), a malformed translation string for the file info caused PHP 8 to throw: `ValueError: Unknown format specifier "�"` when rendering the “amount of downloads since …” line. This PR replaces a direct `sprintf(...)` call with a defensive helper `safeSprintf(...)` in `Modules/File/classes/trait.ilObjFileInfoProvider.php`. The helper catches `ValueError`, escapes stray `%` that are not valid placeholders, retries, and finally falls back to the raw format if needed. This prevents a fatal error in the UI even if a translation is broken.

## What changed
- In `getFileInfoForAuthorsAndAdmins()`, replace:
  ```php
  sprintf($lng->txt("amount_of_downloads_since"), $count, $created_at)
  ```
  with:
  ```php
  $this->safeSprintf($lng->txt("amount_of_downloads_since"), $count, $created_at)
  ```
- Add private method `safeSprintf()` to the trait:
  - try `sprintf` → on `ValueError` escape invalid `%` via regex and retry → final fallback to `$format`.

## Rationale
- Minimal and localized change (one file, small helper).
- Keeps the UI stable even if a translation string is malformed.
- Does not alter correct translations; performance impact is negligible.

## Reproduction
1. Apply PR [#10077](https://github.com/ILIAS-eLearning/ILIAS/pull/10077) (WOPI locale forwarding).  
2. Set UI to Japanese (ja).  
3. Open a file via WOPI, then return to the info screen.  
4. **Before**: crash with `ValueError` at `ilObjFileInfoProvider.php:106`.  
   **After**: info screen renders; values are shown.

## Notes
- The underlying Japanese key `file#:#amount_of_downloads_since` contains a stray `%`. A follow-up PR to fix the ja string is recommended (use positional placeholders, e.g. `%1$d 回のダウンロード（%2$s 以降）`).

**Base:** `release_9`  
**Files changed:** `Modules/File/classes/trait.ilObjFileInfoProvider.php`
