### PR TITLE
Update FileDelivery service README

### DIFF
--- a/src/FileDelivery/README.md
+++ b/src/FileDelivery/README.md
@@ -69,7 +69,7 @@ $file_delivery->legacyDelivery()->inline(
 # Signed Delivery
 
 The IRSS uses exclusively streamss for files and flavours, from ILIAS 9 also for structured data (e.g. later for HTML
-learning modules or SCORM learning modules). Up to ILIAS 9 these dtaeias are also delivered via a special mechanism
+learning modules or SCORM learning modules). Up to ILIAS 9 these files are also delivered via a special mechanism
 through the WebAccessChecker. Now streams can be delivered very easily via a token-based way to protect the files. This
 will be the general way to deliver the files in the future and will replace the WebAccessChecker completely in the
 medium term.
@@ -85,8 +85,9 @@ signature, a secret key as well as a salt is used depending on the use case.
 The serialized payload is merged with the signature, compressed, and formatted for embedding in URLs.
 Once a token is then to be verified, the following happens: URl preparation is reversed, and the data is decompressed.
 The result consists of the serialized payload and the signature. A new signature is now made for the payload and
-compared with the one supplied. If these are identical, it is certain that the dtaen are valid and have not been
+compared with the one supplied. If these are identical, it is certain that the data is valid and has not been
 manipulated.
+
 The mechanism uses a key rotation, currently always 5 keys are kept. with a composer install / dump-autoload a new key
 is generated in each case.
 
@@ -105,7 +106,7 @@ use ILIAS\FileDelivery\Token\Compression\DeflateCompression;
 use ILIAS\FileDelivery\Token\Transport\URLSafeTransport;
 
 // This is the payload we want to sign. It should use a "personal" component, e.g. the user ID, and a "global" component, e.g. the path to the file.
- 
+
 $payload = [
     'user_id' => 123,
     'uri' => '/path/to/file',
@@ -135,7 +136,7 @@ $signer = new KeyRotatingSigner(
 $signature = $signer->sign($signable_payload, new Salt('salt'));
 // $signature = '...';
 
-// we can now merge the payload and the signature. 
+// we can now merge the payload and the signature.
 $signed_payload = $signable_payload.'|'.$signature;
 // $signed_payload = '{"user_id":123,"uri":"/path/to/file"}|1631631631|...';
 

--- a/src/FileDelivery/README.md
+++ b/src/FileDelivery/README.md
@@ -74,6 +74,36 @@ through the WebAccessChecker. Now streams can be delivered very easily via a tok
 will be the general way to deliver the files in the future and will replace the WebAccessChecker completely in the
 medium term.
 
+## Usage
+
+The in-depth process is quite complex and is explained in detail further below in case you have more specialized needs.
+A simplyfied wrapper is offered to generate appropriate tokens for FileStreams, where you get a ready URL, which can
+then deliver the file, if the token is valid:
+
+```php
+use ILIAS\Filesystem\Stream\Streams;
+use ILIAS\FileDelivery\Delivery\Disposition;
+
+global $DIC;
+$stream = Streams::ofResource(fopen('/path/to/file', 'r'));
+$uri = $DIC->fileDelivery()->buildTokenURL(
+    $stream,
+    'Download-Filename.png',
+    Disposition::INLINE
+    123 // user_id
+    6 // valid for at least 6 hours
+)
+
+// $uri = 'http://trunk.ilias.localhost/src/FileDelivery/deliver.php/LY3NasMwEITy[...]RFiKcUmOmJx8Ac'
+```
+
+This mechanism is then simply used, for example, to deliver structured resources (container resources). A URL on HTML
+learning module can then look like this:
+
+```
+http://trunk.ilias.localhost/src/FileDelivery/deliver.php/LY3NasMwEITy[...]RFiKcUmOmJx8Ac/index.html
+```
+
 ## How does the Signing work in general?
 
 The project ["It's Dangerous"](https://itsdangerous.palletsprojects.com/en/2.1.x/) was used as inspiration for the
@@ -203,31 +233,4 @@ if($is_valid) {
     // the token is invalid
     $payload = null;
 }
-```
-
-Since this process is quite complex, this is simply offered to generate appropriate tokens for FileStreams. You get a
-ready URL, which can then deliver the file, if the token is valid:
-
-```php
-use ILIAS\Filesystem\Stream\Streams;
-use ILIAS\FileDelivery\Delivery\Disposition;
-
-global $DIC;
-$stream = Streams::ofResource(fopen('/path/to/file', 'r'));
-$uri = $DIC->fileDelivery()->buildTokenURL(
-    $stream,
-    'Download-Filename.png',
-    Disposition::INLINE
-    123 // user_id
-    6 // valid for at least 6 hours
-)
-
-// $uri = 'http://trunk.ilias.localhost/src/FileDelivery/deliver.php/LY3NasMwEITy[...]RFiKcUmOmJx8Ac'
-```
-
-This mechanism is then simply used, for example, to deliver structured resources (container resources). A URL on HTML
-learning module can then look like this:
-
-```
-http://trunk.ilias.localhost/src/FileDelivery/deliver.php/LY3NasMwEITy[...]RFiKcUmOmJx8Ac/index.html
 ```

--- a/src/FileDelivery/README.md
+++ b/src/FileDelivery/README.md
@@ -118,9 +118,6 @@ The result consists of the serialized payload and the signature. A new signature
 compared with the one supplied. If these are identical, it is certain that the data is valid and has not been
 manipulated.
 
-The mechanism uses a key rotation, currently always 5 keys are kept. with a composer install / dump-autoload a new key
-is generated in each case.
-
 ### Example:
 
 ```php
@@ -234,3 +231,23 @@ if($is_valid) {
     $payload = null;
 }
 ```
+
+### Key Rotation and Synchronization
+
+The standard Signed Delivery (`$DIC['file_delivery.data_signer']`) relies on a key rotation mechanism to ensure tokens
+remain secure over time.
+- **Rotation:** At any given point, five keys are kept in rotation.
+- **Generation:** Keys are automatically generated and rotated _whenever_ `composer install`
+  or `composer dump-autoload` is executed.
+- **Location:** The rotation keys are stored and managed as an artifact in:
+  `./src/FileDelivery/artifacts/key_rotation.php`
+
+# Important for System Administrators
+
+The artifact file `./src/FileDelivery/artifacts/key_rotation.php` must be synchronized across all php host deployments.
+If one deployment generates a new set of keys that others do not share, tokens signed by that php process cannot be
+verified by the others. In such a case, requests will be rejected as invalid.
+
+- If you don't have multiple php hosts you are fine.
+- If you have multiple php hosts and deploy ILIAS code into a centralized storage like an NFS you are fine as well.
+- If you have multiple php hosts and deploy ILIAS code locally onto each host you'll need to sync the artifact after each composer run between all hosts!


### PR DESCRIPTION
This PR makes a few improvements to the FileDelivery service `README.md`, namely:

## Major Changes
- Moved basic usage example for Signed Delivery above in-depth explanation to improve reading flow and sort by relevance
- Move information about key rotation for Signed Delivery into its own section and added some more details
- Added server admin section to inform about key rotation artifact synchronisation and potential issues

## Minor Changes
- Fixed some errors that are probably typos (dtaeias, dtaen -> data)
- Removed / Trimmed some trailing whitespaces
- Added / Removed some line breaks for better readability

This PR applies to ILIAS 9, but all changes should be applied to the ILIAS 10 version as well.
(See <https://github.com/ILIAS-eLearning/ILIAS/blob/release_10/components/ILIAS/FileDelivery/README.md>)

I was also debating whether to add direct solutions for syncing key rotation artifact (eg. symlinking into or push/pull from shared NFS), but I think that would make more sense in the actual installation guide at <https://github.com/ILIAS-eLearning/ILIAS/blob/release_9/docs/configuration/install.md>