### PR TITLE
UI: Readability of system infos 45167

### DIFF
--- a/templates/default/070-components/UI-framework/MainControls/_ui-component_system_info.scss
+++ b/templates/default/070-components/UI-framework/MainControls/_ui-component_system_info.scss
@@ -1,5 +1,7 @@
-@use "../../../010-settings/"as *;
+@use "sass:color";
+@use "../../../010-settings/" as *;
 @use "../../../050-layout/basics" as *;
+@use "../../../030-tools/tool_contrast-color" as cont-col;
 
 /*
 **************************************************************
@@ -40,9 +42,8 @@ $il-standard-page-system-info-color-variant-important: lighten($il-danger-color,
 $il-standard-page-system-info-color-variant-breaking: darken($il-danger-color, 10%);
 
 .il-system-info {
-
   @mixin head-info-color-variant($variant_name, $base-color){
-    $contrast-color: contrast(greyscale($base-color), darken($base-color, $il-standard-page-system-info-contrast), lighten($base-color, $il-standard-page-system-info-contrast), $il-standard-page-system-info-contrast-threshold);
+    $contrast-color: cont-col.contrast-color($base-color, $il-text-color, $il-main-bg, $il-standard-page-system-info-contrast-threshold);
     &.il-system-info-#{$variant_name} {
       // Shadow
       -webkit-box-shadow: $il-standard-page-system-info-shadow;
@@ -57,6 +58,9 @@ $il-standard-page-system-info-color-variant-breaking: darken($il-danger-color, 1
       // Colors
       color: $contrast-color;
 
+      a {
+        color: cont-col.contrast-color($base-color, $il-link-color, color.scale($il-link-color, $whiteness: 70%), $il-standard-page-system-info-contrast-threshold);
+      }
       a.glyph {
         color: $contrast-color;
       }

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -6442,10 +6442,13 @@ footer {
   border-bottom: #dddddd none;
   border-left: #dddddd none;
   border-right: #dddddd none;
-  color: contrast(greyscale(#e2e8ef), #3a4c65, white, 43%);
+  color: #161616;
+}
+.il-system-info.il-system-info-neutral a {
+  color: #4c6586;
 }
 .il-system-info.il-system-info-neutral a.glyph {
-  color: contrast(greyscale(#e2e8ef), #3a4c65, white, 43%);
+  color: #161616;
 }
 .il-system-info.il-system-info-important {
   -webkit-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
@@ -6456,10 +6459,13 @@ footer {
   border-bottom: #dddddd none;
   border-left: #dddddd none;
   border-right: #dddddd none;
-  color: contrast(greyscale(#ffaaaa), #770000, white, 43%);
+  color: #161616;
+}
+.il-system-info.il-system-info-important a {
+  color: #4c6586;
 }
 .il-system-info.il-system-info-important a.glyph {
-  color: contrast(greyscale(#ffaaaa), #770000, white, 43%);
+  color: #161616;
 }
 .il-system-info.il-system-info-breaking {
   -webkit-box-shadow: inset 0px -10px 4px -10px rgba(0, 0, 0, 0.25);
@@ -6470,10 +6476,13 @@ footer {
   border-bottom: #dddddd none;
   border-left: #dddddd none;
   border-right: #dddddd none;
-  color: contrast(greyscale(#aa0000), black, #ffdddd, 43%);
+  color: white;
+}
+.il-system-info.il-system-info-breaking a {
+  color: #9f9f9f;
 }
 .il-system-info.il-system-info-breaking a.glyph {
-  color: contrast(greyscale(#aa0000), black, #ffdddd, 43%);
+  color: white;
 }
 .il-system-info.full {
   height: auto;
@@ -18424,7 +18433,6 @@ div.framed {
 	background-repeat: repeat-x;
 }
 */
-
 span.latex {
   color: green;
   font-weight: bold;


### PR DESCRIPTION
## Readability of system infos 45167 

`small impact` `UI framework` `readability`

[→ Mantis Issue](https://mantis.ilias.de/view.php?id=45167)

### Issue

* when system infos have dark backgrounds, the text, links, close button are not readable
* the color contrast tool seems to not be working in this context

### Changes

<img width="800" height="850" alt="assets_comparison-horizontal-split" src="https://github.com/user-attachments/assets/faea6fdf-33c4-4ec2-a725-5d1357b44493" />

* There was an issue with the SCSS contrast tool that is supposed to switch the text to white not being loaded correctly - it's actually weird that this compiled at all.
* added a restyling of links to guarantee visibility on dark backgrounds

I think this section is now a good example of how to flip text color to white depending on the background.

### Larger Scope

* Currently, we use the main-bg color everywhere when we need white in delos, but there might be cases where we need to differentiate between main-bg color and the most/least contrasting text color. It might be smarter to work with variables like $color-no-contrast-to-main-bg and $color-most-contrast-to-main-bg. We should discuss this during a CSS Squad Meeting.
