### PR TITLE
T&A Fix: Ensure participants are sorted by their name in test result exports

### DIFF
--- a/Modules/Test/classes/Evaluation/class.ilTestEvaluationData.php
+++ b/Modules/Test/classes/Evaluation/class.ilTestEvaluationData.php
@@ -157,9 +157,9 @@ class ilTestEvaluationData
                     $filtered_participants[$active_id] = $participant;
                 }
             }
-            return $filtered_participants;
+            return $this->sortParticipants($filtered_participants);
         } else {
-            return $this->participants;
+            return $this->sortParticipants($this->participants);
         }
     }
 
@@ -212,5 +212,11 @@ class ilTestEvaluationData
     public function getParticipantIds(): array
     {
         return array_keys($this->participants);
+    }
+
+    private function sortParticipants(array $participants): array
+    {
+        uasort($participants, static fn($a, $b) => $a->getName() <=> $b->getName());
+        return $participants;
     }
 }

--- a/Modules/Test/classes/Evaluation/class.ilTestEvaluationData.php
+++ b/Modules/Test/classes/Evaluation/class.ilTestEvaluationData.php
@@ -157,10 +157,10 @@ class ilTestEvaluationData
                     $filtered_participants[$active_id] = $participant;
                 }
             }
-            return $this->sortParticipants($filtered_participants);
-        } else {
-            return $this->sortParticipants($this->participants);
+            return $this->orderParticipants($filtered_participants);
         }
+
+        return $this->orderParticipants($this->participants);
     }
 
     public function resetFilter(): void
@@ -214,7 +214,7 @@ class ilTestEvaluationData
         return array_keys($this->participants);
     }
 
-    private function sortParticipants(array $participants): array
+    private function orderParticipants(array $participants): array
     {
         uasort($participants, static fn($a, $b) => $a->getName() <=> $b->getName());
         return $participants;


### PR DESCRIPTION
Hi everyone,

in this PR I'm proposing a change to the `ilTestEvaluationData` with the goal of sorting participant exports alphabetically by name in ascending order. This is particularly useful for Excel exports, as the change ensures both the rows and the spreadsheets with detailed participant results are sorted. Previously, these were indirectly sorted by activeId, which made it difficult to search for a specific participant.

I look forward to your feedback on this suggestion. As usual, @thojou  has approved this MR in an internal review process.

Thank you in advance and best
@lukas-heinrich 

P.S.: Following the review, I will be happy to provide another PR for ILIAS 10 and 11, as the file has been moved and changed in the namespace.         