### PR TITLE
Fix/44424 add lable course member and  edit

### DIFF
--- a/components/ILIAS/Search/classes/class.ilRepositorySearchGUI.php
+++ b/components/ILIAS/Search/classes/class.ilRepositorySearchGUI.php
@@ -251,13 +251,13 @@ class ilRepositorySearchGUI
         }
 
         if (isset($a_options['user_type']) && count((array) $a_options['user_type'])) {
-            $si = new ilSelectInputGUI("", "user_type");
+            $si = new ilSelectInputGUI($lng->txt("course_role"), "user_type");
             $si->setOptions($a_options['user_type']);
             $si->setValue($a_options['user_type_default']);
             if (!$a_sticky) {
-                $toolbar->addInputItem($si);
+                $toolbar->addInputItem($si, true);      // ← add true
             } else {
-                $toolbar->addStickyItem($si);
+                $toolbar->addStickyItem($si, true);     // ← add true
             }
         }
 

--- a/components/ILIAS/Table/classes/class.ilTable2GUI.php
+++ b/components/ILIAS/Table/classes/class.ilTable2GUI.php
@@ -2320,10 +2320,21 @@ class ilTable2GUI extends ilTableGUI
                 foreach ($this->multi as $mc) {
                     $sel[$mc["cmd"]] = $mc["text"];
                 }
+                // add aria-label only to the TOP dropdown (name="selected_cmd2")
                 $this->tpl->setVariable(
                     "SELECT_CMDS",
-                    ilLegacyFormElementsUtil::formSelect("", "selected_cmd2", $sel, false, true)
+                    ilLegacyFormElementsUtil::formSelect(
+                        "",                      // selected
+                        "selected_cmd2",         // name
+                        $sel,                    // options
+                        false,                   // use_multi
+                        true,                    // submit_after_change
+                        0,                       // size
+                        "",                      // css class
+                        array("aria-label" => $lng->txt("action")) // <-- localized aria-label
+                    )
                 );
+                
                 $this->tpl->setVariable("TXT_EXECUTE", $lng->txt("execute"));
                 $this->tpl->parseCurrentBlock();
             }

--- a/lang/ilias_ar.lang
+++ b/lang/ilias_ar.lang
@@ -4384,6 +4384,7 @@ common#:#il_blog_editor#:#Blog-Editor###30 08 2015 new variable
 common#:#il_chat_moderator#:#مشرف الدردشة
 common#:#il_crs_admin#:#مدير الدورة
 common#:#il_crs_member#:#عضو دورة
+common#:#course_role#:#دور الدورة
 common#:#il_crs_non_member#:#ليس عضو دورة
 common#:#il_crs_tutor#:#مدرس دورة
 common#:#il_frm_moderator#:#مشرف منتدى

--- a/lang/ilias_bg.lang
+++ b/lang/ilias_bg.lang
@@ -4382,6 +4382,7 @@ common#:#il_astpl_loc_qualified#:#Qualifying Test###26 09 2014 new variable
 common#:#il_blog_contributor#:#Blog Contributor###28 09 2012 new variable
 common#:#il_blog_editor#:#Blog-Editor###30 08 2015 new variable
 common#:#il_chat_moderator#:#Chat moderator###06 09 2006 new variable
+common#:#course_role#:#Роля на курса
 common#:#il_crs_admin#:#Course administrator###06 09 2006 new variable
 common#:#il_crs_member#:#Course member###06 09 2006 new variable
 common#:#il_crs_non_member#:#Course non-member###26 07 2008 new variable

--- a/lang/ilias_cs.lang
+++ b/lang/ilias_cs.lang
@@ -4382,6 +4382,7 @@ common#:#il_astpl_loc_qualified#:#Kvalifikační test
 common#:#il_blog_contributor#:#Přispěvatel Blogu
 common#:#il_blog_editor#:#Blog-Editor
 common#:#il_chat_moderator#:#Moderátor besedy
+common#:#course_role#:#Role kurzu
 common#:#il_crs_admin#:#Správce kurzu
 common#:#il_crs_member#:#Člen kurzu
 common#:#il_crs_non_member#:#Nečlen kurzu

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -4383,6 +4383,7 @@ common#:#il_astpl_loc_qualified#:#Qualifizierender Test
 common#:#il_blog_contributor#:#Blog-Autorenschaft
 common#:#il_blog_editor#:#Blog-Redaktion
 common#:#il_chat_moderator#:#Chatmoderation
+common#:#course_role#:#Kursrolle
 common#:#il_crs_admin#:#Kursadministration
 common#:#il_crs_member#:#Kursmitglied
 common#:#il_crs_non_member#:#Kein Kursmitglied

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -3966,6 +3966,7 @@ common#:#deliver#:#Deliver
 common#:#deny_usr_agreement#:#Do Not Accept Terms of Service?
 common#:#deny_usr_agreement_btn#:#Do Not Accept
 common#:#department#:#Department
+
 common#:#desc#:#Description
 common#:#description#:#Description
 common#:#desired_password#:#New Password
@@ -4384,6 +4385,7 @@ common#:#il_astpl_loc_qualified#:#Qualifying Test
 common#:#il_blog_contributor#:#Blog Author
 common#:#il_blog_editor#:#Blog Editor
 common#:#il_chat_moderator#:#Chat Moderator
+common#:#course_role#:#Course Role
 common#:#il_crs_admin#:#Course Administrator
 common#:#il_crs_member#:#Course Member
 common#:#il_crs_non_member#:#Course non-member


### PR DESCRIPTION
Fixes missing accessible label for the user category dropdown in the Members tab.
Added a <label> element (“ course role”) linked to the dropdown.

https://mantis.ilias.de/view.php?id=44424