### PR TITLE
Deps: readd webui-popover (npm)

### DIFF
--- a/components/ILIAS/UI/UI.php
+++ b/components/ILIAS/UI/UI.php
@@ -644,10 +644,9 @@ class UI implements Component\Component
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\NodeModule("mediaelement/build/renderers/vimeo.min.js");
         */
-        /* This library was missing after discussing dependencies for ILIAS 10
+        /* This library was missing after discussing dependencies for ILIAS 10 */
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\NodeModule("webui-popover/dist/jquery.webui-popover.min.js");
-        */
 
         // This is included via anonymous classes
         // because MathJax resources are taken from node_modules and they may be directories

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "linkify-element": "^4.3.2",
         "linkifyjs": "^4.3.2",
         "mathjax": "^3.2.2",
-        "tinymce": "^7.5.1"
+        "tinymce": "^7.5.1",
+        "webui-popover": "^1.2.18"
       },
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.4",
@@ -4416,6 +4417,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/webui-popover": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/webui-popover/-/webui-popover-1.2.18.tgz",
+      "integrity": "sha512-JIpcJnXXjtjg1/VKIEzLRC8ZEutpMZNY9/uBV8ztZ8Hh2IF7Op31Y55krARiTr9CLqXSyBghr9jPAG0dZFL2cA==",
+      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "linkify-element": "^4.3.2",
     "linkifyjs": "^4.3.2",
     "mathjax": "^3.2.2",
-    "tinymce": "^7.5.1"
+    "tinymce": "^7.5.1",
+    "webui-popover": "^1.2.18"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",


### PR DESCRIPTION
**This commit readds webui-popover v. 1.2.18 as npm dependency to ILIAS 11.**

## Usage

ILIAS/UI

## Reasoning

The library is used to create popovers in the UI-framework. This applies to the initial Popover component, as well as to other components, such as Filters, Rating, that use the Popover component.

## Maintenance

There are 26 contributors to the library. The last commit to the library is 9 years old, as well as the last released version. The last open issue is from Oct '21, as well as the last closed issue. Last closed PR is from 2023. The open issues seem to be either feature requests or rather specific bugs.

It seems as if the development of the library has stopped, be it because its feature complete, be it because interest vanished.

## Links

* NPM: https://www.npmjs.com/package/webui-popover
* GitHub: https://github.com/sandywalker/webui-popover
* Documentation: https://www.npmjs.com/package/webui-popover?activeTab=readme

## Alternatives

There are plenty of alternatives to this library in the JS library space. Also, the HTML standard itself has gotten facilities to create popovers, although they are not enough to replace this library.

## Assessment

This has already been a topic during the ILIAS 10 release (https://github.com/ILIAS-eLearning/ILIAS/pull/8377), where the situation was essentially the same. As there is not enough time to search for and integrate a new library for the ILIAS 11 release, we will temporarily rely on this library again for this release to keep top maintain existing functionality.

The library has served us well for quite some time now. We most probably would not add it as a new library now, due to the state of its maintenance. It still seems to be reasonable to accept it for ILIAS 11 now, so we can move on with the release and testing. We should definitely look for alternatives for ILIAS 12, most probably a custom implementation for vanilla HTML/JS. Depending on the complexity of the new solution and the state of the ILIAS 11 release, we could then decide to replace the library.