### PR TITLE
10/UI/toggle fix color contrast for ON state 45424 accessibility

### DIFF
--- a/templates/default/070-components/UI-framework/Button/_ui-component_toggle.scss
+++ b/templates/default/070-components/UI-framework/Button/_ui-component_toggle.scss
@@ -1,4 +1,5 @@
-@use "../../../010-settings/"as *;
+@use "sass:color";
+@use "../../../010-settings/" as *;
 @use "../../../050-layout/basics"as *;
 
 //== Toggle Buttons
@@ -9,6 +10,7 @@
 $il-btn-toggle-border-color: rgba(0, 0, 0, 0.1);
 $il-btn-toggle-switch-border-color: rgba(0, 0, 0, 0.2);
 $il-enabled-btn-toggle-switch-color: $il-main-color;
+$il-enabled-btn-toggle-switch-bg-color: color.change($il-secondary-color, $lightness: 30);
 $il-disabled-btn-toggle-switch-color: #808080;
 
 //** The Toggle Button without the Switch
@@ -35,8 +37,8 @@ $il-btn-toggle-label-font-size: $il-font-size-small;
 $il-btn-toggle-label-on-color: $il-main-bg;
 
 //** on
-$il-btn-toggle-bg-color-on: $il-secondary-color;
-$il-btn-toggle-border-color-on: $il-secondary-color;
+$il-btn-toggle-bg-color-on: $il-enabled-btn-toggle-switch-bg-color;
+$il-btn-toggle-border-color-on: $il-enabled-btn-toggle-switch-bg-color;
 $il-btn-toggle-switch-bg-color-on: $il-main-bg;
 $il-btn-toggle-switch-border-color-on: $il-main-bg;
 

--- a/templates/default/delos.css
+++ b/templates/default/delos.css
@@ -3637,8 +3637,8 @@ button .minimize, button .close {
 }
 
 .il-toggle-button.on {
-  background: #6ea03c;
-  border: 1px solid #6ea03c;
+  background: #4d6f2a;
+  border: 1px solid #4d6f2a;
 }
 .il-toggle-button.on .il-toggle-label-on {
   position: absolute;


### PR DESCRIPTION
https://mantis.ilias.de/view.php?id=45424

# Issue

Background fill for toggle ON status is too light. It doesn't provide sufficient contrast for the white text.

<img width="931" height="160" alt="toggle_low-contrast-color" src="https://github.com/user-attachments/assets/9a1706a6-5c49-4896-a9d2-1af39935f81f" />

# Change

Now forcing a lightness value of 30 using Sass color.change hsl value replacement. This might be a good approach to force a contrast in other places as well.

<img width="958" height="180" alt="toggle_accessible-color" src="https://github.com/user-attachments/assets/e502ec6c-bdf4-4a3d-aa6d-345fb52b5c12" />

# Impact

However, some clients of service providers do not like brand colors to be altered in this way, so we might want to introduce dedicated contrast color variables that brands could fill deliberately. What do you think @yvseiler?