### PR TITLE
_10/UI/Form/Filter expand/collapse glyph with valid html 45422 43345 accessibility W3C validation

### DIFF
--- a/components/ILIAS/UI/src/Implementation/Component/Input/Container/Filter/Renderer.php
+++ b/components/ILIAS/UI/src/Implementation/Component/Input/Container/Filter/Renderer.php
@@ -106,10 +106,8 @@ class Renderer extends AbstractComponentRenderer
         $tpl->parseCurrentBlock();
 
         $tpl->setVariable("TITLE_FILTER", $this->txt("filter"));
-        $glyph_collapse = $f->symbol()->glyph()->collapse();
-        $tpl->setVariable("COLLAPSE_GLYPH", $default_renderer->render($glyph_collapse));
-        $glyph_expand = $f->symbol()->glyph()->expand();
-        $tpl->setVariable("EXPAND_GLYPH", $default_renderer->render($glyph_expand));
+        // Expand/collapse glyphs now in html tpl. KS Glyphs created invalid <a> tag in <button>.
+        // TODO: refactor expand/collapse as individual buttons with glyphs, as they render valid html
 
         $is_expanded = $component->isExpanded();
         $tpl->setVariable("ARIA_EXPANDED", $is_expanded ? "true" : "false");

--- a/components/ILIAS/UI/src/templates/default/Input/tpl.standard_filter.html
+++ b/components/ILIAS/UI/src/templates/default/Input/tpl.standard_filter.html
@@ -4,8 +4,8 @@
         <div class="il-filter-bar-opener">
             <button type="button" aria-expanded="{ARIA_EXPANDED}" aria-controls="active_inputs_{ID_FILTER} section_inputs_{ID_FILTER}" id="opener_{ID_FILTER}">
                     <span>
-                        <span data-collapse-glyph-visibility="{COLLAPSE_GLYPH_VISIBLE}">{COLLAPSE_GLYPH}</span>
-                        <span data-expand-glyph-visibility="{EXPAND_GLYPH_VISIBLE}">{EXPAND_GLYPH}</span>
+                        <span class="glyph" data-collapse-glyph-visibility="{COLLAPSE_GLYPH_VISIBLE}"><span class="glyphicon glyphicon-triangle-bottom"></span></span>
+                        <span class="glyph" data-expand-glyph-visibility="{EXPAND_GLYPH_VISIBLE}"><span class="glyphicon glyphicon-triangle-right"></span></span>
                         {TITLE_FILTER}
                     </span>
             </button>


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45422
https://mantis.ilias.de/view.php?id=43345

# Issue

* expand/collapse button includes a html `<a>` tag inside a button, caused by the glyph default rendering (which is now deprecated in favor of shy buttons withSymbol)
* this is invalid html and gets flagged by html validators
* it also throws off tabbing and certain ways of jumping navigation with screen readers

# Change

* like many early UI components the glyph is now described entirely by classes in the html template (this is deprecated hardcoding, but allows us to fix it for now)
* Unit Tests will be fixed once this approach is discussed/approved

# Outlook

Ideally, the expand/collapse button would be a button with glyph or a new accordion UI component.
The optimal refactoring and further development requires funding.