### PR TITLE
43812: Exercise - Work instruction - Card title Schedule needs a heading markup

### DIFF
--- a/components/ILIAS/UI/src/templates/default/Card/tpl.card.html
+++ b/components/ILIAS/UI/src/templates/default/Card/tpl.card.html
@@ -18,7 +18,9 @@
 	<!-- BEGIN highlight --><div class="card-highlight"></div><!-- END highlight -->
 	<!-- BEGIN no_highlight --><div class="card-no-highlight"></div><!-- END no_highlight -->
 	<div class="caption card-title">
-		<!-- BEGIN title_action_begin --><a href="{HREF}" id="{ID}"><!-- END title_action_begin -->{TITLE}<!-- BEGIN title_action_end --></a><!-- END title_action_end -->
+		<h4>
+			<!-- BEGIN title_action_begin --><a href="{HREF}" id="{ID}"><!-- END title_action_begin -->{TITLE}<!-- BEGIN title_action_end --></a><!-- END title_action_end -->
+		</h4>
 	</div>
 	<!-- BEGIN section -->
 	<div class="caption">{SECTION}</div>

--- a/components/ILIAS/UI/tests/Component/Card/CardTest.php
+++ b/components/ILIAS/UI/tests/Component/Card/CardTest.php
@@ -158,7 +158,7 @@ class CardTest extends ILIAS_UI_TestBase
                 "<div class=\"il-card thumbnail\">" .
                 "   <div class=\"il-card-image-container\"><img src=\"src\" class=\"img-standard\" alt=\"open Card Title\" /></div>" .
                 "   <div class=\"card-no-highlight\"></div>" .
-                "   <div class=\"caption card-title\">Card Title</div>" .
+                "   <div class=\"caption card-title\"><h4>Card Title</h4></div>" .
                 "   <div class=\"caption\">Random Content</div>" .
                 "</div>";
 
@@ -177,7 +177,7 @@ class CardTest extends ILIAS_UI_TestBase
             "<div class=\"il-card thumbnail\">" .
             "   <div class=\"il-card-image-container\"><img src=\"src\" class=\"img-standard\" alt=\"open Card Title\" /></div>" .
             "   <div class=\"card-highlight\"></div>" .
-            "   <div class=\"caption card-title\">Card Title</div>" .
+            "   <div class=\"caption card-title\"><h4>Card Title</h4></div>" .
             "</div>";
 
         $this->assertHTMLEquals($this->brutallyTrimHTML($expected_html), $html);
@@ -196,7 +196,7 @@ class CardTest extends ILIAS_UI_TestBase
             "<div class=\"il-card thumbnail\">" .
             "   <div class=\"il-card-image-container\"><img src=\"src\" class=\"img-standard\" alt=\"open Card Title\" /></div>" .
             "   <div class=\"card-no-highlight\"></div>" .
-            "   <div class=\"caption card-title\">" . $r->render($title) . "</div>" .
+            "   <div class=\"caption card-title\"><h4>" . $r->render($title) . "</h4></div>" .
             "</div>";
 
         $this->assertHTMLEquals($this->brutallyTrimHTML($expected_html), $html);

--- a/components/ILIAS/UI/tests/Component/Card/RepositoryObjectTest.php
+++ b/components/ILIAS/UI/tests/Component/Card/RepositoryObjectTest.php
@@ -181,7 +181,7 @@ class RepositoryObjectTest extends ILIAS_UI_TestBase
 	</div>
     <div class="il-card-image-container"><img src="src" class="img-standard" alt="open Card Title" /></div>
 	<div class="card-no-highlight"></div>
-    <div class="caption card-title">Card Title</div>
+    <div class="caption card-title"><h4>Card Title</h4></div>
 </div>
 EOT);
 
@@ -214,7 +214,7 @@ EOT);
 	</div>
     <div class="il-card-image-container"><img src="src" class="img-standard" alt="open Card Title" /></div>
 	<div class="card-no-highlight"></div>
-    <div class="caption card-title">Card Title</div>
+    <div class="caption card-title"><h4>Card Title</h4></div>
 </div>
 EOT);
 
@@ -249,7 +249,7 @@ EOT);
                    </div>
                    <div class="il-card-image-container"><img src="src" class="img-standard" alt="open Card Title"/></div>
                    <div class="card-no-highlight"></div>
-                   <div class="caption card-title">Card Title</div>
+                   <div class="caption card-title"><h4>Card Title</h4></div>
                 </div>');
 
         $this->assertHTMLEquals($expected_html, $html);
@@ -282,7 +282,7 @@ EOT);
                 </div>
                 <div class="il-card-image-container"><img src="src" class="img-standard" alt="open Card Title" /></div>
                 <div class="card-no-highlight"></div>
-                <div class="caption card-title">Card Title</div>
+                <div class="caption card-title"><h4>Card Title</h4></div>
             </div>
         ');
 

--- a/components/ILIAS/UI/tests/Component/Deck/DeckTest.php
+++ b/components/ILIAS/UI/tests/Component/Deck/DeckTest.php
@@ -120,13 +120,13 @@ class DeckTest extends ILIAS_UI_TestBase
 
         $expected_html =
                 '<div class="il-deck"><div class="row row-eq-height">
-						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title">Card Title</div></div></div>
-						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title">Card Title</div></div></div>
-						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title">Card Title</div></div></div>
-						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title">Card Title</div></div></div>
-						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title">Card Title</div></div></div>
-						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title">Card Title</div></div></div>
-						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title">Card Title</div></div></div>
+						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title"><h4>Card Title</h4></div></div></div>
+						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title"><h4>Card Title</h4></div></div></div>
+						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title"><h4>Card Title</h4></div></div></div>
+						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title"><h4>Card Title</h4></div></div></div>
+						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title"><h4>Card Title</h4></div></div></div>
+						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title"><h4>Card Title</h4></div></div></div>
+						<div class="col-xs-12 col-sm-6 col-md-6 col-lg-4"><div class="il-card thumbnail"><div class="card-no-highlight"></div><div class="caption card-title"><h4>Card Title</h4></div></div></div>
 					</div>
 				</div>';
 

--- a/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
+++ b/components/ILIAS/UI/tests/Component/Panel/PanelTest.php
@@ -278,7 +278,7 @@ EOT;
             <div class="col-sm-4">
                 <div class="il-card thumbnail">
                     <div class="card-no-highlight"></div>
-                    <div class="caption card-title">Card Title</div>
+                    <div class="caption card-title"><h4>Card Title</h4></div>
                 </div>
             </div>
         </div>
@@ -370,7 +370,7 @@ EOT;
                     <div class="col-sm-4">
                         <div class="il-card thumbnail">
                             <div class="card-no-highlight"></div>
-                            <div class="caption card-title">Card Title</div>
+                            <div class="caption card-title"><h4>Card Title</h4></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This PR addresses accessibility issue **[0043812](https://mantis.ilias.de/view.php?id=43812)**: in the Exercise module, under Work Instruction, the card title "Schedule" lacked proper heading markup.

Added an `h4` heading to the card title, ensuring it appears as a subordinate to the main "Work Instruction" heading.

https://mantis.ilias.de/view.php?id=43812
