### PR TITLE
SVY 45841: Fixes the error preventing creation of survey questions and survey question pools

### DIFF
--- a/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestion.php
+++ b/components/ILIAS/SurveyQuestionPool/Questions/class.SurveyQuestion.php
@@ -68,11 +68,8 @@ class SurveyQuestion
         $this->title = $title;
         $this->description = $description;
         $this->questiontext = $questiontext;
-        $this->author = $author;
+        $this->author = $author ?: $ilUser->getFullname();
         $this->cumulated = array();
-        if (!$this->author) {
-            $this->author = $ilUser->fullname;
-        }
         $this->owner = $owner;
         if ($this->owner === -1) {
             $this->owner = $ilUser->getId();
@@ -219,12 +216,7 @@ class SurveyQuestion
 
     public function setAuthor(string $author = ""): void
     {
-        $ilUser = $this->user;
-
-        if (!$author) {
-            $author = $ilUser->fullname;
-        }
-        $this->author = $author;
+        $this->author = $author ?: $this->user->getFullname();
     }
 
     public function setQuestiontext(string $questiontext = ""): void

--- a/components/ILIAS/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPool.php
+++ b/components/ILIAS/SurveyQuestionPool/classes/class.ilObjSurveyQuestionPool.php
@@ -331,7 +331,7 @@ class ilObjSurveyQuestionPool extends ilObject
         } else {
             $title = $question->getTitle() . $suffix;
         }
-        $question->duplicate(false, $title, $ilUser->fullname, $ilUser->id);
+        $question->duplicate(false, $title, $ilUser->getFullname(), $ilUser->id);
     }
 
     /**


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45841

This PR aim to fix the issue described in the Mantis ticket by replacing direct access to the private property ilObjUser::$fullname with the corresponding getter method.