### PR TITLE
Test: Remove Activation Setting

### DIFF
--- a/components/ILIAS/Test/classes/class.ilObjTest.php
+++ b/components/ILIAS/Test/classes/class.ilObjTest.php
@@ -520,13 +520,6 @@ class ilObjTest extends ilObject
             }
         }
 
-        $this->storeActivationSettings(
-            $this->isActivationLimited(),
-            $this->getActivationStartingTime(),
-            $this->getActivationEndingTime(),
-            $this->getActivationVisibility(),
-        );
-
         if ($properties_only) {
             return;
         }
@@ -617,23 +610,6 @@ class ilObjTest extends ilObject
             $data = $this->db->fetchObject($result);
             $this->setTestId($data->test_id);
             $this->loadQuestions();
-        }
-
-        // moved activation to ilObjectActivation
-        if (isset($this->ref_id)) {
-            $activation = ilObjectActivation::getItem($this->ref_id);
-            switch ($activation["timing_type"]) {
-                case ilObjectActivation::TIMINGS_ACTIVATION:
-                    $this->setActivationLimited(true);
-                    $this->setActivationStartingTime($activation["timing_start"]);
-                    $this->setActivationEndingTime($activation["timing_end"]);
-                    $this->setActivationVisibility($activation["visible"]);
-                    break;
-
-                default:
-                    $this->setActivationLimited(false);
-                    break;
-            }
         }
     }
 
@@ -3121,18 +3097,6 @@ class ilObjTest extends ilObject
                 case 'show_grading_mark':
                     $result_summary_settings = $result_summary_settings->withShowGradingMarkEnabled((bool) $metadata["entry"]);
                     break;
-                case 'activation_limited':
-                    $this->setActivationLimited((bool) $metadata['entry']);
-                    break;
-                case 'activation_start_time':
-                    $this->setActivationStartingTime($metadata['entry'] !== 'null' ? (int) $metadata['entry'] : null);
-                    break;
-                case 'activation_end_time':
-                    $this->setActivationEndingTime($metadata['entry'] !== 'null' ? (int) $metadata['entry'] : null);
-                    break;
-                case 'activation_visibility':
-                    $this->setActivationVisibility($metadata['entry']);
-                    break;
                 case 'autosave':
                     $question_behaviour_settings = $question_behaviour_settings->withAutosaveEnabled((bool) $metadata['entry']);
                     break;
@@ -3658,26 +3622,6 @@ class ilObjTest extends ilObject
             );
             $a_xml_writer->xmlEndTag("qtimetadatafield");
         }
-
-        $a_xml_writer->xmlStartTag("qtimetadatafield");
-        $a_xml_writer->xmlElement("fieldlabel", null, "activation_limited");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $this->isActivationLimited());
-        $a_xml_writer->xmlEndTag("qtimetadatafield");
-
-        $a_xml_writer->xmlStartTag("qtimetadatafield");
-        $a_xml_writer->xmlElement("fieldlabel", null, "activation_start_time");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $this->getActivationStartingTime());
-        $a_xml_writer->xmlEndTag("qtimetadatafield");
-
-        $a_xml_writer->xmlStartTag("qtimetadatafield");
-        $a_xml_writer->xmlElement("fieldlabel", null, "activation_end_time");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $this->getActivationEndingTime());
-        $a_xml_writer->xmlEndTag("qtimetadatafield");
-
-        $a_xml_writer->xmlStartTag("qtimetadatafield");
-        $a_xml_writer->xmlElement("fieldlabel", null, "activation_visibility");
-        $a_xml_writer->xmlElement("fieldentry", null, (int) $this->getActivationVisibility());
-        $a_xml_writer->xmlEndTag("qtimetadatafield");
 
         $a_xml_writer->xmlStartTag("qtimetadatafield");
         $a_xml_writer->xmlElement("fieldlabel", null, "autosave");
@@ -5640,11 +5584,6 @@ class ilObjTest extends ilObject
             'questionSetType' => $main_settings->getGeneralSettings()->getQuestionSetType(),
             'Anonymity' => (int) $main_settings->getGeneralSettings()->getAnonymity(),
 
-            'activation_limited' => $this->isActivationLimited(),
-            'activation_start_time' => $this->getActivationStartingTime(),
-            'activation_end_time' => $this->getActivationEndingTime(),
-            'activation_visibility' => $this->getActivationVisibility(),
-
             'IntroEnabled' => (int) $main_settings->getIntroductionSettings()->getIntroductionEnabled(),
             'ExamConditionsCheckboxEnabled' => (int) $main_settings->getIntroductionSettings()->getExamConditionsCheckboxEnabled(),
 
@@ -5771,14 +5710,6 @@ class ilObjTest extends ilObject
         } else {
             $info = 'old_mark_default_not_applied';
         }
-
-
-        $this->storeActivationSettings(
-            (bool) ($testsettings['is_activation_limited'] ?? false),
-            $activation_starting_time,
-            $activation_ending_time,
-            (bool) ($testsettings['activation_visibility'] ?? false),
-        );
 
         $main_settings = $this->getMainSettings();
 
@@ -6674,56 +6605,6 @@ class ilObjTest extends ilObject
         return $this->online;
     }
 
-    public function setActivationVisibility($a_value)
-    {
-        $this->activation_visibility = (bool) $a_value;
-    }
-
-    public function getActivationVisibility(): bool
-    {
-        return $this->activation_visibility;
-    }
-
-    public function isActivationLimited(): ?bool
-    {
-        return $this->activation_limited;
-    }
-
-    public function setActivationLimited($a_value)
-    {
-        $this->activation_limited = (bool) $a_value;
-    }
-
-    public function storeActivationSettings(
-        ?bool $is_activation_limited = false,
-        ?int $activation_starting_time = null,
-        ?int $activation_ending_time = null,
-        bool $activation_visibility = false,
-    ): void {
-        if (!$this->ref_id) {
-            return;
-        }
-
-        $item = new ilObjectActivation();
-        $is_activation_limited ??= false;
-
-        if (!$is_activation_limited) {
-            $item->setTimingType(ilObjectActivation::TIMINGS_DEACTIVATED);
-        } else {
-            $item->setTimingType(ilObjectActivation::TIMINGS_ACTIVATION);
-            $item->setTimingStart($activation_starting_time);
-            $item->setTimingEnd($activation_ending_time);
-            $item->toggleVisible($activation_visibility);
-        }
-
-        $item->update($this->ref_id);
-
-        $this->setActivationLimited($is_activation_limited);
-        $this->setActivationStartingTime($activation_starting_time);
-        $this->setActivationStartingTime($activation_ending_time);
-        $this->setActivationVisibility($activation_visibility);
-    }
-
     public function getIntroductionPageId(): int
     {
         $page_id = $this->getMainSettings()->getIntroductionSettings()->getIntroductionPageId();
@@ -6872,26 +6753,6 @@ class ilObjTest extends ilObject
     public function getEnableExamview(): bool
     {
         return $this->getMainSettings()->getFinishingSettings()->getShowAnswerOverview();
-    }
-
-    public function setActivationStartingTime(?int $starting_time = null)
-    {
-        $this->activation_starting_time = $starting_time;
-    }
-
-    public function setActivationEndingTime(?int $ending_time = null)
-    {
-        $this->activation_ending_time = $ending_time;
-    }
-
-    public function getActivationStartingTime(): ?int
-    {
-        return $this->activation_starting_time;
-    }
-
-    public function getActivationEndingTime(): ?int
-    {
-        return $this->activation_ending_time;
     }
 
     /**

--- a/components/ILIAS/Test/src/Logging/AdditionalInformationGenerator.php
+++ b/components/ILIAS/Test/src/Logging/AdditionalInformationGenerator.php
@@ -57,10 +57,6 @@ class AdditionalInformationGenerator
     public const KEY_TEST_TITLE = 'title';
     public const KEY_TEST_DESCRIPTION = 'description';
     public const KEY_TEST_ONLINE = 'online';
-    public const KEY_TEST_VISIBILITY_PERIOD = 'crs_visibility_until';
-    public const KEY_TEST_VISIBILITY_PERIOD_FROM = 'from';
-    public const KEY_TEST_VISIBILITY_PERIOD_UNTIL = 'to';
-    public const KEY_TEST_VISIBLE_OUTSIDE_PERIOD = 'activation_visible_when_disabled';
     public const KEY_TEST_QUESTION_SET_TYPE = 'test_question_set_type';
     public const KEY_TEST_ANONYMITY = 'tst_anonymity';
     public const KEY_TEST_INTRODUCTION_ENABLED = 'tst_introduction';

--- a/components/ILIAS/Test/src/Settings/MainSettings/class.SettingsMainGUI.php
+++ b/components/ILIAS/Test/src/Settings/MainSettings/class.SettingsMainGUI.php
@@ -292,30 +292,6 @@ class SettingsMainGUI extends TestSettingsGUI
                 )
         ];
 
-        if (!$this->test_object->isActivationLimited()) {
-            $log_array[AdditionalInformationGenerator::KEY_TEST_VISIBILITY_PERIOD] = $this->logger
-                ->getAdditionalInformationGenerator()->getEnabledDisabledTagForBool(false);
-            return $log_array;
-        }
-
-        $none_tag = $this->logger->getAdditionalInformationGenerator()->getNoneTag();
-        $from = $this->test_object->getActivationStartingTime() === null
-            ? $none_tag
-            : \DateTimeImmutable::createFromFormat('U', (string) $this->test_object->getActivationStartingTime())
-                ->format(AdditionalInformationGenerator::DATE_STORAGE_FORMAT);
-        $until = $this->test_object->getActivationEndingTime() === null
-            ? $none_tag
-            : \DateTimeImmutable::createFromFormat('U', (string) $this->test_object->getActivationEndingTime())
-                ->format(AdditionalInformationGenerator::DATE_STORAGE_FORMAT);
-
-        $log_array[AdditionalInformationGenerator::KEY_TEST_VISIBILITY_PERIOD] = [
-            AdditionalInformationGenerator::KEY_TEST_VISIBILITY_PERIOD_FROM => $from,
-            AdditionalInformationGenerator::KEY_TEST_VISIBILITY_PERIOD_UNTIL => $until
-        ];
-        $log_array[AdditionalInformationGenerator::KEY_TEST_VISIBLE_OUTSIDE_PERIOD] = $this->logger
-            ->getAdditionalInformationGenerator()->getEnabledDisabledTagForBool(
-                $this->test_object->getActivationVisibility()
-            );
         return $log_array;
     }
 
@@ -504,7 +480,6 @@ class SettingsMainGUI extends TestSettingsGUI
         $input_factory = $this->ui_factory->input();
 
         $inputs['is_online'] = $this->getIsOnlineSettingInput();
-        $inputs['timebased_availability'] = $this->getTimebasedAvailabilityInputs();
 
         return $input_factory->field()->section(
             $inputs,
@@ -538,76 +513,8 @@ class SettingsMainGUI extends TestSettingsGUI
         return $is_online;
     }
 
-    private function getTimebasedAvailabilityInputs(): OptionalGroup
-    {
-        $field_factory = $this->ui_factory->input()->field();
-        $inputs['time_limit_start'] = $field_factory->dateTime($this->lng->txt('rep_activation_limited_start'))
-            ->withTimezone($this->active_user->getTimeZone())
-            ->withFormat($this->active_user->getDateTimeFormat())
-            ->withUseTime(true);
-        $inputs['time_limit_end'] = $field_factory->dateTime($this->lng->txt('rep_activation_limited_end'))
-            ->withTimezone($this->active_user->getTimeZone())
-            ->withFormat($this->active_user->getDateTimeFormat())
-            ->withUseTime(true);
-        $inputs['activation_visibility'] = $field_factory->checkbox(
-            $this->lng->txt('rep_activation_limited_visibility'),
-            $this->lng->txt('tst_activation_limited_visibility_info')
-        );
-
-        return $field_factory->optionalGroup(
-            $inputs,
-            $this->lng->txt('rep_time_based_availability')
-        )->withAdditionalTransformation(
-            $this->getTransformationForActivationLimitedOptionalGroup()
-        )->withValue(
-            $this->getValueForActivationLimitedOptionalGroup()
-        );
-    }
-
-    private function getTransformationForActivationLimitedOptionalGroup(): TransformationInterface
-    {
-        return $this->refinery->custom()->transformation(
-            static function (?array $vs): array {
-                if ($vs === null
-                    || $vs['time_limit_start'] === null && $vs['time_limit_end'] === null) {
-                    return [
-                        'is_activation_limited' => false,
-                        'activation_starting_time' => null,
-                        'activation_ending_time' => null,
-                        'activation_visibility' => false
-                    ];
-                }
-
-                return [
-                    'is_activation_limited' => true,
-                    'activation_starting_time' => $vs['time_limit_start']?->getTimestamp(),
-                    'activation_ending_time' => $vs['time_limit_end']?->getTimestamp(),
-                    'activation_visibility' => $vs['activation_visibility']
-                ];
-            }
-        );
-    }
-
-    private function getValueForActivationLimitedOptionalGroup(): ?array
-    {
-        $value = null;
-        if ($this->test_object->isActivationLimited()) {
-            $value = [
-                'time_limit_start' => $this->buildDateOrNullFromILIASValue(
-                    $this->test_object->getActivationStartingTime()
-                ),
-                'time_limit_end' => $this->buildDateOrNullFromILIASValue(
-                    $this->test_object->getActivationEndingTime()
-                ),
-                'activation_visibility' => $this->test_object->getActivationVisibility()
-            ];
-        }
-        return $value;
-    }
-
     private function saveAvailabilitySettingsSection(array $section): void
     {
-        $this->test_object->storeActivationSettings(...$section['timebased_availability']);
         $this->test_object->getObjectProperties()->storePropertyIsOnline($section['is_online']);
     }
 

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#True
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please write down this code use it for further actions.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Вярно
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please write down this code use it for further actions.###25 02 2007 new variable
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.###28 08 2012 new variable
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Pravda
 assessment#:#tst_access_code_created#:#Byl vytvořen unikátní kód k Vašemu stálému přístupu k Vašim výsledkům testu, a který Vám umožňuje v testu pokračovat. Zapište si prosím tento kód pro další použití.
 assessment#:#tst_activate_skill_service#:#Aktivujte službu způsobilosti
 assessment#:#tst_activate_skill_service_desc#:#Zobrazí se nová záložka 'Způsobilosti'. V této záložce jsou otázky přiřazeny způsobilostem, poté jsou připsány prahy pro dosažení určité úrovně způsobilosti.
-assessment#:#tst_activation_limited_visibility_info#:#Je-li vybráno, tento test je viditelný i mimo zadanou dostupnost.
 assessment#:#tst_activation_online_info#:#Je-li offline, pouze správci mohou vidět a upravovat tento test.
 assessment#:#tst_add_quest_cont_edit_mode#:#Editační mód pro dodatečný obsah otázky
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Editace dodatečného obsahu s Editorem objektů stránky

--- a/lang/ilias_da.lang
+++ b/lang/ilias_da.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Sandt
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please write down this code use it for further actions.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#Indtil testen er aktiveret er det kun administratorer der kan se og redigere testen.
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###16 09 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###16 09 2013 new variable

--- a/lang/ilias_el.lang
+++ b/lang/ilias_el.lang
@@ -1331,7 +1331,6 @@ assessment#:#true#:#Αληθές
 assessment#:#tst_access_code_created#:#Για να σας παρέχεται μόνιμη πρόσβαση στα αποτελέσματα του τεστ και η δυνατότητα να συνεχίσετε το τεστ, δημιουργήθηκε ένας μοναδικός κωδικός πρόσβασης για το τεστ. Παρακαλώ καταγράψτε αυτόν τον κωδικό και χρησιμοποιήστε το για περαιτέρω ενέργειες.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.###28 08 2012 new variable
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_es.lang
+++ b/lang/ilias_es.lang
@@ -1332,7 +1332,6 @@ assessment#:#true#:#Verdadero
 assessment#:#tst_access_code_created#:#Para proporcionarle acceso permanente a sus resultados de test y ofrecerle la posibilidad de retomar este test, un código de acceso único fue creado. Por favor, anote este código y úselo en acciones posteriores.
 assessment#:#tst_activate_skill_service#:#Activar servicio de Competencias
 assessment#:#tst_activate_skill_service_desc#:#Se mostrará una nueva pestaña 'Competencias'. En esta pestaña las preguntas se asignan a las competencias, luego se establecen los umbrales para alcanzar un nivel específico de una competencia.
-assessment#:#tst_activation_limited_visibility_info#:#Si se activa, el test es visible incluso fuera de la disponibilidad que tenga asignada
 assessment#:#tst_activation_online_info#:#Si está desactivado, sólo los administradores pueden ver y editar el test.
 assessment#:#tst_add_quest_cont_edit_mode#:#Modo de Edición para introducir el texto de la pregunta
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Modo de edición simple (sin formato de texto) para el contenido de las preguntas

--- a/lang/ilias_et.lang
+++ b/lang/ilias_et.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Õige
 assessment#:#tst_access_code_created#:#Et võimaldada oma testi juurde tagasi pöörduda ja testitulemustele pidevat ligipääsu, loodi unikaalne ligipääsukood. Palun kirjuta see kood edaspidiseks kasutamiseks üles.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor

--- a/lang/ilias_fa.lang
+++ b/lang/ilias_fa.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#True
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please write down this code use it for further actions.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.###28 08 2012 new variable
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -1315,7 +1315,6 @@ assessment#:#true#:#Vrai
 assessment#:#tst_access_code_created#:#Pour vous donner un accès permanent aux résultats du test et vous permettre de le refaire, un code d'accès unique a été créé. Veuillez noter et conserver ce code pour consulter les résultats ou refaire ce test ultérieurement.
 assessment#:#tst_activate_skill_service#:#Activer Service de Compétences
 assessment#:#tst_activate_skill_service_desc#:#Un nouvel onglet 'Competences' sera affiché. Dans cet onglet les questions sont affectées aux compétences, puis des seuils sont attribués pour atteindre un niveau spécifique d'une compétence.
-assessment#:#tst_activation_limited_visibility_info#:#Lorsque activé, le test est visible même en dehors de la période de disponibilité.
 assessment#:#tst_activation_online_info#:#Lorsque le test est hors-ligne, seuls les administrateurs peuvent le voir et l'éditer.
 assessment#:#tst_add_quest_cont_edit_mode#:#Mode d'Edition par Défaut pour Contenu Additionnel
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Edition de Contenu Supplémentaire avec Editeur de Page

--- a/lang/ilias_hr.lang
+++ b/lang/ilias_hr.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#True###04 06 2021 new variable
 assessment#:#tst_access_code_created#:#Kako bi Vam se osigurao stalni pristup vašim rezultatima testa i ponudila vam se mogućnost da nastavite ovaj test, za Vas je izrađen jedinstveni kod za pristup testu. Molimo zabilježite si ovaj kod kako biste ga mogli koristiti za daljnje akcije.
 assessment#:#tst_activate_skill_service#:#Kompetencije
 assessment#:#tst_activate_skill_service_desc#:#Podržava raspoređivanje pitanja prema kompetencijama te definiranje pragova za postizanje određene razine kompetencije.
-assessment#:#tst_activation_limited_visibility_info#:#Prije i nakon navedenog razdoblja prikazuje se samo naziv testa. A sudionici ne mogu ispunjavati test.
 assessment#:#tst_activation_online_info#:#Sudionici mogu ispunjavati test samo ako je on stavljen na mrežu (online).
 assessment#:#tst_add_quest_cont_edit_mode#:#Urednik za povratne informacije i savjete
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Za uređivanje povratnih informacija i savjeta koristite urednika stranica aplikacije ILIAS

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Igaz
 assessment#:#tst_access_code_created#:#Egyedi hozzáférési kódot állítottunk be az Ön számára, hogy bármikor elérhesse teszteredményeit, és hogy lehetősége legyen ennek a tesztnek a folytatására. Jegyezze fel ezt a kódot a teszt későbbi elérése érdekében.
 assessment#:#tst_activate_skill_service#:#Kompetenciaszolgáltatás
 assessment#:#tst_activate_skill_service_desc#:#Kérdések kompetenciákhoz rendelését és meghatározott kompetenciaszint eléréshez küszöbérték meghatározását teszi lehetővé.
-assessment#:#tst_activation_limited_visibility_info#:#Az adott időszakon kívül csak a teszt címe látható. Ilyenkor a résztvevők nem tudják kitölteni a tesztet.
 assessment#:#tst_activation_online_info#:#Ha online, a résztvevők kitölthetik a tesztet.
 assessment#:#tst_add_quest_cont_edit_mode#:#Visszajelzések és tippek szerkesztésének módja
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#ILIAS-lapszerkesztő használata

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Vero
 assessment#:#tst_access_code_created#:#Per renderti accessibile sempre il test ed offrirti la possibilità di rivederlo, è stato creato un codice unico. Per favore scrivitelo per usarlo in futuro.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.
-assessment#:#tst_activation_limited_visibility_info#:#Se scelto, il test è visibile anche all'esterno della disponibilità data.
 assessment#:#tst_activation_online_info#:#Se non in linea, solo gli amministratori possono visualizzare e modificare il test.
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor

--- a/lang/ilias_ja.lang
+++ b/lang/ilias_ja.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#True
 assessment#:#tst_access_code_created#:#テスト結果への恒久アクセスと、このテストを再開可能性を提供するためにユニークなテストのアクセス コードが作成されました。以降のアクションはこのコードを使って書いてください。
 assessment#:#tst_activate_skill_service#:#能力サービスを有効化
 assessment#:#tst_activate_skill_service_desc#:#新規タブ'能力'が表示されます。このタブには問題が能力へ割り当てられてしきい値は能力の一定レベル達成用に帰属します。
-assessment#:#tst_activation_limited_visibility_info#:#表示期間前後にテストのタイトルのみが表示されます。受験者はテスト受験できません。
 assessment#:#tst_activation_online_info#:#オンラインの場合に受験者はテスト受験できます。
 assessment#:#tst_add_quest_cont_edit_mode#:#追加問題コンテンツのモード編集
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#ページオブジェクトエディタ付の追加コンテンツ編集

--- a/lang/ilias_ka.lang
+++ b/lang/ilias_ka.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#ჭეშმარიტი
 assessment#:#tst_access_code_created#:#იმისათვის რომ უზრუნველყოთ თქვენთვის ტესტის პასუხებთან მუდმივი ხელმისაწვდომობა და შემოგთავაზოთ ამ ტესტის განახლება, ტესტის უნიკალური ჩართვის კოდი შეიქმნა. გთხოვთ ჩაიწეროთ ეს უნიკალური კოდი მომდევნო მოქმედებებისთვის.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_lt.lang
+++ b/lang/ilias_lt.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Tiesa
 assessment#:#tst_access_code_created#:#Norint suteikti jums prieigą prie jūsų testo rezultatų ir galimybę tęsti šį testą, buvo sukurtas unikalus testo prieigos kodas. Prašome jį užsirašyti ir naudoti ateityje.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.###28 08 2012 new variable
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Waar
 assessment#:#tst_access_code_created#:#Om je permanente toegang te geven tot de toets resultaten en de mogelijkheid te bieden je toets later te hernemem, heeft ILIAS een toegangscode aangemaakt. Schrijf deze code op zodat je deze later kan gebruiken
 assessment#:#tst_activate_skill_service#:#Inschakelen van competenties
 assessment#:#tst_activate_skill_service_desc#:#A new tab ‘Competences’ will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###06 02 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#Als gekozen, is de toets zichtbaar, zelfs buiten de gegeven beschikbaarheid.
 assessment#:#tst_activation_online_info#:#Als offline kunnen alleen beheerders de toets zien en wijzigen.
 assessment#:#tst_add_quest_cont_edit_mode#:#Edit-modus voor extra inhoud
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Edit extra inhoud met behulp van de ILIAS pagina editor

--- a/lang/ilias_pl.lang
+++ b/lang/ilias_pl.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#WAHR
 assessment#:#tst_access_code_created#:#Dla zapewnienia Ci stałego dostępu do wyników Twojego testu i do umożliwienia jego odzyskania, został utworzony unikalny kod dostępu do testu. Zapisz ten kod i użyj go do dalszych operacji.
 assessment#:#tst_activate_skill_service#:#Kompetencje
 assessment#:#tst_activate_skill_service_desc#:#Umożliwia przydzielanie pytań do kompetencji oraz definicję wartości progowych w celu osiągnięcia poszczególnych poziomów kompetencji.
-assessment#:#tst_activation_limited_visibility_info#:#Jeśli wybrano, widoczny jest tylko tytuł testu pomimo ustawień o dostępności testu.
 assessment#:#tst_activation_online_info#:#Jeśli wybrano tryb offline, tylko administratorzy mogą wyświetlać i edytować test.
 assessment#:#tst_add_quest_cont_edit_mode#:#Edytor komunikatów zwrotnych i podpowiedzi
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Użyj edytora stron ILIAS do edytowania komunikatów zwrotnych oraz podpowiedzi.

--- a/lang/ilias_pt.lang
+++ b/lang/ilias_pt.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Verdadeiro
 assessment#:#tst_access_code_created#:#Para fornecer-lhe acesso permanente aos resultados do seu teste e permitir-lhe retomar este teste, foi criado um acesso único ao teste. Anote este código para poder usá-lo noutras ocasiões.
 assessment#:#tst_activate_skill_service#:#Serviço de competência
 assessment#:#tst_activate_skill_service_desc#:#Suporta a atribuição de perguntas a competências e a definição de limites para alcançar um nível de competência específico.
-assessment#:#tst_activation_limited_visibility_info#:#Antes e depois do período indicado, aparece somente o título do teste. Os participantes não podem fazer o teste.
 assessment#:#tst_activation_online_info#:#Se estiverem online, os participantes podem fazer o teste.
 assessment#:#tst_add_quest_cont_edit_mode#:#Editor para feedback e sugestões
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Usar editor de páginas ILIAS para editar feedback e sugestões

--- a/lang/ilias_ro.lang
+++ b/lang/ilias_ro.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Adevarat
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please write down this code use it for further actions.###10 Jul 2006 new variable
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.###28 08 2012 new variable
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_ru.lang
+++ b/lang/ilias_ru.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Верно
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please write down this code use it for further actions.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.
 assessment#:#tst_activation_online_info#:#Если не активен, то только администраторы могут видеть и редактировать тест.
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Editor

--- a/lang/ilias_sk.lang
+++ b/lang/ilias_sk.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Pravda
 assessment#:#tst_access_code_created#:#Byl vytvořen unikátní kód k Vašemu stálému přístupu k Vašim výsledkům testu, a který Vám umožňuje v testu pokračovat. Zapište si prosím tento kód pro další použití.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.###28 08 2012 new variable
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_sl.lang
+++ b/lang/ilias_sl.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#True
 assessment#:#tst_access_code_created#:#Za zagotovitev trajnega dostopa do vaših rezultatov testa in možnosti ponovnega dostopa do prekinjenega testa je bila za vas izdelana osebna koda za dostop. Zabeležite si to kodo, da jo boste lahko uporabili za nadaljnja dejanja.
 assessment#:#tst_activate_skill_service#:#Kompetence
 assessment#:#tst_activate_skill_service_desc#:#Podpira dodelitev vprašanj kompetencam in opredelitev mejnih vrednosti za doseganje določene ravni kompetenc.
-assessment#:#tst_activation_limited_visibility_info#:#Izven določenega obdobja se prikaže ime testa. Testa ni mogoče zagnati.
 assessment#:#tst_activation_online_info#:#Udeleženci lahko opravljajo test le, če je na spletu.
 assessment#:#tst_add_quest_cont_edit_mode#:#Urednik za povratne informacije in namige glede rešitev.
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Uporabite urejevalnik strani ILIAS za urejanje povratnih informacij in nasvetov

--- a/lang/ilias_sq.lang
+++ b/lang/ilias_sq.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Saktë
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please write down this code use it for further actions.###10 Jul 2006 new variable
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.###28 08 2012 new variable
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_sr.lang
+++ b/lang/ilias_sr.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Istina
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please write down this code use it for further actions.###10 Jul 2006 new variable
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.###28 08 2012 new variable
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_sv.lang
+++ b/lang/ilias_sv.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Sant
 assessment#:#tst_access_code_created#:#För att du ska ha permanent tillgång till dina testresultat och kunna återuppta ett avbrutet test har en personlig åtkomstnyckel genererats för dig. Vänligen notera koden nedan för att kunna fortsätta testet senare.
 assessment#:#tst_activate_skill_service#:#Kompetens
 assessment#:#tst_activate_skill_service_desc#:#Tillåter tilldelning av frågor till kompetenser samt definition av tröskelvärden för uppnåendet av vissa kompetensnivåer.
-assessment#:#tst_activation_limited_visibility_info#:#Utanför den angivna tidsperioden visas testtiteln. Testet kan dock inte startas. Ytterligare åtkomst, även till tester som redan pågår, förhindras i slutet av perioden.
 assessment#:#tst_activation_online_info#:#Endast när testet är online kan användare delta i testet.
 assessment#:#tst_add_quest_cont_edit_mode#:#Redaktör
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Oformaterad text för frågor och svar och ILIAS sidredigerare för feedback och lösningsanteckningar

--- a/lang/ilias_tr.lang
+++ b/lang/ilias_tr.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Doğru
 assessment#:#tst_access_code_created#:#Test sonuçlarına kalıcı erişim sağlamak ve bu teste devam etme imkanı sunmak için, benzersiz bir sınama erişim kodu oluşturuldu. Bu kodu, daha sonra kullanmak için not ediniz.
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#Seçilirse, test her zaman görünür
 assessment#:#tst_activation_online_info#:#Çevrimdışıysa, yalnızca yöneticiler testi görebilir ve düzenleyebilir.
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_uk.lang
+++ b/lang/ilias_uk.lang
@@ -1330,7 +1330,6 @@ assessment#:#true#:#Правда
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please write down this code use it for further actions.###25 02 2007 new variable
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.###28 08 2012 new variable
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_vi.lang
+++ b/lang/ilias_vi.lang
@@ -1332,7 +1332,6 @@ assessment#:#true#:#True###06 09 2006 new variable
 assessment#:#tst_access_code_created#:#To provide you with permanent access to your test results and to offer you a possibility to resume this test, a unique test access code was created. Please write down this code use it for further actions.###25 02 2007 new variable
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#If chosen, the test is visible even outside of the given availability.###28 08 2012 new variable
 assessment#:#tst_activation_online_info#:#If offline, only administrators can see and edit the test.###28 08 2012 new variable
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable

--- a/lang/ilias_zh.lang
+++ b/lang/ilias_zh.lang
@@ -1329,7 +1329,6 @@ assessment#:#true#:#是
 assessment#:#tst_access_code_created#:#为您提供永久访问您的测试结果并提供一种恢复这个测试的可能性，一个唯一性的测试访问码将被创建。请抄下这个访问码以备用。
 assessment#:#tst_activate_skill_service#:#Activate Competence Service###26 09 2014 new variable
 assessment#:#tst_activate_skill_service_desc#:#A new tab 'Competences' will be displayed. In this tab questions are assigned to competences, then thresholds are ascribed for reaching a specific level of a competence.###27 01 2015 new variable
-assessment#:#tst_activation_limited_visibility_info#:#如果已选择，测试是可见的，即使超出了给定的可用性之外。
 assessment#:#tst_activation_online_info#:#如果离线，仅管理员能看和编辑测试。
 assessment#:#tst_add_quest_cont_edit_mode#:#Editing Mode for additional Question Content###24 10 2013 new variable
 assessment#:#tst_add_quest_cont_edit_mode_IPE#:#Additional Content Editing with Page Object Editor###24 10 2013 new variable


### PR DESCRIPTION
Hi all

This imply and radically removes ever reference to the activation from inside the test and so implements the abandon request https://docu.ilias.de/go/wiki/wpage_8743_1357 . I don't see much reason to complicate this any further.

Best,
@kergomard 