### PR TITLE
UI/InputField/File: Use proper label for "Select file(s)" button

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -5530,6 +5530,7 @@ common#:#select#:#Auswählen
 common#:#select_all#:#Alle auswählen
 common#:#select_at_least_one_object#:#Bitte wählen Sie mindestens ein Objekt aus.
 common#:#select_file#:#Datei wählen
+common#:#select_file_from_computer#:#Datei wählen
 common#:#select_files_from_computer#:#Dateien wählen
 common#:#select_max_one_item#:#Bitte wählen Sie nur ein Objekt aus.
 common#:#select_object_to_link#:#Bitte wählen Sie das zu verknüpfende Objekt aus.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -5530,6 +5530,7 @@ common#:#select#:#Select
 common#:#select_all#:#Select All
 common#:#select_at_least_one_object#:#Please choose at least one object.
 common#:#select_file#:#Select File
+common#:#select_file_from_computer#:#Select File
 common#:#select_files_from_computer#:#Select Files
 common#:#select_max_one_item#:#Please select one item only
 common#:#select_object_to_link#:#Please select the object which you want to link

--- a/src/UI/Implementation/Component/Input/Field/Renderer.php
+++ b/src/UI/Implementation/Component/Input/Field/Renderer.php
@@ -797,7 +797,9 @@ class Renderer extends AbstractComponentRenderer
         // display the action button (to choose files).
         $template->setVariable('ACTION_BUTTON', $default_renderer->render(
             $this->getUIFactory()->button()->shy(
-                $this->txt('select_files_from_computer'),
+                $input->getMaxFiles() <= 1
+                    ? $this->txt('select_file_from_computer')
+                    : $this->txt('select_files_from_computer'),
                 '#'
             )
         ));

--- a/tests/UI/Component/Input/Field/FileInputTest.php
+++ b/tests/UI/Component/Input/Field/FileInputTest.php
@@ -168,7 +168,7 @@ class FileInputTest extends ILIAS_UI_TestBase
                     <div id="id_3" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
+                            <button class="btn btn-link" data-action="#" id="id_2">select_file_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
                         </div>
                     </div>
@@ -198,7 +198,7 @@ class FileInputTest extends ILIAS_UI_TestBase
                     <div id="id_3" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
+                            <button class="btn btn-link" data-action="#" id="id_2">select_file_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                     <div class="help-block">byline</div>
@@ -224,7 +224,7 @@ class FileInputTest extends ILIAS_UI_TestBase
                     <div id="id_3" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
+                            <button class="btn btn-link" data-action="#" id="id_2">select_file_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                 </div>
@@ -281,7 +281,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 				</div>
 			</div>
 			<div class="ui-input-file-input-dropzone">
-				<button class="btn btn-link" data-action="#" id="id_3">select_files_from_computer</button>
+				<button class="btn btn-link" data-action="#" id="id_3">select_file_from_computer</button>
 				<span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
 			</div>
 		</div>
@@ -354,7 +354,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 				</div>
 			</div>
 			<div class="ui-input-file-input-dropzone">
-				<button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button>
+				<button class="btn btn-link" data-action="#" id="id_5">select_file_from_computer</button>
 				<span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
 			</div>
 		</div>
@@ -436,7 +436,7 @@ class FileInputTest extends ILIAS_UI_TestBase
 				</div>
 			</div>
 			<div class="ui-input-file-input-dropzone">
-				<button class="btn btn-link" data-action="#" id="id_5">select_files_from_computer</button>
+				<button class="btn btn-link" data-action="#" id="id_5">select_file_from_computer</button>
 				<span class="ui-input-file-input-error-msg" data-dz-error-msg></span>
 			</div>
 		</div>
@@ -463,7 +463,7 @@ class FileInputTest extends ILIAS_UI_TestBase
                     <div id="id_3" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
+                            <button class="btn btn-link" data-action="#" id="id_2">select_file_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                 </div>
@@ -488,7 +488,7 @@ class FileInputTest extends ILIAS_UI_TestBase
                     <div id="id_3" class="ui-input-file">
                         <div class="ui-input-file-input-list ui-input-dynamic-inputs-list"></div>
                         <div class="ui-input-file-input-dropzone">
-                            <button class="btn btn-link" data-action="#" id="id_2">select_files_from_computer</button>
+                            <button class="btn btn-link" data-action="#" id="id_2">select_file_from_computer</button>
                             <span class="ui-input-file-input-error-msg" data-dz-error-msg></span></div>
                     </div>
                 </div>


### PR DESCRIPTION
This PR suggests using different labels (depending on the defined number of accepted files) for the trigger button which opens the OS file picker.

So basically, it is a "plural/singular" improvement.

See also: https://mantis.ilias.de/view.php?id=45812