### PR TITLE
PRG: 45797, 'roles' are not visible in PRG assignments

### DIFF
--- a/components/ILIAS/User/src/Profile/Fields/Standard/Roles.php
+++ b/components/ILIAS/User/src/Profile/Fields/Standard/Roles.php
@@ -62,7 +62,7 @@ class Roles implements FieldDefinition
 
     public function visibleInStudyProgrammesForcedTo(): ?bool
     {
-        return true;
+        return false;
     }
 
     public function exportForcedTo(): ?bool


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45797

With the revision of user fields (config), 'roles' happened to be visible in PRG - they didn't use to be, so, for the moment, they still shouldn't.