### PR TITLE
LDAP: reduce similar log on regex errors

### DIFF
--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
@@ -126,6 +126,7 @@ class ilLDAPRoleAssignmentRule
     {
         $pattern = str_replace('*', '.*?', $a_str1);
 
+        $exception = [];
         foreach (ilAuthUtils::REGEX_DELIMITERS as $delimiter) {
             $this->logger->debug('Trying pattern to match attribute value:' . $pattern . ' => ' . $a_str2);
 
@@ -133,13 +134,18 @@ class ilLDAPRoleAssignmentRule
                 throw new ErrorException($message, $severity, $severity, $file, $line);
             });
 
+            $regex = $delimiter . "^" . $pattern . '$' . $delimiter . 'i';
             try {
-                return preg_match($delimiter . "^" . $pattern . '$' . $delimiter . 'i', $a_str2) === 1;
-            } catch (Exception $ex) {
-                $this->logger->warning('Error occurred in preg_match Ex.: ' . $ex->getMessage());
+                return preg_match($regex, $a_str2) === 1;
+            } catch (Exception $e) {
+                $exception[] = 'RegEx: ' . $regex . ' Message: ' . $e->getMessage();
             } finally {
                 restore_error_handler();
             }
+        }
+
+        if ($exception !== []) {
+            $this->logger->warning('Trying the RegEx delimiter chain results in the following problems: ' . implode(',', $exception));
         }
 
         return false;

--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
@@ -138,7 +138,7 @@ class ilLDAPRoleAssignmentRule
             try {
                 return preg_match($regex, $a_str2) === 1;
             } catch (Exception $e) {
-                $exception[] = 'RegEx: ' . $regex . ' Message: ' . $e->getMessage();
+                $exception[] = 'RegEx: ' . $regex . ' -> Message: ' . $e->getMessage();
             } finally {
                 restore_error_handler();
             }

--- a/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
+++ b/Services/LDAP/classes/class.ilLDAPRoleAssignmentRule.php
@@ -145,7 +145,7 @@ class ilLDAPRoleAssignmentRule
         }
 
         if ($exception !== []) {
-            $this->logger->warning('Trying the RegEx delimiter chain results in the following problems: ' . implode(',', $exception));
+            $this->logger->warning('Trying the RegEx delimiter chain results in the following problems: ' . implode(', ', $exception));
         }
 
         return false;


### PR DESCRIPTION
This reduces the error protocol to a minimum on failed regex checks.

Be aware that this might overpass different errors since only the last error is logged.