### PR TITLE
9/container/fix 45830

### DIFF
--- a/Modules/Course/classes/Objectives/Setup/ilCourseCleanupActivationMigration.php
+++ b/Modules/Course/classes/Objectives/Setup/ilCourseCleanupActivationMigration.php
@@ -65,6 +65,9 @@ class ilCourseCleanupActivationMigration implements Migration
         );
 
         if ($parent_data === null) {
+            $this->db->manipulate(
+                "DELETE FROM crs_items WHERE obj_id = {$activation_data->obj_id}"
+            );
             return;
         }
 

--- a/Modules/Course/classes/Objectives/Setup/ilCourseCleanupActivationMigration.php
+++ b/Modules/Course/classes/Objectives/Setup/ilCourseCleanupActivationMigration.php
@@ -59,20 +59,26 @@ class ilCourseCleanupActivationMigration implements Migration
         }
 
         $parent_data = $this->db->fetchObject(
-            $this->db->query(
-                "SELECT parent FROM tree WHERE child={$activation_data->obj_id}"
+            $this->db->queryF(
+                'SELECT parent FROM tree WHERE child=%s',
+                [ilDBConstants::T_INTEGER],
+                [$activation_data->obj_id]
             )
         );
 
         if ($parent_data === null) {
-            $this->db->manipulate(
-                "DELETE FROM crs_items WHERE obj_id = {$activation_data->obj_id}"
+            $this->db->manipulateF(
+                'DELETE FROM crs_items WHERE obj_id = %s',
+                [ilDBConstants::T_INTEGER],
+                [$activation_data->obj_id]
             );
             return;
         }
 
-        $this->db->manipulate(
-            "DELETE FROM crs_items WHERE obj_id = {$activation_data->obj_id} AND parent_id != {$parent_data->parent}"
+        $this->db->manipulateF(
+            'DELETE FROM crs_items WHERE obj_id = %s AND parent_id != %s',
+            [ilDBConstants::T_INTEGER, ilDBConstants::T_INTEGER],
+            [$activation_data->obj_id, $parent_data->parent]
         );
     }
 

--- a/Modules/Course/classes/Objectives/Setup/ilCourseCleanupActivationMigration.php
+++ b/Modules/Course/classes/Objectives/Setup/ilCourseCleanupActivationMigration.php
@@ -27,7 +27,7 @@ class ilCourseCleanupActivationMigration implements Migration
 
     public function getLabel(): string
     {
-        return "Remove Duplicate Roles In Activation Table";
+        return "Remove Duplicate Rows In Activation Table";
     }
 
     public function getDefaultAmountOfStepsPerRun(): int

--- a/Modules/Course/classes/Objectives/Setup/ilCourseCleanupActivationMigration.php
+++ b/Modules/Course/classes/Objectives/Setup/ilCourseCleanupActivationMigration.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+use ILIAS\Setup\Migration;
+use ILIAS\Setup\Environment;
+
+class ilCourseCleanupActivationMigration implements Migration
+{
+    private \ilDBInterface $db;
+
+    public function getLabel(): string
+    {
+        return "Remove Duplicate Roles In Activation Table";
+    }
+
+    public function getDefaultAmountOfStepsPerRun(): int
+    {
+        return 10000;
+    }
+
+    public function getPreconditions(Environment $environment): array
+    {
+        return \ilResourceStorageMigrationHelper::getPreconditions();
+    }
+
+    public function prepare(Environment $environment): void
+    {
+        $this->db = $environment->getResource(Environment::RESOURCE_DATABASE);
+    }
+
+    public function step(Environment $environment): void
+    {
+        $activation_data = $this->db->fetchObject(
+            $this->db->query(
+                'SELECT obj_id FROM crs_items' . PHP_EOL
+                . 'GROUP BY obj_id HAVING COUNT(*) > 1 LIMIT 1'
+            )
+        );
+
+        if ($activation_data === null) {
+            return;
+        }
+
+        $parent_data = $this->db->fetchObject(
+            $this->db->query(
+                "SELECT parent FROM tree WHERE child={$activation_data->obj_id}"
+            )
+        );
+
+        if ($parent_data === null) {
+            return;
+        }
+
+        $this->db->manipulate(
+            "DELETE FROM crs_items WHERE obj_id = {$activation_data->obj_id} AND parent_id != {$parent_data->parent}"
+        );
+    }
+
+    public function getRemainingAmountOfSteps(): int
+    {
+        return $this->db->numRows(
+            $this->db->query(
+                'SELECT obj_id, parent_id FROM crs_items GROUP BY obj_id HAVING COUNT(*) > 1'
+            )
+        );
+    }
+}

--- a/Modules/Course/classes/Objectives/Setup/ilCourseObjectiveSetupAgent.php
+++ b/Modules/Course/classes/Objectives/Setup/ilCourseObjectiveSetupAgent.php
@@ -18,16 +18,21 @@
 
 declare(strict_types=1);
 
-use ILIAS\Setup\Agent\NullAgent;
+use ILIAS\Setup\Agent;
 use ILIAS\Setup\Objective;
 use ILIAS\Setup\Metrics;
 use ILIAS\Setup\Config;
 use ILIAS\Setup;
 use ILIAS\Refinery\Transformation;
 
-class ilCourseObjectiveSetupAgent extends NullAgent
+class ilCourseObjectiveSetupAgent implements Agent
 {
     use Setup\Agent\HasNoNamedObjective;
+
+    public function hasConfig(): bool
+    {
+        return false;
+    }
 
     public function getUpdateObjective(ILIAS\Setup\Config $config = null): Objective
     {

--- a/Modules/Course/classes/Objectives/Setup/ilCourseObjectiveSetupAgent.php
+++ b/Modules/Course/classes/Objectives/Setup/ilCourseObjectiveSetupAgent.php
@@ -53,4 +53,11 @@ class ilCourseObjectiveSetupAgent extends NullAgent
     {
         return new Setup\Objective\NullObjective();
     }
+
+    public function getMigrations(): array
+    {
+        return [
+            new ilCourseCleanupActivationMigration()
+        ];
+    }
 }

--- a/Services/Container/classes/class.ilContainerGUI.php
+++ b/Services/Container/classes/class.ilContainerGUI.php
@@ -1422,6 +1422,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                     $rbacadmin->adjustMovedObjectPermissions($ref_id, $old_parent);
 
                     ilConditionHandler::_adjustMovedObjectConditions($ref_id);
+                    $availability = new ilObjectActivation();
+                    $availability->read($ref_id);
+                    $availability->update($ref_id, $folder_ref_id);
 
                     // BEGIN ChangeEvent: Record cut event.
                     $node_data = $tree->getNodeData($ref_id);
@@ -1738,6 +1741,9 @@ class ilContainerGUI extends ilObjectGUI implements ilDesktopItemHandling
                 $rbacadmin->adjustMovedObjectPermissions($ref_id, $old_parent);
 
                 ilConditionHandler::_adjustMovedObjectConditions($ref_id);
+                $availability = new ilObjectActivation();
+                $availability->read($ref_id);
+                $availability->update($ref_id, $this->object->getRefId());
 
                 // BEGIN ChangeEvent: Record cut event.
                 $node_data = $tree->getNodeData($ref_id);


### PR DESCRIPTION
Hi @alex40724 

This PR forces an update of the parent_id of the activation info in 'crs_items' on paste. This has to happen in the Container.

It also provides a migration for cases where things went sideways already. This is in Course as the table is actually in the course.

If accepted this has to be picked to ILIAS 10 and trunk.

Best,
@kergomard 