### PR TITLE
Fix Mantis #44251: Getting rid of lm_x directories in SCORM Exports and Imports

### DIFF
--- a/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilObjSAHSLearningModuleGUI.php
@@ -507,18 +507,32 @@ class ilObjSAHSLearningModuleGUI extends ilObjectGUI
         // create data directory, copy file to directory
         $new_obj->createDataDirectory();
 
+        // Handle content.zip
         $scorm_file = "content.zip";
-        $scorm_file_path = $import_dirname . "/" . $scorm_file;
-        $file_path = $new_obj->getDataDirectory() . "/" . $scorm_file;
-        ilFileUtils::rename($scorm_file_path, $file_path);
+        $file_path = $import_dirname . "/" . $scorm_file;
+        // Unzip content.zip before copying
+        $content_unzip_dir = $import_dirname . '/content';
         $this->archives->unzip(
             $file_path,
-            $new_obj->getDataDirectory(),
+            $content_unzip_dir,
             false,
             false,
             false
         );
-        unlink($file_path);
+        // Handle ILIAS 9 Exports containing 'lm_x' directories
+        $source_dir_for_copy = $content_unzip_dir;
+        $content_unzip_dir_iterator = new DirectoryIterator( $content_unzip_dir );
+        foreach ( $content_unzip_dir_iterator as $fileinfo ) {
+            if ( $fileinfo->isDir() && !$fileinfo->isDot() ) {
+                if ( preg_match( '/^lm_\d+$/', $fileinfo->getFilename() ) ) {
+                    $source_dir_for_copy = $source_dir_for_copy . '/' . $fileinfo->getFilename();
+                    break;
+                }
+            }
+        }
+        // Move content
+        ilFileUtils::rename($source_dir_for_copy, $new_obj->getDataDirectory());
+        // Cleanup
         ilFileUtils::delDir($lm_temp_dir, false);
         ilFileUtils::renameExecutables($new_obj->getDataDirectory());
 

--- a/components/ILIAS/ScormAicc/classes/class.ilScormAiccDataSet.php
+++ b/components/ILIAS/ScormAicc/classes/class.ilScormAiccDataSet.php
@@ -104,19 +104,19 @@ class ilScormAiccDataSet extends ilDataSet
                     continue;
                 }
                 //end fix
-				if ( isset( $data[ $key ] ) ) {
-					$data_value = '';
-					if ( is_array( $data[ $key ] ) ) {
-						$data_value = $data[ $key ][ 0 ] ?? '';
-					}
-					else {
-						$data_value = $data[ $key ];
-					}
-					$columns [ $value[ "db_col" ] ] = [
-						$value[ "db_type" ],
-						$data_value
-					];
-				}
+                if ( isset( $data[ $key ] ) ) {
+                    $data_value = '';
+                    if ( is_array( $data[ $key ] ) ) {
+                        $data_value = $data[ $key ][ 0 ] ?? '';
+                    }
+                    else {
+                        $data_value = $data[ $key ];
+                    }
+                    $columns [ $value[ "db_col" ] ] = [
+                        $value[ "db_type" ],
+                        $data_value
+                    ];
+                }
             }
             if (is_array($columns)) {
                 if (count($columns) > 0) {
@@ -132,19 +132,19 @@ class ilScormAiccDataSet extends ilDataSet
                 "Description" => ["db_col" => "description", "db_type" => "text"]
             ];
             foreach ($od_properties as $key => $value) {
-				if ( isset( $data[ $key ] ) ) {
-					$data_value = '';
-					if ( is_array( $data[ $key ] ) ) {
-						$data_value = $data[ $key ][ 0 ] ?? '';
-					}
-					else {
-						$data_value = $data[ $key ];
-					}
-					$od_columns [ $value[ "db_col" ] ] = [
-						$value[ "db_type" ],
-						$data_value
-					];
-				}
+                if ( isset( $data[ $key ] ) ) {
+                    $data_value = '';
+                    if ( is_array( $data[ $key ] ) ) {
+                        $data_value = $data[ $key ][ 0 ] ?? '';
+                    }
+                    else {
+                        $data_value = $data[ $key ];
+                    }
+                    $od_columns [ $value[ "db_col" ] ] = [
+                        $value[ "db_type" ],
+                        $data_value
+                    ];
+                }
 
                 if (isset($od_columns) && is_array($od_columns)) {
                     if (count($od_columns) > 0) {
@@ -169,7 +169,11 @@ class ilScormAiccDataSet extends ilDataSet
         bool $a_omit_header = false,
         bool $a_omit_types = false
     ): string {
-        $GLOBALS['DIC']["ilLog"]->write(json_encode($this->getTypes("sahs", "5.1.0"), JSON_PRETTY_PRINT));
+
+        global $DIC;
+        $ilLog = ilLoggerFactory::getLogger('sahs');
+
+        $ilLog->write(json_encode($this->getTypes("sahs", "5.1.0"), JSON_PRETTY_PRINT));
 
         $this->dircnt = 1;
 
@@ -209,8 +213,13 @@ class ilScormAiccDataSet extends ilDataSet
 
         // build content zip file
         if (isset($this->_archive['files']['scormFile'])) {
-            $lmDir = ilFileUtils::getWebspaceDir("filesystem") . "/lm_data/lm_" . $id;
-            ilFileUtils::zip($lmDir, $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['scormFile'], true);
+            $lmDir = './' . ILIAS_WEB_DIR . "/" . CLIENT_ID . "/lm_data/lm_" . $id;
+            // Important: content zip should not contain a 'lm_x' directory
+            $DIC->legacyArchives()->zip(
+                $lmDir,
+                $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['scormFile'],
+                false
+            );
         }
 
         // build property xml file


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=44251

Zipping of content.zip with zip() created an additional directory "lm_x" that threw errors on importing. 
1) Export was changed, so that the directory is not created anymore. 
2) Import was changed so that already exported modules, that already have these directories, can still be imported.

PR for ILIAS 10

@qualitus-dahme 