### PR TITLE
CourseReference: Also copy LP settings when copying a course reference

### DIFF
--- a/Modules/CourseReference/classes/class.ilObjCourseReference.php
+++ b/Modules/CourseReference/classes/class.ilObjCourseReference.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
     +-----------------------------------------------------------------------------+
     | ILIAS open source                                                           |
@@ -160,6 +161,10 @@ class ilObjCourseReference extends ilContainerReference
         $new_obj = parent::cloneObject($a_target_id, $a_copy_id, $a_omit_tree);
         $new_obj->enableMemberUpdate($this->isMemberUpdateEnabled());
         $new_obj->update();
+
+        $lp_settings = new ilLPObjSettings($this->getId());
+        $lp_settings->cloneSettings($new_obj->getId());
+
         return $new_obj;
     }
 }


### PR DESCRIPTION
Has to be picked to 10 and trunk as well, if merged.

Bugfix for: https://mantis.ilias.de/view.php?id=43921