### PR TITLE
UI: 45536,  remove rendering of pagination (Input > ViewControl) if ...

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/ViewControl/Renderer.php
@@ -273,50 +273,46 @@ class Renderer extends AbstractComponentRenderer
                 $entries = $this->sliceRangesToVisibleEntries($ranges, $current, $component->getNumberOfVisibleEntries());
             }
 
-            foreach ($ranges as $idx => $range) {
-                if (in_array($range, $entries)) {
-                    $signal = clone $internal_signal;
-                    $signal->addOption('offset', $range->getStart());
-                    $signal->addOption('limit', $limit);
-                    $tpl->setCurrentBlock("entry");
-                    $entry = $ui_factory->button()->shy((string) ($idx + 1), '#')->withOnClick($signal);
-                    if ($idx === $current) {
-                        $entry = $entry->withEngagedState(true);
-                    }
-                    $tpl->setVariable("ENTRY", $default_renderer->render($entry));
-                    $tpl->parseCurrentBlock();
-                } else {
-                    if ($idx === 1 || $idx === count($ranges) - 2) {
+            if (count($entries) > 1) {
+                foreach ($ranges as $idx => $range) {
+                    if (in_array($range, $entries)) {
+                        $signal = clone $internal_signal;
+                        $signal->addOption('offset', $range->getStart());
+                        $signal->addOption('limit', $limit);
+                        $tpl->setCurrentBlock("entry");
+                        $entry = $ui_factory->button()->shy((string) ($idx + 1), '#')->withOnClick($signal);
+                        if ($idx === $current) {
+                            $entry = $entry->withEngagedState(true);
+                        }
+                        $tpl->setVariable("ENTRY", $default_renderer->render($entry));
+                        $tpl->parseCurrentBlock();
+                    } elseif ($idx === 1 || $idx === count($ranges) - 2) {
                         $tpl->setCurrentBlock("entry");
                         $tpl->touchBlock("spacer");
                         $tpl->parseCurrentBlock();
                     }
                 }
-            }
 
-            $signal = null;
-            if ($current > 0 && count($entries) > 1) {
-                $range = $ranges[$current - 1];
-                $signal = clone $internal_signal;
-                $signal->addOption('offset', $range->getStart());
-                $signal->addOption('limit', $limit);
-            }
-            $btn_left = $ui_factory->button()->shy('', $signal ?? '#')
-                ->withSymbol($ui_factory->symbol()->glyph()->back())
-                ->withUnavailableAction($signal === null);
-            $tpl->setVariable("LEFT_ROCKER", $default_renderer->render($btn_left));
+                if ($current > 0) {
+                    $range = $ranges[$current - 1];
+                    $signal = clone $internal_signal;
+                    $signal->addOption('offset', $range->getStart());
+                    $signal->addOption('limit', $limit);
+                    $btn_left = $ui_factory->button()->shy('', $signal ?? '#')
+                                           ->withSymbol($ui_factory->symbol()->glyph()->back());
+                    $tpl->setVariable("LEFT_ROCKER", $default_renderer->render($btn_left));
+                }
 
-            $signal = null;
-            if ($current < count($ranges) - 1) {
-                $range = $ranges[$current + 1];
-                $signal = clone $internal_signal;
-                $signal->addOption('offset', $range->getStart());
-                $signal->addOption('limit', $limit);
+                if ($current < count($ranges) - 1) {
+                    $range = $ranges[$current + 1];
+                    $signal = clone $internal_signal;
+                    $signal->addOption('offset', $range->getStart());
+                    $signal->addOption('limit', $limit);
+                    $btn_right = $ui_factory->button()->shy('', $signal ?? '#')
+                                            ->withSymbol($ui_factory->symbol()->glyph()->next());
+                    $tpl->setVariable("RIGHT_ROCKER", $default_renderer->render($btn_right));
+                }
             }
-            $btn_right = $ui_factory->button()->shy('', $signal ?? '#')
-                ->withSymbol($ui_factory->symbol()->glyph()->next())
-                ->withUnavailableAction($signal === null);
-            $tpl->setVariable("RIGHT_ROCKER", $default_renderer->render($btn_right));
         }
 
         foreach ($component->getLimitOptions() as $option) {

--- a/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/ViewControl/Renderer.php
@@ -359,21 +359,16 @@ class Renderer extends AbstractComponentRenderer
             $forward_btn = $f->button()->standard("", $url_next);
         }
 
-        if ($component->getCurrentPage() === 0) {
-            $back_btn = $back_btn->withUnavailableAction();
+        if ($component->getCurrentPage() != 0) {
+            $back_glyph = $f->symbol()->glyph()->back();
+            $back_btn = $back_btn->withSymbol($back_glyph);
+            $tpl->setVariable('PREVIOUS', $default_renderer->render($back_btn));
         }
-        if ($component->getCurrentPage() >= $component->getNumberOfPages() - 1) {
-            $forward_btn = $forward_btn->withUnavailableAction();
+        if ($component->getCurrentPage() != $component->getNumberOfPages() - 1) {
+            $forward_glyph = $f->symbol()->glyph()->next();
+            $forward_btn = $forward_btn->withSymbol($forward_glyph);
+            $tpl->setVariable('NEXT', $default_renderer->render($forward_btn));
         }
-
-        $back_glyph = $f->symbol()->glyph()->back();
-        $forward_glyph = $f->symbol()->glyph()->next();
-
-        $back_btn = $back_btn->withSymbol($back_glyph);
-        $forward_btn = $forward_btn->withSymbol($forward_glyph);
-
-        $tpl->setVariable('PREVIOUS', $default_renderer->render($back_btn));
-        $tpl->setVariable('NEXT', $default_renderer->render($forward_btn));
     }
 
     /**

--- a/components/ILIAS/UI/src/examples/Input/ViewControl/Pagination/with_one_page.php
+++ b/components/ILIAS/UI/src/examples/Input/ViewControl/Pagination/with_one_page.php
@@ -9,7 +9,7 @@ use ILIAS\UI\Implementation\Component\Input\ViewControl\Pagination;
 /**
  * ---
  * expected output: >
- *   ILIAS shows the rendered Component.
+ *   No pagination component is rendered.
  * ---
  */
 function with_one_page()
@@ -19,7 +19,7 @@ function with_one_page()
     $r = $DIC->ui()->renderer();
 
     $pagination = $f->input()->viewControl()->pagination()
-        ->withTotalCount(10)
+        ->withTotalCount(3)
         ->withValue([Pagination::FNAME_OFFSET => 0, Pagination::FNAME_LIMIT => 10])
     ;
 
@@ -28,8 +28,6 @@ function with_one_page()
         ->withRequest($DIC->http()->request());
 
     return $r->render([
-        $f->legacy('<pre>' . print_r($vc_container->getData(), true) . '</pre>'),
-        $f->divider()->horizontal(),
         $vc_container
     ]);
 }

--- a/components/ILIAS/UI/tests/Component/ViewControl/PaginationTest.php
+++ b/components/ILIAS/UI/tests/Component/ViewControl/PaginationTest.php
@@ -101,12 +101,9 @@ class PaginationTest extends ILIAS_UI_TestBase
             ->withPageSize(1);
 
         //two entries, first one inactive
-        //browse-left disabled
+        //browse-left not rendered
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
-    <button class="btn btn-default" data-action="?pagination_offset=0" disabled="disabled">
-        <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
-    </button>
     <button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=0" id="id_1">1</button>
     <button class="btn btn-link" data-action="?pagination_offset=1" id="id_2">2</button>
     <button class="btn btn-default" data-action="?pagination_offset=1" id="id_3">
@@ -127,7 +124,7 @@ EOT;
             ->withCurrentPage(1);
 
         //two entries, second one inactive
-        //browse-right disabled
+        //browse-right not rendered
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
     <button class="btn btn-default" data-action="?pagination_offset=0" id="id_3">
@@ -135,9 +132,6 @@ EOT;
     </button>
     <button class="btn btn-link" data-action="?pagination_offset=0" id="id_1">1</button>
     <button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=1" id="id_2">2</button>
-    <button class="btn btn-default" data-action="?pagination_offset=2" disabled="disabled">
-        <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
-    </button>
 </div>
 EOT;
 
@@ -156,13 +150,10 @@ EOT;
             ->withMaxPaginationButtons(1);
 
         //one entry,
-        //browse-left disabled
+        //browse-left not rendered
         //boundary-button right
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
-    <button class="btn btn-default" data-action="?pagination_offset=0" disabled="disabled">
-        <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
-    </button>
     <button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=0" id="id_1">1</button>
     <span class="last"><button class="btn btn-link" data-action="?pagination_offset=2" id="id_2">3</button></span>
     <button class="btn btn-default" data-action="?pagination_offset=1" id="id_3">
@@ -216,7 +207,7 @@ EOT;
             ->withCurrentPage(2);
 
         //one entry,
-        //browse-right disabled
+        //browse-right not rendered
         //boundary-button left only
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
@@ -225,9 +216,6 @@ EOT;
     </button>
     <span class="first"><button class="btn btn-link" data-action="?pagination_offset=0" id="id_2">1</button></span>
     <button class="btn btn-link engaged" aria-pressed="true" data-action="?pagination_offset=2" id="id_1">3</button>
-    <button class="btn btn-default" data-action="?pagination_offset=3" disabled="disabled">
-        <span class="glyph" aria-label="next" role="img"><span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></span>
-    </button>
 </div>
 EOT;
         $html = $this->getDefaultRenderer()->render($p);
@@ -246,9 +234,6 @@ EOT;
 
         $expected_html = <<<EOT
 <div class="il-viewcontrol-pagination l-bar__element">
-    <button class="btn btn-default" data-action="?pagination_offset=0" disabled="disabled">
-        <span class="glyph" aria-label="back" role="img"><span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span></span>
-    </button>
     <div class="dropdown" id="id_4">
         <button class="btn btn-default dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="id_4_menu">pagination_label_x_of_y<span class="caret"></span></button>
         <ul id="id_4_menu" class="dropdown-menu">


### PR DESCRIPTION
… the available pages are equal or less than one.

https://mantis.ilias.de/view.php?id=45536

It's behaviour now matches the Pagination in UI > ViewControl.

**Old behaviour**
<img width="568" height="378" alt="old_input_vc_page_one_page" src="https://github.com/user-attachments/assets/bf673762-3838-4b83-819b-5baed641af96" />

**new behaviour**
<img width="254" height="124" alt="new_input_vc_page_one_page" src="https://github.com/user-attachments/assets/711c9c8e-0b6e-4e2b-a471-d2b933308a27" />



Remove rendering of previous and next button instead of disabling
them if they are not usable. This change concerns the pagination
component in UI > ViewControl and UI > Input > ViewControl.

**Old behaviour**
<img width="375" height="74" alt="old_input_vc_page_left_rocker" src="https://github.com/user-attachments/assets/4de925ce-70b0-4b5a-8249-fe3feb50b06a" />
<img width="375" height="74" alt="old_input_vc_page_right_rocker" src="https://github.com/user-attachments/assets/6eb1bce4-e422-41ef-a8b1-d37ace4c399c" />


**New behaviour**
<img width="375" height="74" alt="new_input_vc_page_no_left_rocker" src="https://github.com/user-attachments/assets/60c13a31-1b3f-4015-a46a-57b021c74858" />
<img width="375" height="74" alt="new_input_vc_page_no_right_rocker" src="https://github.com/user-attachments/assets/ae838943-02e1-4596-8077-3fa1756456c3" />
