### PR TITLE
9/LegacyUI/ContainerHeight Fix for empty item group header, Mantis #45548

### DIFF
--- a/templates/default/070-components/legacy/Services/_component_container.scss
+++ b/templates/default/070-components/legacy/Services/_component_container.scss
@@ -2,7 +2,8 @@
 @use "../../../010-settings/legacy-settings/legacy-settings_symbol" as *;
 @use "../../../010-settings/legacy-settings/legacy-settings_panel" as *;
 @use "../../../050-layout/basics" as *;
-
+@use "../../../010-settings/legacy-settings/legacy-settings_form" as sform;
+@use "../../../050-layout/basics" as basic;
 
 /* Services/Container */
 div.il_Preconditions {
@@ -127,6 +128,8 @@ div.il_ContainerListItem {
 	font-weight: $il-font-weight-base;
 	text-align: left;
 	vertical-align: middle;
+    min-height: sform.$il-input-min-height + basic.$il-padding-xlarge-vertical * 2;
+
 	h3{
 		margin: 0;
 		color: $il-panel-heading-color;

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -14046,6 +14046,7 @@ div.il_ContainerListItem {
   font-weight: 400;
   text-align: left;
   vertical-align: middle;
+  min-height: 46px;
 }
 .ilContainerBlockHeader h3 {
   margin: 0;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45548

# ISSUE

When disabling the title of an item group, the dropdown was outside the document flow and didn't cause the correct height for the header.


# Change

<img width="678" height="604" alt="grafik" src="https://github.com/user-attachments/assets/fae7c318-4396-436e-a44b-dcafc48eabaa" />
<img width="674" height="644" alt="grafik" src="https://github.com/user-attachments/assets/1a47bcde-e970-4593-a286-48f15d38c30f" />

- Implement min-height for .ilContainerBlockHeader calculated by dropdown-size and paddings


# Larger Scope

We should implement an example for panels without title in KitchenSink
