### PR TITLE
NW 45740: Replaces strings with class names in all news module ByClass methods with class name constants

### DIFF
--- a/Modules/Course/classes/class.ilObjCourseGUI.php
+++ b/Modules/Course/classes/class.ilObjCourseGUI.php
@@ -1838,7 +1838,7 @@ class ilObjCourseGUI extends ilContainerGUI
                 $this->tabs_gui->addTab(
                     "news_timeline",
                     $this->lng->txt("cont_news_timeline_tab"),
-                    $this->ctrl->getLinkTargetByClass("ilnewstimelinegui", "show")
+                    $this->ctrl->getLinkTargetByClass(ilNewsTimelineGUI::class, "show")
                 );
                 if ($this->object->isNewsTimelineLandingPageEffective()) {
                     $this->addContentTab();
@@ -2368,7 +2368,7 @@ class ilObjCourseGUI extends ilContainerGUI
                 $this->ctrl->forwardCommand($news_set_gui);
                 break;
 
-            case "ilnewstimelinegui":
+            case strtolower(ilNewsTimelineGUI::class):
                 if (!$this->__checkStartObjects()) {    // see #37236
                     $this->ctrl->redirectByClass(self::class, "view");
                 }
@@ -2465,7 +2465,7 @@ class ilObjCourseGUI extends ilContainerGUI
                 }
                 // if news timeline is landing page, redirect if necessary
                 if ($cmd == "" && $this->object->isNewsTimelineLandingPageEffective()) {
-                    $this->ctrl->redirectByClass("ilnewstimelinegui");
+                    $this->ctrl->redirectByClass(ilNewsTimelineGUI::class);
                 }
 
                 if (!$cmd) {

--- a/Modules/Group/classes/class.ilObjGroupGUI.php
+++ b/Modules/Group/classes/class.ilObjGroupGUI.php
@@ -107,7 +107,7 @@ class ilObjGroupGUI extends ilContainerGUI
         // if news timeline is landing page, redirect if necessary
         if ($next_class == "" && $cmd == "" && $this->object->isNewsTimelineLandingPageEffective()
             && $this->access->checkAccess("read", "", $ref_id)) {
-            $this->ctrl->redirectByClass("ilnewstimelinegui");
+            $this->ctrl->redirectByClass(ilNewsTimelineGUI::class);
         }
 
         $header_action = true;
@@ -335,7 +335,7 @@ class ilObjGroupGUI extends ilContainerGUI
                 $this->ctrl->forwardCommand($news_set_gui);
                 break;
 
-            case "ilnewstimelinegui":
+            case strtolower(ilNewsTimelineGUI::class):
                 $this->checkPermission("read");
                 $this->tabs_gui->setTabActive('news_timeline');
                 $t = ilNewsTimelineGUI::getInstance($this->object->getRefId(), $this->object->getNewsTimelineAutoENtries());
@@ -1047,7 +1047,7 @@ class ilObjGroupGUI extends ilContainerGUI
                 $this->tabs_gui->addTab(
                     "news_timeline",
                     $this->lng->txt("cont_news_timeline_tab"),
-                    $this->ctrl->getLinkTargetByClass("ilnewstimelinegui", "show")
+                    $this->ctrl->getLinkTargetByClass(ilNewsTimelineGUI::class, "show")
                 );
                 if ($this->object->isNewsTimelineLandingPageEffective()) {
                     $this->addContentTab();

--- a/Services/News/classes/class.ilNewsForContextBlockGUI.php
+++ b/Services/News/classes/class.ilNewsForContextBlockGUI.php
@@ -175,7 +175,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
         $ilCtrl = $DIC->ctrl();
 
-        if (strtolower($ilCtrl->getCmdClass()) === "ilnewsitemgui") {
+        if (strcasecmp($ilCtrl->getCmdClass(), ilNewsItemGUI::class) === 0) {
             return IL_SCREEN_FULL;
         }
 
@@ -195,21 +195,14 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
     public function executeCommand()
     {
-        $ilCtrl = $this->ctrl;
-
-        $next_class = $ilCtrl->getNextClass();
-        $cmd = $ilCtrl->getCmd("getHTML");
-
-        switch ($next_class) {
-            case "ilnewsitemgui":
-                $news_item_gui = new ilNewsItemGUI();
-                $news_item_gui->setEnableEdit($this->getEnableEdit());
-                $html = $ilCtrl->forwardCommand($news_item_gui);
-                return $html;
-
-            default:
-                return $this->$cmd();
+        if (strcasecmp($this->ctrl->getNextClass(), ilNewsItemGUI::class) === 0) {
+            $news_item_gui = new ilNewsItemGUI();
+            $news_item_gui->setEnableEdit($this->getEnableEdit());
+            return $this->ctrl->forwardCommand($news_item_gui);
         }
+
+        $cmd = $this->ctrl->getCmd("getHTML");
+        return $this->$cmd();
     }
 
     public function getHTML(): string
@@ -252,13 +245,13 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         // add edit commands
         if ($this->news_access->canAdd()) {
             $this->addBlockCommand(
-                $ilCtrl->getLinkTargetByClass("ilnewsitemgui", "editNews"),
+                $ilCtrl->getLinkTargetByClass(ilNewsItemGUI::class, "editNews"),
                 $lng->txt("edit")
             );
 
             $ilCtrl->setParameter($this, "add_mode", "block");
             $this->addBlockCommand(
-                $ilCtrl->getLinkTargetByClass("ilnewsitemgui", "createNewsItem"),
+                $ilCtrl->getLinkTargetByClass(ilNewsItemGUI::class, "createNewsItem"),
                 $lng->txt("add")
             );
             $ilCtrl->setParameter($this, "add_mode", "");
@@ -272,11 +265,11 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
             $obj_class = strtolower($obj_def->getClassName($obj_type));
             $parent_gui = "ilobj" . $obj_class . "gui";
 
-            $ilCtrl->setParameterByClass("ilcontainernewssettingsgui", "ref_id", $ref_id);
+            $ilCtrl->setParameterByClass(ilContainerNewsSettingsGUI::class, "ref_id", $ref_id);
 
             if (in_array($obj_class, self::OBJECTS_WITH_NEWS_SUBTAB)) {
                 $this->addBlockCommand(
-                    $ilCtrl->getLinkTargetByClass(["ilrepositorygui", $parent_gui, "ilcontainernewssettingsgui"], "show"),
+                    $ilCtrl->getLinkTargetByClass([ilRepositoryGUI::class, $parent_gui, ilContainerNewsSettingsGUI::class], "show"),
                     $lng->txt("settings")
                 );
             } else {
@@ -673,9 +666,9 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
 
                 // file hack, not nice
                 if ($obj_type === "file") {
-                    $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $item["ref_id"]);
-                    $url = $ilCtrl->getLinkTargetByClass("ilrepositorygui", "sendfile");
-                    $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $this->std_request->getRefId());
+                    $ilCtrl->setParameterByClass(ilRepositoryGUI::class, "ref_id", $item["ref_id"]);
+                    $url = $ilCtrl->getLinkTargetByClass(ilRepositoryGUI::class, "sendfile");
+                    $ilCtrl->setParameterByClass(ilRepositoryGUI::class, "ref_id", $this->std_request->getRefId());
 
                     $button = $this->gui->button(
                         $this->lng->txt("download"),
@@ -1207,7 +1200,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $lng = $this->lng;
 
         $ilCtrl->setParameterByClass(
-            "ilcolumngui",
+            ilColumnGUI::class,
             "block_id",
             "block_" . $this->getBlockType() . "_" . $this->getBlockId()
         );
@@ -1217,14 +1210,14 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $rel_tpl->setVariable("BLOCK_ID", "block_" . $this->getBlockType() . "_" . $this->getBlockId());
         $rel_tpl->setVariable(
             "TARGET",
-            $ilCtrl->getLinkTargetByClass("ilcolumngui", "updateBlock", "", true)
+            $ilCtrl->getLinkTargetByClass(ilColumnGUI::class, "updateBlock", "", true)
         );
 
         // no JS
         $rel_tpl->setVariable("TXT_NEWS_CLICK_HERE", $lng->txt("news_no_js_click_here"));
         $rel_tpl->setVariable(
             "TARGET_NO_JS",
-            $ilCtrl->getLinkTargetByClass(strtolower(get_class($this)), "disableJS")
+            $ilCtrl->getLinkTarget($this, "disableJS")
         );
 
         return $rel_tpl->get();
@@ -1235,7 +1228,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $ilCtrl = $this->ctrl;
 
         $ilCtrl->setParameterByClass(
-            "ilcolumngui",
+            ilColumnGUI::class,
             "block_id",
             "block_" . $this->getBlockType() . "_" . $this->getBlockId()
         );
@@ -1244,7 +1237,7 @@ class ilNewsForContextBlockGUI extends ilBlockGUI
         $rel_tpl->setVariable("BLOCK_ID", "block_" . $this->getBlockType() . "_" . $this->getBlockId());
         $rel_tpl->setVariable(
             "TARGET",
-            $ilCtrl->getLinkTargetByClass(strtolower(get_class($this)), "enableJS", "", true, false)
+            $ilCtrl->getLinkTarget($this, "enableJS", "", true, false)
         );
 
         return $rel_tpl->get();

--- a/Services/News/classes/class.ilNewsForContextTableGUI.php
+++ b/Services/News/classes/class.ilNewsForContextTableGUI.php
@@ -142,10 +142,10 @@ class ilNewsForContextTableGUI extends ilTable2GUI
         if ($this->news_access->canEdit($news_item)) {
             $this->tpl->setCurrentBlock("edit");
             $this->tpl->setVariable("TXT_EDIT", $lng->txt("edit"));
-            $ilCtrl->setParameterByClass("ilnewsitemgui", "news_item_id", $a_set["id"]);
+            $ilCtrl->setParameterByClass(ilNewsItemGUI::class, "news_item_id", $a_set["id"]);
             $this->tpl->setVariable(
                 "CMD_EDIT",
-                $ilCtrl->getLinkTargetByClass("ilnewsitemgui", "editNewsItem")
+                $ilCtrl->getLinkTargetByClass(ilNewsItemGUI::class, "editNewsItem")
             );
             $this->tpl->parseCurrentBlock();
         }

--- a/Services/News/classes/class.ilNewsTimelineItemGUI.php
+++ b/Services/News/classes/class.ilNewsTimelineItemGUI.php
@@ -126,7 +126,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
                     $i->getUpdateUserId(),
                     false,
                     true,
-                    $this->ctrl->getLinkTargetByClass("ilnewstimelinegui")
+                    $this->ctrl->getLinkTargetByClass(ilNewsTimelineGUI::class)
                 ) . " - ");
             }
             $tpl->setVariable("TIME_EDITED", ilDatePresentation::formatDate($update_date));
@@ -165,7 +165,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
         $tpl->setVariable("TXT_USR", $p->getNamePresentation(
             $i->getUserId(),
             true,
-            $this->ctrl->getLinkTargetByClass("ilnewstimelinegui")
+            $this->ctrl->getLinkTargetByClass(ilNewsTimelineGUI::class)
         ));
 
         $tpl->setVariable("TIME", ilDatePresentation::formatDate($this->getDateTime()));
@@ -225,13 +225,13 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
             $audio = $ui_factory->player()->audio($media_path);
             $html = $ui_renderer->render($audio);
         } elseif (in_array($mime, ["application/pdf"])) {
-            $this->ctrl->setParameterByClass("ilnewstimelinegui", "news_id", $i->getId());
+            $this->ctrl->setParameterByClass(ilNewsTimelineGUI::class, "news_id", $i->getId());
             $link = $ui_factory->link()->standard(
                 basename($media_path),
-                $this->ctrl->getLinkTargetByClass("ilnewstimelinegui", "downloadMob")
+                $this->ctrl->getLinkTargetByClass(ilNewsTimelineGUI::class, "downloadMob")
             );
             $html = $ui_renderer->render($link);
-            $this->ctrl->setParameterByClass("ilnewstimelinegui", "news_id", null);
+            $this->ctrl->setParameterByClass(ilNewsTimelineGUI::class, "news_id", null);
         } else {
             $html = "";
         }
@@ -269,7 +269,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
         $i = $this->getNewsItem();
 
         // like
-        $this->ctrl->setParameterByClass("ilnewstimelinegui", "news_id", $i->getId());
+        $this->ctrl->setParameterByClass(ilNewsTimelineGUI::class, "news_id", $i->getId());
         $this->like_gui->setObject(
             $i->getContextObjId(),
             $i->getContextObjType(),
@@ -295,7 +295,7 @@ class ilNewsTimelineItemGUI implements ilTimelineItemInt
         $html .= $comments_gui->getWidget();
         //$html .= $this->ctrl->getHTML($comments_gui);
 
-        $this->ctrl->setParameterByClass("ilnewstimelinegui", "news_id", $this->std_request->getNewsId());
+        $this->ctrl->setParameterByClass(ilNewsTimelineGUI::class, "news_id", $this->std_request->getNewsId());
 
         return $html . $this->renderMediaModal($i);
     }

--- a/Services/News/classes/class.ilObjNewsSettingsGUI.php
+++ b/Services/News/classes/class.ilObjNewsSettingsGUI.php
@@ -78,9 +78,9 @@ class ilObjNewsSettingsGUI extends ilObjectGUI
         if ($rbacsystem->checkAccess('edit_permission', $this->object->getRefId())) {
             $this->tabs_gui->addTarget(
                 "perm_settings",
-                $this->ctrl->getLinkTargetByClass('ilpermissiongui', "perm"),
+                $this->ctrl->getLinkTargetByClass(ilPermissionGUI::class, "perm"),
                 [],
-                'ilpermissiongui'
+                ilPermissionGUI::class
             );
         }
     }

--- a/Services/News/classes/class.ilPDNewsGUI.php
+++ b/Services/News/classes/class.ilPDNewsGUI.php
@@ -93,13 +93,13 @@ class ilPDNewsGUI
             return false;
         }
 
-        switch ($next_class) {
-            case "ilnewstimelinegui":
+        switch (strtolower($next_class)) {
+            case strtolower(ilNewsTimelineGUI::class):
                 $t = $this->gui->dashboard()->getTimelineGUI();
                 $this->ctrl->forwardCommand($t);
                 break;
 
-            case "ilcommonactiondispatchergui":
+            case strtolower(ilCommonActionDispatcherGUI::class):
                 $gui = ilCommonActionDispatcherGUI::getInstanceFromAjaxCall();
                 $this->ctrl->forwardCommand($gui);
                 break;

--- a/Services/News/classes/class.ilPDNewsTableGUI.php
+++ b/Services/News/classes/class.ilPDNewsTableGUI.php
@@ -230,9 +230,9 @@ class ilPDNewsTableGUI extends ilTable2GUI
 
         // file hack, not nice
         if ($obj_type === "file") {
-            $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $a_set["ref_id"]);
-            $url = $ilCtrl->getLinkTargetByClass("ilrepositorygui", "sendfile");
-            $ilCtrl->setParameterByClass("ilrepositorygui", "ref_id", $this->std_request->getRefId());
+            $ilCtrl->setParameterByClass(ilRepositoryGUI::class, "ref_id", $a_set["ref_id"]);
+            $url = $ilCtrl->getLinkTargetByClass(ilRepositoryGUI::class, "sendfile");
+            $ilCtrl->setParameterByClass(ilRepositoryGUI::class, "ref_id", $this->std_request->getRefId());
 
             $button = $this->gui->button(
                 $this->lng->txt("download"),

--- a/Services/Repository/classes/class.ilRepositoryGUI.php
+++ b/Services/Repository/classes/class.ilRepositoryGUI.php
@@ -173,7 +173,7 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
                 $this->ctrl->setCmdClass($next_class);
             }
         } elseif ((($next_class = $this->ctrl->getNextClass($this)) == "")
-            || ($next_class === "ilrepositorygui" && $this->ctrl->getCmd() === "return")) {
+            || (strcasecmp($next_class, ilRepositoryGUI::class) === 0 && $this->ctrl->getCmd() === "return")) {
             // get GUI of current object
             $obj_type = ilObject::_lookupType($this->cur_ref_id, true);
             $class_name = $this->objDefinition->getClassName($obj_type);
@@ -202,7 +202,7 @@ class ilRepositoryGUI implements ilCtrlBaseClassInterface
 
             default:
                 // forward all other classes to gui commands
-                if ($next_class !== null && $next_class !== "" && $next_class !== "ilrepositorygui") {
+                if ($next_class !== null && $next_class !== "" && strcasecmp($next_class, ilRepositoryGUI::class) !== 0) {
                     $class_path = $this->ctrl->lookupClassPath($next_class);
                     // get gui class instance
                     //require_once($class_path);


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45740

Aims to replace strings with class names in all news module ByClass methods with class name constants.

@thojou 