### PR TITLE
43780: Missing aria-describedby with form element "Select files" in new text exercise unit

### DIFF
--- a/components/ILIAS/Form/resources/filewizard.js
+++ b/components/ILIAS/Form/resources/filewizard.js
@@ -45,6 +45,7 @@ var ilFileWizardInputTemplate = {
 			$(this).find('input:file').each(function () {
 				that.handleId(this, 'id', rowindex);
 				that.handleId(this, 'name', rowindex);
+				that.handleId(this, 'aria-describedby', rowindex);
 			});
 
 			// hidden
@@ -56,6 +57,11 @@ var ilFileWizardInputTemplate = {
 			$(this).find('> span').each(function () {
 				that.handleId(this, 'id', rowindex);
 				that.handleId(this, 'data-name', rowindex);
+			});
+
+			// help text
+			$(this).find('> div.help-blocks').each(function () {
+				that.handleId(this, 'id', rowindex);
 			});
 
 			rowindex++;

--- a/components/ILIAS/Form/templates/default/tpl.prop_filewizardinput.html
+++ b/components/ILIAS/Form/templates/default/tpl.prop_filewizardinput.html
@@ -2,18 +2,20 @@
 <!-- BEGIN row -->
 	<div class="wzdrow form-inline">
 	<!-- BEGIN image -->	<img style="margin: 5px 0px 5px 0px;" src="{SRC_IMAGE}" alt="{ALT_IMAGE}" {WIDTH} {HEIGHT}  /><input type="hidden" name="picture_{ID}" value="{PICTURE_FILE}" /><br /><!-- END image -->
-		<input type="file" class="form-control" id="{ID}" name="{POST_VAR}" size="30" />
+		<input type="file" class="form-control" id="{ID}" name="{POST_VAR}" size="30" aria-describedby="upload_helptext_{ID}" />
 		<span id="add_{ID}" class="imagewizard_add btn btn-link" data-name="{CMD_ADD}" data-val="{MAX_UPLOAD_VALUE}">{ADD_BUTTON}</span>
 		<span id="remove_{ID}" class="imagewizard_remove btn btn-link" data-name="{CMD_REMOVE}" data-val="{MAX_UPLOAD_VALUE}">{REMOVE_BUTTON}</span>
 	<!-- BEGIN move -->
 		<span id="up_{ID}" class="imagewizard_up btn btn-link" data-name="{CMD_UP}">{UP_BUTTON}</span>
 		<span id="down_{ID}" class="imagewizard_down btn btn-link" data-name="{CMD_DOWN}">{DOWN_BUTTON}</span>
 	<!-- END move -->
-		<div class="help-block">{TXT_MAX_SIZE}</div>
-		<div class="help-block">{TXT_MAX_UPLOADS}</div>
-	<!-- BEGIN allowed_image_suffixes -->
-		<div class="help-block">{TXT_ALLOWED_SUFFIXES}</div>
-	<!-- END allowed_image_suffixes -->
+		<div id="upload_helptext_{ID}" class="help-blocks">
+			<div class="help-block">{TXT_MAX_SIZE}</div>
+			<div class="help-block">{TXT_MAX_UPLOADS}</div>
+			<!-- BEGIN allowed_image_suffixes -->
+			<div class="help-block">{TXT_ALLOWED_SUFFIXES}</div>
+			<!-- END allowed_image_suffixes -->
+		</div>
 	</div>
 <!-- END row -->
 </div>


### PR DESCRIPTION
This PR addresses the accessibility issue [43780](https://mantis.ilias.de/view.php?id=43780). It adds the `aria-describedby`  attribute to the file input element for the file wizard.

It also ensures the correct div ID is used when another file input is added.

https://mantis.ilias.de/view.php?id=43780
