### PR TITLE
Blog: Fix determination of month can result in "array access" error

### DIFF
--- a/Modules/Blog/classes/class.ilObjBlogGUI.php
+++ b/Modules/Blog/classes/class.ilObjBlogGUI.php
@@ -140,7 +140,7 @@ class ilObjBlogGUI extends ilObject2GUI implements ilDesktopItemHandling
             $this->items = $this->buildPostingList($this->object->getId());
             if ($this->items) {
                 // current month (if none given or empty)
-                if (!$this->month || !$this->items[$this->month]) {
+                if (!$this->month || !isset($this->items[$this->month]) || $this->items[$this->month] === []) {
                     $m = array_keys($this->items);
                     $this->month = array_shift($m);
                     $this->month_default = true;


### PR DESCRIPTION
Mantis Issue: https://mantis.ilias.de/view.php?id=45827