### PR TITLE
44583: adding first column heading in a table

### DIFF
--- a/Modules/Exercise/Assignment/class.ilAssignmentsTableGUI.php
+++ b/Modules/Exercise/Assignment/class.ilAssignmentsTableGUI.php
@@ -63,7 +63,7 @@ class ilAssignmentsTableGUI extends ilTable2GUI
         // fix saving of ordering of single pages!
         $this->setLimit(9999);
 
-        $this->addColumn("", "", "1", true);
+        $this->addColumn($this->lng->txt("exc_assignment_selection"), "");
         $this->addColumn($this->lng->txt("title"), "title");
         $this->addColumn($this->lng->txt("exc_assignment_type"), "type");
         $this->addColumn($this->lng->txt("exc_presentation_order"), "order_val");

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -9207,6 +9207,7 @@ exc#:#exc_ass_submission_zip#:#Abgaben
 exc#:#exc_ass_team_wiki#:#Team-Wiki
 exc#:#exc_assignment#:#Übungseinheit
 exc#:#exc_assignment_list#:#Liste der Übungseinheiten
+exc#:#exc_assignment_selection#:#Auswahl
 exc#:#exc_assignment_type#:#Abgabetyp
 exc#:#exc_assignment_view#:#Je Übungseinheit
 exc#:#exc_assignments#:#Übungseinheiten

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -9207,6 +9207,7 @@ exc#:#exc_ass_submission_zip#:#Submissions
 exc#:#exc_ass_team_wiki#:#Assignment Team Wiki
 exc#:#exc_assignment#:#Assignment
 exc#:#exc_assignment_list#:#Assignments List
+exc#:#exc_assignment_selection#:#Selection
 exc#:#exc_assignment_type#:#Type of Submission
 exc#:#exc_assignment_view#:#Assignment View
 exc#:#exc_assignments#:#Assignments


### PR DESCRIPTION
This PR addresses accessibility issue 44583: First column heading in a table has no heading
https://mantis.ilias.de/view.php?id=44583
