### PR TITLE
Fix Mantis #45761: Custom SCORM data is missing in a Container export file

### DIFF
--- a/Modules/ScormAicc/Editing/classes/class.ilSAHSEditGUI.php
+++ b/Modules/ScormAicc/Editing/classes/class.ilSAHSEditGUI.php
@@ -125,8 +125,8 @@ class ilSAHSEditGUI implements ilCtrlBaseClassInterface
             case "ilexportgui":
                 $obj_id = ilObject::_lookupObjectId($this->refId);
                 if ($cmd === "create_xml") {
-                    $exporter = new ilScormAiccExporter();
-                    $xml = $exporter->getXmlRepresentation("sahs", "5.1.0", (string) $obj_id);
+                    $exp = new ilExport();
+                    $exp->exportObject( 'sahs', (int)$obj_id );
                 } elseif ($cmd === "download") {
                     $file = $this->wrapper->query()->retrieve('file', $this->refinery->kindlyTo()->string());
                     $ftmp = explode(":", $file);

--- a/Modules/ScormAicc/classes/class.ilScormAiccDataSet.php
+++ b/Modules/ScormAicc/classes/class.ilScormAiccDataSet.php
@@ -71,6 +71,9 @@ class ilScormAiccDataSet extends ilDataSet
         ];
 
         $this->element_db_mapping = [];
+
+        parent::__construct();
+
         foreach ($this->properties as $key => $value) {
             $this->element_db_mapping [$value["db_col"]] = $key;
         }
@@ -162,6 +165,7 @@ class ilScormAiccDataSet extends ilDataSet
      * own getXmlRepresentation function to embed zipfile in xml
      */
     public function getExtendedXmlRepresentation(
+        string $exportArchiveDir,
         string $a_entity,
         string $a_schema_version,
         array $a_ids,
@@ -179,16 +183,6 @@ class ilScormAiccDataSet extends ilDataSet
 
         $this->readData($a_entity, $a_schema_version, $a_ids, $a_field = "");
         $id = (int) $this->data["id"];
-        $exportDir = ilExport::_getExportDirectory((int) $id, "xml", "sahs");
-
-        // prepare archive skeleton
-        $objTypeAndId = "sahs_" . $id;
-        $this->_archive['directories'] = [
-            "exportDir" => ilExport::_getExportDirectory($id)
-            ,"tempDir" => ilExport::_getExportDirectory($id) . "/temp"
-            ,"archiveDir" => time() . "__" . IL_INST_ID . "__" . $objTypeAndId
-            ,"moduleDir" => $objTypeAndId
-        ];
 
         $this->_archive['files'] = [
             "properties" => "properties.xml",
@@ -197,24 +191,15 @@ class ilScormAiccDataSet extends ilDataSet
             'scormFile' => "content.zip"
         ];
 
-        // Prepare temp storage on the local filesystem
-        if (!file_exists($this->_archive['directories']['exportDir'])) {
-            mkdir($this->_archive['directories']['exportDir'], 0755, true);
-            //$DIC->filesystem()->storage()->createDir($this->_archive['directories']['tempDir']);
-        }
-        if (!file_exists($this->_archive['directories']['tempDir'])) {
-            mkdir($this->_archive['directories']['tempDir'], 0755, true);
-        }
-
         // build metadata xml file
         file_put_contents(
-            $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['metadata'],
+            $exportArchiveDir . "/" . $this->_archive['files']['metadata'],
             $this->buildMetaData($id)
         );
 
         // build manifest xml file
         file_put_contents(
-            $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['manifest'],
+            $exportArchiveDir . "/" . $this->_archive['files']['manifest'],
             $this->buildManifest()
         );
 
@@ -224,52 +209,18 @@ class ilScormAiccDataSet extends ilDataSet
             // Important: content zip should not contain a 'lm_x' directory
             $DIC->legacyArchives()->zip(
                 $lmDir,
-                $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['scormFile'],
+                $exportArchiveDir . "/" . $this->_archive['files']['scormFile'],
                 false
             );
         }
 
         // build property xml file
         file_put_contents(
-            $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['properties'],
+            $exportArchiveDir . "/" . $this->_archive['files']['properties'],
             $this->buildProperties($a_entity, $a_omit_header)
         );
 
-        // zip tempDir and append to export folder
-        $fileName = $this->_archive['directories']['exportDir'] . "/" . $this->_archive['directories']['archiveDir'] . ".zip";
-        $zArchive = new ZipArchive();
-        if ($zArchive->open($fileName, ZipArchive::CREATE) !== true) {
-            exit("cannot open <$fileName>\n");
-        }
-        $zArchive->addFile(
-            $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['properties'],
-            $this->_archive['directories']['archiveDir'] . '/properties.xml'
-        );
-        $zArchive->addFile(
-            $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['manifest'],
-            $this->_archive['directories']['archiveDir'] . '/' . "manifest.xml"
-        );
-        $zArchive->addFile(
-            $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['metadata'],
-            $this->_archive['directories']['archiveDir'] . '/' . "metadata.xml"
-        );
-        if (isset($this->_archive['files']['scormFile'])) {
-            $zArchive->addFile(
-                $this->_archive['directories']['tempDir'] . "/" . $this->_archive['files']['scormFile'],
-                $this->_archive['directories']['archiveDir'] . '/content.zip'
-            );
-        }
-        $zArchive->close();
-
-        // unlink tempDir and its content
-        unlink($this->_archive['directories']['tempDir'] . "/metadata.xml");
-        unlink($this->_archive['directories']['tempDir'] . "/manifest.xml");
-        unlink($this->_archive['directories']['tempDir'] . "/properties.xml");
-        if (isset($this->_archive['files']['scormFile']) && file_exists($this->_archive['directories']['tempDir'] . "/content.zip")) {
-            unlink($this->_archive['directories']['tempDir'] . "/content.zip");
-        }
-
-        return $fileName;
+        return $exportArchiveDir . '.zip';
     }
 
     /**

--- a/Modules/ScormAicc/classes/class.ilScormAiccExporter.php
+++ b/Modules/ScormAicc/classes/class.ilScormAiccExporter.php
@@ -23,6 +23,7 @@ class ilScormAiccExporter extends ilXmlExporter
 
     public function __construct()
     {
+        parent::__construct();
         $this->dataset = new ilScormAiccDataSet();
     }
 
@@ -34,7 +35,7 @@ class ilScormAiccExporter extends ilXmlExporter
     {
         $this->dataset->setExportDirectories($this->dir_relative, $this->dir_absolute);
         //using own getXmlRepresentation function in ilScormAiccDataSet
-        return $this->dataset->getExtendedXmlRepresentation($a_entity, $a_schema_version, [$a_id], "", false, true);
+        return $this->dataset->getExtendedXmlRepresentation( $this->getExport()->export_run_dir, $a_entity, $a_schema_version, [ $a_id ], "", false, true );
     }
     //todo:check if xsd files must be provided
 


### PR DESCRIPTION
Mantis: https://mantis.ilias.de/view.php?id=45761

Container Export ignored directory where custom scorm export data was created. Scorm now creates custom data in a different directory that is used by the container export.

PR for ILIAS 9
@qualitus-dahme 