### PR TITLE
10/UI/Breadcrumb font-weight change font-size change

### DIFF
--- a/templates/default/070-components/UI-framework/Breadcrumbs/_ui-component_breadcrumbs.scss
+++ b/templates/default/070-components/UI-framework/Breadcrumbs/_ui-component_breadcrumbs.scss
@@ -14,10 +14,16 @@
 		text-overflow: ellipsis;
 		text-align: left;
 		margin: 0;
-		font-weight: $il-standard-page-breadcrumbs-font-weight;
-		font-size: $il-font-size-small;
+		font-weight: $il-font-weight-base;
+		font-size: $il-font-size-base;
 		padding: ($il-padding-small-vertical * 2);
 		padding-left: $il-standard-page-content-padding;
+		
+		.breadcrumb-crumb {
+			&:first-child {
+				font-weight: $il-font-weight-xbold;
+			}
+		}
 
 		div.breadcrumb-crumb a {
 			color: $il-standard-page-breadcrumbs-color;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -2587,10 +2587,13 @@ code {
   text-overflow: ellipsis;
   text-align: left;
   margin: 0;
-  font-weight: 600;
-  font-size: 0.75rem;
+  font-weight: 400;
+  font-size: 0.875rem;
   padding: 6px;
   padding-left: 20px;
+}
+.breadcrumb-wrapper .breadcrumb .breadcrumb-crumb:first-child {
+  font-weight: 700;
 }
 .breadcrumb-wrapper .breadcrumb div.breadcrumb-crumb a {
   color: #4c6586;


### PR DESCRIPTION
Mantis issue: https://mantis.ilias.de/view.php?id=45836

**Issue**

The current implementation of the breadcrumb navigation in ILIAS presents some usability issues:

- Insufficient visibility: The breadcrumb is not visually distinct enough and tends to blend in with the rest of the interface, making it easy to overlook for users. This undermines its function as a navigational aid, as users may not notice it or make use of it effectively.
- Missing active node highlighting: The breadcrumb does not adequately indicate the current node (i.e., the active object). As a result, users cannot easily determine their exact position within the system’s hierarchy.

**Change**

The font size of the breadcrumb was increased to match the standard font size used throughout ILIAS. Additionally, the font weight of the active node (current breadcrumb element) was highlighted using the :first-child selector to make it visually distinct from the other breadcrumb items. The font weight of the following nodes was set to standard so that with the increased font size, the active node's emphasis is further reinforced and the breadcrumb trail becomes more legible overall.