### PR TITLE
UI, Modal: 42427 fix backdrop-filter blur issue for firefox.

### DIFF
--- a/templates/default/060-elements/_elements_dialog.scss
+++ b/templates/default/060-elements/_elements_dialog.scss
@@ -13,10 +13,11 @@ dialog::backdrop {
   animation-duration: .3s;
   animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
   animation-fill-mode: both;
+  backdrop-filter: blur(dialog.$modal-backdrop-blur) brightness(dialog.$modal-backdrop-opacity);
 }
 
 @keyframes fadeBackdropIn {
-  from { backdrop-filter: blur(0 px) brightness(dialog.$modal-backdrop-opacity); }
+  from { backdrop-filter: blur(0) brightness(1); }
   to { backdrop-filter: blur(dialog.$modal-backdrop-blur) brightness(dialog.$modal-backdrop-opacity); }
 }
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2051,11 +2051,12 @@ dialog::backdrop {
   animation-duration: 0.3s;
   animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
   animation-fill-mode: both;
+  backdrop-filter: blur(3px) brightness(0.5);
 }
 
 @keyframes fadeBackdropIn {
   from {
-    backdrop-filter: blur(0 px) brightness(0.5);
+    backdrop-filter: blur(0) brightness(1);
   }
   to {
     backdrop-filter: blur(3px) brightness(0.5);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=42427

<img width="600" height="650" alt="ui_modal_backdropfilter_blur_comparison" src="https://github.com/user-attachments/assets/3bceea25-d7a4-4ccc-b23c-dc5895faece7" />

FYI: As firefox has some known issues with backdrop-filters combined with animation the animation is not included here.