### PR TITLE
T&A 45856: Removes method call of resetRequestedHints

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assQuestionGUI.php
@@ -2057,7 +2057,6 @@ abstract class assQuestionGUI
         );
         $this->preview_session->setRandomizerSeed(null);
         $this->preview_session->setParticipantsSolution(null);
-        $this->preview_session->resetRequestedHints();
         $this->preview_session->setInstantResponseActive(false);
     }
 }


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45856

Aims to fix the wrongfull calling of the removed method `resetRequestedHints`.