### PR TITLE
9/UI/dropdown-width 45790

### DIFF
--- a/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
+++ b/templates/default/070-components/UI-framework/Dropdown/_ui-component_dropdown.scss
@@ -62,14 +62,13 @@ $cursor-disabled: not-allowed !default;
 
 // The dropdown menu (ul)
 .dropdown-menu {
-  width: 320px;
   position: absolute;
   top: 100%;
   z-index: $zindex-dropdown;
   display: none; // none by default, but block on "open" of the menu
   float: left;
   overflow: auto;
-  min-width: 160px;
+  min-width: 200px;
   max-height: 50vh;
   padding: l.$il-padding-large-vertical 0;
   margin: l.$il-margin-small-vertical 0 0; // override default ul

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -381,14 +381,13 @@
 }
 
 .dropdown-menu {
-  width: 320px;
   position: absolute;
   top: 100%;
   z-index: 1000;
   display: none;
   float: left;
   overflow: auto;
-  min-width: 160px;
+  min-width: 200px;
   max-height: 50vh;
   padding: 6px 0;
   margin: 3px 0 0;


### PR DESCRIPTION
# Issue

Add new menu width was cut short. Dropdowns don't react that smartly to their context. We need to fix that better in upcoming versions.

# Changes

Reverting back to no width set. Bumped min-width slightly up so menus that do not push the menu open are still readable

<img width="295" height="272" alt="image" src="https://github.com/user-attachments/assets/2e8e3572-b211-4fd8-83bd-081fcb369204" />

<img width="816" height="599" alt="image" src="https://github.com/user-attachments/assets/2c69f1b0-e573-4b33-88e5-61909b69c144" />

<img width="252" height="217" alt="image" src="https://github.com/user-attachments/assets/41a57f48-b530-49c1-b266-23f7011af0ff" />