### PR TITLE
UI: Adapt Header-Size for Sections Inside Groups

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Group.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Group.php
@@ -162,4 +162,19 @@ class Group extends FormInput implements C\Input\Field\Group, GroupInternal
     {
         return $this->getInputs();
     }
+
+    public function setNestingLevel(int $nesting_level): void
+    {
+        $this->updateChildrenNestingLevels($nesting_level);
+    }
+
+    private function updateChildrenNestingLevels(int $nesting_level): void
+    {
+        foreach ($this->getInputs() as $input) {
+            if ($input instanceof Group) {
+                $input->setNestingLevel($nesting_level);
+                continue;
+            }
+        }
+    }
 }

--- a/components/ILIAS/UI/src/Implementation/Component/Input/Field/Section.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Field/Section.php
@@ -66,7 +66,7 @@ class Section extends Group implements C\Input\Field\Section
     private function updateChildrenNestingLevels(): void
     {
         foreach ($this->getInputs() as $input) {
-            if ($input instanceof Section) {
+            if ($input instanceof Group) {
                 $nesting_level = $this->getNestingLevel() + 1;
                 $input->setNestingLevel($nesting_level);
             }

--- a/components/ILIAS/UI/tests/Component/Input/Field/SectionInputTest.php
+++ b/components/ILIAS/UI/tests/Component/Input/Field/SectionInputTest.php
@@ -109,4 +109,27 @@ class SectionInputTest extends ILIAS_UI_TestBase
         $this->assertStringContainsString('<h3>Middle Section</h3>', $nested_sections_html);
         $this->assertStringContainsString('<h4>Inner Section</h4>', $nested_sections_html);
     }
+
+    public function testNestedSectionInsideGroupRendering(): void
+    {
+        $f = $this->getFieldFactory();
+        $inputs_level6 = [$f->text("input3", "input3 byline")];
+        $section_level6 = $f->section($inputs_level6, "Inner Section");
+
+        $group_level5 = $f->group([$section_level6]);
+
+        $inputs_level4 = [$f->text("input2", "input2 byline"), $group_level5];
+        $section_level4 = $f->section($inputs_level4, "Middle Section");
+
+        $group_level3 = $f->group([$section_level4]);
+
+        $inputs_level2 = [$f->text("input1", "input1 byline"), $group_level3];
+        $section_level2 = $f->section($inputs_level2, "Outermost Section");
+
+        $nested_sections_html = $this->render($section_level2);
+
+        $this->assertStringContainsString('<h2>Outermost Section</h2>', $nested_sections_html);
+        $this->assertStringContainsString('<h3>Middle Section</h3>', $nested_sections_html);
+        $this->assertStringContainsString('<h4>Inner Section</h4>', $nested_sections_html);
+    }
 }


### PR DESCRIPTION
Dear UI-Coordinators

This PR would fix the issue described in https://mantis.ilias.de/view.php?id=45793 where `Section`s nested inside `Group`s do not receive the right header size. I also added a test for it.

Thank you very much for all your work and best,
@kergomard 