### PR TITLE
UI, DataTable: adjust spacing of header above data table. 

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Table/tpl.datatable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.datatable.html
@@ -1,7 +1,7 @@
 <div class="c-table-data" id="{ID}">
 
 	<!-- BEGIN header_title -->
-	<h2 class="ilHeader" id="{ID}_label">{TITLE}</h2>
+	<h2 id="{ID}_label">{TITLE}</h2>
 	<!-- END header_title -->
 
 	<div class="viewcontrols">{VIEW_CONTROLS}</div>

--- a/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
+++ b/components/ILIAS/UI/src/templates/default/Table/tpl.orderingtable.html
@@ -2,7 +2,7 @@
 
 
 	<!-- BEGIN header_title -->
-	<h2 class="ilHeader" id="{ID}_label">{TITLE}</h2>
+	<h2 id="{ID}_label">{TITLE}</h2>
 	<!-- END header_title -->
 
 	<div class="viewcontrols">{VIEW_CONTROLS}</div>

--- a/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
+++ b/components/ILIAS/UI/tests/Component/Table/OrderingRendererTest.php
@@ -71,7 +71,7 @@ class OrderingRendererTest extends TableRendererTestBase
 
         $actual = $renderer->renderOrderingTable($table, $this->getDefaultRenderer());
         $expected = <<<EOT
-<div class="c-table-ordering" id="id_1"><h2 class="ilHeader" id="id_1_label"></h2>
+<div class="c-table-ordering" id="id_1"><h2 id="id_1_label"></h2>
     <div class="viewcontrols">
         <form class="il-viewcontrols-form l-bar__space-keeper" method="get" id="id_2"></form>
     </div>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45631


<img width="600" height="650" alt="ui_dt_ot_h2_spacing_comparison" src="https://github.com/user-attachments/assets/1a93f33d-50d1-439a-858c-4377151bcfa5" />
