### PR TITLE
Certificate: Add replacement for old BackgroundImage Paths in Import

### DIFF
--- a/components/ILIAS/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
+++ b/components/ILIAS/Certificate/classes/Template/Action/Import/class.ilCertificateTemplateImportAction.php
@@ -215,6 +215,11 @@ class ilCertificateTemplateImportAction
 
                         if (str_contains($file->getPath(), '.xml')) {
                             $xsl = $this->filesystem->read($file->getPath());
+                            $xsl = preg_replace(
+                                "/url\([']{0,1}(.*?)[']{0,1}\)/",
+                                'url([BACKGROUND_IMAGE])',
+                                $xsl
+                            );
                         } elseif (str_contains($file->getPath(), '.jpg')) {
                             $background_rid = $this->irss->manage()->stream(
                                 $this->filesystem->readStream($file->getPath()),


### PR DESCRIPTION
Ensures that BACKGROUND_IMAGE is properly set in XML of Certificate. So that the background image can be displayed via the ResourceID.

Please also pick to trunk as well.