### PR TITLE
T&A 45712: Fix answering of essay question

### DIFF
--- a/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
+++ b/components/ILIAS/TestQuestionPool/classes/class.assTextQuestion.php
@@ -410,7 +410,7 @@ class assTextQuestion extends assQuestion implements ilObjQuestionScoringAdjusta
     {
         $text = $this->questionpool_request->string('TEXT', '');
 
-        $text = (new ilRTESettings($this->lng, $this->current_user))->setRichTextEditor() === 'tinymce'
+        $text = (new ilRTESettings($this->lng, $this->current_user))->getRichTextEditor() === 'tinymce'
             ? ilUtil::stripSlashes($text, false)
             : htmlentities($text);
 


### PR DESCRIPTION
This PR is related to Mantis Ticket https://mantis.ilias.de/view.php?id=45712
It fixes a typo in the method call that was preventing the code from functioning correctly.

Best,
@thojou 