### PR TITLE
UIComponent/Explorer: Get rid of unused "Max Tree Depth" determination

### DIFF
--- a/Services/UIComponent/Explorer/classes/class.ilExplorer.php
+++ b/Services/UIComponent/Explorer/classes/class.ilExplorer.php
@@ -513,7 +513,6 @@ class ilExplorer
 
     public function getMaximumTreeDepth(): int
     {
-        $this->tree->getMaximumDepth();
         return 0;   // seems to not return the value...
     }
 


### PR DESCRIPTION
This PR suggests to remove the `ilTree::getMaximumDepth` method call in `\ilExplorer::getMaximumTreeDepth`. The calculated value is not used at all, but results (depending on the size of the `tree` table) in
an expensive database call.