### PR TITLE
UI: 45648, add padding to asterisks and adjust property form template.

### DIFF
--- a/components/ILIAS/Form/templates/default/tpl.property_form.html
+++ b/components/ILIAS/Form/templates/default/tpl.property_form.html
@@ -30,7 +30,7 @@
 <!-- BEGIN prop -->
 <!-- BEGIN std_prop_start -->
 <div class="form-group row" id="il_prop_cont_{LAB_ID}">
-	<label {FOR_ID} class="col-lg-2 col-md-3 col-sm-4 control-label">{PROPERTY_TITLE}<!-- BEGIN std_hid_title --> <span class="ilAccHeadingHidden">{PHID_TITLE}</span><!-- END std_hid_title --><!-- BEGIN required --> <span class="asterisk">*</span><!-- END required --></label>
+	<label {FOR_ID} class="col-lg-2 col-md-3 col-sm-4 control-label">{PROPERTY_TITLE}<!-- BEGIN std_hid_title --> <span class="ilAccHeadingHidden">{PHID_TITLE}</span> <!-- END std_hid_title --><!-- BEGIN required --><span class="asterisk">*</span><!-- END required --></label>
 	<div class="col-lg-10 col-md-9 col-sm-8">
 <!-- END std_prop_start -->
 <!-- BEGIN sub_prop_start -->

--- a/templates/default/070-components/UI-framework/Input/_ui-component_input.scss
+++ b/templates/default/070-components/UI-framework/Input/_ui-component_input.scss
@@ -80,6 +80,10 @@
     display: block;
     grid-area: label;
     padding-right: l.$il-margin-large-horizontal;
+
+    > .asterisk:first-child {
+      padding-left: $il-padding-base-vertical;
+    }
   }
 
   > .c-input__field {

--- a/templates/default/070-components/legacy/Services/_component_form.scss
+++ b/templates/default/070-components/legacy/Services/_component_form.scss
@@ -519,6 +519,10 @@ input[type="checkbox"] {
 		&.col-sm-3.il_textarea {
 		  width: 100%;
 		}
+
+        > .asterisk {
+          padding-left: $il-padding-base-vertical;
+        }
 	  }
 	/*
 	// Reset spacing and right align labels, but scope to media queries so that

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -4835,6 +4835,9 @@ hr.il-divider-with-label {
   grid-area: label;
   padding-right: 12px;
 }
+.c-input[data-il-ui-component] > label > .asterisk:first-child {
+  padding-left: 3px;
+}
 .c-input[data-il-ui-component] > .c-input__field {
   grid-area: field;
 }
@@ -17421,6 +17424,9 @@ fieldset[disabled] .checkbox label {
 }
 .form-horizontal .control-label.col-sm-3.il_textarea {
   width: 100%;
+}
+.form-horizontal .control-label > .asterisk {
+  padding-left: 3px;
 }
 
 .ilFormHeader {


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45648

There was a blank character in the property template which resulted into a "fake" padding between a label and asterisk. This is removed and a blank character was added to the hidden title with this PR.
Padding before asterisk is now handled via SCSS.

<img width="600" height="650" alt="ui_no_emptyspace_before_asterisk_tpl_comparison" src="https://github.com/user-attachments/assets/6e306e38-57e6-43c3-9305-3888fe3e209c" />

---

### Added padding via SCSS 

<img width="600" height="650" alt="ui_label_asterisk_space_comparison" src="https://github.com/user-attachments/assets/19cd9eef-c4cf-41a7-b446-83ec3caeb78c" />


Note: The change for asterisk in the UI components  has to be addressed via `> .asterisk::first-child` as sometimes there's an asterisk after an H-Tag which already got space in between.

