### PR TITLE
Mail: Fix Incoming Mail Trafo

### DIFF
--- a/components/ILIAS/Mail/src/UserSettings/IncomingMail.php
+++ b/components/ILIAS/Mail/src/UserSettings/IncomingMail.php
@@ -196,7 +196,9 @@ class IncomingMail implements SettingDefinition
                 }
                 return [
                     'incoming_mail' => $refinery->kindlyTo()->int()->transform($v[0]),
-                    'mail_address_option' => $refinery->kindlyTo()->int()->transform($email_address_option)
+                    'mail_address_option' => $email_address_option === null
+                        ? \ilMailOptions::FIRST_EMAIL
+                        : $refinery->kindlyTo()->int()->transform($email_address_option)
                 ];
             }
         );

--- a/components/ILIAS/Mail/src/UserSettings/NewMailNotification.php
+++ b/components/ILIAS/Mail/src/UserSettings/NewMailNotification.php
@@ -37,7 +37,7 @@ class NewMailNotification implements SettingDefinition
 
     public function isAvailable(): bool
     {
-        return (new \ilSetting())->get('mail_notification') === '1';
+        return (new \ilSetting())->get('show_mail_settings') === '1';
     }
 
     public function getLabel(Language $lng): string


### PR DESCRIPTION
Hi @mjansenDatabay 

This fixes an issue whereby saving the incoming-mail option to local only fails.
See: https://mantis.ilias.de/view.php?id=45861

Best,
@kergomard 