### PR TITLE
[FIX][Accessibility]: #44546 Remove redundant role="contentinfo" from footer

### DIFF
--- a/src/UI/templates/default/Layout/tpl.standardpage.html
+++ b/src/UI/templates/default/Layout/tpl.standardpage.html
@@ -76,7 +76,7 @@
 			{CONTENT}
 
 			<!-- BEGIN pagefooter -->
-			<footer role="contentinfo">
+			<footer>
 				{FOOTER}
 			</footer>
 			<!-- END pagefooter -->


### PR DESCRIPTION
According to the BITV test for ILIAS 9, the attribute `role="contentinfo”` in the footer was unnecessary and has been removed.
This role is redundant since the `<footer>` element already carries an implicit contentinfo landmark, making the explicit role unnecessary.

This change improves compliance with WCAG and BITV accessibility guidelines.

For reference, see the related ticket:
https://mantis.ilias.de/view.php?id=44546